### PR TITLE
🤖 fix: prevent jsdom ENOENT from crashing Docker streaming pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,25 @@ RUN git init && \
 # Thread RELEASE_TAG through to scripts/generate-version.sh when CI provides it.
 RUN RELEASE_TAG="${RELEASE_TAG}" make verify-docker-runtime-artifacts
 
+# Trace jsdom's full transitive dependency tree so the runtime stage can copy
+# exactly the packages it needs. jsdom is externalized from the esbuild bundle
+# because it reads browser/default-stylesheet.css from disk via __dirname.
+RUN node -e " \
+  const fs = require('fs'), path = require('path'); \
+  const seen = new Set(); \
+  function trace(name) { \
+    if (seen.has(name)) return; \
+    seen.add(name); \
+    try { \
+      const pkgPath = require.resolve(name + '/package.json'); \
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')); \
+      for (const d of Object.keys(pkg.dependencies || {})) trace(d); \
+    } catch {} \
+  } \
+  trace('jsdom'); \
+  fs.writeFileSync('/tmp/jsdom-deps.txt', [...seen].join('\n')); \
+"
+
 # ==============================================================================
 # Stage 2: Runtime
 # ==============================================================================
@@ -100,6 +119,17 @@ COPY --from=builder /app/node_modules/bcrypt-pbkdf ./node_modules/bcrypt-pbkdf
 COPY --from=builder /app/node_modules/tweetnacl ./node_modules/tweetnacl
 # - @1password/sdk + sdk-core: externalized; contains native WASM for secret resolution
 COPY --from=builder /app/node_modules/@1password ./node_modules/@1password
+# - jsdom + transitive deps: externalized because it reads CSS from disk via __dirname.
+#   Copy the traced dependency tree built in the builder stage.
+COPY --from=builder /tmp/jsdom-deps.txt /tmp/jsdom-deps.txt
+RUN --mount=from=builder,source=/app/node_modules,target=/mnt/node_modules \
+    while IFS= read -r pkg; do \
+      src="/mnt/node_modules/$pkg"; \
+      if [ -d "$src" ]; then \
+        mkdir -p "node_modules/$pkg" && cp -a "$src/." "node_modules/$pkg/"; \
+      fi; \
+    done < /tmp/jsdom-deps.txt && \
+    rm /tmp/jsdom-deps.txt
 
 # Copy frontend/static assets from least to most volatile for better cache reuse.
 # Vite outputs JS/CSS/HTML directly to dist/ (assetsDir: ".").

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,9 @@ ESBUILD_CLI_FLAGS := --bundle --format=esm --platform=node --target=node20 --out
 # Common esbuild flags for server runtime Docker bundle.
 # Place runtime bundles under dist/runtime so frontend dist/*.js layers remain stable.
 # External native modules (node-pty, ssh2) and electron remain runtime dependencies.
