### PR TITLE
🤖 feat: pin chats to the top of the sidebar

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -62,7 +62,9 @@ import {
   EyeOff,
   ChevronDown,
   HeartPulse,
+  Pin,
 } from "lucide-react";
+import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 import { WorkspaceStatusIndicator } from "../WorkspaceStatusIndicator/WorkspaceStatusIndicator";
 import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
 import { WorkspaceTerminalIcon } from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
@@ -514,6 +516,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
       ? `${groupLabel} · ${workspaceTitle}`
       : workspaceTitle;
   const isEditing = editingWorkspaceId === workspaceId;
+  const isPinned = isWorkspacePinned(metadata);
+  const isPinnable = isWorkspacePinnable(metadata);
   const [heartbeatModalOpen, setHeartbeatModalOpen] = useState(false);
   const overflowMenuButtonRef = useRef<HTMLButtonElement | null>(null);
   const overflowMenuFrameRef = useRef<number | null>(null);
@@ -1002,6 +1006,25 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                     onForkChat={(anchorEl) => {
                       void onForkWorkspace(workspaceId, anchorEl);
                     }}
+                    onTogglePinned={
+                      isPinnable
+                        ? () => {
+                            // Fire-and-forget: the metadata subscription round-trip
+                            // reorders the sidebar on every connected client.
+                            void api?.workspace
+                              .setPinned({ workspaceId, pinned: !isPinned })
+                              .then((result) => {
+                                if (!result.success) {
+                                  console.error("Failed to toggle pin:", result.error);
+                                }
+                              })
+                              .catch((error: unknown) => {
+                                console.error("Failed to toggle pin:", error);
+                              });
+                          }
+                        : null
+                    }
+                    isPinned={isPinned}
                     onArchiveChat={(anchorEl) => {
                       void onArchiveWorkspace(workspaceId, anchorEl);
                     }}
@@ -1109,6 +1132,9 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
 
             {!isInitializing && !isEditing && (
               <div className="flex items-center gap-1">
+                {isPinned && (
+                  <Pin className="text-muted h-3 w-3 shrink-0" aria-label="Pinned" role="img" />
+                )}
                 {shouldShowInlineArchivingStatus ? (
                   <div
                     className="text-muted flex shrink-0 items-center gap-1 text-xs whitespace-nowrap"

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -76,6 +76,7 @@ import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { WorkspaceHeartbeatModal } from "../WorkspaceHeartbeatModal";
 import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import { useAPI } from "@/browser/contexts/API";
+import { useWorkspaceActionsOptional } from "@/browser/contexts/WorkspaceContext";
 
 export interface WorkspaceSelection {
   projectPath: string;
@@ -483,6 +484,10 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const isGeneratingTitle = generatingTitleWorkspaceIds.has(workspaceId);
   const isPendingAutoTitle = metadata.pendingAutoTitle === true;
   const { api } = useAPI();
+  // Route pin toggles through the context wrapper: it applies an optimistic
+  // pinnedAt (instant reorder on click) and works with mock API clients.
+  // Optional because stories/tests render this row without WorkspaceProvider.
+  const setWorkspacePinned = useWorkspaceActionsOptional()?.setWorkspacePinned;
 
   // Local state for title editing
   const [editingTitle, setEditingTitle] = useState<string>("");
@@ -1007,20 +1012,11 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
                       void onForkWorkspace(workspaceId, anchorEl);
                     }}
                     onTogglePinned={
-                      isPinnable
+                      isPinnable && setWorkspacePinned
                         ? () => {
-                            // Fire-and-forget: the metadata subscription round-trip
-                            // reorders the sidebar on every connected client.
-                            void api?.workspace
-                              .setPinned({ workspaceId, pinned: !isPinned })
-                              .then((result) => {
-                                if (!result.success) {
-                                  console.error("Failed to toggle pin:", result.error);
-                                }
-                              })
-                              .catch((error: unknown) => {
-                                console.error("Failed to toggle pin:", error);
-                              });
+                            // Fire-and-forget: optimistic reorder happens synchronously
+                            // inside setWorkspacePinned; errors are logged there.
+                            void setWorkspacePinned(workspaceId, !isPinned);
                           }
                         : null
                     }

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1748,9 +1748,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       } else if (matchesKeybind(e, KEYBINDS.PIN_WORKSPACE) && selectedWorkspace) {
         e.preventDefault();
         // Only root chats are pinnable; a selected sub-agent row is a no-op.
-        const projectWorkspaces =
-          sortedWorkspacesByProject.get(selectedWorkspace.projectPath) ?? [];
-        const meta = projectWorkspaces.find((m) => m.id === selectedWorkspace.workspaceId);
+        // Look up by id in the store rather than indexing sortedWorkspacesByProject
+        // by projectPath: multi-project workspaces are bucketed under the internal
+        // multi-project config key, not their primary project path.
+        const meta = workspaceStore.getWorkspaceMetadata(selectedWorkspace.workspaceId);
         if (meta && isWorkspacePinnable(meta)) {
           void setWorkspacePinned(selectedWorkspace.workspaceId, !isWorkspacePinned(meta));
         }
@@ -1767,6 +1768,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     setWorkspacePinned,
     sortedWorkspacesByProject,
     userProjects,
+    workspaceStore,
   ]);
 
   return (

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -125,6 +125,7 @@ import { ScrollArea } from "../ScrollArea/ScrollArea";
 import { getProjectDisplayName, getSubProjectsForParent } from "@/common/utils/subProjects";
 import { getErrorMessage } from "@/common/utils/errors";
 import { isMultiProject } from "@/common/utils/multiProject";
+import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProject";
 import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
@@ -711,6 +712,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     archiveWorkspace: onArchiveWorkspace,
     removeWorkspace,
     updateWorkspaceTitle: onUpdateTitle,
+    setWorkspacePinned,
     refreshWorkspaceMetadata,
     pendingNewWorkspaceProject,
     pendingNewWorkspaceDraftId,
@@ -1743,6 +1745,15 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       } else if (matchesKeybind(e, KEYBINDS.ARCHIVE_WORKSPACE) && selectedWorkspace) {
         e.preventDefault();
         void handleArchiveWorkspace(selectedWorkspace.workspaceId);
+      } else if (matchesKeybind(e, KEYBINDS.PIN_WORKSPACE) && selectedWorkspace) {
+        e.preventDefault();
+        // Only root chats are pinnable; a selected sub-agent row is a no-op.
+        const projectWorkspaces =
+          sortedWorkspacesByProject.get(selectedWorkspace.projectPath) ?? [];
+        const meta = projectWorkspaces.find((m) => m.id === selectedWorkspace.workspaceId);
+        if (meta && isWorkspacePinnable(meta)) {
+          void setWorkspacePinned(selectedWorkspace.workspaceId, !isWorkspacePinned(meta));
+        }
       }
     };
 
