### PR TITLE
🤖 fix: set Linux app name so windows group under mux.desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mux",
   "version": "0.27.0",
+  "desktopName": "mux.desktop",
   "description": "mux - coder multiplexer",
   "author": "Coder",
   "main": "dist/cli/index.js",

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -63,8 +63,10 @@ import {
 // generic "Electron" entry. Launch modes that don't expose our package.json
 // (e.g. the Nix package's `electron dist/cli/index.js`) otherwise fall back to
 // the "Electron" default. setName sets WM_CLASS (XWayland matches
-// StartupWMClass=mux); CHROME_DESKTOP sets the native-Wayland app_id. Must run
-// before the ready event.
+// StartupWMClass=mux); CHROME_DESKTOP sets the native-Wayland app_id (same var
+// Electron sets from package.json desktopName when it can read it). Must run
+// before the ready event. sanitizeMuxChildEnv strips CHROME_DESKTOP from child
+// processes so apps launched from mux terminals don't inherit our identity.
 if (process.platform === "linux") {
   app.setName("mux");
   process.env.CHROME_DESKTOP = "mux.desktop";

--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -59,6 +59,17 @@ import {
   shell,
 } from "electron";
 
+// Pin the Linux app name so the window groups under mux.desktop instead of a
+// generic "Electron" entry. Launch modes that don't expose our package.json
+// (e.g. the Nix package's `electron dist/cli/index.js`) otherwise fall back to
+// the "Electron" default. setName sets WM_CLASS (XWayland matches
+// StartupWMClass=mux); CHROME_DESKTOP sets the native-Wayland app_id. Must run
+// before the ready event.
+if (process.platform === "linux") {
+  app.setName("mux");
+  process.env.CHROME_DESKTOP = "mux.desktop";
+}
+
 // Enable local crash dump collection so renderer SIGSEGV produces a minidump
 // at ~/.config/mux/Crashpad/completed/*.dmp — no data leaves the machine.
 // Must be called as early as possible, before app.whenReady().

--- a/src/node/runtime/childProcessEnv.ts
+++ b/src/node/runtime/childProcessEnv.ts
@@ -1,10 +1,15 @@
 import * as path from "node:path";
 import { getMuxHome } from "@/common/constants/paths";
 
-const BROWSER_ENV_KEYS_TO_STRIP = [
+const CHILD_ENV_KEYS_TO_STRIP = [
   "AGENT_BROWSER_SESSION",
   "AGENT_BROWSER_STREAM_PORT",
   "MUX_VENDORED_BIN_DIR",
+  // Linux desktop identity (app_id source). Electron sets it in our process env
+  // (from package.json desktopName, or main.ts for launch modes without a
+  // package.json). Chromium/Electron apps launched from a mux terminal would
+  // inherit it and group under mux's taskbar entry.
+  "CHROME_DESKTOP",
 ] as const;
 
 function normalizePathEntry(entry: string): string {
@@ -45,7 +50,7 @@ export function sanitizeMuxChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const sanitizedEnv: NodeJS.ProcessEnv = { ...env };
   const sanitizedPath = sanitizeMuxChildPath(env.PATH ?? env.Path, env);
 
-  for (const key of BROWSER_ENV_KEYS_TO_STRIP) {
+  for (const key of CHILD_ENV_KEYS_TO_STRIP) {
     delete sanitizedEnv[key];
   }
 

--- a/src/node/runtime/ptySpawn.test.ts
+++ b/src/node/runtime/ptySpawn.test.ts
@@ -26,11 +26,13 @@ describe("sanitizeMuxChildEnv", () => {
       AGENT_BROWSER_SESSION: "mux-session",
       AGENT_BROWSER_STREAM_PORT: "9222",
       MUX_VENDORED_BIN_DIR: "/tmp/mux/bin",
+      CHROME_DESKTOP: "mux.desktop",
     });
 
     expect(env.AGENT_BROWSER_SESSION).toBeUndefined();
     expect(env.AGENT_BROWSER_STREAM_PORT).toBeUndefined();
     expect(env.MUX_VENDORED_BIN_DIR).toBeUndefined();
+    expect(env.CHROME_DESKTOP).toBeUndefined();
     expect(env.PATH).toBe("/usr/bin");
   });
 });

--- a/src/node/services/editorService.ts
+++ b/src/node/services/editorService.ts
@@ -3,6 +3,7 @@ import * as fsPromises from "fs/promises";
 import type { Config } from "@/node/config";
 import { isDockerRuntime, isSSHRuntime, isDevcontainerRuntime } from "@/common/types/runtime";
 import { log } from "@/node/services/log";
+import { sanitizeMuxChildEnv } from "@/node/runtime/childProcessEnv";
 import { getErrorMessage } from "@/common/utils/errors";
 
 /**
@@ -136,6 +137,9 @@ export class EditorService {
         stdio: "ignore",
         shell: true,
         windowsHide: true,
+        // Strip mux-internal vars (e.g. CHROME_DESKTOP, our Linux desktop
+        // identity) so GUI editors don't inherit mux's window identity.
+        env: sanitizeMuxChildEnv({ ...process.env }),
       });
       child.unref();
 

--- a/src/node/services/terminalService.ts
+++ b/src/node/services/terminalService.ts
@@ -18,6 +18,7 @@ import {
 } from "@/node/runtime/runtimeHelpers";
 import { log } from "@/node/services/log";
 import { isCommandAvailable, findAvailableCommand } from "@/node/utils/commandDiscovery";
+import { sanitizeMuxChildEnv } from "@/node/runtime/childProcessEnv";
 import { Terminal } from "@xterm/headless";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { NO_OSC_IDLE_FALLBACK_MS } from "@/constants/terminalActivity";
@@ -676,6 +677,9 @@ export class TerminalService {
         cwd: availableTerminal.cwd,
         detached: true,
         stdio: "ignore",
+        // Strip mux-internal vars (e.g. CHROME_DESKTOP, our Linux desktop
+        // identity) so apps launched from this shell don't inherit them.
+        env: sanitizeMuxChildEnv({ ...process.env }),
       });
       child.unref();
     } else {


### PR DESCRIPTION
## Summary

Give Mux windows a stable Linux desktop identity so they group under the pinned `mux.desktop` launcher instead of spawning a separate, generic "Electron" taskbar entry — and contain that identity so apps launched *from* Mux (terminals, custom editors) don't inherit it.

## Background

On Linux, Electron derives the X11/XWayland `WM_CLASS` and native-Wayland `app_id` from the app name, normally read from `package.json`. Launch modes that don't expose our `package.json` (notably the Nix package, which runs `electron dist/cli/index.js`) fall back to the built-in `Electron` default, so the window doesn't match `mux.desktop` (`StartupWMClass=mux`) and KDE/GNOME open a second taskbar entry with the wrong icon. Verified live on KDE Plasma 6: the Mux window reported `resourceName=electron` / `resourceClass=Electron` and userData resolved to `~/.config/Electron`.

## Implementation

- `src/desktop/main.ts`: before the ready event on Linux, `app.setName("mux")` (sets `WM_CLASS`, which XWayland/X11 groups on) and `CHROME_DESKTOP=mux.desktop` (sets the native-Wayland `app_id`; same env var `app.setDesktopName` writes).
- `package.json`: `"desktopName": "mux.desktop"` — the upstream-recommended declarative identity for packaged builds (same approach as Signal), and guards against a future `productName` case change breaking the default-derived name.
- Containment (Codex findings): `CHROME_DESKTOP` is stripped in `sanitizeMuxChildEnv` (covers bash/pty children), and the two Linux paths that hand control to user GUI apps — native terminal launch and custom editor launch — now spawn with a sanitized env. Without this, a Chromium/Electron app launched from a Mux terminal would group under Mux's launcher; packaged builds had this leak already since Electron always sets `CHROME_DESKTOP` when it can read `package.json`.
- macOS (`open`/`osascript`) and Windows paths are unaffected: the identity block is Linux-gated.

## Risks

Low, Linux-only. Setting the app name also moves `userData`/crash dumps from `~/.config/Electron` to `~/.config/mux` on builds that previously fell back to the default name (dev and Nix), aligning them with packaged builds; one-time renderer `localStorage` reset on those installs. Packaged builds already resolving the name to `mux` are unaffected.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$6.19`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=6.19 -->
