### PR TITLE
🤖 feat: add Claude Mythos 5 as a first-class known model

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -14,6 +14,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Model                  | ID                            | Aliases                                                      | Default |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |
 | Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |
+| Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |
 | Opus 4.8               | anthropic:claude-opus-4-8     | `opus`                                                       | ✓       |
 | Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -36,8 +36,10 @@ const MODEL_DEFINITIONS = {
     providerModelId: "claude-fable-5",
     aliases: ["fable"],
     warm: true,
-    // Fable tokenizer not published upstream; reuse Opus 4.5 (Claude tokenization is
-    // unchanged across the 4.x / Mythos line) for approximate counting.
+    // Fable/Mythos use the newer Opus 4.7+ tokenizer, which isn't published upstream;
+    // reuse Opus 4.5 (the newest Anthropic tokenizer in ai-tokenizer) for approximate
+    // counting. Anthropic says the newer tokenizer produces ~30% more tokens for the
+    // same text, so real usage can run ~1.0-1.3x higher than this estimate.
     tokenizerOverride: "anthropic/claude-opus-4.5",
   },
   // Claude Mythos 5 - released June 9, 2026 alongside Fable 5. Same underlying model,
@@ -50,7 +52,8 @@ const MODEL_DEFINITIONS = {
     provider: "anthropic",
     providerModelId: "claude-mythos-5",
     aliases: ["mythos"],
-    // Same tokenizer situation as Fable 5: reuse Opus 4.5 for approximate counting.
+    // Same tokenizer situation as Fable 5 (see FABLE above): reuse Opus 4.5 for
+    // approximate counting; real usage can run ~1.0-1.3x higher.
     tokenizerOverride: "anthropic/claude-opus-4.5",
   },
   OPUS: {

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -40,6 +40,19 @@ const MODEL_DEFINITIONS = {
     // unchanged across the 4.x / Mythos line) for approximate counting.
     tokenizerOverride: "anthropic/claude-opus-4.5",
   },
+  // Claude Mythos 5 - released June 9, 2026 alongside Fable 5. Same underlying model,
+  // specs, and pricing as Fable 5 ($10/M input, $50/M output) but with safeguards lifted
+  // in some areas. Limited availability: restricted to approved Project Glasswing /
+  // trusted-access customers (no self-serve sign-up). API id `claude-mythos-5`.
+  // Not warmed: most users cannot access it, and its tokenizer override is already
+  // warmed via FABLE.
+  MYTHOS: {
+    provider: "anthropic",
+    providerModelId: "claude-mythos-5",
+    aliases: ["mythos"],
+    // Same tokenizer situation as Fable 5: reuse Opus 4.5 for approximate counting.
+    tokenizerOverride: "anthropic/claude-opus-4.5",
+  },
   OPUS: {
     provider: "anthropic",
     providerModelId: "claude-opus-4-8",

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3093,6 +3093,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Model                  | ID                            | Aliases                                                      | Default |",
       "| ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |",
       "| Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |",
+      "| Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |",
       "| Opus 4.8               | anthropic:claude-opus-4-8     | `opus`                                                       | ✓       |",
       "| Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |",
       "| Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |",


### PR DESCRIPTION
## Summary

Registers Claude Mythos 5 (`anthropic:claude-mythos-5`) as a first-class known model, making it selectable in the model picker and reachable via the `mythos` alias.

## Background

The Fable 5 work already landed all Mythos-class plumbing for `claude-mythos-5`: thinking policy (thinking can't be disabled), native 1M context classification, display-name formatting ("Mythos 5"), and token/pricing metadata in `models-extra.ts` ($10/$50 per MTok, 1M context, 128K output). But the model was never added to the curated registry, so users with Project Glasswing / trusted access could not select it without typing a custom model string.

Mythos 5 shares Fable 5's specs and pricing; it ships with safeguards lifted in some areas and is restricted to approved trusted-access customers (no self-serve sign-up).

## Implementation

- Single `MYTHOS` entry in `MODEL_DEFINITIONS` (`src/common/constants/knownModels.ts`), alias `mythos`, same Opus 4.5 tokenizer override as Fable.
- Not `warm`: most users can't access it, and the shared tokenizer override is already warmed via `FABLE`.
- No default refusal-fallback chain (unlike Fable → Opus): Mythos runs with safeguards lifted, and `DEFAULT_MODEL_FALLBACKS` is seeded exactly once so a new entry wouldn't reach existing configs anyway.
- `docs/config/models.mdx` and `builtInSkillContent.generated.ts` regenerated via `make fmt`.

## Validation

- Existing registry-wide tests cover the new entry automatically (token metadata presence, alias/id uniqueness); targeted suites for knownModels, modelDisplay, models, thinking policy, and normalizeModelInput all pass.
- `make static-check` green (including docs sync).

## Risks

Low: additive registry entry; all Mythos-specific behavior paths were already in place and tested from the Fable 5 rollout.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high -->
