### PR TITLE
🤖 fix: let attach_file accept any file type with display-only fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,9 @@ check-docs-links: ## Check documentation for broken links
 	@echo "🔗 Checking documentation links..."
 	# Workaround: katex@0.16.34 ships broken ESM with unreplaced __VERSION__ placeholder.
 	# Remove this NODE_OPTIONS prefix once katex publishes a fixed build.
-	@cd docs && NODE_OPTIONS="$${NODE_OPTIONS:+$$NODE_OPTIONS }--import data:text/javascript,globalThis.__VERSION__=%220.16.34%22" bun x mintlify broken-links
+	# Pin mintlify: 4.2.681 pulls @mintlify/auth-edge@0.0.36, which was unpublished
+	# from npm (404) and breaks resolution. Bump once a fixed release ships.
+	@cd docs && NODE_OPTIONS="$${NODE_OPTIONS:+$$NODE_OPTIONS }--import data:text/javascript,globalThis.__VERSION__=%220.16.34%22" bun x mintlify@4.2.680 broken-links
 
 check-code-docs-links: ## Validate code references to docs paths
 	@./scripts/check-code-docs-links.sh

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1617,9 +1617,9 @@ export const TOOL_DEFINITIONS = {
   },
   attach_file: {
     description:
-      "Attach a supported file from the filesystem so later model steps receive it as a real attachment instead of a huge base64 JSON blob. " +
-      "Accepts absolute or relative paths, including files outside the workspace. " +
-      "Currently supports raster images, SVG, and PDF as model attachments. Markdown files are shown to the user for preview/download only. Unsupported file types are shown to the user in chat when possible, but only a notice is sent to the model.",
+      "Attach a file from the filesystem so later model steps receive it as a real attachment instead of a huge base64 JSON blob. " +
+      "Accepts absolute or relative paths, including files outside the workspace. Accepts any file type. " +
+      "Raster images, SVG, and PDF are sent to the model as real attachments. Every other file type (text, source, diffs, logs, video, audio, archives, etc.) is shown to the user in chat for preview/download, but its contents are NOT sent to the model — you only receive a notice. Use file_read when you need to read a text file's contents yourself.",
     schema: z.preprocess(
       normalizeFilePath,
       z

--- a/src/node/services/tools/attach_file.test.ts
+++ b/src/node/services/tools/attach_file.test.ts
@@ -281,7 +281,6 @@ describe("attach_file tool", () => {
       throw new Error("Expected display-only status text");
     }
     expect(result.value[0].text).toContain("clip.webm");
-    expect(result.value[0].text).toContain("not supported as a model attachment");
     expect(result.value[1]).toEqual({
       type: "display_file",
       data: webmBytes.toString("base64"),
@@ -310,7 +309,6 @@ describe("attach_file tool", () => {
       throw new Error("Expected display-only status text");
     }
     expect(result.value[0].text).toContain("release-notes.md (text/markdown)");
-    expect(result.value[0].text).toContain("not supported as a model attachment");
     expect(result.value[1]).toEqual({
       type: "display_file",
       data: Buffer.from(markdown).toString("base64"),
@@ -343,54 +341,83 @@ describe("attach_file tool", () => {
     });
   });
 
-  it("rejects text-like unsupported files so the model can use file_read", async () => {
+  it("shows text files to the user as display-only text/plain", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
     const textPath = path.join(workspaceDir.path, "notes.txt");
-    await fs.writeFile(textPath, "hello");
+    const text = "hello";
+    await fs.writeFile(textPath, text);
 
-    const result = (await tool.execute!(
-      { path: "notes.txt" },
-      mockToolCallOptions
-    )) as AttachFileToolResult;
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "notes.txt" }, mockToolCallOptions)) as AttachFileToolResult
+    );
 
-    expect(result).toEqual({
-      success: false,
-      error: `Unsupported attachment type: ${textPath}`,
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(text).toString("base64"),
+      mediaType: "text/plain",
+      filename: "notes.txt",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(text) } },
     });
   });
 
-  it("rejects unmapped source files so the model can use file_read", async () => {
+  it("shows unmapped source files to the user as display-only text/plain", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
     const sourcePath = path.join(workspaceDir.path, "script.py");
-    await fs.writeFile(sourcePath, "print('hello')\n");
+    const source = "print('hello')\n";
+    await fs.writeFile(sourcePath, source);
 
-    const result = (await tool.execute!(
-      { path: "script.py" },
-      mockToolCallOptions
-    )) as AttachFileToolResult;
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "script.py" }, mockToolCallOptions)) as AttachFileToolResult
+    );
 
