### PR TITLE
🤖 fix: support JSON attachments

### DIFF
--- a/src/browser/features/ChatInput/AttachFileButton.tsx
+++ b/src/browser/features/ChatInput/AttachFileButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Attach file button - floats inside the chat input textarea next to the voice input button.
- * Opens a native file picker for images, SVGs, PDFs, and workspace-staged ZIPs.
+ * Opens a native file picker for images, SVGs, PDFs, JSON files, and workspace-staged ZIPs.
  */
 
 import React, { useRef } from "react";
@@ -9,7 +9,8 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/To
 import { cn } from "@/common/lib/utils";
 
 /** Accept filter for the file picker: provider attachments plus workspace-staged ZIPs. */
-const FILE_ACCEPT = "image/*,.svg,.pdf,.zip,application/zip,application/x-zip-compressed";
+const FILE_ACCEPT =
+  "image/*,.svg,.pdf,.json,.zip,application/json,application/zip,application/x-zip-compressed";
 
 interface AttachFileButtonProps {
   onFiles: (files: File[]) => void;
@@ -53,7 +54,7 @@ export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <strong>Attach file</strong> — images, SVGs, PDFs, ZIPs
+          <strong>Attach file</strong> — images, SVGs, PDFs, JSON, ZIPs
         </TooltipContent>
       </Tooltip>
       {/* Hidden file input — kept outside Tooltip to avoid stray DOM children */}

--- a/src/browser/utils/attachmentsHandling.test.ts
+++ b/src/browser/utils/attachmentsHandling.test.ts
@@ -108,6 +108,20 @@ describe("attachmentsHandling", () => {
       expect(attachment.mediaType).toBe("image/jpeg");
       expect(attachment.url).toContain("data:image/jpeg;base64,");
     });
+
+    test("handles JSON files", async () => {
+      const blob = new Blob(['{"ok":true}'], { type: "application/json" });
+      const file = new File([blob], "config.json", { type: "application/json" });
+
+      const attachment = await fileToChatAttachment(file);
+
+      expect(attachment.kind).toBe("provider");
+      if (attachment.kind !== "provider") throw new Error("Expected provider attachment");
+      expect(attachment.mediaType).toBe("application/json");
+      expect(attachment.filename).toBe("config.json");
+      expect(attachment.url).toContain("data:application/json");
+      expect(attachment.url).toContain(";base64,");
+    });
   });
 
   describe("extractAttachmentsFromClipboard", () => {
@@ -206,19 +220,21 @@ describe("attachmentsHandling", () => {
       const mockFile1 = new File(["image"], "photo.png", { type: "" }); // Empty type
       const mockFile2 = new File(["image"], "picture.jpg", { type: "" }); // Empty type
       const mockFile3 = new File(["pdf"], "doc.pdf", { type: "" }); // Empty type
-      const mockFile4 = new File(["text"], "document.txt", { type: "" }); // Empty type, unsupported
+      const mockFile4 = new File(['{"ok":true}'], "config.json", { type: "" }); // Empty type
+      const mockFile5 = new File(["text"], "document.txt", { type: "" }); // Empty type, unsupported
 
       const mockDataTransfer = {
-        files: [mockFile1, mockFile2, mockFile3, mockFile4],
+        files: [mockFile1, mockFile2, mockFile3, mockFile4, mockFile5],
       };
 
       const files = extractAttachmentsFromDrop(mockDataTransfer as unknown as DataTransfer);
 
-      expect(files).toHaveLength(3);
+      expect(files).toHaveLength(4);
       expect(files).toContain(mockFile1);
       expect(files).toContain(mockFile2);
       expect(files).toContain(mockFile3);
-      expect(files).not.toContain(mockFile4);
+      expect(files).toContain(mockFile4);
+      expect(files).not.toContain(mockFile5);
     });
   });
 

--- a/src/browser/utils/attachmentsHandling.test.ts
+++ b/src/browser/utils/attachmentsHandling.test.ts
@@ -122,6 +122,19 @@ describe("attachmentsHandling", () => {
       expect(attachment.url).toContain("data:application/json");
       expect(attachment.url).toContain(";base64,");
     });
