### PR TITLE
🤖 fix: allow heartbeat turns to set goals

### DIFF
--- a/src/node/services/heartbeatService.test.ts
+++ b/src/node/services/heartbeatService.test.ts
@@ -620,6 +620,7 @@ describe("HeartbeatService", () => {
         message?: string;
       }
       interface HeartbeatSendOptions {
+        allowAgentSetGoal?: boolean;
         muxMetadata?: {
           type?: string;
           source?: string;
@@ -645,6 +646,7 @@ describe("HeartbeatService", () => {
       expect(heartbeatPrompt).toContain("[Heartbeat]");
       expect(heartbeatPrompt).toContain("idle for approximately 5 minutes");
       expect(heartbeatPrompt).toContain(HEARTBEAT_DEFAULT_MESSAGE_BODY);
+      expect(sendOptions.allowAgentSetGoal).toBe(true);
       expect(sendOptions.muxMetadata?.type).toBe("heartbeat-request");
       expect(sendOptions.muxMetadata?.source).toBe("heartbeat");
       expect(sendOptions.muxMetadata?.displayStatus?.message).toBe("Heartbeat check...");
@@ -747,6 +749,7 @@ describe("HeartbeatService", () => {
                 parsed?: {
                   followUpContent?: {
                     text?: string;
+                    allowAgentSetGoal?: boolean;
                     dispatchOptions?: { requireIdle?: boolean };
                     muxMetadata?: { type?: string };
                   };
@@ -769,6 +772,7 @@ describe("HeartbeatService", () => {
         "Compacting before heartbeat..."
       );
       expect(sendOptions.muxMetadata?.parsed?.followUpContent?.text).toContain("[Heartbeat]");
+      expect(sendOptions.muxMetadata?.parsed?.followUpContent?.allowAgentSetGoal).toBe(true);
       expect(sendOptions.muxMetadata?.parsed?.followUpContent?.dispatchOptions?.requireIdle).toBe(
         true
       );
@@ -794,6 +798,7 @@ describe("HeartbeatService", () => {
           boundaryText: string;
           pendingFollowUp: {
             text?: string;
+            allowAgentSetGoal?: boolean;
             dispatchOptions?: { requireIdle?: boolean };
             muxMetadata?: { type?: string };
           };
@@ -819,6 +824,7 @@ describe("HeartbeatService", () => {
             boundaryText: string;
             pendingFollowUp: {
               text?: string;
+              allowAgentSetGoal?: boolean;
               dispatchOptions?: { requireIdle?: boolean };
               muxMetadata?: { type?: string };
             };
@@ -826,6 +832,7 @@ describe("HeartbeatService", () => {
         | undefined;
       expect(appendCall?.boundaryText).toContain("Heartbeat context reset");
       expect(appendCall?.pendingFollowUp.text).toContain("[Heartbeat]");
+      expect(appendCall?.pendingFollowUp.allowAgentSetGoal).toBe(true);
       expect(appendCall?.pendingFollowUp.dispatchOptions?.requireIdle).toBe(true);
       expect(appendCall?.pendingFollowUp.muxMetadata?.type).toBe("heartbeat-request");
       expect(dispatchPendingCompactionFollowUpIfNeeded).toHaveBeenCalledTimes(1);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9493,6 +9493,9 @@ export class WorkspaceService extends EventEmitter {
         agentId,
         thinkingLevel: enforceThinkingPolicy(model, normalizedThinkingLevel),
         maxOutputTokens: undefined,
+        // Heartbeats are idle control loops; their prompt may ask the agent to seed a bounded
+        // goal before continuing. AIService still gates set_goal to top-level exec-like agents.
+        allowAgentSetGoal: true,
         // Heartbeats should not mutate persisted workspace AI defaults.
         skipAiSettingsPersistence: true,
       },


### PR DESCRIPTION
Summary
- Allow heartbeat-triggered agent turns to opt into model-created goals so heartbeat prompts can instruct agents to call `set_goal`.

Background
- Heartbeats are backend-generated synthetic turns. They were missing `allowAgentSetGoal`, so `AIService` treated them like one-shot hosts and withheld `set_goal` even when the heartbeat prompt asked the agent to seed a bounded goal.

Implementation
- Set `allowAgentSetGoal: true` in heartbeat send options.
- Covered normal heartbeat dispatch plus compact/reset heartbeat follow-up preservation.
- Existing goal-tool availability still gates `set_goal` to top-level exec-like agents, and heartbeat eligibility still excludes child workspaces.

Validation
- `bun test src/node/services/heartbeatService.test.ts`
- `make static-check`

Risks
- Low. The change is limited to heartbeat-initiated sends and still flows through existing goal-tool availability checks.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1168530{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.79 -->
