### PR TITLE
🤖 feat: show model pricing on hover in chat-input picker

### DIFF
--- a/src/browser/components/ModelPricingTooltip/ModelPricingTooltip.tsx
+++ b/src/browser/components/ModelPricingTooltip/ModelPricingTooltip.tsx
@@ -1,0 +1,104 @@
+import type { ModelStats } from "@/common/utils/tokens/modelStats";
+
+/** Format tokens as human-readable string (e.g. 200000 -> "200k") */
+export function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    const k = tokens / 1_000;
+    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
+  }
+  return tokens.toString();
+}
+
+/** Format cost per million tokens (e.g. 0.000001 -> "$1.00") */
+export function formatCostPerMillion(costPerToken: number): string {
+  const perMillion = costPerToken * 1_000_000;
+  if (perMillion < 0.01) return "~$0.00";
+  return `$${perMillion.toFixed(2)}`;
+}
+
+export interface ModelPricingTooltipProps {
+  fullId: string;
+  aliases?: string[];
+  stats: ModelStats | null;
+}
+
+/**
+ * Body of the per-model pricing tooltip. Shared between the Settings → Models
+ * info popover and the chat-input model picker hover tooltip so the two stay
+ * visually identical.
+ */
+export function ModelPricingTooltip(props: ModelPricingTooltipProps) {
+  return (
+    <div className="max-w-xs space-y-2 text-xs">
+      <div className="text-foreground font-mono">{props.fullId}</div>
+
+      {props.aliases && props.aliases.length > 0 && (
+        <div className="text-muted">
+          <span className="text-muted-light">Aliases: </span>
+          {props.aliases.join(", ")}
+        </div>
+      )}
+
+      {props.stats && (
+        <>
+          <div className="border-separator-light border-t pt-2">
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+              <div className="text-muted-light">Context Window</div>
+              <div className="text-foreground">
+                {formatTokenCount(props.stats.max_input_tokens)}
+              </div>
+
+              {props.stats.max_output_tokens && (
+                <>
+                  <div className="text-muted-light">Max Output</div>
+                  <div className="text-foreground">
+                    {formatTokenCount(props.stats.max_output_tokens)}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="border-separator-light border-t pt-2">
+            <div className="text-muted-light mb-1">Pricing (per 1M tokens)</div>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+              <div className="text-muted-light">Input</div>
+              <div className="text-foreground">
+                {formatCostPerMillion(props.stats.input_cost_per_token)}
+              </div>
+
+              <div className="text-muted-light">Output</div>
+              <div className="text-foreground">
+                {formatCostPerMillion(props.stats.output_cost_per_token)}
+              </div>
+
+              {props.stats.cache_read_input_token_cost !== undefined && (
+                <>
+                  <div className="text-muted-light">Cache Read</div>
+                  <div className="text-foreground">
+                    {formatCostPerMillion(props.stats.cache_read_input_token_cost)}
+                  </div>
+                </>
+              )}
+
+              {props.stats.cache_creation_input_token_cost !== undefined && (
+                <>
+                  <div className="text-muted-light">Cache Write</div>
+                  <div className="text-foreground">
+                    {formatCostPerMillion(props.stats.cache_creation_input_token_cost)}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {!props.stats && <div className="text-muted-light italic">No pricing data available</div>}
+    </div>
+  );
+}

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -17,6 +17,8 @@ import { Check, ChevronDown, Eye, Settings, ShieldCheck, Star } from "lucide-rea
 
 import { ProviderIcon } from "../ProviderIcon/ProviderIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
+import { ModelPricingTooltip } from "../ModelPricingTooltip/ModelPricingTooltip";
+import { getModelStats } from "@/common/utils/tokens/modelStats";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { usePolicy } from "@/browser/contexts/PolicyContext";
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
@@ -367,133 +369,146 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                   const modelProvider = getModelProvider(model);
                   const showProviderLabel =
                     modelProvider.length > 0 && duplicateModelNames.has(modelName);
+                  const modelStats = getModelStats(model);
 
                   return (
-                    <div
-                      key={model}
-                      data-highlighted={index === highlightedIndex}
-                      onMouseEnter={() => setHighlightedIndex(index)}
-                      className={cn(
-                        "flex w-full items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs cursor-pointer",
-                        index === highlightedIndex ? "bg-hover" : "hover:bg-hover",
-                        hiddenSet.has(model) && "opacity-50"
-                      )}
-                      onClick={() => handleSelectModel(model)}
-                      role="option"
-                      aria-selected={value === model}
-                    >
-                      <Check
-                        className={cn(
-                          "h-3 w-3 shrink-0",
-                          value === model ? "opacity-100" : "opacity-0"
-                        )}
-                      />
-                      <ProviderIcon
-                        provider={modelProvider}
-                        className="text-muted h-3 w-3 shrink-0"
-                      />
-                      <span className="flex min-w-0 flex-1 items-baseline gap-1">
-                        <span className="min-w-0 truncate">
-                          {formatModelDisplayName(modelName)}
-                        </span>
-                        {showProviderLabel && (
-                          <span className="text-muted shrink-0 text-[10px]">
-                            {formatProviderDisplayName(
-                              modelProvider,
-                              providersConfig?.[modelProvider]
+                    <Tooltip key={model} delayDuration={0}>
+                      <TooltipTrigger asChild>
+                        <div
+                          data-highlighted={index === highlightedIndex}
+                          onMouseEnter={() => setHighlightedIndex(index)}
+                          className={cn(
+                            "flex w-full items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs cursor-pointer",
+                            index === highlightedIndex ? "bg-hover" : "hover:bg-hover",
+                            hiddenSet.has(model) && "opacity-50"
+                          )}
+                          onClick={() => handleSelectModel(model)}
+                          role="option"
+                          aria-selected={value === model}
+                        >
+                          <Check
+                            className={cn(
+                              "h-3 w-3 shrink-0",
+                              value === model ? "opacity-100" : "opacity-0"
+                            )}
+                          />
+                          <ProviderIcon
+                            provider={modelProvider}
+                            className="text-muted h-3 w-3 shrink-0"
+                          />
+                          <span className="flex min-w-0 flex-1 items-baseline gap-1">
+                            <span className="min-w-0 truncate">
+                              {formatModelDisplayName(modelName)}
+                            </span>
+                            {showProviderLabel && (
+                              <span className="text-muted shrink-0 text-[10px]">
+                                {formatProviderDisplayName(
+                                  modelProvider,
+                                  providersConfig?.[modelProvider]
+                                )}
+                              </span>
                             )}
                           </span>
-                        )}
-                      </span>
 
-                      {/* Visibility toggle - Eye with line-through when hidden */}
-                      {(onHideModel ?? onUnhideModel) && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              onMouseDown={(e) => e.preventDefault()}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                if (hiddenSet.has(model)) {
-                                  onUnhideModel?.(model);
-                                } else {
-                                  onHideModel?.(model);
-                                }
-                              }}
-                              className={cn(
-                                "relative flex h-5 w-5 items-center justify-center rounded-sm border transition-colors duration-150",
-                                hiddenSet.has(model)
-                                  ? "text-muted-light border-muted-light/40"
-                                  : "text-muted-light border-border-light/40 hover:border-foreground/60 hover:text-foreground"
-                              )}
-                              aria-label={
-                                hiddenSet.has(model)
+                          {/* Visibility toggle - Eye with line-through when hidden */}
+                          {(onHideModel ?? onUnhideModel) && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <button
+                                  type="button"
+                                  onMouseDown={(e) => e.preventDefault()}
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    if (hiddenSet.has(model)) {
+                                      onUnhideModel?.(model);
+                                    } else {
+                                      onHideModel?.(model);
+                                    }
+                                  }}
+                                  className={cn(
+                                    "relative flex h-5 w-5 items-center justify-center rounded-sm border transition-colors duration-150",
+                                    hiddenSet.has(model)
+                                      ? "text-muted-light border-muted-light/40"
+                                      : "text-muted-light border-border-light/40 hover:border-foreground/60 hover:text-foreground"
+                                  )}
+                                  aria-label={
+                                    hiddenSet.has(model)
+                                      ? "Show model in selector"
+                                      : "Hide model from selector"
+                                  }
+                                >
+                                  <Eye
+                                    className={cn(
+                                      "h-4 w-4 md:h-3 md:w-3",
+                                      hiddenSet.has(model) ? "opacity-30" : "opacity-70"
+                                    )}
+                                  />
+                                  {hiddenSet.has(model) && (
+                                    <span className="bg-muted-light absolute h-px w-3 rotate-45" />
+                                  )}
+                                </button>
+                              </TooltipTrigger>
+                              <TooltipContent align="center">
+                                {hiddenSet.has(model)
                                   ? "Show model in selector"
-                                  : "Hide model from selector"
-                              }
-                            >
-                              <Eye
-                                className={cn(
-                                  "h-4 w-4 md:h-3 md:w-3",
-                                  hiddenSet.has(model) ? "opacity-30" : "opacity-70"
-                                )}
-                              />
-                              {hiddenSet.has(model) && (
-                                <span className="bg-muted-light absolute h-px w-3 rotate-45" />
-                              )}
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent align="center">
-                            {hiddenSet.has(model)
-                              ? "Show model in selector"
-                              : "Hide model from selector"}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
+                                  : "Hide model from selector"}
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
 
-                      {/* Default star */}
-                      {onSetDefaultModel ? (
-                        hiddenSet.has(model) ? (
-                          <span className="h-5 w-5" />
-                        ) : (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                type="button"
-                                onMouseDown={(e) => e.preventDefault()}
-                                onClick={(e) => handleSetDefault(e, model)}
-                                className={cn(
-                                  "flex h-5 w-5 items-center justify-center rounded-sm transition-colors duration-150 cursor-pointer",
-                                  defaultModel === model
-                                    ? "text-yellow-400 cursor-default"
-                                    : "text-muted-light hover:text-foreground"
-                                )}
-                                aria-label={
-                                  defaultModel === model
+                          {/* Default star */}
+                          {onSetDefaultModel ? (
+                            hiddenSet.has(model) ? (
+                              <span className="h-5 w-5" />
+                            ) : (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button
+                                    type="button"
+                                    onMouseDown={(e) => e.preventDefault()}
+                                    onClick={(e) => handleSetDefault(e, model)}
+                                    className={cn(
+                                      "flex h-5 w-5 items-center justify-center rounded-sm transition-colors duration-150 cursor-pointer",
+                                      defaultModel === model
+                                        ? "text-yellow-400 cursor-default"
+                                        : "text-muted-light hover:text-foreground"
+                                    )}
+                                    aria-label={
+                                      defaultModel === model
+                                        ? "Current default model"
+                                        : "Set as default model"
+                                    }
+                                    disabled={defaultModel === model}
+                                  >
+                                    <Star
+                                      className="h-4 w-4 md:h-3 md:w-3"
+                                      fill={defaultModel === model ? "currentColor" : "none"}
+                                    />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent align="center">
+                                  {defaultModel === model
                                     ? "Current default model"
-                                    : "Set as default model"
-                                }
-                                disabled={defaultModel === model}
-                              >
-                                <Star
-                                  className="h-4 w-4 md:h-3 md:w-3"
-                                  fill={defaultModel === model ? "currentColor" : "none"}
-                                />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent align="center">
-                              {defaultModel === model
-                                ? "Current default model"
-                                : "Set as default model"}
-                            </TooltipContent>
-                          </Tooltip>
-                        )
-                      ) : (
-                        <span className="h-5 w-5" />
-                      )}
-                    </div>
+                                    : "Set as default model"}
+                                </TooltipContent>
+                              </Tooltip>
+                            )
+                          ) : (
+                            <span className="h-5 w-5" />
+                          )}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="right"
+                        align="start"
+                        sideOffset={8}
+                        collisionPadding={12}
+                        className="p-3"
+                      >
+                        <ModelPricingTooltip fullId={model} stats={modelStats} />
+                      </TooltipContent>
+                    </Tooltip>
                   );
                 })
               )}

--- a/src/browser/features/Settings/Sections/ModelRow.tsx
+++ b/src/browser/features/Settings/Sections/ModelRow.tsx
@@ -14,103 +14,11 @@ import { ProviderIcon, ProviderWithIcon } from "@/browser/components/ProviderIco
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
 import { cn } from "@/common/lib/utils";
 import type { AvailableRoute } from "@/common/routing";
-import { getModelStats, type ModelStats } from "@/common/utils/tokens/modelStats";
-
-/** Format tokens as human-readable string (e.g. 200000 -> "200k") */
-function formatTokenCount(tokens: number): string {
-  if (tokens >= 1_000_000) {
-    const m = tokens / 1_000_000;
-    return m % 1 === 0 ? `${m}M` : `${m.toFixed(1)}M`;
-  }
-  if (tokens >= 1_000) {
-    const k = tokens / 1_000;
-    return k % 1 === 0 ? `${k}k` : `${k.toFixed(1)}k`;
-  }
-  return tokens.toString();
-}
-
-/** Format cost per million tokens (e.g. 0.000001 -> "$1.00") */
-function formatCostPerMillion(costPerToken: number): string {
-  const perMillion = costPerToken * 1_000_000;
-  if (perMillion < 0.01) return "~$0.00";
-  return `$${perMillion.toFixed(2)}`;
-}
-
-function ModelTooltipContent(props: {
-  fullId: string;
-  aliases?: string[];
-  stats: ModelStats | null;
-}) {
-  return (
-    <div className="max-w-xs space-y-2 text-xs">
-      <div className="text-foreground font-mono">{props.fullId}</div>
-
-      {props.aliases && props.aliases.length > 0 && (
-        <div className="text-muted">
-          <span className="text-muted-light">Aliases: </span>
-          {props.aliases.join(", ")}
-        </div>
-      )}
-
-      {props.stats && (
-        <>
-          <div className="border-separator-light border-t pt-2">
-            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-              <div className="text-muted-light">Context Window</div>
-              <div className="text-foreground">
-                {formatTokenCount(props.stats.max_input_tokens)}
-              </div>
-
-              {props.stats.max_output_tokens && (
-                <>
-                  <div className="text-muted-light">Max Output</div>
-                  <div className="text-foreground">
-                    {formatTokenCount(props.stats.max_output_tokens)}
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-
-          <div className="border-separator-light border-t pt-2">
-            <div className="text-muted-light mb-1">Pricing (per 1M tokens)</div>
-            <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-              <div className="text-muted-light">Input</div>
-              <div className="text-foreground">
-                {formatCostPerMillion(props.stats.input_cost_per_token)}
-              </div>
-
-              <div className="text-muted-light">Output</div>
-              <div className="text-foreground">
-                {formatCostPerMillion(props.stats.output_cost_per_token)}
-              </div>
-
-              {props.stats.cache_read_input_token_cost !== undefined && (
-                <>
-                  <div className="text-muted-light">Cache Read</div>
-                  <div className="text-foreground">
-                    {formatCostPerMillion(props.stats.cache_read_input_token_cost)}
-                  </div>
-                </>
-              )}
-
-              {props.stats.cache_creation_input_token_cost !== undefined && (
-                <>
-                  <div className="text-muted-light">Cache Write</div>
-                  <div className="text-foreground">
-                    {formatCostPerMillion(props.stats.cache_creation_input_token_cost)}
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-        </>
-      )}
-
-      {!props.stats && <div className="text-muted-light italic">No pricing data available</div>}
-    </div>
-  );
-}
+import { getModelStats } from "@/common/utils/tokens/modelStats";
+import {
+  ModelPricingTooltip,
+  formatTokenCount,
+} from "@/browser/components/ModelPricingTooltip/ModelPricingTooltip";
 
 /**
  * Inline toggle that slides between the model's base context window and 1M.
@@ -426,7 +334,7 @@ export function ModelRow(props: ModelRowProps) {
               </button>
             </TooltipTrigger>
             <TooltipContent side="top" align="end" className="p-3">
-              <ModelTooltipContent fullId={props.fullId} aliases={props.aliases} stats={stats} />
+              <ModelPricingTooltip fullId={props.fullId} aliases={props.aliases} stats={stats} />
             </TooltipContent>
           </Tooltip>
           {/* Visibility toggle button */}


### PR DESCRIPTION
## Summary

Hovering a model row in the chat-input picker now shows a tooltip with that model's pricing (input / output / cache-read / cache-write per 1M tokens), context window, and max output. No delay — the tooltip appears as soon as the cursor lands on a row.

![demo](https://owo.whats-th.is/9YDK4q9.gif)

## Background

Users frequently want to know what a model costs before they pick it, but today that info is only available two extra clicks away in **Settings → Models**. Surfacing it right in the picker turns "switch model" into a decision that includes cost without any context switch.

## Implementation

- Extracted the existing per-model tooltip body from `ModelRow.tsx` into a new shared component **`ModelPricingTooltip`** (`src/browser/components/ModelPricingTooltip/ModelPricingTooltip.tsx`). The markup, Tailwind classes, and `formatCostPerMillion` / `formatTokenCount` helpers are moved verbatim so the Settings tooltip is byte-identical to before.
- Wrapped each picker row in `ModelSelector.tsx` with a Radix `Tooltip` (`delayDuration={0}`, portaled `TooltipContent` on `side="right"` with `collisionPadding={12}` so it flips at the viewport edge). Pricing is looked up inline with the existing pure, renderer-local `getModelStats(model)` — no IPC, no prop threading, no async loading.
- Pre-existing intra-row tooltips on the Eye and Star buttons are untouched and continue to take precedence when the cursor is over them.
- When `getModelStats` returns `null` (e.g. Ollama, custom providers with no metadata) the shared component renders the existing "No pricing data available" copy.

Net product LoC: roughly +25 (most of the new file is text moved from `ModelRow.tsx`).

## Validation

- `make typecheck` — clean on both project configs.
- `make lint` — `ESLint checks passed!`.
- `bun test src/browser/features/Settings/Sections/` — 65 pass / 0 fail (covers `ModelRow` and the suites that mock `ModelSelector`).
- `bun test src/common/utils/tokens/modelStats.test.ts` — 19 pass (pricing data layer untouched, sanity check).
- Local sandbox: confirmed the tooltip appears on hover, flips sides near the viewport edge, falls back to "No pricing data available", and the Settings → Models info popover renders identically to before the refactor.

## Risks

Low. The Settings tooltip is the same JSX with the same classes, just imported from a new module; the new picker tooltip is additive and uses the same Radix primitive already in use inside this scrollable list for the Eye/Star buttons. If anything goes wrong the visible blast radius is "tooltip doesn't appear" rather than anything affecting model selection.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$4.36`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=4.36 -->