@@ -1753,6 +1764,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     selectedWorkspace,
     handleAddWorkspace,
     handleArchiveWorkspace,
+    setWorkspacePinned,
     sortedWorkspacesByProject,
     userProjects,
   ]);

--- a/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
+++ b/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
@@ -1,6 +1,15 @@
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
-import { GitBranch, HeartPulse, Maximize2, Pencil, Server, Square } from "lucide-react";
+import {
+  GitBranch,
+  HeartPulse,
+  Maximize2,
+  Pencil,
+  Pin,
+  PinOff,
+  Server,
+  Square,
+} from "lucide-react";
 import React from "react";
 
 interface WorkspaceActionButtonProps {
@@ -45,6 +54,9 @@ interface WorkspaceActionsMenuContentProps {
   onEnterImmersiveReview?: (() => void) | null;
   onStopRuntime?: (() => void) | null;
   onForkChat?: ((anchorEl: HTMLElement) => void) | null;
+  /** Pin/unpin toggle; pass null on sub-agent rows (only root chats are pinnable). */
+  onTogglePinned?: (() => void) | null;
+  isPinned?: boolean;
   onArchiveChat?: ((anchorEl: HTMLElement) => void) | null;
   onCloseMenu: () => void;
   shortcutClassName?: string;
@@ -141,6 +153,25 @@ export const WorkspaceActionsMenuContent: React.FC<WorkspaceActionsMenuContentPr
             e.stopPropagation();
             props.onCloseMenu();
             props.onForkChat?.(e.currentTarget);
+          }}
+        />
+      )}
+      {props.onTogglePinned && (
+        <WorkspaceActionButton
+          label={props.isPinned ? "Unpin chat" : "Pin chat"}
+          shortcut={formatKeybind(KEYBINDS.PIN_WORKSPACE)}
+          shortcutClassName={props.shortcutClassName}
+          icon={
+            props.isPinned ? (
+              <PinOff className="h-3 w-3 shrink-0" />
+            ) : (
+              <Pin className="h-3 w-3 shrink-0" />
+            )
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onCloseMenu();
+            props.onTogglePinned?.();
           }}
         />
       )}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -4,6 +4,7 @@ import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { cn } from "@/common/lib/utils";
 import { getErrorMessage } from "@/common/utils/errors";
