### PR TITLE
🤖 feat: add scheduled prompt queue

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -122,6 +122,15 @@ import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { prependInitialAppProxyBasePath } from "@/browser/utils/frontendBasePath";
 import { WorkspaceActiveGoalsWarningToast } from "@/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast";
 import { LoadingScreen } from "@/browser/components/LoadingScreen/LoadingScreen";
+import { AgentProvider } from "@/browser/contexts/AgentContext";
+import { ThinkingProvider } from "@/browser/contexts/ThinkingContext";
+import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
+import { useScheduledPromptDispatcher } from "@/browser/features/ScheduledPrompts/useScheduledPromptDispatcher";
+import {
+  useAdditionalSystemContextHydrated,
+  useAdditionalSystemContextSnapshot,
+} from "@/browser/utils/additionalSystemContextStore";
 
 function RootRouteShell(props: {
   leftSidebarCollapsed: boolean;
@@ -148,6 +157,56 @@ function RootRouteShell(props: {
       </div>
     </div>
   );
+}
+
+function ActiveWorkspaceScheduledPromptDispatcher(props: {
+  workspaceId: string;
+  projectPath: string;
+  enabled: boolean;
+}) {
+  return (
+    <AgentProvider
+      workspaceId={props.workspaceId}
+      projectPath={props.projectPath}
+      enableGlobalListeners={false}
+    >
+      <ThinkingProvider
+        workspaceId={props.workspaceId}
+        projectPath={props.projectPath}
+        enableGlobalListeners={false}
+      >
+        <ActiveWorkspaceScheduledPromptDispatcherInner
+          workspaceId={props.workspaceId}
+          enabled={props.enabled}
+        />
+      </ThinkingProvider>
+    </AgentProvider>
+  );
+}
+
+function ActiveWorkspaceScheduledPromptDispatcherInner(props: {
+  workspaceId: string;
+  enabled: boolean;
+}) {
+  const { api } = useAPI();
+  const sendMessageOptions = useSendMessageOptions(props.workspaceId);
+  const additionalSystemContext = useAdditionalSystemContextSnapshot(props.workspaceId);
+  const additionalSystemContextHydrated = useAdditionalSystemContextHydrated(props.workspaceId);
+  const scheduledAdditionalSystemContext = additionalSystemContextHydrated
+    ? additionalSystemContext.enabled
+      ? additionalSystemContext.content
+      : ""
+    : undefined;
+
+  useScheduledPromptDispatcher({
+    api,
+    workspaceId: props.workspaceId,
+    sendMessageOptions,
+    additionalSystemContext: scheduledAdditionalSystemContext,
+    enabled: props.enabled,
+  });
+
+  return null;
 }
 
 function AppInner() {
@@ -245,6 +304,17 @@ function AppInner() {
   }, [sidebarCollapsed]);
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
+  const scheduledPromptWorkspaceId = selectedWorkspace?.workspaceId ?? currentWorkspaceId;
+  const scheduledPromptWorkspaceMeta = scheduledPromptWorkspaceId
+    ? workspaceMetadata.get(scheduledPromptWorkspaceId)
+    : undefined;
+  const scheduledPromptProjectPath =
+    selectedWorkspace?.workspaceId === scheduledPromptWorkspaceId
+      ? selectedWorkspace.projectPath
+      : scheduledPromptWorkspaceMeta?.projectPath;
+  const scheduledPromptDispatcherEnabled = canUseScheduledPromptsInWorkspace(
+    scheduledPromptWorkspaceMeta
+  );
 
   // History navigation (back/forward)
   const navigate = useNavigate();
@@ -1251,6 +1321,13 @@ function AppInner() {
 
   return (
     <>
+      {scheduledPromptWorkspaceId && scheduledPromptProjectPath ? (
+        <ActiveWorkspaceScheduledPromptDispatcher
+          workspaceId={scheduledPromptWorkspaceId}
+          projectPath={scheduledPromptProjectPath}
+          enabled={scheduledPromptDispatcherEnabled}
+        />
+      ) : null}
       <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
         <LeftSidebar
           collapsed={sidebarCollapsed}

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -105,6 +105,15 @@ import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { prependInitialAppProxyBasePath } from "@/browser/utils/frontendBasePath";
 import { WorkspaceActiveGoalsWarningToast } from "@/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast";
 import { LoadingScreen } from "@/browser/components/LoadingScreen/LoadingScreen";
+import { AgentProvider } from "@/browser/contexts/AgentContext";
+import { ThinkingProvider } from "@/browser/contexts/ThinkingContext";
+import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
+import { useScheduledPromptDispatcher } from "@/browser/features/ScheduledPrompts/useScheduledPromptDispatcher";
+import {
+  useAdditionalSystemContextHydrated,
+  useAdditionalSystemContextSnapshot,
+} from "@/browser/utils/additionalSystemContextStore";
 
 function RootRouteShell(props: {
   leftSidebarCollapsed: boolean;
@@ -131,6 +140,56 @@ function RootRouteShell(props: {
       </div>
     </div>
   );
+}
+
+function ActiveWorkspaceScheduledPromptDispatcher(props: {
+  workspaceId: string;
+  projectPath: string;
+  enabled: boolean;
+}) {
+  return (
+    <AgentProvider
+      workspaceId={props.workspaceId}
+      projectPath={props.projectPath}
+      enableGlobalListeners={false}
+    >
+      <ThinkingProvider
+        workspaceId={props.workspaceId}
+        projectPath={props.projectPath}
+        enableGlobalListeners={false}
+      >
+        <ActiveWorkspaceScheduledPromptDispatcherInner
+          workspaceId={props.workspaceId}
+          enabled={props.enabled}
+        />
+      </ThinkingProvider>
+    </AgentProvider>
+  );
+}
+
+function ActiveWorkspaceScheduledPromptDispatcherInner(props: {
+  workspaceId: string;
+  enabled: boolean;
+}) {
+  const { api } = useAPI();
+  const sendMessageOptions = useSendMessageOptions(props.workspaceId);
+  const additionalSystemContext = useAdditionalSystemContextSnapshot(props.workspaceId);
+  const additionalSystemContextHydrated = useAdditionalSystemContextHydrated(props.workspaceId);
+  const scheduledAdditionalSystemContext = additionalSystemContextHydrated
+    ? additionalSystemContext.enabled
+      ? additionalSystemContext.content
+      : ""
+    : undefined;
+
+  useScheduledPromptDispatcher({
+    api,
+    workspaceId: props.workspaceId,
+    sendMessageOptions,
+    additionalSystemContext: scheduledAdditionalSystemContext,
+    enabled: props.enabled,
+  });
+
+  return null;
 }
 
 function AppInner() {
@@ -226,6 +285,17 @@ function AppInner() {
   }, [sidebarCollapsed]);
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
+  const scheduledPromptWorkspaceId = selectedWorkspace?.workspaceId ?? currentWorkspaceId;
+  const scheduledPromptWorkspaceMeta = scheduledPromptWorkspaceId
+    ? workspaceMetadata.get(scheduledPromptWorkspaceId)
+    : undefined;
+  const scheduledPromptProjectPath =
+    selectedWorkspace?.workspaceId === scheduledPromptWorkspaceId
+      ? selectedWorkspace.projectPath
+      : scheduledPromptWorkspaceMeta?.projectPath;
+  const scheduledPromptDispatcherEnabled = canUseScheduledPromptsInWorkspace(
+    scheduledPromptWorkspaceMeta
+  );
 
   // History navigation (back/forward)
   const navigate = useNavigate();
@@ -1071,6 +1141,13 @@ function AppInner() {
 
   return (
     <>
+      {scheduledPromptWorkspaceId && scheduledPromptProjectPath ? (
+        <ActiveWorkspaceScheduledPromptDispatcher
+          workspaceId={scheduledPromptWorkspaceId}
+          projectPath={scheduledPromptProjectPath}
+          enabled={scheduledPromptDispatcherEnabled}
+        />
+      ) : null}
       <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
         <LeftSidebar
           collapsed={sidebarCollapsed}

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -309,15 +309,26 @@ function AppInner() {
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
   const [, bumpScheduledPromptStorageVersion] = useState(0);
-  useEffect(
-    () =>
-      subscribePersistedStateWrites((event) => {
+  useEffect(() => {
+    const bumpVersion = () => {
+      bumpScheduledPromptStorageVersion((version) => version + 1);
+    };
+    const unsubscribe = subscribePersistedStateWrites((event) => {
         if (isScheduledPromptsStorageKey(event.key)) {
-          bumpScheduledPromptStorageVersion((version) => version + 1);
+          bumpVersion();
         }
-      }),
-    []
-  );
+      });
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && isScheduledPromptsStorageKey(event.key)) {
+        bumpVersion();
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
   const scheduledPromptDispatcherTargets = getScheduledPromptDispatcherTargets(
     workspaceMetadata,
     (storageKey) => readPersistedState(storageKey, [])

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -290,15 +290,26 @@ function AppInner() {
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
   const [, bumpScheduledPromptStorageVersion] = useState(0);
-  useEffect(
-    () =>
-      subscribePersistedStateWrites((event) => {
+  useEffect(() => {
+    const bumpVersion = () => {
+      bumpScheduledPromptStorageVersion((version) => version + 1);
+    };
+    const unsubscribe = subscribePersistedStateWrites((event) => {
         if (isScheduledPromptsStorageKey(event.key)) {
-          bumpScheduledPromptStorageVersion((version) => version + 1);
+          bumpVersion();
         }
-      }),
-    []
-  );
+      });
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key && isScheduledPromptsStorageKey(event.key)) {
+        bumpVersion();
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      unsubscribe();
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
   const scheduledPromptDispatcherTargets = getScheduledPromptDispatcherTargets(
     workspaceMetadata,
     (storageKey) => readPersistedState(storageKey, [])

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -14,6 +14,7 @@ import {
   usePersistedState,
   updatePersistedState,
   readPersistedState,
+  subscribePersistedStateWrites,
 } from "./hooks/usePersistedState";
 import { useResizableSidebar } from "./hooks/useResizableSidebar";
 import { matchesKeybind, KEYBINDS } from "./utils/ui/keybinds";
@@ -125,7 +126,10 @@ import { LoadingScreen } from "@/browser/components/LoadingScreen/LoadingScreen"
 import { AgentProvider } from "@/browser/contexts/AgentContext";
 import { ThinkingProvider } from "@/browser/contexts/ThinkingContext";
 import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
-import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
+import {
+  getScheduledPromptDispatcherTargets,
+  isScheduledPromptsStorageKey,
+} from "@/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets";
 import { useScheduledPromptDispatcher } from "@/browser/features/ScheduledPrompts/useScheduledPromptDispatcher";
 import {
   useAdditionalSystemContextHydrated,
@@ -304,16 +308,19 @@ function AppInner() {
   }, [sidebarCollapsed]);
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
-  const scheduledPromptWorkspaceId = selectedWorkspace?.workspaceId ?? currentWorkspaceId;
-  const scheduledPromptWorkspaceMeta = scheduledPromptWorkspaceId
-    ? workspaceMetadata.get(scheduledPromptWorkspaceId)
-    : undefined;
-  const scheduledPromptProjectPath =
-    selectedWorkspace?.workspaceId === scheduledPromptWorkspaceId
-      ? selectedWorkspace.projectPath
-      : scheduledPromptWorkspaceMeta?.projectPath;
-  const scheduledPromptDispatcherEnabled = canUseScheduledPromptsInWorkspace(
-    scheduledPromptWorkspaceMeta
+  const [, bumpScheduledPromptStorageVersion] = useState(0);
+  useEffect(
+    () =>
+      subscribePersistedStateWrites((event) => {
+        if (isScheduledPromptsStorageKey(event.key)) {
+          bumpScheduledPromptStorageVersion((version) => version + 1);
+        }
+      }),
+    []
+  );
+  const scheduledPromptDispatcherTargets = getScheduledPromptDispatcherTargets(
+    workspaceMetadata,
+    (storageKey) => readPersistedState(storageKey, [])
   );
 
   // History navigation (back/forward)
@@ -1321,13 +1328,14 @@ function AppInner() {
 
   return (
     <>
-      {scheduledPromptWorkspaceId && scheduledPromptProjectPath ? (
+      {scheduledPromptDispatcherTargets.map((target) => (
         <ActiveWorkspaceScheduledPromptDispatcher
-          workspaceId={scheduledPromptWorkspaceId}
-          projectPath={scheduledPromptProjectPath}
-          enabled={scheduledPromptDispatcherEnabled}
+          key={target.workspaceId}
+          workspaceId={target.workspaceId}
+          projectPath={target.projectPath}
+          enabled={true}
         />
-      ) : null}
+      ))}
       <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
         <LeftSidebar
           collapsed={sidebarCollapsed}

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -314,10 +314,10 @@ function AppInner() {
       bumpScheduledPromptStorageVersion((version) => version + 1);
     };
     const unsubscribe = subscribePersistedStateWrites((event) => {
-        if (isScheduledPromptsStorageKey(event.key)) {
-          bumpVersion();
-        }
-      });
+      if (isScheduledPromptsStorageKey(event.key)) {
+        bumpVersion();
+      }
+    });
     const handleStorage = (event: StorageEvent) => {
       if (event.key && isScheduledPromptsStorageKey(event.key)) {
         bumpVersion();

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -295,10 +295,10 @@ function AppInner() {
       bumpScheduledPromptStorageVersion((version) => version + 1);
     };
     const unsubscribe = subscribePersistedStateWrites((event) => {
-        if (isScheduledPromptsStorageKey(event.key)) {
-          bumpVersion();
-        }
-      });
+      if (isScheduledPromptsStorageKey(event.key)) {
+        bumpVersion();
+      }
+    });
     const handleStorage = (event: StorageEvent) => {
       if (event.key && isScheduledPromptsStorageKey(event.key)) {
         bumpVersion();

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -14,6 +14,7 @@ import {
   usePersistedState,
   updatePersistedState,
   readPersistedState,
+  subscribePersistedStateWrites,
 } from "./hooks/usePersistedState";
 import { useResizableSidebar } from "./hooks/useResizableSidebar";
 import { matchesKeybind, KEYBINDS } from "./utils/ui/keybinds";
@@ -108,7 +109,10 @@ import { LoadingScreen } from "@/browser/components/LoadingScreen/LoadingScreen"
 import { AgentProvider } from "@/browser/contexts/AgentContext";
 import { ThinkingProvider } from "@/browser/contexts/ThinkingContext";
 import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
-import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
+import {
+  getScheduledPromptDispatcherTargets,
+  isScheduledPromptsStorageKey,
+} from "@/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets";
 import { useScheduledPromptDispatcher } from "@/browser/features/ScheduledPrompts/useScheduledPromptDispatcher";
 import {
   useAdditionalSystemContextHydrated,
@@ -285,16 +289,19 @@ function AppInner() {
   }, [sidebarCollapsed]);
   const creationProjectPath =
     !selectedWorkspace && !currentWorkspaceId ? pendingNewWorkspaceProject : null;
-  const scheduledPromptWorkspaceId = selectedWorkspace?.workspaceId ?? currentWorkspaceId;
-  const scheduledPromptWorkspaceMeta = scheduledPromptWorkspaceId
-    ? workspaceMetadata.get(scheduledPromptWorkspaceId)
-    : undefined;
-  const scheduledPromptProjectPath =
-    selectedWorkspace?.workspaceId === scheduledPromptWorkspaceId
-      ? selectedWorkspace.projectPath
-      : scheduledPromptWorkspaceMeta?.projectPath;
-  const scheduledPromptDispatcherEnabled = canUseScheduledPromptsInWorkspace(
-    scheduledPromptWorkspaceMeta
+  const [, bumpScheduledPromptStorageVersion] = useState(0);
+  useEffect(
+    () =>
+      subscribePersistedStateWrites((event) => {
+        if (isScheduledPromptsStorageKey(event.key)) {
+          bumpScheduledPromptStorageVersion((version) => version + 1);
+        }
+      }),
+    []
+  );
+  const scheduledPromptDispatcherTargets = getScheduledPromptDispatcherTargets(
+    workspaceMetadata,
+    (storageKey) => readPersistedState(storageKey, [])
   );
 
   // History navigation (back/forward)
@@ -1141,13 +1148,14 @@ function AppInner() {
 
   return (
     <>
-      {scheduledPromptWorkspaceId && scheduledPromptProjectPath ? (
+      {scheduledPromptDispatcherTargets.map((target) => (
         <ActiveWorkspaceScheduledPromptDispatcher
-          workspaceId={scheduledPromptWorkspaceId}
-          projectPath={scheduledPromptProjectPath}
-          enabled={scheduledPromptDispatcherEnabled}
+          key={target.workspaceId}
+          workspaceId={target.workspaceId}
+          projectPath={target.projectPath}
+          enabled={true}
         />
-      ) : null}
+      ))}
       <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
         <LeftSidebar
           collapsed={sidebarCollapsed}

--- a/src/browser/contexts/AgentContext.test.tsx
+++ b/src/browser/contexts/AgentContext.test.tsx
@@ -220,6 +220,7 @@ function createApiClient(): APIClient {
 function renderAgentHarness(props: {
   projectPath: string;
   workspaceId?: string;
+  enableGlobalListeners?: boolean;
   onChange: (value: AgentContextValue) => void;
 }) {
   return render(
@@ -227,7 +228,11 @@ function renderAgentHarness(props: {
       <RouterProvider>
         <ProjectProvider>
           <WorkspaceProvider>
-            <AgentProvider workspaceId={props.workspaceId} projectPath={props.projectPath}>
+            <AgentProvider
+              workspaceId={props.workspaceId}
+              projectPath={props.projectPath}
+              enableGlobalListeners={props.enableGlobalListeners}
+            >
               <Harness onChange={props.onChange} />
             </AgentProvider>
           </WorkspaceProvider>
@@ -333,6 +338,56 @@ describe("AgentContext", () => {
     await waitFor(() => {
       expect(contextValue?.agentId).toBe("plan");
     });
+  });
+
+  test("disabled global listeners do not handle agent shortcuts", async () => {
+    const projectPath = "/tmp/project";
+    mockAgentDefinitions = [EXEC_AGENT, PLAN_AGENT];
+    window.localStorage.setItem(getAgentIdKey(GLOBAL_SCOPE_ID), JSON.stringify("exec"));
+
+    let contextValue: AgentContextValue | undefined;
+    let openPickerEvents = 0;
+    const handleOpenPicker = () => {
+      openPickerEvents += 1;
+    };
+    window.addEventListener(CUSTOM_EVENTS.OPEN_AGENT_PICKER, handleOpenPicker as EventListener);
+
+    try {
+      renderAgentHarness({
+        projectPath,
+        enableGlobalListeners: false,
+        onChange: (value) => (contextValue = value),
+      });
+
+      await waitFor(() => {
+        expect(contextValue?.agentId).toBe("exec");
+        expect(contextValue?.agents.map((agent) => agent.id)).toEqual(["exec", "plan"]);
+      });
+
+      window.api = { platform: "darwin", versions: {} };
+
+      fireEvent.keyDown(window, {
+        key: "A",
+        ctrlKey: true,
+        metaKey: true,
+        shiftKey: true,
+      });
+      fireEvent.keyDown(window, {
+        key: ".",
+        code: "Period",
+        metaKey: true,
+      });
+
+      await Promise.resolve();
+
+      expect(contextValue?.agentId).toBe("exec");
+      expect(openPickerEvents).toBe(0);
+    } finally {
+      window.removeEventListener(
+        CUSTOM_EVENTS.OPEN_AGENT_PICKER,
+        handleOpenPicker as EventListener
+      );
+    }
   });
 
   test("cycle shortcut advances away from a custom auto agent", async () => {

--- a/src/browser/contexts/AgentContext.tsx
+++ b/src/browser/contexts/AgentContext.tsx
@@ -56,6 +56,7 @@ type AgentProviderProps =
   | {
       workspaceId?: string;
       projectPath?: string;
+      enableGlobalListeners?: boolean;
       children: ReactNode;
     };
 
@@ -78,6 +79,7 @@ export function AgentProvider(props: AgentProviderProps) {
 function AgentProviderWithState(props: {
   workspaceId?: string;
   projectPath?: string;
+  enableGlobalListeners?: boolean;
   children: ReactNode;
 }) {
   const { api } = useAPI();
@@ -297,6 +299,10 @@ function AgentProviderWithState(props: {
   }, [effectiveAgentId, isCurrentAgentLocked, selectableAgents, setAgentId]);
 
   useEffect(() => {
+    if (props.enableGlobalListeners === false) {
+      return;
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
       if (matchesKeybind(e, KEYBINDS.TOGGLE_AGENT)) {
         e.preventDefault();
@@ -315,9 +321,13 @@ function AgentProviderWithState(props: {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [cycleToNextAgent, isCurrentAgentLocked]);
+  }, [cycleToNextAgent, isCurrentAgentLocked, props.enableGlobalListeners]);
 
   useEffect(() => {
+    if (props.enableGlobalListeners === false) {
+      return;
+    }
+
     const handleRefreshRequested = () => {
       void refresh();
     };
@@ -325,7 +335,7 @@ function AgentProviderWithState(props: {
     window.addEventListener(CUSTOM_EVENTS.AGENTS_REFRESH_REQUESTED, handleRefreshRequested);
     return () =>
       window.removeEventListener(CUSTOM_EVENTS.AGENTS_REFRESH_REQUESTED, handleRefreshRequested);
-  }, [refresh]);
+  }, [props.enableGlobalListeners, refresh]);
 
   const agentContextValue = useMemo(
     () => ({

--- a/src/browser/contexts/ThinkingContext.test.tsx
+++ b/src/browser/contexts/ThinkingContext.test.tsx
@@ -698,4 +698,35 @@ describe("ThinkingContext", () => {
       expect(view.getByTestId("thinking-project").textContent).toBe("low");
     });
   });
+
+  test("disabled global listeners do not cycle thinking via keybind", async () => {
+    const projectPath = "/Users/dev/my-project";
+
+    updatePersistedState(getModelKey(getProjectScopeId(projectPath)), "openai:gpt-4.1");
+
+    const ProjectChild: React.FC = () => {
+      const [thinkingLevel] = useThinkingLevel();
+      return <div data-testid="thinking-project">{thinkingLevel}</div>;
+    };
+
+    const view = renderWithAPI(
+      <ThinkingProvider projectPath={projectPath} enableGlobalListeners={false}>
+        <ProjectChild />
+      </ThinkingProvider>
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId("thinking-project").textContent).toBe("off");
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new window.KeyboardEvent("keydown", { key: "T", ctrlKey: true, shiftKey: true })
+      );
+    });
+
+    await Promise.resolve();
+
+    expect(view.getByTestId("thinking-project").textContent).toBe("off");
+  });
 });

--- a/src/browser/contexts/ThinkingContext.test.tsx
+++ b/src/browser/contexts/ThinkingContext.test.tsx
@@ -567,4 +567,35 @@ describe("ThinkingContext", () => {
       expect(view.getByTestId("thinking-project").textContent).toBe("low");
     });
   });
+
+  test("disabled global listeners do not cycle thinking via keybind", async () => {
+    const projectPath = "/Users/dev/my-project";
+
+    updatePersistedState(getModelKey(getProjectScopeId(projectPath)), "openai:gpt-4.1");
+
+    const ProjectChild: React.FC = () => {
+      const [thinkingLevel] = useThinkingLevel();
+      return <div data-testid="thinking-project">{thinkingLevel}</div>;
+    };
+
+    const view = renderWithAPI(
+      <ThinkingProvider projectPath={projectPath} enableGlobalListeners={false}>
+        <ProjectChild />
+      </ThinkingProvider>
+    );
+
+    await waitFor(() => {
+      expect(view.getByTestId("thinking-project").textContent).toBe("off");
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new window.KeyboardEvent("keydown", { key: "T", ctrlKey: true, shiftKey: true })
+      );
+    });
+
+    await Promise.resolve();
+
+    expect(view.getByTestId("thinking-project").textContent).toBe("off");
+  });
 });

--- a/src/browser/contexts/ThinkingContext.tsx
+++ b/src/browser/contexts/ThinkingContext.tsx
@@ -39,6 +39,7 @@ const ThinkingContext = createContext<ThinkingContextType | undefined>(undefined
 interface ThinkingProviderProps {
   workspaceId?: string; // Workspace-scoped storage (highest priority)
   projectPath?: string; // Project-scoped storage (fallback if no workspaceId)
+  enableGlobalListeners?: boolean;
   children: ReactNode;
 }
 
@@ -176,6 +177,10 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
   // Implemented at the ThinkingProvider level so they work in both the workspace view
   // and the "New Workspace" creation screen (which doesn't mount AIView).
   useEffect(() => {
+    if (props.enableGlobalListeners === false) {
+      return;
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
       const isIncrease = matchesKeybind(e, KEYBINDS.INCREASE_THINKING);
       const isDecrease = matchesKeybind(e, KEYBINDS.DECREASE_THINKING);
@@ -213,7 +218,15 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [defaultModel, getMinimum, metadataSettings.model, scopeId, thinkingLevel, setThinkingLevel]);
+  }, [
+    defaultModel,
+    getMinimum,
+    metadataSettings.model,
+    props.enableGlobalListeners,
+    scopeId,
+    thinkingLevel,
+    setThinkingLevel,
+  ]);
 
   // Memoize context value to prevent unnecessary re-renders of consumers.
   const contextValue = useMemo(

--- a/src/browser/contexts/ThinkingContext.tsx
+++ b/src/browser/contexts/ThinkingContext.tsx
@@ -50,6 +50,7 @@ const ThinkingContext = createContext<ThinkingContextType | undefined>(undefined
 interface ThinkingProviderProps {
   workspaceId?: string; // Workspace-scoped storage (highest priority)
   projectPath?: string; // Project-scoped storage (fallback if no workspaceId)
+  enableGlobalListeners?: boolean;
   children: ReactNode;
 }
 
@@ -271,6 +272,10 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
   // Implemented at the ThinkingProvider level so they work in both the workspace view
   // and the "New Workspace" creation screen (which doesn't mount AIView).
   useEffect(() => {
+    if (props.enableGlobalListeners === false) {
+      return;
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
       const isIncrease = matchesKeybind(e, KEYBINDS.INCREASE_THINKING);
       const isDecrease = matchesKeybind(e, KEYBINDS.DECREASE_THINKING);
@@ -318,6 +323,7 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
     getMinimum,
     metadataSettings.model,
     providersConfig,
+    props.enableGlobalListeners,
     scopeId,
     thinkingLevel,
     setThinkingLevel,

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -93,6 +93,7 @@ import {
   type TerminalSessionCreateOptions,
 } from "@/browser/utils/terminal";
 import { ReviewAssistedStatsReporter } from "@/browser/features/RightSidebar/CodeReview/ReviewPanel";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
 import {
   TAB_REGISTRY,
   TerminalTabLabel,
@@ -684,6 +685,10 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     workspaceMetadataContext.workspaceMetadata.get(workspaceId) ?? null;
   const canReviewDiffs = hasWorkspaceRepository(currentWorkspaceMetadata);
   const isChildWorkspaceForGoal = currentWorkspaceMetadata?.parentWorkspaceId != null;
+  const scheduleTabAvailable =
+    currentWorkspaceMetadata === null
+      ? null
+      : canUseScheduledPromptsInWorkspace(currentWorkspaceMetadata);
   // Safe variant: storybook stories may render before addWorkspace() runs; the
   // optional hook returns null instead of throwing assertGet on the unregistered
   // workspace. Real workspaces always have an aggregator by the time RightSidebar
@@ -1029,6 +1034,23 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       return prev;
     });
   }, [initialActiveTab, setLayoutRaw, isChildWorkspaceForGoal]);
+
+  React.useEffect(() => {
+    if (scheduleTabAvailable === null) {
+      return;
+    }
+
+    setLayoutRaw((prevRaw) => {
+      const prev = parseRightSidebarLayoutState(prevRaw, initialActiveTab);
+      const hasSchedule = collectAllTabs(prev.root).includes("schedule");
+
+      if (!scheduleTabAvailable && hasSchedule) {
+        return removeTabEverywhere(prev, "schedule");
+      }
+
+      return prev;
+    });
+  }, [initialActiveTab, scheduleTabAvailable, setLayoutRaw]);
 
   React.useEffect(() => {
     if (!desktopExperimentEnabled) {

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -92,6 +92,7 @@ import {
   type TerminalSessionCreateOptions,
 } from "@/browser/utils/terminal";
 import { ReviewAssistedStatsReporter } from "@/browser/features/RightSidebar/CodeReview/ReviewPanel";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
 import {
   TAB_REGISTRY,
   TerminalTabLabel,
@@ -682,6 +683,10 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
   const currentWorkspaceMetadata =
     workspaceMetadataContext.workspaceMetadata.get(workspaceId) ?? null;
   const isChildWorkspaceForGoal = currentWorkspaceMetadata?.parentWorkspaceId != null;
+  const scheduleTabAvailable =
+    currentWorkspaceMetadata === null
+      ? null
+      : canUseScheduledPromptsInWorkspace(currentWorkspaceMetadata);
   // Safe variant: storybook stories may render before addWorkspace() runs; the
   // optional hook returns null instead of throwing assertGet on the unregistered
   // workspace. Real workspaces always have an aggregator by the time RightSidebar
@@ -1022,6 +1027,23 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       return prev;
     });
   }, [initialActiveTab, setLayoutRaw, isChildWorkspaceForGoal]);
+
+  React.useEffect(() => {
+    if (scheduleTabAvailable === null) {
+      return;
+    }
+
+    setLayoutRaw((prevRaw) => {
+      const prev = parseRightSidebarLayoutState(prevRaw, initialActiveTab);
+      const hasSchedule = collectAllTabs(prev.root).includes("schedule");
+
+      if (!scheduleTabAvailable && hasSchedule) {
+        return removeTabEverywhere(prev, "schedule");
+      }
+
+      return prev;
+    });
+  }, [initialActiveTab, scheduleTabAvailable, setLayoutRaw]);
 
   React.useEffect(() => {
     if (!desktopExperimentEnabled) {

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -10,6 +10,7 @@
 import React from "react";
 import {
   BugPlay,
+  Clock3,
   ExternalLink,
   Monitor,
   Globe,
@@ -258,6 +259,13 @@ export function OutputTabLabel() {
 export function MemoryTabLabel() {
   return <>Memory</>;
 }
+
+export const ScheduleTabLabel: React.FC = () => (
+  <span className="inline-flex items-center gap-1">
+    <Clock3 className="h-3 w-3 shrink-0" />
+    Schedule
+  </span>
+);
 
 interface InstructionsTabLabelProps {
   workspaceId: string;

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -62,6 +62,12 @@ const TAB_CONFIG_DEF = {
     defaultOrder: 36,
     paletteKeywords: ["workflow", "workflows", "orchestration", "agents", "run"],
   },
+  schedule: {
+    name: "Schedule",
+    contentClassName: "overflow-y-auto p-0",
+    defaultOrder: 37,
+    paletteKeywords: ["schedule", "scheduled", "prompt", "queue", "timer"],
+  },
   memory: {
     name: "Memory",
     contentClassName: "overflow-hidden p-0",

--- a/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
+++ b/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
@@ -24,6 +24,7 @@ import { DevToolsTab } from "@/browser/features/RightSidebar/DevToolsTab";
 import { GoalTab, type GoalCreateIntent } from "@/browser/features/RightSidebar/GoalTab";
 import { MemoryTab } from "@/browser/features/RightSidebar/Memory/MemoryTab";
 import { WorkflowsTab } from "@/browser/features/RightSidebar/Workflows/WorkflowsTab";
+import { ScheduledPromptsTab } from "@/browser/features/ScheduledPrompts/ScheduledPromptsTab";
 import type { GoalSnapshot, GoalStatus } from "@/common/types/goal";
 import type { ReviewNoteData } from "@/common/types/review";
 import { BASE_TAB_IDS, TAB_CONFIG, type BaseTabType, type TabConfig } from "./tabConfig";
@@ -36,6 +37,7 @@ import {
   MemoryTabLabel,
   OutputTabLabel,
   ReviewTabLabel,
+  ScheduleTabLabel,
   StatsTabLabel,
   WorkflowsTabLabel,
 } from "./TabLabels";
@@ -161,10 +163,6 @@ const TAB_RENDERERS = {
       </ErrorBoundary>
     ),
   },
-  memory: {
-    Label: MemoryTabLabel,
-    renderPanel: (ctx) => <MemoryTab workspaceId={ctx.workspaceId} />,
-  },
   workflows: {
     Label: ({ workspaceId }) => <WorkflowsTabLabel workspaceId={workspaceId} />,
     renderPanel: (ctx) => (
@@ -172,6 +170,18 @@ const TAB_RENDERERS = {
         <WorkflowsTab workspaceId={ctx.workspaceId} />
       </ErrorBoundary>
     ),
+  },
+  schedule: {
+    Label: ScheduleTabLabel,
+    renderPanel: (ctx) => (
+      <ErrorBoundary workspaceInfo="Schedule tab">
+        <ScheduledPromptsTab workspaceId={ctx.workspaceId} />
+      </ErrorBoundary>
+    ),
+  },
+  memory: {
+    Label: MemoryTabLabel,
+    renderPanel: (ctx) => <MemoryTab workspaceId={ctx.workspaceId} />,
   },
   desktop: {
     Label: DesktopTabLabel,

--- a/src/browser/features/ScheduledPrompts/ScheduledPromptsTab.tsx
+++ b/src/browser/features/ScheduledPrompts/ScheduledPromptsTab.tsx
@@ -1,0 +1,211 @@
+import React, { useState } from "react";
+import { Clock3, Play, Send, Trash2 } from "lucide-react";
+import { Button } from "@/browser/components/Button/Button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { formatTimestamp } from "@/browser/utils/ui/dateTime";
+import { getScheduledPromptsKey } from "@/common/constants/storage";
+import { cn } from "@/common/lib/utils";
+import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
+import {
+  canRunScheduledPromptNow,
+  createScheduledPrompt,
+  formatDateTimeLocalInput,
+  normalizeScheduledPrompts,
+  parseDateTimeLocalInput,
+  removeScheduledPrompt,
+  reschedulePromptNow,
+  type ScheduledPrompt,
+} from "./scheduledPrompts";
+
+interface ScheduledPromptsTabProps {
+  workspaceId: string;
+}
+
+const DEFAULT_DELAY_MS = 60 * 60 * 1000;
+
+export function ScheduledPromptsTab(props: ScheduledPromptsTabProps) {
+  const storageKey = getScheduledPromptsKey(props.workspaceId);
+  const [storedPrompts, setStoredPrompts] = usePersistedState<ScheduledPrompt[]>(storageKey, [], {
+    listener: true,
+  });
+  const prompts = normalizeScheduledPrompts(storedPrompts);
+  const [content, setContent] = useState("");
+  const [runAtInput, setRunAtInput] = useState(() =>
+    formatDateTimeLocalInput(Date.now() + DEFAULT_DELAY_MS)
+  );
+  const [queueDispatchMode, setQueueDispatchMode] = useState<QueueDispatchMode>("tool-end");
+
+  const runAt = parseDateTimeLocalInput(runAtInput);
+  const canSchedule = content.trim().length > 0 && runAt !== null && runAt > Date.now();
+
+  const addPrompt = () => {
+    if (!canSchedule || runAt === null) {
+      return;
+    }
+
+    const prompt = createScheduledPrompt({
+      content,
+      runAt,
+      queueDispatchMode,
+    });
+    setStoredPrompts((current) => [...normalizeScheduledPrompts(current), prompt]);
+    setContent("");
+    setRunAtInput(formatDateTimeLocalInput(runAt + DEFAULT_DELAY_MS));
+  };
+
+  const runPromptNow = (id: string) => {
+    setStoredPrompts((current) => reschedulePromptNow(normalizeScheduledPrompts(current), id));
+  };
+
+  const removePrompt = (id: string) => {
+    setStoredPrompts((current) => removeScheduledPrompt(normalizeScheduledPrompts(current), id));
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 p-3 text-sm">
+      <section className="border-border-light bg-surface-secondary rounded-md border p-3">
+        <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+          <Clock3 aria-hidden="true" className="h-4 w-4" />
+          Schedule prompt
+        </div>
+        <div className="flex flex-col gap-2">
+          <label className="flex flex-col gap-1">
+            <span className="text-muted text-xs">Prompt</span>
+            <textarea
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              className="border-border-light bg-background text-foreground focus:ring-accent min-h-24 resize-y rounded-md border px-2 py-2 text-sm leading-5 focus:ring-1 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-muted text-xs">Run at</span>
+            <input
+              type="datetime-local"
+              value={runAtInput}
+              onChange={(event) => setRunAtInput(event.target.value)}
+              className="border-border-light bg-background text-foreground focus:ring-accent rounded-md border px-2 py-1.5 text-sm focus:ring-1 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-muted text-xs">Dispatch</span>
+            <select
+              value={queueDispatchMode}
+              onChange={(event) => setQueueDispatchMode(event.target.value as QueueDispatchMode)}
+              className="border-border-light bg-background text-foreground focus:ring-accent rounded-md border px-2 py-1.5 text-sm focus:ring-1 focus:outline-none"
+            >
+              <option value="tool-end">After step</option>
+              <option value="turn-end">After turn</option>
+            </select>
+          </label>
+          <Button type="button" size="sm" onClick={addPrompt} disabled={!canSchedule}>
+            <Send aria-hidden="true" className="h-3.5 w-3.5" />
+            Schedule
+          </Button>
+        </div>
+      </section>
+
+      <section className="flex min-h-0 flex-1 flex-col gap-2">
+        <div className="text-muted px-1 text-xs leading-5">
+          {prompts.length.toLocaleString()} scheduled prompt{prompts.length === 1 ? "" : "s"}
+        </div>
+        {prompts.length === 0 ? (
+          <div className="text-muted flex min-h-32 flex-1 items-center justify-center text-center text-sm">
+            No scheduled prompts.
+          </div>
+        ) : (
+          <div className="flex min-h-0 flex-col gap-2 overflow-y-auto">
+            {prompts.map((prompt) => (
+              <ScheduledPromptCard
+                key={prompt.id}
+                prompt={prompt}
+                onRunNow={runPromptNow}
+                onRemove={removePrompt}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+interface ScheduledPromptCardProps {
+  prompt: ScheduledPrompt;
+  onRunNow: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+function ScheduledPromptCard(props: ScheduledPromptCardProps) {
+  const statusClassName =
+    props.prompt.status === "failed"
+      ? "text-error"
+      : props.prompt.status === "sent"
+        ? "text-success"
+        : props.prompt.status === "sending"
+          ? "text-accent"
+          : "text-muted";
+
+  return (
+    <article className="border-border-light bg-surface-secondary overflow-hidden rounded-md border">
+      <div className="px-3 py-2.5">
+        <div className="mb-1 flex items-center justify-between gap-2">
+          <span className={cn("text-[11px] font-medium capitalize", statusClassName)}>
+            {props.prompt.status}
+          </span>
+          <span className="text-muted truncate text-[11px]">
+            {formatTimestamp(props.prompt.runAt)}
+          </span>
+        </div>
+        <p className="text-foreground max-h-20 overflow-hidden text-xs leading-5 whitespace-pre-wrap">
+          {props.prompt.content}
+        </p>
+        {props.prompt.error && (
+          <p className="text-error mt-2 line-clamp-2 text-xs">{props.prompt.error}</p>
+        )}
+      </div>
+      <div className="border-border-light flex items-center justify-between gap-1 border-t px-2 py-1">
+        <span className="text-muted px-1 text-[11px]">
+          {props.prompt.queueDispatchMode === "turn-end" ? "After turn" : "After step"}
+        </span>
+        <div className="flex items-center gap-1">
+          {props.prompt.status !== "sent" && canRunScheduledPromptNow(props.prompt) && (
+            <ScheduledPromptIconButton
+              label="Run now"
+              onClick={() => props.onRunNow(props.prompt.id)}
+            >
+              <Play aria-hidden="true" className="h-3.5 w-3.5" />
+            </ScheduledPromptIconButton>
+          )}
+          <ScheduledPromptIconButton label="Delete" onClick={() => props.onRemove(props.prompt.id)}>
+            <Trash2 aria-hidden="true" className="h-3.5 w-3.5" />
+          </ScheduledPromptIconButton>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+interface ScheduledPromptIconButtonProps {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function ScheduledPromptIconButton(props: ScheduledPromptIconButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={props.label}
+          className="text-muted hover:text-foreground hover:bg-accent/50 flex h-7 w-7 items-center justify-center rounded-sm transition-colors"
+          onClick={props.onClick}
+        >
+          {props.children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{props.label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { canUseScheduledPromptsInWorkspace } from "./scheduledPromptAvailability";
+
+function workspace(overrides: Partial<FrontendWorkspaceMetadata> = {}): FrontendWorkspaceMetadata {
+  return {
+    id: "ws-1",
+    name: "main",
+    projectName: "project",
+    projectPath: "/repo/project",
+    namedWorkspacePath: "/repo/project/main",
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    ...overrides,
+  };
+}
+
+describe("canUseScheduledPromptsInWorkspace", () => {
+  test("allows regular workspaces", () => {
+    expect(canUseScheduledPromptsInWorkspace(workspace())).toBe(true);
+  });
+
+  test("blocks workspaces without a runnable composer", () => {
+    expect(canUseScheduledPromptsInWorkspace(null)).toBe(false);
+    expect(canUseScheduledPromptsInWorkspace(workspace({ transcriptOnly: true }))).toBe(false);
+    expect(canUseScheduledPromptsInWorkspace(workspace({ incompatibleRuntime: "missing" }))).toBe(
+      false
+    );
+    expect(
+      canUseScheduledPromptsInWorkspace(
+        workspace({ parentWorkspaceId: "parent", taskStatus: "queued" })
+      )
+    ).toBe(false);
+  });
+});

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
@@ -24,6 +24,7 @@ describe("canUseScheduledPromptsInWorkspace", () => {
     expect(canUseScheduledPromptsInWorkspace(null)).toBe(false);
     expect(canUseScheduledPromptsInWorkspace(workspace({ transcriptOnly: true }))).toBe(false);
     expect(canUseScheduledPromptsInWorkspace(workspace({ isInitializing: true }))).toBe(false);
+    expect(canUseScheduledPromptsInWorkspace(workspace({ isRemoving: true }))).toBe(false);
     expect(canUseScheduledPromptsInWorkspace(workspace({ incompatibleRuntime: "missing" }))).toBe(
       false
     );

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
@@ -23,6 +23,7 @@ describe("canUseScheduledPromptsInWorkspace", () => {
   test("blocks workspaces without a runnable composer", () => {
     expect(canUseScheduledPromptsInWorkspace(null)).toBe(false);
     expect(canUseScheduledPromptsInWorkspace(workspace({ transcriptOnly: true }))).toBe(false);
+    expect(canUseScheduledPromptsInWorkspace(workspace({ isInitializing: true }))).toBe(false);
     expect(canUseScheduledPromptsInWorkspace(workspace({ incompatibleRuntime: "missing" }))).toBe(
       false
     );

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts
@@ -31,5 +31,10 @@ describe("canUseScheduledPromptsInWorkspace", () => {
         workspace({ parentWorkspaceId: "parent", taskStatus: "queued" })
       )
     ).toBe(false);
+    expect(
+      canUseScheduledPromptsInWorkspace(
+        workspace({ parentWorkspaceId: "parent", taskStatus: "starting" })
+      )
+    ).toBe(false);
   });
 });

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
@@ -1,0 +1,12 @@
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+
+export function canUseScheduledPromptsInWorkspace(
+  meta: FrontendWorkspaceMetadata | null | undefined
+): boolean {
+  if (!meta || meta.incompatibleRuntime || meta.transcriptOnly) {
+    return false;
+  }
+
+  // Queued delegated task workspaces have no active composer/dispatcher yet.
+  return !(Boolean(meta.parentWorkspaceId) && meta.taskStatus === "queued");
+}

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
@@ -3,7 +3,13 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 export function canUseScheduledPromptsInWorkspace(
   meta: FrontendWorkspaceMetadata | null | undefined
 ): boolean {
-  if (!meta || meta.incompatibleRuntime || meta.transcriptOnly || meta.isInitializing) {
+  if (
+    !meta ||
+    meta.incompatibleRuntime ||
+    meta.transcriptOnly ||
+    meta.isInitializing ||
+    meta.isRemoving
+  ) {
     return false;
   }
 

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
@@ -3,7 +3,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 export function canUseScheduledPromptsInWorkspace(
   meta: FrontendWorkspaceMetadata | null | undefined
 ): boolean {
-  if (!meta || meta.incompatibleRuntime || meta.transcriptOnly) {
+  if (!meta || meta.incompatibleRuntime || meta.transcriptOnly || meta.isInitializing) {
     return false;
   }
 

--- a/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptAvailability.ts
@@ -7,6 +7,9 @@ export function canUseScheduledPromptsInWorkspace(
     return false;
   }
 
-  // Queued delegated task workspaces have no active composer/dispatcher yet.
-  return !(Boolean(meta.parentWorkspaceId) && meta.taskStatus === "queued");
+  // Queued/starting delegated task workspaces have no active composer/dispatcher yet.
+  return !(
+    Boolean(meta.parentWorkspaceId) &&
+    (meta.taskStatus === "queued" || meta.taskStatus === "starting")
+  );
 }

--- a/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { createScheduledPrompt, type ScheduledPrompt } from "./scheduledPrompts";
+import {
+  getScheduledPromptDispatcherTargets,
+  isScheduledPromptsStorageKey,
+} from "./scheduledPromptDispatcherTargets";
+
+function workspace(
+  id: string,
+  overrides: Partial<FrontendWorkspaceMetadata> = {}
+): FrontendWorkspaceMetadata {
+  return {
+    id,
+    name: id,
+    projectName: "project",
+    projectPath: `/repo/${id}`,
+    namedWorkspacePath: `/repo/${id}/main`,
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    ...overrides,
+  };
+}
+
+function scheduledPrompt(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  const prompt = createScheduledPrompt(
+    {
+      content: "Continue",
+      runAt: 1,
+      queueDispatchMode: "turn-end",
+    },
+    0,
+    overrides.id ?? "prompt-1"
+  );
+  return { ...prompt, ...overrides };
+}
+
+describe("scheduled prompt dispatcher targets", () => {
+  test("recognizes scheduled prompt storage keys", () => {
+    expect(isScheduledPromptsStorageKey("scheduledPrompts:ws-1")).toBe(true);
+    expect(isScheduledPromptsStorageKey("other:ws-1")).toBe(false);
+  });
+
+  test("returns all runnable workspaces with scheduled prompts", () => {
+    const metadata = new Map([
+      ["active", workspace("active")],
+      ["background", workspace("background")],
+      ["done", workspace("done")],
+      [
+        "queued-child",
+        workspace("queued-child", { parentWorkspaceId: "parent", taskStatus: "queued" }),
+      ],
+    ]);
+    const promptsByKey = new Map<string, unknown>([
+      ["scheduledPrompts:active", [scheduledPrompt({ id: "active-prompt" })]],
+      ["scheduledPrompts:background", [scheduledPrompt({ id: "background-prompt" })]],
+      ["scheduledPrompts:done", [scheduledPrompt({ id: "done-prompt", status: "sent" })]],
+      ["scheduledPrompts:queued-child", [scheduledPrompt({ id: "queued-child-prompt" })]],
+    ]);
+
+    expect(getScheduledPromptDispatcherTargets(metadata, (key) => promptsByKey.get(key))).toEqual([
+      { workspaceId: "active", projectPath: "/repo/active" },
+      { workspaceId: "background", projectPath: "/repo/background" },
+    ]);
+  });
+});

--- a/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.ts
@@ -25,7 +25,9 @@ export function getScheduledPromptDispatcherTargets(
       continue;
     }
 
-    const prompts = normalizeScheduledPrompts(readStoredPrompts(getScheduledPromptsKey(workspaceId)));
+    const prompts = normalizeScheduledPrompts(
+      readStoredPrompts(getScheduledPromptsKey(workspaceId))
+    );
     if (!prompts.some((prompt) => prompt.status === "scheduled")) {
       continue;
     }

--- a/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.ts
@@ -1,0 +1,37 @@
+import { getScheduledPromptsKey } from "@/common/constants/storage";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { canUseScheduledPromptsInWorkspace } from "./scheduledPromptAvailability";
+import { normalizeScheduledPrompts } from "./scheduledPrompts";
+
+export const SCHEDULED_PROMPTS_STORAGE_PREFIX = "scheduledPrompts:";
+
+export interface ScheduledPromptDispatcherTarget {
+  workspaceId: string;
+  projectPath: string;
+}
+
+export function isScheduledPromptsStorageKey(key: string): boolean {
+  return key.startsWith(SCHEDULED_PROMPTS_STORAGE_PREFIX);
+}
+
+export function getScheduledPromptDispatcherTargets(
+  workspaceMetadata: ReadonlyMap<string, FrontendWorkspaceMetadata>,
+  readStoredPrompts: (storageKey: string) => unknown
+): ScheduledPromptDispatcherTarget[] {
+  const targets: ScheduledPromptDispatcherTarget[] = [];
+
+  for (const [workspaceId, meta] of workspaceMetadata) {
+    if (!canUseScheduledPromptsInWorkspace(meta) || !meta.projectPath) {
+      continue;
+    }
+
+    const prompts = normalizeScheduledPrompts(readStoredPrompts(getScheduledPromptsKey(workspaceId)));
+    if (!prompts.some((prompt) => prompt.status === "scheduled")) {
+      continue;
+    }
+
+    targets.push({ workspaceId, projectPath: meta.projectPath });
+  }
+
+  return targets;
+}

--- a/src/browser/features/ScheduledPrompts/scheduledPrompts.test.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPrompts.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canRunScheduledPromptNow,
+  createScheduledPrompt,
+  getDueScheduledPrompts,
+  getNextScheduledPromptRunAt,
+  markScheduledPromptFailed,
+  markScheduledPromptSending,
+  markScheduledPromptSent,
+  normalizeScheduledPrompts,
+  removeScheduledPrompt,
+  reschedulePromptNow,
+  type ScheduledPrompt,
+} from "./scheduledPrompts";
+
+const NOW = 1_700_000_000_000;
+
+function scheduledPrompt(overrides: Partial<ScheduledPrompt> = {}): ScheduledPrompt {
+  return {
+    id: "prompt-1",
+    content: "Continue when quota resets",
+    runAt: NOW + 60_000,
+    createdAt: NOW,
+    updatedAt: NOW,
+    status: "scheduled",
+    queueDispatchMode: "tool-end",
+    ...overrides,
+  };
+}
+
+describe("scheduled prompt helpers", () => {
+  test("normalizes valid prompts and drops malformed entries", () => {
+    const prompts = normalizeScheduledPrompts([
+      scheduledPrompt({ id: "later", runAt: NOW + 120_000 }),
+      { id: "bad", content: "", runAt: NOW, createdAt: NOW, updatedAt: NOW },
+      scheduledPrompt({ id: "earlier", runAt: NOW + 30_000 }),
+    ]);
+
+    expect(prompts.map((prompt) => prompt.id)).toEqual(["earlier", "later"]);
+  });
+
+  test("keeps in-progress sends in sending state when normalizing", () => {
+    const prompts = normalizeScheduledPrompts([
+      scheduledPrompt({
+        status: "sending",
+        updatedAt: NOW - 10 * 60_000,
+        error: "stale",
+      }),
+    ]);
+
+    expect(prompts[0]?.status).toBe("sending");
+    expect(prompts[0]?.error).toBeUndefined();
+  });
+
+  test("finds due prompts and next scheduled time", () => {
+    const prompts = [
+      scheduledPrompt({ id: "due", runAt: NOW - 1 }),
+      scheduledPrompt({ id: "future", runAt: NOW + 5_000 }),
+      scheduledPrompt({ id: "failed", runAt: NOW - 2, status: "failed" }),
+    ];
+
+    expect(getDueScheduledPrompts(prompts, NOW).map((prompt) => prompt.id)).toEqual(["due"]);
+    expect(getNextScheduledPromptRunAt(prompts)).toBe(NOW - 1);
+  });
+
+  test("updates prompt lifecycle state", () => {
+    const prompt = createScheduledPrompt(
+      {
+        content: "  run later  ",
+        runAt: NOW + 1_000,
+        queueDispatchMode: "turn-end",
+      },
+      NOW,
+      "created"
+    );
+
+    expect(prompt).toMatchObject({
+      id: "created",
+      content: "run later",
+      status: "scheduled",
+      queueDispatchMode: "turn-end",
+    });
+
+    const sending = markScheduledPromptSending([prompt], "created", NOW + 1);
+    expect(sending[0]?.status).toBe("sending");
+
+    const failed = markScheduledPromptFailed(sending, "created", "No connection", NOW + 2);
+    expect(failed[0]).toMatchObject({ status: "failed", error: "No connection" });
+
+    const retried = reschedulePromptNow(failed, "created", NOW + 3);
+    expect(retried[0]).toMatchObject({ status: "scheduled", runAt: NOW + 3 });
+
+    const sent = markScheduledPromptSent(retried, "created", NOW + 4);
+    expect(sent[0]).toMatchObject({ status: "sent", sentAt: NOW + 4 });
+
+    expect(removeScheduledPrompt(sent, "created")).toEqual([]);
+  });
+
+  test("allows manual recovery for stale sending prompts without auto-rescheduling", () => {
+    expect(
+      canRunScheduledPromptNow(
+        scheduledPrompt({ status: "sending", updatedAt: NOW - 29 * 60_000 }),
+        NOW
+      )
+    ).toBe(false);
+    expect(
+      canRunScheduledPromptNow(
+        scheduledPrompt({ status: "sending", updatedAt: NOW - 31 * 60_000 }),
+        NOW
+      )
+    ).toBe(true);
+  });
+});

--- a/src/browser/features/ScheduledPrompts/scheduledPrompts.ts
+++ b/src/browser/features/ScheduledPrompts/scheduledPrompts.ts
@@ -1,0 +1,193 @@
+import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
+
+export type ScheduledPromptStatus = "scheduled" | "sending" | "sent" | "failed";
+
+export interface ScheduledPrompt {
+  id: string;
+  content: string;
+  runAt: number;
+  createdAt: number;
+  updatedAt: number;
+  status: ScheduledPromptStatus;
+  queueDispatchMode: QueueDispatchMode;
+  sentAt?: number;
+  error?: string;
+}
+
+export interface ScheduledPromptDraft {
+  content: string;
+  runAt: number;
+  queueDispatchMode: QueueDispatchMode;
+}
+
+const SENDING_MANUAL_RECOVERY_MS = 30 * 60 * 1000;
+
+function isQueueDispatchMode(value: unknown): value is QueueDispatchMode {
+  return value === "tool-end" || value === "turn-end";
+}
+
+function isScheduledPromptStatus(value: unknown): value is ScheduledPromptStatus {
+  return value === "scheduled" || value === "sending" || value === "sent" || value === "failed";
+}
+
+function fallbackId(now: number): string {
+  return `${now.toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createScheduledPrompt(
+  draft: ScheduledPromptDraft,
+  now = Date.now(),
+  id: string = globalThis.crypto?.randomUUID?.() ?? fallbackId(now)
+): ScheduledPrompt {
+  return {
+    id,
+    content: draft.content.trim(),
+    runAt: draft.runAt,
+    createdAt: now,
+    updatedAt: now,
+    status: "scheduled",
+    queueDispatchMode: draft.queueDispatchMode,
+  };
+}
+
+export function normalizeScheduledPrompts(value: unknown): ScheduledPrompt[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const prompts: ScheduledPrompt[] = [];
+  for (const item of value) {
+    if (typeof item !== "object" || item === null) {
+      continue;
+    }
+
+    const raw = item as Record<string, unknown>;
+    if (
+      typeof raw.id !== "string" ||
+      typeof raw.content !== "string" ||
+      raw.content.trim().length === 0 ||
+      typeof raw.runAt !== "number" ||
+      !Number.isFinite(raw.runAt) ||
+      typeof raw.createdAt !== "number" ||
+      typeof raw.updatedAt !== "number" ||
+      !isScheduledPromptStatus(raw.status)
+    ) {
+      continue;
+    }
+
+    prompts.push({
+      id: raw.id,
+      content: raw.content,
+      runAt: raw.runAt,
+      createdAt: raw.createdAt,
+      updatedAt: raw.updatedAt,
+      status: raw.status,
+      queueDispatchMode: isQueueDispatchMode(raw.queueDispatchMode)
+        ? raw.queueDispatchMode
+        : "tool-end",
+      ...(typeof raw.sentAt === "number" ? { sentAt: raw.sentAt } : {}),
+      ...(typeof raw.error === "string" && raw.status === "failed" ? { error: raw.error } : {}),
+    });
+  }
+
+  return prompts.sort((left, right) => {
+    if (left.status !== right.status) {
+      const rank: Record<ScheduledPromptStatus, number> = {
+        sending: 0,
+        scheduled: 1,
+        failed: 2,
+        sent: 3,
+      };
+      return rank[left.status] - rank[right.status];
+    }
+    return left.runAt - right.runAt || left.createdAt - right.createdAt;
+  });
+}
+
+export function getDueScheduledPrompts(
+  prompts: readonly ScheduledPrompt[],
+  now = Date.now()
+): ScheduledPrompt[] {
+  return prompts.filter((prompt) => prompt.status === "scheduled" && prompt.runAt <= now);
+}
+
+export function getNextScheduledPromptRunAt(prompts: readonly ScheduledPrompt[]): number | null {
+  const scheduled = prompts.filter((prompt) => prompt.status === "scheduled");
+  if (scheduled.length === 0) {
+    return null;
+  }
+  return Math.min(...scheduled.map((prompt) => prompt.runAt));
+}
+
+export function canRunScheduledPromptNow(prompt: ScheduledPrompt, now = Date.now()): boolean {
+  return (
+    prompt.status === "scheduled" ||
+    prompt.status === "failed" ||
+    (prompt.status === "sending" && prompt.updatedAt <= now - SENDING_MANUAL_RECOVERY_MS)
+  );
+}
+
+export function markScheduledPromptSending(
+  prompts: readonly ScheduledPrompt[],
+  id: string,
+  now = Date.now()
+): ScheduledPrompt[] {
+  return prompts.map((prompt) =>
+    prompt.id === id ? { ...prompt, status: "sending", updatedAt: now, error: undefined } : prompt
+  );
+}
+
+export function markScheduledPromptSent(
+  prompts: readonly ScheduledPrompt[],
+  id: string,
+  now = Date.now()
+): ScheduledPrompt[] {
+  return prompts.map((prompt) =>
+    prompt.id === id
+      ? { ...prompt, status: "sent", sentAt: now, updatedAt: now, error: undefined }
+      : prompt
+  );
+}
+
+export function markScheduledPromptFailed(
+  prompts: readonly ScheduledPrompt[],
+  id: string,
+  error: string,
+  now = Date.now()
+): ScheduledPrompt[] {
+  return prompts.map((prompt) =>
+    prompt.id === id ? { ...prompt, status: "failed", error, updatedAt: now } : prompt
+  );
+}
+
+export function reschedulePromptNow(
+  prompts: readonly ScheduledPrompt[],
+  id: string,
+  now = Date.now()
+): ScheduledPrompt[] {
+  return prompts.map((prompt) =>
+    prompt.id === id
+      ? { ...prompt, status: "scheduled", runAt: now, updatedAt: now, error: undefined }
+      : prompt
+  );
+}
+
+export function removeScheduledPrompt(
+  prompts: readonly ScheduledPrompt[],
+  id: string
+): ScheduledPrompt[] {
+  return prompts.filter((prompt) => prompt.id !== id);
+}
+
+export function formatDateTimeLocalInput(timestamp: number): string {
+  const date = new Date(timestamp);
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}`;
+}
+
+export function parseDateTimeLocalInput(value: string): number | null {
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
@@ -233,8 +233,12 @@ describe("useScheduledPromptDispatcher", () => {
     );
     writePrompts([prompt]);
 
+    let resolveSend: ((value: SendMessageSuccess) => void) | undefined;
     const sendMessage = mock(
-      (_input: SendMessageInput) => new Promise<SendMessageSuccess>(() => {})
+      (_input: SendMessageInput) =>
+        new Promise<SendMessageSuccess>((resolve) => {
+          resolveSend = resolve;
+        })
     );
     const firstApi = {
       workspace: {
@@ -256,6 +260,11 @@ describe("useScheduledPromptDispatcher", () => {
 
     await waitForDispatcherTick();
     expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSend?.({ success: true, data: {} });
+      await Promise.resolve();
+    });
   });
 
   test("stores formatted structured send errors", async () => {

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import type { APIClient } from "@/browser/contexts/API";
+import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { getScheduledPromptsKey } from "@/common/constants/storage";
+import type { SendMessageOptions } from "@/common/orpc/types";
+import { createScheduledPrompt, type ScheduledPrompt } from "./scheduledPrompts";
+import { useScheduledPromptDispatcher } from "./useScheduledPromptDispatcher";
+
+const WORKSPACE_ID = "workspace-scheduled-dispatcher";
+const NOW = 1_700_000_000_000;
+const SEND_OPTIONS: SendMessageOptions = {
+  agentId: "exec",
+  model: "openai:test",
+};
+
+interface SendMessageInput {
+  message: string;
+  options: {
+    additionalSystemContext?: string;
+    queueDispatchMode?: QueueDispatchMode;
+  };
+}
+
+interface SendMessageSuccess {
+  success: true;
+  data: Record<string, never>;
+}
+
+function Dispatcher(props: { api: APIClient; additionalSystemContext?: string }) {
+  useScheduledPromptDispatcher({
+    api: props.api,
+    workspaceId: WORKSPACE_ID,
+    sendMessageOptions: SEND_OPTIONS,
+    additionalSystemContext: props.additionalSystemContext,
+    enabled: true,
+  });
+  return null;
+}
+
+function writePrompts(prompts: ScheduledPrompt[]) {
+  updatePersistedState(getScheduledPromptsKey(WORKSPACE_ID), prompts);
+}
+
+async function waitForDispatcherTick() {
+  await act(async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+}
+
+describe("useScheduledPromptDispatcher", () => {
+  let originalWindow: typeof globalThis.window;
+  let originalDocument: typeof globalThis.document;
+  let originalLocalStorage: typeof globalThis.localStorage;
+  let originalCustomEvent: typeof globalThis.CustomEvent;
+  let originalStorageEvent: typeof globalThis.StorageEvent;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    originalDocument = globalThis.document;
+    originalLocalStorage = globalThis.localStorage;
+    originalCustomEvent = globalThis.CustomEvent;
+    originalStorageEvent = globalThis.StorageEvent;
+
+    const dom = new GlobalWindow();
+    globalThis.window = dom as unknown as Window & typeof globalThis;
+    globalThis.document = dom.document as unknown as Document;
+    globalThis.localStorage = dom.localStorage as unknown as Storage;
+    globalThis.CustomEvent = dom.CustomEvent as unknown as typeof globalThis.CustomEvent;
+    globalThis.StorageEvent = dom.StorageEvent as unknown as typeof globalThis.StorageEvent;
+    globalThis.window.setTimeout = globalThis.setTimeout.bind(
+      globalThis
+    ) as typeof window.setTimeout;
+    globalThis.window.clearTimeout = globalThis.clearTimeout.bind(
+      globalThis
+    ) as typeof window.clearTimeout;
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    globalThis.window = originalWindow;
+    globalThis.document = originalDocument;
+    globalThis.localStorage = originalLocalStorage;
+    globalThis.CustomEvent = originalCustomEvent;
+    globalThis.StorageEvent = originalStorageEvent;
+  });
+
+  test("dispatches multiple due prompts sequentially", async () => {
+    const first = createScheduledPrompt(
+      { content: "first", runAt: NOW - 2, queueDispatchMode: "tool-end" },
+      NOW,
+      "first"
+    );
+    const second = createScheduledPrompt(
+      { content: "second", runAt: NOW - 1, queueDispatchMode: "turn-end" },
+      NOW,
+      "second"
+    );
+    writePrompts([second, first]);
+
+    const resolvers: Array<(value: SendMessageSuccess) => void> = [];
+    const sendMessage = mock((_input: SendMessageInput) => {
+      return new Promise<SendMessageSuccess>((resolve) => {
+        resolvers.push(resolve);
+      });
+    });
+    const api = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+
+    render(<Dispatcher api={api} />);
+
+    await waitForDispatcherTick();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const firstCall = sendMessage.mock.calls[0]?.[0];
+    if (!firstCall) {
+      throw new Error("Expected first scheduled prompt send");
+    }
+    expect(firstCall.message).toBe("first");
+    expect(firstCall.options.queueDispatchMode).toBe("tool-end");
+
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolvers[0]?.({ success: true, data: {} });
+      await Promise.resolve();
+    });
+
+    await waitForDispatcherTick();
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    const secondCall = sendMessage.mock.calls[1]?.[0];
+    if (!secondCall) {
+      throw new Error("Expected second scheduled prompt send");
+    }
+    expect(secondCall.message).toBe("second");
+    expect(secondCall.options.queueDispatchMode).toBe("turn-end");
+
+    await act(async () => {
+      resolvers[1]?.({ success: true, data: {} });
+      await Promise.resolve();
+    });
+  });
+
+  test("skips queued due prompts that were removed before dispatch", async () => {
+    const first = createScheduledPrompt(
+      { content: "first", runAt: NOW - 2, queueDispatchMode: "tool-end" },
+      NOW,
+      "first"
+    );
+    const second = createScheduledPrompt(
+      { content: "second", runAt: NOW - 1, queueDispatchMode: "turn-end" },
+      NOW,
+      "second"
+    );
+    writePrompts([first, second]);
+
+    let resolveFirst: ((value: SendMessageSuccess) => void) | undefined;
+    const sendMessage = mock((_input: SendMessageInput) => {
+      return new Promise<SendMessageSuccess>((resolve) => {
+        resolveFirst = resolve;
+      });
+    });
+    const api = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+
+    render(<Dispatcher api={api} />);
+
+    await waitForDispatcherTick();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const firstCall = sendMessage.mock.calls[0]?.[0];
+    if (!firstCall) {
+      throw new Error("Expected first scheduled prompt send");
+    }
+    expect(firstCall.message).toBe("first");
+
+    act(() => {
+      writePrompts([first]);
+    });
+
+    await act(async () => {
+      resolveFirst?.({ success: true, data: {} });
+      await Promise.resolve();
+    });
+
+    await Promise.resolve();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("includes additional system context in scheduled sends", async () => {
+    const prompt = createScheduledPrompt(
+      { content: "run with instructions", runAt: NOW - 1, queueDispatchMode: "tool-end" },
+      NOW,
+      "with-context"
+    );
+    writePrompts([prompt]);
+
+    const sendMessage = mock((_input: SendMessageInput) =>
+      Promise.resolve({ success: true as const, data: {} })
+    );
+    const api = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+
+    render(<Dispatcher api={api} additionalSystemContext="Stay concise." />);
+
+    await waitForDispatcherTick();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const firstCall = sendMessage.mock.calls[0]?.[0];
+    if (!firstCall) {
+      throw new Error("Expected scheduled prompt send");
+    }
+    expect(firstCall.options.additionalSystemContext).toBe("Stay concise.");
+  });
+});

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
@@ -48,6 +48,7 @@ function writePrompts(prompts: ScheduledPrompt[]) {
 async function waitForDispatcherTick() {
   await act(async () => {
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
     await Promise.resolve();
   });
 }
@@ -78,6 +79,27 @@ describe("useScheduledPromptDispatcher", () => {
     globalThis.window.clearTimeout = globalThis.clearTimeout.bind(
       globalThis
     ) as typeof window.clearTimeout;
+    let lockHeld = false;
+    Object.defineProperty(globalThis.window.navigator, "locks", {
+      configurable: true,
+      value: {
+        request: async (
+          _name: string,
+          _options: { ifAvailable: true; mode: "exclusive" },
+          callback: (lock: object | null) => unknown
+        ) => {
+          if (lockHeld) {
+            return callback(null);
+          }
+          lockHeld = true;
+          try {
+            return await callback({ name: _name });
+          } finally {
+            lockHeld = false;
+          }
+        },
+      },
+    });
   });
 
   afterEach(() => {

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx
@@ -4,7 +4,7 @@ import { GlobalWindow } from "happy-dom";
 
 import type { APIClient } from "@/browser/contexts/API";
 import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
-import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { getScheduledPromptsKey } from "@/common/constants/storage";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import { createScheduledPrompt, type ScheduledPrompt } from "./scheduledPrompts";
@@ -223,5 +223,72 @@ describe("useScheduledPromptDispatcher", () => {
       throw new Error("Expected scheduled prompt send");
     }
     expect(firstCall.options.additionalSystemContext).toBe("Stay concise.");
+  });
+
+  test("keeps only one renderer dispatching scheduled prompts at a time", async () => {
+    const prompt = createScheduledPrompt(
+      { content: "send once", runAt: NOW - 1, queueDispatchMode: "tool-end" },
+      NOW,
+      "shared-lock"
+    );
+    writePrompts([prompt]);
+
+    const sendMessage = mock(
+      (_input: SendMessageInput) => new Promise<SendMessageSuccess>(() => {})
+    );
+    const firstApi = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+    const secondApi = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+
+    render(
+      <>
+        <Dispatcher api={firstApi} />
+        <Dispatcher api={secondApi} />
+      </>
+    );
+
+    await waitForDispatcherTick();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  test("stores formatted structured send errors", async () => {
+    const prompt = createScheduledPrompt(
+      { content: "needs key", runAt: NOW - 1, queueDispatchMode: "tool-end" },
+      NOW,
+      "structured-error"
+    );
+    writePrompts([prompt]);
+
+    const sendMessage = mock((_input: SendMessageInput) =>
+      Promise.resolve({
+        success: false as const,
+        error: { type: "api_key_not_found" as const, provider: "openai" },
+      })
+    );
+    const api = {
+      workspace: {
+        sendMessage,
+      },
+    } as unknown as APIClient;
+
+    render(<Dispatcher api={api} />);
+
+    await waitForDispatcherTick();
+    await waitForDispatcherTick();
+
+    const storedPrompts = readPersistedState<ScheduledPrompt[]>(
+      getScheduledPromptsKey(WORKSPACE_ID),
+      []
+    );
+    expect(storedPrompts[0]?.status).toBe("failed");
+    expect(storedPrompts[0]?.error).toContain("API key not found for OpenAI.");
+    expect(storedPrompts[0]?.error).toContain("Open Settings");
   });
 });

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
@@ -1,0 +1,184 @@
+import { useEffect, useRef, useState } from "react";
+import type { APIClient } from "@/browser/contexts/API";
+import { readPersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
+import { getScheduledPromptsKey } from "@/common/constants/storage";
+import { prepareUserMessageForSend, type MuxMessageMetadata } from "@/common/types/message";
+import type { SendMessageOptions } from "@/common/orpc/types";
+import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
+import {
+  getDueScheduledPrompts,
+  getNextScheduledPromptRunAt,
+  markScheduledPromptFailed,
+  markScheduledPromptSending,
+  markScheduledPromptSent,
+  normalizeScheduledPrompts,
+  type ScheduledPrompt,
+} from "./scheduledPrompts";
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+interface ScheduledPromptDispatcherOptions {
+  api: APIClient | null;
+  workspaceId: string;
+  sendMessageOptions: SendMessageOptions;
+  additionalSystemContext?: string;
+  enabled: boolean;
+  onMessageSendStarted?: (dispatchMode: QueueDispatchMode) => void;
+  onMessageSent?: (dispatchMode: QueueDispatchMode) => void;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    error.message.trim().length > 0
+  ) {
+    return error.message;
+  }
+  return "Failed to send scheduled prompt";
+}
+
+function getCurrentRunnablePrompt(storageKey: string, promptId: string): ScheduledPrompt | null {
+  const currentPrompts = normalizeScheduledPrompts(
+    readPersistedState<ScheduledPrompt[]>(storageKey, [])
+  );
+  return getDueScheduledPrompts(currentPrompts).find((prompt) => prompt.id === promptId) ?? null;
+}
+
+export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherOptions) {
+  const {
+    api,
+    workspaceId,
+    sendMessageOptions,
+    additionalSystemContext,
+    enabled,
+    onMessageSendStarted,
+    onMessageSent,
+  } = options;
+  const storageKey = getScheduledPromptsKey(workspaceId);
+  const [storedPrompts, setStoredPrompts] = usePersistedState<ScheduledPrompt[]>(storageKey, [], {
+    listener: true,
+  });
+  const inFlightIdsRef = useRef(new Set<string>());
+  const isDispatchingRef = useRef(false);
+  const [timerNonce, setTimerNonce] = useState(0);
+
+  useEffect(() => {
+    if (!enabled || !api) {
+      return;
+    }
+
+    const prompts = normalizeScheduledPrompts(storedPrompts);
+    const duePrompts = getDueScheduledPrompts(prompts);
+    const nextRunAt = getNextScheduledPromptRunAt(prompts);
+    let delay = 0;
+    if (duePrompts.length === 0) {
+      if (nextRunAt === null) {
+        return;
+      }
+      delay = Math.max(0, Math.min(nextRunAt - Date.now(), MAX_TIMER_DELAY_MS));
+    }
+
+    const timeout = window.setTimeout(() => {
+      if (isDispatchingRef.current) {
+        return;
+      }
+
+      const runnablePrompts = getDueScheduledPrompts(prompts).filter(
+        (prompt) => !inFlightIdsRef.current.has(prompt.id)
+      );
+      if (runnablePrompts.length === 0) {
+        setTimerNonce((current) => current + 1);
+        return;
+      }
+
+      isDispatchingRef.current = true;
+
+      void (async () => {
+        for (const queuedPrompt of runnablePrompts) {
+          if (inFlightIdsRef.current.has(queuedPrompt.id)) {
+            continue;
+          }
+
+          const prompt = getCurrentRunnablePrompt(storageKey, queuedPrompt.id);
+          if (!prompt) {
+            continue;
+          }
+
+          inFlightIdsRef.current.add(prompt.id);
+          setStoredPrompts((current) =>
+            markScheduledPromptSending(normalizeScheduledPrompts(current), prompt.id)
+          );
+
+          const dispatchMode = prompt.queueDispatchMode;
+          const muxMetadata: MuxMessageMetadata = {
+            type: "normal",
+            requestedModel: sendMessageOptions.model,
+          };
+          const prepared = prepareUserMessageForSend({ text: prompt.content }, muxMetadata);
+
+          try {
+            onMessageSendStarted?.(dispatchMode);
+            const result = await api.workspace.sendMessage({
+              workspaceId,
+              message: prepared.finalText,
+              options: {
+                ...sendMessageOptions,
+                ...(additionalSystemContext !== undefined ? { additionalSystemContext } : {}),
+                queueDispatchMode: dispatchMode,
+                muxMetadata: prepared.metadata,
+              },
+            });
+
+            if (!result?.success) {
+              const error = result?.error ? getErrorMessage(result.error) : "API not connected";
+              setStoredPrompts((current) =>
+                markScheduledPromptFailed(normalizeScheduledPrompts(current), prompt.id, error)
+              );
+              continue;
+            }
+
+            setStoredPrompts((current) =>
+              markScheduledPromptSent(normalizeScheduledPrompts(current), prompt.id)
+            );
+            onMessageSent?.(dispatchMode);
+          } catch (error) {
+            setStoredPrompts((current) =>
+              markScheduledPromptFailed(
+                normalizeScheduledPrompts(current),
+                prompt.id,
+                getErrorMessage(error)
+              )
+            );
+          } finally {
+            inFlightIdsRef.current.delete(prompt.id);
+          }
+        }
+      })().finally(() => {
+        isDispatchingRef.current = false;
+      });
+    }, delay);
+
+    return () => window.clearTimeout(timeout);
+  }, [
+    api,
+    enabled,
+    onMessageSendStarted,
+    onMessageSent,
+    additionalSystemContext,
+    sendMessageOptions,
+    setStoredPrompts,
+    storedPrompts,
+    storageKey,
+    timerNonce,
+    workspaceId,
+  ]);
+}

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 import type { APIClient } from "@/browser/contexts/API";
-import { readPersistedState, usePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  readPersistedState,
+  updatePersistedState,
+  usePersistedState,
+} from "@/browser/hooks/usePersistedState";
 import { getScheduledPromptsKey } from "@/common/constants/storage";
 import { prepareUserMessageForSend, type MuxMessageMetadata } from "@/common/types/message";
 import type { SendMessageOptions } from "@/common/orpc/types";
@@ -11,7 +15,6 @@ import {
   getDueScheduledPrompts,
   getNextScheduledPromptRunAt,
   markScheduledPromptFailed,
-  markScheduledPromptSending,
   markScheduledPromptSent,
   normalizeScheduledPrompts,
   type ScheduledPrompt,
@@ -37,6 +40,14 @@ const SEND_MESSAGE_ERROR_TYPES = new Set<string>([
 interface ScheduledDispatchLock {
   ownerId: string;
   expiresAt: number;
+}
+
+interface LockManagerLike {
+  request<T>(
+    name: string,
+    options: { ifAvailable: true; mode: "exclusive" },
+    callback: (lock: object | null) => T | Promise<T>
+  ): Promise<T>;
 }
 
 interface ScheduledPromptDispatcherOptions {
@@ -120,6 +131,46 @@ function releaseDispatchLock(lockKey: string, ownerId: string): void {
   }
 }
 
+function getBrowserLockManager(): LockManagerLike | undefined {
+  if (typeof window === "undefined" || !window.navigator) {
+    return undefined;
+  }
+
+  const maybeNavigator = window.navigator as Navigator & { locks?: LockManagerLike };
+  if (typeof maybeNavigator.locks?.request !== "function") {
+    return undefined;
+  }
+  return maybeNavigator.locks;
+}
+
+async function runWithDispatchLock(
+  lockKey: string,
+  ownerId: string,
+  callback: () => Promise<void>
+): Promise<boolean> {
+  const lockManager = getBrowserLockManager();
+  if (lockManager) {
+    return lockManager.request(lockKey, { ifAvailable: true, mode: "exclusive" }, async (lock) => {
+      if (!lock) {
+        return false;
+      }
+      await callback();
+      return true;
+    });
+  }
+
+  if (!tryAcquireDispatchLock(lockKey, ownerId)) {
+    return false;
+  }
+
+  try {
+    await callback();
+    return true;
+  } finally {
+    releaseDispatchLock(lockKey, ownerId);
+  }
+}
+
 function isSendMessageError(error: unknown): error is SendMessageError {
   if (typeof error !== "object" || error === null || !("type" in error)) {
     return false;
@@ -152,11 +203,44 @@ function getErrorMessage(error: unknown): string {
   return "Failed to send scheduled prompt";
 }
 
-function getCurrentRunnablePrompt(storageKey: string, promptId: string): ScheduledPrompt | null {
-  const currentPrompts = normalizeScheduledPrompts(
-    readPersistedState<ScheduledPrompt[]>(storageKey, [])
+function claimCurrentRunnablePrompt(storageKey: string, promptId: string): ScheduledPrompt | null {
+  const claimedAt = Date.now();
+  let claimedPrompt: ScheduledPrompt | null = null;
+
+  updatePersistedState<ScheduledPrompt[]>(
+    storageKey,
+    (current) => {
+      const prompts = normalizeScheduledPrompts(current);
+      const prompt = getDueScheduledPrompts(prompts).find((candidate) => candidate.id === promptId);
+      if (!prompt) {
+        return prompts;
+      }
+
+      const nextPrompt: ScheduledPrompt = {
+        ...prompt,
+        status: "sending",
+        updatedAt: claimedAt,
+        error: undefined,
+      };
+      claimedPrompt = nextPrompt;
+      return prompts.map((candidate) => (candidate.id === promptId ? nextPrompt : candidate));
+    },
+    []
   );
-  return getDueScheduledPrompts(currentPrompts).find((prompt) => prompt.id === promptId) ?? null;
+
+  if (!claimedPrompt) {
+    return null;
+  }
+
+  const storedPrompt = normalizeScheduledPrompts(
+    readPersistedState<ScheduledPrompt[]>(storageKey, [])
+  ).find((prompt) => prompt.id === promptId);
+
+  if (storedPrompt?.status !== "sending" || storedPrompt.updatedAt !== claimedAt) {
+    return null;
+  }
+
+  return claimedPrompt;
 }
 
 export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherOptions) {
@@ -210,79 +294,79 @@ export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherO
         return;
       }
 
-      if (!tryAcquireDispatchLock(lockKey, ownerId)) {
-        window.setTimeout(
-          () => setTimerNonce((current) => current + 1),
-          DISPATCH_LOCK_RETRY_DELAY_MS
-        );
-        return;
-      }
-
-      isDispatchingRef.current = true;
-
       void (async () => {
-        for (const queuedPrompt of runnablePrompts) {
-          if (inFlightIdsRef.current.has(queuedPrompt.id)) {
-            continue;
-          }
-
-          const prompt = getCurrentRunnablePrompt(storageKey, queuedPrompt.id);
-          if (!prompt) {
-            continue;
-          }
-
-          inFlightIdsRef.current.add(prompt.id);
-          setStoredPrompts((current) =>
-            markScheduledPromptSending(normalizeScheduledPrompts(current), prompt.id)
-          );
-
-          const dispatchMode = prompt.queueDispatchMode;
-          const muxMetadata: MuxMessageMetadata = {
-            type: "normal",
-            requestedModel: sendMessageOptions.model,
-          };
-          const prepared = prepareUserMessageForSend({ text: prompt.content }, muxMetadata);
-
+        const acquired = await runWithDispatchLock(lockKey, ownerId, async () => {
+          isDispatchingRef.current = true;
           try {
-            onMessageSendStarted?.(dispatchMode);
-            const result = await api.workspace.sendMessage({
-              workspaceId,
-              message: prepared.finalText,
-              options: {
-                ...sendMessageOptions,
-                ...(additionalSystemContext !== undefined ? { additionalSystemContext } : {}),
-                queueDispatchMode: dispatchMode,
-                muxMetadata: prepared.metadata,
-              },
-            });
+            for (const queuedPrompt of runnablePrompts) {
+              if (inFlightIdsRef.current.has(queuedPrompt.id)) {
+                continue;
+              }
 
-            if (!result?.success) {
-              const error = result?.error ? getErrorMessage(result.error) : "API not connected";
-              setStoredPrompts((current) =>
-                markScheduledPromptFailed(normalizeScheduledPrompts(current), prompt.id, error)
-              );
-              continue;
+              const prompt = claimCurrentRunnablePrompt(storageKey, queuedPrompt.id);
+              if (!prompt) {
+                continue;
+              }
+
+              inFlightIdsRef.current.add(prompt.id);
+
+              const dispatchMode = prompt.queueDispatchMode;
+              const muxMetadata: MuxMessageMetadata = {
+                type: "normal",
+                requestedModel: sendMessageOptions.model,
+              };
+              const prepared = prepareUserMessageForSend({ text: prompt.content }, muxMetadata);
+
+              try {
+                onMessageSendStarted?.(dispatchMode);
+                const result = await api.workspace.sendMessage({
+                  workspaceId,
+                  message: prepared.finalText,
+                  options: {
+                    ...sendMessageOptions,
+                    ...(additionalSystemContext !== undefined ? { additionalSystemContext } : {}),
+                    queueDispatchMode: dispatchMode,
+                    muxMetadata: prepared.metadata,
+                  },
+                });
+
+                if (!result?.success) {
+                  const error = result?.error ? getErrorMessage(result.error) : "API not connected";
+                  setStoredPrompts((current) =>
+                    markScheduledPromptFailed(normalizeScheduledPrompts(current), prompt.id, error)
+                  );
+                  continue;
+                }
+
+                setStoredPrompts((current) =>
+                  markScheduledPromptSent(normalizeScheduledPrompts(current), prompt.id)
+                );
+                onMessageSent?.(dispatchMode);
+              } catch (error) {
+                setStoredPrompts((current) =>
+                  markScheduledPromptFailed(
+                    normalizeScheduledPrompts(current),
+                    prompt.id,
+                    getErrorMessage(error)
+                  )
+                );
+              } finally {
+                inFlightIdsRef.current.delete(prompt.id);
+              }
             }
-
-            setStoredPrompts((current) =>
-              markScheduledPromptSent(normalizeScheduledPrompts(current), prompt.id)
-            );
-            onMessageSent?.(dispatchMode);
-          } catch (error) {
-            setStoredPrompts((current) =>
-              markScheduledPromptFailed(
-                normalizeScheduledPrompts(current),
-                prompt.id,
-                getErrorMessage(error)
-              )
-            );
           } finally {
-            inFlightIdsRef.current.delete(prompt.id);
+            isDispatchingRef.current = false;
           }
+        });
+
+        if (!acquired) {
+          window.setTimeout(
+            () => setTimerNonce((current) => current + 1),
+            DISPATCH_LOCK_RETRY_DELAY_MS
+          );
         }
-      })().finally(() => {
-        isDispatchingRef.current = false;
-        releaseDispatchLock(lockKey, ownerId);
+      })().catch((error) => {
+        console.error("scheduled prompt dispatcher failed", error);
       });
     }, delay);
 

--- a/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
+++ b/src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.ts
@@ -5,6 +5,8 @@ import { getScheduledPromptsKey } from "@/common/constants/storage";
 import { prepareUserMessageForSend, type MuxMessageMetadata } from "@/common/types/message";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import type { QueueDispatchMode } from "@/browser/features/ChatInput/types";
+import type { SendMessageError } from "@/common/types/errors";
+import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
 import {
   getDueScheduledPrompts,
   getNextScheduledPromptRunAt,
@@ -16,6 +18,26 @@ import {
 } from "./scheduledPrompts";
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
+const DISPATCH_LOCK_TTL_MS = 5 * 60 * 1000;
+const DISPATCH_LOCK_RETRY_DELAY_MS = 1_000;
+const SEND_MESSAGE_ERROR_TYPES = new Set<string>([
+  "api_key_not_found",
+  "oauth_not_connected",
+  "provider_disabled",
+  "provider_not_supported",
+  "model_not_available",
+  "invalid_model_string",
+  "incompatible_workspace",
+  "runtime_not_ready",
+  "runtime_start_failed",
+  "policy_denied",
+  "unknown",
+]);
+
+interface ScheduledDispatchLock {
+  ownerId: string;
+  expiresAt: number;
+}
 
 interface ScheduledPromptDispatcherOptions {
   api: APIClient | null;
@@ -27,7 +49,91 @@ interface ScheduledPromptDispatcherOptions {
   onMessageSent?: (dispatchMode: QueueDispatchMode) => void;
 }
 
+function createDispatcherOwnerId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+}
+
+function getDispatchLockKey(storageKey: string): string {
+  return `${storageKey}:dispatch-lock`;
+}
+
+function readDispatchLock(raw: string | null): ScheduledDispatchLock | null {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ScheduledDispatchLock>;
+    if (
+      typeof parsed.ownerId === "string" &&
+      typeof parsed.expiresAt === "number" &&
+      Number.isFinite(parsed.expiresAt)
+    ) {
+      return {
+        ownerId: parsed.ownerId,
+        expiresAt: parsed.expiresAt,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function tryAcquireDispatchLock(lockKey: string, ownerId: string): boolean {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return true;
+  }
+
+  try {
+    const now = Date.now();
+    const currentLock = readDispatchLock(window.localStorage.getItem(lockKey));
+    if (currentLock && currentLock.ownerId !== ownerId && currentLock.expiresAt > now) {
+      return false;
+    }
+
+    const nextLock: ScheduledDispatchLock = {
+      ownerId,
+      expiresAt: now + DISPATCH_LOCK_TTL_MS,
+    };
+    window.localStorage.setItem(lockKey, JSON.stringify(nextLock));
+
+    return readDispatchLock(window.localStorage.getItem(lockKey))?.ownerId === ownerId;
+  } catch {
+    return true;
+  }
+}
+
+function releaseDispatchLock(lockKey: string, ownerId: string): void {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+
+  try {
+    const currentLock = readDispatchLock(window.localStorage.getItem(lockKey));
+    if (!currentLock || currentLock.ownerId === ownerId) {
+      window.localStorage.removeItem(lockKey);
+    }
+  } catch {
+    // Ignore storage failures; the lock expires automatically.
+  }
+}
+
+function isSendMessageError(error: unknown): error is SendMessageError {
+  if (typeof error !== "object" || error === null || !("type" in error)) {
+    return false;
+  }
+  const type = (error as { type?: unknown }).type;
+  return typeof type === "string" && SEND_MESSAGE_ERROR_TYPES.has(type);
+}
+
 function getErrorMessage(error: unknown): string {
+  if (isSendMessageError(error)) {
+    const formatted = formatSendMessageError(error);
+    return [formatted.message, formatted.resolutionHint].filter(Boolean).join(" ");
+  }
+
   if (error instanceof Error && error.message) {
     return error.message;
   }
@@ -69,6 +175,7 @@ export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherO
   });
   const inFlightIdsRef = useRef(new Set<string>());
   const isDispatchingRef = useRef(false);
+  const dispatcherOwnerIdRef = useRef(createDispatcherOwnerId());
   const [timerNonce, setTimerNonce] = useState(0);
 
   useEffect(() => {
@@ -88,6 +195,9 @@ export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherO
     }
 
     const timeout = window.setTimeout(() => {
+      const lockKey = getDispatchLockKey(storageKey);
+      const ownerId = dispatcherOwnerIdRef.current;
+
       if (isDispatchingRef.current) {
         return;
       }
@@ -97,6 +207,14 @@ export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherO
       );
       if (runnablePrompts.length === 0) {
         setTimerNonce((current) => current + 1);
+        return;
+      }
+
+      if (!tryAcquireDispatchLock(lockKey, ownerId)) {
+        window.setTimeout(
+          () => setTimerNonce((current) => current + 1),
+          DISPATCH_LOCK_RETRY_DELAY_MS
+        );
         return;
       }
 
@@ -164,6 +282,7 @@ export function useScheduledPromptDispatcher(options: ScheduledPromptDispatcherO
         }
       })().finally(() => {
         isDispatchingRef.current = false;
+        releaseDispatchLock(lockKey, ownerId);
       });
     }, delay);
 

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -257,6 +257,31 @@ test("buildCoreSources includes create/switch workspace actions", () => {
   expect(titles.includes("Open Terminal Window for Workspace…")).toBe(true);
 });
 
+test("schedule sidebar commands are hidden for transcript-only workspaces", async () => {
+  const workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
+  workspaceMetadata.set("w1", {
+    id: "w1",
+    name: "feat-x",
+    projectName: "a",
+    projectPath: "/repo/a",
+    namedWorkspacePath: "/repo/a/feat-x",
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    transcriptOnly: true,
+  });
+  const actions = getActions({ workspaceMetadata });
+  const addToolAction = actions.find((action) => action.id === "nav:rightSidebar:addTool");
+  const toolField = addToolAction?.prompt?.fields[0];
+
+  if (toolField?.type !== "select") {
+    throw new Error("Expected Add Tool to use a select prompt field");
+  }
+
+  const options = await toolField.getOptions({});
+
+  expect(actions.some((action) => action.id === "nav:toggle-tab:schedule")).toBe(false);
+  expect(options.map((option) => option.id)).not.toContain("schedule");
+});
+
 test("appearance commands offer auto when a manual theme is selected", () => {
   const actions = getActions({ themePreference: "dark" });
 

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -261,6 +261,31 @@ test("buildCoreSources includes create/switch workspace actions", () => {
   expect(titles.includes("Open Terminal Window for Workspace…")).toBe(true);
 });
 
+test("schedule sidebar commands are hidden for transcript-only workspaces", async () => {
+  const workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
+  workspaceMetadata.set("w1", {
+    id: "w1",
+    name: "feat-x",
+    projectName: "a",
+    projectPath: "/repo/a",
+    namedWorkspacePath: "/repo/a/feat-x",
+    runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    transcriptOnly: true,
+  });
+  const actions = getActions({ workspaceMetadata });
+  const addToolAction = actions.find((action) => action.id === "nav:rightSidebar:addTool");
+  const toolField = addToolAction?.prompt?.fields[0];
+
+  if (toolField?.type !== "select") {
+    throw new Error("Expected Add Tool to use a select prompt field");
+  }
+
+  const options = await toolField.getOptions({});
+
+  expect(actions.some((action) => action.id === "nav:toggle-tab:schedule")).toBe(false);
+  expect(options.map((option) => option.id)).not.toContain("schedule");
+});
+
 test("appearance commands offer auto when a manual theme is selected", () => {
   const actions = getActions({ themePreference: "dark" });
 

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -59,6 +59,7 @@ import {
   UNPRICED_CURRENT_MODEL_GOAL_MESSAGE,
 } from "@/common/utils/goals/budgetPricing";
 import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
 
 export interface BuildSourcesParams {
   api: APIClient | null;
@@ -629,12 +630,18 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
     // Right sidebar layout commands require a selected workspace (layout is per-workspace)
     const wsId = p.selectedWorkspace?.workspaceId;
     if (wsId) {
+      const selectedWorkspaceMetadata = p.workspaceMetadata.get(wsId) ?? null;
+      const availableBaseTabIds = getOrderedBaseTabIds().filter(
+        (tabId) =>
+          tabId !== "schedule" || canUseScheduledPromptsInWorkspace(selectedWorkspaceMetadata)
+      );
+
       list.push(
         // Generic per-tab "Hide/Show <Name>" commands are only for optional tabs.
         // Default-layout tabs (Stats/Review/Instructions) are auto-restored by
         // the layout migration, so exposing hide commands for them would be a
         // no-op and obscure the fact that they are meant to be visible by default.
-        ...getOrderedBaseTabIds()
+        ...availableBaseTabIds
           .filter((tabId) => {
             const config = getTabConfig(tabId);
             return config.inDefaultLayout !== true && config.featureFlag == null;
@@ -696,7 +703,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
                 // Static tabs come straight from the lightweight config (in default order).
                 // Terminal is appended manually because it lives outside the static registry.
                 getOptions: () => [
-                  ...getOrderedBaseTabIds()
+                  ...availableBaseTabIds
                     .filter((tabId) => getTabConfig(tabId).featureFlag == null)
                     .map((tabId) => {
                       const config = getTabConfig(tabId);

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -69,6 +69,7 @@ import {
   UNPRICED_CURRENT_MODEL_GOAL_MESSAGE,
 } from "@/common/utils/goals/budgetPricing";
 import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
+import { canUseScheduledPromptsInWorkspace } from "@/browser/features/ScheduledPrompts/scheduledPromptAvailability";
 
 export interface BuildSourcesParams {
   api: APIClient | null;
@@ -697,13 +698,19 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
     // Right sidebar layout commands require a selected workspace (layout is per-workspace)
     const wsId = p.selectedWorkspace?.workspaceId;
     if (wsId) {
-      const canReviewDiffs = hasWorkspaceRepository(p.workspaceMetadata.get(wsId));
+      const selectedWorkspaceMetadata = p.workspaceMetadata.get(wsId) ?? null;
+      const canReviewDiffs = hasWorkspaceRepository(selectedWorkspaceMetadata);
+      const availableBaseTabIds = getOrderedBaseTabIds().filter(
+        (tabId) =>
+          tabId !== "schedule" || canUseScheduledPromptsInWorkspace(selectedWorkspaceMetadata)
+      );
+
       list.push(
         // Generic per-tab "Hide/Show <Name>" commands are only for optional tabs.
         // Default-layout tabs (Stats/Review/Instructions) are auto-restored by
         // the layout migration, so exposing hide commands for them would be a
         // no-op and obscure the fact that they are meant to be visible by default.
-        ...getOrderedBaseTabIds()
+        ...availableBaseTabIds
           .filter((tabId) => {
             const config = getTabConfig(tabId);
             return config.inDefaultLayout !== true && config.featureFlag == null;
@@ -765,7 +772,7 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
                 // Static tabs come straight from the lightweight config (in default order).
                 // Terminal is appended manually because it lives outside the static registry.
                 getOptions: () => [
-                  ...getOrderedBaseTabIds()
+                  ...availableBaseTabIds
                     .filter(
                       (tabId) =>
                         getTabConfig(tabId).featureFlag == null &&

--- a/src/common/constants/storage.test.ts
+++ b/src/common/constants/storage.test.ts
@@ -4,6 +4,7 @@ import {
   deleteWorkspaceStorage,
   getDraftScopeId,
   getInputAttachmentsKey,
+  getScheduledPromptsKey,
   normalizeTranscriptDensity,
 } from "@/common/constants/storage";
 
@@ -64,27 +65,36 @@ describe("storage workspace-scoped keys", () => {
     expect(getInputAttachmentsKey("ws-123")).toBe("inputAttachments:ws-123");
   });
 
+  test("getScheduledPromptsKey formats key", () => {
+    expect(getScheduledPromptsKey("ws-123")).toBe("scheduledPrompts:ws-123");
+  });
+
   test("normalizeTranscriptDensity falls back for corrupt values", () => {
     expect(normalizeTranscriptDensity("hyper")).toBe("hyper");
     expect(normalizeTranscriptDensity("compact")).toBe("normal");
     expect(normalizeTranscriptDensity(null)).toBe("normal");
   });
 
-  test("copyWorkspaceStorage copies inputAttachments key", () => {
+  test("copyWorkspaceStorage copies draft keys but not scheduled sends", () => {
     const source = "ws-source";
     const dest = "ws-dest";
 
-    const sourceKey = getInputAttachmentsKey(source);
-    const destKey = getInputAttachmentsKey(dest);
+    const sourceAttachmentsKey = getInputAttachmentsKey(source);
+    const destAttachmentsKey = getInputAttachmentsKey(dest);
+    const sourceScheduledPromptsKey = getScheduledPromptsKey(source);
+    const destScheduledPromptsKey = getScheduledPromptsKey(dest);
 
-    const value = JSON.stringify([
+    const attachmentsValue = JSON.stringify([
       { id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" },
     ]);
-    localStorage.setItem(sourceKey, value);
+    const scheduledPromptsValue = JSON.stringify([{ id: "prompt-1" }]);
+    localStorage.setItem(sourceAttachmentsKey, attachmentsValue);
+    localStorage.setItem(sourceScheduledPromptsKey, scheduledPromptsValue);
 
     copyWorkspaceStorage(source, dest);
 
-    expect(localStorage.getItem(destKey)).toBe(value);
+    expect(localStorage.getItem(destAttachmentsKey)).toBe(attachmentsValue);
+    expect(localStorage.getItem(destScheduledPromptsKey)).toBeNull();
   });
 
   test("copyWorkspaceStorage drops staged draft attachments", () => {
@@ -114,13 +124,16 @@ describe("storage workspace-scoped keys", () => {
     expect(JSON.parse(localStorage.getItem(destKey) ?? "null")).toEqual([providerAttachment]);
   });
 
-  test("deleteWorkspaceStorage removes inputAttachments key", () => {
+  test("deleteWorkspaceStorage removes workspace draft and scheduled send keys", () => {
     const workspaceId = "ws-delete";
-    const key = getInputAttachmentsKey(workspaceId);
+    const attachmentsKey = getInputAttachmentsKey(workspaceId);
+    const scheduledPromptsKey = getScheduledPromptsKey(workspaceId);
 
-    localStorage.setItem(key, "value");
+    localStorage.setItem(attachmentsKey, "value");
+    localStorage.setItem(scheduledPromptsKey, "value");
     deleteWorkspaceStorage(workspaceId);
 
-    expect(localStorage.getItem(key)).toBeNull();
+    expect(localStorage.getItem(attachmentsKey)).toBeNull();
+    expect(localStorage.getItem(scheduledPromptsKey)).toBeNull();
   });
 });

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -219,6 +219,14 @@ export function getInputKey(workspaceId: string): string {
 }
 
 /**
+ * Get the localStorage key for scheduled prompts for a workspace.
+ * Format: "scheduledPrompts:{workspaceId}"
+ */
+export function getScheduledPromptsKey(workspaceId: string): string {
+  return `scheduledPrompts:${workspaceId}`;
+}
+
+/**
  * Get the localStorage key for the pinned TODO panel expansion state.
  * Format: "pinnedTodoExpanded:{workspaceId}"
  */
@@ -797,6 +805,7 @@ export function getPostCompactionStateKey(workspaceId: string): string {
 const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> = [
   getPendingWorkspaceSendErrorKey,
   getNotifyOnResponseKey,
+  getScheduledPromptsKey, // Avoid duplicating future sends when a workspace is forked
   getPlanContentKey, // Cache only, no need to preserve on fork
   getPostCompactionStateKey, // Cache only, no need to preserve on fork
 ];

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -211,6 +211,14 @@ export function getInputKey(workspaceId: string): string {
 }
 
 /**
+ * Get the localStorage key for scheduled prompts for a workspace.
+ * Format: "scheduledPrompts:{workspaceId}"
+ */
+export function getScheduledPromptsKey(workspaceId: string): string {
+  return `scheduledPrompts:${workspaceId}`;
+}
+
+/**
  * Get the localStorage key for the pinned TODO panel expansion state.
  * Format: "pinnedTodoExpanded:{workspaceId}"
  */
@@ -781,6 +789,7 @@ export function getPostCompactionStateKey(workspaceId: string): string {
 const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> = [
   getPendingWorkspaceSendErrorKey,
   getNotifyOnResponseKey,
+  getScheduledPromptsKey, // Avoid duplicating future sends when a workspace is forked
   getPlanContentKey, // Cache only, no need to preserve on fork
   getPostCompactionStateKey, // Cache only, no need to preserve on fork
 ];


### PR DESCRIPTION
## Summary

Adds a workspace-scoped scheduled prompt queue in the right sidebar. Users can schedule a text prompt for a future local time, choose whether it should dispatch after the current step or after the current turn, run it immediately, delete it, and see sent, failed, sending, or blocked state directly in the Schedule tab.

## Background

Part of #3417. This PR implements the conservative manual scheduling MVP for quota-reset or overnight continuation workflows. Automatic rate-limit reset detection remains out of scope because it likely needs backend/provider-specific signal plumbing rather than a purely local UI queue.

## Implementation

- Adds a `Schedule` right-sidebar tab with prompt text, `datetime-local` scheduling, dispatch-mode selection, run-now/delete controls, and lifecycle badges.
- Stores scheduled prompts per workspace in localStorage and normalizes stale or malformed entries before rendering or dispatching.
- Mounts an active-workspace dispatcher so due prompts are sent through the existing `workspace.sendMessage` API using the current send options, without mutating the visible composer draft.
- Guards scheduling availability for transcript-only, incompatible-runtime, and delegated-task workspaces so the tab and command palette only expose scheduling where dispatch can run.
- Uses a shared localStorage dispatch lock so multiple renderer windows do not concurrently send the same due prompt.
- Observes scheduled-prompt storage writes across runnable workspaces so another mounted workspace can dispatch due prompts without requiring that workspace's tab to be focused.
- Preserves current chat-instruction context for scheduled sends and formats structured send failures through the existing `SendMessageError` formatter.
- Cleans scheduled prompts when a workspace is deleted, but does not copy them when a workspace is forked to avoid duplicating future automated sends.

## Validation

- `bun test --timeout=10000 src/browser/features/ScheduledPrompts/useScheduledPromptDispatcher.test.tsx src/browser/features/ScheduledPrompts/scheduledPrompts.test.ts src/browser/features/ScheduledPrompts/scheduledPromptAvailability.test.ts src/browser/features/ScheduledPrompts/scheduledPromptDispatcherTargets.test.ts src/common/constants/storage.test.ts` - 21 tests passed
- focused ESLint for ScheduledPrompts, App, right-sidebar tab config/registry/labels, and storage files
- `./node_modules/.bin/tsgo --noEmit --project tsconfig.json`
- `git diff --check origin/main...HEAD`
- `make static-check`

## Risks

The dispatcher is renderer-local and runs while the app has mounted workspace state; it is not a background daemon that can wake a closed app. Scheduled prompts are text-only in this first pass, so attachment scheduling and command parsing can be layered on later if maintainers want them. Automatic rate-limit reset detection, provider availability checks, allowed run windows, and retry policies are intentionally left for follow-up work.

---

_Generated with `mux` • Model: `GPT-5` • Thinking: `unknown` • Cost: `$unknown`_

<!-- mux-attribution: model=GPT-5 thinking=unknown costs=unknown -->
