### PR TITLE
🤖 feat: add prompt history sidebar

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -89,6 +89,7 @@ import { useTranscriptDensity } from "@/browser/hooks/useTranscriptDensity";
 import { useReviews } from "@/browser/hooks/useReviews";
 import { ReviewsBanner } from "../ReviewsBanner/ReviewsBanner";
 import type { ReviewNoteData } from "@/common/types/review";
+import { CUSTOM_EVENTS, type CustomEventPayloads } from "@/common/constants/events";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import {
   useBackgroundBashActions,
@@ -729,6 +730,24 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     },
     [contentRef, disableAutoScroll]
   );
+
+  useEffect(() => {
+    const handler = (
+      event: CustomEvent<CustomEventPayloads[typeof CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]>
+    ) => {
+      if (event.detail.workspaceId !== workspaceId) {
+        return;
+      }
+      handleNavigateToMessage(event.detail.historyId);
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE, handler as EventListener);
+    return () =>
+      window.removeEventListener(
+        CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE,
+        handler as EventListener
+      );
+  }, [handleNavigateToMessage, workspaceId]);
 
   // Precompute per-user navigation objects so MessageRenderer rows receive stable prop
   // references across non-message updates (usage bumps, stats updates, etc.).

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -89,6 +89,7 @@ import { useTranscriptDensity } from "@/browser/hooks/useTranscriptDensity";
 import { useReviews } from "@/browser/hooks/useReviews";
 import { ReviewsBanner } from "../ReviewsBanner/ReviewsBanner";
 import type { ReviewNoteData } from "@/common/types/review";
+import { CUSTOM_EVENTS, type CustomEventPayloads } from "@/common/constants/events";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import {
   useBackgroundBashActions,
@@ -732,6 +733,24 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     },
     [contentRef, disableAutoScroll]
   );
+
+  useEffect(() => {
+    const handler = (
+      event: CustomEvent<CustomEventPayloads[typeof CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]>
+    ) => {
+      if (event.detail.workspaceId !== workspaceId) {
+        return;
+      }
+      handleNavigateToMessage(event.detail.historyId);
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE, handler as EventListener);
+    return () =>
+      window.removeEventListener(
+        CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE,
+        handler as EventListener
+      );
+  }, [handleNavigateToMessage, workspaceId]);
 
   // Precompute per-user navigation objects so MessageRenderer rows receive stable prop
   // references across non-message updates (usage bumps, stats updates, etc.).

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -143,6 +143,7 @@ import {
   buildPendingFromRestoredInput,
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
+  mergeNewAttachedReviewsIntoDraft,
   type PendingUserMessage,
   type RestoredDraftPayload,
 } from "@/browser/utils/chatEditing";
@@ -211,6 +212,7 @@ import { appendStagedAttachmentNotice, getStagedAttachments } from "./stagedAtta
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 const AWAITING_NEW_ATTACHED_REVIEWS = Symbol("awaiting-new-attached-reviews");
+const EMPTY_ATTACHED_REVIEWS: Review[] = [];
 
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
@@ -511,9 +513,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const workspaceIdForComposerClear = variant === "workspace" ? props.workspaceId : null;
   const onDetachAllReviewsForComposerClear =
     variant === "workspace" ? props.onDetachAllReviews : undefined;
+  const onDetachReviewForDraftMerge = variant === "workspace" ? props.onDetachReview : undefined;
 
   // draftReviews takes precedence when restoring or editing message drafts.
-  const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
+  const attachedReviews =
+    variant === "workspace"
+      ? (props.attachedReviews ?? EMPTY_ATTACHED_REVIEWS)
+      : EMPTY_ATTACHED_REVIEWS;
   const [draftMuxMetadataOverride, setDraftMuxMetadataOverride] = useState<
     MuxMessageMetadata | undefined
   >(undefined);
@@ -535,6 +541,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
     null
   );
+  const draftReviewMergedAttachedIdsRef = useRef<Set<string> | null>(null);
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -599,6 +606,29 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setDraftReviews(null);
     }
   }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
+
+  // Restored drafts with review notes own their review list, but reviews attached later
+  // from the Code Review tab should still be visible and sent with that draft.
+  useEffect(() => {
+    const mergedAttachedReviewIds = draftReviewMergedAttachedIdsRef.current;
+    if (draftReviews === null || mergedAttachedReviewIds === null || attachedReviews.length === 0) {
+      return;
+    }
+
+    const result = mergeNewAttachedReviewsIntoDraft({
+      draftReviews,
+      attachedReviews,
+      mergedAttachedReviewIds,
+    });
+    draftReviewMergedAttachedIdsRef.current = result.mergedAttachedReviewIds;
+
+    if (result.reviews !== draftReviews) {
+      setDraftReviews(result.reviews);
+      for (const reviewId of result.addedReviewIds) {
+        onDetachReviewForDraftMerge?.(reviewId);
+      }
+    }
+  }, [attachedReviewIdsSignature, attachedReviews, draftReviews, onDetachReviewForDraftMerge]);
 
   // Creation sends can resolve after navigation; guard draft clears on unmounted inputs.
   const isMountedRef = useRef(true);
@@ -1305,6 +1335,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       const restoredAttachments = applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
+      draftReviewMergedAttachedIdsRef.current =
+        pending.reviews.length > 0 ? new Set(attachedReviews.map((review) => review.id)) : null;
       setDraftMuxMetadataOverrideForDraft(pending.muxMetadata, {
         text: pending.content,
         attachments: restoredAttachments,
@@ -1312,18 +1344,22 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       });
       focusMessageInput();
     },
-    [applyDraftFromPending, focusMessageInput, setDraftMuxMetadataOverrideForDraft]
+    [applyDraftFromPending, attachedReviews, focusMessageInput, setDraftMuxMetadataOverrideForDraft]
   );
 
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
+    draftReviewMergedAttachedIdsRef.current =
+      preEditReviewsRef.current && preEditReviewsRef.current.length > 0
+        ? new Set(attachedReviews.map((review) => review.id))
+        : null;
     setDraftMuxMetadataOverrideForDraft(preEditMuxMetadataOverrideRef.current, {
       text: preEditDraftRef.current.text,
       attachments: preEditDraftRef.current.attachments,
       reviews: preEditReviewsRef.current ?? undefined,
     });
-  }, [setDraft, setDraftReviews, setDraftMuxMetadataOverrideForDraft]);
+  }, [attachedReviews, setDraft, setDraftReviews, setDraftMuxMetadataOverrideForDraft]);
 
   // Method to restore text to input (used by compaction cancel)
   const restoreText = useCallback(
@@ -1420,6 +1456,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         `edit-${editingMessage.id}`
       );
       setDraftReviews(editingMessage.pending.reviews);
+      draftReviewMergedAttachedIdsRef.current =
+        editingMessage.pending.reviews.length > 0
+          ? new Set(attachedReviews.map((review) => review.id))
+          : null;
       setDraftMuxMetadataOverrideForDraft(editingMessage.pending.muxMetadata, {
         text: editingMessage.pending.content,
         attachments: editingAttachments,
@@ -2940,6 +2980,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
+          draftReviewMergedAttachedIdsRef.current =
+            preSendReviews && preSendReviews.length > 0
+              ? new Set(attachedReviews.map((review) => review.id))
+              : null;
           setDraftMuxMetadataOverrideForDraft(preSendMuxMetadataOverride, {
             text: preSendDraft.text,
             attachments: preSendDraft.attachments,
@@ -2992,6 +3036,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
+        draftReviewMergedAttachedIdsRef.current =
+          preSendReviews && preSendReviews.length > 0
+            ? new Set(attachedReviews.map((review) => review.id))
+            : null;
         setDraftMuxMetadataOverrideForDraft(preSendMuxMetadataOverride, {
           text: preSendDraft.text,
           attachments: preSendDraft.attachments,

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -207,6 +207,8 @@ import { isGoalRunning } from "@/common/types/goal";
 import { appendStagedAttachmentNotice, getStagedAttachments } from "./stagedAttachments";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
+const AWAITING_NEW_ATTACHED_REVIEWS = Symbol("awaiting-new-attached-reviews");
+
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
 
@@ -509,6 +511,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // draftReviews takes precedence when restoring or editing message drafts.
   const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
+  const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
+  const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
+    null
+  );
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -548,6 +554,31 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       next[reviewIndex] = updatedReview;
       return next;
     });
+
+  // Empty review replacements clear the current parent-attached reviews but should not hide
+  // reviews attached later from the Code Review tab.
+  useEffect(() => {
+    if (
+      draftReviews === null ||
+      draftReviews.length > 0 ||
+      clearedAttachedReviewIdsRef.current === null
+    ) {
+      return;
+    }
+
+    if (attachedReviews.length === 0) {
+      clearedAttachedReviewIdsRef.current = AWAITING_NEW_ATTACHED_REVIEWS;
+      return;
+    }
+
+    if (
+      clearedAttachedReviewIdsRef.current === AWAITING_NEW_ATTACHED_REVIEWS ||
+      clearedAttachedReviewIdsRef.current !== attachedReviewIdsSignature
+    ) {
+      clearedAttachedReviewIdsRef.current = null;
+      setDraftReviews(null);
+    }
+  }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
 
   // Creation sends can resolve after navigation; guard draft clears on unmounted inputs.
   const isMountedRef = useRef(true);
@@ -1780,12 +1811,21 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const hasFileParts = restoredPending.fileParts.length > 0;
       const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
       const hasReviews = restoredPending.reviews.length > 0;
+      const hasDraftReplacementPayload = fileParts !== undefined || reviews !== undefined;
 
       if (mode === "replace") {
         if (editingMessageForUi) {
           return;
         }
-        if (hasFileParts || hasStagedAttachments || hasReviews) {
+        if (hasDraftReplacementPayload) {
+          onDetachAllReviewsForComposerClear?.();
+          const clearsReviews = reviews === undefined || reviews.length === 0;
+          if (clearsReviews) {
+            clearedAttachedReviewIdsRef.current = attachedReviewIdsSignature;
+          } else {
+            clearedAttachedReviewIdsRef.current = null;
+          }
+
           restoreDraft(restoredPending);
         } else {
           restoreText(restoredPending.content);
@@ -1809,11 +1849,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       window.removeEventListener(CUSTOM_EVENTS.UPDATE_CHAT_INPUT, handler as EventListener);
   }, [
     appendText,
-    restoreText,
-    restoreDraft,
     applyDraftFromPending,
-    getDraft,
+    attachedReviewIdsSignature,
     editingMessageForUi,
+    getDraft,
+    onDetachAllReviewsForComposerClear,
+    restoreDraft,
+    restoreText,
     workspaceIdForComposerClear,
   ]);
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -542,6 +542,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     null
   );
   const draftReviewMergedAttachedIdsRef = useRef<Set<string> | null>(null);
+  const draftReviewIdsForCheckRef = useRef(new Map<string, string>());
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -567,9 +568,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     });
 
   const removeDraftReview = (reviewId: string) =>
-    withDraftReview(reviewId, (prev, reviewIndex) =>
-      prev.filter((_, index) => index !== reviewIndex)
-    );
+    withDraftReview(reviewId, (prev, reviewIndex) => {
+      draftReviewIdsForCheckRef.current.delete(reviewId);
+      return prev.filter((_, index) => index !== reviewIndex);
+    });
 
   const updateDraftReviewNote = (reviewId: string, newNote: string) =>
     withDraftReview(reviewId, (prev, reviewIndex) => {
@@ -604,6 +606,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     ) {
       clearedAttachedReviewIdsRef.current = null;
       setDraftReviews(null);
+      draftReviewIdsForCheckRef.current.clear();
     }
   }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
 
@@ -625,6 +628,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (result.reviews !== draftReviews) {
       setDraftReviews(result.reviews);
       for (const reviewId of result.addedReviewIds) {
+        const review = attachedReviews.find((attachedReview) => attachedReview.id === reviewId);
+        if (review) {
+          draftReviewIdsForCheckRef.current.set(getDraftReviewId(review.data), review.id);
+        }
         onDetachReviewForDraftMerge?.(reviewId);
       }
     }
@@ -1148,7 +1155,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     sourceSignature: draftMuxMetadataSourceSignatureRef.current,
     muxMetadata: draftMuxMetadataOverride,
   });