-ESBUILD_SERVER_FLAGS := --bundle --platform=node --target=node22 --format=cjs --outfile=dist/runtime/server-bundle.js --external:@lydell/node-pty --external:node-pty --external:electron --external:ssh2 --external:@1password/sdk --external:@1password/sdk-core --external:agent-browser --alias:jsonc-parser=jsonc-parser/lib/esm/main.js --minify
+# jsdom is externalized because it reads browser/default-stylesheet.css from
+# disk via a __dirname-relative path that breaks when bundled.
+ESBUILD_SERVER_FLAGS := --bundle --platform=node --target=node22 --format=cjs --outfile=dist/runtime/server-bundle.js --external:@lydell/node-pty --external:node-pty --external:electron --external:ssh2 --external:@1password/sdk --external:@1password/sdk-core --external:agent-browser --external:jsdom --alias:jsonc-parser=jsonc-parser/lib/esm/main.js --minify
 
 # Common esbuild flags for tokenizer worker bundle used by server-bundle runtime.
 ESBUILD_TOKENIZER_WORKER_FLAGS := --bundle --platform=node --target=node22 --format=cjs --outfile=dist/runtime/tokenizer.worker.js --minify

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -334,9 +334,21 @@ export async function getToolsForModel(
   const wrap = <TParameters, TResult>(tool: Tool<TParameters, TResult>) =>
     wrapWithInitWait(tool, workspaceId, initStateManager);
 
-  // Lazy-load web_fetch to avoid loading jsdom (ESM-only) at Jest setup time
-  // This allows integration tests to run without transforming jsdom's dependencies
-  const { createWebFetchTool } = await import("@/node/services/tools/web_fetch");
+  // Lazy-load web_fetch to avoid loading jsdom (ESM-only) at Jest setup time.
+  // jsdom has filesystem dependencies (browser/default-stylesheet.css) that break
+  // when bundled with esbuild — the __dirname-relative path resolves incorrectly
+  // in the Docker runtime. Catch import failures so the rest of the toolset still
+  // works; Anthropic models already replace web_fetch with a provider-native tool.
+  let createWebFetchTool:
+    | typeof import("@/node/services/tools/web_fetch")["createWebFetchTool"]
+    | undefined;
+  try {
+    ({ createWebFetchTool } = await import("@/node/services/tools/web_fetch"));
+  } catch (error) {
+    log.warn("Failed to load web_fetch tool (jsdom dependency issue), skipping", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // Runtime-dependent tools need to wait for workspace initialization
   // Wrap them to handle init waiting centrally instead of in each tool
@@ -367,7 +379,7 @@ export async function getToolsForModel(
     bash_background_list: wrap(createBashBackgroundListTool(config)),
     bash_background_terminate: wrap(createBashBackgroundTerminateTool(config)),
 
-    web_fetch: wrap(createWebFetchTool(config)),
+    ...(createWebFetchTool ? { web_fetch: wrap(createWebFetchTool(config)) } : {}),
   };
 
   // Non-runtime tools execute immediately (no init wait needed)


### PR DESCRIPTION
## Summary

Fix `web_fetch` tool crashing the entire streaming pipeline in Docker deployments. jsdom's filesystem dependency on `browser/default-stylesheet.css` breaks when bundled with esbuild, causing ENOENT on first message send and cascading `TypeError: p is not a function` on every subsequent retry.

## Background

Production logs from the web UI showed two interleaved errors when sending any message:

1. `ENOENT: no such file or directory, open '/app/browser/default-stylesheet.css'` — jsdom reads this CSS file from disk via a `__dirname`-relative path. After esbuild bundles jsdom into `server-bundle.js`, `__dirname` resolves to the bundle directory instead of jsdom's original package location, so the path is wrong.

2. `TypeError: p is not a function` — after the initial ENOENT, jsdom's module is left in a partially-initialized state in Node's module cache. Every retry and fresh send re-enters the same corrupted module, hitting an undefined function (minified as `p`). The auto-retry manager retries every ~1 second indefinitely, flooding the logs.

The root cause is that `getToolsForModel()` dynamically imports `web_fetch.ts` (which imports jsdom) on every `streamMessage` call. When jsdom fails to load, the entire tool assembly throws, preventing ALL tools from being registered — not just `web_fetch`.

## Implementation

Two layered fixes:

1. **Graceful fallback** (`tools.ts`): Wrap the jsdom dynamic import in try/catch so `web_fetch` is omitted from the toolset instead of crashing. This is defense-in-depth — Anthropic models already replace `web_fetch` with a provider-native tool (`webFetch_20250910`), so losing it is low-impact.

2. **Externalize jsdom** (`Makefile` + `Dockerfile`): Add `--external:jsdom` to `ESBUILD_SERVER_FLAGS` so jsdom keeps its original filesystem layout at runtime. Trace jsdom's full transitive dependency tree in the builder stage and copy it into the runtime image.

## Risks

- The jsdom dependency tracing runs `require.resolve` in the builder — if a transitive dep uses conditional/optional requires that aren't in `dependencies`, they'll be missed. The graceful fallback (fix 1) covers this as a safety net.
- Adding jsdom's dependency tree to the Docker image increases image size. This is the correct trade-off vs. a broken `web_fetch` tool.

---

_Generated with `mux`_
