### PR TITLE
🤖 fix: keep kickoff-window goals active through synthetic bash-monitor wake turns

### DIFF
--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -774,6 +774,150 @@ describe("WorkspaceGoalService", () => {
     });
   });
 
+  // Regression: bash-monitor wake turns used to disable freshly set goals.
+  // The wake turn's synthetic user row lands before the kickoff continuation
+  // row, so chat-tail reconciliation saw the pre-goal manual user row and
+  // flipped the goal active→paused mid-window.
+  test("getGoal keeps a kickoff-window goal active while a synthetic wake turn runs", async () => {
+    await appendUserHistoryMessage(historyService, workspaceId, "Set yourself a goal and continue");
+    const busy = true;
+    const dispatcher = new IdleDispatcher();
+    const execute = mock(() => Promise.resolve(true));
+    service.registerGoalContinuationConsumer(dispatcher, {
+      ...continuationBridge(execute),
+      getRuntimeState: () => ({ isRuntimeCompatible: true, isBusy: busy }),
+      getKickoffSendOptions: () => ({ model: "openai:gpt-4o", agentId: "exec" }),
+    });
+
+    const goal = await setGoalOk(service, {
+      workspaceId,
+      objective: "Survive a wake turn",
+      status: "active",
+      initiator: "model",
+    });
+    // Simulate a bash-monitor wake turn starting before the kickoff fires: its
+    // synthetic user row is appended and the wake turn's tool build reads the
+    // goal while the kickoff candidate is still armed.
+    await appendUserHistoryMessage(
+      historyService,
+      workspaceId,
+      "A background bash monitor matched output.",
+      { timestamp: Date.now(), synthetic: true, uiVisible: true }
+    );
+
+    expect(await service.getGoal(workspaceId)).toMatchObject({
+      goalId: goal.goalId,
+      status: "active",
+    });
+  });
+
+  test("a wake turn ending during the kickoff window does not drop the kickoff candidate", async () => {
+    await appendUserHistoryMessage(historyService, workspaceId, "Set yourself a goal and continue");
+    let busy = true;
+    const dispatcher = new IdleDispatcher();
+    const executed: Array<Parameters<GoalContinuationRuntimeBridge["executeGoalContinuation"]>[0]> =
+      [];
+    service.registerGoalContinuationConsumer(dispatcher, {
+      ...continuationBridge(async (input) => {
+        executed.push(input);
+        await appendUserHistoryMessage(historyService, workspaceId, input.message, {
+          timestamp: Date.now(),
+          synthetic: true,
+          uiVisible: true,
+          kind: input.kind ?? GOAL_CONTINUATION_KIND,
+        });
+        return true;
+      }),
+      getRuntimeState: () => ({ isRuntimeCompatible: true, isBusy: busy }),
+      getKickoffSendOptions: () => ({ model: "openai:gpt-4o", agentId: "exec" }),
+    });
+
+    const goal = await setGoalOk(service, {
+      workspaceId,
+      objective: "Survive a wake turn end",
+      status: "active",
+      initiator: "model",
+    });
+    await appendUserHistoryMessage(
+      historyService,
+      workspaceId,
+      "A background bash monitor matched output.",
+      { timestamp: Date.now(), synthetic: true, uiVisible: true }
+    );
+    // getGoal during the wake turn must not flip the goal, and the wake turn's
+    // stream-end hook must keep the armed kickoff instead of downgrading or
+    // deleting it.
+    expect(await service.getGoal(workspaceId)).toMatchObject({ status: "active" });
+    await service.requestContinuationAfterStreamEnd({
+      workspaceId,
+      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
+      streamEndedAtMs: Date.now(),
+    });
+
+    busy = false;
+    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
+    await waitForCondition(() => executed.length > 0, { timeoutMs: 1_000 });
+
+    expect(executed[0]?.kind).toBe(GOAL_CONTINUATION_KIND);
+    expect(executed[0]?.startStreamInBackground).toBe(true);
+    expect(await service.getGoal(workspaceId)).toMatchObject({
+      goalId: goal.goalId,
+      status: "active",
+    });
+  });
+
+  test("wake turn stream end preserves a paused kickoff candidate armed by resume", async () => {
+    await setGoalOk(service, { workspaceId, objective: "Resume through a wake turn" });
+    await appendUserHistoryMessage(historyService, workspaceId, "Continue goal", {
+      timestamp: Date.now(),
+      synthetic: true,
+      uiVisible: true,
+      kind: GOAL_CONTINUATION_KIND,
+    });
+    let busy = true;
+    const dispatcher = new IdleDispatcher();
+    const executed: Array<Parameters<GoalContinuationRuntimeBridge["executeGoalContinuation"]>[0]> =
+      [];
+    service.registerGoalContinuationConsumer(dispatcher, {
+      ...continuationBridge(async (input) => {
+        executed.push(input);
+        await appendUserHistoryMessage(historyService, workspaceId, input.message, {
+          timestamp: Date.now(),
+          synthetic: true,
+          uiVisible: true,
+          kind: input.kind ?? GOAL_CONTINUATION_KIND,
+        });
+        return true;
+      }),
+      getRuntimeState: () => ({ isRuntimeCompatible: true, isBusy: busy }),
+      getKickoffSendOptions: () => ({ model: "openai:gpt-4o", agentId: "exec" }),
+    });
+
+    // Explicit pause appends a goal-pause-boundary row and clears candidates;
+    // resume then arms a kickoff whose continuation is deferred while busy. The
+    // chat tail still ends at the boundary, so the persisted status flaps back
+    // to paused — the armed kickoff is the durable carrier of resume intent.
+    await setGoalOk(service, { workspaceId, status: "paused" });
+    const resumed = await setGoalOk(service, { workspaceId, status: "active" });
+
+    // A wake turn's stream end must not delete that paused kickoff candidate.
+    await service.requestContinuationAfterStreamEnd({
+      workspaceId,
+      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
+      streamEndedAtMs: Date.now(),
+    });
+
+    busy = false;
+    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
+    await waitForCondition(() => executed.length > 0, { timeoutMs: 1_000 });
+
+    expect(executed[0]?.kind).toBe(GOAL_CONTINUATION_KIND);
+    expect(await service.getGoal(workspaceId)).toMatchObject({
+      goalId: resumed.goalId,
+      status: "active",
+    });
+  });
+
   test("strips set_goal capability from synthetic goal continuations", async () => {
     const created = await setGoalOk(service, { workspaceId, objective: "Continue safely" });
     const dispatcher = new IdleDispatcher();

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -200,6 +200,13 @@ interface PendingGoalContinuationCandidate {
 
 interface ChatTailGoalModeResult {
   mode: "active" | "paused" | null;
+  /**
+   * Why the tail resolved to paused: an explicit `goal-pause-boundary` row vs
+   * an ordinary manual user row. Reconciliation uses this to distinguish an
+   * explicit pause from the implicit "no continuation appended yet" state of a
+   * freshly armed kickoff (see `applyChatTailGoalMode`).
+   */
+  pausedBy?: "pause_boundary" | "manual_user";
 }
 
 interface GoalContinuationEligibilityResult {
@@ -494,23 +501,45 @@ export class WorkspaceGoalService {
         return { mode: "active" };
       }
       if (message.metadata?.muxMetadata?.type === "goal-pause-boundary") {
-        return { mode: "paused" };
+        return { mode: "paused", pausedBy: "pause_boundary" };
       }
       if (message.metadata?.synthetic === true) {
         continue;
       }
-      return { mode: "paused" };
+      return { mode: "paused", pausedBy: "manual_user" };
     }
 
     return { mode: null };
   }
 
   private applyChatTailGoalMode(
+    workspaceId: string,
     goal: GoalRecordV1,
     chatTailMode: ChatTailGoalModeResult
   ): GoalRecordV1 {
     if (chatTailMode.mode == null || (goal.status !== "active" && goal.status !== "paused")) {
       return goal;
+    }
+
+    // Kickoff window: a freshly activated goal (model set_goal / user Resume)
+    // arms a kickoff continuation candidate before its first goal_continuation
+    // row is appended, so the chat tail still ends at a pre-goal manual user
+    // row. Reconciling active→paused here would let any concurrent read (Goal
+    // panel, tool building, a synthetic bash-monitor wake turn) pause the goal
+    // before the kickoff fires — and the wake turn's stream-end hook could then
+    // drop the kickoff candidate, stranding the goal (see
+    // requestContinuationAfterStreamEnd). Explicit pauses are unaffected: every
+    // explicit pause path deletes the candidate first and appends a
+    // goal-pause-boundary row, which is deliberately not suppressed here.
+    if (
+      goal.status === "active" &&
+      chatTailMode.mode === "paused" &&
+      chatTailMode.pausedBy === "manual_user"
+    ) {
+      const candidate = this.pendingContinuationCandidates.get(workspaceId);
+      if (candidate?.source === "kickoff" && candidate.goalId === goal.goalId) {
+        return goal;
+      }
     }
 
     const desiredStatus = chatTailMode.mode;
@@ -539,7 +568,7 @@ export class WorkspaceGoalService {
         return null;
       }
 
-      const next = this.applyChatTailGoalMode(current, chatTailMode);
+      const next = this.applyChatTailGoalMode(workspaceId, current, chatTailMode);
       if (next === current) {
         return current;
       }
@@ -912,12 +941,25 @@ export class WorkspaceGoalService {
       const kickoffGoal = await this.normalizeGoalLimits(input.workspaceId, {
         syncChatTail: false,
       });
-      if (kickoffGoal?.goalId === existingCandidate.goalId && kickoffGoal.status === "active") {
+      if (
+        kickoffGoal?.goalId === existingCandidate.goalId &&
+        (kickoffGoal.status === "active" || kickoffGoal.status === "paused")
+      ) {
         // Model-created goals arm a kickoff candidate when the queued set_goal
         // drains. The enclosing user stream also calls this stream-end hook; do
         // not downgrade that kickoff into a stream_end candidate, because
         // stream_end candidates reconcile against the pre-goal manual user row
         // and would pause the new goal before it can continue.
+        //
+        // `paused` is included because chat-tail reconciliation can flip a
+        // kickoff-window goal to paused before its first continuation row lands
+        // (e.g. when a synthetic bash-monitor wake turn runs first and its
+        // stream end lands here). Eligibility and dispatch deliberately accept
+        // paused kickoff candidates and recordContinuationFired flips the goal
+        // back to active. Every explicit pause path deletes the candidate
+        // first, so a paused goal with an armed kickoff can only be that
+        // auto-flip — dropping it here would strand the goal (issue: bash
+        // monitor wakes disabling freshly set goals).
         await this.goalContinuationDispatcher.requestDispatch(
           input.workspaceId,
           GOAL_CONTINUATION_IDLE_CONSUMER_NAME
@@ -1371,7 +1413,7 @@ export class WorkspaceGoalService {
       }
       const budgetNormalized = this.applyBudgetDrivenStatus(current);
       const next = chatTailMode
-        ? this.applyChatTailGoalMode(budgetNormalized, chatTailMode)
+        ? this.applyChatTailGoalMode(workspaceId, budgetNormalized, chatTailMode)
         : budgetNormalized;
       if (next !== current) {
         await this.writeGoal(workspaceId, next);


### PR DESCRIPTION
## Summary

Background bash-monitor wake turns could permanently pause a freshly set workspace goal (Goal panel stuck at "ACTIVE (PAUSED)", kickoff never fires). This fixes the goal kickoff-window reconciliation so synthetic wake turns — and any concurrent `getGoal()` read — can no longer strand a goal.

## Background

When a background bash `monitor` matches output, Mux wakes the workspace by sending a synthetic user message. That delivery path was already correct (`synthetic: true`, chat-tail-neutral, same as heartbeats and sub-agent report wakes). The actual bug was a two-step failure in `WorkspaceGoalService` during the kickoff window:

1. **Kickoff-window flip.** Activating a goal (model `set_goal` or user Resume) arms a `kickoff` continuation candidate, but the first `goal_continuation` history row has not landed yet — the chat tail still ends at the pre-goal manual user row. Any `getGoal()` during that window (the wake turn's tool build guarantees one) ran chat-tail reconciliation and flipped the goal `active → paused`.
2. **Candidate deletion.** At the wake turn's stream end, `requestContinuationAfterStreamEnd`'s kickoff protection required persisted status `"active"`; seeing `"paused"` it deleted the armed kickoff candidate, permanently stranding the goal.

## Implementation

- `readChatTailGoalMode` now tags *why* the tail resolved to paused: explicit `goal-pause-boundary` row vs ordinary manual user row.
- `applyChatTailGoalMode` skips only the **implicit** `active → paused` downgrade (`pausedBy: "manual_user"`) while an armed kickoff candidate matches `goal.goalId`. Explicit pauses are unaffected: every explicit pause path deletes the candidate first and appends a pause-boundary row, which is deliberately not suppressed.
- `requestContinuationAfterStreamEnd`'s kickoff protection now also accepts a `paused` kickoff goal instead of deleting the candidate — mirroring existing semantics where eligibility/dispatch tolerate paused-kickoff and `recordContinuationFired` flips the goal back to active.

## Validation

- 3 new regression tests simulate a bash-monitor wake turn during the kickoff window (synthetic wake row + `getGoal` + wake-turn stream end). All 3 **fail without the fix** (verified via `git stash`) and pass with it.
- Full goal suites (`workspaceGoalService`, `agentSession.goalAutoPause`, `workspaceService.goalDefaults` — 160 tests), `bashMonitorWakeStore`, and `workspaceService` monitor-wake tests: green.

## Risks

Low-moderate; touches goal status reconciliation. The suppression is narrowly scoped: only `active → paused`, only for the implicit manual-user-tail case, and only while a kickoff candidate with a matching `goalId` is armed. Kickoff candidates cannot keep a goal artificially active: explicit pause, manual user messages, and user stops all delete the candidate before/at reconciliation, and dispatch/stream-end paths clear or replace it. Worst regression case would be a goal staying active slightly longer during the kickoff window — previous behavior (silent permanent pause) was strictly worse.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$16.04`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=16.04 -->
