### PR TITLE
🤖 fix: carry persisted thinking level into goal continuations; never send disabled thinking to Mythos-class models

### DIFF
--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -238,6 +238,20 @@ export function anthropicSupportsNativeXhigh(modelString: string): boolean {
 }
 
 /**
+ * Whether the given Anthropic model rejects `thinking: { type: "disabled" }`.
+ *
+ * Mythos-class models (Fable/Mythos) cannot turn thinking off: the API errors with
+ * '"thinking.type.disabled" is not supported for this model. Thinking defaults to
+ * adaptive mode when not specified'. Callers must either clamp "off" away via the
+ * thinking policy or omit the `thinking` field entirely (letting the API default
+ * to adaptive).
+ */
+export function anthropicRejectsDisabledThinking(modelString: string): boolean {
+  const withoutPrefix = stripModelProviderPrefixes(modelString);
+  return /claude-(?:fable|mythos)-/.test(withoutPrefix);
+}
+
+/**
  * Default thinking level when no value is set (UI initial state, backend fallback).
  * Semantically different from DEFAULT_THINKING_LEVEL which is the level used
  * when a user opts *into* thinking (e.g., CLI `--thinking` with no explicit level).

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -131,6 +131,25 @@ describe("buildProviderOptions - Anthropic", () => {
     });
   }
 
+  describe("claude-fable-5 (Mythos-class: API rejects disabled thinking)", () => {
+    test("maps medium to adaptive thinking like other adaptive models", () => {
+      const anthropic = anthropicProviderOptions(
+        buildProviderOptions("anthropic:claude-fable-5", "medium")
+      );
+      expect(anthropic.thinking).toEqual({ type: "adaptive" });
+      expect(anthropic.effort).toBe("medium");
+    });
+
+    test("omits thinking instead of sending disabled when off", () => {
+      // The API errors on `thinking: { type: "disabled" }` for Mythos-class models;
+      // omitting the field lets it default to adaptive. "off" can still reach here
+      // when no thinking level was provided upstream (defaults to off).
+      expect(buildProviderOptions("anthropic:claude-fable-5", "off")).toEqual({
+        anthropic: { ...baseAnthropicOptions, effort: "low" },
+      });
+    });
+  });
+
   describe("Other Anthropic models (thinking/budgetTokens)", () => {
     for (const { model, thinking, budgetTokens } of [
       { model: "claude-sonnet-4-5", thinking: "medium", budgetTokens: 10000 },

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -293,9 +293,10 @@ export function buildProviderOptions(
       const budgetTokens = ANTHROPIC_THINKING_BUDGETS[effectiveThinking];
       // Opus 4.6+ / Sonnet 4.6 / Sonnet 5: adaptive thinking when on, disabled when off
       // Opus 4.5: enabled thinking with budgetTokens ceiling (only when not "off")
-      // Mythos-class (Fable/Mythos) rejects `{ type: "disabled" }`; the thinking policy
-      // excludes "off" for them, but an unset thinking level can still reach here as
-      // "off" (defaulted upstream) — omit `thinking` so the API defaults to adaptive.
+      // Mythos-class (Fable/Mythos) rejects `{ type: "disabled" }`. The thinking policy
+      // excludes "off" for them and AIService clamps the effective level via
+      // resolveEffectiveThinkingLevel, so "off" should not reach here — but if a stray
+      // path does, omit `thinking` (API defaults to adaptive) rather than hard-erroring.
       const thinking: AnthropicProviderOptions["thinking"] = usesAdaptiveThinking
         ? effectiveThinking === "off"
           ? anthropicRejectsDisabledThinking(capabilityModel)

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -17,6 +17,7 @@ import type { MuxProviderOptions } from "@/common/types/providerOptions";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import {
   getAnthropicEffort,
+  anthropicRejectsDisabledThinking,
   anthropicSupportsNativeXhigh,
   ANTHROPIC_THINKING_BUDGETS,
   GEMINI_THINKING_BUDGETS,
@@ -292,9 +293,14 @@ export function buildProviderOptions(
       const budgetTokens = ANTHROPIC_THINKING_BUDGETS[effectiveThinking];
       // Opus 4.6+ / Sonnet 4.6 / Sonnet 5: adaptive thinking when on, disabled when off
       // Opus 4.5: enabled thinking with budgetTokens ceiling (only when not "off")
+      // Mythos-class (Fable/Mythos) rejects `{ type: "disabled" }`; the thinking policy
+      // excludes "off" for them, but an unset thinking level can still reach here as
+      // "off" (defaulted upstream) — omit `thinking` so the API defaults to adaptive.
       const thinking: AnthropicProviderOptions["thinking"] = usesAdaptiveThinking
         ? effectiveThinking === "off"
-          ? { type: "disabled" }
+          ? anthropicRejectsDisabledThinking(capabilityModel)
+            ? undefined
+            : { type: "disabled" }
           : { type: "adaptive" }
         : budgetTokens > 0
           ? { type: "enabled", budgetTokens }

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -365,10 +365,10 @@ describe("getThinkingPolicyForModel", () => {
     ]);
   });
 
-  test("returns all 6 levels for Mythos-class Fable 5 / Mythos 5", () => {
-    // Fable / Mythos sit above Opus and support the native xhigh effort level.
+  test("excludes 'off' for Mythos-class Fable 5 / Mythos 5 (API rejects disabled thinking)", () => {
+    // Fable / Mythos sit above Opus and support the native xhigh effort level, but the
+    // API rejects `thinking: { type: "disabled" }`, so "off" is not offered.
     expect(getThinkingPolicyForModel("anthropic:claude-fable-5")).toEqual([
-      "off",
       "low",
       "medium",
       "high",
@@ -376,13 +376,18 @@ describe("getThinkingPolicyForModel", () => {
       "max",
     ]);
     expect(getThinkingPolicyForModel("anthropic:claude-mythos-5")).toEqual([
-      "off",
       "low",
       "medium",
       "high",
       "xhigh",
       "max",
     ]);
+  });
+
+  test("clamps 'off' up to 'low' for Mythos-class models", () => {
+    // A stored/legacy "off" selection must not reach the wire as disabled thinking.
+    expect(enforceThinkingPolicy("anthropic:claude-fable-5", "off")).toBe("low");
+    expect(enforceThinkingPolicy("anthropic:claude-mythos-5", "off")).toBe("low");
   });
 
   test("returns all 6 levels for Sonnet 5 (native xhigh)", () => {

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -6,6 +6,7 @@ import {
   isGeminiFlashThinkingLevelModelName,
   getDefaultMinimumThinkingLevel,
   resolveMinimumThinkingLevel,
+  resolveEffectiveThinkingLevel,
   getAvailableThinkingLevels,
 } from "./policy";
 
@@ -388,6 +389,20 @@ describe("getThinkingPolicyForModel", () => {
     // A stored/legacy "off" selection must not reach the wire as disabled thinking.
     expect(enforceThinkingPolicy("anthropic:claude-fable-5", "off")).toBe("low");
     expect(enforceThinkingPolicy("anthropic:claude-mythos-5", "off")).toBe("low");
+  });
+
+  test("resolveEffectiveThinkingLevel clamps unset/off for Mythos-class only", () => {
+    // Mythos-class cannot disable thinking: unset and "off" both resolve to "low"
+    // so provider options, replay transforms, and metadata stay consistent with
+    // the provider's always-thinking behavior.
+    expect(resolveEffectiveThinkingLevel("anthropic:claude-fable-5", undefined)).toBe("low");
+    expect(resolveEffectiveThinkingLevel("anthropic:claude-fable-5", "off")).toBe("low");
+    expect(resolveEffectiveThinkingLevel("anthropic:claude-fable-5", "medium")).toBe("medium");
+    // Other models keep legacy behavior: unset means "off", explicit levels pass through
+    // unclamped (policy enforcement happens at the call sites that own it).
+    expect(resolveEffectiveThinkingLevel("anthropic:claude-opus-4-8", undefined)).toBe("off");
+    expect(resolveEffectiveThinkingLevel("openai:gpt-5-pro", undefined)).toBe("off");
+    expect(resolveEffectiveThinkingLevel("anthropic:claude-sonnet-4-5", "high")).toBe("high");
   });
 
   test("returns all 6 levels for Sonnet 5 (native xhigh)", () => {

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import {
   getThinkingPolicyForModel,
   enforceThinkingPolicy,
@@ -403,6 +404,28 @@ describe("getThinkingPolicyForModel", () => {
     expect(resolveEffectiveThinkingLevel("anthropic:claude-opus-4-8", undefined)).toBe("off");
     expect(resolveEffectiveThinkingLevel("openai:gpt-5-pro", undefined)).toBe("off");
     expect(resolveEffectiveThinkingLevel("anthropic:claude-sonnet-4-5", "high")).toBe("high");
+  });
+
+  test("resolveEffectiveThinkingLevel resolves mappedToModel aliases before the Mythos check", () => {
+    // A configured alias entry mapped to a Mythos-class model must follow the same
+    // no-disabled-thinking rule as the canonical id, matching buildProviderOptions'
+    // capability resolution.
+    const providersConfig: ProvidersConfigMap = {
+      anthropic: {
+        apiKeySet: true,
+        isEnabled: true,
+        isConfigured: true,
+        models: [{ id: "internal-fable", mappedToModel: "anthropic:claude-fable-5" }],
+      },
+    };
+    expect(
+      resolveEffectiveThinkingLevel("anthropic:internal-fable", undefined, providersConfig)
+    ).toBe("low");
+    expect(resolveEffectiveThinkingLevel("anthropic:internal-fable", "off", providersConfig)).toBe(
+      "low"
+    );
+    // Without providers config the alias is unknown and keeps legacy off behavior.
+    expect(resolveEffectiveThinkingLevel("anthropic:internal-fable", undefined)).toBe("off");
   });
 
   test("returns all 6 levels for Sonnet 5 (native xhigh)", () => {

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -16,6 +16,7 @@ import {
   THINKING_LEVELS,
   DEFAULT_THINKING_LEVEL,
   THINKING_LEVEL_OFF,
+  anthropicRejectsDisabledThinking,
   anthropicSupportsNativeXhigh,
   stripModelProviderPrefixes,
   type ThinkingLevel,
@@ -83,6 +84,13 @@ function getExplicitThinkingPolicy(modelString: string): ThinkingPolicy | null {
   // suffixes. Strips both a `provider:` prefix and any upstream-provider path segment that
   // proxies encode (e.g. `mux-gateway:openai/gpt-5.5-pro` -> `gpt-5.5-pro`).
   const withoutProviderNamespace = stripModelProviderPrefixes(modelString);
+
+  // Mythos-class models (Fable/Mythos) cannot disable thinking — the API rejects
+  // `thinking: { type: "disabled" }` and always thinks (adaptive by default) — so
+  // "off" is not offered and requests for it clamp up to "low".
+  if (anthropicRejectsDisabledThinking(modelString)) {
+    return ["low", "medium", "high", "xhigh", "max"];
+  }
 
   // Opus 4.7+ supports all 6 levels: xhigh is a native API effort level distinct from max.
   if (anthropicSupportsNativeXhigh(modelString)) {

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -12,6 +12,7 @@
  * - Multiple elements = User can select from options
  */
 
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import {
   THINKING_LEVELS,
   DEFAULT_THINKING_LEVEL,
@@ -22,6 +23,7 @@ import {
   type ThinkingLevel,
   type ParsedThinkingInput,
 } from "@/common/types/thinking";
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 
 /**
  * Thinking policy is simply the set of allowed thinking levels for a model.
@@ -210,14 +212,21 @@ export function resolveMinimumThinkingLevel(
  * would run adaptive thinking while the message pipeline skips the Anthropic
  * thinking replay transforms (`anthropicThinkingEnabled` keys off "off"),
  * losing required signed thinking context on follow-up requests.
+ *
+ * Pass `providersConfig` so configured aliases (`mappedToModel`, e.g.
+ * `anthropic:internal-fable` -> `anthropic:claude-fable-5`) are resolved to
+ * their capability model before the Mythos check — matching how
+ * `buildProviderOptions` detects capabilities.
  */
 export function resolveEffectiveThinkingLevel(
   modelString: string,
-  requested: ThinkingLevel | null | undefined
+  requested: ThinkingLevel | null | undefined,
+  providersConfig?: ProvidersConfigMap | null
 ): ThinkingLevel {
   const level = requested ?? THINKING_LEVEL_OFF;
-  return anthropicRejectsDisabledThinking(modelString)
-    ? enforceThinkingPolicy(modelString, level)
+  const capabilityModel = resolveModelForMetadata(modelString, providersConfig ?? null);
+  return anthropicRejectsDisabledThinking(capabilityModel)
+    ? enforceThinkingPolicy(capabilityModel, level)
     : level;
 }
 

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -200,6 +200,28 @@ export function resolveMinimumThinkingLevel(
 }
 
 /**
+ * Resolve the effective thinking level for an outgoing stream request.
+ *
+ * Most models treat an unset level as "off". Models that reject disabled
+ * thinking (Mythos-class Anthropic, see {@link anthropicRejectsDisabledThinking})
+ * clamp unset/legacy "off" up through the thinking policy instead, so the
+ * level Mux tracks (provider options, replay transforms, metadata) matches the
+ * provider's actual always-thinking behavior. Without this, the wire request
+ * would run adaptive thinking while the message pipeline skips the Anthropic
+ * thinking replay transforms (`anthropicThinkingEnabled` keys off "off"),
+ * losing required signed thinking context on follow-up requests.
+ */
+export function resolveEffectiveThinkingLevel(
+  modelString: string,
+  requested: ThinkingLevel | null | undefined
+): ThinkingLevel {
+  const level = requested ?? THINKING_LEVEL_OFF;
+  return anthropicRejectsDisabledThinking(modelString)
+    ? enforceThinkingPolicy(modelString, level)
+    : level;
+}
+
+/**
  * Thinking levels available for a model after applying a minimum floor.
  *
  * - `minimum == null` → no floor; returns the raw capability policy.

--- a/src/node/services/agentSession.autoCompaction.test.ts
+++ b/src/node/services/agentSession.autoCompaction.test.ts
@@ -485,6 +485,100 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     session.dispose();
   });
 
+  test("compaction thinking level prefers compact agent default over baseOptions", async () => {
+    const workspaceId = "ws-auto-compaction-compact-thinking-default";
+
+    const streamMessage = mock((_request: unknown) => Promise.resolve(Ok(undefined)));
+    const config = {
+      srcDir: "/tmp",
+      getSessionDir: (_workspaceId: string) => "/tmp",
+      loadConfigOrDefault: () => ({
+        agentAiDefaults: {
+          compact: { modelString: "openai:gpt-5.5", thinkingLevel: "high" },
+        },
+      }),
+    } as unknown as Config;
+    const { session } = await createSessionHarness({
+      workspaceId,
+      config,
+      streamMessage: streamMessage as unknown as AIService["streamMessage"],
+    });
+
+    const baseOptions: SendMessageOptions = {
+      model: "anthropic:claude-opus-4-6",
+      agentId: "exec",
+      thinkingLevel: "low",
+    };
+    const followUpContent: CompactionFollowUpRequest = {
+      text: "Continue",
+      model: "anthropic:claude-opus-4-6",
+      agentId: "exec",
+    };
+
+    const internals = session as unknown as {
+      buildAutoCompactionRequest: (params: {
+        followUpContent: CompactionFollowUpRequest;
+        baseOptions: SendMessageOptions;
+        reason: "on-send" | "mid-stream";
+      }) => {
+        sendOptions: SendMessageOptions;
+      };
+    };
+
+    const compactionRequest = internals.buildAutoCompactionRequest({
+      followUpContent,
+      baseOptions,
+      reason: "mid-stream",
+    });
+
+    // The compact agent's configured thinking level wins over the active stream's,
+    // matching desktop /compact (applyCompactionOverrides).
+    expect(compactionRequest.sendOptions.thinkingLevel).toBe("high");
+
+    session.dispose();
+  });
+
+  test("compaction thinking level falls back to baseOptions when compact default is unset", async () => {
+    const workspaceId = "ws-auto-compaction-base-thinking-fallback";
+
+    const streamMessage = mock((_request: unknown) => Promise.resolve(Ok(undefined)));
+    const { session } = await createSessionHarness({
+      workspaceId,
+      streamMessage: streamMessage as unknown as AIService["streamMessage"],
+    });
+
+    const baseOptions: SendMessageOptions = {
+      model: "anthropic:claude-opus-4-6",
+      agentId: "exec",
+      thinkingLevel: "medium",
+    };
+    const followUpContent: CompactionFollowUpRequest = {
+      text: "Continue",
+      model: "anthropic:claude-opus-4-6",
+      agentId: "exec",
+    };
+
+    const internals = session as unknown as {
+      buildAutoCompactionRequest: (params: {
+        followUpContent: CompactionFollowUpRequest;
+        baseOptions: SendMessageOptions;
+        reason: "on-send" | "mid-stream";
+      }) => {
+        sendOptions: SendMessageOptions;
+      };
+    };
+
+    const compactionRequest = internals.buildAutoCompactionRequest({
+      followUpContent,
+      baseOptions,
+      reason: "on-send",
+    });
+
+    expect(compactionRequest.sendOptions.thinkingLevel).toBe("medium");
+
+    session.dispose();
+  });
+
   test("threads providers config into pre-send and mid-stream compaction checks", async () => {
     const workspaceId = "ws-auto-compaction-providers-config";
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3221,31 +3221,36 @@ export class AgentSession {
     return followUp;
   }
 
-  private getPreferredCompactionModel(): string | null {
+  private getPreferredCompactionSettings(): {
+    model: string | null;
+    thinkingLevel: ThinkingLevel | null;
+  } {
     try {
       const maybeConfig = this.config as Config & {
         loadConfigOrDefault?: () => {
-          agentAiDefaults?: Record<string, { modelString?: string }>;
+          agentAiDefaults?: Record<string, { modelString?: string; thinkingLevel?: string }>;
         } | null;
       };
       if (typeof maybeConfig.loadConfigOrDefault !== "function") {
-        return null;
+        return { model: null, thinkingLevel: null };
       }
 
-      const compactModelString =
-        maybeConfig.loadConfigOrDefault()?.agentAiDefaults?.compact?.modelString;
+      const compactDefaults = maybeConfig.loadConfigOrDefault()?.agentAiDefaults?.compact;
+      const thinkingLevel = coerceThinkingLevel(compactDefaults?.thinkingLevel) ?? null;
+
+      const compactModelString = compactDefaults?.modelString;
       if (typeof compactModelString !== "string") {
-        return null;
+        return { model: null, thinkingLevel };
       }
 
       const normalized = normalizeToCanonical(compactModelString.trim());
       if (!isValidModelFormat(normalized)) {
-        return null;
+        return { model: null, thinkingLevel };
       }
 
-      return normalized;
+      return { model: normalized, thinkingLevel };
     } catch {
-      return null;
+      return { model: null, thinkingLevel: null };
     }
   }
 
@@ -3261,7 +3266,8 @@ export class AgentSession {
   } {
     // Callers pass the stream model in baseOptions.model; avoid ambient session state
     // here because the current stream is cleared before compaction and could go stale.
-    const compactionModel = this.getPreferredCompactionModel() ?? params.baseOptions.model;
+    const compactSettings = this.getPreferredCompactionSettings();
+    const compactionModel = compactSettings.model ?? params.baseOptions.model;
     assert(
       typeof compactionModel === "string" && compactionModel.trim().length > 0,
       "auto-compaction requires a non-empty model"
@@ -3272,9 +3278,12 @@ export class AgentSession {
       agentId: "compact",
       skipAiSettingsPersistence: true,
       model: compactionModel,
+      // Prefer the compact agent's configured thinking level over the active
+      // stream's, matching desktop /compact (applyCompactionOverrides) — the
+      // stream's level was chosen for its model, not the compaction model.
       thinkingLevel: enforceThinkingPolicy(
         compactionModel,
-        params.baseOptions.thinkingLevel ?? "off"
+        compactSettings.thinkingLevel ?? params.baseOptions.thinkingLevel ?? "off"
       ),
       maxOutputTokens: undefined,
       toolPolicy: [{ regex_match: ".*", action: "disable" }],

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -110,7 +110,11 @@ import { DEFAULT_GOAL_DEFAULTS, normalizeGoalDefaults } from "@/constants/goals"
 import { mergeGoalDefaults } from "@/common/utils/goals/resolveGoalSetIntent";
 import { MULTI_PROJECT_CONFIG_KEY } from "@/common/constants/multiProject";
 import { THINKING_LEVEL_OFF, type ThinkingLevel } from "@/common/types/thinking";
-import { enforceThinkingPolicy, resolveMinimumThinkingLevel } from "@/common/utils/thinking/policy";
+import {
+  enforceThinkingPolicy,
+  resolveEffectiveThinkingLevel,
+  resolveMinimumThinkingLevel,
+} from "@/common/utils/thinking/policy";
 
 import type {
   ErrorEvent,
@@ -1072,7 +1076,13 @@ export class AIService extends EventEmitter {
 
       // Mode (plan|exec|compact) is derived from the selected agent definition.
       const effectiveMuxProviderOptions: MuxProviderOptions = muxProviderOptions ?? {};
-      const effectiveThinkingLevel: ThinkingLevel = thinkingLevel ?? THINKING_LEVEL_OFF;
+      // Clamp away levels the provider rejects (Mythos-class Anthropic cannot
+      // disable thinking) so provider options, replay transforms, and metadata
+      // all agree with the provider's actual thinking behavior.
+      const effectiveThinkingLevel: ThinkingLevel = resolveEffectiveThinkingLevel(
+        modelString,
+        thinkingLevel
+      );
 
       // Resolve model string (xAI variant mapping + gateway routing) and create the model.
       const resolveAndCreateModelStartedAt = Date.now();

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1078,10 +1078,12 @@ export class AIService extends EventEmitter {
       const effectiveMuxProviderOptions: MuxProviderOptions = muxProviderOptions ?? {};
       // Clamp away levels the provider rejects (Mythos-class Anthropic cannot
       // disable thinking) so provider options, replay transforms, and metadata
-      // all agree with the provider's actual thinking behavior.
+      // all agree with the provider's actual thinking behavior. Providers config
+      // is passed so aliases mapped to Mythos models get the same treatment.
       const effectiveThinkingLevel: ThinkingLevel = resolveEffectiveThinkingLevel(
         modelString,
-        thinkingLevel
+        thinkingLevel,
+        this.providerService.getConfig()
       );
 
       // Resolve model string (xAI variant mapping + gateway routing) and create the model.

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -1865,7 +1865,7 @@ export class WorkspaceGoalService {
    * field is part of the public `SendMessageOptionsSchema` and forwarded
    * verbatim by the router, so trusting it would let any oRPC caller flip a
    * single bool to disarm the gate. Internal compaction / heartbeat callers
-   * always pick a priced model via `getPreferredCompactionModel` /
+   * always pick a priced model via `getPreferredCompactionSettings` /
    * heartbeat builders, so they hit the early `modelHasPricingData` exit
    * below without touching `goal.json`.
    */

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -10621,6 +10621,43 @@ describe("WorkspaceService.getGoalContinuationRuntimeState", () => {
       expect(result).toEqual({
         model: "anthropic:claude-sonnet-4-6",
         agentId: "review",
+        thinkingLevel: "off",
+      });
+    });
+
+    test("carries the persisted thinking level with the winning model candidate", async () => {
+      const projectPath = "/tmp/proj";
+      const workspaceId = "ws-thinking";
+      const projects = new Map([
+        [
+          projectPath,
+          {
+            workspaces: [
+              {
+                id: workspaceId,
+                path: "/tmp/proj/ws",
+                aiSettingsByAgent: {
+                  exec: { model: "anthropic:claude-fable-5", thinkingLevel: "medium" as const },
+                },
+              },
+            ],
+          },
+        ],
+      ]);
+      const service = await makeServiceWithConfig({
+        findWorkspace: mock(() => ({ projectPath, workspacePath: "/tmp/proj/ws" })),
+        loadConfigOrDefault: mock(() => ({ projects })),
+      });
+
+      const result = service.getGoalContinuationKickoffSendOptions(workspaceId);
+
+      // Regression: continuations previously dropped the persisted thinking
+      // level, streaming with an implicit "off" that Fable/Mythos-class
+      // Anthropic models reject ("thinking.type.disabled" unsupported).
+      expect(result).toEqual({
+        model: "anthropic:claude-fable-5",
+        agentId: "exec",
+        thinkingLevel: "medium",
       });
     });
 
@@ -10655,6 +10692,7 @@ describe("WorkspaceService.getGoalContinuationRuntimeState", () => {
       expect(result).toEqual({
         model: "openai:gpt-4o",
         agentId: "exec",
+        thinkingLevel: "off",
       });
     });
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8934,26 +8934,43 @@ export class WorkspaceService extends EventEmitter {
         ? workspaceEntry?.aiSettingsByAgent?.[WORKSPACE_DEFAULTS.agentId]
         : undefined;
 
-    const candidates: Array<string | undefined> = [
-      selectedAgentSettings?.model,
-      workspaceEntry?.aiSettings?.model,
-      config.agentAiDefaults?.[agentId]?.modelString,
-      execAgentSettings?.model,
+    // Each candidate pairs the model with the thinking level persisted alongside
+    // it. Dropping the thinking level here caused goal continuations to stream
+    // with an implicit "off" (aiService defaults undefined -> off), which both
+    // ignored the user's UI selection and sent `thinking: { type: "disabled" }`
+    // to Anthropic models that reject disabled thinking (e.g. Fable/Mythos).
+    const candidates: Array<{ model?: string; thinkingLevel?: ThinkingLevel }> = [
+      { model: selectedAgentSettings?.model, thinkingLevel: selectedAgentSettings?.thinkingLevel },
+      {
+        model: workspaceEntry?.aiSettings?.model,
+        thinkingLevel: workspaceEntry?.aiSettings?.thinkingLevel,
+      },
+      {
+        model: config.agentAiDefaults?.[agentId]?.modelString,
+        thinkingLevel: config.agentAiDefaults?.[agentId]?.thinkingLevel,
+      },
+      { model: execAgentSettings?.model, thinkingLevel: execAgentSettings?.thinkingLevel },
       agentId !== WORKSPACE_DEFAULTS.agentId
-        ? config.agentAiDefaults?.[WORKSPACE_DEFAULTS.agentId]?.modelString
-        : undefined,
-      DEFAULT_MODEL,
+        ? {
+            model: config.agentAiDefaults?.[WORKSPACE_DEFAULTS.agentId]?.modelString,
+            thinkingLevel: config.agentAiDefaults?.[WORKSPACE_DEFAULTS.agentId]?.thinkingLevel,
+          }
+        : {},
+      { model: DEFAULT_MODEL },
     ];
 
-    for (const raw of candidates) {
+    for (const candidate of candidates) {
+      const raw = candidate.model;
       if (typeof raw !== "string" || raw.trim().length === 0) {
         continue;
       }
       const normalized = normalizeToCanonical(raw.trim());
       if (isValidModelFormat(normalized)) {
+        const thinkingLevel = coerceThinkingLevel(candidate.thinkingLevel);
         return {
           model: normalized,
           agentId,
+          ...(thinkingLevel != null ? { thinkingLevel } : {}),
         };
       }
     }


### PR DESCRIPTION
## Summary

Goal continuations (and workflow continuations) silently dropped the workspace's persisted thinking level, streaming with an implicit `off`. For adaptive-thinking Anthropic models this both ignored the user's UI selection and — on Mythos-class models (Fable/Mythos), which reject `thinking: { type: "disabled" }` — produced a deterministic API error retry loop:

> `"thinking.type.disabled" is not supported for this model. Thinking defaults to adaptive mode when not specified; use "thinking.type.enabled" with "budget_tokens" for extended thinking.`

## Background

A user running a goal on `anthropic:claude-fable-5` with **medium** thinking selected in the UI saw every goal continuation fail with the error above (screenshot in the report). Root-cause chain:

1. `getGoalContinuationKickoffSendOptions` resolved `{ model, agentId }` from persisted workspace AI settings but omitted the `thinkingLevel` stored right next to the model.
2. `AgentSession` only applies `enforceThinkingPolicy` when a thinking level is present, so the continuation reached `AIService` with `undefined`, which defaults to `off` — bypassing Fable's default "medium" floor.
3. `buildProviderOptions` maps `off` to `thinking: { type: "disabled" }` on adaptive-thinking models, which the Fable API rejects. The error is deterministic, so retries could never succeed.

A codebase sweep found two more members of the same bug family; heartbeats, idle compaction, task spawning, startup retry, and CLI paths were audited and are safe.

## Implementation

- **Goal/workflow kickoff options** (`workspaceService.ts`): the model-resolution cascade now pairs each candidate with the `thinkingLevel` persisted alongside it, so continuations carry the user's selection. Covers goal kickoff, budget wrap-up, restart recovery, and workflow continuations.
- **Mythos-class thinking policy** (`thinking.ts`, `policy.ts`): new `anthropicRejectsDisabledThinking` predicate; Fable/Mythos policies exclude `off` (the API cannot disable thinking), so stored/requested `off` clamps up to `low` and the UI no longer offers it.
- **Wire-format defense** (`providerOptions.ts`): if `off` still reaches request building for a Mythos-class model (thinking level unset end-to-end), omit the `thinking` field — the API then defaults to adaptive — instead of sending `disabled`.
- **Effective-level consistency** (`policy.ts`, `aiService.ts`): new `resolveEffectiveThinkingLevel` clamps unset/legacy `off` for Mythos-class models at the stream derivation point, so provider options, the Anthropic thinking replay transforms (`anthropicThinkingEnabled`), and stream metadata all agree the stream is thinking-enabled (Codex review finding).
- **Auto-compaction** (`agentSession.ts`): `buildAutoCompactionRequest` now prefers the compact agent's configured `thinkingLevel` (like desktop `/compact` via `applyCompactionOverrides` and the startup-retry compaction path) instead of only the active stream's level.

## Validation

- New regression tests: kickoff options carry `medium` for fable; fable/mythos policy excludes `off` and clamps `off → low`; `buildProviderOptions(fable, off)` omits `thinking`; auto-compaction prefers compact-agent thinking level with base-options fallback.
- Existing adaptive-model behavior unchanged (Opus 4.6+/Sonnet 4.6/Sonnet 5 still send `disabled` when off — only Mythos-class models reject it, per the API error).

## Risks

- Medium-blast-radius area (every send path resolves thinking levels), but changes are additive: kickoff options gain a field that downstream code already handles, and policy changes are scoped to `claude-fable-*`/`claude-mythos-*` model IDs.
- Users who previously had `off` selected on Fable/Mythos will now stream at `low` (previously they got a hard API error, so no working behavior changes).
- Auto-compaction thinking-level preference now matches desktop `/compact`; workspaces with a compact-agent thinking default configured will see compaction honor it.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$6.23`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=6.23 -->

