### PR TITLE
🤖 feat: tooltip with full workspace name on truncated sidebar titles

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -27,7 +27,7 @@ import { useDrag } from "react-dnd";
 import { getEmptyImage } from "react-dnd-html5-backend";
 import { SubAgentListItem } from "./SubAgentListItem";
 
-import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipIfPresent } from "../Tooltip/Tooltip";
 import { Popover, PopoverContent, PopoverTrigger, PopoverAnchor } from "../Popover/Popover";
 import { PositionedMenu, PositionedMenuItem } from "../PositionedMenu/PositionedMenu";
 import {
@@ -480,6 +480,26 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       : undefined;
   const displayTitle = groupLabel ? `${groupLabel} · ${workspaceTitle}` : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
+
+  // Track whether the title span is actually clipped by `truncate` so we only
+  // attach a hover tooltip when the user can't already read the full name.
+  // Callback ref instead of useRef so we re-measure when the span mounts/unmounts
+  // (e.g. when toggling in/out of the rename input branch).
+  const [titleEl, setTitleEl] = useState<HTMLSpanElement | null>(null);
+  const [isTitleTruncated, setIsTitleTruncated] = useState(false);
+  useEffect(() => {
+    if (!titleEl) {
+      setIsTitleTruncated(false);
+      return;
+    }
+    const check = () => {
+      setIsTitleTruncated(titleEl.scrollWidth > titleEl.clientWidth);
+    };
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(titleEl);
+    return () => observer.disconnect();
+  }, [titleEl, displayTitle]);
 
   const linkSharingEnabled = useLinkSharingEnabled();
   const [shareTranscriptOpen, setShareTranscriptOpen] = useState(false);
@@ -1030,16 +1050,23 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                 {groupLabel && (
                   <span className="text-muted shrink-0 text-[12px] leading-6">{groupLabel}</span>
                 )}
-                <span
-                  className={cn(
-                    "min-w-0 flex-1 truncate text-left text-[14px] leading-6 transition-colors duration-200",
-                    !isDisabled && "cursor-pointer",
-                    (isGeneratingTitle || isPendingAutoTitle) && "italic",
-                    titleColorClass
-                  )}
+                <TooltipIfPresent
+                  tooltip={isTitleTruncated ? displayTitle : undefined}
+                  side="right"
+                  align="center"
                 >
-                  {workspaceTitle}
-                </span>
+                  <span
+                    ref={setTitleEl}
+                    className={cn(
+                      "min-w-0 flex-1 truncate text-left text-[14px] leading-6 transition-colors duration-200",
+                      !isDisabled && "cursor-pointer",
+                      (isGeneratingTitle || isPendingAutoTitle) && "italic",
+                      titleColorClass
+                    )}
+                  >
+                    {workspaceTitle}
+                  </span>
+                </TooltipIfPresent>
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Show a tooltip with the full workspace name when hovering a sidebar row whose title is clipped by the existing `truncate` utility. Today the only ways to read a clipped name are to expand the sidebar or click the row; this restores quick scanability when the sidebar is resized narrow.

![demo](https://owo.whats-th.is/9t7mFjx.gif)

## Background

`AgentListItem` renders the workspace title in a `<span>` with Tailwind's `truncate` (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`). Inside a narrow `min-w-0` grid column, long titles collapse to ellipses with no native `title` attribute fallback, so users have to widen the sidebar or click the row to see the full name.

## Implementation

Single-file change in `src/browser/components/AgentListItem/AgentListItem.tsx`:

- Wrap the title `<span>` in `TooltipIfPresent` (the same helper used for truncated labels in `FileTree`). `TooltipProvider` is already mounted globally in `App.tsx`, so no extra wiring is required.
- Detect actual overflow with a callback ref + `ResizeObserver` on the span: `scrollWidth > clientWidth` drives an `isTitleTruncated` flag. The tooltip is only attached while overflow is present; non-truncated rows have no trigger at all.
- Pass `displayTitle` (not `workspaceTitle`) so variants/best-of-n group labels appear as `A · fix login`, matching the row's existing `aria-label`s.
- Tooltip is anchored to the title span only — hovering the group-label badge, status icons, terminal-count badge, or row padding does **not** show this tooltip. The pre-existing terminal-count tooltip on the same row is untouched.
- Tooltip rendered with `side="right"` so it floats into the main content area instead of covering neighboring sidebar rows.

## Validation

- `make typecheck` — clean.
- `bunx eslint` on the touched file — clean.
- Manual: resized the left sidebar to the minimum width with long workspace titles and confirmed the tooltip appears only when the name is clipped, only over the title text, and tracks overflow live as the sidebar is resized (via `ResizeObserver`).

## Risks

Low. Presentational, additive wrap around an existing element; no state-management changes. The trigger is fully unmounted when `isTitleTruncated` is false, so the common case (fitting titles) is byte-identical to before. The `ResizeObserver` is per-row and only observes the title span, matching the lifetime of the row itself.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-7` • Thinking: `high` • Cost: `$2.13`_

<!-- mux-attribution: model=anthropic:claude-opus-4-7 thinking=high costs=2.13 -->