+import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 
 import {
   RIGHT_SIDEBAR_COLLAPSED_KEY,
@@ -91,7 +92,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
 }) => {
   const { api } = useAPI();
   const { disableWorkspaceAgents } = useAgent();
-  const { preflightArchiveWorkspace, archiveWorkspace } = useWorkspaceActions();
+  const { preflightArchiveWorkspace, archiveWorkspace, setWorkspacePinned } = useWorkspaceActions();
   const { workspaceMetadata } = useWorkspaceContext();
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
   const openTerminalPopout = useOpenTerminal();
@@ -749,6 +750,14 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               onForkChat={(anchorEl) => {
                 void handleForkChat(anchorEl);
               }}
+              onTogglePinned={
+                workspaceEntry && isWorkspacePinnable(workspaceEntry)
+                  ? () => {
+                      void setWorkspacePinned(workspaceId, !isWorkspacePinned(workspaceEntry));
+                    }
+                  : null
+              }
+              isPinned={workspaceEntry ? isWorkspacePinned(workspaceEntry) : false}
               onArchiveChat={(anchorEl) => {
                 // handleArchiveChat runs preflight and opens a confirmation dialog
                 // when streaming or untracked files are detected.

--- a/src/browser/contexts/ThinkingContext.test.tsx
+++ b/src/browser/contexts/ThinkingContext.test.tsx
@@ -164,6 +164,7 @@ function createWorkspaceContextValue(): WorkspaceContextValue {
       }),
     removeWorkspace: () => Promise.resolve({ success: true }),
     updateWorkspaceTitle: () => Promise.resolve({ success: true }),
+    setWorkspacePinned: () => Promise.resolve({ success: true }),
     preflightArchiveWorkspace: () => Promise.resolve({ success: true }),
     archiveWorkspace: () => Promise.resolve({ success: true }),
     unarchiveWorkspace: () => Promise.resolve({ success: true }),

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -447,6 +447,10 @@ export interface WorkspaceContext extends WorkspaceMetadataContextValue {
     workspaceId: string,
     newTitle: string
   ) => Promise<{ success: boolean; error?: string }>;
+  setWorkspacePinned: (
+    workspaceId: string,
+    pinned: boolean
+  ) => Promise<{ success: boolean; error?: string }>;
   preflightArchiveWorkspace: (
     workspaceId: string
   ) => Promise<{ success: boolean; error?: string; data?: ArchivePreflightResult }>;
@@ -1452,6 +1456,29 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
     [api]
   );
 
+  /**
+   * Pin or unpin a chat. No optimistic state: the workspace metadata
+   * subscription round-trip updates all connected clients, same as title edits.
+   */
+  const setWorkspacePinned = useCallback(
+    async (workspaceId: string, pinned: boolean): Promise<{ success: boolean; error?: string }> => {
+      if (!api) return { success: false, error: "API not connected" };
+      try {
+        const result = await api.workspace.setPinned({ workspaceId, pinned });
+        if (result.success) {
+          return { success: true };
+        }
+        console.error("Failed to update workspace pin state:", result.error);
+        return { success: false, error: result.error };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        console.error("Failed to update workspace pin state:", errorMessage);
+        return { success: false, error: errorMessage };
+      }
+    },
+    [api]
+  );
+
   const preflightArchiveWorkspace = useCallback(
     async (
       workspaceId: string
@@ -1840,6 +1867,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       createWorkspace,
       removeWorkspace,
       updateWorkspaceTitle,
+      setWorkspacePinned,
       preflightArchiveWorkspace,
       archiveWorkspace,
       unarchiveWorkspace,
@@ -1864,6 +1892,7 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
       createWorkspace,
       removeWorkspace,
       updateWorkspaceTitle,
+      setWorkspacePinned,
       preflightArchiveWorkspace,
       archiveWorkspace,
       unarchiveWorkspace,

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -1457,26 +1457,65 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
   );
 
   /**
-   * Pin or unpin a chat. No optimistic state: the workspace metadata
-   * subscription round-trip updates all connected clients, same as title edits.
+   * Pin or unpin a chat. Applies an optimistic pinnedAt locally so the row
+   * moves on click, even over slow connections; the workspace metadata
+   * subscription round-trip then reconciles all clients with the server's
+   * authoritative monotonic timestamp (and reverts on failure).
    */
   const setWorkspacePinned = useCallback(
     async (workspaceId: string, pinned: boolean): Promise<{ success: boolean; error?: string }> => {
       if (!api) return { success: false, error: "API not connected" };
+
+      let previousPinnedAt: string | undefined;
+      let applied = false;
+      setWorkspaceMetadata((prev) => {
+        const meta = prev.get(workspaceId);
+        if (!meta || Boolean(meta.pinnedAt) === pinned) return prev;
+        previousPinnedAt = meta.pinnedAt;
+        applied = true;
+        // Mirror the server's append-only ordering: strictly greater than every
+        // existing pin in the same project so rapid pins stay in click order.
+        let optimisticPinnedAt: string | undefined;
+        if (pinned) {
+          let pinnedAtMs = Date.now();
+          for (const other of prev.values()) {
+            if (other.projectPath !== meta.projectPath || !other.pinnedAt) continue;
+            const otherMs = new Date(other.pinnedAt).getTime();
+            if (Number.isFinite(otherMs) && otherMs >= pinnedAtMs) pinnedAtMs = otherMs + 1;
+          }
+          optimisticPinnedAt = new Date(pinnedAtMs).toISOString();
+        }
+        const next = new Map(prev);
+        next.set(workspaceId, { ...meta, pinnedAt: optimisticPinnedAt });
+        return next;
+      });
+      const revert = () => {
+        if (!applied) return;
+        setWorkspaceMetadata((prev) => {
+          const meta = prev.get(workspaceId);
+          if (!meta) return prev;
+          const next = new Map(prev);
+          next.set(workspaceId, { ...meta, pinnedAt: previousPinnedAt });
+          return next;
+        });
+      };
+
       try {
         const result = await api.workspace.setPinned({ workspaceId, pinned });
         if (result.success) {
           return { success: true };
         }
+        revert();
         console.error("Failed to update workspace pin state:", result.error);
         return { success: false, error: result.error };
       } catch (error) {
+        revert();
         const errorMessage = getErrorMessage(error);
         console.error("Failed to update workspace pin state:", errorMessage);
         return { success: false, error: errorMessage };
       }
     },
-    [api]
+    [api, setWorkspaceMetadata]
   );
 
   const preflightArchiveWorkspace = useCallback(
@@ -1951,6 +1990,17 @@ export function useWorkspaceActions(): Omit<
     throw new Error("useWorkspaceActions must be used within WorkspaceProvider");
   }
   return context;
+}
+
+/**
+ * Like useWorkspaceActions, but returns undefined outside WorkspaceProvider.
+ * For components (e.g. AgentListItem) that are also rendered in Storybook or
+ * tests without the full provider tree.
+ */
+export function useWorkspaceActionsOptional():
+  | Omit<WorkspaceContext, "workspaceMetadata" | "loading" | "loaded" | "loadError">
+  | undefined {
+  return useContext(WorkspaceActionsContext) ?? undefined;
 }
 
 /**

--- a/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/HunkViewer.stories.tsx
@@ -87,6 +87,7 @@ function createStubWorkspaceContextValue(): WorkspaceContextValue {
       }),
     removeWorkspace: () => Promise.resolve({ success: true }),
     updateWorkspaceTitle: () => Promise.resolve({ success: true }),
+    setWorkspacePinned: () => Promise.resolve({ success: true }),
     preflightArchiveWorkspace: () => Promise.resolve({ success: true }),
     archiveWorkspace: () => Promise.resolve({ success: true }),
     unarchiveWorkspace: () => Promise.resolve({ success: true }),

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -24,6 +24,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   EDIT_WORKSPACE_TITLE: "Edit workspace title",
   GENERATE_WORKSPACE_TITLE: "Generate new title",
   ARCHIVE_WORKSPACE: "Archive workspace",
+  PIN_WORKSPACE: "Pin/unpin chat",
   JUMP_TO_BOTTOM: "Jump to bottom",
   LOAD_OLDER_MESSAGES: "Load older messages",
   NEXT_WORKSPACE: "Next workspace",

--- a/src/browser/utils/commandIds.ts
+++ b/src/browser/utils/commandIds.ts
@@ -28,6 +28,7 @@ export const CommandIds = {
   workspaceEditTitle: () => "ws:edit-title" as const,
   workspaceEditTitleAny: () => "ws:edit-title-any" as const,
   workspaceGenerateTitle: () => "ws:generate-title" as const,
+  workspaceTogglePinned: () => "ws:toggle-pinned" as const,
   workspaceOpenTerminal: () => "ws:open-terminal" as const,
   workspaceOpenTerminalCurrent: () => "ws:open-terminal-current" as const,
   workspaceArchiveMergedInProject: () => "ws:archive-merged-in-project" as const,

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -11,6 +11,7 @@ import {
   resolveMinimumThinkingLevel,
 } from "@/common/utils/thinking/policy";
 import assert from "@/common/utils/assert";
+import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import { RIGHT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
@@ -458,6 +459,24 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
           );
         },
       });
+      // Only live root chats are pinnable (sub-agents follow their pinned parent).
+      if (selectedMeta && isWorkspacePinnable(selectedMeta)) {
+        const pinned = isWorkspacePinned(selectedMeta);
+        list.push({
+          id: CommandIds.workspaceTogglePinned(),
+          title: pinned ? "Unpin Current Chat" : "Pin Current Chat",
+          subtitle: workspaceDisplayName,
+          shortcutHint: formatKeybind(KEYBINDS.PIN_WORKSPACE),
+          section: section.workspaces,
+          run: async () => {
+            if (!p.api) return;
+            await p.api.workspace.setPinned({
+              workspaceId: selected.workspaceId,
+              pinned: !pinned,
+            });
+          },
+        });
+      }
     }
 
     if (p.workspaceMetadata.size > 0) {

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -345,6 +345,10 @@ export const KEYBINDS = {
   // macOS: Cmd+Shift+Backspace, Win/Linux: Ctrl+Shift+Backspace
   ARCHIVE_WORKSPACE: { key: "Backspace", ctrl: true, shift: true, macCtrlBehavior: "command" },
 
+  /** Pin/unpin current workspace (chat) in the sidebar */
+  // Use the physical P key: macOS Option+P produces "π" for event.key, so match on code.
+  PIN_WORKSPACE: { key: "p", code: "KeyP", ctrl: true, alt: true },
+
   /** Jump to bottom of chat */
   JUMP_TO_BOTTOM: { key: "G", shift: true },
 

--- a/src/browser/utils/ui/workspaceFiltering.test.ts
+++ b/src/browser/utils/ui/workspaceFiltering.test.ts
@@ -623,6 +623,117 @@ describe("buildSortedWorkspacesByProject", () => {
   });
 });
 
