### PR TITLE
🤖 fix: advisor tool fails on cross-provider transcripts with provider-executed tool parts

### DIFF
--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -6,11 +6,8 @@ import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
 import type { CompletedMessagePart, WorkflowRunAttachedEvent } from "@/common/types/stream";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
-import {
-  StreamManager,
-  stripEncryptedContent,
-  type ModelFallbackPrepareOptions,
-} from "./streamManager";
+import { StreamManager, type ModelFallbackPrepareOptions } from "./streamManager";
+import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedContent";
 import * as aiSdk from "ai";
 import {
   APICallError,

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -54,6 +54,7 @@ import {
 import type { SessionUsageService } from "./sessionUsageService";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { extractToolMediaAsUserMessagesFromModelMessages } from "@/node/utils/messages/extractToolMediaAsUserMessagesFromModelMessages";
+import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedContent";
 import { stripWorkflowRunRecordsFromModelMessages } from "@/node/utils/messages/stripWorkflowRunRecordsFromModelMessages";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { MUX_GATEWAY_SESSION_EXPIRED_MESSAGE } from "@/common/constants/muxGatewayOAuth";
@@ -280,46 +281,6 @@ enum StreamState {
   STOPPING = "stopping",
   COMPLETED = "completed", // Stream finished successfully (before cleanup)
   ERROR = "error",
-}
-
-/**
- * Strip encryptedContent from web search results to reduce token usage.
- * The encrypted page content can be massive (4000+ chars per result) and isn't
- * needed for model context. Keep URL, title, and pageAge for reference.
- */
-function stripEncryptedContentFromArray(output: unknown[]): unknown[] {
-  return output.map((item: unknown) => {
-    if (item && typeof item === "object" && "encryptedContent" in item) {
-      // Remove encryptedContent but keep other fields
-      const { encryptedContent, ...rest } = item as Record<string, unknown>;
-      return rest;
-    }
-
-    return item;
-  });
-}
-
-export function stripEncryptedContent(output: unknown): unknown {
-  if (Array.isArray(output)) {
-    return stripEncryptedContentFromArray(output);
-  }
-
-  // Handle SDK json output shape: { type: "json", value: unknown[] }
-  if (
-    typeof output === "object" &&
-    output !== null &&
-    "type" in output &&
-    output.type === "json" &&
-    "value" in output &&
-    Array.isArray(output.value)
-  ) {
-    return {
-      ...output,
-      value: stripEncryptedContentFromArray(output.value),
-    };
-  }
-
-  return output;
 }
 
 const MAX_ORPHAN_TOOL_RESULT_WARNINGS_PER_STREAM = 3;

--- a/src/node/services/tools/advisor.test.ts
+++ b/src/node/services/tools/advisor.test.ts
@@ -308,6 +308,65 @@ describe("advisor tool", () => {
     expect(getStreamTextMessages(streamTextSpy)).toEqual(transcript);
   });
 
+  it("flattens provider-executed tool parts from the transcript before calling the advisor model", async () => {
+    using tempDir = new TestTempDir("advisor-tool-provider-executed-flatten");
+    // Anthropic-shaped server tool use: providerExecuted tool-call + assistant
+    // tool-result with a foreign srvtoolu_ id. Replaying these against a
+    // different provider fails (OpenAI 404s on unknown item_references).
+    const transcript: ModelMessage[] = [
+      { role: "user", content: "research this" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ",
+            toolName: "web_search",
+            input: { query: "advisor cross-provider bug" },
+            providerExecuted: true,
+          },
+          {
+            type: "tool-result",
+            toolCallId: "srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ",
+            toolName: "web_search",
+            output: { type: "json", value: [{ url: "https://example.com/finding" }] },
+          },
+        ],
+      },
+    ];
+    const { config } = createToolConfig(tempDir.path, { transcript, snapshot: undefined });
+    const streamTextSpy = mockStreamTextSuccess({
+      text: "Advice based on the web findings.",
+      usage: { inputTokens: 30, outputTokens: 10, totalTokens: 40 },
+    });
+
+    const tool = createAdvisorTool(config);
+    await Promise.resolve(
+      tool.execute!({ question: "Challenge the findings" }, mockToolCallOptions)
+    );
+
+    const messages = getStreamTextMessages(streamTextSpy);
+    // Handoff message is still appended last.
+    expect(messages.at(-1)).toEqual({
+      role: "user",
+      content: "## Advisor Handoff\n\n**Question:** Challenge the findings",
+    });
+
+    const assistantMessage = messages[1];
+    expect(assistantMessage?.role).toBe("assistant");
+    if (assistantMessage?.role !== "assistant" || !Array.isArray(assistantMessage.content)) {
+      throw new Error("Expected assistant message with array content");
+    }
+    // No tool parts survive; the web-search payload does, as text.
+    expect(
+      assistantMessage.content.every(
+        (part) => part.type !== "tool-call" && part.type !== "tool-result"
+      )
+    ).toBe(true);
+    const textParts = assistantMessage.content.filter((part) => part.type === "text");
+    expect(textParts.some((part) => part.text.includes("https://example.com/finding"))).toBe(true);
+  });
+
   it("appends a question-only advisor handoff when a normalized question is provided", async () => {
     using tempDir = new TestTempDir("advisor-tool-question-handoff");
     const question = "Should we split this refactor?";

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -21,6 +21,7 @@ import type {
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { AdvisorToolCallSnapshot, ToolConfiguration } from "@/common/utils/tools/tools";
 import { log } from "@/node/services/log";
+import { flattenProviderExecutedToolParts } from "@/node/utils/messages/flattenProviderExecutedToolParts";
 import { emitChatEventBestEffort } from "./toolUtils";
 
 type StreamTextProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
@@ -240,7 +241,12 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
       const remainingUses =
         runtime.maxUsesPerTurn !== null ? runtime.maxUsesPerTurn - usesThisTurn : null;
 
-      const transcript = runtime.getTranscriptSnapshot();
+      // Flatten provider-executed (server-side) tool parts to text: the live
+      // step transcript keeps them as assistant tool-call/tool-result parts,
+      // which cannot be replayed against a different provider (e.g. OpenAI
+      // rejects foreign `srvtoolu_...` ids as unknown item_references). See
+      // flattenProviderExecutedToolParts for details.
+      const transcript = flattenProviderExecutedToolParts(runtime.getTranscriptSnapshot());
       assert(Array.isArray(transcript), "advisor transcript snapshot must be an array");
       assert(transcript.length > 0, "advisor transcript snapshot must not be empty");
       assert(toolCallId, "advisor requires toolCallId");

--- a/src/node/utils/messages/flattenProviderExecutedToolParts.test.ts
+++ b/src/node/utils/messages/flattenProviderExecutedToolParts.test.ts
@@ -143,6 +143,67 @@ describe("flattenProviderExecutedToolParts", () => {
     }
   });
 
+  it("flattens the paired inline client tool-call together with its result", () => {
+    // Contrived but type-legal shape: a non-providerExecuted tool-call whose
+    // result lives inline in the same assistant message. Flattening only the
+    // result would leave a bare tool-call, which providers reject.
+    const result = flattenProviderExecutedToolParts([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "toolu_inline_pair",
+            toolName: "bash",
+            input: { script: "ls" },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "toolu_inline_pair",
+            toolName: "bash",
+            output: { type: "json", value: { exitCode: 0 } },
+          },
+        ],
+      },
+    ]);
+
+    const parts = getAssistantParts(result[0]);
+    expect(parts.every((part) => part.type === "text")).toBe(true);
+  });
+
+  it("strips encryptedContent from web search results before stringifying", () => {
+    const result = flattenProviderExecutedToolParts([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "srvtoolu_websearch",
+            toolName: "web_search",
+            output: {
+              type: "json",
+              value: [
+                {
+                  url: "https://example.com",
+                  title: "Result",
+                  encryptedContent: "OPAQUE_ENCRYPTED_BLOB",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const part = getAssistantParts(result[0])[0];
+    expect(part.type).toBe("text");
+    if (part.type !== "text") {
+      throw new Error("Expected flattened text part");
+    }
+    expect(part.text).toContain("https://example.com");
+    expect(part.text).not.toContain("OPAQUE_ENCRYPTED_BLOB");
+  });
+
   it("self-heals on unstringifiable payloads instead of throwing", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;

--- a/src/node/utils/messages/flattenProviderExecutedToolParts.test.ts
+++ b/src/node/utils/messages/flattenProviderExecutedToolParts.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantModelMessage, ModelMessage } from "ai";
+
+import { flattenProviderExecutedToolParts } from "./flattenProviderExecutedToolParts";
+
+type AssistantContentPart = Exclude<AssistantModelMessage["content"], string>[number];
+type AssistantToolResultOutput = Extract<AssistantContentPart, { type: "tool-result" }>["output"];
+
+function getAssistantParts(message: ModelMessage): AssistantContentPart[] {
+  expect(message.role).toBe("assistant");
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    throw new Error("Expected assistant message with array content");
+  }
+  return message.content;
+}
+
+describe("flattenProviderExecutedToolParts", () => {
+  it("flattens provider-executed tool-call and assistant tool-result parts to text", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "look this up" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Searching..." },
+          {
+            type: "tool-call",
+            toolCallId: "srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ",
+            toolName: "web_search",
+            input: { query: "mux advisor bug" },
+            providerExecuted: true,
+            providerOptions: { anthropic: { foo: "bar" } },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ",
+            toolName: "web_search",
+            output: { type: "json", value: [{ url: "https://example.com", title: "Result" }] },
+            providerOptions: { anthropic: { foo: "bar" } },
+          },
+        ],
+      },
+    ];
+
+    const result = flattenProviderExecutedToolParts(messages);
+    expect(result).not.toBe(messages);
+    // User message untouched (referentially equal).
+    expect(result[0]).toBe(messages[0]);
+
+    const parts = getAssistantParts(result[1]);
+    expect(parts).toHaveLength(3);
+    // Pre-existing text part untouched.
+    expect(parts[0]).toBe(getAssistantParts(messages[1])[0]);
+    // No tool parts remain.
+    expect(parts.every((part) => part.type !== "tool-call" && part.type !== "tool-result")).toBe(
+      true
+    );
+
+    const callPart = parts[1];
+    const resultPart = parts[2];
+    expect(callPart.type).toBe("text");
+    expect(resultPart.type).toBe("text");
+    if (callPart.type !== "text" || resultPart.type !== "text") {
+      throw new Error("Expected flattened text parts");
+    }
+    // Payloads survive flattening.
+    expect(callPart.text).toContain("web_search");
+    expect(callPart.text).toContain("mux advisor bug");
+    expect(resultPart.text).toContain("web_search");
+    expect(resultPart.text).toContain("https://example.com");
+    // Leak prevention: flattened parts carry only { type, text } — no
+    // provider-specific ids/options that could resolve to item_references.
+    for (const part of [callPart, resultPart]) {
+      expect(Object.keys(part).sort()).toEqual(["text", "type"]);
+    }
+  });
+
+  it("leaves client tool call/result pairs and non-assistant messages unchanged", () => {
+    const messages: ModelMessage[] = [
+      { role: "system", content: "be helpful" },
+      { role: "user", content: "run the tool" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "toolu_client_1",
+            toolName: "bash",
+            input: { script: "ls" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "toolu_client_1",
+            toolName: "bash",
+            output: { type: "json", value: { exitCode: 0 } },
+          },
+        ],
+      },
+      { role: "assistant", content: "done" },
+    ];
+
+    const result = flattenProviderExecutedToolParts(messages);
+    // No provider-executed parts → the exact same array reference is returned.
+    expect(result).toBe(messages);
+  });
+
+  it("stringifies each tool-result output union member", () => {
+    const outputs: Array<{ output: AssistantToolResultOutput; expected: string }> = [
+      { output: { type: "text", value: "plain text output" }, expected: "plain text output" },
+      { output: { type: "error-text", value: "boom failed" }, expected: "boom failed" },
+      { output: { type: "json", value: { answer: 42 } }, expected: '{"answer":42}' },
+      // Error-shaped fixture: provider-executed tool errors are normalized
+      // into tool-result parts with error-json output upstream.
+      {
+        output: { type: "error-json", value: { errorText: "rate limited" } },
+        expected: '{"errorText":"rate limited"}',
+      },
+      {
+        output: { type: "content", value: [{ type: "text", text: "inline content" }] },
+        expected: '[{"type":"text","text":"inline content"}]',
+      },
+    ];
+
+    for (const { output, expected } of outputs) {
+      const result = flattenProviderExecutedToolParts([
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-result", toolCallId: "srvtoolu_x", toolName: "web_fetch", output },
+          ],
+        },
+      ]);
+      const part = getAssistantParts(result[0])[0];
+      expect(part.type).toBe("text");
+      if (part.type !== "text") {
+        throw new Error("Expected flattened text part");
+      }
+      expect(part.text).toBe(`[Server tool result: web_fetch] ${expected}`);
+    }
+  });
+
+  it("self-heals on unstringifiable payloads instead of throwing", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    const result = flattenProviderExecutedToolParts([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "srvtoolu_circular",
+            toolName: "web_search",
+            input: circular,
+            providerExecuted: true,
+          },
+          {
+            type: "tool-call",
+            toolCallId: "srvtoolu_undefined",
+            toolName: "web_search",
+            input: undefined,
+            providerExecuted: true,
+          },
+        ],
+      },
+    ]);
+
+    for (const part of getAssistantParts(result[0])) {
+      expect(part.type).toBe("text");
+      if (part.type !== "text") {
+        throw new Error("Expected flattened text part");
+      }
+      expect(typeof part.text).toBe("string");
+      expect(part.text.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/node/utils/messages/flattenProviderExecutedToolParts.ts
+++ b/src/node/utils/messages/flattenProviderExecutedToolParts.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+
+import type { AssistantModelMessage, ModelMessage, ToolResultPart } from "ai";
+
+type AssistantContentPart = Exclude<AssistantModelMessage["content"], string>[number];
+
+/**
+ * Stringify arbitrary tool payloads for prompt text. This runs in a
+ * request-building path, so it must self-heal instead of crashing: it never
+ * throws and always returns a non-empty string (circular refs, BigInt, and
+ * undefined all fall back to a primitive stringification or a placeholder).
+ */
+function safeStringifyForPrompt(value: unknown): string {
+  if (typeof value === "string") {
+    return value.length > 0 ? value : '""';
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  try {
+    const json = JSON.stringify(value);
+    // JSON.stringify returns undefined for e.g. bare functions/symbols.
+    if (typeof json === "string" && json.length > 0) {
+      return json;
+    }
+  } catch {
+    // Circular references, BigInt, throwing toJSON — fall through.
+  }
+  switch (typeof value) {
+    case "number":
+    case "boolean":
+    case "bigint":
+    case "symbol":
+    case "function":
+      return String(value);
+    default:
+      // Objects that failed JSON.stringify would render as "[object Object]".
+      return "[unserializable value]";
+  }
+}
+
+function stringifyToolResultOutput(output: ToolResultPart["output"]): string {
+  switch (output.type) {
+    case "text":
+    case "error-text":
+      return output.value;
+    case "json":
+    case "error-json":
+    case "content":
+      return safeStringifyForPrompt(output.value);
+    default:
+      // Unknown/future output shapes: self-heal with a generic stringification.
+      return safeStringifyForPrompt(output);
+  }
+}
+
+/**
+ * Rewrite provider-executed (server-side) tool parts in a live transcript into
+ * plain text parts so the transcript can be replayed against a *different*
+ * provider.
+ *
+ * Why: the in-memory step messages captured from streamText keep
+ * provider-executed tool calls/results (e.g. Anthropic web_search with
+ * `srvtoolu_...` ids) as assistant-content parts with `providerExecuted: true`.
+ * The OpenAI Responses input converter replays assistant tool-result parts as
+ * `item_reference` items keyed by `providerOptions.openai.itemId ?? toolCallId`;
+ * for foreign-origin parts there is no OpenAI itemId, so the raw foreign id
+ * leaks and OpenAI rejects the request with `404 Item with id 'srvtoolu_...'
+ * not found`. (The Coder AI gateway can further garble that error into
+ * `AI_JSONParseError: Text: {` — if you see that symptom on an advisor call,
+ * this is the likely cause.) The advisor consumer is tool-less, so flattening
+ * the blocks to text preserves the content it needs while dropping the
+ * provider-specific wire shape.
+ *
+ * Assistant `tool-result` parts are flattened unconditionally: in AI SDK v6
+ * response messages they are provider-executed by construction (client tool
+ * results live in `tool`-role messages), and provider-executed `tool-error`
+ * parts are normalized into `tool-result` parts with error-json output before
+ * they reach the transcript, so no separate error branch is needed.
+ *
+ * Leak vectors reviewed and intentionally left untouched:
+ * - Reasoning parts with foreign providerOptions: the OpenAI converter skips
+ *   non-OpenAI reasoning parts with a warning; not a fatal leak.
+ * - Text/file parts with providerOptions itemIds: only resolve to
+ *   item_reference for same-provider OpenAI transcripts where the stored
+ *   items exist; unknown namespaces are ignored cross-provider.
+ * - Client tool call/result pairs (`tool`-role messages): replay as
+ *   function_call/function_call_output, which providers accept with foreign
+ *   call ids.
+ *
+ * Returns the original array (and original message objects) when nothing
+ * changed so callers can cheaply detect no-ops.
+ */
+export function flattenProviderExecutedToolParts(messages: ModelMessage[]): ModelMessage[] {
+  assert(Array.isArray(messages), "flattenProviderExecutedToolParts requires a message array");
+
+  let didChange = false;
+
+  const result = messages.map((message): ModelMessage => {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      return message;
+    }
+
+    let changedMessage = false;
+    const newContent = message.content.map((part): AssistantContentPart => {
+      if (part.type === "tool-call" && part.providerExecuted === true) {
+        changedMessage = true;
+        // Build the text part fresh: drop providerOptions/toolCallId/
+        // providerExecuted — provider-specific ids are exactly the leak.
+        return {
+          type: "text",
+          text: `[Server tool call: ${part.toolName}] ${safeStringifyForPrompt(part.input)}`,
+        };
+      }
+      if (part.type === "tool-result") {
+        changedMessage = true;
+        return {
+          type: "text",
+          text: `[Server tool result: ${part.toolName}] ${stringifyToolResultOutput(part.output)}`,
+        };
+      }
+      return part;
+    });
+
+    if (!changedMessage) {
+      return message;
+    }
+    didChange = true;
+    return { ...message, content: newContent };
+  });
+
+  return didChange ? result : messages;
+}

--- a/src/node/utils/messages/flattenProviderExecutedToolParts.ts
+++ b/src/node/utils/messages/flattenProviderExecutedToolParts.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 
 import type { AssistantModelMessage, ModelMessage, ToolResultPart } from "ai";
 
+import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedContent";
+
 type AssistantContentPart = Exclude<AssistantModelMessage["content"], string>[number];
 
 /**
@@ -47,7 +49,11 @@ function stringifyToolResultOutput(output: ToolResultPart["output"]): string {
     case "json":
     case "error-json":
     case "content":
-      return safeStringifyForPrompt(output.value);
+      // Provider-native web_search results can carry huge opaque
+      // encryptedContent blobs. The persistence path strips them before
+      // saving, but the live SDK transcript still has them — drop them here
+      // too so the advisor prompt keeps only the useful URL/title fields.
+      return safeStringifyForPrompt(stripEncryptedContent(output.value));
     default:
       // Unknown/future output shapes: self-heal with a generic stringification.
       return safeStringifyForPrompt(output);
@@ -76,7 +82,9 @@ function stringifyToolResultOutput(output: ToolResultPart["output"]): string {
  * response messages they are provider-executed by construction (client tool
  * results live in `tool`-role messages), and provider-executed `tool-error`
  * parts are normalized into `tool-result` parts with error-json output before
- * they reach the transcript, so no separate error branch is needed.
+ * they reach the transcript, so no separate error branch is needed. If an
+ * assistant message ever carries an inline *client* tool pair, the paired
+ * tool-call is flattened alongside its result so no orphaned call remains.
  *
  * Leak vectors reviewed and intentionally left untouched:
  * - Reasoning parts with foreign providerOptions: the OpenAI converter skips
@@ -101,9 +109,20 @@ export function flattenProviderExecutedToolParts(messages: ModelMessage[]): Mode
       return message;
     }
 
+    // Tool-call ids that have an inline tool-result in this assistant
+    // message. Their calls must be flattened together with the results —
+    // even when not flagged providerExecuted — or we'd leave a bare
+    // tool-call with no matching result, which providers reject.
+    const inlineResultCallIds = new Set(
+      message.content.filter((part) => part.type === "tool-result").map((part) => part.toolCallId)
+    );
+
     let changedMessage = false;
     const newContent = message.content.map((part): AssistantContentPart => {
-      if (part.type === "tool-call" && part.providerExecuted === true) {
+      if (
+        part.type === "tool-call" &&
+        (part.providerExecuted === true || inlineResultCallIds.has(part.toolCallId))
+      ) {
         changedMessage = true;
         // Build the text part fresh: drop providerOptions/toolCallId/
         // providerExecuted — provider-specific ids are exactly the leak.

--- a/src/node/utils/messages/stripEncryptedContent.ts
+++ b/src/node/utils/messages/stripEncryptedContent.ts
@@ -1,0 +1,39 @@
+/**
+ * Strip encryptedContent from web search results to reduce token usage.
+ * The encrypted page content can be massive (4000+ chars per result) and isn't
+ * needed for model context. Keep URL, title, and pageAge for reference.
+ */
+function stripEncryptedContentFromArray(output: unknown[]): unknown[] {
+  return output.map((item: unknown) => {
+    if (item && typeof item === "object" && "encryptedContent" in item) {
+      // Remove encryptedContent but keep other fields
+      const { encryptedContent, ...rest } = item as Record<string, unknown>;
+      return rest;
+    }
+
+    return item;
+  });
+}
+
+export function stripEncryptedContent(output: unknown): unknown {
+  if (Array.isArray(output)) {
+    return stripEncryptedContentFromArray(output);
+  }
+
+  // Handle SDK json output shape: { type: "json", value: unknown[] }
+  if (
+    typeof output === "object" &&
+    output !== null &&
+    "type" in output &&
+    output.type === "json" &&
+    "value" in output &&
+    Array.isArray(output.value)
+  ) {
+    return {
+      ...output,
+      value: stripEncryptedContentFromArray(output.value),
+    };
+  }
+
+  return output;
+}


### PR DESCRIPTION
## Summary

Fixes deterministic advisor tool failures (`Advisor request failed: JSON parsing failed: Text: {`) when the parent conversation runs on Anthropic with server-side tools (`web_search`/`web_fetch`) and the advisor model is OpenAI.

## Background

`createAdvisorTool` forwards the live in-memory step transcript verbatim to the advisor model. Unlike persisted history, that transcript retains provider-executed tool parts: assistant `tool-call` parts with `providerExecuted: true` and assistant `tool-result` parts carrying Anthropic server tool ids (`srvtoolu_...`).

`@ai-sdk/openai`'s Responses input converter replays assistant `tool-result` parts as `{ type: "item_reference", id: providerOptions.openai.itemId ?? toolCallId }` when `store` is on. Anthropic-origin parts have no OpenAI `itemId`, so the raw `srvtoolu_...` id leaks and OpenAI rejects the request with `404 Item with id 'srvtoolu_...' not found`. The Coder AI gateway then garbles that error inside the committed SSE stream, producing the misleading `AI_JSONParseError: Text: {`.

The main chat path is unaffected: persisted history never stores `providerExecuted`, so replayed server-tool calls become ordinary client-style call/result pairs, which OpenAI accepts.

## Implementation

New pure utility `flattenProviderExecutedToolParts` (modeled on the sibling `stripWorkflowRunRecordsFromModelMessages`):

- assistant `tool-call` with `providerExecuted: true` → `[Server tool call: <name>] <input>` text part
- assistant `tool-result` parts (provider-executed by construction in AI SDK v6; client tool results live in `tool`-role messages) → `[Server tool result: <name>] <output>` text part
- flattened parts are built fresh (`{type, text}` only), dropping `providerOptions`/`toolCallId` — provider-specific ids are exactly the leak
- everything else (client tool pairs, `tool`-role messages, text/reasoning/files) untouched; referential equality preserved on no-op
- stringification self-heals (circular refs, BigInt, undefined) since this is a request-building path

Applied unconditionally at the single advisor transcript-snapshot site. The advisor is deliberately tool-less, so text replay is lossless for its purpose and works for every provider combination without plumbing parent-provider identity into the runtime.

## Validation

- Wire-level before/after dogfood against the real OpenAI gateway with the exact failing shape (Anthropic `providerExecuted` `web_search` + `srvtoolu_` id, `store: true`): raw transcript fails with `404 Item with id 'srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ' not found`; flattened transcript streams a successful answer that cites the web-search payload.
- Unit tests cover flattening + leak-prevention (no `providerOptions`/`toolCallId` keys survive), pass-through referential equality, the full `ToolResultOutput` union incl. an error-json fixture, and unstringifiable payloads.
- Advisor regression test asserts `streamText` never receives assistant `tool-result`/`providerExecuted` parts while the payload survives as text and the handoff message stays last.

## Risks

- Low; scoped to the advisor transcript handoff. No changes to the main chat streaming path, persistence schema, or IPC.
- Same-provider advisors (e.g. Anthropic→Anthropic) previously replayed native server-tool blocks and now see text. Content-equivalent for a tool-less consultation; accepted trade-off documented in the module comment.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix: Advisor tool fails with cross-provider transcripts containing provider-executed tool parts

## Problem statement (verified root cause)

The `advisor` tool fails deterministically with `Advisor request failed: JSON parsing failed: Text: {.` whenever:

1. The parent conversation runs on **Anthropic** (e.g. `anthropic:claude-fable-5`) and uses Anthropic **server-side tools** (`web_search` / `web_fetch`, enabled in `src/common/utils/tools/tools.ts:657-658`), producing tool parts with `providerExecuted: true` and Anthropic server tool IDs (`srvtoolu_...`), and
2. The advisor model is **OpenAI** (e.g. `openai:gpt-5.5-pro`).

**Verified failure chain** (diagnosed against workspaces `c13e23dfcb` / `c19e3f134d`, 9/9 advisor calls failed):

- `createAdvisorTool` (`src/node/services/tools/advisor.ts:243`) forwards `runtime.getTranscriptSnapshot()` verbatim to `streamText` with the advisor model.
- That snapshot is the **live in-memory `stepMessages`** captured from `streamText`'s `prepareStep` hook (`src/node/services/streamManager.ts:1525-1540` → `onStepMessages` → `advisorTranscriptRef.messages`, `src/node/services/aiService.ts:2735`). Unlike persisted history, these AI-SDK-built messages **retain `providerExecuted: true`** and keep provider-executed tool results as `tool-result` parts inside **assistant** messages (`node_modules/ai/src/generate-text/to-response-messages.ts:30-36,77-92`).
- `@ai-sdk/openai`'s Responses input converter replays assistant `tool-result` parts as `{ type: "item_reference", id: providerOptions.openai.itemId ?? part.toolCallId }` when `store` is on (`convert-to-openai-responses-input.ts`, dist ~line 3105-3112). For Anthropic-origin parts there is no OpenAI `itemId`, so the raw Anthropic ID `srvtoolu_...` leaks as an OpenAI item reference.
- OpenAI rejects the request: `404 Item with id 'srvtoolu_...' not found` (reproduced by replaying the exact captured `rawRequest` from `devtools.jsonl` via curl).
- The Coder AI gateway then garbles this error inside the already-committed SSE stream (only `data: {` survives), producing the misleading `AI_JSONParseError: Text: {`.

**Why the main chat path is NOT affected** (verified): persisted history (`chat.jsonl`) never stores `providerExecuted` (`MuxToolPartSchema` in `src/common/orpc/schemas/message.ts` omits it; `streamManager.ts:1701-1710` never sets it), so `convertToModelMessages` replays old server-tool calls as ordinary client-style tool call/result pairs (`function_call`/`function_call_output`), which OpenAI accepts even with foreign `toolu_` call IDs (confirmed in the captured failing request — only the `item_reference` was rejected). The bug is scoped to the advisor's live-transcript handoff.

## Design decision

**Approach A (recommended): unconditionally flatten provider-executed tool parts to text in the advisor transcript.** Net product LoC: **~+80**.

Add a pure utility that maps assistant-message parts:

- `tool-call` part with `providerExecuted === true` → text part `[Server tool call: <toolName>] <stringified input>`
- `tool-result` part in assistant content (these are provider-executed by construction in AI SDK v6) → text part `[Server tool result: <toolName>] <stringified output>`
- **Tool errors are covered by the same branch** (verified): `toResponseMessages` normalizes provider-executed `tool-error` parts into `tool-result` parts with JSON error output (`node_modules/ai/src/generate-text/to-response-messages.ts`, `case 'tool-error'` → pushes `type: 'tool-result'`, `errorMode: 'json'`), and the `AssistantContent` part union contains no `tool-error` type — so no separate branch is needed, but an error-shaped fixture is tested (see Step 3).
- Everything else (client tool calls, `tool`-role messages, text, reasoning, files, string content) untouched.

Apply it unconditionally in `advisor.ts` to the transcript snapshot (not to the handoff message).

Rationale:
- The advisor is deliberately **tool-less** (`tools: {}`), so native provider tool blocks carry no functional value in the handoff; the *content* (e.g. web-search findings the caller wants challenged) is what matters, and flattening preserves it.
- Unconditional application avoids plumbing the parent model string / provider comparison into `advisorRuntime` and is robust for every provider combination (Anthropic→OpenAI, OpenAI→Anthropic, gateway-routed models where the provider prefix is ambiguous).
- Dropping (instead of flattening) would silently discard web-search evidence that advisor questions frequently reference — unacceptable.

<details>
<summary>Rejected alternatives (with LoC)</summary>

- **B. Conditional sanitize only when advisor provider ≠ parent provider** (~+85 LoC): requires extending `AdvisorRuntime` (`src/common/utils/tools/tools.ts`) and `aiService.ts` wiring to pass the parent model string, plus `parseModelString` comparison. Preserves native tool-block replay for same-provider advisors, but that replay has no user-visible benefit for a tool-less consultation, and provider-prefix comparison is murky for gateway-routed models. More code, more coupling, no practical upside.
- **C. Sanitize in `prepareStep` for all stream consumers** (~+60 LoC): touches the hot path of every stream step and would alter the *parent* conversation's own wire format (breaking same-provider native server-tool replay in the main chat, which works today). Wrong blast radius; main path is not affected by the bug.
- **D. Flatten ALL tool parts to text (explore-agent suggestion)** (~+90 LoC): over-broad; client tool call/result pairs replay fine cross-provider (verified in the captured request) and keeping them structured preserves fidelity.
</details>

## Implementation steps

### Step 1 — New utility: `src/node/utils/messages/flattenProviderExecutedToolParts.ts` (~65 LoC)

Model the structure on `stripWorkflowRunRecordsFromModelMessages.ts` (same directory): map over messages, track `didChange`, and **preserve referential equality** (return the original array/message objects when nothing changed).

```ts
export function flattenProviderExecutedToolParts(messages: ModelMessage[]): ModelMessage[]
```

Behavior:
- Only assistant messages with array content are inspected.
- Flatten **all** assistant `tool-result` parts, not just ones flagged `providerExecuted` — the flag is not present on the normalized assistant `tool-result` shape; assistant-content residence is the discriminator (client tool results live in `tool`-role messages).
- No `as any`: use type narrowing on `part.type` and `Extract<...>`/local type guards, per repo TypeScript discipline.
- `tool-call` part with `providerExecuted === true` → `{ type: "text", text: "[Server tool call: <toolName>] <input>" }` where input is `safeStringifyForPrompt(part.input)` (string inputs pass through as-is).
- `tool-result` part → `{ type: "text", text: "[Server tool result: <toolName>] <output>" }` with a small `stringifyToolResultOutput` helper handling the `ToolResultPart["output"]` union: `text`/`error-text` → `value`; `json`/`error-json`/`content` → safe-stringified value.
- All stringification goes through a `safeStringifyForPrompt(value): string` helper that never throws and always returns a non-empty string: handles `undefined`/`null`, plain strings, and catches `JSON.stringify` failures (circular refs, BigInt) with a `String(value)` fallback. This is a request-building path, so it must self-heal rather than crash (no assert-then-fallback contradiction).
- Converted text parts are built **fresh** — they carry only `{ type, text }` and drop `providerOptions`, `providerMetadata`, `toolCallId`, and `providerExecuted` (provider-specific `itemId`s/signatures are exactly the leak being fixed).
- `tool`-role messages, user/system messages, string-content assistant messages: returned unchanged.
- Module doc comment explaining the "why": OpenAI Responses converter replays assistant tool-result parts as `item_reference` items; foreign (e.g. Anthropic `srvtoolu_`) IDs 404, and the advisor model is tool-less so text replay is lossless for its purpose. Include the gateway-garbling note (`AI_JSONParseError: Text: {`) so future debuggers can map the symptom to this cause.

Defensive checks per house style: `assert(Array.isArray(messages))` on entry. Unknown/future output `type` values fall through to `safeStringifyForPrompt(output)` (self-healing, forward-compatible).

**Leak vectors reviewed and intentionally left untouched** (documented in the module comment so future implementers don't overcorrect):
- **Reasoning parts with foreign `providerOptions`**: the OpenAI converter already skips non-OpenAI reasoning parts with a warning (observed in the captured `stream-start` warnings); not a fatal leak.
- **Text/file parts with `providerOptions` itemIds**: only resolve to `item_reference` for same-provider OpenAI transcripts, where the referenced stored items exist; harmless cross-provider (unknown namespaces are ignored).
- **Client tool call/result pairs (`tool`-role messages)**: replay as `function_call`/`function_call_output`, which OpenAI accepts with foreign `toolu_` call IDs (verified in the captured failing request).
- **`tool-approval-request` parts**: mux handles tool approval outside the SDK flow; these do not appear in advisor transcripts.

### Step 2 — Apply in `src/node/services/tools/advisor.ts` (~4 LoC changed)

At the transcript snapshot site (line ~243):

```ts
const transcript = flattenProviderExecutedToolParts(runtime.getTranscriptSnapshot());
```

Keep the existing asserts (array, non-empty) — run them on the flattened result. The handoff message construction and everything else is unchanged.

### Step 3 — Tests

**`src/node/utils/messages/flattenProviderExecutedToolParts.test.ts`** (new, mirrors sibling test files):
- Assistant message with `providerExecuted: true` `tool-call` (toolName `web_search`, `srvtoolu_`-style id) + assistant `tool-result` part → both become text parts containing the tool name and payload; no `tool-call`/`tool-result` parts remain in that message.
- **Leak-prevention assertion:** flattened text parts carry no `providerOptions`, `providerMetadata`, `toolCallId`, or `providerExecuted` keys (guards the `item_reference` leak directly).
- Client-executed `tool-call` (no `providerExecuted`) in assistant message + its `tool`-role result message → returned **unchanged, referentially equal** (both the message objects and the top-level array).
- String-content assistant message, user/system messages → untouched.
- Output-union coverage: `{type:"json"}`, `{type:"text"}`, `{type:"error-text"}`, and an **error-shaped `{type:"error-json"}` fixture** (represents a provider-executed tool error after `toResponseMessages` normalization) stringify correctly.
- `safeStringifyForPrompt` robustness: circular-reference object and `undefined` output still yield a non-empty string (no throw, no `text: undefined`).
- No-change input → the exact same array reference is returned.

**`src/node/services/tools/advisor.test.ts`** (extend, using existing `mockStreamTextSuccess` + `getStreamTextMessages` helpers, lines 76-138):
- Regression test: `getTranscriptSnapshot` returns a transcript containing an assistant message with provider-executed `web_search` tool-call/tool-result parts (Anthropic-shaped, `srvtoolu_` id) → assert the messages passed to `streamText` contain **no** `tool-result` parts and no `providerExecuted` tool-calls in assistant content, and that a text part containing the web-search payload is present; assert the handoff message is still appended last.

These assert behavior (part transformation / pass-through branching), not prose — no tautological string-equality tests on the `[Server tool ...]` labels beyond confirming payload survival.

### Step 4 — Validation gate

- `make typecheck`
- `bun test src/node/utils/messages/flattenProviderExecutedToolParts.test.ts src/node/services/tools/advisor.test.ts`
- `MUX_ESLINT_CONCURRENCY=1 make static-check` (memory-constrained workspace)

## Dogfooding & evidence (required before claiming success)

This environment is headless (no Electron GUI), but the failure is a **wire-level** issue, so it can be dogfooded end-to-end against the real gateway (`$OPENAI_BASE_URL` + `OPENAI_CODER_AIGATEWAY_SESSION_TOKEN`, both present in this workspace):

1. **Negative control (bug reproduction, already captured):** the exact failing `rawRequest` extracted from `~/.mux/sessions/c19e3f134d/devtools.jsonl` replayed via curl returns `404 Item with id 'srvtoolu_013m4MqeeoVpBWdeyQvGkvqQ' not found`. Keep `/tmp/advisor-real-body.json` + curl transcript as before-evidence.
2. **Fix verification script (`/tmp/advisor-fix-dogfood.ts`, not committed):** a small bun script that
   - builds a `ModelMessage[]` transcript replicating the failing shape (assistant message with `providerExecuted: true` `web_search` tool-call + tool-result parts carrying an `srvtoolu_` id, plus normal client tool call/result pairs),
   - calls `streamText` with `@ai-sdk/openai`'s `gpt-5.5-pro` via the gateway **without** the new utility → expect failure, accepting either the real `404 Item ... not found` or the gateway-masked `AI_JSONParseError` (proves the repro shape is faithful),
   - then **with** `flattenProviderExecutedToolParts` applied → expect a successful streamed answer.
   - Record both runs with `script -q -e -c "bun /tmp/advisor-fix-dogfood.ts ..." /tmp/advisor-dogfood-{before,after}.typescript` so a reviewer gets verbatim terminal recordings; include key excerpts in the final report.
   - Evidence-format blocker, stated explicitly: this Coder workspace is headless (`DISPLAY` empty, no Xvfb), so GUI screenshots/video of the Electron app are environmentally impossible; terminal recordings of the wire-level before/after runs are the evidence fallback.
3. **In-app dogfood (best-effort, if a dev-server sandbox is quick to stand up):** use the `dev-server-sandbox` skill to boot an isolated mux instance with `advisorModelString: openai:gpt-5.5-pro`, run an Anthropic parent turn that triggers `web_search`, then ask it to consult the advisor; verify the advisor tool call succeeds in `devtools.jsonl`. If the sandbox route is disproportionate, the wire-level script in (2) is the primary gate and this step is skipped with a note.

**Gate:** Step 2's "with fix" run MUST succeed and "without fix" MUST fail before the change is declared complete.

## Acceptance criteria

1. `flattenProviderExecutedToolParts` converts provider-executed tool-call/tool-result assistant parts to text parts and preserves referential equality when nothing changes (unit-tested).
2. Advisor `streamText` invocations never receive assistant `tool-result` parts or `providerExecuted` tool-calls (regression-tested in `advisor.test.ts`).
3. Wire-level dogfood: previously-failing transcript shape succeeds against the real OpenAI gateway with the fix applied; fails without it.
4. `make typecheck`, targeted `bun test`, and `MUX_ESLINT_CONCURRENCY=1 make static-check` all pass.
5. No changes to the main chat streaming path, persistence schema, or IPC.

## Risks & notes

- **Token size:** flattened text parts are roughly the same size as the native blocks they replace; no material context growth.
- **Same-provider advisor behavior change:** Anthropic→Anthropic advisors previously replayed native server-tool blocks; they now see text. Content-equivalent for a tool-less consultation; accepted trade-off for simplicity/robustness (documented in the module comment).
- **Upstream issues (out of scope, worth filing separately):** `@ai-sdk/openai`'s `?? part.toolCallId` fallback leaks foreign IDs as `item_reference`s; the Coder AI gateway's SSE error framing destroys multi-line JSON error bodies (`data: {`).
- **Follow-up candidate (out of scope):** surface clearer advisor errors when the gateway garbles upstream errors (map `JSON parsing failed: Text: {` to a hint). Not needed once this fix lands.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$24.56`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=24.56 -->
