### PR TITLE
🤖 fix: stamp real version in Nix flake builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,7 +111,7 @@
             # git describe/rev-parse fall back to "unknown". Feed the revision
             # the flake already resolved so the version stamp is accurate.
             export RELEASE_TAG="${version}"
-            export GIT_COMMIT="${builtins.substring 0 12 version}"
+            export MUX_GIT_COMMIT="${builtins.substring 0 12 version}"
             make SHELL=${pkgs.bash}/bin/bash build
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -107,6 +107,11 @@
           buildPhase = ''
             echo "Building mux with make..."
             export LD_LIBRARY_PATH="${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+            # Nix strips .git from the build sandbox, so generate-version.sh's
+            # git describe/rev-parse fall back to "unknown". Feed the revision
+            # the flake already resolved so the version stamp is accurate.
+            export RELEASE_TAG="${version}"
+            export GIT_COMMIT="${builtins.substring 0 12 version}"
             make SHELL=${pkgs.bash}/bin/bash build
           '';
 

--- a/scripts/generate-version.sh
+++ b/scripts/generate-version.sh
@@ -11,9 +11,11 @@ VERSION_FILE="src/version.ts"
 TMP_FILE=$(mktemp)
 trap 'rm -f "$TMP_FILE"' EXIT
 
-# Allow the environment to override GIT_COMMIT (e.g. Nix builds where .git is
+# MUX_GIT_COMMIT overrides the commit stamp (e.g. Nix builds where .git is
 # unavailable in the sandbox but the revision is known to the flake).
-GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
+# Namespaced deliberately: plain GIT_COMMIT is exported ambiently by some CI
+# systems (Jenkins) and could pair a stale commit with HEAD's describe.
+GIT_COMMIT="${MUX_GIT_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 if [ -n "${RELEASE_TAG:-}" ]; then

--- a/scripts/generate-version.sh
+++ b/scripts/generate-version.sh
@@ -11,7 +11,9 @@ VERSION_FILE="src/version.ts"
 TMP_FILE=$(mktemp)
 trap 'rm -f "$TMP_FILE"' EXIT
 
-GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+# Allow the environment to override GIT_COMMIT (e.g. Nix builds where .git is
+# unavailable in the sandbox but the revision is known to the flake).
+GIT_COMMIT="${GIT_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")}"
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 if [ -n "${RELEASE_TAG:-}" ]; then


### PR DESCRIPTION
## Summary

Nix flake builds displayed `unknown` as the app version (top-left title bar and About dialog) because the version stamp could never be computed inside the build sandbox. This feeds the revision the flake already knows into the build so the version is stamped correctly.

## Background

The version shown in the UI comes from `src/version.ts`, which is generated at build time by `scripts/generate-version.sh` using `git describe --tags --always --dirty` and `git rev-parse --short HEAD`. Both fall back to the literal string `"unknown"` when the git commands fail.

Nix copies only git-tracked files into the build sandbox and strips the `.git` directory, so those git commands have no repository to read and both fall back to `"unknown"`. Having `git` in `nativeBuildInputs` only provides the binary, not the repo metadata, so it doesn't help.

Ironically the flake already computes the revision (`version = self.rev or self.dirtyRev or "dev"`) but never passed it into the build, so that value was discarded before the script ran.

## Implementation

The version script already supports a `RELEASE_TAG` override that skips the git calls and sets `git_describe` directly (used by CI release builds). The flake's `buildPhase` now exports that revision:

- `RELEASE_TAG="${version}"` sets `git_describe`.
- `GIT_COMMIT="${builtins.substring 0 12 version}"` sets the commit field via a new override.

`generate-version.sh` now honors an incoming `GIT_COMMIT` env var, keeping the git-based default when it's unset so non-Nix builds are unchanged.

## Risks

Low. The change only affects build-time version stamping. Non-Nix builds keep their existing git-based behavior (the `GIT_COMMIT` default is unchanged when the env var is unset), and the script's `unknown` fallback still applies when neither git nor overrides are available.

One cosmetic note: Nix dev builds now log `Release build: using RELEASE_TAG=...` in build output, which is slightly misleading but harmless.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$1.11`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=1.11 -->
