### PR TITLE
🤖 feat: show sidebar activity for armed background bash monitors

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -396,6 +396,25 @@ describe("AgentListItem", () => {
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
 
+  test("armed monitor status outranks delegated activity text", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({ activeBashMonitorCount: 1 });
+
+    const { row } = renderWorkspaceItem({
+      delegatedActivity: {
+        activeCount: 0,
+        queuedCount: 1,
+        workflowActiveCount: 0,
+        workflowQueuedCount: 0,
+      },
+    });
+    const rowView = within(row);
+
+    // Own-workspace watching state wins over the delegated subtitle, mirroring
+    // the workflow-status precedence.
+    expect(rowView.getByText("Watching background bash")).toBeTruthy();
+    expect(rowView.queryByTestId(`workspace-delegated-activity-${TEST_WORKSPACE_ID}`)).toBeNull();
+  });
+
   test("keeps sidebar status text while an armed monitor drives the active dot", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       activeBashMonitorCount: 1,

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -76,6 +76,7 @@ function createWorkspaceSidebarState(
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     terminalActiveCount: 0,
     terminalSessionCount: 0,
     ...overrides,
@@ -382,6 +383,31 @@ describe("AgentListItem", () => {
     expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Workflow running")).toBeNull();
+  });
+
+  test("shows armed background bash monitor activity on idle workspace rows", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({ activeBashMonitorCount: 1 });
+
+    const { row } = renderWorkspaceItem();
+    const rowView = within(row);
+
+    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    expect(rowView.getByText("Watching background bash")).toBeTruthy();
+    expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
+  });
+
+  test("keeps sidebar status text while an armed monitor drives the active dot", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({
+      activeBashMonitorCount: 1,
+      agentStatus: { emoji: "⌛", message: "Awaiting PR readiness check" },
+    });
+
+    const { row } = renderWorkspaceItem();
+    const rowView = within(row);
+
+    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
+    expect(rowView.queryByText("Watching background bash")).toBeNull();
   });
 
   test("shows active delegated workflow work on idle workspace rows", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -653,7 +653,10 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     awaitingUserQuestion ||
     displayStreamingStatusPhase !== null ||
     isRemoving ||
-    shouldShowWorkflowStatus;
+    shouldShowWorkflowStatus ||
+    // Own-workspace signals (like workflow status above) outrank delegated text so a
+    // coordinator waiting on an armed monitor still surfaces the watching state.
+    shouldShowBashMonitorStatus;
   const shouldShowDelegatedStatus = hasDelegatedStatusText && !hasOwnLiveStatusText && !hasError;
   const visualState = getVisualState({
     awaitingUserQuestion,

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -221,6 +221,11 @@ function formatWorkflowRunCount(count: number): string {
   return count === 1 ? "Workflow running" : `${count} workflows running`;
 }
 
+function formatBashMonitorCount(count: number): string {
+  assert(count > 0, "formatBashMonitorCount requires a positive count");
+  return count === 1 ? "Watching background bash" : `Watching ${count} background bashes`;
+}
+
 function SidebarActivityIndicator(props: { text: string; testId: string }) {
   return (
     <div
@@ -613,6 +618,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     isStarting,
     agentStatus,
     activeWorkflowRunCount,
+    activeBashMonitorCount,
     terminalActiveCount,
     lastAbortReason,
   } = useWorkspaceSidebarState(workspaceId);
@@ -628,6 +634,9 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const isWorking = displayStreamingStatusPhase !== null && !awaitingUserQuestion;
   const hasError = lastAbortReason?.reason === "system";
   const hasActiveWorkflowRun = activeWorkflowRunCount > 0;
+  // An armed background bash monitor means the workspace is still waiting to be
+  // woken, so keep the row on the active dot instead of letting it look finished.
+  const hasActiveBashMonitor = activeBashMonitorCount > 0;
   const hasActiveDelegatedWork = (delegatedActivity?.activeCount ?? 0) > 0;
   const delegatedStatusText = delegatedActivity
     ? formatDelegatedActivityText(delegatedActivity)
@@ -635,6 +644,11 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const hasDelegatedStatusText = delegatedStatusText != null;
   const shouldShowWorkflowStatus =
     hasActiveWorkflowRun && !agentStatus && displayStreamingStatusPhase === null;
+  const shouldShowBashMonitorStatus =
+    hasActiveBashMonitor &&
+    !agentStatus &&
+    displayStreamingStatusPhase === null &&
+    !shouldShowWorkflowStatus;
   const hasOwnLiveStatusText =
     awaitingUserQuestion ||
     displayStreamingStatusPhase !== null ||
@@ -648,7 +662,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     isArchiving: isArchiving === true,
     isWorking,
     isStarting: displayStreamingStatusPhase === "starting",
-    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun,
+    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun || hasActiveBashMonitor,
     isUnread,
     isSelected,
     hasError,
@@ -661,7 +675,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     awaitingUserQuestion ||
     displayStreamingStatusPhase !== null ||
     isRemoving ||
-    shouldShowWorkflowStatus;
+    shouldShowWorkflowStatus ||
+    shouldShowBashMonitorStatus;
   // Keep archiving feedback inline with the title so the row doesn't jump to a
   // two-line layout right before it disappears from the sidebar.
   const shouldShowInlineArchivingStatus = isArchiving === true && !isRemoving;
@@ -1143,6 +1158,11 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                 <WorkflowActivityIndicator
                   workspaceId={workspaceId}
                   activeWorkflowRunCount={activeWorkflowRunCount}
+                />
+              ) : shouldShowBashMonitorStatus ? (
+                <SidebarActivityIndicator
+                  text={formatBashMonitorCount(activeBashMonitorCount)}
+                  testId={`workspace-bash-monitor-activity-${workspaceId}`}
                 />
               ) : (
                 <WorkspaceStatusIndicator

--- a/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
+++ b/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
@@ -49,6 +49,7 @@ function buildWorkspaceState(workspaceId: string, state: MockWorkspaceState): Wo
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     lastAbortReason: null,
     pendingStreamStartTime: null,
     pendingStreamModel: null,

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -535,6 +535,7 @@ function installProjectSidebarTestDoubles() {
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     terminalActiveCount: 0,
     terminalSessionCount: 0,
   }));

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -168,7 +168,10 @@ function getWorkspaceAttentionSignal(
     const isWorking =
       (sidebarState.canInterrupt ||
         sidebarState.isStarting ||
-        sidebarState.activeWorkflowRunCount > 0) &&
+        sidebarState.activeWorkflowRunCount > 0 ||
+        // An armed background bash monitor keeps the workspace "working" so collapsed
+        // project/parent rows don't look idle while it waits to be woken.
+        sidebarState.activeBashMonitorCount > 0) &&
       !sidebarState.awaitingUserQuestion;
     return {
       isWorking,

--- a/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
@@ -24,6 +24,7 @@ function mockSidebarState(
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     terminalActiveCount: 0,
     terminalSessionCount: 0,
     ...overrides,
@@ -145,6 +146,7 @@ describe("WorkspaceStatusIndicator", () => {
       skillLoadErrors: [],
       agentStatus: undefined,
       activeWorkflowRunCount: 0,
+      activeBashMonitorCount: 0,
       terminalActiveCount: 0,
       terminalSessionCount: 0,
     };
@@ -204,6 +206,7 @@ describe("WorkspaceStatusIndicator", () => {
       skillLoadErrors: [],
       agentStatus: undefined,
       activeWorkflowRunCount: 0,
+      activeBashMonitorCount: 0,
       terminalActiveCount: 0,
       terminalSessionCount: 0,
     };

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewAgentStatusBar.test.tsx
@@ -59,6 +59,7 @@ function buildState(workspaceId: string, input: SeedInput): WorkspaceState {
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     lastAbortReason: null,
     pendingStreamStartTime: null,
     pendingStreamModel: null,

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -124,6 +124,7 @@ export interface WorkspaceState {
   skillLoadErrors: SkillLoadError[];
   agentStatus: { emoji: string; message: string; url?: string } | undefined;
   activeWorkflowRunCount: number;
+  activeBashMonitorCount: number;
   lastAbortReason: StreamAbortReasonSnapshot | null;
   pendingStreamStartTime: number | null;
   // Model used for the pending send (used during "starting" phase)
@@ -183,6 +184,7 @@ export interface WorkspaceSidebarState {
   skillLoadErrors: SkillLoadError[];
   agentStatus: { emoji: string; message: string; url?: string } | undefined;
   activeWorkflowRunCount: number;
+  activeBashMonitorCount: number;
   terminalActiveCount: number;
   terminalSessionCount: number;
   goal?: GoalSnapshot | null;
@@ -1977,6 +1979,7 @@ export class WorkspaceStore {
       const agentStatus =
         displayStatus ?? liveTodoStatus ?? fallbackAgentStatus ?? persistedTodoStatus;
       const activeWorkflowRunCount = activity?.activeWorkflowRunCount ?? 0;
+      const activeBashMonitorCount = activity?.activeBashMonitorCount ?? 0;
       const goal = activity?.goal ?? null;
 
       return {
@@ -2002,6 +2005,7 @@ export class WorkspaceStore {
         lastAbortReason: aggregator.getLastAbortReason(),
         agentStatus,
         activeWorkflowRunCount,
+        activeBashMonitorCount,
         pendingStreamStartTime,
         pendingStreamModel: aggregator.getPendingStreamModel(),
         autoRetryStatus: transient.autoRetryStatus,
@@ -2113,6 +2117,7 @@ export class WorkspaceStore {
       cached.skillLoadErrors === fullState.skillLoadErrors &&
       cached.agentStatus === fullState.agentStatus &&
       cached.activeWorkflowRunCount === fullState.activeWorkflowRunCount &&
+      cached.activeBashMonitorCount === fullState.activeBashMonitorCount &&
       cached.terminalActiveCount === terminalActiveCount &&
       cached.terminalSessionCount === terminalSessionCount &&
       cached.goal === fullState.goal
@@ -2136,6 +2141,7 @@ export class WorkspaceStore {
       skillLoadErrors: fullState.skillLoadErrors,
       agentStatus: fullState.agentStatus,
       activeWorkflowRunCount: fullState.activeWorkflowRunCount,
+      activeBashMonitorCount: fullState.activeBashMonitorCount,
       terminalActiveCount,
       terminalSessionCount,
       goal: fullState.goal,
@@ -2798,6 +2804,7 @@ export class WorkspaceStore {
       previous?.recency !== snapshot?.recency ||
       previous?.hasTodos !== snapshot?.hasTodos ||
       (previous?.activeWorkflowRunCount ?? 0) !== (snapshot?.activeWorkflowRunCount ?? 0) ||
+      (previous?.activeBashMonitorCount ?? 0) !== (snapshot?.activeBashMonitorCount ?? 0) ||
       !areAgentStatusesEqual(previous?.displayStatus, snapshot?.displayStatus) ||
       !areAgentStatusesEqual(previous?.todoStatus, snapshot?.todoStatus) ||
       previous?.goal?.goalId !== snapshot?.goal?.goalId ||

--- a/src/browser/utils/commands/sources.test.ts
+++ b/src/browser/utils/commands/sources.test.ts
@@ -537,6 +537,7 @@ function makeWorkspaceState(goal: WorkspaceState["goal"]): WorkspaceState {
     skillLoadErrors: [],
     agentStatus: undefined,
     activeWorkflowRunCount: 0,
+    activeBashMonitorCount: 0,
     lastAbortReason: null,
     pendingStreamStartTime: null,
     pendingStreamModel: null,

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -290,6 +290,16 @@ export const WorkspaceActivitySnapshotSchema = z.object({
     description:
       "Number of top-level workflow runs in this workspace that are pending, running, or backgrounded.",
   }),
+  activeBashMonitorCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional()
+    .meta({
+      description:
+        "Number of running background bash processes with an armed wake-on-match monitor. " +
+        "Signals the workspace is still waiting to be woken even though no stream is active.",
+    }),
   goal: GoalSnapshotSchema.nullable().optional().meta({
     description: "Current workspace goal snapshot for sidebar indicators and the Goal tab",
   }),

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import {
   BackgroundProcessManager,
   computeTailStartOffset,
@@ -240,6 +240,10 @@ describe("BackgroundProcessManager", () => {
       expect(result.success).toBe(true);
       if (!result.success) return;
 
+      // Armed monitor on a running process counts as active workspace monitoring.
+      expect(manager.getActiveMonitorCount(testWorkspaceId)).toBe(1);
+      expect(manager.getActiveMonitorCount(testWorkspaceId2)).toBe(0);
+
       const event = await eventPromise;
       expect(event.payload.lines).toEqual(["ERR1"]);
       expect(event.payload.totalMatches).toBe(1);
@@ -249,6 +253,48 @@ describe("BackgroundProcessManager", () => {
       expect(proc?.status).toBe("running");
       expect(proc ? manager.getMonitorSnapshot(proc)?.totalMatches : undefined).toBe(1);
       expect(proc ? manager.getMonitorSnapshot(proc)?.stopped : undefined).toBe(true);
+      // The monitor stopped (maxEvents) while the process kept running: no longer active.
+      expect(manager.getActiveMonitorCount(testWorkspaceId)).toBe(0);
+    });
+
+    it("emits a change event when the monitor tail fails", async () => {
+      const result = await manager.spawn(runtime, testWorkspaceId, "sleep 5", {
+        cwd: process.cwd(),
+        displayName: "monitor-tail-failure",
+        monitor: {
+          filter: "NEVER_MATCHES",
+          pattern: /NEVER_MATCHES/,
+          exclude: false,
+          cooldownMs: 0,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const proc = await manager.getProcess(result.processId);
+      expect(proc).not.toBeNull();
+      if (!proc) return;
+      expect(manager.getActiveMonitorCount(testWorkspaceId)).toBe(1);
+
+      const changedWorkspaceIds: string[] = [];
+      manager.on("change", (wsId) => changedWorkspaceIds.push(wsId));
+      // Simulate a runtime read failure (e.g. dropped SSH connection) inside the tail loop.
+      // Reject per-call (not mockRejectedValue) so no eagerly-created rejected promise
+      // sits unhandled before the tail loop consumes it.
+      spyOn(proc.handle, "readOutput").mockImplementation(() =>
+        Promise.reject(new Error("read failure"))
+      );
+
+      for (let attempt = 0; attempt < 40; attempt++) {
+        if (manager.getActiveMonitorCount(testWorkspaceId) === 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+
+      // The failed tail must disarm the monitor AND broadcast the change so
+      // activity consumers (sidebar watching indicator) can clear.
+      expect(manager.getActiveMonitorCount(testWorkspaceId)).toBe(0);
+      expect(changedWorkspaceIds).toContain(testWorkspaceId);
     });
 
     describe("armed/stopped registry events", () => {

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -289,6 +289,27 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     };
   }
 
+  /**
+   * Count running background processes whose wake-on-match monitor is still armed.
+   * Surfaced through workspace activity so the sidebar can show that a workspace is
+   * still waiting on a monitor even though no stream is active.
+   */
+  getActiveMonitorCount(workspaceId: string): number {
+    assert(workspaceId.length > 0, "getActiveMonitorCount requires a workspaceId");
+    let count = 0;
+    for (const proc of this.processes.values()) {
+      if (
+        proc.workspaceId === workspaceId &&
+        proc.status === "running" &&
+        proc.monitor !== undefined &&
+        !proc.monitor.stopped
+      ) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   private emitMonitorMatch(proc: BackgroundProcess, monitor: BackgroundProcessMonitorState): void {
     if (monitor.pendingLines.length === 0) return;
 
@@ -359,6 +380,10 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     if (!this.shuttingDown) {
       this.emit("monitor:stopped", proc.workspaceId, { processId: proc.id });
     }
+    // Armed -> stopped is workspace-visible state (sidebar "watching" indicator), and not
+    // every stop path also changes process status or flushes a match (e.g. maxEvents
+    // reached with the wake suppressed), so always notify subscribers.
+    this.emitChange(proc.workspaceId);
   }
 
   private scheduleMonitorFlush(
@@ -537,8 +562,9 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     void this.monitorTailLoop(proc.id).catch((error: unknown) => {
       const current = this.processes.get(proc.id);
       if (current?.monitor && !current.monitor.stopped) {
-        // Route through stopMonitor so the retirement also clears any pending flush timer
-        // and emits "monitor:stopped" (registry cleanup). No flush: the loop failed.
+        // Route through stopMonitor so the retirement also clears any pending flush timer,
+        // emits "monitor:stopped" (registry cleanup), and broadcasts the change event so
+        // activity consumers see the armed-monitor count drop. No flush: the loop failed.
         this.stopMonitor(current, false);
       }
       log.debug(

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -542,6 +542,250 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("re-emits workspace activity when the armed monitor count changes", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-activity";
+      let activeMonitorCount = 1;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(() => Promise.resolve(null));
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 1);
+      expect(events[0].workspaceId).toBe(workspaceId);
+      expect(events[0].activity?.activeBashMonitorCount).toBe(1);
+      expect(getSnapshot).toHaveBeenCalledTimes(1);
+
+      // Same count after the previous emit settled: deduped synchronously,
+      // so no extra snapshot read or emit.
+      backgroundProcessManager.emit("change", workspaceId);
+      expect(getSnapshot).toHaveBeenCalledTimes(1);
+
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+
+      await waitForCondition(() => events.length === 2);
+      // Monitor stopped with no other persisted activity: the snapshot clears entirely.
+      expect(events[1].activity).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("retries the monitor-count activity emit after a failed snapshot read", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-activity-retry";
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => 1),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(
+        (): Promise<WorkspaceActivitySnapshot | null> =>
+          Promise.reject(new Error("transient read failure"))
+      );
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => getSnapshot.mock.calls.length === 1);
+      expect(events.length).toBe(0);
+
+      // The failed emit must not be recorded as delivered: the next change event
+      // with the same count retries instead of being deduped.
+      getSnapshot.mockImplementation(() => Promise.resolve(null));
+      backgroundProcessManager.emit("change", workspaceId);
+
+      await waitForCondition(() => events.length === 1);
+      expect(events[0].activity?.activeBashMonitorCount).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("emits the zero-count clear even when the armed emit never succeeded", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-clear-after-failure";
+      let activeMonitorCount = 1;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(
+        (): Promise<WorkspaceActivitySnapshot | null> =>
+          Promise.reject(new Error("transient read failure"))
+      );
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      // Armed emit fails; renderers may still have bootstrapped count=1 via getActivityList.
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => getSnapshot.mock.calls.length === 1);
+      expect(events.length).toBe(0);
+
+      // Monitor stops: the unknown->0 transition must emit the clear rather than
+      // treating the missing cache entry as an already-emitted zero.
+      getSnapshot.mockImplementation(() => Promise.resolve(null));
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+
+      await waitForCondition(() => events.length === 1);
+      expect(events[0].workspaceId).toBe(workspaceId);
+      expect(events[0].activity).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("does not dedupe a clear against a zero recorded before a failed armed emit", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-stale-zero";
+      let activeMonitorCount = 0;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(
+        (): Promise<WorkspaceActivitySnapshot | null> => Promise.resolve(null)
+      );
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      // Monitorless churn records 0 as successfully emitted.
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 1);
+
+      // Armed transition fails to emit; renderers may still observe count=1 via
+      // workspace.activity.list(). The stale recorded 0 must not survive.
+      getSnapshot.mockImplementation(() => Promise.reject(new Error("transient read failure")));
+      activeMonitorCount = 1;
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => getSnapshot.mock.calls.length === 2);
+      expect(events.length).toBe(1);
+
+      // Stop: 0 equals the pre-failure recorded 0, but the clear must still emit.
+      getSnapshot.mockImplementation(() => Promise.resolve(null));
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+
+      await waitForCondition(() => events.length === 2);
+      expect(events[1].workspaceId).toBe(workspaceId);
+      expect(events[1].activity).toBeNull();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("keeps a zero-count tombstone in getActivityList after a monitor stops", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-tombstone";
+      let activeMonitorCount = 1;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot: mock(() => Promise.resolve(null)),
+        getAllSnapshots: mock(() => Promise.resolve(new Map<string, WorkspaceActivitySnapshot>())),
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 1);
+      expect(events[0].activity?.activeBashMonitorCount).toBe(1);
+
+      // Renderer disconnected: the monitor stops and the clear emit lands nowhere.
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 2);
+
+      // Reconnect bootstrap: the list must include a zero-count tombstone so the
+      // renderer's last-known "watching" snapshot gets replaced rather than preserved.
+      const activityList = await workspaceService.getActivityList();
+      const entry = activityList[workspaceId];
+      expect(entry).toBeDefined();
+      expect(entry.activeBashMonitorCount).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("marks an accepted wake delivered when stream startup fails before provider start", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -739,6 +739,73 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("emits the clear when a stop races a still-pending armed emit", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-pending-race";
+      let activeMonitorCount = 0;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(
+        (): Promise<WorkspaceActivitySnapshot | null> => Promise.resolve(null)
+      );
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      // Record 0 as the last successfully emitted count.
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 1);
+
+      // Armed emit hangs: its snapshot read stays pending while the stop arrives.
+      let rejectArmedSnapshot: ((error: Error) => void) | undefined;
+      getSnapshot.mockImplementation(
+        () =>
+          new Promise<WorkspaceActivitySnapshot | null>((_resolve, reject) => {
+            rejectArmedSnapshot = reject;
+          })
+      );
+      activeMonitorCount = 1;
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => rejectArmedSnapshot !== undefined);
+
+      // Stop while the armed emit is in flight: the pre-emit delete means this 0 must
+      // not dedupe against the previously recorded 0 — the clear still goes out.
+      getSnapshot.mockImplementation(() => Promise.resolve(null));
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+
+      await waitForCondition(() => events.length === 2);
+      expect(events[1].activity).toBeNull();
+
+      // The armed emit failing afterwards must not corrupt the recorded state: the
+      // successfully emitted 0 stays recorded, and a later re-arm still emits.
+      rejectArmedSnapshot?.(new Error("slow read failed"));
+      await drainPendingDispatches();
+      activeMonitorCount = 1;
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 3);
+      expect(events[2].activity?.activeBashMonitorCount).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("keeps a zero-count tombstone in getActivityList after a monitor stops", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -806,6 +806,59 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("keeps the zero-count tombstone in getActivityList after a failed clear emit", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-tombstone-failed-clear";
+      let activeMonitorCount = 1;
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getActiveMonitorCount: mock(() => activeMonitorCount),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const getSnapshot = mock(
+        (): Promise<WorkspaceActivitySnapshot | null> => Promise.resolve(null)
+      );
+      const extensionMetadata = {
+        ...mockExtensionMetadataService,
+        getSnapshot,
+        getAllSnapshots: mock(() => Promise.resolve(new Map<string, WorkspaceActivitySnapshot>())),
+      } as unknown as ExtensionMetadataService;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        extensionMetadata,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+
+      const events: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      workspaceService.on("activity", (event) => events.push(event));
+
+      // Armed emit succeeds: renderers now show "watching".
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => events.length === 1);
+      expect(events[0].activity?.activeBashMonitorCount).toBe(1);
+
+      // Stop transition fails to emit (snapshot read rejects).
+      getSnapshot.mockImplementation(() => Promise.reject(new Error("transient read failure")));
+      activeMonitorCount = 0;
+      backgroundProcessManager.emit("change", workspaceId);
+      await waitForCondition(() => getSnapshot.mock.calls.length === 2);
+      expect(events.length).toBe(1);
+
+      // Reconnect bootstrap must still return the zero-count tombstone even though the
+      // clear emit failed, so the renderer's stale "watching" snapshot gets replaced.
+      const activityList = await workspaceService.getActivityList();
+      const entry = activityList[workspaceId];
+      expect(entry).toBeDefined();
+      expect(entry.activeBashMonitorCount).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("keeps a zero-count tombstone in getActivityList after a monitor stops", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1542,6 +1542,20 @@ function mergeActiveWorkflowRunCount(
   return merged;
 }
 
+function mergeActiveBashMonitorCount(
+  snapshot: WorkspaceActivitySnapshot | null,
+  activeBashMonitorCount: number
+): WorkspaceActivitySnapshot {
+  assert(activeBashMonitorCount >= 0, "active bash monitor count must be non-negative");
+  const merged: WorkspaceActivitySnapshot = { ...(snapshot ?? createDefaultActivitySnapshot()) };
+  if (activeBashMonitorCount > 0) {
+    merged.activeBashMonitorCount = activeBashMonitorCount;
+  } else {
+    delete merged.activeBashMonitorCount;
+  }
+  return merged;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class WorkspaceService extends EventEmitter {
   private readonly sessions = new Map<string, AgentSession>();
@@ -1611,6 +1625,42 @@ export class WorkspaceService extends EventEmitter {
       )
       .catch((error: unknown) => {
         log.error("Failed to remove retired bash monitor registry record", { workspaceId, error });
+      });
+  };
+  // Last armed-monitor count successfully broadcast per workspace, so background process
+  // churn that doesn't change the count (e.g. a monitorless bash exiting) skips the
+  // activity re-emit. A missing entry means "unknown" (never successfully emitted), which
+  // must never dedupe: renderers may have bootstrapped a non-zero count from
+  // getActivityList(), so suppressing an unknown->0 transition would strand the sidebar.
+  private readonly lastEmittedBashMonitorCounts = new Map<string, number>();
+  private readonly bashProcessChangeListener = (workspaceId: string): void => {
+    const count = this.getActiveBashMonitorCount(workspaceId);
+    if (this.lastEmittedBashMonitorCounts.get(workspaceId) === count) {
+      return;
+    }
+    void this.extensionMetadata
+      .getSnapshot(workspaceId)
+      .then((snapshot) => {
+        this.emitWorkspaceActivity(workspaceId, snapshot);
+        // Record only after a successful emit; recording up front would dedupe the
+        // next change event and strand the sidebar if the snapshot read failed.
+        // Re-read the count because the emit merges the live value, which may have
+        // moved past the one that triggered this listener.
+        this.lastEmittedBashMonitorCounts.set(
+          workspaceId,
+          this.getActiveBashMonitorCount(workspaceId)
+        );
+      })
+      .catch((error: unknown) => {
+        // Drop the recorded count entirely: a failed emit means we no longer know what
+        // the renderer believes (it may have observed a newer count via
+        // workspace.activity.list()), so a stale entry here could dedupe the next
+        // transition back to that value (e.g. 0 -> failed 1 -> 0) and strand the UI.
+        this.lastEmittedBashMonitorCounts.delete(workspaceId);
+        log.debug("Failed to emit activity after background bash monitor change", {
+          workspaceId,
+          error,
+        });
       });
   };
 
@@ -1701,6 +1751,7 @@ export class WorkspaceService extends EventEmitter {
       this.backgroundProcessManager.on("monitor:match", this.bashMonitorMatchListener);
       this.backgroundProcessManager.on("monitor:armed", this.bashMonitorArmedListener);
       this.backgroundProcessManager.on("monitor:stopped", this.bashMonitorStoppedListener);
+      this.backgroundProcessManager.on("change", this.bashProcessChangeListener);
     }
     void this.recoverBashMonitorStateAfterRestart();
     this.policyService = policyService;
@@ -2417,6 +2468,26 @@ export class WorkspaceService extends EventEmitter {
     return mergeActiveWorkflowRunCount(snapshot, activeRunIds.size);
   }
 
+  private getActiveBashMonitorCount(workspaceId: string): number {
+    // Tests may construct WorkspaceService with a partial BackgroundProcessManager stub
+    // (same reason the constructor guards the event subscriptions).
+    if (typeof this.backgroundProcessManager.getActiveMonitorCount !== "function") {
+      return 0;
+    }
+    return this.backgroundProcessManager.getActiveMonitorCount(workspaceId);
+  }
+
+  private mergeCurrentActiveBashMonitorCount(
+    workspaceId: string,
+    snapshot: WorkspaceActivitySnapshot | null
+  ): WorkspaceActivitySnapshot | null {
+    const count = this.getActiveBashMonitorCount(workspaceId);
+    if (snapshot == null && count === 0) {
+      return snapshot;
+    }
+    return mergeActiveBashMonitorCount(snapshot, count);
+  }
+
   private async mergeCurrentActiveWorkflowRunCount(
     workspaceId: string,
     snapshot: WorkspaceActivitySnapshot
@@ -2449,9 +2520,12 @@ export class WorkspaceService extends EventEmitter {
   ): void {
     this.emit("activity", {
       workspaceId,
-      activity: this.mergeCachedActiveWorkflowRunCount(
+      activity: this.mergeCurrentActiveBashMonitorCount(
         workspaceId,
-        this.overlayPendingGoal(workspaceId, snapshot)
+        this.mergeCachedActiveWorkflowRunCount(
+          workspaceId,
+          this.overlayPendingGoal(workspaceId, snapshot)
+        )
       ),
     });
   }
@@ -8298,6 +8372,9 @@ export class WorkspaceService extends EventEmitter {
       for (const workspaceId of this.activeWorkflowRunIdsByWorkspace.keys()) {
         workspaceIds.add(workspaceId);
       }
+      for (const workspaceId of this.lastEmittedBashMonitorCounts.keys()) {
+        workspaceIds.add(workspaceId);
+      }
       try {
         for (const metadata of await this.config.getAllWorkspaceMetadata()) {
           workspaceIds.add(metadata.id);
@@ -8312,10 +8389,21 @@ export class WorkspaceService extends EventEmitter {
           async (workspaceId): Promise<readonly [string, WorkspaceActivitySnapshot] | null> => {
             const snapshot = snapshots.get(workspaceId) ?? null;
             const hadWorkflowActivityCache = this.activeWorkflowRunIdsByWorkspace.has(workspaceId);
+            // Bash-monitor counterpart of the workflow tombstone: a monitor that stopped
+            // while the renderer was disconnected must still surface a zero-count entry
+            // here, otherwise the renderer's last-known "watching" state survives reconnect.
+            const hadBashMonitorActivityCache = this.lastEmittedBashMonitorCounts.has(workspaceId);
             const activeWorkflowRunCount = await this.getActiveWorkflowRunCount(workspaceId);
-            // Keep a zero-count tombstone for workspaces whose workflow-only activity
-            // was cleared while a frontend activity subscription was disconnected.
-            if (snapshot == null && activeWorkflowRunCount === 0 && !hadWorkflowActivityCache) {
+            const activeBashMonitorCount = this.getActiveBashMonitorCount(workspaceId);
+            // Keep a zero-count tombstone for workspaces whose workflow- or monitor-only
+            // activity was cleared while a frontend activity subscription was disconnected.
+            if (
+              snapshot == null &&
+              activeWorkflowRunCount === 0 &&
+              !hadWorkflowActivityCache &&
+              activeBashMonitorCount === 0 &&
+              !hadBashMonitorActivityCache
+            ) {
               return null;
             }
             return [
@@ -8326,9 +8414,12 @@ export class WorkspaceService extends EventEmitter {
               // still-pre-stream persisted goal. Without this, a reconnect/reload
               // during a mid-stream goal set would seed the UI with the stale
               // goal until the next live emit or goal read.
-              mergeActiveWorkflowRunCount(
-                this.overlayPendingGoal(workspaceId, snapshot),
-                activeWorkflowRunCount
+              mergeActiveBashMonitorCount(
+                mergeActiveWorkflowRunCount(
+                  this.overlayPendingGoal(workspaceId, snapshot),
+                  activeWorkflowRunCount
+                ),
+                activeBashMonitorCount
               ),
             ] as const;
           }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1638,25 +1638,26 @@ export class WorkspaceService extends EventEmitter {
     if (this.lastEmittedBashMonitorCounts.get(workspaceId) === count) {
       return;
     }
+    // Clear the entry synchronously BEFORE the async emit: while an emit is in flight
+    // the last delivered count is unknown (the snapshot read may fail, and renderers
+    // may observe transient counts via workspace.activity.list()). Deleting up front
+    // means a concurrent change event — e.g. a stop racing a slow armed emit in a fast
+    // 0 -> 1 -> 0 sequence — can never dedupe against a stale pre-emit value and drop
+    // the clear. Cost: an occasional duplicate emit, which renderers apply idempotently.
+    this.lastEmittedBashMonitorCounts.delete(workspaceId);
     void this.extensionMetadata
       .getSnapshot(workspaceId)
       .then((snapshot) => {
         this.emitWorkspaceActivity(workspaceId, snapshot);
-        // Record only after a successful emit; recording up front would dedupe the
-        // next change event and strand the sidebar if the snapshot read failed.
-        // Re-read the count because the emit merges the live value, which may have
-        // moved past the one that triggered this listener.
+        // Record only after a successful emit. Re-read the count because the emit merges
+        // the live value, which may have moved past the one that triggered this listener.
         this.lastEmittedBashMonitorCounts.set(
           workspaceId,
           this.getActiveBashMonitorCount(workspaceId)
         );
       })
       .catch((error: unknown) => {
-        // Drop the recorded count entirely: a failed emit means we no longer know what
-        // the renderer believes (it may have observed a newer count via
-        // workspace.activity.list()), so a stale entry here could dedupe the next
-        // transition back to that value (e.g. 0 -> failed 1 -> 0) and strand the UI.
-        this.lastEmittedBashMonitorCounts.delete(workspaceId);
+        // Leave the entry absent ("unknown") so the next change event always re-emits.
         log.debug("Failed to emit activity after background bash monitor change", {
           workspaceId,
           error,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1633,8 +1633,17 @@ export class WorkspaceService extends EventEmitter {
   // must never dedupe: renderers may have bootstrapped a non-zero count from
   // getActivityList(), so suppressing an unknown->0 transition would strand the sidebar.
   private readonly lastEmittedBashMonitorCounts = new Map<string, number>();
+  // Workspaces where an armed monitor has ever been observed (by the change listener or
+  // a getActivityList read). Deliberately never pruned and kept separate from the dedupe
+  // map above: the dedupe entry is dropped while emits are in flight or failed, but the
+  // tombstone decision in getActivityList must survive those windows, otherwise a
+  // renderer that bootstrapped a non-zero count can never see the zero-count clear.
+  private readonly bashMonitorSeenWorkspaces = new Set<string>();
   private readonly bashProcessChangeListener = (workspaceId: string): void => {
     const count = this.getActiveBashMonitorCount(workspaceId);
+    if (count > 0) {
+      this.bashMonitorSeenWorkspaces.add(workspaceId);
+    }
     if (this.lastEmittedBashMonitorCounts.get(workspaceId) === count) {
       return;
     }
@@ -8373,7 +8382,7 @@ export class WorkspaceService extends EventEmitter {
       for (const workspaceId of this.activeWorkflowRunIdsByWorkspace.keys()) {
         workspaceIds.add(workspaceId);
       }
-      for (const workspaceId of this.lastEmittedBashMonitorCounts.keys()) {
+      for (const workspaceId of this.bashMonitorSeenWorkspaces) {
         workspaceIds.add(workspaceId);
       }
       try {
@@ -8391,11 +8400,18 @@ export class WorkspaceService extends EventEmitter {
             const snapshot = snapshots.get(workspaceId) ?? null;
             const hadWorkflowActivityCache = this.activeWorkflowRunIdsByWorkspace.has(workspaceId);
             // Bash-monitor counterpart of the workflow tombstone: a monitor that stopped
-            // while the renderer was disconnected must still surface a zero-count entry
-            // here, otherwise the renderer's last-known "watching" state survives reconnect.
-            const hadBashMonitorActivityCache = this.lastEmittedBashMonitorCounts.has(workspaceId);
+            // while the renderer was disconnected (or whose stop emit failed) must still
+            // surface a zero-count entry here, otherwise the renderer's last-known
+            // "watching" state survives reconnect. The seen-set is used instead of the
+            // dedupe map because dedupe entries are dropped around in-flight/failed emits.
+            const hadBashMonitorActivityCache = this.bashMonitorSeenWorkspaces.has(workspaceId);
             const activeWorkflowRunCount = await this.getActiveWorkflowRunCount(workspaceId);
             const activeBashMonitorCount = this.getActiveBashMonitorCount(workspaceId);
+            if (activeBashMonitorCount > 0) {
+              // A list-delivered non-zero count is a renderer-visible observation too:
+              // remember it so the eventual stop always yields a tombstone entry.
+              this.bashMonitorSeenWorkspaces.add(workspaceId);
+            }
             // Keep a zero-count tombstone for workspaces whose workflow- or monitor-only
             // activity was cleared while a frontend activity subscription was disconnected.
             if (


### PR DESCRIPTION
## Summary

Workspaces with an armed background bash monitor (wake-on-match) now show the active green dot in the left sidebar, with a "Watching background bash" subtitle when no other status text applies. Previously such workspaces looked finished/idle even though they were still waiting to be woken by a monitor match.

## Background

When an agent arms a `bash` monitor (e.g. a PR-readiness watcher) and ends its turn, the workspace has no active stream, so the sidebar row went idle. To the user it appeared the workspace was done while it was actually waiting for the monitor to trigger.

## Implementation

The armed-monitor count rides the existing bulk `workspace.activity` channel — no new per-workspace subscriptions:

- `BackgroundProcessManager.getActiveMonitorCount(workspaceId)` counts running background processes with a non-stopped monitor. `stopMonitor` now emits a `change` event so disarming (e.g. `max_events` reached) propagates even while the process keeps running.
- `WorkspaceService` listens to process `change` events, dedupes on the last-emitted count, and re-broadcasts activity. `activeBashMonitorCount` (new optional field on `WorkspaceActivitySnapshotSchema`) is merged into every activity emit and the `getActivityList` bootstrap, with a zero-count tombstone so reconnecting clients see it clear.
- Frontend: `WorkspaceStore` carries the count into `WorkspaceSidebarState`; `AgentListItem` keeps the row in the active visual state while a monitor is armed and shows the "Watching background bash(es)" subtitle only when no higher-priority status text (agent status, streaming, workflow, delegated work) wins.

## Validation

Dogfooded in a dev-server sandbox: armed a real monitor via an agent turn, confirmed `activeBashMonitorCount: 1` via the activity API and the green dot + subtitle on the idle sidebar row in the browser; terminated the bash from the UI and confirmed the dot and the activity field cleared immediately.

## Risks

Low. The new field is optional on the activity snapshot, so absent values behave exactly as before. The main moving part is the extra `change`-event emit in `stopMonitor`; it is deduped by count in `WorkspaceService`, so no re-render storms. Affected areas: sidebar row status dot/subtitle and workspace activity emits.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$24.99`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=24.99 -->
