### PR TITLE
🤖 fix: gate bash monitor wake delivery on the settled shown-frontier

### DIFF
--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -789,6 +789,77 @@ describe("BackgroundProcessManager", () => {
     });
   });
 
+  describe("getSettledShownThroughOffset", () => {
+    it("resolves to the advanced frontier only after an in-flight unfiltered read settles", async () => {
+      // Delay output so the unfiltered read is observably in flight (long-polling) when we query the
+      // frontier. getSettledShownThroughOffset must await that read and return the post-read offset,
+      // never the stale pre-read 0 -- this is what lets the drain gate see a settled frontier.
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "sleep 0.5; printf 'line\\n'; sleep 3",
+        { cwd: process.cwd(), displayName: "settled-unfiltered" }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const readPromise = manager.getOutput(result.processId, undefined, false, 2);
+
+      // Wait until the read is in flight (tracker set); the frontier has not advanced yet.
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 200; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if (proc?.unfilteredReadSettled) break;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(proc?.unfilteredReadSettled).toBeDefined();
+      expect(proc?.shownThroughOffset ?? -1).toBe(0);
+
+      const settled = await manager.getSettledShownThroughOffset(result.processId);
+      const read = await readPromise;
+      expect(read.success).toBe(true);
+      // "line\n" is 5 bytes; the settled frontier reflects the completed read, not the stale 0.
+      expect(settled).toBe(5);
+    });
+
+    it("does not block on an in-flight filtered read", async () => {
+      // A filtered read with no matching output long-polls, holding outputLock. Filtered reads never
+      // advance shownThroughOffset, so the frontier query must return immediately rather than wait
+      // out the read's timeout.
+      const result = await manager.spawn(runtime, testWorkspaceId, "sleep 3", {
+        cwd: process.cwd(),
+        displayName: "settled-filtered",
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const filteredRead = manager.getOutput(result.processId, "NOMATCH", false, 2);
+      const start = Date.now();
+      const settled = await manager.getSettledShownThroughOffset(result.processId);
+      expect(Date.now() - start).toBeLessThan(500);
+      expect(settled).toBe(0);
+
+      await manager.terminate(result.processId);
+      await filteredRead;
+    });
+
+    it("emits matchedThroughOffset on the monitor:match payload", async () => {
+      const eventPromise = waitForMonitorMatch(manager);
+      const result = await manager.spawn(runtime, testWorkspaceId, "printf 'FAILED\\n'", {
+        cwd: process.cwd(),
+        displayName: "monitor-payload-offset",
+        monitor: { filter: "FAILED", pattern: /FAILED/, exclude: false, cooldownMs: 0 },
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const event = await eventPromise;
+      expect(event.payload.lines).toEqual(["FAILED"]);
+      // End of "FAILED\n" (6 chars + newline).
+      expect(event.payload.matchedThroughOffset).toBe(7);
+    });
+  });
+
   describe("getProcess", () => {
     it("should return process by ID", async () => {
       const spawnResult = await manager.spawn(runtime, testWorkspaceId, "sleep 1", {

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -896,6 +896,39 @@ describe("BackgroundProcessManager", () => {
       // End of "FAILED\n" (6 chars + newline).
       expect(event.payload.matchedThroughOffset).toBe(7);
     });
+
+    it("returns undefined when the live process started after the wake's origin (reused ID)", async () => {
+      // Process IDs are display-name-derived and reclaimed after a restart, so a pending wake for a
+      // dead instance could otherwise be answered with an unrelated newer process's frontier. The
+      // caller passes the wake record's createdAt: the originating instance necessarily started
+      // before its first match created the record, so a live process whose startTime is *after*
+      // createdAt reused the ID and the query returns undefined -- the drain then fails open.
+      const result = await manager.spawn(runtime, testWorkspaceId, "printf 'x\\n'; sleep 3", {
+        cwd: process.cwd(),
+        displayName: "reused-id",
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const proc = await manager.getProcess(result.processId);
+      const liveStartTime = proc?.startTime ?? 0;
+      expect(liveStartTime).toBeGreaterThan(0);
+
+      // Origin created at/after this instance started -> the real frontier (0 here, nothing read).
+      expect(await manager.getSettledShownThroughOffset(result.processId, liveStartTime)).toBe(0);
+      expect(
+        await manager.getSettledShownThroughOffset(result.processId, liveStartTime + 1000)
+      ).toBe(0);
+      // Origin predates this instance -> a reused ID from a newer process, so undefined and the
+      // prior instance's wake is never wrongly superseded.
+      expect(
+        await manager.getSettledShownThroughOffset(result.processId, liveStartTime - 1)
+      ).toBeUndefined();
+      // No origin bound -> unconditional frontier, preserving the legacy-record fail path.
+      expect(await manager.getSettledShownThroughOffset(result.processId)).toBe(0);
+
+      await manager.terminate(result.processId);
+    });
   });
 
   describe("getProcess", () => {

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -707,6 +707,44 @@ describe("BackgroundProcessManager", () => {
       manager.off("monitor:match", handler);
     });
 
+    it("does not advance the shown frontier across lines a prior filtered read consumed", async () => {
+      // Regression for the drain-time suppression edge case Codex flagged: outputBytesRead is a
+      // shared cursor, so a filtered read that consumes a matched complete line (without ever
+      // showing it) advances the cursor past that line while leaving shownThroughOffset behind. A
+      // later unfiltered read with no new output must not let the frontier jump that gap -- else
+      // getSettledShownThroughOffset would report the filtered-out line as shown and the drain gate
+      // would supersede the only wake for output the agent never saw.
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "printf 'ERR boom\\nDONE\\n'; sleep 5",
+        { cwd: process.cwd(), displayName: "frontier-gap-filtered" }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Filtered read consumes both complete lines (cursor advances to 14) but shows only "DONE".
+      const filtered = await manager.getOutput(result.processId, "DONE", false, 2);
+      expect(filtered.success).toBe(true);
+      if (filtered.success) {
+        expect(filtered.output).toContain("DONE");
+        expect(filtered.output).not.toContain("ERR boom");
+      }
+      let proc = await manager.getProcess(result.processId);
+      expect(proc?.outputBytesRead ?? 0).toBeGreaterThanOrEqual(14);
+      expect(proc?.shownThroughOffset ?? -1).toBe(0);
+
+      // Unfiltered read finds no new output; the contiguity guard must keep the frontier pinned.
+      const unfiltered = await manager.getOutput(result.processId, undefined, false, 1);
+      expect(unfiltered.success).toBe(true);
+      proc = await manager.getProcess(result.processId);
+      expect(proc?.shownThroughOffset ?? -1).toBe(0);
+      // The delivery gate therefore still treats the filtered-out ERR line as unshown.
+      expect(await manager.getSettledShownThroughOffset(result.processId)).toBe(0);
+
+      await manager.terminate(result.processId);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -77,6 +77,12 @@ export interface MonitorMatchPayload {
   totalMatches: number;
   droppedLines?: number;
   timestamp: number;
+  /**
+   * File byte offset at the end of the last matched line, carried so the drain can re-check it
+   * against the settled shown-frontier at delivery time. The emit-time suppression in
+   * emitMonitorMatch is only a point-in-time fast path; drainBashMonitorWakes is authoritative.
+   */
+  matchedThroughOffset: number;
 }
 
 /** Emitted when a spawn arms a monitor; drives the persisted armed-monitor registry. */
@@ -145,6 +151,15 @@ export interface BackgroundProcess {
    * the monitor's matchedThroughOffset are absolute file offsets, so suppression is race-free.
    */
   shownThroughOffset: number;
+  /**
+   * Resolves when the current in-flight *unfiltered* getOutput read settles (i.e. after it has
+   * advanced shownThroughOffset and returned). undefined when no unfiltered read is in flight.
+   * getSettledShownThroughOffset awaits this so the drain gate reads a settled frontier instead of
+   * racing a concurrent task_await. Filtered reads are deliberately not tracked here: they never
+   * advance shownThroughOffset and a filtered long-poll can hold the lock for the full timeout, so
+   * waiting on them would stall wake delivery for nothing.
+   */
+  unfilteredReadSettled?: Promise<void>;
   /** Mutex to serialize getOutput() calls (prevents race condition when
    * parallel tool calls read from same offset before position is updated) */
   outputLock: AsyncMutex;
@@ -318,14 +333,15 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       monitor.flushTimer = undefined;
     }
 
-    // Don't wake the agent about output it has already been shown. shownThroughOffset is the file
-    // position an unfiltered task_await / bash_output read has delivered complete lines through;
-    // matchedThroughOffset is where the matched line ends. Both are absolute file offsets, so this
-    // is order-independent (no race between the reader and the monitor). If the agent was shown
-    // through the match, a wake would only double-report it (e.g. a concurrent task_await that just
-    // returned the same line), so drop. Anything still beyond the shown mark -- a filtered-out
-    // match (filtered reads never advance the mark), a line still buffered unterminated (matched
-    // only on exit), or genuinely new output -- stays above it and still wakes.
+    // Fast-path drop: don't even emit a wake for output the agent has already been shown.
+    // shownThroughOffset is the file position an unfiltered task_await / bash_output read has
+    // delivered complete lines through; matchedThroughOffset is where the matched line ends. Both
+    // are absolute file offsets, so this is order-independent. This check is only a point-in-time
+    // optimization -- it suppresses the common cooldown-deferred case with zero store I/O. It can
+    // still race a concurrent task_await that advances shownThroughOffset just after this flush
+    // (e.g. a process that prints its final line then exits, triggering an immediate exit flush).
+    // drainBashMonitorWakes re-checks matchedThroughOffset against the settled frontier at delivery
+    // time and is the authoritative suppression point; this is the cheap early-out ahead of it.
     if (proc.shownThroughOffset >= monitor.matchedThroughOffset) {
       monitor.pendingLines = [];
       monitor.droppedLines = 0;
@@ -348,6 +364,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       totalMatches: monitor.matchesCount,
       ...(droppedLines > 0 ? { droppedLines } : {}),
       timestamp: Date.now(),
+      matchedThroughOffset: monitor.matchedThroughOffset,
     });
     this.emitChange(proc.workspaceId);
   }
@@ -971,6 +988,50 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
   }
 
   /**
+   * Register an in-flight unfiltered read on the process and return a disposable that resolves +
+   * clears it when the read settles. Filtered reads get an inert disposable: they never advance the
+   * shown frontier, so wake delivery must not wait on them. See BackgroundProcess.unfilteredReadSettled.
+   */
+  private trackUnfilteredRead(proc: BackgroundProcess, filter: string | undefined): Disposable {
+    if (filter) {
+      // Filtered read: nothing to track, so the disposable is a no-op.
+      return { [Symbol.dispose]: () => undefined };
+    }
+    let resolve!: () => void;
+    const settled = new Promise<void>((r) => {
+      resolve = r;
+    });
+    proc.unfilteredReadSettled = settled;
+    return {
+      [Symbol.dispose]: () => {
+        // A later read only starts after this one releases outputLock, so the field is still ours.
+        if (proc.unfilteredReadSettled === settled) {
+          proc.unfilteredReadSettled = undefined;
+        }
+        resolve();
+      },
+    };
+  }
+
+  /**
+   * The shown-frontier (shownThroughOffset) after any in-flight unfiltered read settles. Used by
+   * drainBashMonitorWakes to decide, at delivery time, whether a monitor match has already been
+   * shown to the agent by a concurrent task_await. Returns undefined for an unknown process so the
+   * drain fails open (delivers the wake) rather than silently dropping it.
+   */
+  async getSettledShownThroughOffset(processId: string): Promise<number | undefined> {
+    const proc = await this.getProcess(processId);
+    if (!proc) return undefined;
+    // Await the current unfiltered read (if any). The matched output already exists on disk, so an
+    // unfiltered long-poll picks it up on its first iteration and returns promptly -- this does not
+    // hang on an idle process (no read in flight => field is undefined).
+    if (proc.unfilteredReadSettled) {
+      await proc.unfilteredReadSettled;
+    }
+    return proc.shownThroughOffset;
+  }
+
+  /**
    * Get incremental output from a background process.
    * Returns only NEW output since the last call (tracked per process).
    * @param processId Process ID to get output from
@@ -1019,6 +1080,12 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     // This prevents race conditions where parallel tool calls both read from
     // the same offset before either updates the read position.
     await using _lock = await proc.outputLock.acquire();
+
+    // Register this read so the wake drain (getSettledShownThroughOffset) can await it before
+    // reading the shown-frontier, closing the race where a monitor exit-flush emits a wake for the
+    // same final line a concurrent task_await is still delivering. Filtered reads return an inert
+    // tracker: they never advance shownThroughOffset, so wake delivery must not block on them.
+    using _readTracker = this.trackUnfilteredRead(proc, filter);
 
     // Track call count for polling detection
     proc.getOutputCallCount++;

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -1124,6 +1124,10 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
 
     // Track the previous buffer to prepend to accumulated output
     const previousBuffer = proc.incompleteLineBuffer;
+    // File offset where this read's processable content begins (start cursor minus the buffered
+    // fragment that cursor already advanced past). Used below to detect a gap left by a prior
+    // filtered read so the shown-frontier never jumps over lines this read never showed.
+    const readStartOffset = proc.outputBytesRead;
 
     while (true) {
       // Read new content via the handle (works for both local and SSH runtimes)
@@ -1259,10 +1263,20 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     // dropped matched lines, so it must not count as having shown them. End-of-last-complete-line =
     // read cursor minus the trailing fragment we just buffered (cleared, hence 0, on exit). Offsets
     // only grow; Math.max guards against any out-of-order/partial call regressing the mark.
+    //
+    // Contiguity guard: outputBytesRead is a shared cursor that *filtered* reads also advance while
+    // dropping non-matching complete lines. If a prior filtered read consumed lines past our last
+    // shown frontier, this read starts beyond that frontier (shownRegionStart > shownThroughOffset)
+    // and those skipped lines were never shown to the agent. Advancing across that gap would let a
+    // wake for filtered-out output be wrongly suppressed, so only advance when this read's content
+    // is contiguous with the frontier. A gap pins the frontier low (safe: it can only over-wake).
     if (!filter) {
-      const shownThrough =
-        proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
-      proc.shownThroughOffset = Math.max(proc.shownThroughOffset, shownThrough);
+      const shownRegionStart = readStartOffset - Buffer.byteLength(previousBuffer, "utf8");
+      if (shownRegionStart <= proc.shownThroughOffset) {
+        const shownThrough =
+          proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
+        proc.shownThroughOffset = Math.max(proc.shownThroughOffset, shownThrough);
+      }
     }
 
     log.debug(

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -1018,10 +1018,21 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
    * drainBashMonitorWakes to decide, at delivery time, whether a monitor match has already been
    * shown to the agent by a concurrent task_await. Returns undefined for an unknown process so the
    * drain fails open (delivers the wake) rather than silently dropping it.
+   *
+   * `originNotAfterMs` binds the answer to the process instance that produced the wake. Process
+   * IDs are derived from display_name and reclaimed across restarts, so a pending wake for a dead
+   * instance could otherwise be superseded by a newer process's frontier. Callers pass the wake
+   * record's createdAt: the originating instance necessarily started before its first match created
+   * the record, so an instance whose startTime is after createdAt reused the ID and we return
+   * undefined (fail open) rather than let it suppress the prior instance's undelivered output.
    */
-  async getSettledShownThroughOffset(processId: string): Promise<number | undefined> {
+  async getSettledShownThroughOffset(
+    processId: string,
+    originNotAfterMs?: number
+  ): Promise<number | undefined> {
     const proc = await this.getProcess(processId);
     if (!proc) return undefined;
+    if (originNotAfterMs != null && proc.startTime > originNotAfterMs) return undefined;
     // Await the current unfiltered read (if any). The matched output already exists on disk, so an
     // unfiltered long-poll picks it up on its first iteration and returns promptly -- this does not
     // hang on an idle process (no read in flight => field is undefined).

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -69,6 +69,33 @@ describe("BashMonitorWakeStore", () => {
     expect(pending[0].totalMatches).toBe(2);
   });
 
+  test("merge advances the matched offset to the newest match", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR one"], matchedThroughOffset: 50 }));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR two"], matchedThroughOffset: 80 }));
+
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR one", "ERROR two"]);
+    expect(pending[0].matchedThroughOffset).toBe(80);
+  });
+
+  test("merge takes the max offset even if a later enqueue reports a smaller one", async () => {
+    // Offsets only grow, so Math.max is defensive against out-of-order enqueues. Cross-generation
+    // fail-open (a restart reused this display-name-derived ID) is no longer handled here by
+    // clearing the offset -- the drain gate binds its check to the record's createdAt, so a newer
+    // instance fails that check and the whole record delivers. See the drain-gate coverage in
+    // workspaceService.test.ts and the createdAt guard in backgroundProcessManager.test.ts.
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["OLD fail"], matchedThroughOffset: 50 }));
+    const merged = await store.enqueueOrMergePending(
+      payload({ lines: ["NEW fail"], matchedThroughOffset: 40 })
+    );
+
+    expect(merged.lines).toEqual(["OLD fail", "NEW fail"]);
+    expect(merged.matchedThroughOffset).toBe(50);
+  });
+
   test("delivered records allow later pending wakes for the same process", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     const first = await store.enqueueOrMergePending(payload({ lines: ["ERROR one"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -28,6 +28,7 @@ function payload(overrides: Partial<BashMonitorWakePayload> = {}): BashMonitorWa
     lines: ["ERROR one"],
     totalMatches: 1,
     timestamp: Date.now(),
+    matchedThroughOffset: 0,
     ...overrides,
   };
 }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -40,6 +40,8 @@ export interface BashMonitorWakePayload {
   totalMatches: number;
   droppedLines?: number;
   timestamp: number;
+  /** File byte offset at the end of the last matched line; see BashMonitorWakeRecord. */
+  matchedThroughOffset: number;
 }
 
 /**
@@ -71,6 +73,13 @@ export interface BashMonitorWakeRecord {
   lines: string[];
   totalMatches: number;
   droppedLines: number;
+  /**
+   * File byte offset at the end of the last matched line (match records only). drainBashMonitorWakes
+   * re-checks this against the settled shown-frontier at delivery time so a wake never re-reports
+   * output a concurrent task_await already showed the agent. Optional so pending records written
+   * before this field existed keep parsing under `.strict()` (they deliver as before -- fail open).
+   */
+  matchedThroughOffset?: number;
   status: BashMonitorWakeStatus;
   createdAt: string;
   updatedAt: string;
@@ -91,6 +100,7 @@ const BashMonitorWakeRecordSchema = z
     lines: z.array(z.string()),
     totalMatches: z.number().int().nonnegative(),
     droppedLines: z.number().int().nonnegative(),
+    matchedThroughOffset: z.number().int().nonnegative().optional(),
     status: z.enum(BASH_MONITOR_WAKE_STATUSES),
     createdAt: z.string().min(1),
     updatedAt: z.string().min(1),
@@ -263,6 +273,18 @@ export class BashMonitorWakeStore {
           lines: merged.lines,
           totalMatches: payload.totalMatches,
           droppedLines: existing.droppedLines + (payload.droppedLines ?? 0) + merged.droppedLines,
+          // Offsets only grow, so the newest match is the furthest; Math.max is defensive against
+          // any out-of-order enqueue and a legacy existing record that lacked the field. When the
+          // payload omits the offset (legacy emitter), keep whatever `existing` carried rather than
+          // coercing to a bogus 0/NaN -- the spread above already preserves it.
+          ...(payload.matchedThroughOffset != null
+            ? {
+                matchedThroughOffset: Math.max(
+                  existing.matchedThroughOffset ?? 0,
+                  payload.matchedThroughOffset
+                ),
+              }
+            : {}),
           updatedAt: now,
         };
         await this.write(record);
@@ -281,6 +303,9 @@ export class BashMonitorWakeStore {
         lines: bounded.lines,
         totalMatches: payload.totalMatches,
         droppedLines: (payload.droppedLines ?? 0) + bounded.droppedLines,
+        ...(payload.matchedThroughOffset != null
+          ? { matchedThroughOffset: payload.matchedThroughOffset }
+          : {}),
         status: "pending",
         createdAt: now,
         updatedAt: now,

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -25,7 +25,7 @@ export type BashMonitorWakeStatus = (typeof BASH_MONITOR_WAKE_STATUSES)[number];
 // "match" wakes deliver monitor-matched output lines; "monitor-lost" wakes tell the owner
 // that a Mux restart terminated (or orphaned) the process and retired its monitor, so the
 // agent can decide whether to relaunch. The schema defaults to "match" so pending records
-// written before this field existed keep parsing despite `.strict()`.
+// written before this field existed still parse.
 const BASH_MONITOR_WAKE_KINDS = ["match", "monitor-lost"] as const;
 export type BashMonitorWakeKind = (typeof BASH_MONITOR_WAKE_KINDS)[number];
 
@@ -76,8 +76,16 @@ export interface BashMonitorWakeRecord {
   /**
    * File byte offset at the end of the last matched line (match records only). drainBashMonitorWakes
    * re-checks this against the settled shown-frontier at delivery time so a wake never re-reports
-   * output a concurrent task_await already showed the agent. Optional so pending records written
-   * before this field existed keep parsing under `.strict()` (they deliver as before -- fail open).
+   * output a concurrent task_await already showed the agent. The gate binds the check to the
+   * originating process instance via this record's createdAt (see getSettledShownThroughOffset), so
+   * no separate instance token is persisted. Optional so records written before this field existed
+   * still parse (they deliver as before -- fail open).
+   *
+   * This is the only field this delivery gate added to the persisted record. Downgrading to a build
+   * whose `.strict()` parser predates it drops an in-flight pending wake as malformed, but the file
+   * is not deleted, so re-upgrading recovers it; the loss is bounded to nightly builds mid-drain
+   * (stable v0.27.0 has no wake store at all). The schema below is `.strip()` so the reverse
+   * direction -- this build reading a newer record -- never chokes on future additive fields.
    */
   matchedThroughOffset?: number;
   status: BashMonitorWakeStatus;
@@ -106,7 +114,10 @@ const BashMonitorWakeRecordSchema = z
     updatedAt: z.string().min(1),
     deliveredAt: z.string().optional(),
   })
-  .strict();
+  // Strip (not reject) unknown keys: this is a persisted, evolving record, so a record written by
+  // a newer build that added a field must still parse here and deliver rather than be dropped as
+  // malformed. Missing required fields and wrong types are still rejected -- only extra keys pass.
+  .strip();
 
 export function truncateUtf8Prefix(value: string, maxBytes: number): string {
   assert(maxBytes > 0, "truncateUtf8Prefix requires a positive byte limit");
@@ -265,6 +276,13 @@ export class BashMonitorWakeStore {
       // fresh match record instead of mislabeling live output as lost-monitor output.
       if (existing?.status === "pending" && existing.kind === "match") {
         const merged = boundLines([...existing.lines, ...payload.lines]);
+        // Offsets only grow (each match ends further into the append-only output file), so the
+        // merged frontier is the newest match's end; Math.max is defensive against out-of-order
+        // enqueues, and a legacy existing record with no offset falls back to the payload's. The
+        // merge does not reconcile process instances: the drain gate binds its shown-frontier check
+        // to this record's createdAt, which stays the originating instance's. So if a restart reused
+        // this display-name-derived ID, the live (newer) instance fails that createdAt check and the
+        // whole record delivers -- a now-dead instance's undelivered lines are never dropped.
         const record: BashMonitorWakeRecord = {
           ...existing,
           ...(payload.displayName != null ? { displayName: payload.displayName } : {}),
@@ -273,18 +291,10 @@ export class BashMonitorWakeStore {
           lines: merged.lines,
           totalMatches: payload.totalMatches,
           droppedLines: existing.droppedLines + (payload.droppedLines ?? 0) + merged.droppedLines,
-          // Offsets only grow, so the newest match is the furthest; Math.max is defensive against
-          // any out-of-order enqueue and a legacy existing record that lacked the field. When the
-          // payload omits the offset (legacy emitter), keep whatever `existing` carried rather than
-          // coercing to a bogus 0/NaN -- the spread above already preserves it.
-          ...(payload.matchedThroughOffset != null
-            ? {
-                matchedThroughOffset: Math.max(
-                  existing.matchedThroughOffset ?? 0,
-                  payload.matchedThroughOffset
-                ),
-              }
-            : {}),
+          matchedThroughOffset: Math.max(
+            existing.matchedThroughOffset ?? 0,
+            payload.matchedThroughOffset ?? 0
+          ),
           updatedAt: now,
         };
         await this.write(record);
@@ -303,9 +313,7 @@ export class BashMonitorWakeStore {
         lines: bounded.lines,
         totalMatches: payload.totalMatches,
         droppedLines: (payload.droppedLines ?? 0) + bounded.droppedLines,
-        ...(payload.matchedThroughOffset != null
-          ? { matchedThroughOffset: payload.matchedThroughOffset }
-          : {}),
+        matchedThroughOffset: payload.matchedThroughOffset,
         status: "pending",
         createdAt: now,
         updatedAt: now,

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -380,6 +380,7 @@ describe("WorkspaceService bash monitor wakes", () => {
         lines: ["FAILED before shutdown"],
         totalMatches: 1,
         timestamp: Date.now(),
+        matchedThroughOffset: 0,
       });
       // …and the monitor was still armed.
       const registryStore = new BashMonitorRegistryStore(config);
@@ -1760,6 +1761,253 @@ describe("WorkspaceService bash monitor wakes", () => {
 
       await drainPendingDispatches();
       expect(waitForIdleSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+  test("supersedes a monitor wake whose matched output was already shown by a concurrent read", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-shown-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // The screenshot bug: a task_await already delivered "ALL DONE exit=0" inline, advancing the
+      // settled shown-frontier to (or past) where the match ends. The drain must drop the wake
+      // rather than re-report the same line. This fails without the drain gate (emit-time
+      // suppression alone loses the race with the exit-flush).
+      const getSettledShownThroughOffset = mock(() => Promise.resolve(100));
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getSettledShownThroughOffset,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "ALL DONE|FAIL",
+        filterExclude: false,
+        lines: ["ALL DONE exit=0"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      // Positive signal that the drain reached the gate (without the gate this is never called, so
+      // this wait times out and the test fails -- proving the assertion below is not vacuous).
+      await waitForCondition(() => getSettledShownThroughOffset.mock.calls.length >= 1);
+      // The gate supersedes the record (no longer pending) without ever building a wake message.
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+      expect(sendSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("delivers a monitor wake when the matched output has not yet been shown", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-unshown-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // Shown-frontier sits behind the match: the agent has not seen this output, so deliver.
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getSettledShownThroughOffset: mock(() => Promise.resolve(40)),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED one"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED one");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("delivers the wake when the manager cannot report a shown-frontier (fail open)", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-failopen-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // Partial manager stub without getSettledShownThroughOffset (older manager / narrow stub).
+      // Even with a matchedThroughOffset present, the gate must fail open and deliver rather than
+      // silently drop the wake.
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED one"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED one");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("supersedes only the shown records in a mixed pending batch", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-mixed-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // Two undelivered match wakes for different processes: one already shown to the agent, one not.
+      // Seed them on disk before the service boots so its startup recovery drains both in one pass.
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-shown",
+        taskId: "bash:proc-shown",
+        workspaceId,
+        filter: "DONE",
+        filterExclude: false,
+        lines: ["SHOWN-ALREADY done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 50,
+      });
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-unshown",
+        taskId: "bash:proc-unshown",
+        workspaceId,
+        filter: "DONE",
+        filterExclude: false,
+        lines: ["UNSHOWN done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        // proc-shown: frontier past its match (superseded). proc-unshown: frontier behind (delivered).
+        getSettledShownThroughOffset: mock((processId: string) =>
+          Promise.resolve(processId === "proc-shown" ? 100 : 10)
+        ),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      // Startup recovery schedules a single drain for the owner's pending records.
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      const prompt = sendSpy.mock.calls[0][1];
+      expect(prompt).toContain("UNSHOWN done");
+      expect(prompt).not.toContain("SHOWN-ALREADY done");
+      // Only the unshown record survives into the delivered batch.
+      expect(sendSpy.mock.calls[0][2]).toMatchObject({
+        muxMetadata: {
+          type: "bash-monitor-wake",
+          records: [{ kind: "match", displayName: "proc-unshown", filter: "DONE" }],
+        },
+      });
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      // proc-shown superseded, proc-unshown delivered -> nothing left pending.
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -2012,6 +2012,71 @@ describe("WorkspaceService bash monitor wakes", () => {
       await cleanup();
     }
   });
+
+  test("delivers a stale-instance wake even after a reused process ID was read past the match", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-reused-id-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // A wake from a dead instance is still pending. Its process ID was reclaimed by a newer live
+      // instance that has since been read past the match. The gate binds its shown-frontier query
+      // to the record's createdAt (the origin instance started before it), so the manager reports
+      // it cannot vouch (undefined) for a live process that started later -- the wake fails open and
+      // delivers rather than being superseded against the unrelated instance's frontier.
+      const getSettledShownThroughOffset = mock((_processId: string, _originNotAfterMs?: number) =>
+        Promise.resolve<number | undefined>(undefined)
+      );
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getSettledShownThroughOffset,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      const beforeEnqueue = Date.now();
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-reused",
+        taskId: "bash:proc-reused",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED stale"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      const afterDelivery = Date.now();
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED stale");
+      // The gate binds the query to the record's createdAt (a wall-clock ms stamped at enqueue),
+      // not a persisted instance token -- so the forwarded origin bound falls in the enqueue window.
+      const forwardedOrigin = getSettledShownThroughOffset.mock.calls[0][1];
+      expect(typeof forwardedOrigin).toBe("number");
+      expect(forwardedOrigin).toBeGreaterThanOrEqual(beforeEnqueue);
+      expect(forwardedOrigin).toBeLessThanOrEqual(afterDelivery);
+    } finally {
+      await cleanup();
+    }
+  });
 });
 
 describe("WorkspaceService workflow activity", () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1980,25 +1980,12 @@ export class WorkspaceService extends EventEmitter {
       return;
     }
 
-    const prompt = buildBashMonitorWakePrompt(pending);
-    const retryAfterIdleIfBusy = (reason: string): void => {
-      if (
-        this.isBusyForMessage(ownerWorkspaceId) ||
-        this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId)
-      ) {
-        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
-        return;
-      }
-      log.debug("Bash monitor wake left pending without immediate retry", {
-        ownerWorkspaceId,
-        reason,
-      });
-    };
     // Both terminal transitions return false when the persisted record picked up new merged
     // matches after this drain snapshotted `pending`; in that case reschedule so the freshly
-    // merged lines get their own drain pass. The delivered/canceled callbacks differ only in
+    // merged lines get their own drain pass. The delivered/superseded callbacks differ only in
     // which store transition they apply, so share the resolve-each-then-reschedule-on-any-miss
-    // loop rather than copy-pasting it.
+    // loop rather than copy-pasting it. Defined ahead of the delivery gate below so the gate can
+    // reuse markSupersededSnapshots for matches it drops as already-shown.
     const resolveWakeSnapshots = async (
       records: readonly BashMonitorWakeRecord[],
       resolve: (record: BashMonitorWakeRecord) => Promise<boolean>
@@ -2017,12 +2004,54 @@ export class WorkspaceService extends EventEmitter {
       resolveWakeSnapshots(records, (record) =>
         this.bashMonitorWakeStore.markDeliveredSnapshot(ownerWorkspaceId, record)
       );
-    const markSupersededAfterCanceled = (
-      records: readonly BashMonitorWakeRecord[]
-    ): Promise<void> =>
+    const markSupersededSnapshots = (records: readonly BashMonitorWakeRecord[]): Promise<void> =>
       resolveWakeSnapshots(records, (record) =>
         this.bashMonitorWakeStore.markSupersededSnapshot(ownerWorkspaceId, record)
       );
+
+    // Delivery gate: the authoritative "don't re-report shown output" check. emitMonitorMatch's
+    // shownThroughOffset comparison is only a point-in-time fast path -- it can lose a race with a
+    // concurrent task_await that advances the shown-frontier just after the wake is emitted (a
+    // process printing its final line then exiting triggers an immediate exit flush that bypasses
+    // the cooldown). Here, at the moment each wake would become a transcript message, re-check its
+    // matched offset against the settled shown-frontier and drop any match already shown. Records
+    // without matchedThroughOffset (legacy on-disk) and managers without the query (partial test
+    // stubs) fail open -- the wake delivers, matching the pre-gate behavior.
+    const canQueryShownFrontier =
+      typeof this.backgroundProcessManager.getSettledShownThroughOffset === "function";
+    const deliverable: BashMonitorWakeRecord[] = [];
+    const supersededByShown: BashMonitorWakeRecord[] = [];
+    for (const record of pending) {
+      if (canQueryShownFrontier && record.kind === "match" && record.matchedThroughOffset != null) {
+        const shown = await this.backgroundProcessManager.getSettledShownThroughOffset(
+          record.processId
+        );
+        if (shown != null && shown >= record.matchedThroughOffset) {
+          supersededByShown.push(record);
+          continue;
+        }
+      }
+      deliverable.push(record);
+    }
+    if (supersededByShown.length > 0) {
+      await markSupersededSnapshots(supersededByShown);
+    }
+    if (deliverable.length === 0) return;
+
+    const prompt = buildBashMonitorWakePrompt(deliverable);
+    const retryAfterIdleIfBusy = (reason: string): void => {
+      if (
+        this.isBusyForMessage(ownerWorkspaceId) ||
+        this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId)
+      ) {
+        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+        return;
+      }
+      log.debug("Bash monitor wake left pending without immediate retry", {
+        ownerWorkspaceId,
+        reason,
+      });
+    };
 
     // Once the synthetic wake turn is accepted into durable chat history, the wake has
     // been delivered. If provider startup fails after acceptance, AgentSession's
@@ -2034,7 +2063,7 @@ export class WorkspaceService extends EventEmitter {
       if (delivered) return;
       delivered = true;
       try {
-        await markDeliveredAfterAccepted(pending);
+        await markDeliveredAfterAccepted(deliverable);
       } catch (error) {
         log.error("Failed to mark bash monitor wake delivered after accepted send", {
           ownerWorkspaceId,
@@ -2050,7 +2079,7 @@ export class WorkspaceService extends EventEmitter {
         ...sendOptions,
         queueDispatchMode: "tool-end",
         // Compact display summaries; the transcript collapses the raw prompt.
-        muxMetadata: buildBashMonitorWakeMetadata(pending),
+        muxMetadata: buildBashMonitorWakeMetadata(deliverable),
       },
       {
         skipAutoResumeReset: true,
@@ -2074,7 +2103,7 @@ export class WorkspaceService extends EventEmitter {
         },
         onCanceled: async (reason) => {
           if (delivered) return;
-          const cancelingKeys = pending.map((record) =>
+          const cancelingKeys = deliverable.map((record) =>
             this.bashMonitorWakeKey(ownerWorkspaceId, record.id)
           );
           for (const key of cancelingKeys) {
@@ -2085,7 +2114,7 @@ export class WorkspaceService extends EventEmitter {
             reason,
           });
           try {
-            await markSupersededAfterCanceled(pending);
+            await markSupersededSnapshots(deliverable);
           } catch (error) {
             log.error("Failed to supersede canceled bash monitor wake snapshot", {
               ownerWorkspaceId,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2016,7 +2016,10 @@ export class WorkspaceService extends EventEmitter {
     // the cooldown). Here, at the moment each wake would become a transcript message, re-check its
     // matched offset against the settled shown-frontier and drop any match already shown. Records
     // without matchedThroughOffset (legacy on-disk) and managers without the query (partial test
-    // stubs) fail open -- the wake delivers, matching the pre-gate behavior.
+    // stubs) fail open -- the wake delivers, matching the pre-gate behavior. The record's createdAt
+    // pins the check to the instance that produced the match: process IDs are display-name-derived
+    // and reclaimed across restarts, so a fresh process that reused the ID started after createdAt,
+    // getSettledShownThroughOffset returns undefined, and the dead instance's wake still delivers.
     const canQueryShownFrontier =
       typeof this.backgroundProcessManager.getSettledShownThroughOffset === "function";
     const deliverable: BashMonitorWakeRecord[] = [];
@@ -2024,7 +2027,8 @@ export class WorkspaceService extends EventEmitter {
     for (const record of pending) {
       if (canQueryShownFrontier && record.kind === "match" && record.matchedThroughOffset != null) {
         const shown = await this.backgroundProcessManager.getSettledShownThroughOffset(
-          record.processId
+          record.processId,
+          Date.parse(record.createdAt)
         );
         if (shown != null && shown >= record.matchedThroughOffset) {
           supersededByShown.push(record);


### PR DESCRIPTION
## Summary

A background bash monitor could wake the agent about output it had _already_ been shown. In the reported case a monitor armed with `/ALL DONE|FAIL|error/` fired a synthetic "monitor matched" wake for `ALL DONE exit=0` **after** a concurrent `task_await` had already returned that exact line in its completed report. This moves the "don't re-report shown output" invariant from emit time to delivery time, where it can be enforced against a settled view of what the agent has seen.

## Background

PR #3663 introduced the correct primitives — two absolute file offsets, `proc.shownThroughOffset` (end of the last complete line an _unfiltered_ read delivered to the agent) and `monitor.matchedThroughOffset` (end of the last matched line) — but it compared them exactly once, inside `emitMonitorMatch`. The monitor tail loop and `task_await`'s read run as independent async loops. On process exit the monitor flushes immediately (bypassing the cooldown), so that exit-flush can win the race against the read that advances `shownThroughOffset`: the comparison sees a stale frontier, emits the wake, and persists it. `drainBashMonitorWakes` then delivers it later — possibly seconds afterward, at idle — with no re-check. This is exactly the common terminal case: a process prints its final `DONE`/`FAIL` line and exits while a `task_await` is reading it.

## Implementation

"A wake must not re-report shown output" is a property of _delivery_, not of _matching_, so the authoritative check now lives at the single point where a wake becomes a transcript message.

- The match's `matchedThroughOffset` travels through `MonitorMatchPayload` into the persisted `BashMonitorWakeRecord` (optional on the record/schema so older on-disk records keep parsing).
- `BackgroundProcessManager.getSettledShownThroughOffset(processId, originNotAfterMs?)` reports the shown-frontier _after_ any in-flight unfiltered read settles. `getOutput` registers a settled-promise for unfiltered reads only — filtered reads never advance the frontier and a filtered long-poll can hold the lock for its full timeout, so gating on them would stall delivery for nothing.
- `drainBashMonitorWakes` re-checks each match record against that settled frontier and supersedes any record already shown, dropping it from the batch (and returning early if the batch empties). The emit-time check is retained as a cheap fast-path early-out.

### Delivery-time correctness edge cases

Two ways the settled frontier could otherwise mislead the gate, both handled here:

- **Filtered reads share the byte cursor.** `outputBytesRead` is advanced by _filtered_ reads too, which drop non-matching complete lines without showing them. A filtered read that consumed a matched line, followed by an unfiltered read with no new output, previously let `shownThroughOffset` jump the gap and falsely mark the dropped line as shown. `getOutput` now advances the frontier only when the read's processable region is contiguous with it; a gap pins the frontier low, which can only over-wake, never suppress genuinely-unshown output.
- **Process IDs are reused across restarts.** IDs are derived from `display_name` and reclaimed when a relaunched process lands on an empty manager, so a pending wake for a dead instance could otherwise be superseded by an unrelated newer process that shares the ID and has been read past the old match. Rather than persist a separate instance token, the gate binds the check to the record's own `createdAt`: the originating instance necessarily started _before_ its first match created the record, so `getSettledShownThroughOffset` returns `undefined` (fail open) whenever the live process's `startTime` is _after_ `createdAt` — i.e. it reused the ID. A cross-generation merge therefore needs no special handling: it simply takes the max offset, and the `createdAt` binding makes the whole record deliver against a newer instance, so a dead instance's undelivered lines are never dropped.

Fail-open is preserved everywhere: legacy records without `matchedThroughOffset` and managers that don't implement the query still deliver, matching prior behavior.

### Downgrade safety

`matchedThroughOffset` is the only field this change adds to the persisted `BashMonitorWakeRecord`. To keep the record forward/backward tolerant, its Zod schema is relaxed from `.strict()` to `.strip()`, so this build never rejects a record written by a newer build that added a field. Downgrading to a build whose parser predates `matchedThroughOffset` drops an in-flight pending wake as malformed, but the file is not deleted, so re-upgrading recovers it; the loss is bounded to nightly builds mid-drain (stable `v0.27.0` ships no wake store at all).

## Risks

Low-to-moderate; scoped to background bash monitor wake delivery. The gate only ever _suppresses_ a wake when the settled shown-frontier is at or past the match **and** the live process is the same instance that produced it (per the `createdAt` binding), so the worst-case failure mode is a missed wake rather than a spurious one — and that only triggers when the agent has provably already seen the output. All other paths (filtered-read gaps, reused IDs, legacy records, missing query) fail open.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$26.26`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=26.26 -->
