### PR TITLE
🤖 fix: prevent bash monitor wake redelivery

### DIFF
--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -278,6 +278,67 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("marks an accepted wake delivered when stream startup fails before provider start", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-accepted-startup-failure";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const aiService = Object.assign(new EventEmitter(), {
+        isStreaming: mock(() => false),
+      }) as unknown as AIService & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService,
+      });
+      const startupError: SendMessageError = { type: "unknown", raw: "startup failed" };
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          await args[3]?.onAcceptedPreStreamFailure?.(startupError);
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED after accept"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(0);
+
+      aiService.emit("error", { workspaceId, error: "startup failed" });
+      await drainPendingDispatches();
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("queues monitor wakes immediately for a session-backed streaming owner", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
@@ -501,7 +562,7 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
-  test("keeps an accepted monitor wake pending when stream startup fails before streaming", async () => {
+  test("marks an accepted monitor wake delivered when sendMessage fails after acceptance", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
       const workspaceId = "bash-monitor-startup-failure-owner";
@@ -548,14 +609,15 @@ describe("WorkspaceService bash monitor wakes", () => {
           bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
         }
       ).bashMonitorWakeStore;
-      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(0);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
       sendSpy.mockRestore();
     } finally {
       await cleanup();
     }
   });
 
-  test("keeps a queued monitor wake pending when accepted dispatch fails before stream start", async () => {
+  test("marks a queued monitor wake delivered when accepted dispatch fails before stream start", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
       const workspaceId = "bash-monitor-queued-startup-failure-owner";
@@ -608,14 +670,15 @@ describe("WorkspaceService bash monitor wakes", () => {
           bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
         }
       ).bashMonitorWakeStore;
-      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(0);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
       sendSpy.mockRestore();
     } finally {
       await cleanup();
     }
   });
 
-  test("marks an accepted monitor wake delivered when startup retry later starts streaming", async () => {
+  test("keeps an accepted monitor wake delivered when startup retry later starts streaming", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
       const workspaceId = "bash-monitor-startup-retry-owner";

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1812,25 +1812,15 @@ export class WorkspaceService extends EventEmitter {
       }
     };
 
-    // `onAccepted` only proves the synthetic user turn reached history; keep
-    // the wake pending until the provider stream starts so startup failures can retry it.
+    // Once the synthetic wake turn is accepted into durable chat history, the wake has
+    // been delivered. If provider startup fails after acceptance, AgentSession's
+    // startup retry must resume that accepted turn instead of appending another copy
+    // of the same monitor wake.
     let accepted = false;
     let delivered = false;
-    let startupFailed = false;
-    let removeStreamStartListener: (() => void) | undefined;
-    const removeDeliveryListener = (): void => {
-      removeStreamStartListener?.();
-      removeStreamStartListener = undefined;
-    };
-    const isOwnerStreamStart = (data: unknown): data is { workspaceId: string } =>
-      typeof data === "object" &&
-      data !== null &&
-      "workspaceId" in data &&
-      data.workspaceId === ownerWorkspaceId;
     const markDeliveredOnce = async (): Promise<void> => {
       if (delivered) return;
       delivered = true;
-      removeDeliveryListener();
       try {
         await markDeliveredAfterAccepted(pending);
       } catch (error) {
@@ -1839,16 +1829,6 @@ export class WorkspaceService extends EventEmitter {
           error,
         });
       }
-    };
-    const armDeliveryAfterStreamStart = (): void => {
-      removeDeliveryListener();
-      const onStreamStart = (data: unknown): void => {
-        if (isOwnerStreamStart(data)) {
-          void markDeliveredOnce();
-        }
-      };
-      this.aiService.on("stream-start", onStreamStart);
-      removeStreamStartListener = () => this.aiService.off("stream-start", onStreamStart);
     };
 
     const sendResult = await this.sendMessage(
@@ -1859,24 +1839,23 @@ export class WorkspaceService extends EventEmitter {
         skipAutoResumeReset: true,
         synthetic: true,
         agentInitiated: true,
-        onAccepted: () => {
+        onAccepted: async () => {
           accepted = true;
-          armDeliveryAfterStreamStart();
+          await markDeliveredOnce();
         },
-        onAcceptedPreStreamFailure: (error) => {
-          startupFailed = true;
-          if (!accepted) {
-            removeDeliveryListener();
+        onAcceptedPreStreamFailure: async (error) => {
+          if (accepted) {
+            await markDeliveredOnce();
+            return;
           }
           if (delivered) return;
-          log.debug("Bash monitor wake accepted send failed before stream start; leaving pending", {
+          log.debug("Bash monitor wake send failed before acceptance; leaving pending", {
             ownerWorkspaceId,
             error,
           });
           retryAfterIdleIfBusy("pre-stream failure");
         },
         onCanceled: async (reason) => {
-          removeDeliveryListener();
           if (delivered) return;
           const cancelingKeys = pending.map((record) =>
             this.bashMonitorWakeKey(ownerWorkspaceId, record.id)
@@ -1905,8 +1884,9 @@ export class WorkspaceService extends EventEmitter {
     );
 
     if (!sendResult.success) {
-      if (!accepted) {
-        removeDeliveryListener();
+      if (accepted) {
+        await markDeliveredOnce();
+        return;
       }
       if (!delivered) {
         log.debug("Bash monitor wake-up not accepted; leaving pending", {
@@ -1918,7 +1898,7 @@ export class WorkspaceService extends EventEmitter {
       return;
     }
 
-    if (accepted && !startupFailed) {
+    if (accepted) {
       await markDeliveredOnce();
     }
   }


### PR DESCRIPTION
## Summary

Fix bash monitor wake delivery so accepted synthetic wake messages are marked delivered as soon as they are persisted to chat history. This prevents pre-stream provider startup failures from repeatedly appending the same background-monitor wake to the workspace transcript.

## Background

Workspace `f5d85266cf` showed one persisted bash monitor wake with a handful of matched lines, but hundreds of duplicate synthetic user wake messages. The wake record stayed pending after the synthetic message was accepted because delivery waited for provider `stream-start`; later error/drain events retried the same pending wake and appended duplicates.

## Implementation

`WorkspaceService.drainBashMonitorWakes()` now treats chat-history acceptance as the delivery boundary. If startup fails after acceptance, AgentSession's existing startup retry resumes the accepted turn instead of relying on bash-monitor wake re-enqueue. Rejected sends before acceptance still leave the wake pending for retry.

## Validation

- `make static-check`
- `make typecheck`
- `bun test src/node/services/workspaceService.test.ts --test-name-pattern "WorkspaceService bash monitor wakes"`
- `make fmt-check`
- `MUX_ESLINT_CONCURRENCY=1 make lint`

## Risks

Low-to-medium risk, limited to bash monitor wake auto-delivery. The main semantic change is that an accepted synthetic wake is considered delivered before provider streaming starts; this relies on existing accepted-turn startup retry, which is already set before the acceptance callback runs.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `1731989{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=25.61 -->
