### PR TITLE
🤖 fix: tombstone consumed workspace-turn wake-ups

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2662,6 +2662,76 @@ describe("TaskService", () => {
     expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
   });
 
+  test("workspace turn task_await consumption tombstones later terminal wake-ups", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    const sendMessage = mock(
+      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const internal = taskService as unknown as {
+      enqueueTerminalAttention: (params: {
+        ownerWorkspaceId: string;
+        sourceKind: "workspace_turn";
+        sourceId: string;
+        outputDelivery: "requires_task_await";
+        terminalOutcome: "completed" | "error" | "interrupted";
+      }) => Promise<void>;
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+
+    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
+      ownerWorkspaceId: parentId,
+      handleId: "wst_consumed_then_enqueued",
+      status: "completed",
+    });
+    await internal.enqueueTerminalAttention({
+      ownerWorkspaceId: parentId,
+      sourceKind: "workspace_turn",
+      sourceId: "wst_consumed_then_enqueued",
+      outputDelivery: "requires_task_await",
+      terminalOutcome: "completed",
+    });
+    await flushTerminalAttentionDrains(taskService);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
+
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "workspace_turn",
+      sourceId: "wst_pending_then_consumed",
+      outputDelivery: "requires_task_await",
+      terminalOutcome: "completed",
+    });
+    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
+      ownerWorkspaceId: parentId,
+      handleId: "wst_pending_then_consumed",
+      status: "completed",
+    });
+    await internal.drainTerminalAttention(parentId);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
+
+    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
+      ownerWorkspaceId: parentId,
+      handleId: "wst_running_not_consumed",
+      status: "running",
+    });
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "workspace_turn",
+      sourceId: "wst_running_not_consumed",
+      outputDelivery: "requires_task_await",
+      terminalOutcome: "completed",
+    });
+
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
+  });
+
   test("startup recovery persists terminal workflow wake-ups", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -4381,6 +4381,35 @@ export class TaskService {
     );
   }
 
