### PR TITLE
🤖 feat: show command and monitor info in background bash output dialog

### DIFF
--- a/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
+++ b/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { CopyButton } from "../CopyButton/CopyButton";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../Dialog/Dialog";
-import {
-  DetailContent,
-  DetailLabel,
-  DetailSection,
-} from "@/browser/features/Tools/Shared/ToolPrimitives";
+import { DetailContent } from "@/browser/features/Tools/Shared/ToolPrimitives";
 import { useAPI } from "@/browser/contexts/API";
 import { useBackgroundProcesses } from "@/browser/stores/BackgroundBashStore";
 import {
@@ -29,7 +25,7 @@ interface BackgroundBashOutputDialogProps {
 
 export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProps> = (props) => (
   <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-    <DialogContent className="max-h-[80vh] max-w-4xl overflow-hidden">
+    <DialogContent className="max-h-[80vh] max-w-4xl gap-3 overflow-hidden">
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <span className="font-mono text-sm">{props.displayName ?? props.processId}</span>
@@ -39,52 +35,29 @@ export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProp
             </code>
           )}
         </DialogTitle>
+        {/* The script sits right under the title (no label) so the user can tell what
+            the process is doing without a full labeled section eating vertical space. */}
+        {props.script && (
+          <DetailContent className="max-h-24 px-2 py-1">{props.script}</DetailContent>
+        )}
       </DialogHeader>
-
-      {props.script && (
-        <DetailSection>
-          <DetailLabel>Command</DetailLabel>
-          <DetailContent className="max-h-32 px-2 py-1.5">{props.script}</DetailContent>
-        </DetailSection>
-      )}
-
-      <BackgroundBashMonitorSection workspaceId={props.workspaceId} processId={props.processId} />
 
       <BackgroundBashOutputViewer workspaceId={props.workspaceId} processId={props.processId} />
     </DialogContent>
   </Dialog>
 );
 
