### PR TITLE
🤖 fix: sidebar not updating when pin chat doesn't reorder rows

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1692,6 +1692,19 @@ describe("WorkspaceStore", () => {
       expect(global.window.localStorage.getItem(autoRetryKey)).toBeNull();
     });
 
+    it("refreshes metadata for existing workspaces", () => {
+      const metadata = makeWorkspaceMetadata("workspace-1");
+      store.syncWorkspaces(new Map([[metadata.id, metadata]]));
+      expect(store.getWorkspaceMetadata("workspace-1")?.pinnedAt).toBeUndefined();
+
+      // Same workspace id, updated field (e.g. pinned after initial load).
+      // Imperative readers like the pin keybind must see the fresh value.
+      const pinned = { ...metadata, pinnedAt: "2026-01-01T00:00:00.000Z" };
+      store.syncWorkspaces(new Map([[pinned.id, pinned]]));
+
+      expect(store.getWorkspaceMetadata("workspace-1")?.pinnedAt).toBe("2026-01-01T00:00:00.000Z");
+    });
+
     it("should remove deleted workspaces", () => {
       createAndAddWorkspace(
         store,

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -3848,10 +3848,14 @@ export class WorkspaceStore {
     const metadataIds = new Set(Array.from(workspaceMetadata.values()).map((m) => m.id));
     const currentIds = new Set(this.workspaceMetadata.keys());
 
-    // Add new workspaces
+    // Add new workspaces; refresh the metadata snapshot for existing ones so
+    // imperative readers (getWorkspaceMetadata) don't act on stale fields
+    // (e.g. the pin keybind toggling off a pinnedAt set after initial load).
     for (const metadata of workspaceMetadata.values()) {
       if (!currentIds.has(metadata.id)) {
         this.addWorkspace(metadata);
+      } else {
+        this.workspaceMetadata.set(metadata.id, metadata);
       }
     }
 

--- a/src/browser/utils/workspace.test.ts
+++ b/src/browser/utils/workspace.test.ts
@@ -26,6 +26,16 @@ describe("getWorkspaceSidebarKey", () => {
     expect(getWorkspaceSidebarKey(running)).not.toBe(getWorkspaceSidebarKey(reported));
   });
 
+  // Pinning may not change sidebar row order (new pins append at the bottom of
+  // the pinned block), so the key itself must change or the sidebar never
+  // re-renders and the pin appears to do nothing.
+  test("changes when pinnedAt changes", () => {
+    const unpinned = createWorkspaceMeta();
+    const pinned = createWorkspaceMeta({ pinnedAt: "2026-01-01T00:00:00.000Z" });
+
+    expect(getWorkspaceSidebarKey(unpinned)).not.toBe(getWorkspaceSidebarKey(pinned));
+  });
+
   test("changes when heartbeat enabled changes", () => {
     const disabled = createWorkspaceMeta({
       heartbeat: {

--- a/src/browser/utils/workspace.ts
+++ b/src/browser/utils/workspace.ts
@@ -19,6 +19,7 @@ export function getWorkspaceSidebarKey(meta: FrontendWorkspaceMetadata): string 
     initKey,
     removingKey,
     heartbeatEnabledKey, // Heartbeat icon replaces the seen-state archive affordance in the sidebar.
+    meta.pinnedAt ?? "", // Pin icon + pinned-first ordering; pinning may not change row order
     meta.parentWorkspaceId ?? "", // Nested sidebar indentation/order
     meta.taskStatus ?? "", // Task lifecycle label/state for sub-agent rows
     meta.agentType ?? "", // Agent preset badge/label (future)


### PR DESCRIPTION
## Summary

Pinning a chat persisted `pinnedAt` on the backend but the sidebar often showed no change: no pin icon, row menu stuck on "Pin chat", and `Ctrl+Alt+P` could not unpin.

## Background

Follow-up to #3683. The bug triggers whenever pinning does not reorder rows, which is common: new pins append at the bottom of the pinned block, so pinning the row directly below it (or the only row in a project) is an order no-op.

Two causes:

1. `getWorkspaceSidebarKey()` omitted `pinnedAt`, so `useStableReference` in `App.tsx` kept the stale `sortedWorkspacesByProject` map whenever pin state changed without changing order.
2. `WorkspaceStore.syncWorkspaces()` never refreshed metadata for existing workspaces, so the `Ctrl+Alt+P` keybind read a stale `pinnedAt` and kept re-sending `pinned=true` instead of toggling.

## Implementation

- Add `pinnedAt` to the sidebar key in `src/browser/utils/workspace.ts`.
- Refresh metadata for existing workspaces in `WorkspaceStore.syncWorkspaces()` so keybind toggles read current pin state.

## Validation

- Unit tests added for both causes (sidebar key changes with `pinnedAt`; `syncWorkspaces` refreshes existing metadata).
- Verified live twice against the sole-workspace repro (zero reorder): once via dev-server sandbox, and once end-to-end over the production remote path (Docker container, HTTP + WS, second observer client with no optimistic update). Pre-fix build reproduces the bug; this build shows the pin icon instantly in both acting and observer clients, and `Ctrl+Alt+P` toggles both ways with `config.json` following each toggle.

## Risks

Low. `syncWorkspaces` now replaces metadata for existing workspaces on every sync; this is the same data the backend just sent, so the only behavior change is dropping stale local copies. Sidebar keys gain one field, which can only invalidate a memoized map that should have been invalidated.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$42.07`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=42.07 -->