+  async markWorkspaceTurnTerminalAttentionConsumed(params: {
+    ownerWorkspaceId: string;
+    handleId: string;
+    status: WorkspaceTurnTaskStatus;
+  }): Promise<void> {
+    assert(
+      params.ownerWorkspaceId.length > 0,
+      "markWorkspaceTurnTerminalAttentionConsumed requires ownerWorkspaceId"
+    );
+    assert(
+      params.handleId.length > 0,
+      "markWorkspaceTurnTerminalAttentionConsumed requires handleId"
+    );
+    if (!this.isTerminalWorkspaceTurnStatus(params.status)) {
+      return;
+    }
+    await this.terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: params.ownerWorkspaceId,
+      sourceKind: "workspace_turn",
+      sourceId: params.handleId,
+      outputDelivery: "requires_task_await",
+      terminalOutcome: workspaceTurnTerminalOutcome(params.status),
+    });
+    await this.terminalAttentionStore.markDelivered(
+      params.ownerWorkspaceId,
+      TerminalAttentionStore.notificationId("workspace_turn", params.handleId)
+    );
+  }
+
   private async enqueueTerminalAttention(params: {
     ownerWorkspaceId: string;
     sourceKind: TerminalAttentionNotification["sourceKind"];

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -44,11 +44,13 @@ describe("task_await tool", () => {
     using tempDir = new TestTempDir("test-task-await-workspace-turn");
     const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
 
+    const markWorkspaceTurnTerminalAttentionConsumed = mock(() => Promise.resolve());
     const taskService = {
       listActiveDescendantAgentTaskIds: mock(() => []),
       listWorkspaceTurnTasks: mock(() => []),
       isDescendantAgentTask: mock(() => Promise.resolve(false)),
       getAgentTaskStatuses: mock(() => new Map()),
+      markWorkspaceTurnTerminalAttentionConsumed,
       getWorkspaceTurnSnapshot: mock(() =>
         Promise.resolve({
           kind: "workspace_turn",
@@ -93,6 +95,53 @@ describe("task_await tool", () => {
       },
     ]);
     expect(result.results[0]?.finalMessage).toBeUndefined();
+    expect(markWorkspaceTurnTerminalAttentionConsumed).toHaveBeenCalledWith({
+      ownerWorkspaceId: "parent-workspace",
+      handleId: "wst_done",
+      status: "completed",
+    });
+  });
+
+  it("does not mark active workspace-turn awaits consumed", async () => {
+    using tempDir = new TestTempDir("test-task-await-active-workspace-turn-consumption");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+    const markWorkspaceTurnTerminalAttentionConsumed = mock(() => Promise.resolve());
+    const runningSnapshot = {
+      kind: "workspace_turn",
+      handleId: "wst_running",
+      ownerWorkspaceId: "parent-workspace",
+      workspaceId: "child-running",
+      turnId: "turn-running",
+      status: "running",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      updatedAt: "2026-06-19T00:00:00.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+    } as const;
+    const taskService = {
+      listActiveDescendantAgentTaskIds: mock(() => []),
+      listWorkspaceTurnTasks: mock(() => Promise.resolve([runningSnapshot])),
+      isDescendantAgentTask: mock(() => Promise.resolve(false)),
+      getAgentTaskStatuses: mock(() => new Map()),
+      markWorkspaceTurnTerminalAttentionConsumed,
+      getWorkspaceTurnSnapshot: mock(() => Promise.resolve(runningSnapshot)),
+    } as unknown as TaskService;
+
+    const tool = createTaskAwaitTool({ ...baseConfig, taskService });
+    const result = (await Promise.resolve(
+      tool.execute!({ task_ids: ["wst_running"], timeout_secs: 0 }, mockToolCallOptions)
+    )) as { results: Array<Record<string, unknown>> };
+
+    expect(result.results).toEqual([
+      {
+        status: "running",
+        taskId: "wst_running",
+        handleKind: "workspace_turn",
+        workspaceId: "child-running",
+        note: "Workspace turn is still running.",
+      },
+    ]);
+    expect(markWorkspaceTurnTerminalAttentionConsumed).not.toHaveBeenCalled();
   });
 
   it("returns live workspace-turn status when min_completed detaches an unfinished await", async () => {
@@ -192,12 +241,14 @@ describe("task_await tool", () => {
     } as const;
     let observedTimeoutMs: number | undefined;
 
+    const markWorkspaceTurnTerminalAttentionConsumed = mock(() => Promise.resolve());
     const taskService = {
       listActiveDescendantAgentTaskIds: mock(() => []),
       listWorkspaceTurnTasks: mock(() => Promise.resolve([runningSnapshot])),
       isDescendantAgentTask: mock(() => Promise.resolve(false)),
       getAgentTaskStatuses: mock(() => new Map()),
       getWorkspaceTurnSnapshot: mock(() => Promise.resolve(runningSnapshot)),
+      markWorkspaceTurnTerminalAttentionConsumed,
       waitForWorkspaceTurn: mock((_taskId: string, options: { timeoutMs?: number }) => {
         observedTimeoutMs = options.timeoutMs;
         return Promise.resolve({ workspaceId: "child-running", reportMarkdown: "Done" });
@@ -209,6 +260,11 @@ describe("task_await tool", () => {
       tool.execute!({ task_ids: ["wst_running"], timeout_secs: null }, mockToolCallOptions)
     );
 
+    expect(markWorkspaceTurnTerminalAttentionConsumed).toHaveBeenCalledWith({
+      ownerWorkspaceId: "parent-workspace",
+      handleId: "wst_running",
+      status: "completed",
+    });
     expect(observedTimeoutMs).toBe(600_000);
   });
 
@@ -237,12 +293,14 @@ describe("task_await tool", () => {
     } as const;
     const snapshots = [runningSnapshot, completedSnapshot];
 
+    const markWorkspaceTurnTerminalAttentionConsumed = mock(() => Promise.resolve());
     const taskService = {
       listActiveDescendantAgentTaskIds: mock(() => []),
       listWorkspaceTurnTasks: mock(() => Promise.resolve([runningSnapshot])),
       isDescendantAgentTask: mock(() => Promise.resolve(false)),
       getAgentTaskStatuses: mock(() => new Map()),
       getWorkspaceTurnSnapshot: mock(() => Promise.resolve(snapshots.shift() ?? completedSnapshot)),
+      markWorkspaceTurnTerminalAttentionConsumed,
       waitForWorkspaceTurn: mock(() => Promise.reject(new Error("timed out"))),
     } as unknown as TaskService;
 
@@ -263,6 +321,63 @@ describe("task_await tool", () => {
         note: COMPLETED_REPORT_REFETCH_NOTE,
       },
     ]);
+    expect(markWorkspaceTurnTerminalAttentionConsumed).toHaveBeenCalledWith({
+      ownerWorkspaceId: "parent-workspace",
+      handleId: "wst_race",
+      status: "completed",
+    });
+  });
+
+  it("returns terminal workspace-turn result when wait rejects after the turn fails", async () => {
+    using tempDir = new TestTempDir("test-task-await-workspace-turn-generic-terminal");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+    const runningSnapshot = {
+      kind: "workspace_turn",
+      handleId: "wst_failed",
+      ownerWorkspaceId: "parent-workspace",
+      workspaceId: "child-failed",
+      turnId: "turn-failed",
+      status: "running",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      updatedAt: "2026-06-19T00:00:00.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+    } as const;
+    const errorSnapshot = {
+      ...runningSnapshot,
+      status: "error",
+      updatedAt: "2026-06-19T00:00:01.000Z",
+      error: "Child turn failed",
+    } as const;
+    const snapshots = [runningSnapshot, errorSnapshot];
+    const markWorkspaceTurnTerminalAttentionConsumed = mock(() => Promise.resolve());
+    const taskService = {
+      listActiveDescendantAgentTaskIds: mock(() => []),
+      listWorkspaceTurnTasks: mock(() => Promise.resolve([runningSnapshot])),
+      isDescendantAgentTask: mock(() => Promise.resolve(false)),
+      getAgentTaskStatuses: mock(() => new Map()),
+      getWorkspaceTurnSnapshot: mock(() => Promise.resolve(snapshots.shift() ?? errorSnapshot)),
+      markWorkspaceTurnTerminalAttentionConsumed,
+      waitForWorkspaceTurn: mock(() => Promise.reject(new Error("workspace turn settled"))),
+    } as unknown as TaskService;
+
+    const tool = createTaskAwaitTool({ ...baseConfig, taskService });
+    const result = (await Promise.resolve(
+      tool.execute!({ task_ids: ["wst_failed"], timeout_secs: 1 }, mockToolCallOptions)
+    )) as { results: Array<Record<string, unknown>> };
+
+    expect(result.results).toEqual([
+      {
+        status: "error",
+        taskId: "wst_failed",
+        error: "Child turn failed",
+      },
+    ]);
+    expect(markWorkspaceTurnTerminalAttentionConsumed).toHaveBeenCalledWith({
+      ownerWorkspaceId: "parent-workspace",
+      handleId: "wst_failed",
+      status: "error",
+    });
   });
 
   it("includes gitFormatPatch artifacts written during waitForAgentReport", async () => {

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -548,8 +548,18 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               activeTaskIds,
             };
           }
+          const markWorkspaceTurnTerminalAttentionConsumed = async (
+            status: WorkspaceTurnTaskStatus
+          ): Promise<void> => {
+            await taskService.markWorkspaceTurnTerminalAttentionConsumed?.({
+              ownerWorkspaceId: workspaceId,
+              handleId: taskId,
+              status,
+            });
+          };
           if (timeoutMs === 0 || !isWorkspaceTurnActiveStatus(snapshot.status)) {
             if (snapshot.status === "completed") {
+              await markWorkspaceTurnTerminalAttentionConsumed(snapshot.status);
               return {
                 status: "completed" as const,
                 taskId,
@@ -564,6 +574,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               };
             }
             if (snapshot.status === "interrupted") {
+              await markWorkspaceTurnTerminalAttentionConsumed(snapshot.status);
               return {
                 status: "interrupted" as const,
                 taskId,
@@ -573,6 +584,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               };
             }
             if (snapshot.status === "error") {
+              await markWorkspaceTurnTerminalAttentionConsumed(snapshot.status);
               return {
                 status: "error" as const,
                 taskId,
@@ -596,6 +608,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               requestingWorkspaceId: workspaceId,
               backgroundOnMessageQueued: true,
             });
+            await markWorkspaceTurnTerminalAttentionConsumed("completed");
             return {
               status: "completed" as const,
               taskId,
@@ -630,6 +643,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               const latest = await taskService.getWorkspaceTurnSnapshot(workspaceId, taskId);
               if (latest == null) return { status: "not_found" as const, taskId };
               if (latest.status === "completed") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
                 return {
                   status: "completed" as const,
                   taskId,
@@ -644,16 +658,25 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
                 };
               }
               if (latest.status === "error") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
                 return {
                   status: "error" as const,
                   taskId,
                   error: latest.error ?? WORKSPACE_TURN_DEFAULT_ERROR,
                 };
               }
+              if (latest.status === "interrupted") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
+                return {
+                  status: "interrupted" as const,
+                  taskId,
+                  handleKind: "workspace_turn" as const,
+                  workspaceId: latest.workspaceId,
+                  note: "Workspace turn was interrupted. The full workspace is preserved.",
+                };
+              }
               return {
-                status: isWorkspaceTurnActiveStatus(latest.status)
-                  ? (latest.status as "queued" | "starting" | "running")
-                  : "interrupted",
+                status: latest.status,
                 taskId,
                 handleKind: "workspace_turn" as const,
                 workspaceId: latest.workspaceId,
@@ -664,6 +687,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               const latest = await taskService.getWorkspaceTurnSnapshot(workspaceId, taskId);
               if (latest == null) return { status: "not_found" as const, taskId };
               if (latest.status === "completed") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
                 return {
                   status: "completed" as const,
                   taskId,
@@ -678,6 +702,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
                 };
               }
               if (latest.status === "error") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
                 return {
                   status: "error" as const,
                   taskId,
@@ -685,6 +710,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
                 };
               }
               if (latest.status === "interrupted") {
+                await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
                 return {
                   status: "interrupted" as const,
                   taskId,
@@ -702,6 +728,42 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             }
             if (/out of scope/i.test(message) || /not found/i.test(message)) {
               return { status: "invalid_scope" as const, taskId };
+            }
+            const latest = await taskService
+              .getWorkspaceTurnSnapshot(workspaceId, taskId)
+              .catch(() => null);
+            if (latest?.status === "completed") {
+              await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
+              return {
+                status: "completed" as const,
+                taskId,
+                handleKind: "workspace_turn" as const,
+                workspaceId: latest.workspaceId,
+                reportMarkdown:
+                  latest.reportMarkdown ?? "Workspace turn completed without final text output.",
+                title: latest.title,
+                messageId: latest.messageId,
+                finalMessageRef: latest.finalMessageRef,
+                note: COMPLETED_REPORT_REFETCH_NOTE,
+              };
+            }
+            if (latest?.status === "error") {
+              await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
+              return {
+                status: "error" as const,
+                taskId,
+                error: latest.error ?? WORKSPACE_TURN_DEFAULT_ERROR,
+              };
+            }
+            if (latest?.status === "interrupted") {
+              await markWorkspaceTurnTerminalAttentionConsumed(latest.status);
+              return {
+                status: "interrupted" as const,
+                taskId,
+                handleKind: "workspace_turn" as const,
+                workspaceId: latest.workspaceId,
+                note: "Workspace turn was interrupted. The full workspace is preserved.",
+              };
             }
             return { status: "error" as const, taskId, error: message };
           }


### PR DESCRIPTION
## Summary

Tombstone terminal workspace-turn output when `task_await` has already returned it, preventing later terminal-attention drains from injecting duplicate “call `task_await`” synthetic reminders for the same `wst_...` handle.

## Background

A parent workspace could proactively retrieve terminal background workspace-turn output with `task_await`, archive the child workspace, and still receive a later synthetic wake-up asking it to call `task_await` for that already-consumed handle. Workflow runs already had consumption tombstones; workspace-turn handles did not.

## Implementation

- Added `TaskService.markWorkspaceTurnTerminalAttentionConsumed(...)`, mirroring workflow-run consumption by creating a delivered `workspace_turn:<handleId>` terminal-attention tombstone.
- Mark terminal workspace-turn results consumed in `task_await` for already-terminal snapshots, successful waits, timeout races, task-signal abort races, and generic wait rejections where the latest snapshot is terminal.
- Kept active statuses and foreground-backgrounded waits unconsumed, so unresolved output still wakes the parent later.

## Validation

- `bun test src/node/services/tools/task_await.test.ts`
- `bun test src/node/services/taskService.test.ts -t "workspace turn task_await consumption tombstones later terminal wake-ups"`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `git diff --check`

## Dogfooding

- Started an isolated `make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"` instance and captured the sandbox UI.
- Ran script-driven dogfood for the terminal-attention semantics:
  - consumed before enqueue produced no duplicate `task_await` reminder;
  - pending terminal notification consumed before drain produced no synthetic wake-up;
  - archived but unconsumed terminal workspace turn still produced the expected `task_await` reminder.
- Captured local evidence under `/tmp/mux-dogfood-evidence/`:
  - `initial-ui.png`
  - `dogfood-report.png`
  - `dogfood-report.webm`
  - `workspace-turn-terminal-attention.typescript`

## Risks

The touched path is central to background workspace-turn completion UX. The main risk is over-suppressing reminders, mitigated by only tombstoning when `task_await` returns a terminal workspace-turn status/output and by test/dogfood coverage proving archive-only unconsumed output still wakes the parent.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: Suppress duplicate workspace-turn `task_await` reminders after terminal output is consumed

## Goal

Prevent Mux from injecting a synthetic auto-message that tells a parent agent to call `task_await` for a background workspace-turn handle after that same terminal workspace-turn output was already retrieved through `task_await`.

The concrete observed failure was workspace `eb9acb1788`: the parent awaited terminal workspace turns, archived their child workspaces, and later received another synthetic prompt asking it to call `task_await` for the same terminal handles.

## Evidence and current behavior

### Verified workspace evidence

- Parent workspace `eb9acb1788` had terminal workspace-turn handles such as `wst_146af51f60`, `wst_9428f29f11`, `wst_162340f81f`, and `wst_ed6660b5ed`.
- The parent transcript shows an assistant turn that called `task_await` for those handles and received `completed` workspace-turn results.
- The same assistant turn then called `task_workspace_lifecycle` with `action: "archive"` for those child workspace-turn handles.
- A later synthetic user message still said: “Background workspace turn(s) have reached a terminal state... Call `task_await` now...”.
- The per-handle terminal-attention records under the session directory were eventually marked `delivered`, but only when that later synthetic message was sent, not when the earlier `task_await` consumed the results.

### Verified repo evidence

- `src/node/services/terminalAttentionStore.ts` stores terminal-attention records keyed by `sourceKind:sourceId`; `enqueueIfAbsent` leaves existing `pending`, `delivered`, or `superseded` records untouched, which makes a delivered record a durable tombstone.
- `src/node/services/taskService.ts` already has workflow-run consumption support via `markWorkflowRunTerminalAttentionConsumed(...)`; it creates a terminal-attention record if needed and marks it `delivered`.
- `src/node/services/tools/task_await.ts` already calls `markWorkflowRunTerminalAttentionConsumed(...)` when a terminal workflow run is returned by `task_await`.
- The workspace-turn branch in `src/node/services/tools/task_await.ts` returns terminal workspace-turn results but does not mark the corresponding terminal-attention notification as consumed.
- `src/node/services/taskService.test.ts` already contains an analogous test: `workflow task_await consumption tombstones later terminal wake-ups`.

## Recommended approach

### Approach A — explicit workspace-turn terminal-attention consumption tombstone

**Recommendation:** implement this approach.

**Product-code LoC estimate:** ~35–45 net LoC.

Add a workspace-turn equivalent of workflow-run terminal-attention consumption. When `task_await` returns a terminal workspace-turn result, mark that `workspace_turn:<wst_id>` terminal-attention record as `delivered`. If the terminal-attention notification has not been enqueued yet, create the delivered record first so later enqueue attempts are suppressed by `enqueueIfAbsent`.

This is the cleanest fix because it records the semantic event that matters: the parent has retrieved the terminal output. It also handles races where the direct `task_await` happens before the notifier has enqueued or drained the terminal-attention record.

### Alternatives considered

#### Archive-based suppression

Do **not** use this as the primary fix.

Archiving is storage/workspace lifecycle state, not output-consumption state. A parent or user can archive a child workspace without ever retrieving the terminal report. Suppressing reminders from archive alone could lose important results or failure information. It also couples terminal-attention UX to unrelated cleanup behavior.

#### Prompt-only change

Do **not** use this as the primary fix.

Changing the synthetic prompt text might reduce agent confusion, but it would not fix the duplicate wake-up. The system would still spend an extra synthetic turn and clutter the transcript.

## Implementation details

### Phase 1 — Add workspace-turn consumption API in `TaskService`

**File:** `src/node/services/taskService.ts`

Add a public method near `markWorkflowRunTerminalAttentionConsumed(...)`:

```ts
async markWorkspaceTurnTerminalAttentionConsumed(params: {
  ownerWorkspaceId: string;
  handleId: string;
  status: WorkspaceTurnTaskStatus;
}): Promise<void> {
  assert(
    params.ownerWorkspaceId.length > 0,
    "markWorkspaceTurnTerminalAttentionConsumed requires ownerWorkspaceId"
  );
  assert(params.handleId.length > 0, "markWorkspaceTurnTerminalAttentionConsumed requires handleId");

  if (!this.isTerminalWorkspaceTurnStatus(params.status)) {
    return;
  }

  await this.terminalAttentionStore.enqueueIfAbsent({
    ownerWorkspaceId: params.ownerWorkspaceId,
    sourceKind: "workspace_turn",
    sourceId: params.handleId,
    outputDelivery: "requires_task_await",
    terminalOutcome: workspaceTurnTerminalOutcome(params.status),
  });

  await this.terminalAttentionStore.markDelivered(
    params.ownerWorkspaceId,
    TerminalAttentionStore.notificationId("workspace_turn", params.handleId)
  );
}
```

Implementation notes:

- Keep the method intentionally parallel to `markWorkflowRunTerminalAttentionConsumed(...)`.
- Use existing defensive assertions for non-empty `ownerWorkspaceId` and `handleId`.
- No-op for non-terminal statuses.
- Use existing `this.isTerminalWorkspaceTurnStatus(...)` and `workspaceTurnTerminalOutcome(...)` helpers.
- Do not add archive/lifecycle coupling.
- Do not delete terminal-attention files; `delivered` is the needed durable tombstone.
- Do not mutate workspace-turn handle records from this consumption method. In particular, do **not** set `terminalAttentionNotifiedAt`; the `TerminalAttentionStore` delivered tombstone is sufficient because later `enqueueIfAbsent(...)` attempts are suppressed by source kind/id.

**Quality gate after Phase 1:** run targeted typechecking/test compile if available; at minimum ensure no new imports are required beyond symbols already present in `taskService.ts`.

### Phase 2 — Mark workspace-turn terminal results consumed from `task_await`

**File:** `src/node/services/tools/task_await.ts`

Inside the `if (isWorkspaceTurnTaskId(taskId))` branch of `awaitOne(...)`, add a local helper after the snapshot is loaded and before terminal returns:

```ts
const markWorkspaceTurnTerminalAttentionConsumed = async (
  status: WorkspaceTurnTaskStatus
): Promise<void> => {
  await taskService.markWorkspaceTurnTerminalAttentionConsumed?.({
    ownerWorkspaceId: workspaceId,
    handleId: taskId,
    status,
  });
};
```

Call the helper before returning any terminal workspace-turn output that the tool result exposes to the parent:

1. Initial terminal snapshot path:
   - `snapshot.status === "completed"`
   - `snapshot.status === "interrupted"`
   - `snapshot.status === "error"`
2. Successful `waitForWorkspaceTurn(...)` path:
   - call with `"completed"` before returning the completed report.
3. `taskSignal.aborted` race path:
   - after fetching `latest`, if `latest.status` is terminal and the result returned to the model reflects that terminal state, mark it consumed before returning.
   - For `latest.status === "completed"`, mark before returning the completed report.
   - For `latest.status === "error"`, mark before returning the error result.
   - For `latest.status === "interrupted"`, mark before returning the interrupted result/status.
4. Timeout race path:
   - if the fresh `latest` snapshot is `completed`, `error`, or `interrupted`, mark consumed before returning that terminal result.
5. Generic workspace-turn rejection path:
   - keep true tool-call abort handling first; do not convert an actual user/tool abort into a consumed terminal result.
   - if `waitForWorkspaceTurn(...)` rejects outside the explicit timeout/abort/backgrounded branches, fetch the latest workspace-turn snapshot when possible.
   - If the latest snapshot is terminal, mark it consumed and return the same terminal-shaped result the timeout/abort branches would return.
   - This closes cases where the wait rejects because the underlying turn ended as `interrupted` or `error` without matching the timeout/abort branches.

Do **not** mark consumed for:

- active statuses: `queued`, `starting`, `running`
- `ForegroundWaitBackgroundedError` paths that only tell the parent the wait was sent to the background and do not return terminal output
- `not_found` or `invalid_scope` paths

Implementation notes:

- Follow the existing workflow-run helper pattern in this file.
- Use optional chaining when calling the new `TaskService` method, matching the workflow-run code and keeping older/narrow mocks simple.
- Prefer a tiny local helper for “mark consumed and return terminal workspace-turn snapshot/result” if it avoids divergent return shapes across completed/error/interrupted branches; do not introduce a broad abstraction.
- Let failures propagate consistently with the workflow-run consumption path; do not add special catch-and-hide behavior unless tests reveal an existing convention that requires it.

**Quality gate after Phase 2:** run the focused `task_await` test file and fix compile/test failures before broadening validation.

### Phase 3 — Unit tests for `task_await` consumption calls

**File:** `src/node/services/tools/task_await.test.ts`

Add or update tests around the existing workspace-turn cases.

Required assertions:

1. Completed snapshot path:
   - mock `taskService.markWorkspaceTurnTerminalAttentionConsumed`
   - execute `task_await` with a completed workspace-turn snapshot and `timeout_secs: 0`
   - assert result remains unchanged
   - assert the mock was called with:

```ts
{
  ownerWorkspaceId: "parent-workspace",
  handleId: "wst_done",
  status: "completed",
}
```

2. Successful wait path:
   - simulate active snapshot followed by successful `waitForWorkspaceTurn(...)`
   - assert the mock is called with status `"completed"`

3. Active snapshot path:
   - simulate running workspace-turn snapshot with `timeout_secs: 0`
   - assert the mock is **not** called

4. Generic rejection path if implemented in Phase 2:
   - simulate `waitForWorkspaceTurn(...)` rejecting while `getWorkspaceTurnSnapshot(...)` returns a terminal `error` or `interrupted` snapshot
   - assert the terminal result is returned and the consumption mock is called

Optional but useful if implementation touches those branches:

- terminal `error` snapshot marks consumed
- terminal `interrupted` snapshot marks consumed
- timeout race to terminal result marks consumed

Avoid tautological tests. The tests should assert behavior and side effects, not prompt wording.

**Quality gate after Phase 3:**

```bash
bun test src/node/services/tools/task_await.test.ts
```

### Phase 4 — Service-level tombstone regression test

**File:** `src/node/services/taskService.test.ts`

Add a test mirroring `workflow task_await consumption tombstones later terminal wake-ups`.

Suggested test name:

```ts
"workspace turn task_await consumption tombstones later terminal wake-ups"
```

Test outline:

1. Create test config and parent workspace using existing test helpers.
2. Create a `TerminalAttentionStore` for the config.
3. Create a `sendMessage` mock that would record synthetic wake-ups.
4. Create `taskService` harness with that `workspaceService` mock.
5. Cover both race orderings:

   **A. Consumed before later enqueue**

   ```ts
   await taskService.markWorkspaceTurnTerminalAttentionConsumed({
     ownerWorkspaceId: parentId,
     handleId: "wst_consumed_then_enqueued",
     status: "completed",
   });
   ```

   Then attempt to enqueue terminal attention for the same source. Since `enqueueTerminalAttention(...)` is private, mirror nearby tests by casting the service to call the internal method.

   **B. Pending notification exists before consumption**

   Use `terminalAttentionStore.enqueueIfAbsent(...)` directly to create a pending `workspace_turn` notification for `wst_pending_then_consumed`, then call `markWorkspaceTurnTerminalAttentionConsumed(...)` for that same handle. This mirrors the observed race where terminal attention can be pending while the parent is busy, and the parent proactively calls `task_await` before the synthetic wake-up drains. Because direct store enqueue does not schedule a drain, assert `listPending(parentId)` is `0` after consumption and/or call internal `drainTerminalAttention(parentId)` directly to prove no synthetic send; do not rely on `flushTerminalAttentionDrains(...)` alone for this subcase.

6. Flush terminal attention drains with the existing helper after each ordering.
7. Assert for both orderings:
   - `sendMessage` was not called
   - `await terminalAttentionStore.listPending(parentId)` has length `0`

Add a non-terminal no-op check:

- call `markWorkspaceTurnTerminalAttentionConsumed(...)` with an active status such as `"running"`
- assert no delivered/pending terminal-attention tombstone is created for that handle, or assert a subsequent enqueue still produces a pending notification

Do not add a reset API unless a real use case exists.

**Quality gate after Phase 4:**

```bash
bun test src/node/services/taskService.test.ts -t "workspace turn task_await consumption tombstones later terminal wake-ups"
```

### Phase 5 — Full validation

Run focused checks first, then broader checks:

```bash
bun test src/node/services/tools/task_await.test.ts
bun test src/node/services/taskService.test.ts -t "workspace turn task_await consumption tombstones later terminal wake-ups"
make typecheck
MUX_ESLINT_CONCURRENCY=1 make static-check
```

If `make static-check` is too expensive or environmentally blocked, record the exact blocker and run the narrowest equivalent checks that still cover touched code.

## Dogfooding plan

Because the user-visible failure is transcript behavior, dogfooding should verify both the positive and negative cases in an isolated Mux environment and capture visual evidence.

### Setup

1. Start an isolated dev server so state does not leak into the normal Mux root:

```bash
make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-projects"
```

2. Use `agent-browser` against the sandbox UI. Before interacting, load current CLI instructions:

```bash
agent-browser skills get core
```

3. Start video recording and take screenshots for the reviewer. Use the installed `agent-browser` recording/screenshot commands from `agent-browser skills get core` so the evidence format matches the local CLI version.

### Positive dogfood: `task_await` suppresses duplicate terminal reminder

1. In the sandbox UI, create/open a disposable parent workspace.
2. Prompt the parent to start one background workspace turn with `run_in_background: true` that produces a short final response.
3. Wait for the child workspace turn to reach a terminal state.
4. In the parent, call `task_await` for the `wst_...` handle and verify the terminal report appears in the parent transcript.
5. Archive the child workspace.
6. Leave the parent idle long enough for terminal-attention drain/retry behavior.
7. Verify no duplicate synthetic message appears asking the parent to call `task_await` for the same `wst_...` handle.
8. Capture:
   - screenshot after `task_await` result appears
   - screenshot after the idle/drain period showing no duplicate reminder
   - video covering the await/archive/idle sequence

### Negative dogfood: archive alone does not suppress unconsumed terminal output

1. Start another background workspace turn in the same isolated environment.
2. Let it complete.
3. Archive the child workspace without first calling `task_await` for its handle.
4. Leave the parent idle long enough for terminal-attention delivery.
5. Verify the synthetic reminder still appears and names the unconsumed `wst_...` handle.
6. Capture:
   - screenshot of the archive-before-await state
   - screenshot of the later reminder
   - short video of the sequence

### Dogfood quality gate

Do not claim the UX bug is fixed until both cases pass:

- consumed terminal workspace-turn output: no duplicate reminder
- archived but unconsumed terminal workspace-turn output: reminder still appears

If UI dogfooding is blocked by local display/headless constraints, fall back to a script-driven sandbox transcript check and capture terminal transcripts with `script -q -e -c ...`; still attach any available screenshots from browser/dev-server views.

## Acceptance criteria

- Calling `task_await` on a terminal workspace-turn handle creates or updates a durable delivered terminal-attention tombstone for `workspace_turn:<handleId>`.
- Later terminal-attention enqueue/drain attempts for that same handle do not send a synthetic “Call `task_await` now” message.
- Already-pending terminal-attention notifications are marked delivered when `task_await` later consumes the same terminal workspace-turn handle, and no synthetic wake-up is sent afterward.
- Active workspace-turn awaits do not mark terminal attention consumed.
- Archiving a child workspace without `task_await` does not suppress the terminal reminder.
- Workflow-run terminal-attention behavior remains unchanged.
- Tests cover both tool-level consumption calls and service-level tombstone behavior.
- Targeted tests, typecheck, and static-check pass or have precise documented environmental blockers.
- Dogfooding includes screenshots and video evidence for positive and negative cases.

## Risks and mitigations

- **Race between direct `task_await` and notifier enqueue:** mitigated by creating a delivered tombstone with `enqueueIfAbsent(...)` before `markDelivered(...)`; later enqueue attempts will be suppressed.
- **Over-suppression for unconsumed outputs:** mitigated by only marking consumed when `task_await` returns terminal output/status; archive alone remains insufficient.
- **Mocks missing new method:** mitigated by optional chaining in `task_await.ts` and focused tests that add the mock where assertions need it.
- **Hidden behavior changes for workflows:** mitigated by leaving existing workflow code unchanged and running existing workflow-related tests in touched files.
- **Terminal interrupted/error semantics:** treat returned terminal status as consumed because the parent has now seen the terminal outcome; do not consume if the tool only returns an active/backgrounded snapshot.

## Non-goals

- Do not change synthetic prompt wording except if tests reveal a required minor adjustment.
- Do not infer output consumption from archive/remove/delete-worktree lifecycle actions.
- Do not delete terminal-attention records; delivered records are useful durable tombstones.
- Do not add broad lifecycle reset APIs unless a concrete regression requires them.

## Advisor review status

Approved after advisor review. Round 1 requested amendments for pending-before-consumed race coverage, generic workspace-turn terminal rejection handling, non-terminal no-op tests, and explicit clarification that `terminalAttentionNotifiedAt` does not need to be mutated. Round 2 approved the amended plan; non-blocking execution notes about direct-store test draining, true abort ordering, and avoiding divergent terminal return shapes have been incorporated.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$26.62`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=26.62 -->