-    expect(result).toEqual({
-      success: false,
-      error: `Unsupported attachment type: ${sourcePath}`,
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(source).toString("base64"),
+      mediaType: "text/plain",
+      filename: "script.py",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(source) } },
     });
   });
 
-  it("rejects extensionless text files so the model can use file_read", async () => {
+  it("shows a diff file to the user as display-only text/plain", async () => {
+    using workspaceDir = new TestTempDir("attach-file-workspace");
+    const tool = createTestAttachFileTool(workspaceDir.path);
+    const diffPath = path.join(workspaceDir.path, "changes.diff");
+    const diff = "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n";
+    await fs.writeFile(diffPath, diff);
+
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "changes.diff" }, mockToolCallOptions)) as AttachFileToolResult
+    );
+
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(diff).toString("base64"),
+      mediaType: "text/plain",
+      filename: "changes.diff",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(diff) } },
+    });
+  });
+
+  it("shows extensionless text files to the user as display-only text/plain", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
     const makefilePath = path.join(workspaceDir.path, "Makefile");
-    await fs.writeFile(makefilePath, "all:\n\techo hello\n");
+    const makefile = "all:\n\techo hello\n";
+    await fs.writeFile(makefilePath, makefile);
 
-    const result = (await tool.execute!(
-      { path: "Makefile" },
-      mockToolCallOptions
-    )) as AttachFileToolResult;
+    const result = expectSuccessfulAttachFileResult(
+      (await tool.execute!({ path: "Makefile" }, mockToolCallOptions)) as AttachFileToolResult
+    );
 
-    expect(result).toEqual({
-      success: false,
-      error: `Unsupported attachment type: ${makefilePath}`,
+    expect(result.value[1]).toEqual({
+      type: "display_file",
+      data: Buffer.from(makefile).toString("base64"),
+      mediaType: "text/plain",
+      filename: "Makefile",
+      providerOptions: { mux: { displayOnly: true, size: Buffer.byteLength(makefile) } },
     });
   });
 
@@ -414,7 +441,7 @@ describe("attach_file tool", () => {
     });
   });
 