-  const reviewIdsForCheck = reviewOverrideActive ? [] : attachedReviews.map((review) => review.id);
+  const reviewIdsForCheck = reviewOverrideActive
+    ? [...draftReviewIdsForCheckRef.current.values()]
+    : attachedReviews.map((review) => review.id);
   const reviewPanelItems: Review[] = reviewOverrideActive
     ? draftReviewItems.map((data) => ({
         id: getDraftReviewId(data),
@@ -1335,6 +1344,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       const restoredAttachments = applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
+      draftReviewIdsForCheckRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         pending.reviews.length > 0 ? new Set(attachedReviews.map((review) => review.id)) : null;
       setDraftMuxMetadataOverrideForDraft(pending.muxMetadata, {
@@ -1350,6 +1360,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
+    draftReviewIdsForCheckRef.current.clear();
     draftReviewMergedAttachedIdsRef.current =
       preEditReviewsRef.current && preEditReviewsRef.current.length > 0
         ? new Set(attachedReviews.map((review) => review.id))
@@ -1456,6 +1467,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         `edit-${editingMessage.id}`
       );
       setDraftReviews(editingMessage.pending.reviews);
+      draftReviewIdsForCheckRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         editingMessage.pending.reviews.length > 0
           ? new Set(attachedReviews.map((review) => review.id))
@@ -1963,6 +1975,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
+      draftReviewIdsForCheckRef.current.clear();
       clearDraftMuxMetadataOverride();
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
@@ -2402,6 +2415,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
+      draftReviewIdsForCheckRef.current.clear();
       clearDraftMuxMetadataOverride();
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
@@ -2807,6 +2821,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
       const preSendMuxMetadataOverride = activeDraftMuxMetadataOverride;
+      const preSendDraftReviewIdsForCheck = new Map(draftReviewIdsForCheckRef.current);
       const editMessageForSend = editingMessageForUi;
 
       try {
@@ -2920,6 +2935,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
+        draftReviewIdsForCheckRef.current.clear();
         clearDraftMuxMetadataOverride();
         setAttachments([]);
         setHideReviewsDuringSend(true);
@@ -2980,6 +2996,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
+          draftReviewIdsForCheckRef.current = new Map(preSendDraftReviewIdsForCheck);
           draftReviewMergedAttachedIdsRef.current =
             preSendReviews && preSendReviews.length > 0
               ? new Set(attachedReviews.map((review) => review.id))
@@ -3014,6 +3031,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           if (sentReviewIds.length > 0) {
             props.onCheckReviews?.(sentReviewIds);
           }
+          draftReviewIdsForCheckRef.current.clear();
 
           // Exit editing mode if we were editing
           if (editMessageForSend && props.onCancelEdit) {
@@ -3036,6 +3054,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
+        draftReviewIdsForCheckRef.current = new Map(preSendDraftReviewIdsForCheck);
         draftReviewMergedAttachedIdsRef.current =
           preSendReviews && preSendReviews.length > 0
             ? new Set(attachedReviews.map((review) => review.id))

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -214,12 +214,14 @@ import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 const AWAITING_NEW_ATTACHED_REVIEWS = Symbol("awaiting-new-attached-reviews");
 const EMPTY_ATTACHED_REVIEWS: Review[] = [];
-type DraftReviewCheckIdsBySignature = Map<string, Set<string>>;
+type DraftReviewCheckIdsByDraftId = Map<string, Set<string>>;
 
-function cloneDraftReviewCheckIdsBySignature(
-  source: DraftReviewCheckIdsBySignature
-): DraftReviewCheckIdsBySignature {
-  return new Map(Array.from(source, ([signature, reviewIds]) => [signature, new Set(reviewIds)]));
+function cloneDraftReviewCheckIdsByDraftId(
+  source: DraftReviewCheckIdsByDraftId
+): DraftReviewCheckIdsByDraftId {
+  return new Map(
+    Array.from(source, ([draftReviewId, reviewIds]) => [draftReviewId, new Set(reviewIds)])
+  );
 }
 
 // localStorage quotas are environment-dependent and relatively small.
@@ -550,7 +552,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     null
   );
   const draftReviewMergedAttachedIdsRef = useRef<Set<string> | null>(null);
-  const draftReviewCheckIdsBySignatureRef = useRef<DraftReviewCheckIdsBySignature>(new Map());
+  const draftReviewCheckIdsByDraftIdRef = useRef<DraftReviewCheckIdsByDraftId>(new Map());
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -577,10 +579,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const removeDraftReview = (reviewId: string) =>
     withDraftReview(reviewId, (prev, reviewIndex) => {
-      const review = prev[reviewIndex];
-      if (review) {
-        draftReviewCheckIdsBySignatureRef.current.delete(getReviewNoteSignature(review));
-      }
+      draftReviewCheckIdsByDraftIdRef.current.delete(reviewId);
       return prev.filter((_, index) => index !== reviewIndex);
     });
 
@@ -617,7 +616,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     ) {
       clearedAttachedReviewIdsRef.current = null;
       setDraftReviews(null);
-      draftReviewCheckIdsBySignatureRef.current.clear();
+      draftReviewCheckIdsByDraftIdRef.current.clear();
     }
   }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
 
@@ -644,11 +643,17 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const review = attachedReviews.find((attachedReview) => attachedReview.id === reviewId);
       if (review) {
         const signature = getReviewNoteSignature(review.data);
-        const reviewIds = draftReviewCheckIdsBySignatureRef.current.get(signature);
-        if (reviewIds) {
-          reviewIds.add(review.id);
-        } else {
-          draftReviewCheckIdsBySignatureRef.current.set(signature, new Set([review.id]));
+        const draftReview = result.reviews.find(
+          (draftReview) => getReviewNoteSignature(draftReview) === signature
+        );
+        if (draftReview) {
+          const draftReviewId = getDraftReviewId(draftReview);
+          const reviewIds = draftReviewCheckIdsByDraftIdRef.current.get(draftReviewId);
+          if (reviewIds) {
+            reviewIds.add(review.id);
+          } else {
+            draftReviewCheckIdsByDraftIdRef.current.set(draftReviewId, new Set([review.id]));
+          }
         }
       }
       onDetachReviewForDraftMerge?.(reviewId);
@@ -1177,9 +1182,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     ? [
         ...new Set(
           draftReviewItems.flatMap((review) =>
-            Array.from(
-              draftReviewCheckIdsBySignatureRef.current.get(getReviewNoteSignature(review)) ?? []
-            )
+            Array.from(draftReviewCheckIdsByDraftIdRef.current.get(getDraftReviewId(review)) ?? [])
           )
         ),
       ]
@@ -1370,7 +1373,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       const restoredAttachments = applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
-      draftReviewCheckIdsBySignatureRef.current.clear();
+      draftReviewCheckIdsByDraftIdRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         pending.reviews.length > 0 ? new Set(attachedReviews.map((review) => review.id)) : null;
       setDraftMuxMetadataOverrideForDraft(pending.muxMetadata, {
@@ -1386,7 +1389,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
-    draftReviewCheckIdsBySignatureRef.current.clear();
+    draftReviewCheckIdsByDraftIdRef.current.clear();
     draftReviewMergedAttachedIdsRef.current =
       preEditReviewsRef.current && preEditReviewsRef.current.length > 0
         ? new Set(attachedReviews.map((review) => review.id))
@@ -1493,7 +1496,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         `edit-${editingMessage.id}`
       );
       setDraftReviews(editingMessage.pending.reviews);
-      draftReviewCheckIdsBySignatureRef.current.clear();
+      draftReviewCheckIdsByDraftIdRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         editingMessage.pending.reviews.length > 0
           ? new Set(attachedReviews.map((review) => review.id))
@@ -2001,7 +2004,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
-      draftReviewCheckIdsBySignatureRef.current.clear();
+      draftReviewCheckIdsByDraftIdRef.current.clear();
       clearDraftMuxMetadataOverride();
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
@@ -2441,7 +2444,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
-      draftReviewCheckIdsBySignatureRef.current.clear();
+      draftReviewCheckIdsByDraftIdRef.current.clear();
       clearDraftMuxMetadataOverride();
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
@@ -2847,8 +2850,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
       const preSendMuxMetadataOverride = activeDraftMuxMetadataOverride;
-      const preSendDraftReviewCheckIdsBySignature = cloneDraftReviewCheckIdsBySignature(
-        draftReviewCheckIdsBySignatureRef.current
+      const preSendDraftReviewCheckIdsByDraftId = cloneDraftReviewCheckIdsByDraftId(
+        draftReviewCheckIdsByDraftIdRef.current
       );
       const editMessageForSend = editingMessageForUi;
 
@@ -2963,7 +2966,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
-        draftReviewCheckIdsBySignatureRef.current.clear();
+        draftReviewCheckIdsByDraftIdRef.current.clear();
         clearDraftMuxMetadataOverride();
         setAttachments([]);
         setHideReviewsDuringSend(true);
@@ -3024,8 +3027,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
-          draftReviewCheckIdsBySignatureRef.current = cloneDraftReviewCheckIdsBySignature(
-            preSendDraftReviewCheckIdsBySignature
+          draftReviewCheckIdsByDraftIdRef.current = cloneDraftReviewCheckIdsByDraftId(
+            preSendDraftReviewCheckIdsByDraftId
           );
           draftReviewMergedAttachedIdsRef.current =
             preSendReviews && preSendReviews.length > 0
@@ -3061,7 +3064,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           if (sentReviewIds.length > 0) {
             props.onCheckReviews?.(sentReviewIds);
           }
-          draftReviewCheckIdsBySignatureRef.current.clear();
+          draftReviewCheckIdsByDraftIdRef.current.clear();
 
           // Exit editing mode if we were editing
           if (editMessageForSend && props.onCancelEdit) {
@@ -3084,8 +3087,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
-        draftReviewCheckIdsBySignatureRef.current = cloneDraftReviewCheckIdsBySignature(
-          preSendDraftReviewCheckIdsBySignature
+        draftReviewCheckIdsByDraftIdRef.current = cloneDraftReviewCheckIdsByDraftId(
+          preSendDraftReviewCheckIdsByDraftId
         );
         draftReviewMergedAttachedIdsRef.current =
           preSendReviews && preSendReviews.length > 0

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -141,6 +141,7 @@ import {
 } from "@/browser/utils/attachmentsHandling";
 import {
   buildPendingFromRestoredInput,
+  getReviewNoteSignature,
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
   mergeNewAttachedReviewsIntoDraft,
@@ -542,7 +543,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     null
   );
   const draftReviewMergedAttachedIdsRef = useRef<Set<string> | null>(null);
-  const draftReviewIdsForCheckRef = useRef(new Map<string, string>());
+  const draftReviewCheckIdsBySignatureRef = useRef(new Map<string, string>());
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -569,7 +570,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const removeDraftReview = (reviewId: string) =>
     withDraftReview(reviewId, (prev, reviewIndex) => {
-      draftReviewIdsForCheckRef.current.delete(reviewId);
+      const review = prev[reviewIndex];
+      if (review) {
+        draftReviewCheckIdsBySignatureRef.current.delete(getReviewNoteSignature(review));
+      }
       return prev.filter((_, index) => index !== reviewIndex);
     });
 
@@ -606,7 +610,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     ) {
       clearedAttachedReviewIdsRef.current = null;
       setDraftReviews(null);
-      draftReviewIdsForCheckRef.current.clear();
+      draftReviewCheckIdsBySignatureRef.current.clear();
     }
   }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
 
@@ -627,13 +631,17 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     if (result.reviews !== draftReviews) {
       setDraftReviews(result.reviews);
-      for (const reviewId of result.addedReviewIds) {
-        const review = attachedReviews.find((attachedReview) => attachedReview.id === reviewId);
-        if (review) {
-          draftReviewIdsForCheckRef.current.set(getDraftReviewId(review.data), review.id);
-        }
-        onDetachReviewForDraftMerge?.(reviewId);
+    }
+
+    for (const reviewId of result.mergedReviewIds) {
+      const review = attachedReviews.find((attachedReview) => attachedReview.id === reviewId);
+      if (review) {
+        draftReviewCheckIdsBySignatureRef.current.set(
+          getReviewNoteSignature(review.data),
+          review.id
+        );
       }
+      onDetachReviewForDraftMerge?.(reviewId);
     }
   }, [attachedReviewIdsSignature, attachedReviews, draftReviews, onDetachReviewForDraftMerge]);
 
@@ -1156,7 +1164,15 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     muxMetadata: draftMuxMetadataOverride,
   });
   const reviewIdsForCheck = reviewOverrideActive
-    ? [...draftReviewIdsForCheckRef.current.values()]
+    ? [
+        ...new Set(
+          draftReviewItems
+            .map((review) =>
+              draftReviewCheckIdsBySignatureRef.current.get(getReviewNoteSignature(review))
+            )
+            .filter((reviewId): reviewId is string => reviewId !== undefined)
+        ),
+      ]
     : attachedReviews.map((review) => review.id);
   const reviewPanelItems: Review[] = reviewOverrideActive
     ? draftReviewItems.map((data) => ({
@@ -1344,7 +1360,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       const restoredAttachments = applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
-      draftReviewIdsForCheckRef.current.clear();
+      draftReviewCheckIdsBySignatureRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         pending.reviews.length > 0 ? new Set(attachedReviews.map((review) => review.id)) : null;
       setDraftMuxMetadataOverrideForDraft(pending.muxMetadata, {
@@ -1360,7 +1376,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
-    draftReviewIdsForCheckRef.current.clear();
+    draftReviewCheckIdsBySignatureRef.current.clear();
     draftReviewMergedAttachedIdsRef.current =
       preEditReviewsRef.current && preEditReviewsRef.current.length > 0
         ? new Set(attachedReviews.map((review) => review.id))
@@ -1467,7 +1483,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         `edit-${editingMessage.id}`
       );
       setDraftReviews(editingMessage.pending.reviews);
-      draftReviewIdsForCheckRef.current.clear();
+      draftReviewCheckIdsBySignatureRef.current.clear();
       draftReviewMergedAttachedIdsRef.current =
         editingMessage.pending.reviews.length > 0
           ? new Set(attachedReviews.map((review) => review.id))
@@ -1975,7 +1991,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
-      draftReviewIdsForCheckRef.current.clear();
+      draftReviewCheckIdsBySignatureRef.current.clear();
       clearDraftMuxMetadataOverride();
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
@@ -2415,7 +2431,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
-      draftReviewIdsForCheckRef.current.clear();
+      draftReviewCheckIdsBySignatureRef.current.clear();
       clearDraftMuxMetadataOverride();
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
@@ -2821,7 +2837,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
       const preSendMuxMetadataOverride = activeDraftMuxMetadataOverride;
-      const preSendDraftReviewIdsForCheck = new Map(draftReviewIdsForCheckRef.current);
+      const preSendDraftReviewCheckIdsBySignature = new Map(
+        draftReviewCheckIdsBySignatureRef.current
+      );
       const editMessageForSend = editingMessageForUi;
 
       try {
@@ -2935,7 +2953,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
-        draftReviewIdsForCheckRef.current.clear();
+        draftReviewCheckIdsBySignatureRef.current.clear();
         clearDraftMuxMetadataOverride();
         setAttachments([]);
         setHideReviewsDuringSend(true);
@@ -2996,7 +3014,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
-          draftReviewIdsForCheckRef.current = new Map(preSendDraftReviewIdsForCheck);
+          draftReviewCheckIdsBySignatureRef.current = new Map(
+            preSendDraftReviewCheckIdsBySignature
+          );
           draftReviewMergedAttachedIdsRef.current =
             preSendReviews && preSendReviews.length > 0
               ? new Set(attachedReviews.map((review) => review.id))
@@ -3031,7 +3051,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           if (sentReviewIds.length > 0) {
             props.onCheckReviews?.(sentReviewIds);
           }
-          draftReviewIdsForCheckRef.current.clear();
+          draftReviewCheckIdsBySignatureRef.current.clear();
 
           // Exit editing mode if we were editing
           if (editMessageForSend && props.onCancelEdit) {
@@ -3054,7 +3074,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
-        draftReviewIdsForCheckRef.current = new Map(preSendDraftReviewIdsForCheck);
+        draftReviewCheckIdsBySignatureRef.current = new Map(preSendDraftReviewCheckIdsBySignature);
         draftReviewMergedAttachedIdsRef.current =
           preSendReviews && preSendReviews.length > 0
             ? new Set(attachedReviews.map((review) => review.id))

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1880,6 +1880,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
+      setDraftMuxMetadataOverride(undefined);
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
         inputRef.current.style.height = "";

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -692,6 +692,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   );
   const preEditDraftRef = useRef<DraftState>({ text: "", attachments: [] });
   const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
+  const preEditMuxMetadataOverrideRef = useRef<MuxMessageMetadata | undefined>(undefined);
   const { open } = useSettings();
   const { selectedWorkspace } = useWorkspaceContext();
   const { agentId, currentAgent } = useAgent();
@@ -1285,6 +1286,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
+    setDraftMuxMetadataOverride(preEditMuxMetadataOverrideRef.current);
   }, [setDraft, setDraftReviews]);
 
   // Method to restore text to input (used by compaction cancel)
@@ -1375,8 +1377,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (editingMessage) {
       preEditDraftRef.current = getDraft();
       preEditReviewsRef.current = draftReviews;
+      preEditMuxMetadataOverrideRef.current = draftMuxMetadataOverride;
       applyDraftFromPending(editingMessage.pending, `edit-${editingMessage.id}`);
       setDraftReviews(editingMessage.pending.reviews);
+      setDraftMuxMetadataOverride(editingMessage.pending.muxMetadata);
       // Auto-resize textarea and focus
       setTimeout(() => {
         if (inputRef.current) {
@@ -1835,6 +1839,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
           restoreDraft(restoredPending);
         } else {
+          setDraftMuxMetadataOverride(undefined);
           restoreText(restoredPending.content);
         }
       } else if (hasFileParts || hasStagedAttachments || hasReviews) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -144,6 +144,7 @@ import {
   getReviewNoteSignature,
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
+  hasRestoredDraftReplacementPayload,
   mergeNewAttachedReviewsIntoDraft,
   releaseDraftReviewMergeTracking,
   type PendingUserMessage,
@@ -1951,8 +1952,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const hasFileParts = restoredPending.fileParts.length > 0;
       const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
       const hasReviews = restoredPending.reviews.length > 0;
-      const hasDraftReplacementPayload =
-        fileParts !== undefined || reviews !== undefined || muxMetadata !== undefined;
+      const hasDraftReplacementPayload = hasRestoredDraftReplacementPayload({
+        fileParts,
+        reviews,
+        muxMetadata,
+        stagedAttachments: restoredPending.stagedAttachments,
+      });
 
       if (mode === "replace") {
         if (editingMessageForUi) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1853,6 +1853,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
+      setDraftMuxMetadataOverride(undefined);
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
         inputRef.current.style.height = "";

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -511,6 +511,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // draftReviews takes precedence when restoring or editing message drafts.
   const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
+  const [draftMuxMetadataOverride, setDraftMuxMetadataOverride] = useState<
+    MuxMessageMetadata | undefined
+  >(undefined);
   const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
   const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
     null
@@ -1273,6 +1276,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
+      setDraftMuxMetadataOverride(pending.muxMetadata);
       focusMessageInput();
     },
     [applyDraftFromPending, focusMessageInput, setDraftReviews]
@@ -1791,6 +1795,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         fileParts?: FilePart[];
         reviews?: ReviewNoteDataForDisplay[];
         workspaceId?: string;
+        muxMetadata?: MuxMessageMetadata;
       }>;
 
       if (
@@ -1800,18 +1805,20 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         return;
       }
 
-      const { text, mode = "append", fileParts, reviews } = customEvent.detail;
+      const { text, mode = "append", fileParts, reviews, muxMetadata } = customEvent.detail;
       const restoredIdPrefix = `restored-${Date.now()}`;
       const restoredPending = buildPendingFromRestoredInput({
         content: text,
         fileParts: fileParts ?? [],
         reviews: reviews ?? [],
         idPrefix: restoredIdPrefix,
+        muxMetadata,
       });
       const hasFileParts = restoredPending.fileParts.length > 0;
       const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
       const hasReviews = restoredPending.reviews.length > 0;
-      const hasDraftReplacementPayload = fileParts !== undefined || reviews !== undefined;
+      const hasDraftReplacementPayload =
+        fileParts !== undefined || reviews !== undefined || muxMetadata !== undefined;
 
       if (mode === "replace") {
         if (editingMessageForUi) {
@@ -2286,6 +2293,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       onCancelEdit: commandOnCancelEdit,
       reviews: reviewsData,
       attachments,
+      followUpMuxMetadata: draftMuxMetadataOverride,
       fileParts: commandFileParts.length > 0 ? commandFileParts : undefined,
       onMessageSent: variant === "workspace" ? props.onMessageSent : undefined,
       onDetachAllReviews: variant === "workspace" ? props.onDetachAllReviews : undefined,
@@ -2299,6 +2307,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
+      setDraftMuxMetadataOverride(undefined);
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
           props.onCheckReviews?.(reviewIdsForCheck);
@@ -2702,6 +2711,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Save current draft state for restoration on error
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
+      const preSendMuxMetadataOverride = draftMuxMetadataOverride;
       const editMessageForSend = editingMessageForUi;
 
       try {
@@ -2747,6 +2757,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                       text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", attachments),
                       fileParts: sendFileParts,
                       reviews: reviewsData,
+                      muxMetadata: draftMuxMetadataOverride,
                     }
                   : undefined,
               model: parsed.model,
@@ -2814,6 +2825,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
+        setDraftMuxMetadataOverride(undefined);
         setAttachments([]);
         setHideReviewsDuringSend(true);
         // Clear inline height style - VimTextArea's useLayoutEffect will handle sizing
@@ -2873,6 +2885,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
+          setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
         } else {
           // Track telemetry for successful message send
           telemetry.messageSent(
@@ -2920,6 +2933,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
+        setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
       } finally {
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -201,6 +201,8 @@ import { isGoalRunning } from "@/common/types/goal";
 import { appendStagedAttachmentNotice, getStagedAttachments } from "./stagedAttachments";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
+const AWAITING_NEW_ATTACHED_REVIEWS = Symbol("awaiting-new-attached-reviews");
+
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
 
@@ -501,6 +503,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // draftReviews takes precedence when restoring or editing message drafts.
   const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
+  const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
+  const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
+    null
+  );
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -540,6 +546,31 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       next[reviewIndex] = updatedReview;
       return next;
     });
+
+  // Empty review replacements clear the current parent-attached reviews but should not hide
+  // reviews attached later from the Code Review tab.
+  useEffect(() => {
+    if (
+      draftReviews === null ||
+      draftReviews.length > 0 ||
+      clearedAttachedReviewIdsRef.current === null
+    ) {
+      return;
+    }
+
+    if (attachedReviews.length === 0) {
+      clearedAttachedReviewIdsRef.current = AWAITING_NEW_ATTACHED_REVIEWS;
+      return;
+    }
+
+    if (
+      clearedAttachedReviewIdsRef.current === AWAITING_NEW_ATTACHED_REVIEWS ||
+      clearedAttachedReviewIdsRef.current !== attachedReviewIdsSignature
+    ) {
+      clearedAttachedReviewIdsRef.current = null;
+      setDraftReviews(null);
+    }
+  }, [attachedReviewIdsSignature, attachedReviews.length, draftReviews]);
 
   // Creation sends can resolve after navigation; guard draft clears on unmounted inputs.
   const isMountedRef = useRef(true);
@@ -1754,12 +1785,21 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const hasFileParts = restoredPending.fileParts.length > 0;
       const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
       const hasReviews = restoredPending.reviews.length > 0;
+      const hasDraftReplacementPayload = fileParts !== undefined || reviews !== undefined;
 
       if (mode === "replace") {
         if (editingMessageForUi) {
           return;
         }
-        if (hasFileParts || hasStagedAttachments || hasReviews) {
+        if (hasDraftReplacementPayload) {
+          onDetachAllReviewsForComposerClear?.();
+          const clearsReviews = reviews === undefined || reviews.length === 0;
+          if (clearsReviews) {
+            clearedAttachedReviewIdsRef.current = attachedReviewIdsSignature;
+          } else {
+            clearedAttachedReviewIdsRef.current = null;
+          }
+
           restoreDraft(restoredPending);
         } else {
           restoreText(restoredPending.content);
@@ -1781,7 +1821,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     window.addEventListener(CUSTOM_EVENTS.UPDATE_CHAT_INPUT, handler as EventListener);
     return () =>
       window.removeEventListener(CUSTOM_EVENTS.UPDATE_CHAT_INPUT, handler as EventListener);
-  }, [appendText, restoreText, restoreDraft, applyDraftFromPending, getDraft, editingMessageForUi]);
+  }, [
+    appendText,
+    applyDraftFromPending,
+    attachedReviewIdsSignature,
+    editingMessageForUi,
+    getDraft,
+    onDetachAllReviewsForComposerClear,
+    restoreDraft,
+    restoreText,
+  ]);
 
   useEffect(() => {
     const handler = (event: CustomEvent<{ workspaceId: string }>) => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -684,6 +684,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   );
   const preEditDraftRef = useRef<DraftState>({ text: "", attachments: [] });
   const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
+  const preEditMuxMetadataOverrideRef = useRef<MuxMessageMetadata | undefined>(undefined);
   const { open } = useSettings();
   const { selectedWorkspace } = useWorkspaceContext();
   const { agentId, currentAgent } = useAgent();
@@ -1267,6 +1268,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
+    setDraftMuxMetadataOverride(preEditMuxMetadataOverrideRef.current);
   }, [setDraft, setDraftReviews]);
 
   // Method to restore text to input (used by compaction cancel)
@@ -1357,8 +1359,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (editingMessage) {
       preEditDraftRef.current = getDraft();
       preEditReviewsRef.current = draftReviews;
+      preEditMuxMetadataOverrideRef.current = draftMuxMetadataOverride;
       applyDraftFromPending(editingMessage.pending, `edit-${editingMessage.id}`);
       setDraftReviews(editingMessage.pending.reviews);
+      setDraftMuxMetadataOverride(editingMessage.pending.muxMetadata);
       // Auto-resize textarea and focus
       setTimeout(() => {
         if (inputRef.current) {
@@ -1809,6 +1813,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
           restoreDraft(restoredPending);
         } else {
+          setDraftMuxMetadataOverride(undefined);
           restoreText(restoredPending.content);
         }
       } else if (hasFileParts || hasStagedAttachments || hasReviews) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -145,6 +145,7 @@ import {
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
   mergeNewAttachedReviewsIntoDraft,
+  releaseDraftReviewMergeTracking,
   type PendingUserMessage,
   type RestoredDraftPayload,
 } from "@/browser/utils/chatEditing";
@@ -579,7 +580,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const removeDraftReview = (reviewId: string) =>
     withDraftReview(reviewId, (prev, reviewIndex) => {
-      draftReviewCheckIdsByDraftIdRef.current.delete(reviewId);
+      releaseDraftReviewMergeTracking({
+        draftReviewId: reviewId,
+        checkIdsByDraftId: draftReviewCheckIdsByDraftIdRef.current,
+        mergedAttachedReviewIds: draftReviewMergedAttachedIdsRef.current,
+      });
       return prev.filter((_, index) => index !== reviewIndex);
     });
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -141,8 +141,10 @@ import {
 } from "@/browser/utils/attachmentsHandling";
 import {
   buildPendingFromRestoredInput,
-  getRestoredMuxMetadataForCurrentText,
+  getRestoredDraftPayloadSignature,
+  getRestoredMuxMetadataForCurrentDraft,
   type PendingUserMessage,
+  type RestoredDraftPayload,
 } from "@/browser/utils/chatEditing";
 
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
@@ -515,23 +517,20 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [draftMuxMetadataOverride, setDraftMuxMetadataOverride] = useState<
     MuxMessageMetadata | undefined
   >(undefined);
-  const draftMuxMetadataSourceTextRef = useRef<string | null>(null);
-  const setDraftMuxMetadataOverrideForContent = useCallback(
-    (metadata: MuxMessageMetadata | undefined, content: string) => {
-      draftMuxMetadataSourceTextRef.current = metadata ? content : null;
+  const draftMuxMetadataSourceSignatureRef = useRef<string | null>(null);
+  const setDraftMuxMetadataOverrideForDraft = useCallback(
+    (metadata: MuxMessageMetadata | undefined, draft: RestoredDraftPayload) => {
+      draftMuxMetadataSourceSignatureRef.current = metadata
+        ? getRestoredDraftPayloadSignature(draft)
+        : null;
       setDraftMuxMetadataOverride(metadata);
     },
     []
   );
   const clearDraftMuxMetadataOverride = useCallback(() => {
-    draftMuxMetadataSourceTextRef.current = null;
+    draftMuxMetadataSourceSignatureRef.current = null;
     setDraftMuxMetadataOverride(undefined);
   }, []);
-  const activeDraftMuxMetadataOverride = getRestoredMuxMetadataForCurrentText({
-    currentText: input,
-    sourceText: draftMuxMetadataSourceTextRef.current,
-    muxMetadata: draftMuxMetadataOverride,
-  });
   const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
   const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
     null
@@ -1110,6 +1109,15 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     : attachedReviews.length > 0
       ? attachedReviews.map((review) => review.data)
       : undefined;
+  const activeDraftMuxMetadataOverride = getRestoredMuxMetadataForCurrentDraft({
+    currentDraft: {
+      text: input,
+      attachments,
+      reviews: reviewData,
+    },
+    sourceSignature: draftMuxMetadataSourceSignatureRef.current,
+    muxMetadata: draftMuxMetadataOverride,
+  });
   const reviewIdsForCheck = reviewOverrideActive ? [] : attachedReviews.map((review) => review.id);
   const reviewPanelItems: Review[] = reviewOverrideActive
     ? draftReviewItems.map((data) => ({
@@ -1282,10 +1290,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         ...attachment,
         id: `${attachmentKeyPrefix}-staged-${index}`,
       }));
+      const nextAttachments = [...providerAttachments, ...stagedAttachments];
       setDraft({
         text: pending.content,
-        attachments: [...providerAttachments, ...stagedAttachments],
+        attachments: nextAttachments,
       });
+      return nextAttachments;
     },
     [setDraft]
   );
@@ -1293,22 +1303,27 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   // Restore a full pending draft (text + attachments + reviews), e.g. queued message edits.
   const restoreDraft = useCallback(
     (pending: PendingUserMessage) => {
-      applyDraftFromPending(pending, `restored-${Date.now()}`);
+      const restoredAttachments = applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
-      setDraftMuxMetadataOverrideForContent(pending.muxMetadata, pending.content);
+      setDraftMuxMetadataOverrideForDraft(pending.muxMetadata, {
+        text: pending.content,
+        attachments: restoredAttachments,
+        reviews: pending.reviews,
+      });
       focusMessageInput();
     },
-    [applyDraftFromPending, focusMessageInput, setDraftMuxMetadataOverrideForContent]
+    [applyDraftFromPending, focusMessageInput, setDraftMuxMetadataOverrideForDraft]
   );
 
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
-    setDraftMuxMetadataOverrideForContent(
-      preEditMuxMetadataOverrideRef.current,
-      preEditDraftRef.current.text
-    );
-  }, [setDraft, setDraftReviews, setDraftMuxMetadataOverrideForContent]);
+    setDraftMuxMetadataOverrideForDraft(preEditMuxMetadataOverrideRef.current, {
+      text: preEditDraftRef.current.text,
+      attachments: preEditDraftRef.current.attachments,
+      reviews: preEditReviewsRef.current ?? undefined,
+    });
+  }, [setDraft, setDraftReviews, setDraftMuxMetadataOverrideForDraft]);
 
   // Method to restore text to input (used by compaction cancel)
   const restoreText = useCallback(
@@ -1400,12 +1415,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       preEditDraftRef.current = getDraft();
       preEditReviewsRef.current = draftReviews;
       preEditMuxMetadataOverrideRef.current = activeDraftMuxMetadataOverride;
-      applyDraftFromPending(editingMessage.pending, `edit-${editingMessage.id}`);
-      setDraftReviews(editingMessage.pending.reviews);
-      setDraftMuxMetadataOverrideForContent(
-        editingMessage.pending.muxMetadata,
-        editingMessage.pending.content
+      const editingAttachments = applyDraftFromPending(
+        editingMessage.pending,
+        `edit-${editingMessage.id}`
       );
+      setDraftReviews(editingMessage.pending.reviews);
+      setDraftMuxMetadataOverrideForDraft(editingMessage.pending.muxMetadata, {
+        text: editingMessage.pending.content,
+        attachments: editingAttachments,
+        reviews: editingMessage.pending.reviews,
+      });
       // Auto-resize textarea and focus
       setTimeout(() => {
         if (inputRef.current) {
@@ -2921,7 +2940,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
-          setDraftMuxMetadataOverrideForContent(preSendMuxMetadataOverride, preSendDraft.text);
+          setDraftMuxMetadataOverrideForDraft(preSendMuxMetadataOverride, {
+            text: preSendDraft.text,
+            attachments: preSendDraft.attachments,
+            reviews: preSendReviews ?? undefined,
+          });
         } else {
           // Track telemetry for successful message send
           telemetry.messageSent(
@@ -2969,7 +2992,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
-        setDraftMuxMetadataOverrideForContent(preSendMuxMetadataOverride, preSendDraft.text);
+        setDraftMuxMetadataOverrideForDraft(preSendMuxMetadataOverride, {
+          text: preSendDraft.text,
+          attachments: preSendDraft.attachments,
+          reviews: preSendReviews ?? undefined,
+        });
       } finally {
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -214,6 +214,13 @@ import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 const AWAITING_NEW_ATTACHED_REVIEWS = Symbol("awaiting-new-attached-reviews");
 const EMPTY_ATTACHED_REVIEWS: Review[] = [];
+type DraftReviewCheckIdsBySignature = Map<string, Set<string>>;
+
+function cloneDraftReviewCheckIdsBySignature(
+  source: DraftReviewCheckIdsBySignature
+): DraftReviewCheckIdsBySignature {
+  return new Map(Array.from(source, ([signature, reviewIds]) => [signature, new Set(reviewIds)]));
+}
 
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
@@ -543,7 +550,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     null
   );
   const draftReviewMergedAttachedIdsRef = useRef<Set<string> | null>(null);
-  const draftReviewCheckIdsBySignatureRef = useRef(new Map<string, string>());
+  const draftReviewCheckIdsBySignatureRef = useRef<DraftReviewCheckIdsBySignature>(new Map());
   const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
@@ -636,10 +643,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     for (const reviewId of result.mergedReviewIds) {
       const review = attachedReviews.find((attachedReview) => attachedReview.id === reviewId);
       if (review) {
-        draftReviewCheckIdsBySignatureRef.current.set(
-          getReviewNoteSignature(review.data),
-          review.id
-        );
+        const signature = getReviewNoteSignature(review.data);
+        const reviewIds = draftReviewCheckIdsBySignatureRef.current.get(signature);
+        if (reviewIds) {
+          reviewIds.add(review.id);
+        } else {
+          draftReviewCheckIdsBySignatureRef.current.set(signature, new Set([review.id]));
+        }
       }
       onDetachReviewForDraftMerge?.(reviewId);
     }
@@ -1166,11 +1176,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const reviewIdsForCheck = reviewOverrideActive
     ? [
         ...new Set(
-          draftReviewItems
-            .map((review) =>
-              draftReviewCheckIdsBySignatureRef.current.get(getReviewNoteSignature(review))
+          draftReviewItems.flatMap((review) =>
+            Array.from(
+              draftReviewCheckIdsBySignatureRef.current.get(getReviewNoteSignature(review)) ?? []
             )
-            .filter((reviewId): reviewId is string => reviewId !== undefined)
+          )
         ),
       ]
     : attachedReviews.map((review) => review.id);
@@ -2837,7 +2847,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
       const preSendMuxMetadataOverride = activeDraftMuxMetadataOverride;
-      const preSendDraftReviewCheckIdsBySignature = new Map(
+      const preSendDraftReviewCheckIdsBySignature = cloneDraftReviewCheckIdsBySignature(
         draftReviewCheckIdsBySignatureRef.current
       );
       const editMessageForSend = editingMessageForUi;
@@ -3014,7 +3024,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
-          draftReviewCheckIdsBySignatureRef.current = new Map(
+          draftReviewCheckIdsBySignatureRef.current = cloneDraftReviewCheckIdsBySignature(
             preSendDraftReviewCheckIdsBySignature
           );
           draftReviewMergedAttachedIdsRef.current =
@@ -3074,7 +3084,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
-        draftReviewCheckIdsBySignatureRef.current = new Map(preSendDraftReviewCheckIdsBySignature);
+        draftReviewCheckIdsBySignatureRef.current = cloneDraftReviewCheckIdsBySignature(
+          preSendDraftReviewCheckIdsBySignature
+        );
         draftReviewMergedAttachedIdsRef.current =
           preSendReviews && preSendReviews.length > 0
             ? new Set(attachedReviews.map((review) => review.id))

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -141,6 +141,7 @@ import {
 } from "@/browser/utils/attachmentsHandling";
 import {
   buildPendingFromRestoredInput,
+  getRestoredMuxMetadataForCurrentText,
   type PendingUserMessage,
 } from "@/browser/utils/chatEditing";
 
@@ -514,6 +515,23 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [draftMuxMetadataOverride, setDraftMuxMetadataOverride] = useState<
     MuxMessageMetadata | undefined
   >(undefined);
+  const draftMuxMetadataSourceTextRef = useRef<string | null>(null);
+  const setDraftMuxMetadataOverrideForContent = useCallback(
+    (metadata: MuxMessageMetadata | undefined, content: string) => {
+      draftMuxMetadataSourceTextRef.current = metadata ? content : null;
+      setDraftMuxMetadataOverride(metadata);
+    },
+    []
+  );
+  const clearDraftMuxMetadataOverride = useCallback(() => {
+    draftMuxMetadataSourceTextRef.current = null;
+    setDraftMuxMetadataOverride(undefined);
+  }, []);
+  const activeDraftMuxMetadataOverride = getRestoredMuxMetadataForCurrentText({
+    currentText: input,
+    sourceText: draftMuxMetadataSourceTextRef.current,
+    muxMetadata: draftMuxMetadataOverride,
+  });
   const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
   const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
     null
@@ -1277,25 +1295,29 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
-      setDraftMuxMetadataOverride(pending.muxMetadata);
+      setDraftMuxMetadataOverrideForContent(pending.muxMetadata, pending.content);
       focusMessageInput();
     },
-    [applyDraftFromPending, focusMessageInput, setDraftReviews]
+    [applyDraftFromPending, focusMessageInput, setDraftMuxMetadataOverrideForContent]
   );
 
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
-    setDraftMuxMetadataOverride(preEditMuxMetadataOverrideRef.current);
-  }, [setDraft, setDraftReviews]);
+    setDraftMuxMetadataOverrideForContent(
+      preEditMuxMetadataOverrideRef.current,
+      preEditDraftRef.current.text
+    );
+  }, [setDraft, setDraftReviews, setDraftMuxMetadataOverrideForContent]);
 
   // Method to restore text to input (used by compaction cancel)
   const restoreText = useCallback(
     (text: string) => {
+      clearDraftMuxMetadataOverride();
       setInput(() => text);
       focusMessageInput();
     },
-    [focusMessageInput, setInput]
+    [clearDraftMuxMetadataOverride, focusMessageInput, setInput]
   );
 
   // Method to append text to input (used by Code Review notes)
@@ -1377,10 +1399,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (editingMessage) {
       preEditDraftRef.current = getDraft();
       preEditReviewsRef.current = draftReviews;
-      preEditMuxMetadataOverrideRef.current = draftMuxMetadataOverride;
+      preEditMuxMetadataOverrideRef.current = activeDraftMuxMetadataOverride;
       applyDraftFromPending(editingMessage.pending, `edit-${editingMessage.id}`);
       setDraftReviews(editingMessage.pending.reviews);
-      setDraftMuxMetadataOverride(editingMessage.pending.muxMetadata);
+      setDraftMuxMetadataOverrideForContent(
+        editingMessage.pending.muxMetadata,
+        editingMessage.pending.content
+      );
       // Auto-resize textarea and focus
       setTimeout(() => {
         if (inputRef.current) {
@@ -1839,7 +1864,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
           restoreDraft(restoredPending);
         } else {
-          setDraftMuxMetadataOverride(undefined);
           restoreText(restoredPending.content);
         }
       } else if (hasFileParts || hasStagedAttachments || hasReviews) {
@@ -1880,7 +1904,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput("");
       setAttachments([]);
       setDraftReviews(null);
-      setDraftMuxMetadataOverride(undefined);
+      clearDraftMuxMetadataOverride();
       onDetachAllReviewsForComposerClear?.();
       if (inputRef.current) {
         inputRef.current.style.height = "";
@@ -1890,7 +1914,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     window.addEventListener(CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER, handler as EventListener);
     return () =>
       window.removeEventListener(CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER, handler as EventListener);
-  }, [onDetachAllReviewsForComposerClear, setAttachments, setInput, workspaceIdForComposerClear]);
+  }, [
+    clearDraftMuxMetadataOverride,
+    onDetachAllReviewsForComposerClear,
+    setAttachments,
+    setInput,
+    workspaceIdForComposerClear,
+  ]);
 
   // Allow external components to open the Model Selector
   useEffect(() => {
@@ -2299,7 +2329,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       onCancelEdit: commandOnCancelEdit,
       reviews: reviewsData,
       attachments,
-      followUpMuxMetadata: draftMuxMetadataOverride,
+      followUpMuxMetadata: activeDraftMuxMetadataOverride,
       fileParts: commandFileParts.length > 0 ? commandFileParts : undefined,
       onMessageSent: variant === "workspace" ? props.onMessageSent : undefined,
       onDetachAllReviews: variant === "workspace" ? props.onDetachAllReviews : undefined,
@@ -2313,7 +2343,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
-      setDraftMuxMetadataOverride(undefined);
+      clearDraftMuxMetadataOverride();
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
           props.onCheckReviews?.(reviewIdsForCheck);
@@ -2717,7 +2747,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Save current draft state for restoration on error
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
-      const preSendMuxMetadataOverride = draftMuxMetadataOverride;
+      const preSendMuxMetadataOverride = activeDraftMuxMetadataOverride;
       const editMessageForSend = editingMessageForUi;
 
       try {
@@ -2763,7 +2793,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                       text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", attachments),
                       fileParts: sendFileParts,
                       reviews: reviewsData,
-                      muxMetadata: draftMuxMetadataOverride,
+                      muxMetadata: activeDraftMuxMetadataOverride,
                     }
                   : undefined,
               model: parsed.model,
@@ -2831,7 +2861,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
-        setDraftMuxMetadataOverride(undefined);
+        clearDraftMuxMetadataOverride();
         setAttachments([]);
         setHideReviewsDuringSend(true);
         // Clear inline height style - VimTextArea's useLayoutEffect will handle sizing
@@ -2891,7 +2921,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
-          setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
+          setDraftMuxMetadataOverrideForContent(preSendMuxMetadataOverride, preSendDraft.text);
         } else {
           // Track telemetry for successful message send
           telemetry.messageSent(
@@ -2939,7 +2969,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
-        setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
+        setDraftMuxMetadataOverrideForContent(preSendMuxMetadataOverride, preSendDraft.text);
       } finally {
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -503,6 +503,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   // draftReviews takes precedence when restoring or editing message drafts.
   const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
+  const [draftMuxMetadataOverride, setDraftMuxMetadataOverride] = useState<
+    MuxMessageMetadata | undefined
+  >(undefined);
   const attachedReviewIdsSignature = attachedReviews.map((review) => review.id).join("\u0000");
   const clearedAttachedReviewIdsRef = useRef<string | typeof AWAITING_NEW_ATTACHED_REVIEWS | null>(
     null
@@ -1255,6 +1258,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     (pending: PendingUserMessage) => {
       applyDraftFromPending(pending, `restored-${Date.now()}`);
       setDraftReviews(pending.reviews);
+      setDraftMuxMetadataOverride(pending.muxMetadata);
       focusMessageInput();
     },
     [applyDraftFromPending, focusMessageInput, setDraftReviews]
@@ -1772,20 +1776,23 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         mode?: "append" | "replace";
         fileParts?: FilePart[];
         reviews?: ReviewNoteDataForDisplay[];
+        muxMetadata?: MuxMessageMetadata;
       }>;
 
-      const { text, mode = "append", fileParts, reviews } = customEvent.detail;
+      const { text, mode = "append", fileParts, reviews, muxMetadata } = customEvent.detail;
       const restoredIdPrefix = `restored-${Date.now()}`;
       const restoredPending = buildPendingFromRestoredInput({
         content: text,
         fileParts: fileParts ?? [],
         reviews: reviews ?? [],
         idPrefix: restoredIdPrefix,
+        muxMetadata,
       });
       const hasFileParts = restoredPending.fileParts.length > 0;
       const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
       const hasReviews = restoredPending.reviews.length > 0;
-      const hasDraftReplacementPayload = fileParts !== undefined || reviews !== undefined;
+      const hasDraftReplacementPayload =
+        fileParts !== undefined || reviews !== undefined || muxMetadata !== undefined;
 
       if (mode === "replace") {
         if (editingMessageForUi) {
@@ -2259,6 +2266,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       onCancelEdit: commandOnCancelEdit,
       reviews: reviewsData,
       attachments,
+      followUpMuxMetadata: draftMuxMetadataOverride,
       fileParts: commandFileParts.length > 0 ? commandFileParts : undefined,
       onMessageSent: variant === "workspace" ? props.onMessageSent : undefined,
       onDetachAllReviews: variant === "workspace" ? props.onDetachAllReviews : undefined,
@@ -2272,6 +2280,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setInput(restoreInput);
     } else {
       setDraftReviews(null);
+      setDraftMuxMetadataOverride(undefined);
       if (variant === "workspace" && parsed.type === "compact") {
         if (reviewIdsForCheck.length > 0) {
           props.onCheckReviews?.(reviewIdsForCheck);
@@ -2668,6 +2677,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Save current draft state for restoration on error
       const preSendDraft = getDraft();
       const preSendReviews = draftReviews;
+      const preSendMuxMetadataOverride = draftMuxMetadataOverride;
       const editMessageForSend = editingMessageForUi;
 
       try {
@@ -2713,6 +2723,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                       text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", attachments),
                       fileParts: sendFileParts,
                       reviews: reviewsData,
+                      muxMetadata: draftMuxMetadataOverride,
                     }
                   : undefined,
               model: parsed.model,
@@ -2780,6 +2791,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // so they'll reappear naturally on failure (we only call onCheckReviews on success)
         setInput("");
         setDraftReviews(null);
+        setDraftMuxMetadataOverride(undefined);
         setAttachments([]);
         setHideReviewsDuringSend(true);
         // Clear inline height style - VimTextArea's useLayoutEffect will handle sizing
@@ -2839,6 +2851,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           setOptimisticallyDismissedEditId(null);
           setDraft(preSendDraft);
           setDraftReviews(preSendReviews);
+          setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
         } else {
           // Track telemetry for successful message send
           telemetry.messageSent(
@@ -2886,6 +2899,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         setOptimisticallyDismissedEditId(null);
         setDraft(preSendDraft);
         setDraftReviews(preSendReviews);
+        setDraftMuxMetadataOverride(preSendMuxMetadataOverride);
       } finally {
         setSendingCount((c) => c - 1);
         setHideReviewsDuringSend(false);

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -57,7 +57,7 @@ describe("getPromptHistoryEntries", () => {
   });
 
   test("preserves synthetic auto-compaction follow-up prompts", () => {
-    const [entry] = getPromptHistoryEntries([
+    const entries = getPromptHistoryEntries([
       userMessage("auto-compact", "Synthetic compaction request", 1, {
         isSynthetic: true,
         compactionRequest: {
@@ -70,8 +70,35 @@ describe("getPromptHistoryEntries", () => {
           },
         },
       }),
+      userMessage("internal-resume", "Internal resume compaction request", 2, {
+        isSynthetic: true,
+        compactionRequest: {
+          parsed: {
+            followUpContent: {
+              text: "Continue",
+              model: "openai:gpt-5",
+              agentId: "exec",
+              dispatchOptions: { source: "internal-resume" },
+            },
+          },
+        },
+      }),
+      userMessage("literal-continue", "Synthetic compaction request", 3, {
+        isSynthetic: true,
+        compactionRequest: {
+          parsed: {
+            followUpContent: {
+              text: "Continue",
+              model: "openai:gpt-5",
+              agentId: "exec",
+            },
+          },
+        },
+      }),
     ]);
 
+    expect(entries.map((entry) => entry.historyId)).toEqual(["auto-compact", "literal-continue"]);
+    const entry = entries[0];
     if (!entry) throw new Error("expected prompt history entry");
     expect(entry).toMatchObject({
       historyId: "auto-compact",
@@ -84,6 +111,42 @@ describe("getPromptHistoryEntries", () => {
       mode: "replace",
       fileParts: [],
       reviews: [],
+    });
+  });
+
+  test("inserts raw commands for synthetic auto-compaction slash follow-ups", () => {
+    const muxMetadata = {
+      type: "agent-skill" as const,
+      skillName: "tests",
+      scope: "global" as const,
+      rawCommand: "/tests run focused tests",
+      commandPrefix: "/tests",
+    };
+    const [entry] = getPromptHistoryEntries([
+      userMessage("auto-compact-skill", "Synthetic compaction request", 1, {
+        isSynthetic: true,
+        compactionRequest: {
+          parsed: {
+            followUpContent: {
+              text: "run focused tests",
+              model: "openai:gpt-5",
+              agentId: "exec",
+              muxMetadata,
+            },
+          },
+        },
+      }),
+    ]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(entry.content).toBe("run focused tests");
+    expect(entry.muxMetadata).toEqual(muxMetadata);
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: "/tests run focused tests",
+      mode: "replace",
+      fileParts: [],
+      reviews: [],
+      muxMetadata,
     });
   });
 

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import type { DisplayedMessage } from "@/common/types/message";
 import type { ReviewNoteData } from "@/common/types/review";
 import { createPromptHistoryInsertPayload } from "./PromptHistoryTab";
@@ -146,6 +147,53 @@ const marker = '</review>';
     expect(entry.reviews).toEqual(reviews);
     expect(createPromptHistoryInsertPayload(entry)).toEqual({
       text: "Reuse review context",
+      mode: "replace",
+      fileParts: [],
+      reviews,
+    });
+  });
+
+  test("insert payload preserves staged attachments without duplicating review text", () => {
+    const reviews: ReviewNoteData[] = [
+      {
+        filePath: "src/example.ts",
+        lineRange: "+10-12",
+        selectedCode: "const archived = true;",
+        userNote: "Use this with the ZIP.",
+      },
+    ];
+    const serializedReview = `<review>
+Re src/example.ts:+10-12
+\`\`\`
+const archived = true;
+\`\`\`
+> Use this with the ZIP.
+</review>`;
+    const stagedAttachment = {
+      kind: "staged" as const,
+      id: "zip-1",
+      filename: "archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: 128,
+      stagedPath: ".mux/user-attachments/id/archive.zip",
+    };
+    const visibleText = "Inspect the attached archive.";
+    const messageContent = appendStagedAttachmentNotice(`${serializedReview}\n\n${visibleText}`, [
+      stagedAttachment,
+    ]);
+    const [entry] = getPromptHistoryEntries([
+      userMessage("with-staged", messageContent, 1, {
+        reviews,
+      }),
+    ]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(entry.content).toBe(visibleText);
+    expect(entry.fileCount).toBe(1);
+    expect(entry.insertContent).toContain("<attached-files>");
+    expect(entry.insertContent).not.toContain("<review>");
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: appendStagedAttachmentNotice(visibleText, [stagedAttachment]),
       mode: "replace",
       fileParts: [],
       reviews,

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -152,7 +152,7 @@ const marker = '</review>';
     });
   });
 
-  test("insert payload preserves compaction follow-up attachments and reviews", () => {
+  test("insert payload preserves compaction follow-up payloads", () => {
     const fileParts = [
       {
         url: "data:text/plain;base64,SGVsbG8=",
@@ -178,6 +178,13 @@ const marker = '</review>';
               agentId: "exec",
               fileParts,
               reviews,
+              muxMetadata: {
+                type: "agent-skill",
+                skillName: "tests",
+                scope: "global",
+                rawCommand: "/tests run focused tests",
+                commandPrefix: "/tests",
+              },
             },
           },
         },
@@ -188,11 +195,25 @@ const marker = '</review>';
     expect(entry.fileCount).toBe(1);
     expect(entry.fileParts).toEqual(fileParts);
     expect(entry.reviews).toEqual(reviews);
+    expect(entry.muxMetadata).toEqual({
+      type: "agent-skill",
+      skillName: "tests",
+      scope: "global",
+      rawCommand: "/tests run focused tests",
+      commandPrefix: "/tests",
+    });
     expect(createPromptHistoryInsertPayload(entry)).toEqual({
       text: "/compact\nContinue after compaction",
       mode: "replace",
       fileParts,
       reviews,
+      muxMetadata: {
+        type: "agent-skill",
+        skillName: "tests",
+        scope: "global",
+        rawCommand: "/tests run focused tests",
+        commandPrefix: "/tests",
+      },
     });
   });
 });

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -56,6 +56,37 @@ describe("getPromptHistoryEntries", () => {
     expect(getPromptHistoryEntries(messages).map((entry) => entry.historyId)).toEqual(["real"]);
   });
 
+  test("preserves synthetic auto-compaction follow-up prompts", () => {
+    const [entry] = getPromptHistoryEntries([
+      userMessage("auto-compact", "Synthetic compaction request", 1, {
+        isSynthetic: true,
+        compactionRequest: {
+          parsed: {
+            followUpContent: {
+              text: "Original prompt near the context limit",
+              model: "openai:gpt-5",
+              agentId: "exec",
+            },
+          },
+        },
+      }),
+    ]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(entry).toMatchObject({
+      historyId: "auto-compact",
+      content: "Original prompt near the context limit",
+      fileCount: 0,
+      isSideQuestion: false,
+    });
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: "Original prompt near the context limit",
+      mode: "replace",
+      fileParts: [],
+      reviews: [],
+    });
+  });
+
   test("skips completed local command output rows", () => {
     const entries = getPromptHistoryEntries([
       userMessage("stdout", "<local-command-stdout>build complete</local-command-stdout>", 1),

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -151,4 +151,48 @@ const marker = '</review>';
       reviews,
     });
   });
+
+  test("insert payload preserves compaction follow-up attachments and reviews", () => {
+    const fileParts = [
+      {
+        url: "data:text/plain;base64,SGVsbG8=",
+        mediaType: "text/plain",
+        filename: "follow-up.txt",
+      },
+    ];
+    const reviews: ReviewNoteData[] = [
+      {
+        filePath: "src/follow-up.ts",
+        lineRange: "+3-5",
+        selectedCode: "const retry = true;",
+        userNote: "Keep this context when retrying.",
+      },
+    ];
+    const [entry] = getPromptHistoryEntries([
+      userMessage("compact", "/compact\nContinue after compaction", 1, {
+        compactionRequest: {
+          parsed: {
+            followUpContent: {
+              text: "Continue after compaction",
+              model: "openai:gpt-5",
+              agentId: "exec",
+              fileParts,
+              reviews,
+            },
+          },
+        },
+      }),
+    ]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(entry.fileCount).toBe(1);
+    expect(entry.fileParts).toEqual(fileParts);
+    expect(entry.reviews).toEqual(reviews);
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: "/compact\nContinue after compaction",
+      mode: "replace",
+      fileParts,
+      reviews,
+    });
+  });
 });

--- a/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import type { DisplayedMessage } from "@/common/types/message";
+import type { ReviewNoteData } from "@/common/types/review";
+import { createPromptHistoryInsertPayload } from "./PromptHistoryTab";
+import { getPromptHistoryEntries } from "./promptHistoryEntries";
+
+function userMessage(
+  id: string,
+  content: string,
+  historySequence: number,
+  overrides: Partial<Extract<DisplayedMessage, { type: "user" }>> = {}
+): Extract<DisplayedMessage, { type: "user" }> {
+  return {
+    type: "user",
+    id,
+    historyId: id,
+    content,
+    historySequence,
+    ...overrides,
+  };
+}
+
+describe("getPromptHistoryEntries", () => {
+  test("returns real user prompts sorted from oldest to newest", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage("newer", "Newer prompt", 3),
+      {
+        type: "assistant",
+        id: "assistant",
+        historyId: "assistant",
+        content: "Response",
+        historySequence: 2,
+        isStreaming: false,
+        isPartial: false,
+        isCompacted: false,
+        isIdleCompacted: false,
+      },
+      userMessage("older", "Older prompt", 1),
+    ];
+
+    expect(getPromptHistoryEntries(messages).map((entry) => entry.historyId)).toEqual([
+      "older",
+      "newer",
+    ]);
+  });
+
+  test("skips synthetic continuation prompts", () => {
+    const messages: DisplayedMessage[] = [
+      userMessage("real", "Please continue the work", 1),
+      userMessage("auto", "Continue", 2, { isSynthetic: true }),
+      userMessage("goal", "Synthetic goal continuation", 3, { isGoalContinuation: true }),
+      userMessage("wrap", "Budget wrap-up", 4, { isBudgetLimitWrapup: true }),
+    ];
+
+    expect(getPromptHistoryEntries(messages).map((entry) => entry.historyId)).toEqual(["real"]);
+  });
+
+  test("skips completed local command output rows", () => {
+    const entries = getPromptHistoryEntries([
+      userMessage("stdout", "<local-command-stdout>build complete</local-command-stdout>", 1),
+      userMessage("prompt", "What changed?", 2),
+    ]);
+
+    expect(entries.map((entry) => entry.historyId)).toEqual(["prompt"]);
+  });
+
+  test("keeps side-question prompts visible", () => {
+    const [entry] = getPromptHistoryEntries([
+      userMessage("side", "Can you compare this quickly?", 1, {
+        commandPrefix: "/btw",
+        isSideQuestion: true,
+      }),
+    ]);
+
+    expect(entry).toMatchObject({
+      historyId: "side",
+      commandPrefix: "/btw",
+      isSideQuestion: true,
+    });
+  });
+
+  test("keeps attachment-only user prompts with file parts", () => {
+    const fileParts = [
+      {
+        url: "data:text/plain;base64,SGVsbG8=",
+        mediaType: "text/plain",
+        filename: "note.txt",
+      },
+    ];
+    const entries = getPromptHistoryEntries([
+      userMessage("file-only", "", 1, {
+        fileParts,
+      }),
+    ]);
+
+    expect(entries).toEqual([
+      {
+        historyId: "file-only",
+        content: "",
+        historySequence: 1,
+        timestamp: undefined,
+        commandPrefix: undefined,
+        isSideQuestion: false,
+        fileCount: 1,
+        fileParts,
+      },
+    ]);
+  });
+
+  test("insert payload clears attachments and reviews for text-only history", () => {
+    const [entry] = getPromptHistoryEntries([userMessage("text-only", "Reuse this", 1)]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: "Reuse this",
+      mode: "replace",
+      fileParts: [],
+      reviews: [],
+    });
+  });
+
+  test("insert payload preserves attached review notes from history", () => {
+    const reviews: ReviewNoteData[] = [
+      {
+        filePath: "src/example.ts",
+        lineRange: "+10-12",
+        selectedCode: "const marker = '</review>';",
+        userNote: "Please revisit this branch.",
+      },
+    ];
+    const serializedReview = `<review>
+Re src/example.ts:+10-12
+\`\`\`
+const marker = '</review>';
+\`\`\`
+> Please revisit this branch.
+</review>`;
+    const [entry] = getPromptHistoryEntries([
+      userMessage("with-review", `${serializedReview}\n\nReuse review context`, 1, {
+        reviews,
+      }),
+    ]);
+
+    if (!entry) throw new Error("expected prompt history entry");
+    expect(entry.content).toBe("Reuse review context");
+    expect(entry.reviews).toEqual(reviews);
+    expect(createPromptHistoryInsertPayload(entry)).toEqual({
+      text: "Reuse review context",
+      mode: "replace",
+      fileParts: [],
+      reviews,
+    });
+  });
+});

--- a/src/browser/features/RightSidebar/PromptHistoryTab.tsx
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.tsx
@@ -74,6 +74,7 @@ export function createPromptHistoryInsertPayload(
     mode: "replace",
     fileParts: entry.fileParts ?? [],
     reviews: entry.reviews ?? [],
+    muxMetadata: entry.muxMetadata,
   };
 }
 

--- a/src/browser/features/RightSidebar/PromptHistoryTab.tsx
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { Clipboard, CornerDownLeft, LocateFixed, MessageSquareText } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
+import { copyToClipboard } from "@/browser/utils/clipboard";
+import { formatTimestamp } from "@/browser/utils/ui/dateTime";
+import {
+  CUSTOM_EVENTS,
+  createCustomEvent,
+  type CustomEventPayloads,
+} from "@/common/constants/events";
+import { cn } from "@/common/lib/utils";
+import { getPromptHistoryEntries, type PromptHistoryEntry } from "./promptHistoryEntries";
+
+interface PromptHistoryTabProps {
+  workspaceId: string;
+}
+
+export function PromptHistoryTab(props: PromptHistoryTabProps) {
+  const workspaceState = useWorkspaceState(props.workspaceId);
+  const entries = getPromptHistoryEntries(workspaceState.messages);
+
+  const navigateToMessage = (historyId: string) => {
+    // The transcript owns its scroll container, so the sidebar asks it to reveal
+    // the message instead of reaching across the layout with a DOM query.
+    window.dispatchEvent(
+      createCustomEvent(CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE, {
+        workspaceId: props.workspaceId,
+        historyId,
+      })
+    );
+  };
+
+  const insertIntoComposer = (entry: PromptHistoryEntry) => {
+    window.dispatchEvent(
+      createCustomEvent(CUSTOM_EVENTS.UPDATE_CHAT_INPUT, createPromptHistoryInsertPayload(entry))
+    );
+  };
+
+  if (entries.length === 0) {
+    return (
+      <div className="text-muted flex h-full flex-col items-center justify-center px-5 text-center text-sm">
+        <MessageSquareText aria-hidden="true" className="mb-3 h-5 w-5 opacity-70" />
+        <p>No user prompts yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3 text-sm">
+      <div className="text-muted px-1 text-xs leading-5">
+        {entries.length.toLocaleString()} prompt{entries.length === 1 ? "" : "s"} in this transcript
+      </div>
+      <div className="flex flex-col gap-2">
+        {entries.map((entry, index) => (
+          <PromptHistoryEntryCard
+            key={entry.historyId}
+            entry={entry}
+            ordinal={index + 1}
+            onNavigate={navigateToMessage}
+            onInsert={insertIntoComposer}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function createPromptHistoryInsertPayload(
+  entry: PromptHistoryEntry
+): CustomEventPayloads[typeof CUSTOM_EVENTS.UPDATE_CHAT_INPUT] {
+  return {
+    text: entry.content,
+    mode: "replace",
+    fileParts: entry.fileParts ?? [],
+    reviews: entry.reviews ?? [],
+  };
+}
+
+interface PromptHistoryEntryCardProps {
+  entry: PromptHistoryEntry;
+  ordinal: number;
+  onNavigate: (historyId: string) => void;
+  onInsert: (entry: PromptHistoryEntry) => void;
+}
+
+function PromptHistoryEntryCard(props: PromptHistoryEntryCardProps) {
+  const timestamp = props.entry.timestamp ? formatTimestamp(props.entry.timestamp) : null;
+  const accessoryLabel = props.entry.isSideQuestion
+    ? "Side question"
+    : (props.entry.commandPrefix ??
+      (props.entry.fileCount > 0
+        ? `${props.entry.fileCount.toLocaleString()} file${props.entry.fileCount === 1 ? "" : "s"}`
+        : null));
+
+  return (
+    <article className="border-border-light bg-surface-secondary overflow-hidden rounded-md border">
+      <button
+        type="button"
+        className={cn(
+          "hover:bg-accent/40 block w-full px-3 py-2.5 text-left transition-colors",
+          "focus-visible:ring-accent focus-visible:ring-1 focus-visible:outline-none"
+        )}
+        onClick={() => props.onNavigate(props.entry.historyId)}
+      >
+        <div className="mb-1 flex min-w-0 items-center justify-between gap-2">
+          <span className="text-muted shrink-0 text-[11px] tabular-nums">
+            #{props.ordinal.toLocaleString()}
+          </span>
+          {timestamp && <span className="text-muted truncate text-[11px]">{timestamp}</span>}
+        </div>
+        {accessoryLabel && (
+          <div className="text-accent mb-1 truncate text-[11px] font-medium">{accessoryLabel}</div>
+        )}
+        <p className="text-foreground max-h-20 overflow-hidden text-xs leading-5 whitespace-pre-wrap">
+          {props.entry.content || "(attachments only)"}
+        </p>
+      </button>
+      <div className="border-border-light flex items-center justify-end gap-1 border-t px-2 py-1">
+        <PromptHistoryIconButton
+          label="Copy prompt"
+          onClick={() => void copyToClipboard(props.entry.content)}
+        >
+          <Clipboard aria-hidden="true" className="h-3.5 w-3.5" />
+        </PromptHistoryIconButton>
+        <PromptHistoryIconButton
+          label="Insert into composer"
+          onClick={() => props.onInsert(props.entry)}
+        >
+          <CornerDownLeft aria-hidden="true" className="h-3.5 w-3.5" />
+        </PromptHistoryIconButton>
+        <PromptHistoryIconButton
+          label="Go to message"
+          onClick={() => props.onNavigate(props.entry.historyId)}
+        >
+          <LocateFixed aria-hidden="true" className="h-3.5 w-3.5" />
+        </PromptHistoryIconButton>
+      </div>
+    </article>
+  );
+}
+
+interface PromptHistoryIconButtonProps {
+  label: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function PromptHistoryIconButton(props: PromptHistoryIconButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={props.label}
+          className="text-muted hover:text-foreground hover:bg-accent/50 flex h-7 w-7 items-center justify-center rounded-sm transition-colors"
+          onClick={props.onClick}
+        >
+          {props.children}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{props.label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/browser/features/RightSidebar/PromptHistoryTab.tsx
+++ b/src/browser/features/RightSidebar/PromptHistoryTab.tsx
@@ -70,7 +70,7 @@ export function createPromptHistoryInsertPayload(
   entry: PromptHistoryEntry
 ): CustomEventPayloads[typeof CUSTOM_EVENTS.UPDATE_CHAT_INPUT] {
   return {
-    text: entry.content,
+    text: entry.insertContent ?? entry.content,
     mode: "replace",
     fileParts: entry.fileParts ?? [],
     reviews: entry.reviews ?? [],

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import {
   BugPlay,
   ExternalLink,
+  History,
   Monitor,
   Globe,
   Sparkles,
@@ -250,6 +251,13 @@ export const WorkflowsTabLabel: React.FC<WorkflowsTabLabelProps> = ({ workspaceI
     </span>
   );
 };
+
+export const PromptHistoryTabLabel: React.FC = () => (
+  <span className="inline-flex items-center gap-1">
+    <History className="h-3 w-3 shrink-0" />
+    History
+  </span>
+);
 
 export function OutputTabLabel() {
   return <>Output</>;

--- a/src/browser/features/RightSidebar/Tabs/tabConfig.ts
+++ b/src/browser/features/RightSidebar/Tabs/tabConfig.ts
@@ -62,6 +62,12 @@ const TAB_CONFIG_DEF = {
     defaultOrder: 36,
     paletteKeywords: ["workflow", "workflows", "orchestration", "agents", "run"],
   },
+  history: {
+    name: "History",
+    contentClassName: "overflow-y-auto p-0",
+    defaultOrder: 37,
+    paletteKeywords: ["prompt", "message", "history", "reuse"],
+  },
   memory: {
     name: "Memory",
     contentClassName: "overflow-hidden p-0",

--- a/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
+++ b/src/browser/features/RightSidebar/Tabs/tabRegistry.tsx
@@ -23,6 +23,7 @@ import { BrowserTab } from "@/browser/features/RightSidebar/BrowserTab";
 import { DevToolsTab } from "@/browser/features/RightSidebar/DevToolsTab";
 import { GoalTab, type GoalCreateIntent } from "@/browser/features/RightSidebar/GoalTab";
 import { MemoryTab } from "@/browser/features/RightSidebar/Memory/MemoryTab";
+import { PromptHistoryTab } from "@/browser/features/RightSidebar/PromptHistoryTab";
 import { WorkflowsTab } from "@/browser/features/RightSidebar/Workflows/WorkflowsTab";
 import type { GoalSnapshot, GoalStatus } from "@/common/types/goal";
 import type { ReviewNoteData } from "@/common/types/review";
@@ -35,6 +36,7 @@ import {
   InstructionsTabLabel,
   MemoryTabLabel,
   OutputTabLabel,
+  PromptHistoryTabLabel,
   ReviewTabLabel,
   StatsTabLabel,
   WorkflowsTabLabel,
@@ -158,6 +160,14 @@ const TAB_RENDERERS = {
           onClear={ctx.goal.onClear}
           onCreate={ctx.goal.onCreate}
         />
+      </ErrorBoundary>
+    ),
+  },
+  history: {
+    Label: PromptHistoryTabLabel,
+    renderPanel: (ctx) => (
+      <ErrorBoundary workspaceInfo="History tab">
+        <PromptHistoryTab workspaceId={ctx.workspaceId} />
       </ErrorBoundary>
     ),
   },

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -1,4 +1,4 @@
-import type { DisplayedMessage } from "@/common/types/message";
+import type { DisplayedMessage, MuxMessageMetadata } from "@/common/types/message";
 import { getEditableUserMessageText } from "@/browser/utils/messages/messageUtils";
 
 type UserMessage = Extract<DisplayedMessage, { type: "user" }>;
@@ -15,6 +15,7 @@ export interface PromptHistoryEntry {
   fileCount: number;
   fileParts?: UserMessage["fileParts"];
   reviews?: UserMessage["reviews"];
+  muxMetadata?: MuxMessageMetadata;
 }
 
 function isCompletedLocalCommandOutput(message: UserMessage): boolean {
@@ -55,6 +56,7 @@ export function getPromptHistoryEntries(
         fileCount: fileParts.length,
         ...(fileParts.length > 0 ? { fileParts } : {}),
         ...(reviews.length > 0 ? { reviews } : {}),
+        ...(followUpContent?.muxMetadata ? { muxMetadata: followUpContent.muxMetadata } : {}),
       };
     })
     .sort((left, right) => left.historySequence - right.historySequence);

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -1,0 +1,60 @@
+import type { DisplayedMessage } from "@/common/types/message";
+import { getEditableUserMessageText } from "@/browser/utils/messages/messageUtils";
+
+type UserMessage = Extract<DisplayedMessage, { type: "user" }>;
+const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
+const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
+
+export interface PromptHistoryEntry {
+  historyId: string;
+  content: string;
+  historySequence: number;
+  timestamp?: number;
+  commandPrefix?: string;
+  isSideQuestion: boolean;
+  fileCount: number;
+  fileParts?: UserMessage["fileParts"];
+  reviews?: UserMessage["reviews"];
+}
+
+function isCompletedLocalCommandOutput(message: UserMessage): boolean {
+  return (
+    message.content.startsWith(LOCAL_COMMAND_STDOUT_OPEN_TAG) &&
+    message.content.endsWith(LOCAL_COMMAND_STDOUT_CLOSE_TAG)
+  );
+}
+
+export function getPromptHistoryEntries(
+  messages: readonly DisplayedMessage[]
+): PromptHistoryEntry[] {
+  return messages
+    .filter((message): message is Extract<DisplayedMessage, { type: "user" }> => {
+      if (message.type !== "user") {
+        return false;
+      }
+      if (message.isSynthetic || message.isGoalContinuation || message.isBudgetLimitWrapup) {
+        return false;
+      }
+      if (isCompletedLocalCommandOutput(message)) {
+        return false;
+      }
+      return message.content.trim().length > 0 || (message.fileParts?.length ?? 0) > 0;
+    })
+    .map((message) => {
+      const fileParts = message.fileParts ?? [];
+      const reviews = message.reviews ?? [];
+      const content = getEditableUserMessageText(message);
+      return {
+        historyId: message.historyId,
+        content,
+        historySequence: message.historySequence,
+        timestamp: message.timestamp,
+        commandPrefix: message.commandPrefix,
+        isSideQuestion: message.isSideQuestion === true,
+        fileCount: fileParts.length,
+        ...(fileParts.length > 0 ? { fileParts } : {}),
+        ...(reviews.length > 0 ? { reviews } : {}),
+      };
+    })
+    .sort((left, right) => left.historySequence - right.historySequence);
+}

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -1,5 +1,6 @@
 import type { DisplayedMessage, MuxMessageMetadata } from "@/common/types/message";
-import { getEditableUserMessageText } from "@/browser/utils/messages/messageUtils";
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
+import { getEditableUserMessageDraftContent } from "@/browser/utils/messages/messageUtils";
 
 type UserMessage = Extract<DisplayedMessage, { type: "user" }>;
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
@@ -8,6 +9,7 @@ const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
 export interface PromptHistoryEntry {
   historyId: string;
   content: string;
+  insertContent?: string;
   historySequence: number;
   timestamp?: number;
   commandPrefix?: string;
@@ -45,15 +47,21 @@ export function getPromptHistoryEntries(
       const followUpContent = message.compactionRequest?.parsed.followUpContent;
       const fileParts = followUpContent?.fileParts ?? message.fileParts ?? [];
       const reviews = followUpContent?.reviews ?? message.reviews ?? [];
-      const content = getEditableUserMessageText(message);
+      const draft = getEditableUserMessageDraftContent(message);
+      const content = draft.text;
+      const insertContent =
+        draft.stagedAttachments.length > 0
+          ? appendStagedAttachmentNotice(content, draft.stagedAttachments)
+          : content;
       return {
         historyId: message.historyId,
         content,
+        ...(insertContent !== content ? { insertContent } : {}),
         historySequence: message.historySequence,
         timestamp: message.timestamp,
         commandPrefix: message.commandPrefix,
         isSideQuestion: message.isSideQuestion === true,
-        fileCount: fileParts.length,
+        fileCount: fileParts.length + draft.stagedAttachments.length,
         ...(fileParts.length > 0 ? { fileParts } : {}),
         ...(reviews.length > 0 ? { reviews } : {}),
         ...(followUpContent?.muxMetadata ? { muxMetadata: followUpContent.muxMetadata } : {}),

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -41,8 +41,9 @@ export function getPromptHistoryEntries(
       return message.content.trim().length > 0 || (message.fileParts?.length ?? 0) > 0;
     })
     .map((message) => {
-      const fileParts = message.fileParts ?? [];
-      const reviews = message.reviews ?? [];
+      const followUpContent = message.compactionRequest?.parsed.followUpContent;
+      const fileParts = followUpContent?.fileParts ?? message.fileParts ?? [];
+      const reviews = followUpContent?.reviews ?? message.reviews ?? [];
       const content = getEditableUserMessageText(message);
       return {
         historyId: message.historyId,

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -1,5 +1,14 @@
-import type { DisplayedMessage, MuxMessageMetadata } from "@/common/types/message";
-import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
+import {
+  isDefaultSourceContent,
+  type CompactionFollowUpRequest,
+  type DisplayedMessage,
+  type MuxMessageMetadata,
+} from "@/common/types/message";
+import {
+  appendStagedAttachmentNotice,
+  displayStagedAttachmentsToChatAttachments,
+  parseStagedAttachmentNotice,
+} from "@/browser/features/ChatInput/stagedAttachments";
 import { getEditableUserMessageDraftContent } from "@/browser/utils/messages/messageUtils";
 
 type UserMessage = Extract<DisplayedMessage, { type: "user" }>;
@@ -27,24 +36,76 @@ function isCompletedLocalCommandOutput(message: UserMessage): boolean {
   );
 }
 
+function buildSyntheticFollowUpEntry(
+  message: UserMessage,
+  followUpContent?: CompactionFollowUpRequest
+): PromptHistoryEntry | null {
+  if (!followUpContent || isDefaultSourceContent(followUpContent)) {
+    return null;
+  }
+
+  const parsed = parseStagedAttachmentNotice(followUpContent.text ?? "");
+  const stagedAttachments = displayStagedAttachmentsToChatAttachments(
+    parsed.attachments,
+    `history-${message.historyId}`
+  );
+  const fileParts = followUpContent.fileParts ?? [];
+  const reviews = followUpContent.reviews ?? [];
+
+  if (
+    parsed.text.trim().length === 0 &&
+    stagedAttachments.length === 0 &&
+    fileParts.length === 0 &&
+    reviews.length === 0
+  ) {
+    return null;
+  }
+
+  const insertContent =
+    stagedAttachments.length > 0
+      ? appendStagedAttachmentNotice(parsed.text, stagedAttachments)
+      : parsed.text;
+
+  return {
+    historyId: message.historyId,
+    content: parsed.text,
+    ...(insertContent !== parsed.text ? { insertContent } : {}),
+    historySequence: message.historySequence,
+    timestamp: message.timestamp,
+    commandPrefix: undefined,
+    isSideQuestion: false,
+    fileCount: fileParts.length + stagedAttachments.length,
+    ...(fileParts.length > 0 ? { fileParts } : {}),
+    ...(reviews.length > 0 ? { reviews } : {}),
+    ...(followUpContent.muxMetadata ? { muxMetadata: followUpContent.muxMetadata } : {}),
+  };
+}
+
 export function getPromptHistoryEntries(
   messages: readonly DisplayedMessage[]
 ): PromptHistoryEntry[] {
   return messages
-    .filter((message): message is Extract<DisplayedMessage, { type: "user" }> => {
+    .flatMap((message): PromptHistoryEntry[] => {
       if (message.type !== "user") {
-        return false;
+        return [];
       }
-      if (message.isSynthetic || message.isGoalContinuation || message.isBudgetLimitWrapup) {
-        return false;
+      if (message.isGoalContinuation || message.isBudgetLimitWrapup) {
+        return [];
       }
       if (isCompletedLocalCommandOutput(message)) {
-        return false;
+        return [];
       }
-      return message.content.trim().length > 0 || (message.fileParts?.length ?? 0) > 0;
-    })
-    .map((message) => {
+
       const followUpContent = message.compactionRequest?.parsed.followUpContent;
+      if (message.isSynthetic) {
+        const entry = buildSyntheticFollowUpEntry(message, followUpContent);
+        return entry ? [entry] : [];
+      }
+
+      if (message.content.trim().length === 0 && (message.fileParts?.length ?? 0) === 0) {
+        return [];
+      }
+
       const fileParts = followUpContent?.fileParts ?? message.fileParts ?? [];
       const reviews = followUpContent?.reviews ?? message.reviews ?? [];
       const draft = getEditableUserMessageDraftContent(message);
@@ -53,19 +114,21 @@ export function getPromptHistoryEntries(
         draft.stagedAttachments.length > 0
           ? appendStagedAttachmentNotice(content, draft.stagedAttachments)
           : content;
-      return {
-        historyId: message.historyId,
-        content,
-        ...(insertContent !== content ? { insertContent } : {}),
-        historySequence: message.historySequence,
-        timestamp: message.timestamp,
-        commandPrefix: message.commandPrefix,
-        isSideQuestion: message.isSideQuestion === true,
-        fileCount: fileParts.length + draft.stagedAttachments.length,
-        ...(fileParts.length > 0 ? { fileParts } : {}),
-        ...(reviews.length > 0 ? { reviews } : {}),
-        ...(followUpContent?.muxMetadata ? { muxMetadata: followUpContent.muxMetadata } : {}),
-      };
+      return [
+        {
+          historyId: message.historyId,
+          content,
+          ...(insertContent !== content ? { insertContent } : {}),
+          historySequence: message.historySequence,
+          timestamp: message.timestamp,
+          commandPrefix: message.commandPrefix,
+          isSideQuestion: message.isSideQuestion === true,
+          fileCount: fileParts.length + draft.stagedAttachments.length,
+          ...(fileParts.length > 0 ? { fileParts } : {}),
+          ...(reviews.length > 0 ? { reviews } : {}),
+          ...(followUpContent?.muxMetadata ? { muxMetadata: followUpContent.muxMetadata } : {}),
+        },
+      ];
     })
     .sort((left, right) => left.historySequence - right.historySequence);
 }

--- a/src/browser/features/RightSidebar/promptHistoryEntries.ts
+++ b/src/browser/features/RightSidebar/promptHistoryEntries.ts
@@ -1,5 +1,4 @@
 import {
-  isDefaultSourceContent,
   type CompactionFollowUpRequest,
   type DisplayedMessage,
   type MuxMessageMetadata,
@@ -36,11 +35,20 @@ function isCompletedLocalCommandOutput(message: UserMessage): boolean {
   );
 }
 
+function getMuxMetadataRawCommand(metadata?: MuxMessageMetadata): string | undefined {
+  if (!metadata || !("rawCommand" in metadata)) {
+    return undefined;
+  }
+
+  const { rawCommand } = metadata;
+  return rawCommand && rawCommand.trim().length > 0 ? rawCommand : undefined;
+}
+
 function buildSyntheticFollowUpEntry(
   message: UserMessage,
   followUpContent?: CompactionFollowUpRequest
 ): PromptHistoryEntry | null {
-  if (!followUpContent || isDefaultSourceContent(followUpContent)) {
+  if (!followUpContent || followUpContent.dispatchOptions?.source === "internal-resume") {
     return null;
   }
 
@@ -51,24 +59,27 @@ function buildSyntheticFollowUpEntry(
   );
   const fileParts = followUpContent.fileParts ?? [];
   const reviews = followUpContent.reviews ?? [];
+  const rawCommand = getMuxMetadataRawCommand(followUpContent.muxMetadata);
 
   if (
     parsed.text.trim().length === 0 &&
     stagedAttachments.length === 0 &&
     fileParts.length === 0 &&
-    reviews.length === 0
+    reviews.length === 0 &&
+    !rawCommand
   ) {
     return null;
   }
 
   const insertContent =
-    stagedAttachments.length > 0
+    rawCommand ??
+    (stagedAttachments.length > 0
       ? appendStagedAttachmentNotice(parsed.text, stagedAttachments)
-      : parsed.text;
+      : parsed.text);
 
   return {
     historyId: message.historyId,
-    content: parsed.text,
+    content: parsed.text.trim().length > 0 ? parsed.text : (rawCommand ?? parsed.text),
     ...(insertContent !== parsed.text ? { insertContent } : {}),
     historySequence: message.historySequence,
     timestamp: message.timestamp,

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -1643,6 +1643,7 @@ export interface CommandHandlerContext {
   fileParts?: FilePart[];
   /** Reviews attached to the message (from code review panel) */
   reviews?: ReviewNoteData[];
+  followUpMuxMetadata?: MuxMessageMetadata;
   editMessageId?: string;
   setInput: (value: string) => void;
   setAttachments: (attachments: ChatAttachment[]) => void;
@@ -1789,6 +1790,7 @@ export async function handleCompactCommand(
           text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", stagedAttachments),
           fileParts: context.fileParts,
           reviews: context.reviews,
+          muxMetadata: context.followUpMuxMetadata,
         }
       : undefined;
 

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -12,7 +12,8 @@ import {
   buildPendingFromDisplayed,
   buildPendingFromRestoredInput,
   canEditDisplayedUserMessage,
-  getRestoredMuxMetadataForCurrentText,
+  getRestoredDraftPayloadSignature,
+  getRestoredMuxMetadataForCurrentDraft,
   normalizeQueuedMessage,
 } from "./chatEditing";
 
@@ -34,6 +35,13 @@ const STAGED_ATTACHMENT = {
   mediaType: "application/zip",
   sizeBytes: 199,
   stagedPath: ".mux/user-attachments/id/archive.zip",
+};
+
+const REVIEW_NOTE = {
+  filePath: "src/app.ts",
+  lineRange: "+1",
+  selectedCode: "const value = 1;",
+  userNote: "Review this",
 };
 
 describe("canEditDisplayedUserMessage", () => {
@@ -132,7 +140,7 @@ describe("canEditDisplayedUserMessage", () => {
     });
   });
 
-  test("keeps restored mux metadata only while the restored text is unchanged", () => {
+  test("keeps restored mux metadata only while the restored draft payload is unchanged", () => {
     const metadata: MuxMessageMetadata = {
       type: "agent-skill",
       rawCommand: "/test-skill investigate",
@@ -140,19 +148,50 @@ describe("canEditDisplayedUserMessage", () => {
       skillName: "test-skill",
       scope: "project",
     };
+    const sourceDraft = {
+      text: "investigate",
+      attachments: [STAGED_ATTACHMENT],
+      reviews: [REVIEW_NOTE],
+    };
+    const sourceSignature = getRestoredDraftPayloadSignature(sourceDraft);
 
     expect(
-      getRestoredMuxMetadataForCurrentText({
-        currentText: "investigate",
-        sourceText: "investigate",
+      getRestoredMuxMetadataForCurrentDraft({
+        currentDraft: sourceDraft,
+        sourceSignature,
         muxMetadata: metadata,
       })
     ).toBe(metadata);
 
     expect(
-      getRestoredMuxMetadataForCurrentText({
-        currentText: "plain follow-up",
-        sourceText: "investigate",
+      getRestoredMuxMetadataForCurrentDraft({
+        currentDraft: {
+          ...sourceDraft,
+          text: "plain follow-up",
+        },
+        sourceSignature,
+        muxMetadata: metadata,
+      })
+    ).toBeUndefined();
+
+    expect(
+      getRestoredMuxMetadataForCurrentDraft({
+        currentDraft: {
+          ...sourceDraft,
+          attachments: [],
+        },
+        sourceSignature,
+        muxMetadata: metadata,
+      })
+    ).toBeUndefined();
+
+    expect(
+      getRestoredMuxMetadataForCurrentDraft({
+        currentDraft: {
+          ...sourceDraft,
+          reviews: [{ ...REVIEW_NOTE, userNote: "Different review" }],
+        },
+        sourceSignature,
         muxMetadata: metadata,
       })
     ).toBeUndefined();

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -222,21 +222,32 @@ describe("canEditDisplayedUserMessage", () => {
           createdAt: 2,
         },
         {
+          id: "second-duplicate-parent-review",
+          data: REVIEW_NOTE,
+          status: "attached",
+          createdAt: 3,
+        },
+        {
           id: "new-parent-review",
           data: laterReview,
           status: "attached",
-          createdAt: 3,
+          createdAt: 4,
         },
       ],
       mergedAttachedReviewIds: new Set(["existing-parent-review"]),
     });
 
     expect(result.reviews).toEqual([REVIEW_NOTE, laterReview]);
-    expect(result.mergedReviewIds).toEqual(["duplicate-parent-review", "new-parent-review"]);
+    expect(result.mergedReviewIds).toEqual([
+      "duplicate-parent-review",
+      "second-duplicate-parent-review",
+      "new-parent-review",
+    ]);
     expect([...result.mergedAttachedReviewIds].sort()).toEqual([
       "duplicate-parent-review",
       "existing-parent-review",
       "new-parent-review",
+      "second-duplicate-parent-review",
     ]);
   });
 

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -14,6 +14,7 @@ import {
   canEditDisplayedUserMessage,
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
+  mergeNewAttachedReviewsIntoDraft,
   normalizeQueuedMessage,
 } from "./chatEditing";
 
@@ -195,6 +196,41 @@ describe("canEditDisplayedUserMessage", () => {
         muxMetadata: metadata,
       })
     ).toBeUndefined();
+  });
+
+  test("merges newly attached reviews into restored draft reviews", () => {
+    const laterReview = {
+      filePath: "src/later.ts",
+      lineRange: "+8",
+      selectedCode: "const later = true;",
+      userNote: "Add this too",
+    };
+
+    const result = mergeNewAttachedReviewsIntoDraft({
+      draftReviews: [REVIEW_NOTE],
+      attachedReviews: [
+        {
+          id: "existing-parent-review",
+          data: REVIEW_NOTE,
+          status: "attached",
+          createdAt: 1,
+        },
+        {
+          id: "new-parent-review",
+          data: laterReview,
+          status: "attached",
+          createdAt: 2,
+        },
+      ],
+      mergedAttachedReviewIds: new Set(["existing-parent-review"]),
+    });
+
+    expect(result.reviews).toEqual([REVIEW_NOTE, laterReview]);
+    expect(result.addedReviewIds).toEqual(["new-parent-review"]);
+    expect([...result.mergedAttachedReviewIds].sort()).toEqual([
+      "existing-parent-review",
+      "new-parent-review",
+    ]);
   });
 
   test("restores staged ZIPs from compaction follow-up content", () => {

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -216,18 +216,25 @@ describe("canEditDisplayedUserMessage", () => {
           createdAt: 1,
         },
         {
+          id: "duplicate-parent-review",
+          data: REVIEW_NOTE,
+          status: "attached",
+          createdAt: 2,
+        },
+        {
           id: "new-parent-review",
           data: laterReview,
           status: "attached",
-          createdAt: 2,
+          createdAt: 3,
         },
       ],
       mergedAttachedReviewIds: new Set(["existing-parent-review"]),
     });
 
     expect(result.reviews).toEqual([REVIEW_NOTE, laterReview]);
-    expect(result.addedReviewIds).toEqual(["new-parent-review"]);
+    expect(result.mergedReviewIds).toEqual(["duplicate-parent-review", "new-parent-review"]);
     expect([...result.mergedAttachedReviewIds].sort()).toEqual([
+      "duplicate-parent-review",
       "existing-parent-review",
       "new-parent-review",
     ]);

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -3,6 +3,7 @@ import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stage
 import type {
   CompactionFollowUpRequest,
   DisplayedUserMessage,
+  MuxMessageMetadata,
   QueuedMessage,
 } from "@/common/types/message";
 import {
@@ -11,6 +12,7 @@ import {
   buildPendingFromDisplayed,
   buildPendingFromRestoredInput,
   canEditDisplayedUserMessage,
+  getRestoredMuxMetadataForCurrentText,
   normalizeQueuedMessage,
 } from "./chatEditing";
 
@@ -128,6 +130,32 @@ describe("canEditDisplayedUserMessage", () => {
       ],
       reviews: [review],
     });
+  });
+
+  test("keeps restored mux metadata only while the restored text is unchanged", () => {
+    const metadata: MuxMessageMetadata = {
+      type: "agent-skill",
+      rawCommand: "/test-skill investigate",
+      commandPrefix: "/test-skill",
+      skillName: "test-skill",
+      scope: "project",
+    };
+
+    expect(
+      getRestoredMuxMetadataForCurrentText({
+        currentText: "investigate",
+        sourceText: "investigate",
+        muxMetadata: metadata,
+      })
+    ).toBe(metadata);
+
+    expect(
+      getRestoredMuxMetadataForCurrentText({
+        currentText: "plain follow-up",
+        sourceText: "investigate",
+        muxMetadata: metadata,
+      })
+    ).toBeUndefined();
   });
 
   test("restores staged ZIPs from compaction follow-up content", () => {

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -16,6 +16,7 @@ import {
   getRestoredMuxMetadataForCurrentDraft,
   mergeNewAttachedReviewsIntoDraft,
   normalizeQueuedMessage,
+  releaseDraftReviewMergeTracking,
 } from "./chatEditing";
 
 function userMessage(overrides: Partial<DisplayedUserMessage> = {}): DisplayedUserMessage {
@@ -249,6 +250,42 @@ describe("canEditDisplayedUserMessage", () => {
       "new-parent-review",
       "second-duplicate-parent-review",
     ]);
+  });
+
+  test("allows a removed merged review to be attached again", () => {
+    const laterReview = {
+      filePath: "src/later.ts",
+      lineRange: "+8",
+      selectedCode: "const later = true;",
+      userNote: "Add this too",
+    };
+    const checkIdsByDraftId = new Map([["draft-later", new Set(["later-parent-review"])]]);
+    const mergedAttachedReviewIds = new Set(["existing-parent-review", "later-parent-review"]);
+
+    releaseDraftReviewMergeTracking({
+      draftReviewId: "draft-later",
+      checkIdsByDraftId,
+      mergedAttachedReviewIds,
+    });
+
+    expect(checkIdsByDraftId.has("draft-later")).toBe(false);
+    expect([...mergedAttachedReviewIds]).toEqual(["existing-parent-review"]);
+
+    const result = mergeNewAttachedReviewsIntoDraft({
+      draftReviews: [REVIEW_NOTE],
+      attachedReviews: [
+        {
+          id: "later-parent-review",
+          data: laterReview,
+          status: "attached",
+          createdAt: 2,
+        },
+      ],
+      mergedAttachedReviewIds,
+    });
+
+    expect(result.reviews).toEqual([REVIEW_NOTE, laterReview]);
+    expect(result.mergedReviewIds).toEqual(["later-parent-review"]);
   });
 
   test("restores staged ZIPs from compaction follow-up content", () => {

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -14,6 +14,7 @@ import {
   canEditDisplayedUserMessage,
   getRestoredDraftPayloadSignature,
   getRestoredMuxMetadataForCurrentDraft,
+  hasRestoredDraftReplacementPayload,
   mergeNewAttachedReviewsIntoDraft,
   normalizeQueuedMessage,
   releaseDraftReviewMergeTracking,
@@ -140,6 +141,26 @@ describe("canEditDisplayedUserMessage", () => {
       ],
       reviews: [review],
     });
+  });
+
+  test("treats parsed staged ZIPs as a full draft replacement payload", () => {
+    const pending = buildPendingFromRestoredInput({
+      content: appendStagedAttachmentNotice("Restore failed retry.", [STAGED_ATTACHMENT]),
+      fileParts: [],
+      reviews: [],
+      idPrefix: "restored-retry",
+    });
+
+    expect(
+      hasRestoredDraftReplacementPayload({
+        stagedAttachments: pending.stagedAttachments,
+      })
+    ).toBe(true);
+    expect(
+      hasRestoredDraftReplacementPayload({
+        stagedAttachments: [],
+      })
+    ).toBe(false);
   });
 
   test("keeps restored mux metadata only while the restored draft payload is unchanged", () => {

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -180,6 +180,19 @@ export function mergeNewAttachedReviewsIntoDraft(params: {
   };
 }
 
+export function releaseDraftReviewMergeTracking(params: {
+  draftReviewId: string;
+  checkIdsByDraftId: Map<string, Set<string>>;
+  mergedAttachedReviewIds: Set<string> | null;
+}): void {
+  const attachedReviewIds = params.checkIdsByDraftId.get(params.draftReviewId);
+  params.checkIdsByDraftId.delete(params.draftReviewId);
+
+  for (const attachedReviewId of attachedReviewIds ?? []) {
+    params.mergedAttachedReviewIds?.delete(attachedReviewId);
+  }
+}
+
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
 const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
 

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -130,7 +130,7 @@ export function getRestoredMuxMetadataForCurrentDraft(params: {
     : undefined;
 }
 
-function getReviewNoteSignature(review: ReviewNoteDataForDisplay): string {
+export function getReviewNoteSignature(review: ReviewNoteDataForDisplay): string {
   return JSON.stringify({
     filePath: review.filePath,
     lineRange: review.lineRange,
@@ -149,12 +149,12 @@ export function mergeNewAttachedReviewsIntoDraft(params: {
 }): {
   reviews: ReviewNoteDataForDisplay[];
   mergedAttachedReviewIds: Set<string>;
-  addedReviewIds: string[];
+  mergedReviewIds: string[];
 } {
   const mergedAttachedReviewIds = new Set(params.mergedAttachedReviewIds);
   const existingReviewSignatures = new Set(params.draftReviews.map(getReviewNoteSignature));
   const additions: ReviewNoteDataForDisplay[] = [];
-  const addedReviewIds: string[] = [];
+  const mergedReviewIds: string[] = [];
 
   for (const review of params.attachedReviews) {
     if (mergedAttachedReviewIds.has(review.id)) {
@@ -164,18 +164,19 @@ export function mergeNewAttachedReviewsIntoDraft(params: {
     mergedAttachedReviewIds.add(review.id);
     const signature = getReviewNoteSignature(review.data);
     if (existingReviewSignatures.has(signature)) {
+      mergedReviewIds.push(review.id);
       continue;
     }
 
     existingReviewSignatures.add(signature);
     additions.push(review.data);
-    addedReviewIds.push(review.id);
+    mergedReviewIds.push(review.id);
   }
 
   return {
     reviews: additions.length > 0 ? [...params.draftReviews, ...additions] : params.draftReviews,
     mergedAttachedReviewIds,
-    addedReviewIds,
+    mergedReviewIds,
   };
 }
 

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -14,6 +14,7 @@ import type {
   QueuedMessage,
   ReviewNoteDataForDisplay,
 } from "@/common/types/message";
+import type { Review } from "@/common/types/review";
 import { getEditableUserMessageDraftContent } from "@/browser/utils/messages/messageUtils";
 
 // Keep pending edit data normalized with required arrays so edits can't drop attachments/reviews.
@@ -127,6 +128,55 @@ export function getRestoredMuxMetadataForCurrentDraft(params: {
   return getRestoredDraftPayloadSignature(params.currentDraft) === params.sourceSignature
     ? params.muxMetadata
     : undefined;
+}
+
+function getReviewNoteSignature(review: ReviewNoteDataForDisplay): string {
+  return JSON.stringify({
+    filePath: review.filePath,
+    lineRange: review.lineRange,
+    newStart: review.newStart,
+    oldStart: review.oldStart,
+    selectedCode: review.selectedCode,
+    selectedDiff: review.selectedDiff,
+    userNote: review.userNote,
+  });
+}
+
+export function mergeNewAttachedReviewsIntoDraft(params: {
+  draftReviews: ReviewNoteDataForDisplay[];
+  attachedReviews: Review[];
+  mergedAttachedReviewIds: ReadonlySet<string>;
+}): {
+  reviews: ReviewNoteDataForDisplay[];
+  mergedAttachedReviewIds: Set<string>;
+  addedReviewIds: string[];
+} {
+  const mergedAttachedReviewIds = new Set(params.mergedAttachedReviewIds);
+  const existingReviewSignatures = new Set(params.draftReviews.map(getReviewNoteSignature));
+  const additions: ReviewNoteDataForDisplay[] = [];
+  const addedReviewIds: string[] = [];
+
+  for (const review of params.attachedReviews) {
+    if (mergedAttachedReviewIds.has(review.id)) {
+      continue;
+    }
+
+    mergedAttachedReviewIds.add(review.id);
+    const signature = getReviewNoteSignature(review.data);
+    if (existingReviewSignatures.has(signature)) {
+      continue;
+    }
+
+    existingReviewSignatures.add(signature);
+    additions.push(review.data);
+    addedReviewIds.push(review.id);
+  }
+
+  return {
+    reviews: additions.length > 0 ? [...params.draftReviews, ...additions] : params.draftReviews,
+    mergedAttachedReviewIds,
+    addedReviewIds,
+  };
 }
 
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -73,6 +73,14 @@ export function buildPendingFromRestoredInput(params: {
   };
 }
 
+export function getRestoredMuxMetadataForCurrentText(params: {
+  currentText: string;
+  sourceText: string | null;
+  muxMetadata?: MuxMessageMetadata;
+}): MuxMessageMetadata | undefined {
+  return params.sourceText === params.currentText ? params.muxMetadata : undefined;
+}
+
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
 const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
 

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -77,6 +77,20 @@ export function buildPendingFromRestoredInput(params: {
   };
 }
 
+export function hasRestoredDraftReplacementPayload(params: {
+  fileParts?: FilePart[];
+  reviews?: ReviewNoteDataForDisplay[];
+  muxMetadata?: MuxMessageMetadata;
+  stagedAttachments: readonly StagedChatAttachment[];
+}): boolean {
+  return (
+    params.fileParts !== undefined ||
+    params.reviews !== undefined ||
+    params.muxMetadata !== undefined ||
+    params.stagedAttachments.length > 0
+  );
+}
+
 export interface RestoredDraftPayload {
   text: string;
   attachments: ChatAttachment[];

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -1,5 +1,8 @@
 import type { FilePart } from "@/common/orpc/types";
-import type { StagedChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
+import type {
+  ChatAttachment,
+  StagedChatAttachment,
+} from "@/browser/features/ChatInput/ChatAttachments";
 import {
   displayStagedAttachmentsToChatAttachments,
   parseStagedAttachmentNotice,
@@ -73,12 +76,57 @@ export function buildPendingFromRestoredInput(params: {
   };
 }
 
-export function getRestoredMuxMetadataForCurrentText(params: {
-  currentText: string;
-  sourceText: string | null;
+export interface RestoredDraftPayload {
+  text: string;
+  attachments: ChatAttachment[];
+  reviews?: ReviewNoteDataForDisplay[];
+}
+
+export function getRestoredDraftPayloadSignature(payload: RestoredDraftPayload): string {
+  return JSON.stringify({
+    text: payload.text,
+    attachments: payload.attachments.map((attachment) =>
+      attachment.kind === "staged"
+        ? {
+            kind: attachment.kind,
+            id: attachment.id,
+            filename: attachment.filename,
+            mediaType: attachment.mediaType,
+            sizeBytes: attachment.sizeBytes,
+            stagedPath: attachment.stagedPath,
+          }
+        : {
+            kind: attachment.kind,
+            id: attachment.id,
+            filename: attachment.filename,
+            mediaType: attachment.mediaType,
+            resizeInfo: attachment.resizeInfo,
+            url: attachment.url,
+          }
+    ),
+    reviews: (payload.reviews ?? []).map((review) => ({
+      filePath: review.filePath,
+      lineRange: review.lineRange,
+      newStart: review.newStart,
+      oldStart: review.oldStart,
+      selectedCode: review.selectedCode,
+      selectedDiff: review.selectedDiff,
+      userNote: review.userNote,
+    })),
+  });
+}
+
+export function getRestoredMuxMetadataForCurrentDraft(params: {
+  currentDraft: RestoredDraftPayload;
+  sourceSignature: string | null;
   muxMetadata?: MuxMessageMetadata;
 }): MuxMessageMetadata | undefined {
-  return params.sourceText === params.currentText ? params.muxMetadata : undefined;
+  if (!params.muxMetadata || params.sourceSignature === null) {
+    return undefined;
+  }
+  return getRestoredDraftPayloadSignature(params.currentDraft) === params.sourceSignature
+    ? params.muxMetadata
+    : undefined;
 }
 
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -7,6 +7,7 @@ import {
 import type {
   CompactionFollowUpRequest,
   DisplayedUserMessage,
+  MuxMessageMetadata,
   QueuedMessage,
   ReviewNoteDataForDisplay,
 } from "@/common/types/message";
@@ -20,6 +21,7 @@ export interface PendingUserMessage extends Omit<
   fileParts: FilePart[];
   stagedAttachments: StagedChatAttachment[];
   reviews: ReviewNoteDataForDisplay[];
+  muxMetadata?: MuxMessageMetadata;
 }
 
 export interface EditingMessageState {
@@ -56,6 +58,7 @@ export function buildPendingFromRestoredInput(params: {
   fileParts: FilePart[];
   reviews: ReviewNoteDataForDisplay[];
   idPrefix: string;
+  muxMetadata?: MuxMessageMetadata;
 }): PendingUserMessage {
   const parsed = parseStagedAttachmentNotice(params.content);
   return {
@@ -66,6 +69,7 @@ export function buildPendingFromRestoredInput(params: {
       params.idPrefix
     ),
     reviews: params.reviews,
+    muxMetadata: params.muxMetadata,
   };
 }
 
@@ -119,5 +123,6 @@ export const buildEditingStateFromCompaction = (
     fileParts: followUp?.fileParts ?? [],
     stagedAttachments: stagedAttachmentsFromText(followUp?.text, `compaction-${messageId}`),
     reviews: followUp?.reviews ?? [],
+    muxMetadata: followUp?.muxMetadata,
   },
 });

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -23,6 +23,12 @@ export const CUSTOM_EVENTS = {
   UPDATE_CHAT_INPUT: "mux:updateChatInput",
 
   /**
+   * Event to scroll the active transcript to a persisted message.
+   * Detail: { workspaceId: string, historyId: string }
+   */
+  NAVIGATE_TO_TRANSCRIPT_MESSAGE: "mux:navigateToTranscriptMessage",
+
+  /**
    * Event to clear the active chat composer after an out-of-band command succeeds.
    * Detail: { workspaceId: string }
    */
@@ -148,8 +154,13 @@ export interface CustomEventPayloads {
   [CUSTOM_EVENTS.UPDATE_CHAT_INPUT]: {
     text: string;
     mode?: "replace" | "append";
+    /** In replace mode, presence means replace the whole draft, even when empty. */
     fileParts?: FilePart[];
     reviews?: ReviewNoteDataForDisplay[];
+  };
+  [CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]: {
+    workspaceId: string;
+    historyId: string;
   };
   [CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER]: {
     workspaceId: string;

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -23,6 +23,12 @@ export const CUSTOM_EVENTS = {
   UPDATE_CHAT_INPUT: "mux:updateChatInput",
 
   /**
+   * Event to scroll the active transcript to a persisted message.
+   * Detail: { workspaceId: string, historyId: string }
+   */
+  NAVIGATE_TO_TRANSCRIPT_MESSAGE: "mux:navigateToTranscriptMessage",
+
+  /**
    * Event to clear the active chat composer after an out-of-band command succeeds.
    * Detail: { workspaceId: string }
    */
@@ -148,10 +154,15 @@ export interface CustomEventPayloads {
   [CUSTOM_EVENTS.UPDATE_CHAT_INPUT]: {
     text: string;
     mode?: "replace" | "append";
+    /** In replace mode, presence means replace the whole draft, even when empty. */
     fileParts?: FilePart[];
     reviews?: ReviewNoteDataForDisplay[];
     /** When set, only the matching workspace composer may apply this update. */
     workspaceId?: string;
+  };
+  [CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]: {
+    workspaceId: string;
+    historyId: string;
   };
   [CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER]: {
     workspaceId: string;

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ThinkingLevel } from "@/common/types/thinking";
-import type { ReviewNoteDataForDisplay } from "@/common/types/message";
+import type { MuxMessageMetadata, ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
 
 export const CUSTOM_EVENTS = {
@@ -157,6 +157,7 @@ export interface CustomEventPayloads {
     /** In replace mode, presence means replace the whole draft, even when empty. */
     fileParts?: FilePart[];
     reviews?: ReviewNoteDataForDisplay[];
+    muxMetadata?: MuxMessageMetadata;
   };
   [CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]: {
     workspaceId: string;

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ThinkingLevel } from "@/common/types/thinking";
-import type { ReviewNoteDataForDisplay } from "@/common/types/message";
+import type { MuxMessageMetadata, ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
 
 export const CUSTOM_EVENTS = {
@@ -159,6 +159,7 @@ export interface CustomEventPayloads {
     reviews?: ReviewNoteDataForDisplay[];
     /** When set, only the matching workspace composer may apply this update. */
     workspaceId?: string;
+    muxMetadata?: MuxMessageMetadata;
   };
   [CUSTOM_EVENTS.NAVIGATE_TO_TRANSCRIPT_MESSAGE]: {
     workspaceId: string;


### PR DESCRIPTION
## Summary

Adds a right-sidebar History tab for the current transcript. The tab lists real user prompts from oldest to newest and provides quick actions to jump back to the original transcript row, copy the prompt, or insert it into the composer with its restorable draft payload.

## Background

Part of #3416. This supersedes closed PR #3421, which GitHub would not reopen after its head branch was force-pushed/recreated. The PR keeps the scope to the prompt-history MVP; persistent snippets, slash-command integration, and configurable keybindings remain follow-up ideas.

## Implementation

- Adds a pure prompt-history selector that filters synthetic continuation/budget wrap-up messages and completed local-command output rows while preserving attachment-only user prompts, file payloads, staged attachment notices, structured reviews, and compaction follow-up payloads.
- Registers a new `history` right-sidebar tab and label alongside the upstream Memory and Workflows tabs.
- Uses a typed custom event so the sidebar can ask `ChatPane` to reveal a transcript message without reaching across layout boundaries with DOM queries.
- Reuses the existing `UPDATE_CHAT_INPUT` event to insert selected history text, files, staged attachments, structured reviews, and follow-up mux metadata into the composer.
- Handles full-draft replacement carefully so stale attached reviews are cleared when a history entry does not carry reviews.
- Binds restored mux metadata to the full restored draft payload signature, so editing restored text, attachments, or reviews invalidates stale follow-up command metadata before `/compact` queues a follow-up.
- Merges reviews attached later from the Code Review tab into restored review drafts, detaches the copied parent reviews, and keeps their parent IDs so successful sends mark them checked.

## Validation

- `bun test --timeout=10000 src/browser/features/RightSidebar/PromptHistoryTab.test.ts src/browser/utils/chatEditing.test.ts` - 21 tests passed
- `bun run prettier --check src/browser/features/ChatInput/index.tsx src/browser/utils/chatEditing.ts src/browser/utils/chatEditing.test.ts src/browser/features/RightSidebar/promptHistoryEntries.ts src/browser/features/RightSidebar/PromptHistoryTab.tsx src/browser/features/RightSidebar/PromptHistoryTab.test.ts`
- `./node_modules/.bin/eslint src/browser/features/ChatInput/index.tsx src/browser/utils/chatEditing.ts src/browser/utils/chatEditing.test.ts src/browser/features/RightSidebar/promptHistoryEntries.ts src/browser/features/RightSidebar/PromptHistoryTab.tsx src/browser/features/RightSidebar/PromptHistoryTab.test.ts`
- `./scripts/generate-version.sh && ./node_modules/.bin/tsgo --noEmit --project tsconfig.json`
- `git diff --check fork/codex/prompt-history-sidebar-v2...HEAD`
- `make static-check`

## Risks

The UI is intentionally small and additive: users need to add/open the History tab from the right sidebar. The restore path now preserves more draft payload shape, so the main regression risk is stale or hidden payload after composer edits; this is guarded by payload-signature invalidation, later-review merge/check handling, and focused tests. The remaining #3416 ideas around persistent snippets and custom keybindings are not implemented here.

---

_Generated with `mux` • Model: `GPT-5` • Thinking: `unknown` • Cost: `$unknown`_

<!-- mux-attribution: model=GPT-5 thinking=unknown costs=unknown -->