-/**
- * Live monitor info (wake-on-match regex + match count) for the process, looked up
- * from the store so it stays current while the dialog is open. Rendered as its own
- * component (mounted only while the dialog is open) so tool cards that keep the
- * dialog closed don't hold a background-bash subscription.
- */
-const BackgroundBashMonitorSection: React.FC<{ workspaceId: string; processId: string }> = (
-  props
-) => {
-  const processes = useBackgroundProcesses(props.workspaceId);
-  const monitor = processes.find((p) => p.id === props.processId)?.monitor;
-
-  if (!monitor) return null;
-
-  return (
-    <DetailSection>
-      <DetailLabel>Monitor</DetailLabel>
-      <DetailContent className="px-2 py-1.5">
-        {monitor.filter_exclude ? "waking on lines not matching" : "waking on lines matching"} /
-        {monitor.filter}/ · {monitor.totalMatches} match{monitor.totalMatches === 1 ? "" : "es"}
-        {monitor.stopped ? " · stopped" : ""}
-      </DetailContent>
-    </DetailSection>
-  );
-};
-
 const BackgroundBashOutputViewer: React.FC<{ workspaceId: string; processId: string }> = (
   props
 ) => {
   const { api } = useAPI();
+
+  // Live wake-on-match monitor info, folded into the status row (banner-style
+  // phrasing) so it costs no extra vertical space. Looked up from the store so
+  // the match count stays current while the dialog is open; the viewer is only
+  // mounted while open, so closed tool cards hold no subscription.
+  const processes = useBackgroundProcesses(props.workspaceId);
+  const monitor = processes.find((p) => p.id === props.processId)?.monitor;
 
   const [output, setOutput] = useState<LiveBashOutputInternal | undefined>(undefined);
   const [status, setStatus] = useState<"running" | "exited" | "killed" | "failed">("running");
@@ -172,7 +145,17 @@ const BackgroundBashOutputViewer: React.FC<{ workspaceId: string; processId: str
   return (
     <div className="flex min-h-0 flex-col gap-2 overflow-hidden">
       <div className="flex items-center justify-between gap-3">
-        <div className="text-muted font-mono text-[11px]">status: {status}</div>
+        <div className="text-muted min-w-0 flex-1 truncate font-mono text-[11px]">
+          status: {status}
+          {monitor && (
+            <>
+              {" · watching "}
+              {monitor.filter_exclude && "not "}/{monitor.filter}/ · {monitor.totalMatches} match
+              {monitor.totalMatches === 1 ? "" : "es"}
+              {monitor.stopped && " · stopped"}
+            </>
+          )}
+        </div>
         <CopyButton text={text} className="h-6" />
       </div>
 

--- a/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
+++ b/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
@@ -25,7 +25,10 @@ interface BackgroundBashOutputDialogProps {
 
 export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProps> = (props) => (
   <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-    <DialogContent className="max-h-[80vh] max-w-4xl gap-3 overflow-hidden">
+    {/* flex-col (not the default grid) so the output viewer shrinks when the
+        header + script push total content past max-h; otherwise overflow-hidden
+        would clip the bottom of the output pane at small window heights. */}
+    <DialogContent className="flex max-h-[80vh] max-w-4xl flex-col gap-3 overflow-hidden">
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
           <span className="font-mono text-sm">{props.displayName ?? props.processId}</span>
@@ -171,7 +174,12 @@ const BackgroundBashOutputViewer: React.FC<{ workspaceId: string; processId: str
 
       {error && <div className="text-error text-[11px]">{error}</div>}
 
-      <DetailContent className="max-h-[60vh] min-h-[200px] px-2 py-1.5">
+      {/* flex-1 + max-h-none: fill whatever height remains inside the dialog's
+          80vh cap and scroll internally, instead of a fixed 60vh that could
+          overflow the dialog once the header/script take their share. The small
+          min-h keeps a visible pane for "No output yet" while still letting very
+          short windows shrink it instead of clipping it at the dialog edge. */}
+      <DetailContent className="max-h-none min-h-24 flex-1 px-2 py-1.5">
         {isLoading ? "Loading…" : text.length > 0 ? text : error ? "" : "No output yet"}
       </DetailContent>
     </div>

--- a/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
+++ b/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useState } from "react";
 import { CopyButton } from "../CopyButton/CopyButton";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../Dialog/Dialog";
-import { DetailContent } from "@/browser/features/Tools/Shared/ToolPrimitives";
+import {
+  DetailContent,
+  DetailLabel,
+  DetailSection,
+} from "@/browser/features/Tools/Shared/ToolPrimitives";
 import { useAPI } from "@/browser/contexts/API";
 import {
   appendLiveBashOutputChunk,
@@ -18,6 +22,8 @@ interface BackgroundBashOutputDialogProps {
   workspaceId: string;
   processId: string;
   displayName?: string;
+  /** The bash script being run, shown so the user can tell what the process is doing. */
+  script?: string;
 }
 
 export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProps> = (props) => (
@@ -33,6 +39,13 @@ export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProp
           )}
         </DialogTitle>
       </DialogHeader>
+
+      {props.script && (
+        <DetailSection>
+          <DetailLabel>Command</DetailLabel>
+          <DetailContent className="max-h-32 px-2 py-1.5">{props.script}</DetailContent>
+        </DetailSection>
+      )}
 
       <BackgroundBashOutputViewer workspaceId={props.workspaceId} processId={props.processId} />
     </DialogContent>

--- a/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
+++ b/src/browser/components/BackgroundBashOutputDialog/BackgroundBashOutputDialog.tsx
@@ -7,6 +7,7 @@ import {
   DetailSection,
 } from "@/browser/features/Tools/Shared/ToolPrimitives";
 import { useAPI } from "@/browser/contexts/API";
+import { useBackgroundProcesses } from "@/browser/stores/BackgroundBashStore";
 import {
   appendLiveBashOutputChunk,
   type LiveBashOutputInternal,
@@ -47,10 +48,38 @@ export const BackgroundBashOutputDialog: React.FC<BackgroundBashOutputDialogProp
         </DetailSection>
       )}
 
+      <BackgroundBashMonitorSection workspaceId={props.workspaceId} processId={props.processId} />
+
       <BackgroundBashOutputViewer workspaceId={props.workspaceId} processId={props.processId} />
     </DialogContent>
   </Dialog>
 );
+
+/**
+ * Live monitor info (wake-on-match regex + match count) for the process, looked up
+ * from the store so it stays current while the dialog is open. Rendered as its own
+ * component (mounted only while the dialog is open) so tool cards that keep the
+ * dialog closed don't hold a background-bash subscription.
+ */
+const BackgroundBashMonitorSection: React.FC<{ workspaceId: string; processId: string }> = (
+  props
+) => {
+  const processes = useBackgroundProcesses(props.workspaceId);
+  const monitor = processes.find((p) => p.id === props.processId)?.monitor;
+
+  if (!monitor) return null;
+
+  return (
+    <DetailSection>
+      <DetailLabel>Monitor</DetailLabel>
+      <DetailContent className="px-2 py-1.5">
+        {monitor.filter_exclude ? "waking on lines not matching" : "waking on lines matching"} /
+        {monitor.filter}/ · {monitor.totalMatches} match{monitor.totalMatches === 1 ? "" : "es"}
+        {monitor.stopped ? " · stopped" : ""}
+      </DetailContent>
+    </DetailSection>
+  );
+};
 
 const BackgroundBashOutputViewer: React.FC<{ workspaceId: string; processId: string }> = (
   props

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
@@ -44,7 +44,10 @@ export const BackgroundProcesses: AppStory = {
             {
               id: "bash_1",
               pid: 12345,
-              script: "npm run dev",
+              // Multi-line script: exercises the dialog's capped command block
+              // together with tall output at small window heights.
+              script:
+                "export NODE_ENV=development\nexport PORT=3000\nnpm run dev -- --host 0.0.0.0 --port $PORT",
               displayName: "Dev Server",
               startTime: Date.now() - 45000, // 45 seconds ago
               monitor: {

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -174,6 +174,7 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
           workspaceId={props.workspaceId}
           processId={viewingProcessId}
           displayName={viewingProcess?.displayName}
+          script={viewingProcess?.script}
         />
       )}
     </>

--- a/src/browser/features/Tools/BashToolCall.tsx
+++ b/src/browser/features/Tools/BashToolCall.tsx
@@ -252,6 +252,7 @@ export const BashToolCall: React.FC<BashToolCallProps> = ({
           workspaceId={workspaceId}
           processId={backgroundProcessId}
           displayName={args.display_name}
+          script={args.script}
         />
       )}
 

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -1631,11 +1631,25 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
           await new Promise<void>(() => undefined);
         },
         terminate: () => Promise.resolve({ success: true, data: undefined }),
-        getOutput: () =>
-          Promise.resolve({
+        getOutput: (input: { fromOffset?: number }) => {
+          // Return sample output on the initial tail read only; follow-up polls
+          // (fromOffset set) return nothing so the dialog doesn't grow forever.
+          const sample =
+            input.fromOffset === undefined
+              ? Array.from({ length: 120 }, (_, i) => `[dev] GET /api/items/${i} 200 in 12ms`).join(
+                  "\n"
+                )
+              : "";
+          return Promise.resolve({
             success: true,
-            data: { status: "running" as const, output: "", nextOffset: 0, truncatedStart: false },
-          }),
+            data: {
+              status: "running" as const,
+              output: sample,
+              nextOffset: sample.length,
+              truncatedStart: false,
+            },
+          });
+        },
         sendToBackground: () => Promise.resolve({ success: true, data: undefined }),
       },
       stats: {


### PR DESCRIPTION
## Summary

The background bash output dialog (opened from the "N background bashes" banner or a backgrounded bash tool card) only showed a display name, status, and output — making it hard to tell what a process was actually doing, especially while it had produced no output yet. The dialog now shows the running command and, when present, the wake-on-match monitor regex with its live match count.

## Background

A long-running monitored bash (e.g. a PR watch loop) often sits at "No output yet" for minutes. Without the script or the monitor filter visible, the dialog gave no clue what the process was or what would wake the agent.

## Implementation

- `BackgroundBashOutputDialog` accepts an optional `script` prop, rendered as an unlabeled code block directly under the title (capped height, scrollable) to keep vertical chrome minimal.
- Monitor info is folded into the existing status row using the banner's phrasing — `status: running · watching /regex/ · N matches` (plus `not` for exclude filters and `· stopped` when monitoring ended) — costing no extra vertical space. It's looked up live from `BackgroundBashStore` by `workspaceId`/`processId`, so the match count updates while the dialog is open; the subscription only exists while the dialog is mounted.
- Both call sites pass the script: the background-processes banner (`proc.script`) and the bash tool card (`args.script`).

## Validation

Dogfooded in Storybook (`App/Chat/Components/BackgroundProcesses`) via agent-browser: verified the monitored process shows command + `watching /FAILED|ERROR/ · 2 matches` in the status row, and a monitor-less process shows just `status: running` with no stray separators.

## Risks

Low — display-only changes to one dialog; no behavioral changes to process management, polling, or IPC.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$12.51`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=12.51 -->