-  it("rejects oversized unsupported files with both unsupported-type and size context", async () => {
+  it("rejects oversized display-only files with the size cap message", async () => {
     using workspaceDir = new TestTempDir("attach-file-workspace");
     const tool = createTestAttachFileTool(workspaceDir.path);
     const largePath = path.join(workspaceDir.path, "huge.webm");
@@ -427,7 +454,7 @@ describe("attach_file tool", () => {
 
     expect(result).toEqual({
       success: false,
-      error: `Unsupported attachment type: ${largePath}. Could not show file to user: Attachment is too large (10.00MB). The maximum supported size is 10.00MB.`,
+      error: "Attachment is too large (10.00MB). The maximum supported size is 10.00MB.",
     });
   });
 

--- a/src/node/services/tools/attach_file.ts
+++ b/src/node/services/tools/attach_file.ts
@@ -40,7 +40,7 @@ export const createAttachFileTool: ToolFactory = (config: ToolConfiguration) => 
                 type: "text",
                 text:
                   `[File shown to user: ${label}. ` +
-                  "This type is not supported as a model attachment, so the model will receive this notice. Use another tool to inspect or convert the file if needed.]",
+                  "Only images, SVG, and PDF can be sent to the model as attachments; this file was shown to the user for preview/download but its contents were NOT sent to you. Use file_read if you need to read its contents.]",
               },
               createDisplayOnlyFilePart(result.file),
             ],

--- a/src/node/utils/attachments/readAttachmentFromPath.ts
+++ b/src/node/utils/attachments/readAttachmentFromPath.ts
@@ -52,48 +52,6 @@ const EXTENSION_TO_DISPLAY_MEDIA_TYPE: Record<string, string> = {
   mdown: MARKDOWN_MEDIA_TYPE,
 };
 
-// Markdown is intentionally display-only: agents should use file_read when they need
-// the contents, while attach_file gives users a quick preview/download affordance.
-const DISPLAY_ONLY_MARKDOWN_MEDIA_TYPES = new Set([MARKDOWN_MEDIA_TYPE, "text/x-markdown"]);
-
-const TEXT_EXTENSIONS_REQUIRING_FILE_READ = new Set([
-  "c",
-  "cpp",
-  "cs",
-  "csv",
-  "css",
-  "go",
-  "h",
-  "hpp",
-  "html",
-  "htm",
-  "java",
-  "js",
-  "json",
-  "jsx",
-  "log",
-  "md",
-  "mdx",
-  "mjs",
-  "py",
-  "rs",
-  "sh",
-  "toml",
-  "ts",
-  "tsx",
-  "txt",
-  "xml",
-  "yaml",
-  "yml",
-]);
-
-const TEXT_MEDIA_TYPES_REQUIRING_FILE_READ = new Set([
-  "application/json",
-  "application/javascript",
-  "application/xml",
-  "text/csv",
-]);
-
 function normalizeOptionalString(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed != null && trimmed.length > 0 ? trimmed : undefined;
@@ -191,35 +149,28 @@ function getFallbackFilename(
   return normalizeOptionalString(filename) ?? normalizeOptionalString(path.basename(resolvedPath));
 }
 
-interface DisplayMediaTypeCandidate {
-  mediaType: string;
-  requireBinaryContent: boolean;
-}
-
-function getDisplayFileMediaTypeCandidate(
+// Pick the media type for a display-only file. Images/SVG/PDF never reach here
+// (they become real model attachments); everything else is shown to the user for
+// preview/download. A caller override wins, then known audio/video/markdown
+// extensions keep their specific type, and anything else is classified as text or
+// binary by sniffing the bytes so the download and inline preview behave sensibly.
+function resolveDisplayMediaType(
   args: ReadAttachmentFromPathArgs,
-  resolvedPath: string
-): DisplayMediaTypeCandidate | null {
+  resolvedPath: string,
+  bytes: Buffer
+): string {
   const override = normalizeOptionalString(args.mediaType);
+  if (override != null) {
+    return normalizeAttachmentMediaType(override);
+  }
+
   const extension = path.extname(resolvedPath).slice(1).toLowerCase();
-  const rawMediaType = override ?? EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension];
-
-  if (rawMediaType != null) {
-    const mediaType = normalizeAttachmentMediaType(rawMediaType);
-    if (DISPLAY_ONLY_MARKDOWN_MEDIA_TYPES.has(mediaType)) {
-      return { mediaType, requireBinaryContent: false };
-    }
-    if (mediaType.startsWith("text/") || TEXT_MEDIA_TYPES_REQUIRING_FILE_READ.has(mediaType)) {
-      return null;
-    }
-    return { mediaType, requireBinaryContent: false };
+  const mapped = EXTENSION_TO_DISPLAY_MEDIA_TYPE[extension];
+  if (mapped != null) {
+    return normalizeAttachmentMediaType(mapped);
   }
 
-  if (TEXT_EXTENSIONS_REQUIRING_FILE_READ.has(extension)) {
-    return null;
-  }
-
-  return { mediaType: "application/octet-stream", requireBinaryContent: true };
+  return isLikelyTextFile(bytes) ? "text/plain" : "application/octet-stream";
 }
 
 function isLikelyTextFile(bytes: Buffer): boolean {
@@ -280,26 +231,18 @@ export async function readAttachFileFromPath(
   });
 
   if (mediaType == null) {
-    const displayMediaTypeCandidate = getDisplayFileMediaTypeCandidate(args, resolvedPath);
-    if (displayMediaTypeCandidate == null) {
-      throw createUnsupportedAttachmentError(args, resolvedPath);
-    }
+    // Not an image/SVG/PDF, so it can't be a real model attachment. Show it to the
+    // user for preview/download instead of rejecting it; the size cap still applies.
     if (fileStat.size > MAX_ATTACH_FILE_SIZE_BYTES) {
-      throw new Error(
-        `${getErrorMessage(createUnsupportedAttachmentError(args, resolvedPath))}. Could not show file to user: ${buildTooLargeMessage(fileStat.size)}`
-      );
+      throw new Error(buildTooLargeMessage(fileStat.size));
     }
 
     const bytes = await readRegularFileBytes(args, resolvedPath, fileStat.size);
-    if (displayMediaTypeCandidate.requireBinaryContent && isLikelyTextFile(bytes)) {
-      throw createUnsupportedAttachmentError(args, resolvedPath);
-    }
-
     return {
       type: "display",
       file: createLoadedFile({
         data: bytes,
-        mediaType: displayMediaTypeCandidate.mediaType,
+        mediaType: resolveDisplayMediaType(args, resolvedPath, bytes),
         filename,
         resolvedPath,
       }),


### PR DESCRIPTION
## Summary

`attach_file` now accepts any file type. Images, SVG, and PDF are still forwarded to the model as real attachments; every other file type (text, source, diffs, logs, video, audio, archives, etc.) is shown to the user in chat for preview/download while the model receives a clear notice that the contents were not forwarded.

This PR also pins the `mintlify` CLI in `check-docs-links` to unbreak `static-check-full` / the merge queue (see Background).

## Background

`attach_file` previously hard-rejected text files it could not turn into a model attachment, throwing `Unsupported attachment type`. This surfaced when an agent tried to hand the user a `.diff` file: the only workaround was renaming it to `.md` to squeeze through the markdown display-only path. The rejection was a deliberate guardrail (steer agents toward `file_read` for text contents) but it blocked the legitimate "give the user a downloadable artifact" use case for any non-markdown text file.

Separately, the merge queue's `Static Checks` job runs `make static-check-full`, which includes `check-docs-links` (regular PR CI runs only `make static-check` and skips it). That step invoked `bun x mintlify` unpinned, resolving to `mintlify@4.2.681`, whose transitive dependency `@mintlify/auth-edge@0.0.36` was unpublished from npm and now 404s. Resolution failed and the merge queue's static checks errored out even though the PR's own checks were green. This is an external breakage affecting any PR reaching `static-check-full`.

## Implementation

- `readAttachmentFromPath.ts`: the `mediaType == null` branch no longer throws. It always falls through to a display-only result after enforcing the size cap. A new `resolveDisplayMediaType` picks the media type by precedence: caller override, then known audio/video/markdown extensions, then byte-sniffing (`text/plain` vs `application/octet-stream`). The now-dead text-extension/media-type reject sets and the `requireBinaryContent` sniff-reject were removed.
- `attach_file.ts`: the display-only notice returned to the model now states plainly that only images/SVG/PDF are sent as attachments, that this file's contents were not forwarded, and to use `file_read` for contents.
- `toolDefinitions.ts`: tool description rewritten to describe the accept-any-file behavior and the two tiers.
- `Makefile`: pin `check-docs-links` to `mintlify@4.2.680` (last known-good; `4.2.681` pulls the unpublished `@mintlify/auth-edge`). Comment notes to bump once a fixed release ships.
- The 10MB size cap remains the only hard rejection. The image/SVG/PDF real-attachment path is unchanged.

## Risks

Low. The attach_file change only affects the previously-rejected branch of a single tool; the real-attachment path and size cap are untouched. Frontend rendering (`DisplayOnlyFile`) already handles arbitrary media types with a download affordance, so no UI change was needed. The Makefile pin is a version constraint on a dev/CI-only docs-links check and does not affect shipped code.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$3.46`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=3.46 -->
