### PR TITLE
🤖 feat: add custom model parameter override fields to custom model editing

### DIFF
--- a/src/browser/features/Settings/Sections/ModelRow.tsx
+++ b/src/browser/features/Settings/Sections/ModelRow.tsx
@@ -179,6 +179,9 @@ export interface ModelRowProps {
   editModelValue?: string;
   editContextValue?: string;
   editMappedToModel?: string;
+  editMaxOutputTokensValue?: string;
+  editTemperatureValue?: string;
+  editTopPValue?: string;
   editAutofocus?: "model" | "context";
   customContextWindowTokens?: number | null;
   mappedToModel?: string | null;
@@ -211,6 +214,9 @@ export interface ModelRowProps {
   onEditModelChange?: (value: string) => void;
   onEditContextChange?: (value: string) => void;
   onEditMappedToModelChange?: (value: string) => void;
+  onEditMaxOutputTokensChange?: (value: string) => void;
+  onEditTemperatureChange?: (value: string) => void;
+  onEditTopPChange?: (value: string) => void;
   onRemove?: () => void;
   /** Set/clear explicit route override (null = auto) */
   onSetRouteOverride?: (route: string | null) => void;
@@ -330,6 +336,52 @@ export function ModelRow(props: ModelRowProps) {
                   emptyOption={{ value: "", label: "None (use own metadata)" }}
                   compact
                 />
+              </div>
+            )}
+            {props.isCustom && (
+              <div className="mt-1.5 flex items-center gap-2">
+                <span className="text-muted w-16 shrink-0 text-xs md:w-20">Params</span>
+                <div className="grid min-w-0 flex-1 grid-cols-3 gap-1.5">
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={props.editMaxOutputTokensValue ?? ""}
+                    onChange={(e) => props.onEditMaxOutputTokensChange?.(e.target.value)}
+                    onKeyDown={createEditKeyHandler({
+                      onSave: () => props.onSaveEdit?.(),
+                      onCancel: () => props.onCancelEdit?.(),
+                    })}
+                    className="bg-modal-bg border-border-medium focus:border-accent min-w-0 rounded border px-2 py-0.5 text-right font-mono text-xs focus:outline-none"
+                    placeholder="max_output_tokens"
+                    title="max_output_tokens"
+                  />
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={props.editTemperatureValue ?? ""}
+                    onChange={(e) => props.onEditTemperatureChange?.(e.target.value)}
+                    onKeyDown={createEditKeyHandler({
+                      onSave: () => props.onSaveEdit?.(),
+                      onCancel: () => props.onCancelEdit?.(),
+                    })}
+                    className="bg-modal-bg border-border-medium focus:border-accent min-w-0 rounded border px-2 py-0.5 text-right font-mono text-xs focus:outline-none"
+                    placeholder="temperature"
+                    title="temperature"
+                  />
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={props.editTopPValue ?? ""}
+                    onChange={(e) => props.onEditTopPChange?.(e.target.value)}
+                    onKeyDown={createEditKeyHandler({
+                      onSave: () => props.onSaveEdit?.(),
+                      onCancel: () => props.onCancelEdit?.(),
+                    })}
+                    className="bg-modal-bg border-border-medium focus:border-accent min-w-0 rounded border px-2 py-0.5 text-right font-mono text-xs focus:outline-none"
+                    placeholder="top_p"
+                    title="top_p"
+                  />
+                </div>
               </div>
             )}
           </div>

--- a/src/browser/features/Settings/Sections/ModelsSection.test.ts
+++ b/src/browser/features/Settings/Sections/ModelsSection.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
-import { shouldAllowRouteOverrideInSettings, shouldShowModelInSettings } from "./ModelsSection";
+import {
+  buildUpdatedModelParameters,
+  parseBoundedNumberInput,
+  parsePositiveIntegerInput,
+  shouldAllowRouteOverrideInSettings,
+  shouldShowModelInSettings,
+} from "./ModelsSection";
 
 describe("shouldShowModelInSettings", () => {
   test("hides OAuth-required Codex model when OpenAI OAuth is not configured", () => {
@@ -43,5 +49,51 @@ describe("shouldAllowRouteOverrideInSettings", () => {
 
   test("keeps route overrides enabled for direct custom providers", () => {
     expect(shouldAllowRouteOverrideInSettings("ollama:gpt-oss:20b")).toBe(true);
+  });
+});
+
+describe("model parameter edit helpers", () => {
+  test("parses positive integer input for max_output_tokens", () => {
+    expect(parsePositiveIntegerInput("42")).toBe(42);
+    expect(parsePositiveIntegerInput("0")).toBeNull();
+    expect(parsePositiveIntegerInput("1.5")).toBeNull();
+    expect(parsePositiveIntegerInput("abc")).toBeNull();
+  });
+
+  test("parses bounded decimal input for temperature and top_p", () => {
+    expect(parseBoundedNumberInput("0", 0, 2)).toBe(0);
+    expect(parseBoundedNumberInput("1.5", 0, 2)).toBe(1.5);
+    expect(parseBoundedNumberInput("2", 0, 2)).toBe(2);
+    expect(parseBoundedNumberInput("2.1", 0, 2)).toBeNull();
+    expect(parseBoundedNumberInput("-0.1", 0, 1)).toBeNull();
+  });
+
+  test("buildUpdatedModelParameters updates overrides and clears renamed entries", () => {
+    const withRenamed = buildUpdatedModelParameters(
+      {
+        legacy: { temperature: 0.2 },
+      },
+      "legacy",
+      {
+        max_output_tokens: null,
+        temperature: null,
+        top_p: null,
+      }
+    );
+
+    expect(withRenamed).toBeUndefined();
+
+    const withNewOverrides = buildUpdatedModelParameters(withRenamed, "renamed", {
+      max_output_tokens: 2048,
+      temperature: 0.5,
+      top_p: null,
+    });
+
+    expect(withNewOverrides).toEqual({
+      renamed: {
+        max_output_tokens: 2048,
+        temperature: 0.5,
+      },
+    });
   });
 });

--- a/src/browser/features/Settings/Sections/ModelsSection.test.ts
+++ b/src/browser/features/Settings/Sections/ModelsSection.test.ts
@@ -4,6 +4,7 @@ import {
   buildUpdatedModelParameters,
   parseBoundedNumberInput,
   parsePositiveIntegerInput,
+  removeModelParameterEntry,
   shouldAllowRouteOverrideInSettings,
   shouldShowModelInSettings,
 } from "./ModelsSection";
@@ -68,12 +69,16 @@ describe("model parameter edit helpers", () => {
     expect(parseBoundedNumberInput("-0.1", 0, 1)).toBeNull();
   });
 
-  test("buildUpdatedModelParameters updates overrides and clears renamed entries", () => {
-    const withRenamed = buildUpdatedModelParameters(
+  test("buildUpdatedModelParameters preserves non-editable parameters when clearing editable fields", () => {
+    const updated = buildUpdatedModelParameters(
       {
-        legacy: { temperature: 0.2 },
+        "gpt-5": {
+          max_output_tokens: 1024,
+          temperature: 0.7,
+          top_k: 42,
+        },
       },
-      "legacy",
+      "gpt-5",
       {
         max_output_tokens: null,
         temperature: null,
@@ -81,9 +86,15 @@ describe("model parameter edit helpers", () => {
       }
     );
 
-    expect(withRenamed).toBeUndefined();
+    expect(updated).toEqual({
+      "gpt-5": {
+        top_k: 42,
+      },
+    });
+  });
 
-    const withNewOverrides = buildUpdatedModelParameters(withRenamed, "renamed", {
+  test("buildUpdatedModelParameters updates editable fields", () => {
+    const withNewOverrides = buildUpdatedModelParameters(undefined, "renamed", {
       max_output_tokens: 2048,
       temperature: 0.5,
       top_p: null,
@@ -94,6 +105,20 @@ describe("model parameter edit helpers", () => {
         max_output_tokens: 2048,
         temperature: 0.5,
       },
+    });
+  });
+
+  test("removeModelParameterEntry clears old model parameter keys", () => {
+    const withoutLegacy = removeModelParameterEntry(
+      {
+        legacy: { temperature: 0.2 },
+        renamed: { top_p: 0.8 },
+      },
+      "legacy"
+    );
+
+    expect(withoutLegacy).toEqual({
+      renamed: { top_p: 0.8 },
     });
   });
 });

--- a/src/browser/features/Settings/Sections/ModelsSection.test.ts
+++ b/src/browser/features/Settings/Sections/ModelsSection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import {
   buildUpdatedModelParameters,
+  migrateModelParameterEntry,
   parseBoundedNumberInput,
   parsePositiveIntegerInput,
   removeModelParameterEntry,
@@ -104,6 +105,58 @@ describe("model parameter edit helpers", () => {
       renamed: {
         max_output_tokens: 2048,
         temperature: 0.5,
+      },
+    });
+  });
+
+  test("rename migration preserves non-editable overrides and removes legacy key", () => {
+    const migrated = migrateModelParameterEntry(
+      {
+        legacy: {
+          temperature: 0.2,
+          top_k: 42,
+          seed: 7,
+        },
+      },
+      "legacy",
+      "renamed"
+    );
+
+    const updated = buildUpdatedModelParameters(migrated, "renamed", {
+      max_output_tokens: null,
+      temperature: 0.8,
+      top_p: null,
+    });
+
+    expect(updated).toEqual({
+      renamed: {
+        temperature: 0.8,
+        top_k: 42,
+        seed: 7,
+      },
+    });
+  });
+
+  test("rename migration merges existing destination overrides", () => {
+    const migrated = migrateModelParameterEntry(
+      {
+        legacy: {
+          temperature: 0.4,
+          top_k: 12,
+        },
+        renamed: {
+          seed: 99,
+        },
+      },
+      "legacy",
+      "renamed"
+    );
+
+    expect(migrated).toEqual({
+      renamed: {
+        seed: 99,
+        temperature: 0.4,
+        top_k: 12,
       },
     });
   });

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -225,7 +225,9 @@ export function migrateModelParameterEntry(
   const destinationOverrides = currentModelParameters[nextModelId];
   const nextModelParameters = { ...currentModelParameters };
   nextModelParameters[nextModelId] = {
-    ...(destinationOverrides && typeof destinationOverrides === "object" ? destinationOverrides : {}),
+    ...(destinationOverrides && typeof destinationOverrides === "object"
+      ? destinationOverrides
+      : {}),
     ...originalOverrides,
   };
   delete nextModelParameters[originalModelId];
@@ -543,30 +545,11 @@ export function ModelsSection() {
       const setOverridesResult = await api.providers.setModelParameters({
         provider: providerId,
         modelId: trimmedModelId,
+        renameFromModelId: trimmedModelId !== originalModelId ? originalModelId : undefined,
         overrides,
       });
       if (!setOverridesResult.success) {
         setError(setOverridesResult.error);
-        void refresh();
-        return;
-      }
-
-      if (trimmedModelId === originalModelId) {
-        return;
-      }
-
-      const clearLegacyOverridesResult = await api.providers.setModelParameters({
-        provider: providerId,
-        modelId: originalModelId,
-        overrides: {
-          max_output_tokens: null,
-          temperature: null,
-          top_p: null,
-        },
-      });
-
-      if (!clearLegacyOverridesResult.success) {
-        setError(clearLegacyOverridesResult.error);
         void refresh();
       }
     })();

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -57,16 +57,36 @@ function ModelsTableHeader() {
   );
 }
 
+interface EditableModelParameterOverrides {
+  max_output_tokens: number | null;
+  temperature: number | null;
+  top_p: number | null;
+}
+
 interface EditingState {
   provider: string;
   originalModelId: string;
   newModelId: string;
   contextWindowTokens: string;
   mappedToModel: string;
+  maxOutputTokens: string;
+  temperature: string;
+  topP: string;
   focus?: "model" | "context";
 }
 
-function parseContextWindowTokensInput(value: string): number | null {
+interface CustomModelInfo {
+  provider: string;
+  modelId: string;
+  fullId: string;
+  contextWindowTokens: number | null;
+  mappedToModel: string | null;
+  maxOutputTokens: number | null;
+  temperature: number | null;
+  topP: number | null;
+}
+
+export function parsePositiveIntegerInput(value: string): number | null {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
     return null;
@@ -78,6 +98,51 @@ function parseContextWindowTokensInput(value: string): number | null {
   }
 
   return parsed;
+}
+
+function parseContextWindowTokensInput(value: string): number | null {
+  return parsePositiveIntegerInput(value);
+}
+
+export function parseBoundedNumberInput(value: string, min: number, max: number): number | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function getEditableModelParameterOverrides(
+  modelParametersByModel: Record<
+    string,
+    { max_output_tokens?: number; temperature?: number; top_p?: number } | undefined
+  >,
+  modelId: string
+): EditableModelParameterOverrides {
+  const modelOverrides = modelParametersByModel[modelId];
+  return {
+    max_output_tokens:
+      typeof modelOverrides?.max_output_tokens === "number"
+        ? modelOverrides.max_output_tokens
+        : null,
+    temperature:
+      typeof modelOverrides?.temperature === "number" ? modelOverrides.temperature : null,
+    top_p: typeof modelOverrides?.top_p === "number" ? modelOverrides.top_p : null,
+  };
+}
+
+function hasAnyEditableModelParameterOverride(overrides: EditableModelParameterOverrides): boolean {
+  return (
+    overrides.max_output_tokens !== null ||
+    overrides.temperature !== null ||
+    overrides.top_p !== null
+  );
 }
 
 function buildProviderModelEntry(
@@ -98,6 +163,42 @@ function buildProviderModelEntry(
   }
 
   return entry;
+}
+
+export function buildUpdatedModelParameters(
+  currentModelParameters: Record<string, Record<string, unknown>> | undefined,
+  modelId: string,
+  overrides: EditableModelParameterOverrides
+): Record<string, Record<string, unknown>> | undefined {
+  const nextModelParameters = { ...(currentModelParameters ?? {}) };
+
+  if (!hasAnyEditableModelParameterOverride(overrides)) {
+    delete nextModelParameters[modelId];
+  } else {
+    const currentOverrides = nextModelParameters[modelId];
+    const nextOverrides: Record<string, unknown> = {
+      ...(typeof currentOverrides === "object" && currentOverrides !== null
+        ? currentOverrides
+        : {}),
+      max_output_tokens: overrides.max_output_tokens,
+      temperature: overrides.temperature,
+      top_p: overrides.top_p,
+    };
+
+    if (overrides.max_output_tokens === null) {
+      delete nextOverrides.max_output_tokens;
+    }
+    if (overrides.temperature === null) {
+      delete nextOverrides.temperature;
+    }
+    if (overrides.top_p === null) {
+      delete nextOverrides.top_p;
+    }
+
+    nextModelParameters[modelId] = nextOverrides;
+  }
+
+  return Object.keys(nextModelParameters).length > 0 ? nextModelParameters : undefined;
 }
 
 export function shouldShowModelInSettings(modelId: string, codexOauthConfigured: boolean): boolean {
@@ -126,7 +227,8 @@ export function ModelsSection() {
 
   const { api } = useAPI();
   const { open: openSettings } = useSettings();
-  const { config, loading, updateModelsOptimistically } = useProvidersConfig();
+  const { config, loading, refresh, updateModelsOptimistically, updateOptimistically } =
+    useProvidersConfig();
   const [lastProvider, setLastProvider] = usePersistedState(LAST_CUSTOM_MODEL_PROVIDER_KEY, "");
   const [newModelId, setNewModelId] = useState("");
   const [editing, setEditing] = useState<EditingState | null>(null);
@@ -224,44 +326,34 @@ export function ModelsSection() {
     [api, config, updateModelsOptimistically]
   );
 
+  const startModelEdit = useCallback((model: CustomModelInfo, focus: "model" | "context") => {
+    setEditing({
+      provider: model.provider,
+      originalModelId: model.modelId,
+      newModelId: model.modelId,
+      contextWindowTokens:
+        model.contextWindowTokens === null ? "" : String(model.contextWindowTokens),
+      mappedToModel: model.mappedToModel ?? "",
+      maxOutputTokens: model.maxOutputTokens === null ? "" : String(model.maxOutputTokens),
+      temperature: model.temperature === null ? "" : String(model.temperature),
+      topP: model.topP === null ? "" : String(model.topP),
+      focus,
+    });
+    setError(null);
+  }, []);
+
   const handleStartEdit = useCallback(
-    (
-      provider: string,
-      modelId: string,
-      contextWindowTokens: number | null,
-      mappedToModel: string | null
-    ) => {
-      setEditing({
-        provider,
-        originalModelId: modelId,
-        newModelId: modelId,
-        contextWindowTokens: contextWindowTokens === null ? "" : String(contextWindowTokens),
-        mappedToModel: mappedToModel ?? "",
-        focus: "model",
-      });
-      setError(null);
+    (model: CustomModelInfo) => {
+      startModelEdit(model, "model");
     },
-    []
+    [startModelEdit]
   );
 
   const handleStartContextEdit = useCallback(
-    (
-      provider: string,
-      modelId: string,
-      contextWindowTokens: number | null,
-      mappedToModel: string | null
-    ) => {
-      setEditing({
-        provider,
-        originalModelId: modelId,
-        newModelId: modelId,
-        contextWindowTokens: contextWindowTokens === null ? "" : String(contextWindowTokens),
-        mappedToModel: mappedToModel ?? "",
-        focus: "context",
-      });
-      setError(null);
+    (model: CustomModelInfo) => {
+      startModelEdit(model, "context");
     },
-    []
+    [startModelEdit]
   );
 
   const handleCancelEdit = useCallback(() => {
@@ -285,6 +377,27 @@ export function ModelsSection() {
       return;
     }
 
+    const maxOutputTokensInput = editing.maxOutputTokens.trim();
+    const parsedMaxOutputTokens = parsePositiveIntegerInput(maxOutputTokensInput);
+    if (maxOutputTokensInput.length > 0 && parsedMaxOutputTokens === null) {
+      setError("Max output tokens must be a positive integer");
+      return;
+    }
+
+    const temperatureInput = editing.temperature.trim();
+    const parsedTemperature = parseBoundedNumberInput(temperatureInput, 0, 2);
+    if (temperatureInput.length > 0 && parsedTemperature === null) {
+      setError("Temperature must be a number between 0 and 2");
+      return;
+    }
+
+    const topPInput = editing.topP.trim();
+    const parsedTopP = parseBoundedNumberInput(topPInput, 0, 1);
+    if (topPInput.length > 0 && parsedTopP === null) {
+      setError("Top P must be a number between 0 and 1");
+      return;
+    }
+
     // Only validate duplicates if the model ID actually changed
     if (trimmedModelId !== editing.originalModelId) {
       if (modelExists(editing.provider, trimmedModelId)) {
@@ -301,6 +414,11 @@ export function ModelsSection() {
       parsedContextWindowTokens,
       mappedTo
     );
+    const overrides: EditableModelParameterOverrides = {
+      max_output_tokens: parsedMaxOutputTokens,
+      temperature: parsedTemperature,
+      top_p: parsedTopP,
+    };
 
     // Optimistic update - returns new models array for API call
     const updatedModels = updateModelsOptimistically(editing.provider, (models) => {
@@ -323,11 +441,88 @@ export function ModelsSection() {
 
       return nextModels;
     });
+
+    const providerModelParameters = config[editing.provider]?.modelParameters as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    let nextModelParameters = providerModelParameters;
+
+    if (trimmedModelId !== editing.originalModelId) {
+      nextModelParameters = buildUpdatedModelParameters(
+        nextModelParameters,
+        editing.originalModelId,
+        {
+          max_output_tokens: null,
+          temperature: null,
+          top_p: null,
+        }
+      );
+    }
+
+    nextModelParameters = buildUpdatedModelParameters(
+      nextModelParameters,
+      trimmedModelId,
+      overrides
+    );
+
+    updateOptimistically(editing.provider, {
+      modelParameters: nextModelParameters,
+    });
+
+    const providerId = editing.provider;
+    const originalModelId = editing.originalModelId;
     setEditing(null);
 
-    // Save in background
-    void api.providers.setModels({ provider: editing.provider, models: updatedModels });
-  }, [api, editing, config, modelExists, updateModelsOptimistically]);
+    void (async () => {
+      const setModelsResult = await api.providers.setModels({
+        provider: providerId,
+        models: updatedModels,
+      });
+      if (!setModelsResult.success) {
+        setError(setModelsResult.error);
+        void refresh();
+        return;
+      }
+
+      const setOverridesResult = await api.providers.setModelParameters({
+        provider: providerId,
+        modelId: trimmedModelId,
+        overrides,
+      });
+      if (!setOverridesResult.success) {
+        setError(setOverridesResult.error);
+        void refresh();
+        return;
+      }
+
+      if (trimmedModelId === originalModelId) {
+        return;
+      }
+
+      const clearLegacyOverridesResult = await api.providers.setModelParameters({
+        provider: providerId,
+        modelId: originalModelId,
+        overrides: {
+          max_output_tokens: null,
+          temperature: null,
+          top_p: null,
+        },
+      });
+
+      if (!clearLegacyOverridesResult.success) {
+        setError(clearLegacyOverridesResult.error);
+        void refresh();
+      }
+    })();
+  }, [
+    api,
+    editing,
+    config,
+    modelExists,
+    refresh,
+    updateModelsOptimistically,
+    updateOptimistically,
+  ]);
 
   // Show loading state while config is being fetched
   if (loading || !config) {
@@ -340,34 +535,32 @@ export function ModelsSection() {
   }
 
   // Get all custom models across providers (excluding hidden providers like mux-gateway)
-  const getCustomModels = (): Array<{
-    provider: string;
-    modelId: string;
-    fullId: string;
-    contextWindowTokens: number | null;
-    mappedToModel: string | null;
-  }> => {
-    const models: Array<{
-      provider: string;
-      modelId: string;
-      fullId: string;
-      contextWindowTokens: number | null;
-      mappedToModel: string | null;
-    }> = [];
+  const getCustomModels = (): CustomModelInfo[] => {
+    const models: CustomModelInfo[] = [];
 
     for (const [provider, providerConfig] of Object.entries(config)) {
       // Skip hidden providers (mux-gateway models are routed, not managed as a standalone list)
       if (HIDDEN_PROVIDERS.has(provider)) continue;
       if (!providerConfig.models) continue;
 
+      const modelParametersByModel =
+        (providerConfig.modelParameters as Record<
+          string,
+          { max_output_tokens?: number; temperature?: number; top_p?: number } | undefined
+        > | null) ?? {};
+
       for (const modelEntry of providerConfig.models) {
         const modelId = getProviderModelEntryId(modelEntry);
+        const modelOverrides = getEditableModelParameterOverrides(modelParametersByModel, modelId);
         models.push({
           provider,
           modelId,
           fullId: `${provider}:${modelId}`,
           contextWindowTokens: getProviderModelEntryContextWindowTokens(modelEntry),
           mappedToModel: getProviderModelEntryMappedTo(modelEntry),
+          maxOutputTokens: modelOverrides.max_output_tokens,
+          temperature: modelOverrides.temperature,
+          topP: modelOverrides.top_p,
         });
       }
     }
@@ -470,6 +663,11 @@ export function ModelsSection() {
                       editModelValue={isModelEditing ? editing.newModelId : undefined}
                       editContextValue={isModelEditing ? editing.contextWindowTokens : undefined}
                       editMappedToModel={isModelEditing ? editing.mappedToModel : undefined}
+                      editMaxOutputTokensValue={
+                        isModelEditing ? editing.maxOutputTokens : undefined
+                      }
+                      editTemperatureValue={isModelEditing ? editing.temperature : undefined}
+                      editTopPValue={isModelEditing ? editing.topP : undefined}
                       editAutofocus={isModelEditing ? editing.focus : undefined}
                       customContextWindowTokens={model.contextWindowTokens}
                       allModels={knownModelIds}
@@ -481,22 +679,8 @@ export function ModelsSection() {
                       availableRoutes={routing.availableRoutes(model.fullId)}
                       is1MContextEnabled={has1MContext(model.fullId)}
                       onSetDefault={() => setDefaultModel(model.fullId)}
-                      onStartEdit={() =>
-                        handleStartEdit(
-                          model.provider,
-                          model.modelId,
-                          model.contextWindowTokens,
-                          model.mappedToModel
-                        )
-                      }
-                      onStartContextEdit={() =>
-                        handleStartContextEdit(
-                          model.provider,
-                          model.modelId,
-                          model.contextWindowTokens,
-                          model.mappedToModel
-                        )
-                      }
+                      onStartEdit={() => handleStartEdit(model)}
+                      onStartContextEdit={() => handleStartContextEdit(model)}
                       onSaveEdit={handleSaveEdit}
                       onCancelEdit={handleCancelEdit}
                       onEditModelChange={(value) =>
@@ -509,6 +693,15 @@ export function ModelsSection() {
                       }
                       onEditMappedToModelChange={(value) =>
                         setEditing((prev) => (prev ? { ...prev, mappedToModel: value } : null))
+                      }
+                      onEditMaxOutputTokensChange={(value) =>
+                        setEditing((prev) => (prev ? { ...prev, maxOutputTokens: value } : null))
+                      }
+                      onEditTemperatureChange={(value) =>
+                        setEditing((prev) => (prev ? { ...prev, temperature: value } : null))
+                      }
+                      onEditTopPChange={(value) =>
+                        setEditing((prev) => (prev ? { ...prev, topP: value } : null))
                       }
                       onRemove={() => handleRemoveModel(model.provider, model.modelId)}
                       isHiddenFromSelector={hiddenModels.includes(model.fullId)}

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -137,14 +137,6 @@ function getEditableModelParameterOverrides(
   };
 }
 
-function hasAnyEditableModelParameterOverride(overrides: EditableModelParameterOverrides): boolean {
-  return (
-    overrides.max_output_tokens !== null ||
-    overrides.temperature !== null ||
-    overrides.top_p !== null
-  );
-}
-
 function buildProviderModelEntry(
   modelId: string,
   contextWindowTokens: number | null,
@@ -171,33 +163,48 @@ export function buildUpdatedModelParameters(
   overrides: EditableModelParameterOverrides
 ): Record<string, Record<string, unknown>> | undefined {
   const nextModelParameters = { ...(currentModelParameters ?? {}) };
+  const currentOverrides = nextModelParameters[modelId];
+  const nextOverrides: Record<string, unknown> = {
+    ...(typeof currentOverrides === "object" && currentOverrides !== null ? currentOverrides : {}),
+  };
 
-  if (!hasAnyEditableModelParameterOverride(overrides)) {
+  if (overrides.max_output_tokens === null) {
+    delete nextOverrides.max_output_tokens;
+  } else {
+    nextOverrides.max_output_tokens = overrides.max_output_tokens;
+  }
+
+  if (overrides.temperature === null) {
+    delete nextOverrides.temperature;
+  } else {
+    nextOverrides.temperature = overrides.temperature;
+  }
+
+  if (overrides.top_p === null) {
+    delete nextOverrides.top_p;
+  } else {
+    nextOverrides.top_p = overrides.top_p;
+  }
+
+  if (Object.keys(nextOverrides).length === 0) {
     delete nextModelParameters[modelId];
   } else {
-    const currentOverrides = nextModelParameters[modelId];
-    const nextOverrides: Record<string, unknown> = {
-      ...(typeof currentOverrides === "object" && currentOverrides !== null
-        ? currentOverrides
-        : {}),
-      max_output_tokens: overrides.max_output_tokens,
-      temperature: overrides.temperature,
-      top_p: overrides.top_p,
-    };
-
-    if (overrides.max_output_tokens === null) {
-      delete nextOverrides.max_output_tokens;
-    }
-    if (overrides.temperature === null) {
-      delete nextOverrides.temperature;
-    }
-    if (overrides.top_p === null) {
-      delete nextOverrides.top_p;
-    }
-
     nextModelParameters[modelId] = nextOverrides;
   }
 
+  return Object.keys(nextModelParameters).length > 0 ? nextModelParameters : undefined;
+}
+
+export function removeModelParameterEntry(
+  currentModelParameters: Record<string, Record<string, unknown>> | undefined,
+  modelId: string
+): Record<string, Record<string, unknown>> | undefined {
+  if (!currentModelParameters || !(modelId in currentModelParameters)) {
+    return currentModelParameters;
+  }
+
+  const nextModelParameters = { ...currentModelParameters };
+  delete nextModelParameters[modelId];
   return Object.keys(nextModelParameters).length > 0 ? nextModelParameters : undefined;
 }
 
@@ -320,10 +327,38 @@ export function ModelsSection() {
         models.filter((entry) => getProviderModelEntryId(entry) !== modelId)
       );
 
-      // Save in background
-      void api.providers.setModels({ provider, models: updatedModels });
+      const providerModelParameters = config[provider]?.modelParameters as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+      updateOptimistically(provider, {
+        modelParameters: removeModelParameterEntry(providerModelParameters, modelId),
+      });
+
+      void (async () => {
+        const setModelsResult = await api.providers.setModels({ provider, models: updatedModels });
+        if (!setModelsResult.success) {
+          setError(setModelsResult.error);
+          void refresh();
+          return;
+        }
+
+        const clearOverridesResult = await api.providers.setModelParameters({
+          provider,
+          modelId,
+          overrides: {
+            max_output_tokens: null,
+            temperature: null,
+            top_p: null,
+          },
+        });
+
+        if (!clearOverridesResult.success) {
+          setError(clearOverridesResult.error);
+          void refresh();
+        }
+      })();
     },
-    [api, config, updateModelsOptimistically]
+    [api, config, refresh, updateModelsOptimistically, updateOptimistically]
   );
 
   const startModelEdit = useCallback((model: CustomModelInfo, focus: "model" | "context") => {
@@ -448,15 +483,7 @@ export function ModelsSection() {
     let nextModelParameters = providerModelParameters;
 
     if (trimmedModelId !== editing.originalModelId) {
-      nextModelParameters = buildUpdatedModelParameters(
-        nextModelParameters,
-        editing.originalModelId,
-        {
-          max_output_tokens: null,
-          temperature: null,
-          top_p: null,
-        }
-      );
+      nextModelParameters = removeModelParameterEntry(nextModelParameters, editing.originalModelId);
     }
 
     nextModelParameters = buildUpdatedModelParameters(

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -208,6 +208,31 @@ export function removeModelParameterEntry(
   return Object.keys(nextModelParameters).length > 0 ? nextModelParameters : undefined;
 }
 
+export function migrateModelParameterEntry(
+  currentModelParameters: Record<string, Record<string, unknown>> | undefined,
+  originalModelId: string,
+  nextModelId: string
+): Record<string, Record<string, unknown>> | undefined {
+  if (!currentModelParameters || originalModelId === nextModelId) {
+    return currentModelParameters;
+  }
+
+  const originalOverrides = currentModelParameters[originalModelId];
+  if (!originalOverrides || typeof originalOverrides !== "object") {
+    return currentModelParameters;
+  }
+
+  const destinationOverrides = currentModelParameters[nextModelId];
+  const nextModelParameters = { ...currentModelParameters };
+  nextModelParameters[nextModelId] = {
+    ...(destinationOverrides && typeof destinationOverrides === "object" ? destinationOverrides : {}),
+    ...originalOverrides,
+  };
+  delete nextModelParameters[originalModelId];
+
+  return Object.keys(nextModelParameters).length > 0 ? nextModelParameters : undefined;
+}
+
 export function shouldShowModelInSettings(modelId: string, codexOauthConfigured: boolean): boolean {
   // OpenAI OAuth gating only applies to OpenAI-routed models; other providers can
   // reuse the same providerModelId string without requiring OpenAI OAuth.
@@ -483,7 +508,11 @@ export function ModelsSection() {
     let nextModelParameters = providerModelParameters;
 
     if (trimmedModelId !== editing.originalModelId) {
-      nextModelParameters = removeModelParameterEntry(nextModelParameters, editing.originalModelId);
+      nextModelParameters = migrateModelParameterEntry(
+        nextModelParameters,
+        editing.originalModelId,
+        trimmedModelId
+      );
     }
 
     nextModelParameters = buildUpdatedModelParameters(

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -361,6 +361,7 @@ export const providers = {
     input: z.object({
       provider: z.string(),
       modelId: z.string().min(1),
+      renameFromModelId: z.string().min(1).optional(),
       overrides: EditableCustomModelParameterOverridesSchema,
     }),
     output: ResultSchema(z.void(), z.string()),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -110,6 +110,10 @@ import {
   CodexOauthDefaultAuthSchema,
   ServiceTierSchema,
 } from "../../config/schemas/providersConfig";
+import {
+  ModelParametersByModelSchema,
+  StandardModelParameterOverridesSchema,
+} from "../../config/schemas/modelParameters";
 import { ProviderModelEntrySchema } from "../../config/schemas/providerModelEntry";
 import { TaskSettingsSchema } from "../../config/schemas/taskSettings";
 import { ThinkingLevelSchema } from "../../types/thinking";
@@ -226,6 +230,7 @@ export const ProviderConfigInfoSchema = z.object({
   displayName: z.string().optional(),
   isCustom: z.boolean().optional(),
   models: z.array(ProviderModelEntrySchema).optional(),
+  modelParameters: ModelParametersByModelSchema.optional(),
   /** OpenAI-specific fields */
   serviceTier: ServiceTierSchema.optional(),
   wireFormat: z.enum(["responses", "chatCompletions"]).optional(),
@@ -299,6 +304,16 @@ export const CustomProviderMutationErrorSchema = z.discriminatedUnion("code", [
   }),
 ]);
 
+const EditableCustomModelParameterOverridesSchema = StandardModelParameterOverridesSchema.pick({
+  max_output_tokens: true,
+  temperature: true,
+  top_p: true,
+}).extend({
+  max_output_tokens: z.number().int().positive().nullish(),
+  temperature: z.number().min(0).max(2).nullish(),
+  top_p: z.number().min(0).max(1).nullish(),
+});
+
 export const providers = {
   addCustomOpenAICompatibleProvider: {
     input: z.object({
@@ -339,6 +354,14 @@ export const providers = {
     input: z.object({
       provider: z.string(),
       models: z.array(ProviderModelEntrySchema),
+    }),
+    output: ResultSchema(z.void(), z.string()),
+  },
+  setModelParameters: {
+    input: z.object({
+      provider: z.string(),
+      modelId: z.string().min(1),
+      overrides: EditableCustomModelParameterOverridesSchema,
     }),
     output: ResultSchema(z.void(), z.string()),
   },

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1948,6 +1948,12 @@ export const router = (authToken?: string) => {
         .handler(({ context, input }) =>
           context.providerService.setModels(input.provider, input.models)
         ),
+      setModelParameters: t
+        .input(schemas.providers.setModelParameters.input)
+        .output(schemas.providers.setModelParameters.output)
+        .handler(({ context, input }) =>
+          context.providerService.setModelParameters(input.provider, input.modelId, input.overrides)
+        ),
       onConfigChanged: t
         .input(schemas.providers.onConfigChanged.input)
         .output(schemas.providers.onConfigChanged.output)

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -1952,7 +1952,12 @@ export const router = (authToken?: string) => {
         .input(schemas.providers.setModelParameters.input)
         .output(schemas.providers.setModelParameters.output)
         .handler(({ context, input }) =>
-          context.providerService.setModelParameters(input.provider, input.modelId, input.overrides)
+          context.providerService.setModelParameters(
+            input.provider,
+            input.modelId,
+            input.overrides,
+            input.renameFromModelId
+          )
         ),
       onConfigChanged: t
         .input(schemas.providers.onConfigChanged.input)

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -682,12 +682,79 @@ describe("ProviderService model parameter overrides", () => {
     });
   });
 
-  it("clears stale model parameter overrides after a model rename", () => {
+  it("clears editable keys without dropping non-editable model parameters", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        models: ["gpt-5"],
+        modelParameters: {
+          "gpt-5": {
+            temperature: 0.3,
+            top_k: 16,
+          },
+        },
+      });
+
+      const result = service.setModelParameters("openai", "gpt-5", {
+        max_output_tokens: null,
+        temperature: null,
+        top_p: null,
+      });
+
+      expect(result.success).toBe(true);
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.openai?.modelParameters).toEqual({
+        "gpt-5": {
+          top_k: 16,
+        },
+      });
+    });
+  });
+
+  it("retains valid model parameter entries when another entry is malformed", () => {
     withTempConfig((config, service) => {
       saveOpenAIConfig(config, {
         modelParameters: {
+          "*": {
+            top_p: 0.8,
+            custom_passthrough: true,
+          },
+          "bad-model": {
+            temperature: 3,
+          },
+          "gpt-5": {
+            temperature: 0.4,
+          },
+        },
+      });
+
+      const result = service.setModelParameters("openai", "gpt-5", {
+        max_output_tokens: 2048,
+        temperature: null,
+        top_p: null,
+      });
+
+      expect(result.success).toBe(true);
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.openai?.modelParameters).toEqual({
+        "*": {
+          top_p: 0.8,
+          custom_passthrough: true,
+        },
+        "gpt-5": {
+          max_output_tokens: 2048,
+        },
+      });
+    });
+  });
+
+  it("clears stale model parameter overrides after a model rename", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        models: ["renamed"],
+        modelParameters: {
           legacy: {
             temperature: 0.2,
+            top_k: 32,
           },
         },
       });

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -628,6 +628,117 @@ describe("ProviderService model normalization", () => {
   });
 });
 
+describe("ProviderService model parameter overrides", () => {
+  it("surfaces modelParameters in getConfig", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        modelParameters: {
+          "gpt-5": {
+            max_output_tokens: 2048,
+            temperature: 0.4,
+            top_p: 0.9,
+          },
+        },
+      });
+
+      const providers = service.getConfig();
+
+      expect(providers.openai.modelParameters).toEqual({
+        "gpt-5": {
+          max_output_tokens: 2048,
+          temperature: 0.4,
+          top_p: 0.9,
+        },
+      });
+    });
+  });
+
+  it("sets model parameters while preserving unrelated model parameter keys", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        modelParameters: {
+          "gpt-5": {
+            max_output_tokens: 1024,
+            top_k: 32,
+          },
+        },
+      });
+
+      const result = service.setModelParameters("openai", "gpt-5", {
+        max_output_tokens: null,
+        temperature: 0.7,
+        top_p: 0.95,
+      });
+
+      expect(result.success).toBe(true);
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.openai?.modelParameters).toEqual({
+        "gpt-5": {
+          temperature: 0.7,
+          top_p: 0.95,
+          top_k: 32,
+        },
+      });
+    });
+  });
+
+  it("clears stale model parameter overrides after a model rename", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        modelParameters: {
+          legacy: {
+            temperature: 0.2,
+          },
+        },
+      });
+
+      const setNewModelParameters = service.setModelParameters("openai", "renamed", {
+        max_output_tokens: 4096,
+        temperature: 0.5,
+        top_p: null,
+      });
+      expect(setNewModelParameters.success).toBe(true);
+
+      const clearLegacyModelParameters = service.setModelParameters("openai", "legacy", {
+        max_output_tokens: null,
+        temperature: null,
+        top_p: null,
+      });
+      expect(clearLegacyModelParameters.success).toBe(true);
+
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.openai?.modelParameters).toEqual({
+        renamed: {
+          max_output_tokens: 4096,
+          temperature: 0.5,
+        },
+      });
+    });
+  });
+
+  it("removes modelParameters when the last override entry is cleared", () => {
+    withTempConfig((config, service) => {
+      saveOpenAIConfig(config, {
+        modelParameters: {
+          "gpt-5": {
+            max_output_tokens: 1024,
+          },
+        },
+      });
+
+      const result = service.setModelParameters("openai", "gpt-5", {
+        max_output_tokens: null,
+        temperature: null,
+        top_p: null,
+      });
+
+      expect(result.success).toBe(true);
+      const providersConfig = config.loadProvidersConfig();
+      expect(providersConfig?.openai?.modelParameters).toBeUndefined();
+    });
+  });
+});
+
 describe("ProviderService custom provider mutations", () => {
   it("rejects adding a built-in provider id", () => {
     withTempConfig((config, service) => {

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -747,7 +747,7 @@ describe("ProviderService model parameter overrides", () => {
     });
   });
 
-  it("clears stale model parameter overrides after a model rename", () => {
+  it("renames model parameter entries while preserving non-editable overrides", () => {
     withTempConfig((config, service) => {
       saveOpenAIConfig(config, {
         models: ["renamed"],
@@ -755,29 +755,30 @@ describe("ProviderService model parameter overrides", () => {
           legacy: {
             temperature: 0.2,
             top_k: 32,
+            seed: 7,
           },
         },
       });
 
-      const setNewModelParameters = service.setModelParameters("openai", "renamed", {
-        max_output_tokens: 4096,
-        temperature: 0.5,
-        top_p: null,
-      });
-      expect(setNewModelParameters.success).toBe(true);
-
-      const clearLegacyModelParameters = service.setModelParameters("openai", "legacy", {
-        max_output_tokens: null,
-        temperature: null,
-        top_p: null,
-      });
-      expect(clearLegacyModelParameters.success).toBe(true);
+      const renameResult = service.setModelParameters(
+        "openai",
+        "renamed",
+        {
+          max_output_tokens: 4096,
+          temperature: 0.5,
+          top_p: null,
+        },
+        "legacy"
+      );
+      expect(renameResult.success).toBe(true);
 
       const providersConfig = config.loadProvidersConfig();
       expect(providersConfig?.openai?.modelParameters).toEqual({
         renamed: {
           max_output_tokens: 4096,
           temperature: 0.5,
+          top_k: 32,
+          seed: 7,
         },
       });
     });

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -948,11 +948,20 @@ export class ProviderService {
   public setModelParameters(
     provider: string,
     modelId: string,
-    overrides: EditableModelParameterOverrides
+    overrides: EditableModelParameterOverrides,
+    renameFromModelId?: string
   ): Result<void, string> {
     const normalizedModelId = modelId.trim();
     if (normalizedModelId.length === 0) {
       return { success: false, error: "Model ID cannot be empty" };
+    }
+
+    const normalizedRenameFromModelId = renameFromModelId?.trim();
+    if (
+      renameFromModelId !== undefined &&
+      (!normalizedRenameFromModelId || normalizedRenameFromModelId.length === 0)
+    ) {
+      return { success: false, error: "Rename source model ID cannot be empty" };
     }
 
     try {
@@ -986,7 +995,34 @@ export class ProviderService {
       const providerConfig = providersConfig[provider] as BaseProviderConfig;
       const currentModelParameters = normalizeModelParameters(providerConfig.modelParameters) ?? {};
       const nextModelParameters = { ...currentModelParameters };
-      const existingModelOverrides = currentModelParameters[normalizedModelId];
+
+      if (
+        normalizedRenameFromModelId &&
+        normalizedRenameFromModelId !== normalizedModelId &&
+        normalizedRenameFromModelId in nextModelParameters
+      ) {
+        const renameSourceOverrides = nextModelParameters[normalizedRenameFromModelId];
+        const destinationOverrides = nextModelParameters[normalizedModelId];
+
+        if (
+          renameSourceOverrides &&
+          typeof renameSourceOverrides === "object" &&
+          !Array.isArray(renameSourceOverrides)
+        ) {
+          nextModelParameters[normalizedModelId] = {
+            ...(destinationOverrides &&
+            typeof destinationOverrides === "object" &&
+            !Array.isArray(destinationOverrides)
+              ? destinationOverrides
+              : {}),
+            ...renameSourceOverrides,
+          };
+        }
+
+        delete nextModelParameters[normalizedRenameFromModelId];
+      }
+
+      const existingModelOverrides = nextModelParameters[normalizedModelId];
       const nextModelOverrides: Record<string, unknown> =
         typeof existingModelOverrides === "object" &&
         existingModelOverrides !== null &&

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -6,7 +6,10 @@ import {
   type ProviderName,
 } from "@/common/constants/providers";
 import type { BaseProviderConfig } from "@/common/config/schemas/providersConfig";
-import { ModelParametersByModelSchema } from "@/common/config/schemas/modelParameters";
+import {
+  ModelParameterOverridesSchema,
+  ModelParametersByModelSchema,
+} from "@/common/config/schemas/modelParameters";
 import type { Result } from "@/common/types/result";
 import type {
   AddCustomOpenAICompatibleProviderInput,
@@ -75,10 +78,37 @@ function normalizeModelParameters(
   modelParameters: unknown
 ): BaseProviderConfig["modelParameters"] | undefined {
   const parsed = ModelParametersByModelSchema.safeParse(modelParameters);
-  if (!parsed.success) {
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  if (
+    typeof modelParameters !== "object" ||
+    modelParameters === null ||
+    Array.isArray(modelParameters)
+  ) {
     return undefined;
   }
-  return parsed.data;
+
+  const recoveredEntries: Array<[string, Record<string, unknown>]> = [];
+  for (const [modelId, overrides] of Object.entries(modelParameters)) {
+    if (modelId.trim().length === 0) {
+      continue;
+    }
+
+    const parsedOverrides = ModelParameterOverridesSchema.safeParse(overrides);
+    if (!parsedOverrides.success) {
+      continue;
+    }
+
+    recoveredEntries.push([modelId, parsedOverrides.data]);
+  }
+
+  if (recoveredEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(recoveredEntries);
 }
 
 function filterModelParametersByPolicy(
@@ -956,28 +986,33 @@ export class ProviderService {
       const providerConfig = providersConfig[provider] as BaseProviderConfig;
       const currentModelParameters = normalizeModelParameters(providerConfig.modelParameters) ?? {};
       const nextModelParameters = { ...currentModelParameters };
+      const existingModelOverrides = currentModelParameters[normalizedModelId];
+      const nextModelOverrides: Record<string, unknown> =
+        typeof existingModelOverrides === "object" &&
+        existingModelOverrides !== null &&
+        !Array.isArray(existingModelOverrides)
+          ? { ...existingModelOverrides }
+          : {};
 
-      if (hasAnyEditableModelParameterOverride(overrides)) {
-        const existingModelOverrides = currentModelParameters[normalizedModelId];
-        const nextModelOverrides: Record<string, unknown> =
-          typeof existingModelOverrides === "object" &&
-          existingModelOverrides !== null &&
-          !Array.isArray(existingModelOverrides)
-            ? { ...existingModelOverrides }
-            : {};
-
-        for (const key of MODEL_PARAMETER_OVERRIDE_KEYS) {
-          const value = overrides[key as ModelParameterOverrideKey];
-          if (typeof value === "number") {
-            nextModelOverrides[key] = value;
-          } else {
-            delete nextModelOverrides[key];
-          }
+      for (const key of MODEL_PARAMETER_OVERRIDE_KEYS) {
+        const value = overrides[key as ModelParameterOverrideKey];
+        if (typeof value === "number") {
+          nextModelOverrides[key] = value;
+        } else {
+          delete nextModelOverrides[key];
         }
+      }
 
-        nextModelParameters[normalizedModelId] = nextModelOverrides;
-      } else {
+      const modelIsConfigured = normalizeProviderModelEntries(providerConfig.models).some(
+        (entry) => getProviderModelEntryId(entry) === normalizedModelId
+      );
+
+      if (!modelIsConfigured && !hasAnyEditableModelParameterOverride(overrides)) {
         delete nextModelParameters[normalizedModelId];
+      } else if (Object.keys(nextModelOverrides).length === 0) {
+        delete nextModelParameters[normalizedModelId];
+      } else {
+        nextModelParameters[normalizedModelId] = nextModelOverrides;
       }
 
       if (Object.keys(nextModelParameters).length === 0) {

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -6,6 +6,7 @@ import {
   type ProviderName,
 } from "@/common/constants/providers";
 import type { BaseProviderConfig } from "@/common/config/schemas/providersConfig";
+import { ModelParametersByModelSchema } from "@/common/config/schemas/modelParameters";
 import type { Result } from "@/common/types/result";
 import type {
   AddCustomOpenAICompatibleProviderInput,
@@ -60,14 +61,69 @@ function filterProviderModelsByPolicy(
   return models.filter((entry) => allowedModels.includes(getProviderModelEntryId(entry)));
 }
 
+type EditableModelParameterOverrides = {
+  max_output_tokens?: number | null;
+  temperature?: number | null;
+  top_p?: number | null;
+};
+
+const MODEL_PARAMETER_OVERRIDE_KEYS = ["max_output_tokens", "temperature", "top_p"] as const;
+
+type ModelParameterOverrideKey = (typeof MODEL_PARAMETER_OVERRIDE_KEYS)[number];
+
+function normalizeModelParameters(
+  modelParameters: unknown
+): BaseProviderConfig["modelParameters"] | undefined {
+  const parsed = ModelParametersByModelSchema.safeParse(modelParameters);
+  if (!parsed.success) {
+    return undefined;
+  }
+  return parsed.data;
+}
+
+function filterModelParametersByPolicy(
+  modelParameters: BaseProviderConfig["modelParameters"] | undefined,
+  allowedModels: string[] | null
+): BaseProviderConfig["modelParameters"] | undefined {
+  if (!modelParameters) {
+    return undefined;
+  }
+
+  if (!Array.isArray(allowedModels)) {
+    return modelParameters;
+  }
+
+  const filteredEntries = Object.entries(modelParameters).filter(
+    ([modelId]) => modelId === "*" || allowedModels.includes(modelId)
+  );
+
+  if (filteredEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(filteredEntries);
+}
+
+function hasAnyEditableModelParameterOverride(overrides: EditableModelParameterOverrides): boolean {
+  return MODEL_PARAMETER_OVERRIDE_KEYS.some((key) => {
+    const value = overrides[key as ModelParameterOverrideKey];
+    return typeof value === "number";
+  });
+}
+
 function buildCustomProviderConfigInfo(
   config: BaseProviderConfig,
   policy?: { forcedBaseUrl?: string; allowedModels?: string[] | null }
 ): ProviderConfigInfo {
   const baseUrl = policy?.forcedBaseUrl ?? resolveConfigBaseUrl(config);
+  const allowedModels = policy?.allowedModels ?? null;
   const models = filterProviderModelsByPolicy(
     normalizeProviderModelEntries(config.models),
-    policy?.allowedModels ?? null
+    allowedModels
+  );
+  const modelParameters = filterModelParametersByPolicy(
+    normalizeModelParameters(config.modelParameters),
+    allowedModels
   );
   const apiKeyIsOpRef = isOpReference(config.apiKey);
   const apiKeySet = typeof config.apiKey === "string" && config.apiKey.trim().length > 0;
@@ -83,6 +139,7 @@ function buildCustomProviderConfigInfo(
     apiKeySource: apiKeySet ? "config" : apiKeyFile ? "file" : "keyless",
     baseUrl,
     models,
+    modelParameters,
     displayName: config.displayName,
     providerType: "openai-compatible",
     isCustom: true,
@@ -304,6 +361,7 @@ export class ProviderService {
         baseUrl?: string;
         baseURL?: string;
         models?: unknown[];
+        modelParameters?: unknown;
         serviceTier?: string;
         wireFormat?: string;
         store?: unknown;
@@ -336,6 +394,10 @@ export class ProviderService {
       const normalizedModels =
         config.models === undefined ? undefined : normalizeProviderModelEntries(config.models);
       const filteredModels = filterProviderModelsByPolicy(normalizedModels, allowedModels);
+      const filteredModelParameters = filterModelParametersByPolicy(
+        normalizeModelParameters(config.modelParameters),
+        allowedModels
+      );
 
       const codexOauthSet =
         provider === "openai" && parseCodexOauthAuth(config.codexOauth) !== null;
@@ -358,6 +420,7 @@ export class ProviderService {
         baseUrl: forcedBaseUrl ?? explicitBaseUrl,
         apiKeyFile: typeof config.apiKeyFile === "string" ? config.apiKeyFile : undefined,
         models: filteredModels,
+        modelParameters: filteredModelParameters,
       };
 
       // OpenAI-specific fields
@@ -849,6 +912,87 @@ export class ProviderService {
     } catch (error) {
       const message = getErrorMessage(error);
       return { success: false, error: `Failed to set models: ${message}` };
+    }
+  }
+
+  public setModelParameters(
+    provider: string,
+    modelId: string,
+    overrides: EditableModelParameterOverrides
+  ): Result<void, string> {
+    const normalizedModelId = modelId.trim();
+    if (normalizedModelId.length === 0) {
+      return { success: false, error: "Model ID cannot be empty" };
+    }
+
+    try {
+      if (this.policyService?.isEnforced()) {
+        if (!this.policyService.isProviderAllowed(provider)) {
+          return { success: false, error: `Provider ${provider} is not allowed by policy` };
+        }
+
+        const allowedModels =
+          this.policyService.getEffectivePolicy()?.providerAccess?.find((p) => p.id === provider)
+            ?.allowedModels ?? null;
+
+        if (
+          normalizedModelId !== "*" &&
+          Array.isArray(allowedModels) &&
+          !allowedModels.includes(normalizedModelId)
+        ) {
+          return {
+            success: false,
+            error: `Model ${normalizedModelId} is not allowed by policy`,
+          };
+        }
+      }
+
+      const providersConfig = this.config.loadProvidersConfig() ?? {};
+
+      if (!providersConfig[provider]) {
+        providersConfig[provider] = {};
+      }
+
+      const providerConfig = providersConfig[provider] as BaseProviderConfig;
+      const currentModelParameters = normalizeModelParameters(providerConfig.modelParameters) ?? {};
+      const nextModelParameters = { ...currentModelParameters };
+
+      if (hasAnyEditableModelParameterOverride(overrides)) {
+        const existingModelOverrides = currentModelParameters[normalizedModelId];
+        const nextModelOverrides: Record<string, unknown> =
+          typeof existingModelOverrides === "object" &&
+          existingModelOverrides !== null &&
+          !Array.isArray(existingModelOverrides)
+            ? { ...existingModelOverrides }
+            : {};
+
+        for (const key of MODEL_PARAMETER_OVERRIDE_KEYS) {
+          const value = overrides[key as ModelParameterOverrideKey];
+          if (typeof value === "number") {
+            nextModelOverrides[key] = value;
+          } else {
+            delete nextModelOverrides[key];
+          }
+        }
+
+        nextModelParameters[normalizedModelId] = nextModelOverrides;
+      } else {
+        delete nextModelParameters[normalizedModelId];
+      }
+
+      if (Object.keys(nextModelParameters).length === 0) {
+        delete providerConfig.modelParameters;
+      } else {
+        providerConfig.modelParameters = nextModelParameters;
+      }
+
+      this.config.saveProvidersConfig(providersConfig);
+      this.notifyFromMutation();
+
+      return { success: true, data: undefined };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      return { success: false, error: `Failed to set model parameters: ${message}` };
     }
   }
 


### PR DESCRIPTION
## Summary
Adds `max_output_tokens`, `temperature`, and `top_p` editing to the **Custom Models** edit flow in Settings, so users can configure per-model provider overrides in-app instead of editing `~/.mux/providers.jsonc` manually.

## Background
`providers.jsonc` already supports per-model parameter overrides and runtime consumption, but the Settings UI had no controls for these fields. This expands on https://github.com/coder/mux/pull/2743 by exposing those existing capabilities in the custom model editing UX.

## Implementation
- Added `modelParameters` to provider config payloads returned to the UI.
- Added a new typed provider mutation: `providers.setModelParameters` for setting/clearing per-model overrides.
- Extended `ProviderService` to:
  - surface filtered `modelParameters` in `getConfig`
  - persist/clear overrides at `provider.modelParameters[modelId]`
  - remove empty entries/maps when cleared
- Extended custom model editing UI (`ModelsSection` + `ModelRow`) to:
  - show edit fields for `max_output_tokens`, `temperature`, `top_p`
  - validate ranges (`>0` int, `0..2`, `0..1`)
  - save overrides along with model metadata updates
  - clear stale override entries when model IDs are renamed

## Demo
https://owo.whats-th.is/4nedYg5.mp4

## Validation
- `make typecheck`
- `bun test src/node/services/providerService.test.ts src/browser/features/Settings/Sections/ModelsSection.test.ts`
- Attempted `make static-check` in this environment, but it is blocked by missing local tools: `shfmt`, `shellcheck`, and `hadolint`.

## Risks
- Main risk is save sequencing when both model metadata and model-parameter overrides are updated in one edit operation.
- Mitigated by targeted service/UI helper tests and by falling back to config refresh on mutation failures.

---

_Generated with `mux` • Model: `openai:gpt-5.3-codex` • Thinking: `high` • Cost: `$4.54`_

<!-- mux-attribution: model=openai:gpt-5.3-codex thinking=high costs=4.54 -->