+describe("buildSortedWorkspacesByProject pinning", () => {
+  const now = Date.now();
+  const projectsWithIds = (ids: string[]): Map<string, ProjectConfig> =>
+    new Map<string, ProjectConfig>([
+      ["/project/a", { workspaces: ids.map((id) => ({ path: `/a/${id}`, id })) }],
+    ]);
+
+  it("sorts pinned chats above unpinned ones in pinnedAt order regardless of recency", () => {
+    const projects = projectsWithIds(["ws1", "ws2", "ws3", "ws4"]);
+    const metadata = new Map<string, FrontendWorkspaceMetadata>([
+      // ws2 pinned second, ws4 pinned first: pin order must be ws4, ws2.
+      ["ws1", createWorkspace("ws1", "/project/a")],
+      ["ws2", { ...createWorkspace("ws2", "/project/a"), pinnedAt: "2026-01-02T00:00:00.000Z" }],
+      ["ws3", createWorkspace("ws3", "/project/a")],
+      ["ws4", { ...createWorkspace("ws4", "/project/a"), pinnedAt: "2026-01-01T00:00:00.000Z" }],
+    ]);
+    // Pinned rows have the *lowest* recency; unpinned ws1 is most recent.
+    const recency = { ws1: now, ws2: now - 500_000, ws3: now - 1_000, ws4: now - 900_000 };
+
+    const result = buildSortedWorkspacesByProject(projects, metadata, recency);
+
+    expect(result.get("/project/a")?.map((w) => w.id)).toEqual(["ws4", "ws2", "ws1", "ws3"]);
+  });
+
+  it("keeps pin order stable when an unpinned chat's recency is bumped", () => {
+    const projects = projectsWithIds(["pinnedA", "pinnedB", "free"]);
+    const metadata = new Map<string, FrontendWorkspaceMetadata>([
+      [
+        "pinnedA",
+        { ...createWorkspace("pinnedA", "/project/a"), pinnedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+      [
+        "pinnedB",
+        { ...createWorkspace("pinnedB", "/project/a"), pinnedAt: "2026-01-02T00:00:00.000Z" },
+      ],
+      ["free", createWorkspace("free", "/project/a")],
+    ]);
+
+    const before = buildSortedWorkspacesByProject(projects, metadata, { free: now - 10_000 });
+    // Simulate activity on the unpinned chat: it must stay below the pinned block.
+    const after = buildSortedWorkspacesByProject(projects, metadata, { free: now });
+
+    expect(before.get("/project/a")?.map((w) => w.id)).toEqual(["pinnedA", "pinnedB", "free"]);
+    expect(after.get("/project/a")?.map((w) => w.id)).toEqual(["pinnedA", "pinnedB", "free"]);
+  });
+
+  it("keeps child rows attached under a pinned parent and ignores stale child pins", () => {
+    const projects = projectsWithIds(["root", "child", "other"]);
+    const metadata = new Map<string, FrontendWorkspaceMetadata>([
+      ["root", { ...createWorkspace("root", "/project/a"), pinnedAt: "2026-01-01T00:00:00.000Z" }],
+      [
+        "child",
+        {
+          ...createWorkspace("child", { projectPath: "/project/a", parentWorkspaceId: "root" }),
+          // Stale/malformed pin on a sub-agent must not detach it from its parent.
+          pinnedAt: "2026-06-01T00:00:00.000Z",
+        },
+      ],
+      ["other", createWorkspace("other", "/project/a")],
+    ]);
+    // The unpinned root is the most recent chat.
+    const recency = { root: now - 500_000, child: now - 400_000, other: now };
+
+    const result = buildSortedWorkspacesByProject(projects, metadata, recency);
+
+    expect(result.get("/project/a")?.map((w) => w.id)).toEqual(["root", "child", "other"]);
+  });
+
+  it("ignores pinnedAt on archived workspaces", () => {
+    const projects = projectsWithIds(["stale", "fresh"]);
+    const metadata = new Map<string, FrontendWorkspaceMetadata>([
+      [
+        "stale",
+        {
+          ...createWorkspace("stale", "/project/a"),
+          pinnedAt: "2026-01-01T00:00:00.000Z",
+          archivedAt: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+      ["fresh", createWorkspace("fresh", "/project/a")],
+    ]);
+
+    const result = buildSortedWorkspacesByProject(projects, metadata, { fresh: now });
+
+    expect(result.get("/project/a")?.map((w) => w.id)).toEqual(["fresh", "stale"]);
+  });
+});
+
+describe("partitionWorkspacesByAge pinning", () => {
+  const now = Date.now();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+  it("classifies an old pinned root and its children as recent", () => {
+    const pinnedRoot = {
+      ...createWorkspace("pinned-root"),
+      pinnedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const child = createWorkspace("child", { parentWorkspaceId: "pinned-root" });
+    const oldFree = createWorkspace("old-free");
+
+    const { recent, buckets } = partitionWorkspacesByAge([pinnedRoot, child, oldFree], {
+      "pinned-root": now - 40 * ONE_DAY_MS,
+      child: now - 40 * ONE_DAY_MS,
+      "old-free": now - 40 * ONE_DAY_MS,
+    });
+
+    expect(recent.map((w) => w.id)).toEqual(["pinned-root", "child"]);
+    expect(getAllOld(buckets).map((w) => w.id)).toEqual(["old-free"]);
+  });
+});
+
 describe("delegated workspace activity roll-up", () => {
   it("rolls active workflow-owned descendants up to every ancestor", () => {
     const workflowTask = { runId: "run-1", stepId: "step-1" };

--- a/src/browser/utils/ui/workspaceFiltering.ts
+++ b/src/browser/utils/ui/workspaceFiltering.ts
@@ -2,6 +2,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { ProjectConfig } from "@/common/types/project";
 import { hasCompletedAgentReport } from "@/common/utils/agentTaskCompletion";
 import { assert } from "@/common/utils/assert";
+import { isWorkspacePinned } from "@/common/utils/pin";
 
 interface WorkspaceGroupConfig {
   id: string;
@@ -642,6 +643,25 @@ export function buildSortedWorkspacesByProject(
   // flip ordering when multiple workspaces have equal recency.
   for (const metadataList of result.values()) {
     metadataList.sort((a, b) => {
+      // Pinned chats float above unpinned ones in stable pin order (pinnedAt asc:
+      // new pins append at the bottom of the pinned block). Recency is intentionally
+      // ignored for pinned rows so activity never reshuffles them.
+      const aPinned = isWorkspacePinned(a);
+      const bPinned = isWorkspacePinned(b);
+      if (aPinned !== bPinned) {
+        return aPinned ? -1 : 1;
+      }
+      if (aPinned && bPinned) {
+        const aPinnedAtRaw = Date.parse(a.pinnedAt ?? "");
+        const bPinnedAtRaw = Date.parse(b.pinnedAt ?? "");
+        const aPinnedAt = Number.isFinite(aPinnedAtRaw) ? aPinnedAtRaw : 0;
+        const bPinnedAt = Number.isFinite(bPinnedAtRaw) ? bPinnedAtRaw : 0;
+        if (aPinnedAt !== bPinnedAt) {
+          return aPinnedAt - bPinnedAt;
+        }
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      }
+
       const aTimestamp = workspaceRecency[a.id] ?? 0;
       const bTimestamp = workspaceRecency[b.id] ?? 0;
       if (aTimestamp !== bTimestamp) {
@@ -746,6 +766,12 @@ export function partitionWorkspacesByAge(
   const visiting = new Set<string>();
 
   const classifyByOwnRecency = (workspace: FrontendWorkspaceMetadata): number => {
+    // Pinned chats never age out into the collapsed "Older than N days" buckets;
+    // children inherit this tier via resolveTierIndex so the whole subtree stays visible.
+    if (isWorkspacePinned(workspace)) {
+      return -1;
+    }
+
     const recencyTimestamp = workspaceRecency[workspace.id] ?? 0;
     const age = now - recencyTimestamp;
 

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1125,6 +1125,10 @@ export const workspace = {
     input: z.object({ workspaceId: z.string(), title: z.string() }),
     output: ResultSchema(z.void(), z.string()),
   },
+  setPinned: {
+    input: z.object({ workspaceId: z.string(), pinned: z.boolean() }),
+    output: ResultSchema(z.void(), z.string()),
+  },
   updateTags: {
     /** Merge tag updates into a workspace; a null value deletes that key. */
     input: z.object({

--- a/src/common/orpc/schemas/workspace.ts
+++ b/src/common/orpc/schemas/workspace.ts
@@ -216,6 +216,10 @@ export const WorkspaceMetadataSchema = z.object({
     description:
       "ISO 8601 timestamp when workspace was last unarchived. Used for recency calculation to bump restored workspaces to top.",
   }),
+  pinnedAt: z.string().optional().meta({
+    description:
+      "ISO 8601 timestamp when workspace was pinned. Pinned workspaces sort to the top of their project in pin order (ascending). Cleared on archive.",
+  }),
   projects: z
     .array(ProjectRefSchema)
     .optional()

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -212,6 +212,10 @@ export const WorkspaceConfigSchema = z.object({
     description:
       "ISO 8601 timestamp when workspace was last unarchived. Used for recency calculation to bump restored workspaces to top.",
   }),
+  pinnedAt: z.string().optional().meta({
+    description:
+      "ISO 8601 timestamp when workspace was pinned. Pinned workspaces sort to the top of their project in pin order (ascending). Cleared on archive.",
+  }),
   worktreeArchiveSnapshot: WorktreeArchiveSnapshotSchema.optional().meta({
     description:
       "Durable restore metadata captured before archive-time worktree deletion. Present only while an archived snapshot is awaiting restore.",

--- a/src/common/utils/pin.ts
+++ b/src/common/utils/pin.ts
@@ -1,0 +1,35 @@
+import { isWorkspaceArchived } from "./archive";
+
+/**
+ * Determine if a workspace is effectively pinned.
+ *
+ * A workspace is pinned only when all of the following hold:
+ * - `pinnedAt` is set
+ * - the workspace is not archived (archive clears pins; stale timestamps are ignored)
+ * - it is a root workspace (sub-agents follow their parent and are never pinned themselves)
+ *
+ * Single definition shared by sorting, age-bucketing, and UI affordances so a stale or
+ * malformed `pinnedAt` (e.g. on a child workspace) can never detach a row from its parent.
+ */
+export function isWorkspacePinned(workspace: {
+  pinnedAt?: string;
+  archivedAt?: string;
+  unarchivedAt?: string;
+  parentWorkspaceId?: string;
+}): boolean {
+  return Boolean(workspace.pinnedAt) && isWorkspacePinnable(workspace);
+}
+
+/**
+ * Whether the pin/unpin action applies to this workspace at all: only live
+ * (non-archived) root chats are pinnable. UI entry points hide the action when
+ * this is false; the backend enforces the same rule in setPinned.
+ */
+export function isWorkspacePinnable(workspace: {
+  archivedAt?: string;
+  unarchivedAt?: string;
+  parentWorkspaceId?: string;
+}): boolean {
+  if (workspace.parentWorkspaceId) return false;
+  return !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt);
+}

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1740,6 +1740,7 @@ export class Config {
               taskTrunkBranch: workspace.taskTrunkBranch,
               archivedAt: workspace.archivedAt,
               unarchivedAt: workspace.unarchivedAt,
+              pinnedAt: workspace.pinnedAt,
               projects: workspaceProjects,
               subProjectPath: workspace.subProjectPath,
             };
@@ -1913,6 +1914,7 @@ export class Config {
               taskTrunkBranch: workspace.taskTrunkBranch,
               archivedAt: workspace.archivedAt,
               unarchivedAt: workspace.unarchivedAt,
+              pinnedAt: workspace.pinnedAt,
               projects: workspaceProjects,
               subProjectPath: workspace.subProjectPath,
             };
@@ -2039,6 +2041,7 @@ export class Config {
         taskTrunkBranch: metadata.taskTrunkBranch,
         archivedAt: metadata.archivedAt,
         unarchivedAt: metadata.unarchivedAt,
+        pinnedAt: metadata.pinnedAt,
         projects: metadata.projects,
         subProjectPath: metadata.subProjectPath,
       };

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -4097,6 +4097,12 @@ export const router = (authToken?: string) => {
         .handler(async ({ context, input }) => {
           return context.workspaceService.updateTitle(input.workspaceId, input.title);
         }),
+      setPinned: t
+        .input(schemas.workspace.setPinned.input)
+        .output(schemas.workspace.setPinned.output)
+        .handler(async ({ context, input }) => {
+          return context.workspaceService.setPinned(input.workspaceId, input.pinned);
+        }),
       updateTags: t
         .input(schemas.workspace.updateTags.input)
         .output(schemas.workspace.updateTags.output)

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -7544,6 +7544,186 @@ describe("WorkspaceService metadata listeners", () => {
   });
 });
 
+describe("WorkspaceService setPinned", () => {
+  const projectPath = "/tmp/project";
+  const rootId = "ws-root";
+  const otherRootId = "ws-other";
+  const childId = "ws-child";
+  const archivedId = "ws-archived";
+
+  let workspaceService: WorkspaceService;
+  let configState: ProjectsConfig;
+  let historyService: HistoryService;
+  let cleanupHistory: () => Promise<void>;
+  let emittedMetadata: Array<{ workspaceId: string; metadata: FrontendWorkspaceMetadata | null }>;
+
+  const getEntry = (id: string) =>
+    configState.projects.get(projectPath)?.workspaces.find((w) => w.id === id);
+
+  beforeEach(async () => {
+    configState = {
+      projects: new Map([
+        [
+          projectPath,
+          {
+            workspaces: [
+              { path: `${projectPath}/${rootId}`, id: rootId },
+              { path: `${projectPath}/${otherRootId}`, id: otherRootId },
+              {
+                path: `${projectPath}/${childId}`,
+                id: childId,
+                parentWorkspaceId: rootId,
+              },
+              {
+                path: `${projectPath}/${archivedId}`,
+                id: archivedId,
+                archivedAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          },
+        ],
+      ]),
+    };
+
+    ({ historyService, cleanup: cleanupHistory } = await createTestHistoryService());
+
+    const mockConfig: Partial<Config> = {
+      srcDir: "/tmp/src",
+      getSessionDir: mock(() => "/tmp/test/sessions"),
+      findWorkspace: mock((id: string) => {
+        const entry = getEntry(id);
+        if (!entry) return null;
+        return {
+          projectPath,
+          workspacePath: entry.path,
+          parentWorkspaceId: entry.parentWorkspaceId,
+        };
+      }),
+      editConfig: mock((fn: (config: ProjectsConfig) => ProjectsConfig) => {
+        configState = fn(configState);
+        return Promise.resolve();
+      }),
+      // Project config entries back into metadata so emitted events carry pin state.
+      getAllWorkspaceMetadata: mock(() =>
+        Promise.resolve(
+          (configState.projects.get(projectPath)?.workspaces ?? [])
+            .filter((w): w is typeof w & { id: string } => w.id != null)
+            .map(
+              (w): FrontendWorkspaceMetadata => ({
+                id: w.id,
+                name: w.id,
+                projectName: "proj",
+                projectPath,
+                namedWorkspacePath: w.path,
+                runtimeConfig: { type: "local", srcBaseDir: "/tmp" },
+                parentWorkspaceId: w.parentWorkspaceId,
+                archivedAt: w.archivedAt,
+                unarchivedAt: w.unarchivedAt,
+                pinnedAt: w.pinnedAt,
+              })
+            )
+        )
+      ),
+      loadConfigOrDefault: mock(() => configState),
+    };
+
+    workspaceService = createWorkspaceServiceForTest({
+      config: mockConfig,
+      historyService,
+    });
+
+    emittedMetadata = [];
+    workspaceService.on("metadata", (payload) => {
+      emittedMetadata.push(payload as (typeof emittedMetadata)[number]);
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupHistory();
+  });
+
+  test("pin persists pinnedAt and emits metadata; unpin clears it and emits", async () => {
+    const pinResult = await workspaceService.setPinned(rootId, true);
+    expect(pinResult.success).toBe(true);
+
+    const pinnedAt = getEntry(rootId)?.pinnedAt;
+    expect(pinnedAt).toBeDefined();
+    expect(emittedMetadata).toHaveLength(1);
+    expect(emittedMetadata[0].workspaceId).toBe(rootId);
+    expect(emittedMetadata[0].metadata?.pinnedAt).toBe(pinnedAt);
+
+    const unpinResult = await workspaceService.setPinned(rootId, false);
+    expect(unpinResult.success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBeUndefined();
+    expect(emittedMetadata).toHaveLength(2);
+    expect(emittedMetadata[1].metadata?.pinnedAt).toBeUndefined();
+  });
+
+  test("pin-when-pinned and unpin-when-unpinned are no-ops without event churn", async () => {
+    const first = await workspaceService.setPinned(rootId, true);
+    expect(first.success).toBe(true);
+    const firstPinnedAt = getEntry(rootId)?.pinnedAt;
+    expect(emittedMetadata).toHaveLength(1);
+
+    // Concurrent double-pin from another client must not move the row.
+    const again = await workspaceService.setPinned(rootId, true);
+    expect(again.success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBe(firstPinnedAt);
+    expect(emittedMetadata).toHaveLength(1);
+
+    // Unpinning a chat that is not pinned is also a quiet no-op.
+    const noopUnpin = await workspaceService.setPinned(otherRootId, false);
+    expect(noopUnpin.success).toBe(true);
+    expect(emittedMetadata).toHaveLength(1);
+  });
+
+  test("rejects pinning sub-agent and archived workspaces", async () => {
+    const subAgentResult = await workspaceService.setPinned(childId, true);
+    expect(subAgentResult.success).toBe(false);
+    expect(getEntry(childId)?.pinnedAt).toBeUndefined();
+
+    const archivedResult = await workspaceService.setPinned(archivedId, true);
+    expect(archivedResult.success).toBe(false);
+    expect(getEntry(archivedId)?.pinnedAt).toBeUndefined();
+
+    expect(emittedMetadata).toHaveLength(0);
+  });
+
+  test("pinning after an existing pin yields a strictly greater pinnedAt", async () => {
+    expect((await workspaceService.setPinned(otherRootId, true)).success).toBe(true);
+    expect((await workspaceService.setPinned(rootId, true)).success).toBe(true);
+
+    const firstMs = Date.parse(getEntry(otherRootId)?.pinnedAt ?? "");
+    const secondMs = Date.parse(getEntry(rootId)?.pinnedAt ?? "");
+    expect(secondMs).toBeGreaterThan(firstMs);
+  });
+
+  test("appends after an existing future pinnedAt (clock skew)", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    getEntry(otherRootId)!.pinnedAt = future;
+
+    expect((await workspaceService.setPinned(rootId, true)).success).toBe(true);
+    expect(Date.parse(getEntry(rootId)?.pinnedAt ?? "")).toBeGreaterThan(Date.parse(future));
+  });
+
+  test("archive clears pinnedAt and unarchive does not restore it", async () => {
+    expect((await workspaceService.setPinned(rootId, true)).success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBeDefined();
+
+    const archiveResult = await workspaceService.archive(rootId);
+    expect(archiveResult.success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBeUndefined();
+
+    const unarchiveResult = await workspaceService.unarchive(rootId);
+    expect(unarchiveResult.success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBeUndefined();
+
+    // Re-pinning after unarchive works (pin state starts fresh).
+    expect((await workspaceService.setPinned(rootId, true)).success).toBe(true);
+    expect(getEntry(rootId)?.pinnedAt).toBeDefined();
+  });
+});
+
 describe("WorkspaceService archive lifecycle hooks", () => {
   const workspaceId = "ws-archive";
   const projectPath = "/tmp/project";

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5446,6 +5446,87 @@ export class WorkspaceService extends EventEmitter {
   }
 
   /**
+   * Pin or unpin a chat (root workspace) so it floats to the top of its project
+   * in the sidebar. Pin order is stable: pinnedAt ascending, new pins append at
+   * the bottom of the pinned block. Recency is intentionally untouched, so
+   * unpinning drops the chat back to its natural recency position.
+   */
+  async setPinned(workspaceId: string, pinned: boolean): Promise<Result<void>> {
+    try {
+      const workspace = this.config.findWorkspace(workspaceId);
+      if (!workspace) {
+        return Err("Workspace not found");
+      }
+      const { projectPath, workspacePath } = workspace;
+
+      let updated = false;
+      let validationError: string | undefined;
+      await this.config.editConfig((config) => {
+        const projectConfig = config.projects.get(projectPath);
+        if (!projectConfig) {
+          validationError = "Workspace not found";
+          return config;
+        }
+
+        const workspaceEntry =
+          projectConfig.workspaces.find((entry) => entry.id === workspaceId) ??
+          projectConfig.workspaces.find((entry) => entry.path === workspacePath);
+        if (!workspaceEntry) {
+          validationError = "Workspace not found";
+          return config;
+        }
+
+        // Only root chats are pinnable; sub-agents follow their pinned parent.
+        if (workspaceEntry.parentWorkspaceId) {
+          validationError = "Sub-agent chats cannot be pinned";
+          return config;
+        }
+
+        if (pinned) {
+          if (isWorkspaceArchived(workspaceEntry.archivedAt, workspaceEntry.unarchivedAt)) {
+            validationError = "Archived chats cannot be pinned";
+            return config;
+          }
+          // Idempotent: a concurrent double-pin from another client must not move the row.
+          if (workspaceEntry.pinnedAt) {
+            return config;
+          }
+          // Server-generated monotonic timestamp: strictly greater than every existing
+          // pin in the project so rapid pins always append deterministically, even if
+          // the wall clock is skewed or several pins land within the same millisecond.
+          let pinnedAtMs = Date.now();
+          for (const entry of projectConfig.workspaces) {
+            if (!entry.pinnedAt) continue;
+            const existingMs = new Date(entry.pinnedAt).getTime();
+            if (Number.isFinite(existingMs) && existingMs >= pinnedAtMs) {
+              pinnedAtMs = existingMs + 1;
+            }
+          }
+          workspaceEntry.pinnedAt = new Date(pinnedAtMs).toISOString();
+          updated = true;
+        } else if (workspaceEntry.pinnedAt) {
+          delete workspaceEntry.pinnedAt;
+          updated = true;
+        }
+
+        return config;
+      });
+
+      if (validationError) {
+        return Err(validationError);
+      }
+
+      if (updated) {
+        await this.emitCurrentWorkspaceMetadata(workspaceId);
+      }
+
+      return Ok(undefined);
+    } catch (error) {
+      return Err(`Failed to update pin state: ${getErrorMessage(error)}`);
+    }
+  }
+
+  /**
    * Regenerate the workspace title from chat history using AI.
    * Uses the first user message as the durable objective, plus a context block with
    * that first user message and the latest turns, then persists the generated title.
@@ -5718,6 +5799,8 @@ export class WorkspaceService extends EventEmitter {
           if (workspaceEntry) {
             // Just set archivedAt - archived state is derived from archivedAt > unarchivedAt.
             workspaceEntry.archivedAt = new Date().toISOString();
+            // Archiving clears the pin; unarchive does not restore it.
+            delete workspaceEntry.pinnedAt;
             if (capturedWorktreeSnapshot) {
               workspaceEntry.worktreeArchiveSnapshot = capturedWorktreeSnapshot;
             } else {


### PR DESCRIPTION
## Summary

Adds chat pinning: workspaces can be pinned to the top of the project sidebar in a stable, user-controlled order that is immune to recency reshuffling.

## Background

Sidebar ordering is recency-based, so long-running or reference chats constantly drift down as other workspaces see activity. Pinning gives important chats a fixed spot at the top of their project.

## Implementation

- `pinnedAt` timestamp on `WorkspaceConfigSchema` / `WorkspaceMetadataSchema`; shared `isWorkspacePinned` / `isWorkspacePinnable` helpers (`src/common/utils/pin.ts`). Only root chats can be pinned; sub-agents and archived workspaces cannot.
- `WorkspaceService.setPinned` with a server-generated monotonic timestamp (`max(now, maxPinInProject + 1ms)`) so pin order is append-only and stable even with client clock skew; exposed via `workspace.setPinned` ORPC route. Archiving clears `pinnedAt`; unarchive does not restore it.
- Sorting: pinned roots sort first by `pinnedAt` ascending (id tie-break) in `buildSortedWorkspacesByProject`; `partitionWorkspacesByAge` treats pinned roots (and their children via tier inheritance) as recent so pins never fall into the aged bucket.
- Frontend applies an optimistic `pinnedAt` on click (mirroring the server's append-only ordering) so rows reorder instantly; the metadata subscription reconciles and failures revert.
- UI: Pin/Unpin chat item in the sidebar row menu and workspace menu bar, pin icon on pinned rows, `Ctrl/Cmd+Alt+P` keybind, and a Pin/Unpin Current Chat palette action.

## Validation

Full UAT against a `dev-server-sandbox` instance driven with agent-browser (16 scenarios): pin/unpin via row menu, menu bar, keybind, and palette; stable append-below-existing-pins order; new workspaces landing below pins; persistence across reload; `pinnedAt` cleared on archive and not restored on unarchive; two-client live sync (pin in client A instantly reorders client B); pin icon rendering at 375px mobile width with no overflow. Rapid-pinning four chats via the row menu reorders the sidebar immediately on each click (verified with no-wait DOM snapshots) and converges with the server's persisted order.

## Risks

Low. Sorting changes are scoped to `buildSortedWorkspacesByProject` / `partitionWorkspacesByAge` and covered by new unit tests (pin ordering vs recency, stale-pin child attachment, archived-pin ignore, age bucketing). Unpinned workspaces keep the existing recency order; workspaces without `pinnedAt` are unaffected.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$75.72`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=75.72 -->