+
+    test("handles JSON files reported with a generic MIME type", async () => {
+      const blob = new Blob(['{"ok":true}'], { type: "text/plain" });
+      const file = new File([blob], "config.json", { type: "text/plain" });
+
+      const attachment = await fileToChatAttachment(file);
+
+      expect(attachment.kind).toBe("provider");
+      if (attachment.kind !== "provider") throw new Error("Expected provider attachment");
+      expect(attachment.mediaType).toBe("application/json");
+      expect(attachment.filename).toBe("config.json");
+      expect(attachment.url).toContain("data:application/json");
+    });
   });
 
   describe("extractAttachmentsFromClipboard", () => {

--- a/src/browser/utils/attachmentsHandling.ts
+++ b/src/browser/utils/attachmentsHandling.ts
@@ -169,11 +169,12 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
     reader.onerror = () => reject(new Error("Failed to read file"));
     reader.readAsDataURL(file);
   });
+  const normalizedDataUrl = dataUrl.replace(/^data:[^;,]*/i, `data:${mediaType}`);
 
   const isRasterImage = mediaType.startsWith("image/") && mediaType !== SVG_MEDIA_TYPE;
   if (isRasterImage) {
     // Auto-resize large images before sending so providers don't reject oversized inputs.
-    const resizeResult = await resizeImageIfNeeded(dataUrl, mediaType);
+    const resizeResult = await resizeImageIfNeeded(normalizedDataUrl, mediaType);
 
     return {
       kind: "provider",
@@ -197,7 +198,7 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
   return {
     kind: "provider",
     id: generateAttachmentId(),
-    url: dataUrl,
+    url: normalizedDataUrl,
     mediaType,
     filename: file.name.trim() ? file.name : undefined,
   };

--- a/src/browser/utils/attachmentsHandling.ts
+++ b/src/browser/utils/attachmentsHandling.ts
@@ -2,7 +2,7 @@ import type { FilePart } from "@/common/orpc/types";
 import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 import { MAX_STAGED_ATTACHMENT_SIZE_BYTES } from "@/common/constants/stagedAttachments";
 import {
-  getSupportedAttachmentMediaType,
+  getSupportedChatAttachmentMediaType,
   getSupportedStagedAttachmentMediaType,
 } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import type { ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
@@ -27,7 +27,7 @@ export interface ProcessAttachmentOptions {
 }
 
 function getSupportedMediaType(file: File): string | null {
-  return getSupportedAttachmentMediaType({
+  return getSupportedChatAttachmentMediaType({
     mediaType: file.type !== "" ? file.type : null,
     filename: file.name,
   });

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
@@ -22,10 +22,22 @@ describe("supportedAttachmentMediaTypes", () => {
     expect(getSupportedChatAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
       "application/json"
     );
+    expect(
+      getSupportedChatAttachmentMediaType({ mediaType: "text/plain", filename: "package.json" })
+    ).toBe("application/json");
+    expect(
+      getSupportedChatAttachmentMediaType({
+        mediaType: "application/octet-stream",
+        filename: "package.json",
+      })
+    ).toBe("application/json");
   });
 
   test("keeps .json extension fallback scoped to chat attachments", () => {
     expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(null);
+    expect(
+      getSupportedAttachmentMediaType({ mediaType: "text/plain", filename: "package.json" })
+    ).toBe(null);
     expect(getSupportedChatAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
       "application/json"
     );
@@ -34,6 +46,9 @@ describe("supportedAttachmentMediaTypes", () => {
   test("keeps arbitrary text files unsupported", () => {
     expect(
       getSupportedAttachmentMediaType({ mediaType: "text/plain", filename: "notes.txt" })
+    ).toBeNull();
+    expect(
+      getSupportedChatAttachmentMediaType({ mediaType: "text/plain", filename: "notes.txt" })
     ).toBeNull();
   });
 

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
@@ -1,11 +1,31 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  getAttachmentMediaTypeFromExtension,
   getSupportedAttachmentMediaType,
   getSupportedStagedAttachmentMediaType,
+  isSupportedAttachmentMediaType,
 } from "./supportedAttachmentMediaTypes";
 
 describe("supportedAttachmentMediaTypes", () => {
+  test("supports JSON attachments by media type and extension", () => {
+    expect(isSupportedAttachmentMediaType("application/json")).toBe(true);
+    expect(isSupportedAttachmentMediaType("application/json; charset=utf-8")).toBe(true);
+    expect(getAttachmentMediaTypeFromExtension("config.json")).toBe("application/json");
+  });
+
+  test("falls back to .json extension when MIME type is empty", () => {
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
+      "application/json"
+    );
+  });
+
+  test("keeps arbitrary text files unsupported", () => {
+    expect(
+      getSupportedAttachmentMediaType({ mediaType: "text/plain", filename: "notes.txt" })
+    ).toBeNull();
+  });
+
   test("classifies zip files as staged attachments without making them provider attachments", () => {
     expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBeNull();
     expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBe(

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
@@ -3,19 +3,30 @@ import { describe, expect, test } from "bun:test";
 import {
   getAttachmentMediaTypeFromExtension,
   getSupportedAttachmentMediaType,
+  getSupportedChatAttachmentMediaType,
   getSupportedStagedAttachmentMediaType,
   isSupportedAttachmentMediaType,
+  isSupportedChatAttachmentMediaType,
 } from "./supportedAttachmentMediaTypes";
 
 describe("supportedAttachmentMediaTypes", () => {
-  test("supports JSON attachments by media type and extension", () => {
-    expect(isSupportedAttachmentMediaType("application/json")).toBe(true);
-    expect(isSupportedAttachmentMediaType("application/json; charset=utf-8")).toBe(true);
+  test("keeps JSON out of provider attachments while mapping its extension", () => {
+    expect(isSupportedAttachmentMediaType("application/json")).toBe(false);
+    expect(isSupportedAttachmentMediaType("application/json; charset=utf-8")).toBe(false);
     expect(getAttachmentMediaTypeFromExtension("config.json")).toBe("application/json");
   });
 
-  test("falls back to .json extension when MIME type is empty", () => {
-    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
+  test("supports JSON chat attachments by media type and extension", () => {
+    expect(isSupportedChatAttachmentMediaType("application/json")).toBe(true);
+    expect(isSupportedChatAttachmentMediaType("application/json; charset=utf-8")).toBe(true);
+    expect(getSupportedChatAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
+      "application/json"
+    );
+  });
+
+  test("keeps .json extension fallback scoped to chat attachments", () => {
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(null);
+    expect(getSupportedChatAttachmentMediaType({ mediaType: "", filename: "package.json" })).toBe(
       "application/json"
     );
   });

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -64,18 +64,18 @@ export function getSupportedChatAttachmentMediaType(args: {
   filename?: string | null;
 }): string | null {
   const trimmedMediaType = args.mediaType?.trim();
-  const rawMediaType =
-    trimmedMediaType != null && trimmedMediaType.length > 0
-      ? trimmedMediaType
-      : args.filename != null
-        ? (getAttachmentMediaTypeFromExtension(args.filename) ?? "")
-        : "";
-  if (rawMediaType.length === 0) {
-    return null;
+  if (trimmedMediaType != null && trimmedMediaType.length > 0) {
+    const normalized = normalizeAttachmentMediaType(trimmedMediaType);
+    if (isSupportedChatAttachmentMediaType(normalized)) {
+      return normalized;
+    }
   }
 
-  const normalized = normalizeAttachmentMediaType(rawMediaType);
-  return isSupportedChatAttachmentMediaType(normalized) ? normalized : null;
+  const extensionMediaType =
+    args.filename != null ? getAttachmentMediaTypeFromExtension(args.filename) : null;
+  return extensionMediaType != null && isSupportedChatAttachmentMediaType(extensionMediaType)
+    ? extensionMediaType
+    : null;
 }
 
 export function isSupportedStagedAttachmentMediaType(mediaType: string): boolean {

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -2,6 +2,7 @@ import { SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 import { ZIP_MEDIA_TYPE, ZIP_MEDIA_TYPES } from "@/common/constants/stagedAttachments";
 
 export const PDF_MEDIA_TYPE = "application/pdf";
+export const JSON_MEDIA_TYPE = "application/json";
 export const MARKDOWN_MEDIA_TYPE = "text/markdown";
 
 const EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
@@ -14,7 +15,10 @@ const EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
   avif: "image/avif",
   svg: SVG_MEDIA_TYPE,
   pdf: PDF_MEDIA_TYPE,
+  json: JSON_MEDIA_TYPE,
 };
+
+const SUPPORTED_DOCUMENT_MEDIA_TYPES = new Set([PDF_MEDIA_TYPE, JSON_MEDIA_TYPE]);
 
 export function normalizeAttachmentMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
@@ -27,7 +31,7 @@ export function getAttachmentMediaTypeFromExtension(filename: string): string | 
 
 export function isSupportedAttachmentMediaType(mediaType: string): boolean {
   const normalized = normalizeAttachmentMediaType(mediaType);
-  return normalized.startsWith("image/") || normalized === PDF_MEDIA_TYPE;
+  return normalized.startsWith("image/") || SUPPORTED_DOCUMENT_MEDIA_TYPES.has(normalized);
 }
 
 export function getSupportedAttachmentMediaType(args: {

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -18,7 +18,8 @@ const EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
   json: JSON_MEDIA_TYPE,
 };
 
-const SUPPORTED_DOCUMENT_MEDIA_TYPES = new Set([PDF_MEDIA_TYPE, JSON_MEDIA_TYPE]);
+const SUPPORTED_PROVIDER_DOCUMENT_MEDIA_TYPES = new Set([PDF_MEDIA_TYPE]);
+const SUPPORTED_CHAT_DOCUMENT_MEDIA_TYPES = new Set([PDF_MEDIA_TYPE, JSON_MEDIA_TYPE]);
 
 export function normalizeAttachmentMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
@@ -31,7 +32,12 @@ export function getAttachmentMediaTypeFromExtension(filename: string): string | 
 
 export function isSupportedAttachmentMediaType(mediaType: string): boolean {
   const normalized = normalizeAttachmentMediaType(mediaType);
-  return normalized.startsWith("image/") || SUPPORTED_DOCUMENT_MEDIA_TYPES.has(normalized);
+  return normalized.startsWith("image/") || SUPPORTED_PROVIDER_DOCUMENT_MEDIA_TYPES.has(normalized);
+}
+
+export function isSupportedChatAttachmentMediaType(mediaType: string): boolean {
+  const normalized = normalizeAttachmentMediaType(mediaType);
+  return normalized.startsWith("image/") || SUPPORTED_CHAT_DOCUMENT_MEDIA_TYPES.has(normalized);
 }
 
 export function getSupportedAttachmentMediaType(args: {
@@ -51,6 +57,25 @@ export function getSupportedAttachmentMediaType(args: {
 
   const normalized = normalizeAttachmentMediaType(rawMediaType);
   return isSupportedAttachmentMediaType(normalized) ? normalized : null;
+}
+
+export function getSupportedChatAttachmentMediaType(args: {
+  mediaType?: string | null;
+  filename?: string | null;
+}): string | null {
+  const trimmedMediaType = args.mediaType?.trim();
+  const rawMediaType =
+    trimmedMediaType != null && trimmedMediaType.length > 0
+      ? trimmedMediaType
+      : args.filename != null
+        ? (getAttachmentMediaTypeFromExtension(args.filename) ?? "")
+        : "";
+  if (rawMediaType.length === 0) {
+    return null;
+  }
+
+  const normalized = normalizeAttachmentMediaType(rawMediaType);
+  return isSupportedChatAttachmentMediaType(normalized) ? normalized : null;
 }
 
 export function isSupportedStagedAttachmentMediaType(mediaType: string): boolean {

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -362,6 +362,26 @@ describe("attach_file tool", () => {
     });
   });
 
+  it("shows JSON files to the user without sending them as model attachments", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const jsonPath = path.join(workspaceDir.path, "package.json");
+    const json = '{"name":"demo"}\n';
+    await fs.writeFile(jsonPath, json);
+
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "package.json" }, mockToolCallOptions)) as AttachFileToolResult
+    );
+
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(json).toString("base64"),
+      mediaType: "text/plain",
+      filename: "package.json",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(json) } },
+    });
+  });
+
   it("shows unmapped source files to the user as display-only text/plain", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);


### PR DESCRIPTION
## Summary

Allow JSON files to be attached in the chat composer while keeping the shared provider attachment allowlist restricted to model-supported media types.

## Background

Fixes #3546. JSON files were rejected by the chat composer even though they can be carried through the existing generic file-part send path. The agent-facing `attach_file` tool must still reject JSON so agents use `file_read` for text files.

## Implementation

- Adds a chat-scoped attachment helper that accepts `application/json` and `.json` without expanding the shared provider attachment allowlist.
- Includes JSON in the chat file picker accept list and tooltip copy.
- Adds focused coverage for JSON MIME handling, extension-based detection when macOS drag/drop provides an empty MIME type, and the `attach_file` boundary.

## Validation

- Focused attachment tests: 40 passed
- Focused ESLint and Prettier checks passed
- `tsgo --noEmit --project tsconfig.json` passed
- `git diff --check` passed
- `make static-check` passed

## Risks

Low. JSON support is scoped to user-selected chat attachments. The provider media allowlist and agent `attach_file` behavior remain unchanged.

---

_Generated with `mux` • Model: `GPT-5` • Thinking: `unknown` • Cost: `$unknown`_

<!-- mux-attribution: model=GPT-5 thinking=unknown costs=unknown -->
