### PR TITLE
🤖 fix: prevent sub-agent workspace garbage in the sidebar (config resurrection race + interrupted workflow children)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -199,16 +199,10 @@
   },
   "trustedDependencies": [
     "esbuild",
+    "node-pty",
     "sharp",
-<<<<<<< Updated upstream
     "ssh2",
     "@swc/core",
-||||||| Stash base
-    "lzma-native",
-=======
-    "node-pty",
-    "lzma-native",
->>>>>>> Stashed changes
     "electron",
     "core-js",
     "cpu-features",
@@ -1457,13 +1451,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-<<<<<<< Updated upstream
     "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-||||||| Stash base
-    "@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-=======
-    "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
->>>>>>> Stashed changes
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -3845,13 +3833,25 @@
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
+    "@jest/console/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "@jest/console/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@jest/core/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/core/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "@jest/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/core/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
+
+    "@jest/environment/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/fake-timers/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/pattern/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/reporters/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/reporters/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3868,6 +3868,8 @@
     "@jest/transform/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
+
+    "@jest/types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3955,7 +3957,6 @@
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
-<<<<<<< Updated upstream
     "@types/asn1/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/body-parser/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
@@ -3963,37 +3964,12 @@
     "@types/connect/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/cors/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-||||||| Stash base
-    "@types/cors/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-=======
-    "@types/asn1/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
->>>>>>> Stashed changes
-
-<<<<<<< Updated upstream
-    "@types/express-serve-static-core/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-||||||| Stash base
-    "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-=======
-    "@types/body-parser/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
->>>>>>> Stashed changes
-
-    "@types/cacheable-request/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/connect/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/express-serve-static-core/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
-    "@types/keyv/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+    "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
-    "@types/plist/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/responselike/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/send/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/serve-static/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+    "@types/jsdom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/plist/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -4003,21 +3979,13 @@
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
-<<<<<<< Updated upstream
     "@types/sshpk/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/wait-on/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/write-file-atomic/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-||||||| Stash base
-    "@types/write-file-atomic/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-=======
-    "@types/sshpk/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
->>>>>>> Stashed changes
 
-    "@types/wait-on/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/yauzl/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+    "@types/ws/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/yauzl/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -4053,38 +4021,8 @@
 
     "builder-util/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
-<<<<<<< Updated upstream
     "bun-types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
-||||||| Stash base
-    "bun-types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
-    "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
-
-    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "cacache/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "cacache/minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
-
-    "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
-
-    "cacache/tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
-
-=======
-    "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
-
-    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "cacache/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
-
-    "cacache/minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
-
-    "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
-
-    "cacache/tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
-
->>>>>>> Stashed changes
     "caching-transform/write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -4122,8 +4060,6 @@
     "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
-
-    "electron/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4173,6 +4109,8 @@
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "happy-dom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
@@ -4211,15 +4149,9 @@
 
     "jest-each/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-<<<<<<< Updated upstream
     "jest-environment-node/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "jest-haste-map/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-||||||| Stash base
-    "jest-haste-map/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-=======
-    "jest-environment-node/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
->>>>>>> Stashed changes
 
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -4230,6 +4162,8 @@
     "jest-matcher-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-message-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-mock/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-process-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4243,6 +4177,8 @@
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
+    "jest-runtime/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "jest-runtime/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-runtime/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -4250,6 +4186,8 @@
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "jest-snapshot/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-util/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4259,11 +4197,15 @@
 
     "jest-watch-typeahead/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
+    "jest-watcher/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "jest-watcher/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "jest-watcher/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-watcher/string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
+
+    "jest-worker/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -199,10 +199,16 @@
   },
   "trustedDependencies": [
     "esbuild",
-    "node-pty",
     "sharp",
+<<<<<<< Updated upstream
     "ssh2",
     "@swc/core",
+||||||| Stash base
+    "lzma-native",
+=======
+    "node-pty",
+    "lzma-native",
+>>>>>>> Stashed changes
     "electron",
     "core-js",
     "cpu-features",
@@ -1451,7 +1457,13 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
+<<<<<<< Updated upstream
     "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+||||||| Stash base
+    "@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+=======
+    "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+>>>>>>> Stashed changes
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -3833,25 +3845,13 @@
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "@jest/console/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
     "@jest/console/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@jest/core/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/core/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "@jest/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/core/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
-
-    "@jest/environment/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
-    "@jest/fake-timers/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
-    "@jest/pattern/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
-    "@jest/reporters/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/reporters/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3868,8 +3868,6 @@
     "@jest/transform/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
-
-    "@jest/types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3957,6 +3955,7 @@
 
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+<<<<<<< Updated upstream
     "@types/asn1/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/body-parser/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
@@ -3964,12 +3963,37 @@
     "@types/connect/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/cors/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+||||||| Stash base
+    "@types/cors/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+=======
+    "@types/asn1/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+>>>>>>> Stashed changes
 
+<<<<<<< Updated upstream
     "@types/express-serve-static-core/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+||||||| Stash base
+    "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+=======
+    "@types/body-parser/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+>>>>>>> Stashed changes
 
-    "@types/jsdom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+    "@types/cacheable-request/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/connect/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/express-serve-static-core/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/keyv/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/plist/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/responselike/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/send/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/serve-static/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/plist/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -3979,13 +4003,21 @@
 
     "@types/ssh2/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+<<<<<<< Updated upstream
     "@types/sshpk/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/wait-on/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/write-file-atomic/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+||||||| Stash base
+    "@types/write-file-atomic/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+=======
+    "@types/sshpk/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+>>>>>>> Stashed changes
 
-    "@types/ws/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+    "@types/wait-on/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/yauzl/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/yauzl/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -4021,8 +4053,38 @@
 
     "builder-util/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+<<<<<<< Updated upstream
     "bun-types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
+||||||| Stash base
+    "bun-types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
+    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "cacache/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "cacache/minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "cacache/tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
+
+=======
+    "cacache/fs-minipass": ["fs-minipass@3.0.3", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw=="],
+
+    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "cacache/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "cacache/minipass-collect": ["minipass-collect@2.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw=="],
+
+    "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "cacache/tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
+
+>>>>>>> Stashed changes
     "caching-transform/write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
     "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -4060,6 +4122,8 @@
     "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
+
+    "electron/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4109,8 +4173,6 @@
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "happy-dom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
     "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
@@ -4149,9 +4211,15 @@
 
     "jest-each/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+<<<<<<< Updated upstream
     "jest-environment-node/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "jest-haste-map/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+||||||| Stash base
+    "jest-haste-map/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+=======
+    "jest-environment-node/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+>>>>>>> Stashed changes
 
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -4162,8 +4230,6 @@
     "jest-matcher-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-message-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "jest-mock/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-process-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4177,8 +4243,6 @@
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
-    "jest-runtime/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
     "jest-runtime/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-runtime/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -4186,8 +4250,6 @@
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "jest-snapshot/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "jest-util/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4197,15 +4259,11 @@
 
     "jest-watch-typeahead/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
-    "jest-watcher/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
-
     "jest-watcher/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "jest-watcher/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-watcher/string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
-
-    "jest-worker/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -467,10 +467,8 @@ async function main(): Promise<number> {
     }
 
     if (trustOnlyProjects.size > 0) {
-      await config.saveConfig({
-        ...config.loadConfigOrDefault(),
-        projects: trustOnlyProjects,
-      });
+      // Config.saveConfig is private (lost-update safety); route through the queue.
+      await config.editConfig((cfg) => ({ ...cfg, projects: trustOnlyProjects }));
     }
   }
 

--- a/src/cli/workflow.test.ts
+++ b/src/cli/workflow.test.ts
@@ -21,7 +21,7 @@ async function getRejectedMessage(promise: Promise<unknown>): Promise<string> {
 }
 
 async function trustProject(muxRoot: string, repo: string): Promise<void> {
-  await Bun.$`${BUN_EXECUTABLE} -e ${`import { Config } from "./src/node/config"; const c = new Config(); const cfg = c.loadConfigOrDefault(); cfg.projects.set(process.argv[1], { workspaces: [], trusted: true }); await c.saveConfig(cfg);`} ${repo}`
+  await Bun.$`${BUN_EXECUTABLE} -e ${`import { Config } from "./src/node/config"; const c = new Config(); await c.editConfig((cfg) => { cfg.projects.set(process.argv[1], { workspaces: [], trusted: true }); return cfg; });`} ${repo}`
     .env({ ...process.env, MUX_ROOT: muxRoot })
     .quiet();
 }

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -212,7 +212,8 @@ async function copyPersistentConfig(realConfig: Config, config: Config): Promise
     }
   }
   if (trustOnlyProjects.size > 0) {
-    await config.saveConfig({ ...config.loadConfigOrDefault(), projects: trustOnlyProjects });
+    // Config.saveConfig is private (lost-update safety); route through the queue.
+    await config.editConfig((cfg) => ({ ...cfg, projects: trustOnlyProjects }));
   }
 }
 

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -209,7 +209,9 @@ describe("Config", () => {
       await config.editConfig((cfg) => {
         cfg.projects.set("/repo", {
           // Legacy entry (no id/name) with settings the migration would carry over.
-          workspaces: [{ path: sharedPath, aiSettings: { modelString: "old:model" } }],
+          workspaces: [
+            { path: sharedPath, aiSettings: { model: "old:model", thinkingLevel: "medium" } },
+          ],
         });
         return cfg;
       });

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -30,6 +30,14 @@ describe("Config", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  // Load-time migrations persist through the serialized editConfig queue (an async
+  // identity transform) instead of a synchronous write-back, so tests asserting the
+  // migrated on-disk form must flush the queue first. Awaiting an identity edit is
+  // sufficient: it re-runs the idempotent load migrations and writes the result.
+  async function flushConfigEdits(): Promise<void> {
+    await config.editConfig((cfg) => cfg);
+  }
+
   describe("loadConfigOrDefault with trailing slash migration", () => {
     it("should strip trailing slashes from project paths on load", () => {
       // Create config file with trailing slashes in project paths
@@ -388,7 +396,7 @@ describe("Config", () => {
     const OPUS = KNOWN_MODELS.OPUS.id;
     const configFilePath = () => path.join(tempDir, "config.json");
 
-    it("seeds the default chain once on first load and persists the migration flag", () => {
+    it("seeds the default chain once on first load and persists the migration flag", async () => {
       fs.writeFileSync(configFilePath(), JSON.stringify({ projects: [] }));
 
       const loaded = config.loadConfigOrDefault();
@@ -396,6 +404,7 @@ describe("Config", () => {
       expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
 
       // Seed is written back so the flag survives restarts even without saves.
+      await flushConfigEdits();
       const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
         modelFallbacks?: unknown;
         migrations?: { defaultModelFallbacksSeeded?: unknown };
@@ -416,7 +425,7 @@ describe("Config", () => {
       expect(config.loadConfigOrDefault().modelFallbacks).toBeUndefined();
     });
 
-    it("merges the seeded default with pre-existing chains for other source models", () => {
+    it("merges the seeded default with pre-existing chains for other source models", async () => {
       fs.writeFileSync(
         configFilePath(),
         JSON.stringify({
@@ -434,6 +443,7 @@ describe("Config", () => {
       });
 
       // The user's chain must survive the seed write-back on disk unchanged.
+      await flushConfigEdits();
       const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
         modelFallbacks?: unknown;
         migrations?: { defaultModelFallbacksSeeded?: unknown };
@@ -922,7 +932,7 @@ describe("Config", () => {
       );
     });
 
-    it("removes mirrored exec subagent fields on first load", () => {
+    it("removes mirrored exec subagent fields on first load", async () => {
       fs.writeFileSync(
         path.join(tempDir, "config.json"),
         JSON.stringify({
@@ -942,6 +952,7 @@ describe("Config", () => {
       expect(loaded.subagentAiDefaults?.worker?.modelString).toBe("openai:gpt-5.2");
       expect(loaded.migrations?.execSubagentDefaultsSplit).toBe(true);
 
+      await flushConfigEdits();
       const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
         subagentAiDefaults?: Record<string, unknown>;
         migrations?: { execSubagentDefaultsSplit?: boolean };
@@ -950,7 +961,7 @@ describe("Config", () => {
       expect(raw.migrations?.execSubagentDefaultsSplit).toBe(true);
     });
 
-    it("preserves session usage cache when only exec-split cleanup modifies config", () => {
+    it("preserves session usage cache when only exec-split cleanup modifies config", async () => {
       fs.writeFileSync(
         path.join(tempDir, "config.json"),
         JSON.stringify({
@@ -975,6 +986,7 @@ describe("Config", () => {
       expect(loaded.subagentAiDefaults?.worker?.modelString).toBe("openai:gpt-5.2");
       expect(loaded.migrations?.execSubagentDefaultsSplit).toBe(true);
 
+      await flushConfigEdits();
       const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
         subagentAiDefaults?: Record<string, unknown>;
         migrations?: { execSubagentDefaultsSplit?: boolean };
@@ -1311,7 +1323,7 @@ describe("Config", () => {
       });
     }
 
-    it("preserves legacy fields on disk alongside synthesized modern routing state", () => {
+    it("preserves legacy fields on disk alongside synthesized modern routing state", async () => {
       writeRawConfig({
         muxGatewayEnabled: true,
         muxGatewayModels: ["anthropic/claude-sonnet-4-6"],
@@ -1326,6 +1338,7 @@ describe("Config", () => {
         "anthropic:claude-sonnet-4-6": "mux-gateway",
       });
 
+      await flushConfigEdits();
       expect(readRawConfig()).toMatchObject({
         muxGatewayEnabled: true,
         muxGatewayModels: ["anthropic/claude-sonnet-4-6"],
@@ -1369,7 +1382,7 @@ describe("Config", () => {
       expect(loaded.routeOverrides).toBeUndefined();
     });
 
-    it("clears stale muxGatewayEnabled disables when routePriority already includes mux-gateway", () => {
+    it("clears stale muxGatewayEnabled disables when routePriority already includes mux-gateway", async () => {
       writeRawConfig({
         muxGatewayEnabled: false,
         routePriority: ["mux-gateway", "direct"],
@@ -1379,6 +1392,7 @@ describe("Config", () => {
 
       expect(loaded.routePriority).toEqual(["mux-gateway", "direct"]);
       expect(loaded.muxGatewayEnabled).toBeUndefined();
+      await flushConfigEdits();
       expect(readRawConfig().muxGatewayEnabled).toBeUndefined();
       expect(new Config(tempDir).loadConfigOrDefault().muxGatewayEnabled).toBeUndefined();
     });

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -199,6 +199,54 @@ describe("Config", () => {
       expect(persisted?.name).toBe(metadata[0]?.name);
     });
 
+    // Regression (PR #3694 Codex P2): paths are reusable after deletion. A queued
+    // migration replay recorded for a legacy entry must not apply the old workspace's
+    // settings to a replacement workspace created at the same path while the replay
+    // waited in the editConfig queue.
+    it("does not retarget queued migrations onto a replacement workspace at the same path", async () => {
+      const sharedPath = "/repo/reused";
+      const staleHeartbeat = { enabled: true, intervalMs: 45 * 60 * 1000 };
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/repo", {
+          // Legacy entry (no id/name) with settings the migration would carry over.
+          workspaces: [{ path: sharedPath, aiSettings: { modelString: "old:model" } }],
+        });
+        return cfg;
+      });
+
+      // Enqueue remove+recreate FIFO-ahead of getAllWorkspaceMetadata's queued replay:
+      // its snapshot read (sync) sees the legacy entry, but by the time its editConfig
+      // transform runs, the path belongs to a NEW workspace with a different id.
+      const loader = new Config(tempDir);
+      const removal = loader.editConfig((cfg) => {
+        cfg.projects.set("/repo", { workspaces: [] });
+        return cfg;
+      });
+      const recreate = loader.editConfig((cfg) => {
+        cfg.projects.get("/repo")?.workspaces.push({
+          id: "replacement-id",
+          name: "replacement",
+          path: sharedPath,
+          heartbeat: staleHeartbeat,
+        });
+        return cfg;
+      });
+      await loader.getAllWorkspaceMetadata();
+      await Promise.all([removal, recreate]);
+
+      const persisted = new Config(tempDir).loadConfigOrDefault().projects.get("/repo")?.workspaces;
+      expect(persisted).toHaveLength(1);
+      const replacement = persisted?.[0];
+      // The replacement keeps its own identity and never inherits the legacy entry's
+      // migrated defaults: pre-fix the path-only replay match filled the replacement's
+      // missing createdAt/runtimeConfig from the removed legacy workspace's migration.
+      expect(replacement?.id).toBe("replacement-id");
+      expect(replacement?.name).toBe("replacement");
+      expect(replacement?.createdAt).toBeUndefined();
+      expect(replacement?.runtimeConfig).toBeUndefined();
+      expect(replacement?.heartbeat).toEqual(staleHeartbeat);
+    });
+
     it("returns the persisted name for an entry missing only an id", async () => {
       await config.editConfig((cfg) => {
         cfg.projects.set("/repo", {

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -172,6 +172,52 @@ describe("Config", () => {
     });
   });
 
+  describe("legacy workspace migration identity", () => {
+    // Regression (PR #3694 Codex P2): the queued ??= migration preserves values already
+    // persisted in config. Returned metadata must use those same values — returning a
+    // generated legacyId for a partially-migrated entry (id present, name missing) hands
+    // the UI an ID that findWorkspace cannot resolve until the next reload.
+    it("returns the persisted id for a partially-migrated entry and persists the same value", async () => {
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/repo", {
+          workspaces: [
+            // id present, name missing -> legacy fallback path (no metadata.json on disk).
+            { path: "/repo/partial", id: "persisted-id-1" },
+          ],
+        });
+        return cfg;
+      });
+
+      const metadata = await new Config(tempDir).getAllWorkspaceMetadata();
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0]?.id).toBe("persisted-id-1");
+
+      // The migration must persist exactly what was returned.
+      const persisted = new Config(tempDir).loadConfigOrDefault().projects.get("/repo")
+        ?.workspaces[0];
+      expect(persisted?.id).toBe("persisted-id-1");
+      expect(persisted?.name).toBe(metadata[0]?.name);
+    });
+
+    it("returns the persisted name for an entry missing only an id", async () => {
+      await config.editConfig((cfg) => {
+        cfg.projects.set("/repo", {
+          workspaces: [{ path: "/repo/named", name: "persisted-name" }],
+        });
+        return cfg;
+      });
+
+      const metadata = await new Config(tempDir).getAllWorkspaceMetadata();
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0]?.name).toBe("persisted-name");
+
+      const persisted = new Config(tempDir).loadConfigOrDefault().projects.get("/repo")
+        ?.workspaces[0];
+      expect(persisted?.name).toBe("persisted-name");
+      expect(persisted?.id).toBe(metadata[0]?.id);
+    });
+  });
+
   describe("userPreferences", () => {
     it("loads and saves user preferences", async () => {
       await config.editConfig((cfg) => ({

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1916,6 +1916,16 @@ export class Config {
             metadata.forkFamilyBaseName ??= workspace.forkFamilyBaseName;
             metadata.tags ??= workspace.tags;
 
+            // Persisted config identity fields win over metadata.json values. The queued
+            // migration below uses ??= (it must never clobber concurrent edits), so any
+            // field already present in config keeps its persisted value — returning a
+            // different value here would hand the UI an ID that findWorkspace cannot
+            // resolve until the next reload.
+            metadata.id = workspace.id ?? metadata.id;
+            metadata.name = workspace.name ?? metadata.name;
+            metadata.createdAt = workspace.createdAt ?? metadata.createdAt;
+            metadata.runtimeConfig = workspace.runtimeConfig ?? metadata.runtimeConfig;
+
             if (!workspace.aiSettingsByAgent && metadata.aiSettingsByAgent) {
               workspace.aiSettingsByAgent = metadata.aiSettingsByAgent;
               recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
@@ -1961,14 +1971,18 @@ export class Config {
           if (!metadataFound) {
             const legacyId = this.generateLegacyId(projectPath, workspace.path);
             const metadata: WorkspaceMetadata = {
-              id: legacyId,
-              name: workspaceBasename,
+              // Prefer already-persisted identity fields: the queued ??= migration below
+              // keeps existing config values, so returning a generated legacyId for a
+              // partially-migrated entry that already has an id would expose an ID that
+              // findWorkspace cannot resolve until the next reload.
+              id: workspace.id ?? legacyId,
+              name: workspace.name ?? workspaceBasename,
               projectName: resolvedProjectName,
               projectPath: resolvedProjectPath,
               // GUARANTEE: All workspaces must have createdAt
-              createdAt: new Date().toISOString(),
+              createdAt: workspace.createdAt ?? new Date().toISOString(),
               // GUARANTEE: All workspaces must have runtimeConfig
-              runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+              runtimeConfig: workspace.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG,
               aiSettings: workspace.aiSettings,
               heartbeat: workspace.heartbeat,
               goalDefaults: workspace.goalDefaults,
@@ -2021,14 +2035,16 @@ export class Config {
           // Fallback to basic metadata if migration fails
           const legacyId = this.generateLegacyId(projectPath, workspace.path);
           const metadata: WorkspaceMetadata = {
-            id: legacyId,
-            name: workspaceBasename,
+            // Same invariant as the branches above: never return an ID/name that
+            // diverges from a value already persisted in config.
+            id: workspace.id ?? legacyId,
+            name: workspace.name ?? workspaceBasename,
             projectName: resolvedProjectName,
             projectPath: resolvedProjectPath,
             // GUARANTEE: All workspaces must have createdAt (even in error cases)
-            createdAt: new Date().toISOString(),
+            createdAt: workspace.createdAt ?? new Date().toISOString(),
             // GUARANTEE: All workspaces must have runtimeConfig (even in error cases)
-            runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+            runtimeConfig: workspace.runtimeConfig ?? DEFAULT_RUNTIME_CONFIG,
             aiSettings: workspace.aiSettings,
             heartbeat: workspace.heartbeat,
             goalDefaults: workspace.goalDefaults,

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1037,7 +1037,7 @@ export class Config {
           // re-applied on every load, so the identity transform re-reads disk, re-runs them,
           // and persists the migrated form under the queue. One-shot guard: while a persist
           // is in flight, the loads it performs internally must not re-schedule.
-          this.migrationPersist = this.editConfig((migratedConfig) => migratedConfig)
+          this.migrationPersist = this.enqueueConfigEdit((migratedConfig) => migratedConfig)
             .catch((error: unknown) => {
               // Keep startup resilient even if persisting migration fails.
               log.warn("Failed to persist migrated config", { error });
@@ -1430,6 +1430,16 @@ export class Config {
    * and the later write silently clobbers the earlier one.
    */
   async editConfig(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
+    return this.enqueueConfigEdit(fn);
+  }
+
+  /**
+   * Internal queue primitive shared by editConfig and the load-time migration persist.
+   * The migration persist must not call the public editConfig: that method is commonly
+   * spied/overridden in tests, and the internally scheduled write is an implementation
+   * detail rather than a caller-initiated mutation.
+   */
+  private enqueueConfigEdit(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
     const run = this.editConfigQueue.then(async () => {
       const config = this.loadConfigOrDefault();
       const newConfig = fn(config);

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -674,6 +674,8 @@ export class Config {
   private readonly emitter = new EventEmitter();
   /** Serializes editConfig calls; see editConfig for why. */
   private editConfigQueue: Promise<void> = Promise.resolve();
+  /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
+  private migrationPersist: Promise<void> | null = null;
 
   constructor(rootDir?: string) {
     this.rootDir = rootDir ?? getMuxHome();
@@ -1026,15 +1028,23 @@ export class Config {
           }
         }
 
-        if (configModified) {
-          try {
-            writeFileAtomic.sync(this.configFile, JSON.stringify(parsed, null, 2), {
-              encoding: "utf-8",
+        if (configModified && this.migrationPersist == null) {
+          // Persist load-time migrations through the serialized editConfig queue instead of
+          // writing `parsed` synchronously here: a sync write bypasses the queue, so a
+          // concurrent editConfig write landing between this load's read and the write-back
+          // would be clobbered with stale data (same lost-update class that resurrected
+          // removed workspaces via the old public saveConfig). Migrations are idempotent and
+          // re-applied on every load, so the identity transform re-reads disk, re-runs them,
+          // and persists the migrated form under the queue. One-shot guard: while a persist
+          // is in flight, the loads it performs internally must not re-schedule.
+          this.migrationPersist = this.editConfig((migratedConfig) => migratedConfig)
+            .catch((error: unknown) => {
+              // Keep startup resilient even if persisting migration fails.
+              log.warn("Failed to persist migrated config", { error });
+            })
+            .finally(() => {
+              this.migrationPersist = null;
             });
-          } catch (error) {
-            // Keep startup resilient even if persisting migration fails.
-            log.warn("Failed to persist migrated config", { error });
-          }
         }
 
         const coderWorkspaceArchiveBehavior = resolveCoderWorkspaceArchiveBehavior(
@@ -1140,7 +1150,17 @@ export class Config {
     };
   }
 
-  async saveConfig(config: ProjectsConfig): Promise<void> {
+  /**
+   * Write the full config snapshot to disk (atomic write, log-and-swallow errors).
+   *
+   * PRIVATE on purpose: this is editConfig's write primitive only. Direct external
+   * callers used to write stale full snapshots outside the editConfig queue, which
+   * caused lost-update races — e.g. a snapshot read before a concurrent
+   * removeWorkspace() and written after it resurrected the removed workspace entry
+   * as a permanent sidebar ghost. All mutations must go through editConfig so each
+   * write is derived from a fresh serialized read.
+   */
+  private async saveConfig(config: ProjectsConfig): Promise<void> {
     try {
       if (!fs.existsSync(this.rootDir)) {
         ensurePrivateDirSync(this.rootDir);
@@ -1689,7 +1709,23 @@ export class Config {
   async getAllWorkspaceMetadata(): Promise<FrontendWorkspaceMetadata[]> {
     const config = this.loadConfigOrDefault();
     const workspaceMetadata: FrontendWorkspaceMetadata[] = [];
-    let configModified = false;
+    // Read-time migrations recorded here are re-applied to a FRESH config snapshot inside
+    // editConfig below. Persisting the local `config` snapshot directly (the old
+    // saveConfig(config) call) raced concurrent removeWorkspace() edits and resurrected
+    // removed workspace entries (lost-update). Each `apply` only fills still-missing fields
+    // (??=), so re-application onto fresh state is idempotent and never clobbers newer data.
+    const pendingWorkspaceMigrations: Array<{
+      projectPath: string;
+      workspacePath: string;
+      apply: (entry: Workspace) => void;
+    }> = [];
+    const recordWorkspaceMigration = (
+      migrationProjectPath: string,
+      workspacePath: string,
+      apply: (entry: Workspace) => void
+    ) => {
+      pendingWorkspaceMigrations.push({ projectPath: migrationProjectPath, workspacePath, apply });
+    };
 
     for (const [projectPath, projectConfig] of config.projects) {
       // Validate project path is not empty (defensive check for corrupted config)
@@ -1763,7 +1799,9 @@ export class Config {
             // Migrate missing createdAt to config for next load
             if (!workspace.createdAt) {
               workspace.createdAt = metadata.createdAt;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.createdAt ??= metadata.createdAt;
+              });
             }
 
             // Migrate missing runtimeConfig to config for next load
@@ -1776,18 +1814,24 @@ export class Config {
                 : undefined;
               if (derived) {
                 workspace.aiSettingsByAgent = derived;
-                configModified = true;
+                recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                  entry.aiSettingsByAgent ??= derived;
+                });
               }
             }
 
             if (!workspace.runtimeConfig) {
               workspace.runtimeConfig = metadata.runtimeConfig;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.runtimeConfig ??= metadata.runtimeConfig;
+              });
             }
 
             if (!workspace.projects && metadata.projects) {
               workspace.projects = metadata.projects;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.projects ??= metadata.projects;
+              });
             }
 
             // Populate containerName for Docker workspaces (computed from project path and workspace name)
@@ -1864,12 +1908,16 @@ export class Config {
 
             if (!workspace.aiSettingsByAgent && metadata.aiSettingsByAgent) {
               workspace.aiSettingsByAgent = metadata.aiSettingsByAgent;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.aiSettingsByAgent ??= metadata.aiSettingsByAgent;
+              });
             }
 
             if (!workspace.heartbeat && metadata.heartbeat) {
               workspace.heartbeat = metadata.heartbeat;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.heartbeat ??= metadata.heartbeat;
+              });
             }
 
             // Migrate to config for next load
@@ -1878,11 +1926,19 @@ export class Config {
             workspace.createdAt = metadata.createdAt;
             workspace.runtimeConfig = metadata.runtimeConfig;
             workspace.forkFamilyBaseName = metadata.forkFamilyBaseName;
-            configModified = true;
+            recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+              entry.id ??= metadata.id;
+              entry.name ??= metadata.name;
+              entry.createdAt ??= metadata.createdAt;
+              entry.runtimeConfig ??= metadata.runtimeConfig;
+              entry.forkFamilyBaseName ??= metadata.forkFamilyBaseName;
+            });
 
             if (!workspace.projects && metadata.projects) {
               workspace.projects = metadata.projects;
-              configModified = true;
+              recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+                entry.projects ??= metadata.projects;
+              });
             }
 
             workspaceMetadata.push(
@@ -1939,7 +1995,12 @@ export class Config {
             workspace.name = metadata.name;
             workspace.createdAt = metadata.createdAt;
             workspace.runtimeConfig = metadata.runtimeConfig;
-            configModified = true;
+            recordWorkspaceMigration(projectPath, workspace.path, (entry) => {
+              entry.id ??= metadata.id;
+              entry.name ??= metadata.name;
+              entry.createdAt ??= metadata.createdAt;
+              entry.runtimeConfig ??= metadata.runtimeConfig;
+            });
 
             workspaceMetadata.push(
               await this.addPathsToMetadata(metadata, workspace.path, projectPath)
@@ -1993,9 +2054,21 @@ export class Config {
       }
     }
 
-    // Save config if we migrated any workspaces
-    if (configModified) {
-      await this.saveConfig(config);
+    // Persist migrated workspace fields under the editConfig queue, re-resolving each
+    // entry from the fresh snapshot. Entries removed concurrently are skipped so this
+    // write can never resurrect them.
+    if (pendingWorkspaceMigrations.length > 0) {
+      await this.editConfig((freshConfig) => {
+        for (const migration of pendingWorkspaceMigrations) {
+          const project = freshConfig.projects.get(migration.projectPath);
+          const entry = project?.workspaces.find(
+            (candidate) => candidate.path === migration.workspacePath
+          );
+          if (!entry) continue; // workspace removed concurrently — do not resurrect
+          migration.apply(entry);
+        }
+        return freshConfig;
+      });
     }
 
     return workspaceMetadata;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1726,16 +1726,11 @@ export class Config {
     // (??=), so re-application onto fresh state is idempotent and never clobbers newer data.
     const pendingWorkspaceMigrations: Array<{
       projectPath: string;
+      /** Entry id as persisted on disk BEFORE this load's in-memory migrations. */
+      persistedWorkspaceId: string | undefined;
       workspacePath: string;
       apply: (entry: Workspace) => void;
     }> = [];
-    const recordWorkspaceMigration = (
-      migrationProjectPath: string,
-      workspacePath: string,
-      apply: (entry: Workspace) => void
-    ) => {
-      pendingWorkspaceMigrations.push({ projectPath: migrationProjectPath, workspacePath, apply });
-    };
 
     for (const [projectPath, projectConfig] of config.projects) {
       // Validate project path is not empty (defensive check for corrupted config)
@@ -1752,6 +1747,24 @@ export class Config {
         // Extract workspace basename from path (could be stable ID or legacy name)
         const workspaceBasename =
           workspace.path.split("/").pop() ?? workspace.path.split("\\").pop() ?? "unknown";
+
+        // Captured BEFORE any in-memory migration mutates workspace.id: the queued
+        // replay must retarget by persisted identity, never by path alone — paths are
+        // reusable after deletion, and applying a stale migration to a replacement
+        // workspace at the same path would leak the old workspace's settings into it.
+        const persistedWorkspaceId = workspace.id;
+        const recordWorkspaceMigration = (
+          migrationProjectPath: string,
+          workspacePath: string,
+          apply: (entry: Workspace) => void
+        ) => {
+          pendingWorkspaceMigrations.push({
+            projectPath: migrationProjectPath,
+            persistedWorkspaceId,
+            workspacePath,
+            apply,
+          });
+        };
 
         const workspaceProjects = workspace.projects?.length ? workspace.projects : undefined;
         const primaryWorkspaceProject = workspaceProjects?.[0];
@@ -2082,14 +2095,21 @@ export class Config {
 
     // Persist migrated workspace fields under the editConfig queue, re-resolving each
     // entry from the fresh snapshot. Entries removed concurrently are skipped so this
-    // write can never resurrect them.
+    // write can never resurrect them. Matching is by persisted identity: entries with
+    // an id must match by id, and only id-less legacy entries may match by path — a
+    // path match with a different id is a replacement workspace that must not inherit
+    // the removed workspace's migrated settings.
     if (pendingWorkspaceMigrations.length > 0) {
       await this.editConfig((freshConfig) => {
         for (const migration of pendingWorkspaceMigrations) {
           const project = freshConfig.projects.get(migration.projectPath);
-          const entry = project?.workspaces.find(
-            (candidate) => candidate.path === migration.workspacePath
-          );
+          const entry = migration.persistedWorkspaceId
+            ? project?.workspaces.find(
+                (candidate) => candidate.id === migration.persistedWorkspaceId
+              )
+            : project?.workspaces.find(
+                (candidate) => candidate.path === migration.workspacePath && !candidate.id
+              );
           if (!entry) continue; // workspace removed concurrently — do not resurrect
           migration.apply(entry);
         }

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1319,7 +1319,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     advisorModelString = KNOWN_MODELS.SONNET.id
   ): Promise<void> {
     const baseConfig = harness.config.loadConfigOrDefault();
-    await harness.config.saveConfig({
+    await harness.config.editConfig(() => ({
       ...baseConfig,
       advisorModelString,
       agentAiDefaults: {
@@ -1329,7 +1329,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
           advisorEnabled: true,
         },
       },
-    });
+    }));
   }
 
   async function startAdvisorStream(
@@ -2656,7 +2656,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
       },
     });
     const baseConfig = harness.config.loadConfigOrDefault();
-    await harness.config.saveConfig({
+    await harness.config.editConfig(() => ({
       ...baseConfig,
       advisorModelString: KNOWN_MODELS.GPT_53_CODEX.id,
       agentAiDefaults: {
@@ -2666,7 +2666,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
           advisorEnabled: true,
         },
       },
-    });
+    }));
 
     const result = await harness.service.streamMessage({
       messages: [createMuxMessage("latest-user", "user", "continue")],

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -206,6 +206,32 @@ describe("ProjectService", () => {
       // Pre-existing directory not created by this call must survive the rejection.
       expect((await fs.stat(pkgPath)).isDirectory()).toBe(true);
     });
+
+    // Regression (PR #3694 Codex P1): when create() made the directory itself and the
+    // hierarchy rejection is caused by a NEW DESCENDANT registered concurrently, the
+    // descendant's checkout lives inside that directory tree — recursive cleanup would
+    // delete the winning project's files.
+    it("create keeps the directory when a descendant project registered concurrently", async () => {
+      const parentPath = path.join(tempDir, "race-parent");
+      const descendantPath = path.join(parentPath, "pkg");
+
+      // Deterministic interleaving: queue the descendant registration so create()'s
+      // synchronous snapshot read misses it (createdDirectory === true, no validated
+      // descendants) while its queued transform sees the new descendant.
+      const registerDescendant = config.editConfig((cfg) => {
+        cfg.projects.set(descendantPath, { workspaces: [] });
+        return cfg;
+      });
+      const result = await service.create(parentPath);
+      await registerDescendant;
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error).toContain("changed concurrently");
+      // The created directory now hosts the registered descendant project's tree:
+      // it must NOT be recursively deleted by the loser's cleanup.
+      expect((await fs.stat(parentPath)).isDirectory()).toBe(true);
+      expect(config.loadConfigOrDefault().projects.has(descendantPath)).toBe(true);
+    });
   });
 
   describe("listDirectory", () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -115,6 +115,32 @@ describe("ProjectService", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
+  describe("create", () => {
+    // Regression (PR #3694 Codex P1): two concurrent create() calls for the same
+    // not-yet-existing path both compute createdDirectory === true before either
+    // registration is serialized. The loser hits the duplicate re-check inside the
+    // editConfig transform; it must NOT recursively delete the directory, which now
+    // belongs to the winning registration.
+    it("concurrent create of the same new path keeps the winner's directory", async () => {
+      const projectPath = path.join(tempDir, "concurrent-project");
+
+      const [first, second] = await Promise.all([
+        service.create(projectPath),
+        service.create(projectPath),
+      ]);
+
+      const outcomes = [first, second];
+      expect(outcomes.filter((r) => r.success)).toHaveLength(1);
+      const loser = outcomes.find((r) => !r.success);
+      expect(loser && !loser.success ? loser.error : "").toContain("already exists");
+
+      // The winner's registered checkout must survive the loser's failure path.
+      const stat = await fs.stat(projectPath);
+      expect(stat.isDirectory()).toBe(true);
+      expect(config.loadConfigOrDefault().projects.has(projectPath)).toBe(true);
+    });
+  });
+
   describe("listDirectory", () => {
     it("returns root node with the actual requested path, not empty string", async () => {
       // Create test directory structure

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -176,6 +176,36 @@ describe("ProjectService", () => {
       const stat = await fs.stat(apiPath);
       expect(stat.isDirectory()).toBe(true);
     });
+
+    // Regression (PR #3694 Codex P2): the same-git-repo validations only run against
+    // the snapshot. A concurrent registration can introduce a parent (or descendant)
+    // that was never git-validated; the transform must reject rather than persist an
+    // unvalidated hierarchy (here: a sub-project from a DIFFERENT git repository).
+    it("create rejects when a concurrent registration changes the unvalidated hierarchy", async () => {
+      const repoPath = path.join(tempDir, "hier-repo");
+      const pkgPath = path.join(repoPath, "pkg");
+      await fs.mkdir(pkgPath, { recursive: true });
+      await Bun.spawn(["git", "init", "-q", repoPath]).exited;
+      // pkg is a SEPARATE git repository: had /repo existed at snapshot time, the
+      // same-git-repo validation would have rejected registering pkg beneath it.
+      await Bun.spawn(["git", "init", "-q", pkgPath]).exited;
+
+      // Deterministic interleaving: queue the registration of /hier-repo (the would-be
+      // parent) so create(pkg)'s synchronous snapshot read misses it — its git-root
+      // validation therefore never runs — while its queued transform sees it.
+      const registerRepo = config.editConfig((cfg) => {
+        cfg.projects.set(repoPath, { workspaces: [] });
+        return cfg;
+      });
+      const result = await service.create(pkgPath);
+      await registerRepo;
+
+      expect(result.success).toBe(false);
+      expect(!result.success && result.error).toContain("changed concurrently");
+      expect(config.loadConfigOrDefault().projects.has(pkgPath)).toBe(false);
+      // Pre-existing directory not created by this call must survive the rejection.
+      expect((await fs.stat(pkgPath)).isDirectory()).toBe(true);
+    });
   });
 
   describe("listDirectory", () => {
@@ -1748,6 +1778,43 @@ exit 1
       expect(result.success).toBe(false);
       if (result.success) throw new Error("Expected failure");
       expect(result.error).toContain("Sub-project not found under parent");
+    });
+
+    // Regression (PR #3694 Codex P2): the sub-project is validated on the snapshot
+    // read; if it is removed while the edit is queued, the transform must not persist
+    // the stale pointer (send/runtime paths use subProjectPath as the execution root).
+    it("rejects when the sub-project is removed while the edit is queued", async () => {
+      const parentPath = "/fake/project";
+      const subProjectPath = "/fake/project/packages/api";
+      const workspaceId = "workspace-1";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(parentPath, {
+        workspaces: [{ id: workspaceId, path: path.join(tempDir, "workspace-1") }],
+      });
+      cfg.projects.set(subProjectPath, {
+        parentProjectPath: parentPath,
+        workspaces: [],
+      });
+      await config.editConfig(() => cfg);
+
+      // Deterministic interleaving: queue the sub-project removal so the assign call's
+      // synchronous snapshot read still sees it while its queued transform does not.
+      const removeSubProject = config.editConfig((fresh) => {
+        fresh.projects.delete(subProjectPath);
+        return fresh;
+      });
+      const result = await service.assignWorkspaceToSubProject(
+        parentPath,
+        workspaceId,
+        subProjectPath
+      );
+      await removeSubProject;
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected failure");
+      expect(result.error).toContain("Sub-project not found under parent");
+      const workspace = config.loadConfigOrDefault().projects.get(parentPath)?.workspaces[0];
+      expect(workspace?.subProjectPath).toBeUndefined();
     });
   });
 

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -139,6 +139,43 @@ describe("ProjectService", () => {
       expect(stat.isDirectory()).toBe(true);
       expect(config.loadConfigOrDefault().projects.has(projectPath)).toBe(true);
     });
+
+    // Regression (PR #3694 Codex P2): the snapshot-time depth check can miss a
+    // sub-project ancestor registered concurrently, persisting a project nested
+    // under a registered sub-project ("one level deep" invariant violation). The
+    // serialized transform must re-validate depth against the fresh hierarchy.
+    it("create rejects a path nested under a concurrently registered sub-project", async () => {
+      const repoPath = path.join(tempDir, "repo");
+      const pkgPath = path.join(repoPath, "pkg");
+      const apiPath = path.join(pkgPath, "api");
+      await fs.mkdir(apiPath, { recursive: true });
+      // Same-git-repo hierarchy so the snapshot-time git-root validations pass.
+      const git = Bun.spawn(["git", "init", "-q", repoPath]);
+      await git.exited;
+
+      const topLevel = await service.create(repoPath);
+      expect(topLevel.success).toBe(true);
+
+      // Deterministic interleaving: enqueue the concurrent sub-project registration
+      // of /repo/pkg first (not yet written), then call create(/repo/pkg/api). The
+      // create's synchronous snapshot read runs before the queued write lands, so
+      // its snapshot-time depth check misses pkg; its transform is queued after and
+      // sees pkg — only the fresh in-transform depth re-check can reject it.
+      const registerPkg = config.editConfig((cfg) => {
+        cfg.projects.set(pkgPath, { workspaces: [], parentProjectPath: repoPath });
+        return cfg;
+      });
+      const api = await service.create(apiPath);
+      await registerPkg;
+
+      expect(api.success).toBe(false);
+      expect(!api.success && api.error).toContain("one level deep");
+      const persisted = config.loadConfigOrDefault().projects;
+      expect(persisted.has(apiPath)).toBe(false);
+      // The pre-existing directory was not created by this call; it must survive.
+      const stat = await fs.stat(apiPath);
+      expect(stat.isDirectory()).toBe(true);
+    });
   });
 
   describe("listDirectory", () => {

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -1637,7 +1637,7 @@ exit 1
         parentProjectPath: parentPath,
         workspaces: [],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.assignWorkspaceToSubProject(
         subProjectPath,
@@ -1674,7 +1674,7 @@ exit 1
         parentProjectPath: "/other/project",
         workspaces: [],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.assignWorkspaceToSubProject(
         parentPath,
@@ -1693,7 +1693,7 @@ exit 1
       const projectPath = "/fake/project";
       const cfg = config.loadConfigOrDefault();
       cfg.projects.set(projectPath, { workspaces: [] });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1763,7 +1763,7 @@ exit 1
 
         const cfg = config.loadConfigOrDefault();
         cfg.projects.set(projectPath, { workspaces });
-        await config.saveConfig(cfg);
+        await config.editConfig(() => cfg);
 
         const removedWorkspaceIds: string[] = [];
         service.setWorkspaceService({
@@ -1793,7 +1793,7 @@ exit 1
       cfg.projects.set(projectPath, {
         workspaces: [{ path: archivedWorkspaceDir, archivedAt: ARCHIVED_AT }],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const legacyWorkspaceId = config.generateLegacyId(projectPath, archivedWorkspaceDir);
       const metadataPath = path.join(config.getSessionDir(legacyWorkspaceId), "metadata.json");
@@ -1832,7 +1832,7 @@ exit 1
       cfg.projects.set(projectPath, {
         workspaces: [{ id: "archived-workspace-1", path: archivedWorkspaceDir, archivedAt }],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       let removeCallCount = 0;
       service.setWorkspaceService({
@@ -1864,7 +1864,7 @@ exit 1
       cfg.projects.set(projectPath, {
         workspaces: [{ path: wsDir }],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1888,7 +1888,7 @@ exit 1
           },
         ],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1920,7 +1920,7 @@ exit 1
           },
         ],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1946,7 +1946,7 @@ exit 1
       cfg.projects.set(projectPath, {
         workspaces: [{ path: stalePath }],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1966,7 +1966,7 @@ exit 1
           },
         ],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 
@@ -1992,7 +1992,7 @@ exit 1
       cfg.projects.set(projectPath, {
         workspaces: [{ path: stalePath }, { path: realDir }],
       });
-      await config.saveConfig(cfg);
+      await config.editConfig(() => cfg);
 
       const result = await service.remove(projectPath);
 

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -511,7 +511,7 @@ export class ProjectService {
       // Distinguishes in-transform failures for directory cleanup: when a concurrent
       // call registered this same path ("duplicate"), the directory belongs to that
       // winner and must not be deleted; other rejections leave the directory ours.
-      let transformFailure: "duplicate" | "depth" | null = null;
+      let transformFailure: "duplicate" | "depth" | "hierarchy-changed" | null = null;
       await this.config.editConfig((freshConfig) => {
         if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
           transformFailure = "duplicate";
@@ -532,6 +532,24 @@ export class ProjectService {
           normalizedPath,
           freshConfig.projects
         );
+        // The same-git-repository validations above ran against the snapshot hierarchy
+        // only, and this transform is synchronous so it cannot re-run readGitTopLevel.
+        // If a concurrent edit introduced a different parent or new descendants, those
+        // were never git-validated — reject instead of persisting an unvalidated
+        // hierarchy (e.g. a sub-project from a different git repository).
+        const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
+          (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
+        );
+        if (
+          freshParentProjectPath !== parentProjectPath ||
+          freshDescendantProjectPaths.some(
+            (candidatePath) => !descendantProjectPaths.includes(candidatePath)
+          )
+        ) {
+          transformFailure = "hierarchy-changed";
+          createResult = Err("Project hierarchy changed concurrently; please retry");
+          return freshConfig;
+        }
         const projectConfig: ProjectConfig = {
           workspaces: [],
           parentProjectPath: freshParentProjectPath ?? undefined,
@@ -545,9 +563,9 @@ export class ProjectService {
       // Do NOT clean up the created directory when the transform loses the duplicate
       // re-check: a concurrent registration of this same path owns the directory now.
       // Deleting it would destroy the winner's checkout (including any files created
-      // there after the winning call returned). Depth rejections imply no concurrent
-      // claim on this path, so the directory we created is still ours to remove.
-      if (transformFailure === "depth") {
+      // there after the winning call returned). Depth/hierarchy rejections imply no
+      // concurrent claim on this path, so the directory we created is still ours.
+      if (transformFailure === "depth" || transformFailure === "hierarchy-changed") {
         await cleanupCreatedDirectory();
       }
       return createResult;
@@ -1504,6 +1522,16 @@ export class ProjectService {
       // resurrects concurrently removed workspaces). Entry gone meanwhile → Err.
       let result: Result<void> = Err(`Workspace not found: ${workspaceId}`);
       await this.config.editConfig((freshConfig) => {
+        // Re-validate the target sub-project against FRESH config: it can be removed or
+        // re-parented while this edit is queued, and send/runtime paths consume
+        // metadata.subProjectPath as the execution root — never persist a stale pointer.
+        if (subProjectPath !== null) {
+          const freshSubProject = freshConfig.projects.get(subProjectPath);
+          if (freshSubProject?.parentProjectPath !== owningProjectPath) {
+            result = Err(`Sub-project not found under parent: ${subProjectPath}`);
+            return freshConfig;
+          }
+        }
         const freshWorkspace = freshConfig.projects
           .get(owningProjectPath)
           ?.workspaces.find((w) => w.id === workspaceId);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -501,15 +501,37 @@ export class ProjectService {
         }
       }
 
-      const projectConfig: ProjectConfig = {
-        workspaces: [],
-        parentProjectPath: parentProjectPath ?? undefined,
-      };
-      config.projects.set(normalizedPath, projectConfig);
-      config.projects = deriveProjectHierarchy(config.projects);
-      await this.config.saveConfig(config);
+      // Register the project inside the serialized editConfig transform, re-checking for
+      // duplicates and re-deriving the hierarchy from FRESH config: persisting the pre-read
+      // snapshot would clobber concurrent config edits (lost-update race). The async
+      // validations above (git roots, sub-project depth) ran against the snapshot; the
+      // transform only re-resolves state that a concurrent edit could have changed.
+      let createResult: Result<{ projectConfig: ProjectConfig; normalizedPath: string }> =
+        Err("Project already exists");
+      await this.config.editConfig((freshConfig) => {
+        if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
+          createResult = Err("Project already exists");
+          return freshConfig;
+        }
+        freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+        const freshParentProjectPath = findDeepestTopLevelParentProject(
+          normalizedPath,
+          freshConfig.projects
+        );
+        const projectConfig: ProjectConfig = {
+          workspaces: [],
+          parentProjectPath: freshParentProjectPath ?? undefined,
+        };
+        freshConfig.projects.set(normalizedPath, projectConfig);
+        freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+        createResult = Ok({ projectConfig, normalizedPath });
+        return freshConfig;
+      });
 
-      return Ok({ projectConfig, normalizedPath });
+      if (!createResult.success) {
+        await cleanupCreatedDirectory();
+      }
+      return createResult;
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to create project: ${message}`);
@@ -886,8 +908,8 @@ export class ProjectService {
       });
 
       if (!this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
-        // Config.saveConfig logs-and-continues on write failures, so verify persistence
-        // explicitly before reporting success.
+        // Config persistence (editConfig → private saveConfig) logs-and-continues on write
+        // failures, so verify persistence explicitly before reporting success.
         try {
           await fsPromises.rm(normalizedPath, { recursive: true, force: true });
         } catch {
@@ -943,21 +965,28 @@ export class ProjectService {
       }
 
       if (projectConfig.parentProjectPath) {
-        const parentProject = config.projects.get(projectConfig.parentProjectPath);
-        if (parentProject) {
-          for (const workspace of parentProject.workspaces) {
-            if (workspace.subProjectPath === normalizedPath) {
-              workspace.subProjectPath = undefined;
-            }
-          }
-        }
         try {
           await this.config.updateProjectSecrets(normalizedPath, []);
         } catch (error) {
           log.error(`Failed to clean up secrets for sub-project ${normalizedPath}:`, error);
         }
-        config.projects.delete(normalizedPath);
-        await this.config.saveConfig(config);
+        // Mutate inside the serialized editConfig transform, re-resolving the sub-project
+        // and its parent from FRESH config: persisting the pre-read snapshot would clobber
+        // concurrent config edits (e.g. resurrect concurrently removed workspaces).
+        await this.config.editConfig((freshConfig) => {
+          const freshSubProject = freshConfig.projects.get(normalizedPath);
+          const parentPath = freshSubProject?.parentProjectPath;
+          const parentProject = parentPath ? freshConfig.projects.get(parentPath) : undefined;
+          if (parentProject) {
+            for (const workspace of parentProject.workspaces) {
+              if (workspace.subProjectPath === normalizedPath) {
+                workspace.subProjectPath = undefined;
+              }
+            }
+          }
+          freshConfig.projects.delete(normalizedPath);
+          return freshConfig;
+        });
         return Ok(undefined);
       }
 
@@ -966,7 +995,7 @@ export class ProjectService {
       // Only check local/worktree runtimes — remote runtimes (SSH, Docker, devcontainer)
       // have paths on the remote host that won't exist locally.
       const localRuntimeTypes = new Set(["local", "worktree"]);
-      const survivingWorkspaces = [];
+      const survivingWorkspaces: ProjectConfig["workspaces"] = [];
       for (const ws of projectConfig.workspaces) {
         const runtimeType = ws.runtimeConfig?.type;
         const isLocal = runtimeType == null || localRuntimeTypes.has(runtimeType);
@@ -992,8 +1021,29 @@ export class ProjectService {
         }
       }
       if (survivingWorkspaces.length !== projectConfig.workspaces.length) {
-        projectConfig.workspaces = survivingWorkspaces;
-        await this.config.saveConfig(config);
+        // Prune inside the serialized editConfig transform, filtering the FRESH workspace
+        // list by the paths verified missing above: replacing the list from the pre-read
+        // snapshot would drop workspaces added concurrently (lost-update race).
+        const prunedWorkspacePaths = new Set(
+          projectConfig.workspaces
+            .filter((ws) => !survivingWorkspaces.includes(ws))
+            .map((ws) => ws.path)
+        );
+        await this.config.editConfig((freshConfig) => {
+          const freshProject = freshConfig.projects.get(normalizedPath);
+          if (freshProject) {
+            freshProject.workspaces = freshProject.workspaces.filter(
+              (ws) => !prunedWorkspacePaths.has(ws.path)
+            );
+          }
+          return freshConfig;
+        });
+        // Re-read so the counting below reflects the persisted state.
+        config = this.config.loadConfigOrDefault();
+        projectConfig = config.projects.get(normalizedPath);
+        if (!projectConfig) {
+          return Err({ type: "project_not_found" as const });
+        }
       }
 
       let counts = getProjectWorkspaceCounts(projectConfig.workspaces);
@@ -1082,15 +1132,21 @@ export class ProjectService {
         return Err({ type: "workspace_blockers" as const, ...counts });
       }
 
+      // Delete inside the serialized editConfig transform, re-collecting sub-projects from
+      // FRESH config: persisting the pre-read snapshot would clobber concurrent config
+      // edits (e.g. resurrect concurrently removed workspaces in other projects).
       const removedSubProjectPaths: string[] = [];
-      for (const [candidatePath, candidateConfig] of Array.from(config.projects.entries())) {
-        if (candidateConfig.parentProjectPath === normalizedPath) {
-          removedSubProjectPaths.push(candidatePath);
-          config.projects.delete(candidatePath);
+      await this.config.editConfig((freshConfig) => {
+        removedSubProjectPaths.length = 0;
+        for (const [candidatePath, candidateConfig] of Array.from(freshConfig.projects.entries())) {
+          if (candidateConfig.parentProjectPath === normalizedPath) {
+            removedSubProjectPaths.push(candidatePath);
+            freshConfig.projects.delete(candidatePath);
+          }
         }
-      }
-      config.projects.delete(normalizedPath);
-      await this.config.saveConfig(config);
+        freshConfig.projects.delete(normalizedPath);
+        return freshConfig;
+      });
 
       for (const subProjectPath of removedSubProjectPaths) {
         try {
@@ -1365,16 +1421,18 @@ export class ProjectService {
    */
   async setIdleCompactionHours(projectPath: string, hours: number | null): Promise<Result<void>> {
     try {
-      const config = this.config.loadConfigOrDefault();
-      const project = config.projects.get(projectPath);
-
-      if (!project) {
-        return Err(`Project not found: ${projectPath}`);
-      }
-
-      project.idleCompactionHours = hours;
-      await this.config.saveConfig(config);
-      return Ok(undefined);
+      // Mutate inside the serialized editConfig transform, re-finding the project from
+      // FRESH config: persisting a pre-read snapshot loses concurrent config edits.
+      let result: Result<void> = Err(`Project not found: ${projectPath}`);
+      await this.config.editConfig((freshConfig) => {
+        const project = freshConfig.projects.get(projectPath);
+        if (project) {
+          project.idleCompactionHours = hours;
+          result = Ok(undefined);
+        }
+        return freshConfig;
+      });
+      return result;
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to set idle compaction hours: ${message}`);
@@ -1418,14 +1476,25 @@ export class ProjectService {
         }
       }
 
-      const workspace = owningProject.workspaces.find((w) => w.id === workspaceId);
-      if (!workspace) {
+      if (!owningProject.workspaces.some((w) => w.id === workspaceId)) {
         return Err(`Workspace not found: ${workspaceId}`);
       }
 
-      workspace.subProjectPath = subProjectPath ?? undefined;
-      await this.config.saveConfig(config);
-      return Ok(undefined);
+      // Mutate inside the serialized editConfig transform, re-finding the workspace from
+      // FRESH config: persisting a pre-read snapshot loses concurrent config edits (e.g.
+      // resurrects concurrently removed workspaces). Entry gone meanwhile → Err.
+      let result: Result<void> = Err(`Workspace not found: ${workspaceId}`);
+      await this.config.editConfig((freshConfig) => {
+        const freshWorkspace = freshConfig.projects
+          .get(owningProjectPath)
+          ?.workspaces.find((w) => w.id === workspaceId);
+        if (freshWorkspace) {
+          freshWorkspace.subProjectPath = subProjectPath ?? undefined;
+          result = Ok(undefined);
+        }
+        return freshConfig;
+      });
+      return result;
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to assign workspace to sub-project: ${message}`);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -511,7 +511,12 @@ export class ProjectService {
       // Distinguishes in-transform failures for directory cleanup: when a concurrent
       // call registered this same path ("duplicate"), the directory belongs to that
       // winner and must not be deleted; other rejections leave the directory ours.
-      let transformFailure: "duplicate" | "depth" | "hierarchy-changed" | null = null;
+      let transformFailure:
+        | "duplicate"
+        | "depth"
+        | "hierarchy-changed"
+        | "hierarchy-changed-descendant"
+        | null = null;
       await this.config.editConfig((freshConfig) => {
         if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
           transformFailure = "duplicate";
@@ -540,13 +545,16 @@ export class ProjectService {
         const freshDescendantProjectPaths = Array.from(freshConfig.projects.keys()).filter(
           (candidatePath) => isPathDescendant(normalizedPath, candidatePath)
         );
-        if (
-          freshParentProjectPath !== parentProjectPath ||
-          freshDescendantProjectPaths.some(
-            (candidatePath) => !descendantProjectPaths.includes(candidatePath)
-          )
-        ) {
-          transformFailure = "hierarchy-changed";
+        const hasNewDescendantProject = freshDescendantProjectPaths.some(
+          (candidatePath) => !descendantProjectPaths.includes(candidatePath)
+        );
+        if (freshParentProjectPath !== parentProjectPath || hasNewDescendantProject) {
+          // A new descendant registered under this path claims the directory tree we
+          // created: recursive cleanup would delete that project's checkout, so treat
+          // it like the duplicate case and leave the directory alone.
+          transformFailure = hasNewDescendantProject
+            ? "hierarchy-changed-descendant"
+            : "hierarchy-changed";
           createResult = Err("Project hierarchy changed concurrently; please retry");
           return freshConfig;
         }
@@ -560,11 +568,11 @@ export class ProjectService {
         return freshConfig;
       });
 
-      // Do NOT clean up the created directory when the transform loses the duplicate
-      // re-check: a concurrent registration of this same path owns the directory now.
-      // Deleting it would destroy the winner's checkout (including any files created
-      // there after the winning call returned). Depth/hierarchy rejections imply no
-      // concurrent claim on this path, so the directory we created is still ours.
+      // Do NOT clean up the created directory when a concurrent registration claims
+      // it: a duplicate owns this exact path, and a new descendant project lives
+      // inside the tree we created — recursive removal would destroy the winner's
+      // checkout either way (including files created after its call returned). Only
+      // depth and parent-only hierarchy rejections leave the directory ours to remove.
       if (transformFailure === "depth" || transformFailure === "hierarchy-changed") {
         await cleanupCreatedDirectory();
       }

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -508,12 +508,26 @@ export class ProjectService {
       // transform only re-resolves state that a concurrent edit could have changed.
       let createResult: Result<{ projectConfig: ProjectConfig; normalizedPath: string }> =
         Err("Project already exists");
+      // Distinguishes in-transform failures for directory cleanup: when a concurrent
+      // call registered this same path ("duplicate"), the directory belongs to that
+      // winner and must not be deleted; other rejections leave the directory ours.
+      let transformFailure: "duplicate" | "depth" | null = null;
       await this.config.editConfig((freshConfig) => {
         if (freshConfig.projects.has(normalizedPath) || freshConfig.projects.has(canonicalPath)) {
+          transformFailure = "duplicate";
           createResult = Err("Project already exists");
           return freshConfig;
         }
         freshConfig.projects = deriveProjectHierarchy(freshConfig.projects);
+        // Re-run the sub-project depth check against FRESH hierarchy: a concurrent
+        // registration (e.g. /repo/pkg landing while /repo/pkg/api is validating)
+        // can introduce a sub-project ancestor that the snapshot-time check missed,
+        // which would persist a second-level sub-project.
+        if (hasRegisteredSubProjectAncestor(normalizedPath, freshConfig.projects)) {
+          transformFailure = "depth";
+          createResult = Err("Sub-projects can only be one level deep");
+          return freshConfig;
+        }
         const freshParentProjectPath = findDeepestTopLevelParentProject(
           normalizedPath,
           freshConfig.projects
@@ -529,10 +543,13 @@ export class ProjectService {
       });
 
       // Do NOT clean up the created directory when the transform loses the duplicate
-      // re-check: the only in-transform failure is a concurrent registration of this
-      // same path, so the directory on disk now belongs to the winning project.
-      // Deleting it here would destroy the winner's checkout (including any files
-      // already created there after the winning call returned).
+      // re-check: a concurrent registration of this same path owns the directory now.
+      // Deleting it would destroy the winner's checkout (including any files created
+      // there after the winning call returned). Depth rejections imply no concurrent
+      // claim on this path, so the directory we created is still ours to remove.
+      if (transformFailure === "depth") {
+        await cleanupCreatedDirectory();
+      }
       return createResult;
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -528,9 +528,11 @@ export class ProjectService {
         return freshConfig;
       });
 
-      if (!createResult.success) {
-        await cleanupCreatedDirectory();
-      }
+      // Do NOT clean up the created directory when the transform loses the duplicate
+      // re-check: the only in-transform failure is a concurrent registration of this
+      // same path, so the directory on disk now belongs to the winning project.
+      // Deleting it here would destroy the winner's checkout (including any files
+      // already created there after the winning call returned).
       return createResult;
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -56,11 +56,11 @@ async function saveRoutePriority(
   routePriority: string[],
   overrides: Record<string, unknown> = {}
 ): Promise<void> {
-  await config.saveConfig({
+  await config.editConfig(() => ({
     ...config.loadConfigOrDefault(),
     ...overrides,
     routePriority,
-  });
+  }));
 }
 
 type ResolveAndCreateModelResult = Awaited<

--- a/src/node/services/providerService.test.ts
+++ b/src/node/services/providerService.test.ts
@@ -32,7 +32,7 @@ async function saveRoutePriority(
   routePriority: string[],
   overrides: Record<string, unknown> = {}
 ): Promise<void> {
-  await config.saveConfig({ ...config.loadConfigOrDefault(), ...overrides, routePriority });
+  await config.editConfig(() => ({ ...config.loadConfigOrDefault(), ...overrides, routePriority }));
 }
 
 function saveMuxGatewayConfig(config: Config): void {
@@ -843,10 +843,10 @@ describe("ProviderService custom provider mutations", () => {
           baseUrl: LOCAL_VLLM_BASE_URL,
         },
       });
-      await config.saveConfig({
+      await config.editConfig(() => ({
         ...config.loadConfigOrDefault(),
         defaultModel: "openai:gpt-4.1",
-      });
+      }));
 
       const result = await service.removeCustomProvider("openai");
 
@@ -914,10 +914,10 @@ describe("ProviderService custom provider mutations", () => {
       config.saveProvidersConfig({
         "local-vllm": localVllmConfig(),
       });
-      await config.saveConfig({
+      await config.editConfig(() => ({
         ...config.loadConfigOrDefault(),
         defaultModel: "local-vllm:qwen3-coder",
-      });
+      }));
       const saveProvidersConfigSpy = spyOn(config, "saveProvidersConfig");
       saveProvidersConfigSpy.mockImplementationOnce(() => {
         throw new Error("disk is read-only");
@@ -940,10 +940,10 @@ describe("ProviderService custom provider mutations", () => {
       config.saveProvidersConfig({
         "local-vllm": localVllmConfig(),
       });
-      await config.saveConfig({
+      await config.editConfig(() => ({
         ...config.loadConfigOrDefault(),
         defaultModel: "local-vllm:qwen3-coder",
-      });
+      }));
       let configChangedCount = 0;
       const unsubscribe = service.onConfigChanged(() => {
         configChangedCount += 1;

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -10072,6 +10072,79 @@ describe("TaskService", () => {
     expect(userInterrupted?.archivedAt).toBeUndefined();
   });
 
+  test("initialize re-sweeps a run whose interrupted children were archived but reported ancestor was not", async () => {
+    // Regression (PR #3694 Codex P2): crash window between sweep phases. If a previous
+    // session archived the interrupted child (phase 1) but crashed before archiving the
+    // reported ancestor it blocks (phase 2), no unarchived interrupted task remains to
+    // seed the startup sweep — so the reported ancestor stayed visible forever. The
+    // seeding now also considers unarchived reported workflow-owned tasks.
+    const config = await createTestConfig(rootDir);
+
+    const projectPath = path.join(rootDir, "repo");
+    const rootId = "root-crash-window";
+    const reportedParentId = "reported-parent-crash-window";
+    const archivedChildId = "archived-interrupted-child";
+    const workflowRunId = "wfr_crash_window_sweep";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "root", rootId),
+        // Phase-2 leftover: reported, unarchived, blocked by its archived child.
+        projectWorkspace(projectPath, "reported-parent", reportedParentId, {
+          name: "agent_exec_reported_parent",
+          parentWorkspaceId: rootId,
+          agentId: "exec",
+          agentType: "exec",
+          taskStatus: "reported",
+          reportedAt: "2026-05-29T00:00:02.000Z",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "parent" },
+        }),
+        // Phase-1 result from the crashed session: interrupted child already archived.
+        projectWorkspace(projectPath, "archived-child", archivedChildId, {
+          name: "agent_explore_archived",
+          parentWorkspaceId: reportedParentId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+          archivedAt: "2026-05-29T00:00:03.000Z",
+        }),
+      ],
+      testTaskSettings(10, 3)
+    );
+    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(rootId) });
+    await runStore.createRun({
+      id: workflowRunId,
+      workspaceId: rootId,
+      workflow: {
+        name: "interrupted",
+        description: "Interrupted",
+        scope: "built-in",
+        executable: true,
+      },
+      source: "export default function workflow() { return {}; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    await runStore.appendStatus(workflowRunId, "interrupted", "2026-05-29T00:00:01.000Z");
+
+    const archive = createConfigMutatingArchiveMock(() => config);
+    const { aiService } = createAIServiceMocks(config, { isStreaming: mock(() => false) });
+    const { workspaceService } = createWorkspaceServiceMocks({ archive });
+    const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+
+    await taskService.initialize();
+
+    // The startup sweep re-seeded the run from the unarchived reported ancestor and
+    // archived it (blocked only by its archived child), completing the interrupted sweep.
+    const reportedParent = findWorkspaceInConfig(config, reportedParentId);
+    expect(reportedParent?.archivedAt).toBeString();
+    expect(reportedParent?.taskStatus).toBe("reported");
+  });
+
   test("initialize drains queued tasks after interrupting inactive workflow children", async () => {
     const config = await createTestConfig(rootDir);
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -220,10 +220,10 @@ async function saveTestConfig(
   projects: Array<[string, ProjectConfig]>,
   overrides: TestConfigOverrides = {}
 ): Promise<void> {
-  await config.saveConfig({
+  await config.editConfig(() => ({
     projects: new Map(projects),
     ...overrides,
-  });
+  }));
 }
 
 async function saveWorkspaces(
@@ -4785,7 +4785,7 @@ describe("TaskService", () => {
       },
     ];
 
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           primaryProjectPath,
@@ -4818,7 +4818,7 @@ describe("TaskService", () => {
         [secondaryProjectPath, { trusted: true, workspaces: [] }],
       ]),
       taskSettings: { maxParallelAgentTasks: 1, maxTaskNestingDepth: 3 },
-    });
+    }));
 
     await config.updateProjectSecrets(primaryProjectPath, [
       { key: "PRIMARY_SECRET", value: "primary-secret" },
@@ -5336,7 +5336,7 @@ describe("TaskService", () => {
       },
     ];
 
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           primaryProjectPath,
@@ -5369,7 +5369,7 @@ describe("TaskService", () => {
         [secondaryProjectPath, { trusted: true, workspaces: [] }],
       ]),
       taskSettings: { maxParallelAgentTasks: 1, maxTaskNestingDepth: 3 },
-    });
+    }));
 
     await config.editConfig((cfg) => {
       const secondaryProject = cfg.projects.get(secondaryProjectPath);
@@ -15398,7 +15398,7 @@ describe("TaskService", () => {
     if (!childEntry) return;
 
     childEntry.taskModelString = "   ";
-    await config.saveConfig(preCfg);
+    await config.editConfig(() => preCfg);
 
     await internal.handleStreamEnd(makeSuccessfulProposePlanStreamEndEvent(childId));
 
@@ -16648,7 +16648,7 @@ describe("TaskService", () => {
     // This simulates the case where parent workspace name (e.g., from SSH)
     // doesn't correspond to a local branch in the project repository.
     const nonExistentBranchName = "non-existent-branch-xyz";
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           projectPath,
@@ -16667,7 +16667,7 @@ describe("TaskService", () => {
         ],
       ]),
       taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-    });
+    }));
     const { taskService } = createTaskServiceHarness(config);
 
     // Creating a task should succeed by falling back to "main" as trunkBranch
@@ -16700,7 +16700,7 @@ describe("TaskService", () => {
     }
 
     assert(removed, `Expected workspace ${workspaceId} to exist in test config`);
-    await config.saveConfig(cfg);
+    await config.editConfig(() => cfg);
   }
 
   test("reported leaf cleanup deletes the finished leaf but keeps siblings and parents", async () => {
@@ -16712,7 +16712,7 @@ describe("TaskService", () => {
     const childTaskAId = "child-a-333";
     const childTaskBId = "child-b-444";
 
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           projectPath,
@@ -16743,7 +16743,7 @@ describe("TaskService", () => {
         ],
       ]),
       taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-    });
+    }));
 
     const isStreaming = mock(() => false);
     const remove = mock(async (workspaceId: string, _force?: boolean): Promise<Result<void>> => {
@@ -16783,7 +16783,7 @@ describe("TaskService", () => {
     const parentTaskId = "parent-222";
     const childTaskId = "child-a-333";
 
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           projectPath,
@@ -16814,7 +16814,7 @@ describe("TaskService", () => {
         ],
       ]),
       taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-    });
+    }));
 
     const isStreaming = mock(() => false);
     const remove = mock(async (workspaceId: string, _force?: boolean): Promise<Result<void>> => {
@@ -16862,7 +16862,7 @@ describe("TaskService", () => {
     const childTaskId = "child-a-333";
     const completedAt = "2026-03-09T11:05:58.780Z";
 
-    await config.saveConfig({
+    await config.editConfig(() => ({
       projects: new Map([
         [
           projectPath,
@@ -16896,7 +16896,7 @@ describe("TaskService", () => {
         ],
       ]),
       taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-    });
+    }));
 
     const isStreaming = mock(() => false);
     const remove = mock(async (workspaceId: string, _force?: boolean): Promise<Result<void>> => {
@@ -17341,7 +17341,7 @@ describe("TaskService", () => {
       const rootWorkspaceId = "root-resume-111";
       const childTaskId = "child-resume-222";
 
-      await config.saveConfig({
+      await config.editConfig(() => ({
         projects: new Map([
           [
             projectPath,
@@ -17362,7 +17362,7 @@ describe("TaskService", () => {
           ],
         ]),
         taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-      });
+      }));
 
       const { aiService } = createAIServiceMocks(config);
       const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
@@ -17440,7 +17440,7 @@ describe("TaskService", () => {
       const rootWorkspaceId = "root-workflow-budget";
       const firstRunId = "wfr_budget_first";
       const secondRunId = "wfr_budget_second";
-      await config.saveConfig({
+      await config.editConfig(() => ({
         projects: new Map([
           [
             projectPath,
@@ -17451,7 +17451,7 @@ describe("TaskService", () => {
           ],
         ]),
         taskSettings: { maxParallelAgentTasks: 3, maxTaskNestingDepth: 3 },
-      });
+      }));
 
       const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(rootWorkspaceId) });
       await runStore.createRun({
@@ -17554,7 +17554,7 @@ describe("TaskService", () => {
       const childA = "child-A";
       const childB = "child-B";
 
-      await config.saveConfig({
+      await config.editConfig(() => ({
         projects: new Map([
           [
             projectPath,
@@ -17582,7 +17582,7 @@ describe("TaskService", () => {
           ],
         ]),
         taskSettings: { maxParallelAgentTasks: 5, maxTaskNestingDepth: 3 },
-      });
+      }));
 
       const { aiService } = createAIServiceMocks(config);
       const { workspaceService, sendMessage } = createWorkspaceServiceMocks();

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -9815,6 +9815,263 @@ describe("TaskService", () => {
     );
   });
 
+  // Archive mock that mirrors the real WorkspaceService.archive persistence effect
+  // (sets archivedAt in config) so tests can assert the sidebar-relevant state rather
+  // than only mock call counts.
+  function createConfigMutatingArchiveMock(getConfig: () => Config) {
+    return mock(async (workspaceId: string): Promise<Result<{ kind: "archived" }>> => {
+      await getConfig().editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const workspace = project.workspaces.find((w) => w.id === workspaceId);
+          if (workspace) workspace.archivedAt = new Date().toISOString();
+        }
+        return cfg;
+      });
+      return Ok({ kind: "archived" });
+    });
+  }
+
+  test("markWorkflowRunEnded archives interrupted workflow children and blocked reported ancestors", async () => {
+    const config = await createTestConfig(rootDir);
+
+    const projectPath = path.join(rootDir, "repo");
+    const rootId = "root-run-ended";
+    const reportedParentId = "reported-parent-blocked";
+    const interruptedChildId = "interrupted-child-no-report";
+    const completedChildId = "completed-leaf-child";
+    const userInterruptedId = "user-spawned-interrupted";
+    const workflowRunId = "wfr_ended_garbage_sweep";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "root", rootId),
+        // Reported workflow-owned task blocked by the structural-leaf topology gate:
+        // its interrupted-without-report child keeps hasChildAgentTasks true forever.
+        projectWorkspace(projectPath, "reported-parent", reportedParentId, {
+          name: "agent_exec_reported_parent",
+          parentWorkspaceId: rootId,
+          agentId: "exec",
+          agentType: "exec",
+          taskStatus: "reported",
+          reportedAt: "2026-05-29T00:00:02.000Z",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "parent" },
+        }),
+        // Interrupted WITHOUT a completed report: canCleanupReportedTask never accepts
+        // it, so before the sweep it lingered in the active sidebar forever.
+        projectWorkspace(projectPath, "interrupted-child", interruptedChildId, {
+          name: "agent_explore_interrupted",
+          parentWorkspaceId: reportedParentId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+        }),
+        // Completed-report leaf: must go through the existing remove-based cleanup,
+        // not the archive path.
+        projectWorkspace(projectPath, "completed-child", completedChildId, {
+          name: "agent_explore_completed",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "reported",
+          reportedAt: "2026-05-29T00:00:03.000Z",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "completed" },
+        }),
+        // User-spawned interrupted task (no workflowTask in ancestry): intentionally
+        // stays visible for manual inspection.
+        projectWorkspace(projectPath, "user-interrupted", userInterruptedId, {
+          name: "agent_explore_user",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+        }),
+      ],
+      testTaskSettings(10, 3)
+    );
+
+    const archive = createConfigMutatingArchiveMock(() => config);
+    const remove = mock(async (workspaceId: string): Promise<Result<void>> => {
+      await config.editConfig((cfg) => {
+        for (const project of cfg.projects.values()) {
+          const index = project.workspaces.findIndex((w) => w.id === workspaceId);
+          if (index !== -1) project.workspaces.splice(index, 1);
+        }
+        return cfg;
+      });
+      return Ok(undefined);
+    });
+    const { aiService } = createAIServiceMocks(config, { isStreaming: mock(() => false) });
+    const { workspaceService } = createWorkspaceServiceMocks({ archive, remove });
+    const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+
+    await taskService.markWorkflowRunEnded(workflowRunId);
+
+    // Interrupted-without-report workflow child: archived (hidden from the active
+    // sidebar) but preserved, still interrupted.
+    const interruptedChild = findWorkspaceInConfig(config, interruptedChildId);
+    expect(interruptedChild?.archivedAt).toBeString();
+    expect(interruptedChild?.taskStatus).toBe("interrupted");
+
+    // Completed-report leaf: removed via the existing cleanup walk, never archived.
+    expect(findWorkspaceInConfig(config, completedChildId)).toBeUndefined();
+
+    // Reported ancestor blocked only by its archived interrupted child: archived too,
+    // so the garbage cluster leaves the active sidebar without deleting anything.
+    const reportedParent = findWorkspaceInConfig(config, reportedParentId);
+    expect(reportedParent?.archivedAt).toBeString();
+    expect(reportedParent?.taskStatus).toBe("reported");
+
+    // User-spawned interrupted task keeps current behavior: visible, untouched.
+    const userInterrupted = findWorkspaceInConfig(config, userInterruptedId);
+    expect(userInterrupted?.archivedAt).toBeUndefined();
+    expect(userInterrupted?.taskStatus).toBe("interrupted");
+  });
+
+  test("terminateAllDescendantAgentTasks archives run-scoped interrupted children immediately", async () => {
+    const config = await createTestConfig(rootDir);
+
+    const projectPath = path.join(rootDir, "repo");
+    const rootId = "root-run-interrupt";
+    const workflowChildId = "workflow-running-child";
+    const userChildId = "user-running-child";
+    const workflowRunId = "wfr_interrupt_sweep";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "root", rootId),
+        projectWorkspace(projectPath, "workflow-child", workflowChildId, {
+          name: "agent_explore_workflow",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "child" },
+        }),
+        projectWorkspace(projectPath, "user-child", userChildId, {
+          name: "agent_explore_user",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+          taskModelString: defaultModel,
+        }),
+      ],
+      testTaskSettings(10, 3)
+    );
+
+    const archive = createConfigMutatingArchiveMock(() => config);
+    const { aiService } = createAIServiceMocks(config, { isStreaming: mock(() => false) });
+    const { workspaceService } = createWorkspaceServiceMocks({ archive });
+    const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+
+    // Run-scoped interrupt (WorkflowService.interruptRun path): the sweep archives the
+    // freshly interrupted workflow child even if the runner's onRunEnded hook already
+    // fired before the children were interrupted.
+    await taskService.terminateAllDescendantAgentTasks(rootId, { workflowRunId });
+
+    const workflowChild = findWorkspaceInConfig(config, workflowChildId);
+    expect(workflowChild?.taskStatus).toBe("interrupted");
+    expect(workflowChild?.archivedAt).toBeString();
+
+    // The run-scoped filter leaves the user-spawned sibling running and unarchived.
+    const userChild = findWorkspaceInConfig(config, userChildId);
+    expect(userChild?.taskStatus).toBe("running");
+    expect(userChild?.archivedAt).toBeUndefined();
+  });
+
+  test("initialize archives interrupted workflow-owned children of inactive runs but not user-spawned tasks", async () => {
+    const config = await createTestConfig(rootDir);
+
+    const projectPath = path.join(rootDir, "repo");
+    const rootId = "root-startup-sweep";
+    const workflowChildId = "workflow-child-startup";
+    const staleInterruptedId = "workflow-child-stale-interrupted";
+    const userInterruptedId = "user-interrupted-startup";
+    const workflowRunId = "wfr_startup_sweep";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "root", rootId),
+        // Running child of an inactive run: the startup prepass transitions it to
+        // "interrupted"; the startup sweep must then archive it.
+        projectWorkspace(projectPath, "workflow-child", workflowChildId, {
+          name: "agent_explore_workflow",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "child" },
+        }),
+        // Historical garbage: already interrupted (pre-sweep sessions) — must self-heal.
+        projectWorkspace(projectPath, "stale-interrupted", staleInterruptedId, {
+          name: "agent_explore_stale",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "stale" },
+        }),
+        projectWorkspace(projectPath, "user-interrupted", userInterruptedId, {
+          name: "agent_explore_user",
+          parentWorkspaceId: rootId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+        }),
+      ],
+      testTaskSettings(10, 3)
+    );
+    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(rootId) });
+    await runStore.createRun({
+      id: workflowRunId,
+      workspaceId: rootId,
+      workflow: {
+        name: "interrupted",
+        description: "Interrupted",
+        scope: "built-in",
+        executable: true,
+      },
+      source: "export default function workflow() { return {}; }\n",
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    await runStore.appendStatus(workflowRunId, "interrupted", "2026-05-29T00:00:01.000Z");
+
+    const archive = createConfigMutatingArchiveMock(() => config);
+    const { aiService } = createAIServiceMocks(config, { isStreaming: mock(() => false) });
+    const { workspaceService } = createWorkspaceServiceMocks({ archive });
+    const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+
+    await taskService.initialize();
+
+    // Prepass interrupted the running child; the startup sweep archived both it and
+    // the historical interrupted leftover.
+    for (const taskId of [workflowChildId, staleInterruptedId]) {
+      const workspace = findWorkspaceInConfig(config, taskId);
+      expect(workspace?.taskStatus).toBe("interrupted");
+      expect(workspace?.archivedAt).toBeString();
+    }
+
+    // User-spawned interrupted task keeps current behavior: visible, untouched.
+    const userInterrupted = findWorkspaceInConfig(config, userInterruptedId);
+    expect(userInterrupted?.taskStatus).toBe("interrupted");
+    expect(userInterrupted?.archivedAt).toBeUndefined();
+  });
+
   test("initialize drains queued tasks after interrupting inactive workflow children", async () => {
     const config = await createTestConfig(rootDir);
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -9988,6 +9988,77 @@ describe("TaskService", () => {
     expect(userChild?.archivedAt).toBeUndefined();
   });
 
+  test("sweep keeps an ancestor visible when a descendant archive is skipped", async () => {
+    // Regression (PR #3694 Codex P2): a child archive skipped by the lossy-untracked-file
+    // confirmation (or a failed archive) must block its ancestors' archives too —
+    // otherwise the parent gets hidden while its unarchived child stays active in the
+    // sidebar as an orphan.
+    const config = await createTestConfig(rootDir);
+
+    const projectPath = path.join(rootDir, "repo");
+    const rootId = "root-skip-blocks-ancestor";
+    const parentTaskId = "interrupted-parent-task";
+    const childTaskId = "interrupted-child-lossy";
+    const workflowRunId = "wfr_skip_blocks_ancestor";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "root", rootId),
+        projectWorkspace(projectPath, "interrupted-parent", parentTaskId, {
+          name: "agent_exec_parent",
+          parentWorkspaceId: rootId,
+          agentId: "exec",
+          agentType: "exec",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+          workflowTask: { runId: workflowRunId, stepId: "parent" },
+        }),
+        projectWorkspace(projectPath, "interrupted-child", childTaskId, {
+          name: "agent_exec_child",
+          parentWorkspaceId: parentTaskId,
+          agentId: "exec",
+          agentType: "exec",
+          taskStatus: "interrupted",
+          taskModelString: defaultModel,
+        }),
+      ],
+      testTaskSettings(10, 3)
+    );
+
+    // Child archive is deferred pending untracked-file confirmation; parent would archive.
+    const archived: string[] = [];
+    const archive = mock(
+      async (
+        workspaceId: string
+      ): Promise<Result<{ kind: "archived" } | { kind: "confirm-lossy-untracked-files" }>> => {
+        if (workspaceId === childTaskId) {
+          return Ok({ kind: "confirm-lossy-untracked-files" });
+        }
+        await config.editConfig((cfg) => {
+          for (const project of cfg.projects.values()) {
+            const workspace = project.workspaces.find((w) => w.id === workspaceId);
+            if (workspace) workspace.archivedAt = new Date().toISOString();
+          }
+          return cfg;
+        });
+        archived.push(workspaceId);
+        return Ok({ kind: "archived" });
+      }
+    );
+    const { aiService } = createAIServiceMocks(config, { isStreaming: mock(() => false) });
+    const { workspaceService } = createWorkspaceServiceMocks({ archive });
+    const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
+
+    await taskService.markWorkflowRunEnded(workflowRunId);
+
+    // Child stayed visible (confirmation pending) — so the parent must stay visible too.
+    expect(findWorkspaceInConfig(config, childTaskId)?.archivedAt).toBeUndefined();
+    expect(findWorkspaceInConfig(config, parentTaskId)?.archivedAt).toBeUndefined();
+    expect(archived).not.toContain(parentTaskId);
+  });
+
   test("initialize archives interrupted workflow-owned children of inactive runs but not user-spawned tasks", async () => {
     const config = await createTestConfig(rootDir);
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -3953,10 +3953,16 @@ export class TaskService {
     const index = this.buildAgentTaskIndex(cfg);
     const inactiveRunIds = new Set<string>();
     for (const [taskId, workspace] of index.byId) {
-      if (workspace.taskStatus !== "interrupted" || hasCompletedAgentReport(workspace)) {
+      if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) continue;
+      // Seed from two unarchived shapes so a crash mid-sweep still self-heals:
+      // - interrupted-without-report children (normal leftover garbage), and
+      // - reported tasks, covering a crash after phase 1 archived the interrupted
+      //   children but before phase 2 archived the reported ancestor they block —
+      //   at that point no unarchived interrupted task remains to re-seed the run.
+      // Reported tasks of ACTIVE runs are filtered out by the inactivity check below.
+      if (workspace.taskStatus !== "interrupted" && !hasCompletedAgentReport(workspace)) {
         continue;
       }
-      if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) continue;
       // Non-workflow-owned tasks have no owner in ancestry → null → skipped (user-spawned
       // interrupted tasks intentionally stay visible).
       const inactiveOwner = await this.getInactiveWorkflowTaskOwnerForRecovery(taskId, cfg, index);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -2112,6 +2112,17 @@ export class TaskService {
     }
     const cleanupReportedTasksMs = Date.now() - cleanupReportedTasksStartedAt;
 
+    // Startup self-heal for leftover workflow task garbage: interrupted-without-report
+    // workflow-owned children of inactive runs (both the ones the prepass above just
+    // interrupted and historical leftovers) are archived out of the active sidebar.
+    // Startup-time rule: never crash the app — archive failures are logged and retried
+    // on the next launch.
+    try {
+      await this.archiveLeftoverTasksOfInactiveWorkflowRuns();
+    } catch (error: unknown) {
+      log.error("Startup workflow task archive sweep failed", { error });
+    }
+
     const recoveredTerminalWorkflowRunNotificationCount =
       await this.recoverTerminalWorkflowRunAttentionNotifications();
     const recoveredTerminalWorkspaceTurnNotificationCount =
@@ -3789,26 +3800,173 @@ export class TaskService {
     return Ok({ terminatedTaskIds });
   }
 
-  /** Best-effort final recheck for any completed workflow children still deferred by cleanup gates. */
+  /**
+   * Best-effort sweep of leftover task workspaces once a workflow run reached a terminal
+   * state (completed, failed, interrupted): recheck completed children still deferred by
+   * cleanup gates and archive interrupted-without-report garbage.
+   */
   async markWorkflowRunEnded(workflowRunId: string): Promise<void> {
     assert(workflowRunId.length > 0, "markWorkflowRunEnded: workflowRunId must be non-empty");
+    await this.sweepEndedWorkflowRunTasks(workflowRunId);
+  }
 
-    const cfg = this.config.loadConfigOrDefault();
-    const completedTaskIds: string[] = [];
-    for (const project of cfg.projects.values()) {
-      for (const workspace of project.workspaces) {
-        if (
-          workspace.id &&
-          workspace.workflowTask?.runId === workflowRunId &&
-          hasCompletedAgentReport(workspace)
-        ) {
-          completedTaskIds.push(workspace.id);
+  /**
+   * Hide leftover task workspaces of a workflow run that reached a terminal state.
+   *
+   * Why: interrupting a run leaves its children in taskStatus "interrupted" WITHOUT a
+   * completed report, and canCleanupReportedTask requires a completed report — so those
+   * children would linger in the active sidebar forever (until manual deletion).
+   * Workflow-owned children are transient by design (results persist in the workflow
+   * run/report artifacts), so archive them — never remove — once the owning run has
+   * ended. Archived entries disappear from the active sidebar but keep their data for
+   * inspection. User-spawned interrupted tasks are untouched: they intentionally stay
+   * visible for manual inspection/resume.
+   *
+   * workflow_resume stays safe: resume replays the journal and restarts incomplete steps
+   * with FRESH task ids (see WorkflowRunner's unrecoverable-started-task restart), so
+   * archived old children are never reused.
+   *
+   * Idempotent (interrupted + not-already-archived filter), so it runs from both the
+   * run-end hook and the run-scoped interrupt path: WorkflowService.interruptRun aborts
+   * the runner BEFORE terminating descendants, so the runner's onRunEnded can fire while
+   * children are still "running" — only the later interrupt-path sweep sees them.
+   */
+  private async sweepEndedWorkflowRunTasks(workflowRunId: string): Promise<void> {
+    assert(workflowRunId.length > 0, "sweepEndedWorkflowRunTasks: workflowRunId must be non-empty");
+
+    // Phase 1: archive interrupted-without-report descendants of the run. Descendants of
+    // run children (spawned by workflow-owned agents) are included via ancestry.
+    {
+      const cfg = this.config.loadConfigOrDefault();
+      const index = this.buildAgentTaskIndex(cfg);
+      const interruptedTaskIds = [...index.byId.entries()]
+        .filter(
+          ([taskId, workspace]) =>
+            this.isWorkflowRunDescendant(index, taskId, workflowRunId) &&
+            workspace.taskStatus === "interrupted" &&
+            !hasCompletedAgentReport(workspace) &&
+            !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)
+        )
+        .map(([taskId]) => taskId);
+      await this.archiveWorkflowTaskWorkspacesDeepestFirst(interruptedTaskIds, index);
+    }
+
+    // Phase 2: recheck reported descendants of the run (deepest-first). Eligible ones are
+    // removed by the normal cleanup walk. The rest can be blocked by the structural-leaf
+    // topology gate: hasChildAgentTasks counts archived children too, so a reported
+    // ancestor whose only remaining children are the entries archived in phase 1 can
+    // never become removable — removing it anyway would orphan those archived config
+    // entries. Archive such ancestors instead: hidden from the active sidebar, fully
+    // preserved for inspection, tree intact.
+    {
+      const cfg = this.config.loadConfigOrDefault();
+      const index = this.buildAgentTaskIndex(cfg);
+      const reportedTaskIds = [...index.byId.entries()]
+        .filter(
+          ([taskId, workspace]) =>
+            this.isWorkflowRunDescendant(index, taskId, workflowRunId) &&
+            hasCompletedAgentReport(workspace)
+        )
+        .map(([taskId]) => taskId);
+      const depthById = new Map<string, number>();
+      for (const taskId of reportedTaskIds) {
+        depthById.set(taskId, this.getTaskDepthFromParentById(index.parentById, taskId));
+      }
+      reportedTaskIds.sort((a, b) => (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0));
+
+      for (const taskId of reportedTaskIds) {
+        await this.cleanupReportedLeafTask(taskId);
+
+        const freshConfig = this.config.loadConfigOrDefault();
+        const entry = findWorkspaceEntry(freshConfig, taskId);
+        if (!entry) continue; // removed by the cleanup walk
+        if (isWorkspaceArchived(entry.workspace.archivedAt, entry.workspace.unarchivedAt)) {
+          continue;
         }
+        // Defensive: never hide a workspace with an active stream.
+        if (this.aiService.isStreaming(taskId)) continue;
+        const freshIndex = this.buildAgentTaskIndex(freshConfig);
+        const childTaskIds = freshIndex.childrenByParent.get(taskId) ?? [];
+        // Leaf tasks deferred by non-topology gates (pending patch artifact, best-of
+        // grouping) keep their own event-driven rechecks; do not archive them here.
+        if (childTaskIds.length === 0) continue;
+        const blockedOnlyByArchivedChildren = childTaskIds.every((childTaskId) => {
+          const child = freshIndex.byId.get(childTaskId);
+          return child != null && isWorkspaceArchived(child.archivedAt, child.unarchivedAt);
+        });
+        if (!blockedOnlyByArchivedChildren) continue;
+        await this.archiveWorkflowTaskWorkspacesDeepestFirst([taskId], freshIndex);
       }
     }
-    for (const taskId of completedTaskIds) {
-      await this.cleanupReportedLeafTask(taskId);
+  }
+
+  /**
+   * Archive task workspaces deepest-first (so WorkspaceService.archive preconditions on
+   * descendants hold), logging and continuing on per-task failures — one failed archive
+   * must not abort the sweep; failures self-heal on the next startup sweep.
+   */
+  private async archiveWorkflowTaskWorkspacesDeepestFirst(
+    taskIds: readonly string[],
+    index: AgentTaskIndex
+  ): Promise<void> {
+    if (taskIds.length === 0) return;
+    const depthById = new Map<string, number>();
+    for (const taskId of taskIds) {
+      depthById.set(taskId, this.getTaskDepthFromParentById(index.parentById, taskId));
     }
+    const orderedTaskIds = [...taskIds].sort(
+      (a, b) => (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0)
+    );
+    for (const taskId of orderedTaskIds) {
+      try {
+        const result = await this.workspaceService.archive(taskId);
+        if (!result.success) {
+          log.warn("Failed to archive leftover workflow task workspace", {
+            taskId,
+            error: result.error,
+          });
+        } else if (result.data.kind === "confirm-lossy-untracked-files") {
+          // Snapshot-archive mode asks for user confirmation before discarding untracked
+          // files. Auto-acknowledging would silently lose data, so leave this workspace
+          // visible for manual handling instead.
+          log.warn(
+            "Skipping auto-archive of workflow task workspace pending untracked-file confirmation",
+            { taskId }
+          );
+        }
+      } catch (error: unknown) {
+        log.warn("Archive of leftover workflow task workspace threw", { taskId, error });
+      }
+    }
+  }
+
+  /**
+   * Startup self-heal: archive interrupted-without-report workflow-owned tasks whose
+   * owning workflow run is no longer active. Covers both children the startup prepass
+   * just transitioned to "interrupted" (inactive workflow owner) and historical garbage
+   * left by interrupts before this sweep existed. Delegates to
+   * sweepEndedWorkflowRunTasks per inactive run so blocked reported ancestors are also
+   * resolved. Returns the number of inactive runs swept.
+   */
+  private async archiveLeftoverTasksOfInactiveWorkflowRuns(): Promise<number> {
+    const cfg = this.config.loadConfigOrDefault();
+    const index = this.buildAgentTaskIndex(cfg);
+    const inactiveRunIds = new Set<string>();
+    for (const [taskId, workspace] of index.byId) {
+      if (workspace.taskStatus !== "interrupted" || hasCompletedAgentReport(workspace)) {
+        continue;
+      }
+      if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) continue;
+      // Non-workflow-owned tasks have no owner in ancestry → null → skipped (user-spawned
+      // interrupted tasks intentionally stay visible).
+      const inactiveOwner = await this.getInactiveWorkflowTaskOwnerForRecovery(taskId, cfg, index);
+      if (inactiveOwner == null) continue;
+      inactiveRunIds.add(inactiveOwner.runId);
+    }
+    for (const runId of inactiveRunIds) {
+      await this.sweepEndedWorkflowRunTasks(runId);
+    }
+    return inactiveRunIds.size;
   }
 
   /**
@@ -3919,6 +4077,16 @@ export class TaskService {
 
     for (const taskId of interruptedTaskIds) {
       await this.emitWorkspaceMetadata(taskId);
+    }
+
+    if (options?.workflowRunId != null) {
+      // Run-scoped interrupts arrive after the owning run's terminal status write
+      // (WorkflowService.interruptRun aborts the runner, persists "interrupted", THEN
+      // terminates descendants), so the children just interrupted above can be archived
+      // right away. markWorkflowRunEnded also sweeps, but the runner-abort path can fire
+      // onRunEnded before this termination completes — sweeping here closes that
+      // ordering race (the sweep is idempotent).
+      await this.sweepEndedWorkflowRunTasks(options.workflowRunId);
     }
 
     // Free slots and start any queued tasks (best-effort).

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -3917,7 +3917,26 @@ export class TaskService {
     const orderedTaskIds = [...taskIds].sort(
       (a, b) => (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0)
     );
+    // Ancestors of a task whose archive failed or was skipped must stay visible too:
+    // hiding the parent while its child remains active would orphan the child in the
+    // sidebar. Deepest-first ordering guarantees descendants settle before ancestors.
+    const blockedAncestorIds = new Set<string>();
+    const markAncestorsBlocked = (taskId: string): void => {
+      let currentId = index.parentById.get(taskId);
+      for (let depth = 0; currentId != null && depth < 32; depth++) {
+        blockedAncestorIds.add(currentId);
+        currentId = index.parentById.get(currentId);
+      }
+    };
     for (const taskId of orderedTaskIds) {
+      if (blockedAncestorIds.has(taskId)) {
+        // Own ancestors are already in the set: the failing descendant's walk went to root.
+        log.warn(
+          "Skipping auto-archive of workflow task workspace; a descendant stayed unarchived",
+          { taskId }
+        );
+        continue;
+      }
       try {
         const result = await this.workspaceService.archive(taskId);
         if (!result.success) {
@@ -3925,6 +3944,7 @@ export class TaskService {
             taskId,
             error: result.error,
           });
+          markAncestorsBlocked(taskId);
         } else if (result.data.kind === "confirm-lossy-untracked-files") {
           // Snapshot-archive mode asks for user confirmation before discarding untracked
           // files. Auto-acknowledging would silently lose data, so leave this workspace
@@ -3933,9 +3953,11 @@ export class TaskService {
             "Skipping auto-archive of workflow task workspace pending untracked-file confirmation",
             { taskId }
           );
+          markAncestorsBlocked(taskId);
         }
       } catch (error: unknown) {
         log.warn("Archive of leftover workflow task workspace threw", { taskId, error });
+        markAncestorsBlocked(taskId);
       }
     }
   }

--- a/src/node/services/tools/task_list.test.ts
+++ b/src/node/services/tools/task_list.test.ts
@@ -42,7 +42,7 @@ async function writeWorkspaceConfig(tempDir: string, workspaces: Workspace[]): P
   const config = new Config(tempDir);
   const cfg = config.loadConfigOrDefault();
   cfg.projects.set(path.join(tempDir, "project"), { workspaces });
-  await config.saveConfig(cfg);
+  await config.editConfig(() => cfg);
 }
 
 function buildAgentTask(

--- a/src/node/services/workspaceService.configResurrection.test.ts
+++ b/src/node/services/workspaceService.configResurrection.test.ts
@@ -38,12 +38,13 @@ describe("WorkspaceService config resurrection regression", () => {
   let service: WorkspaceService;
 
   function workspaceEntry(id: string, extra?: Partial<Workspace>): Workspace {
-    return {
+    const entry: Workspace = {
       id,
       path: path.join(PROJECT_PATH, id),
       name: id,
       ...extra,
-    } as Workspace;
+    };
+    return entry;
   }
 
   async function seedWorkspaces(entries: Workspace[]): Promise<void> {
@@ -84,9 +85,8 @@ describe("WorkspaceService config resurrection regression", () => {
     (
       service as unknown as { emitCurrentWorkspaceMetadata: () => Promise<void> }
     ).emitCurrentWorkspaceMetadata = mock(() => Promise.resolve());
-    (
-      service as unknown as { updateRecencyTimestamp: () => Promise<void> }
-    ).updateRecencyTimestamp = mock(() => Promise.resolve());
+    (service as unknown as { updateRecencyTimestamp: () => Promise<void> }).updateRecencyTimestamp =
+      mock(() => Promise.resolve());
   });
 
   afterEach(() => {

--- a/src/node/services/workspaceService.configResurrection.test.ts
+++ b/src/node/services/workspaceService.configResurrection.test.ts
@@ -163,4 +163,35 @@ describe("WorkspaceService config resurrection regression", () => {
     expect(unsetResult.success).toBe(true);
     expect(readPersistedWorkspaces().find((w) => w.id === "doomed")).toBeUndefined();
   });
+
+  // Regression (PR #3694 Codex P2): workspace paths are reusable after deletion. A
+  // settings write queued behind a remove+recreate that reuses the same path must
+  // treat its original entry as gone — the path fallback previously retargeted the
+  // stale write onto the REPLACEMENT workspace's fresh entry.
+  test("stale heartbeat write does not leak onto a replacement workspace at the same path", async () => {
+    const sharedPath = path.join(PROJECT_PATH, "reused-checkout");
+    await seedWorkspaces([workspaceEntry("original", { path: sharedPath })]);
+
+    // Enqueue remove + recreate back-to-back (editConfig is FIFO) so BOTH land before
+    // the heartbeat write's transform: a NEW workspace (different id) reuses the path.
+    const removal = config.removeWorkspace("original");
+    const recreate = config.editConfig((cfg) => {
+      cfg.projects
+        .get(PROJECT_PATH)
+        ?.workspaces.push(workspaceEntry("replacement", { path: sharedPath }));
+      return cfg;
+    });
+    // Resolves "original" from the pre-removal snapshot, then its transform runs
+    // after the remove+recreate and must NOT match the replacement by path.
+    const writeResult = await service.setHeartbeatSettings("original", {
+      enabled: true,
+      intervalMs: 45 * 60 * 1000,
+    });
+    await Promise.all([removal, recreate]);
+
+    expect(writeResult.success).toBe(false);
+    const replacement = readPersistedWorkspaces().find((w) => w.id === "replacement");
+    expect(replacement).toBeDefined();
+    expect(replacement?.heartbeat).toBeUndefined();
+  });
 });

--- a/src/node/services/workspaceService.configResurrection.test.ts
+++ b/src/node/services/workspaceService.configResurrection.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { EventEmitter } from "events";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { Workspace } from "@/common/types/project";
+import { Config } from "@/node/config";
+import type { AIService } from "./aiService";
+import type { BackgroundProcessManager } from "./backgroundProcessManager";
+import type { ExtensionMetadataService } from "./ExtensionMetadataService";
+import type { HistoryService } from "./historyService";
+import type { InitStateManager } from "./initStateManager";
+import { WorkspaceService } from "./workspaceService";
+
+/**
+ * Regression coverage for the config lost-update resurrection race.
+ *
+ * Pre-fix interleaving (Config.saveConfig was public):
+ *   1. setHeartbeatSettings(B) read a full config snapshot via loadConfigOrDefault()
+ *      — the snapshot still contained workspace A.
+ *   2. config.removeWorkspace(A) ran through the serialized editConfig queue and
+ *      persisted a config without A.
+ *   3. setHeartbeatSettings(B) then called saveConfig(staleSnapshot) directly,
+ *      bypassing the queue — the stale snapshot write landed after the removal and
+ *      resurrected A as a permanent sidebar ghost pointing at a deleted
+ *      worktree/session (reproduced in 14/17 timing probes with a 1200-workspace
+ *      config).
+ *
+ * Post-fix, saveConfig is private and every mutation is an editConfig transform that
+ * re-resolves its target from the fresh snapshot, so this interleaving cannot lose
+ * the removal regardless of scheduling. The loop below is a bounded stress run so a
+ * regression fails deterministically rather than by scheduler luck.
+ */
+describe("WorkspaceService config resurrection regression", () => {
+  const PROJECT_PATH = "/test/project";
+  let tempDir: string;
+  let config: Config;
+  let service: WorkspaceService;
+
+  function workspaceEntry(id: string, extra?: Partial<Workspace>): Workspace {
+    return {
+      id,
+      path: path.join(PROJECT_PATH, id),
+      name: id,
+      ...extra,
+    } as Workspace;
+  }
+
+  async function seedWorkspaces(entries: Workspace[]): Promise<void> {
+    await config.editConfig((cfg) => {
+      cfg.projects = new Map([[PROJECT_PATH, { workspaces: entries }]]);
+      return cfg;
+    });
+  }
+
+  /** Re-read the persisted state through a fresh Config so assertions hit disk. */
+  function readPersistedWorkspaces(): Workspace[] {
+    const persisted = new Config(tempDir).loadConfigOrDefault();
+    return persisted.projects.get(PROJECT_PATH)?.workspaces ?? [];
+  }
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mux-resurrection-"));
+    config = new Config(tempDir);
+
+    service = new WorkspaceService(
+      config,
+      {} as HistoryService,
+      new EventEmitter() as unknown as AIService,
+      new EventEmitter() as unknown as InitStateManager,
+      {
+        updateRecency: mock(() =>
+          Promise.resolve({
+            recency: Date.now(),
+            streaming: false,
+            lastModel: null,
+            lastThinkingLevel: null,
+            agentStatus: null,
+          })
+        ),
+      } as unknown as ExtensionMetadataService,
+      {} as BackgroundProcessManager
+    );
+    (
+      service as unknown as { emitCurrentWorkspaceMetadata: () => Promise<void> }
+    ).emitCurrentWorkspaceMetadata = mock(() => Promise.resolve());
+    (
+      service as unknown as { updateRecencyTimestamp: () => Promise<void> }
+    ).updateRecencyTimestamp = mock(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  test("removeWorkspace cannot be resurrected by a concurrent heartbeat write", async () => {
+    // Large-ish config widens the read/write window that made the pre-fix race
+    // near-certain; several iterations make a regression fail deterministically.
+    const filler = Array.from({ length: 200 }, (_, i) => workspaceEntry(`filler-${i}`));
+
+    for (let iteration = 0; iteration < 8; iteration++) {
+      const removalTargetId = `removal-target-${iteration}`;
+      const heartbeatTargetId = `heartbeat-target-${iteration}`;
+      await seedWorkspaces([
+        workspaceEntry(removalTargetId),
+        workspaceEntry(heartbeatTargetId),
+        ...filler,
+      ]);
+
+      // Fire both mutations without awaiting in between so their internal reads and
+      // writes interleave exactly like the production race.
+      const removal = config.removeWorkspace(removalTargetId);
+      const heartbeatWrite = service.setHeartbeatSettings(heartbeatTargetId, {
+        enabled: true,
+        intervalMs: 45 * 60 * 1000,
+      });
+      const [, writeResult] = await Promise.all([removal, heartbeatWrite]);
+
+      const persistedWorkspaces = readPersistedWorkspaces();
+      const resurrected = persistedWorkspaces.find((w) => w.id === removalTargetId);
+      expect(resurrected).toBeUndefined();
+
+      // The concurrent mutation must still land — serialization, not starvation.
+      expect(writeResult.success).toBe(true);
+      const heartbeatTarget = persistedWorkspaces.find((w) => w.id === heartbeatTargetId);
+      expect(heartbeatTarget?.heartbeat?.enabled).toBe(true);
+      expect(heartbeatTarget?.heartbeat?.intervalMs).toBe(45 * 60 * 1000);
+    }
+  });
+
+  test("heartbeat writes racing removal of the same workspace degrade gracefully", async () => {
+    await seedWorkspaces([workspaceEntry("doomed"), workspaceEntry("other")]);
+
+    const removal = config.removeWorkspace("doomed");
+    const setResult = await service.setHeartbeatSettings("doomed", {
+      enabled: true,
+      intervalMs: 45 * 60 * 1000,
+    });
+    await removal;
+
+    // Depending on queue order the write either landed before the removal (Ok) or
+    // found the entry gone (Err) — both are acceptable; resurrection is not.
+    if (!setResult.success) {
+      expect(setResult.error).toContain("Workspace not found");
+    }
+    expect(readPersistedWorkspaces().find((w) => w.id === "doomed")).toBeUndefined();
+  });
+
+  test("unset heartbeat racing removal of the same workspace stays Ok and never resurrects", async () => {
+    await seedWorkspaces([
+      workspaceEntry("doomed", {
+        heartbeat: { enabled: true, intervalMs: 45 * 60 * 1000 },
+      }),
+      workspaceEntry("other"),
+    ]);
+
+    const removal = config.removeWorkspace("doomed");
+    const unsetResult = await service.unsetHeartbeatSettings("doomed");
+    await removal;
+
+    // Unset on a concurrently removed entry is trivially satisfied.
+    expect(unsetResult.success).toBe(true);
+    expect(readPersistedWorkspaces().find((w) => w.id === "doomed")).toBeUndefined();
+  });
+});

--- a/src/node/services/workspaceService.goalDefaults.test.ts
+++ b/src/node/services/workspaceService.goalDefaults.test.ts
@@ -61,8 +61,10 @@ describe("WorkspaceService goal-defaults override", () => {
         workspacePath: TEST_WORKSPACE_PATH,
         projectPath: TEST_PROJECT_PATH,
       })),
-      saveConfig: mock((nextConfig: ProjectsConfig) => {
-        currentProjectsConfig = nextConfig;
+      // Goal-defaults writes mutate inside serialized editConfig transforms (saveConfig
+      // is private); mirror that by applying the transform and counting queued writes.
+      editConfig: mock((transform: (config: ProjectsConfig) => ProjectsConfig) => {
+        currentProjectsConfig = transform(currentProjectsConfig);
         saveConfigCalls += 1;
         return Promise.resolve();
       }),

--- a/src/node/services/workspaceService.heartbeatSettings.test.ts
+++ b/src/node/services/workspaceService.heartbeatSettings.test.ts
@@ -64,8 +64,10 @@ describe("WorkspaceService heartbeat settings", () => {
         workspacePath: TEST_WORKSPACE_PATH,
         projectPath: TEST_PROJECT_PATH,
       })),
-      saveConfig: mock((nextConfig: ProjectsConfig) => {
-        currentProjectsConfig = nextConfig;
+      // Heartbeat writers mutate inside serialized editConfig transforms (saveConfig is
+      // private); mirror that by applying the transform to the current config snapshot.
+      editConfig: mock((transform: (config: ProjectsConfig) => ProjectsConfig) => {
+        currentProjectsConfig = transform(currentProjectsConfig);
         return Promise.resolve();
       }),
     } as unknown as Config;

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -4590,7 +4590,13 @@ export class WorkspaceService extends EventEmitter {
     const projectConfig = config.projects.get(target.projectPath);
     return (
       projectConfig?.workspaces.find((workspace) => workspace.id === target.workspaceId) ??
-      projectConfig?.workspaces.find((workspace) => workspace.path === target.workspacePath)
+      // Path fallback is for legacy entries that predate stable IDs only. A path match
+      // that carries a DIFFERENT id is a replacement workspace (paths are reusable after
+      // deletion) — treat the original entry as gone rather than leaking the stale
+      // settings write into the fresh workspace.
+      projectConfig?.workspaces.find(
+        (workspace) => workspace.path === target.workspacePath && !workspace.id
+      )
     );
   }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -295,7 +295,15 @@ type WorkspaceHeartbeatSettingsUpdate = Partial<WorkspaceHeartbeatSettings>;
 type WorkspaceGoalDefaultsOverride = z.infer<typeof WorkspaceGoalDefaultsOverrideSchema>;
 interface HeartbeatWorkspaceConfigEntry {
   normalizedWorkspaceId: string;
+  /** Project/workspace paths so editConfig transforms can re-find the FRESH entry. */
+  projectPath: string;
+  workspacePath: string;
   config: ProjectsConfig;
+  /**
+   * Entry from the pre-read snapshot: valid for read paths and input validation only.
+   * Mutations must re-resolve the entry from fresh config inside editConfig — persisting
+   * a stale snapshot loses concurrent edits (e.g. resurrects removed workspaces).
+   */
   workspaceEntry: Workspace;
 }
 interface HeartbeatExecutionRequest {
@@ -4559,7 +4567,31 @@ export class WorkspaceService extends EventEmitter {
       return Err("Workspace not found");
     }
 
-    return Ok({ normalizedWorkspaceId, config, workspaceEntry });
+    return Ok({
+      normalizedWorkspaceId,
+      projectPath: found.projectPath,
+      workspacePath: found.workspacePath,
+      config,
+      workspaceEntry,
+    });
+  }
+
+  /**
+   * Re-resolve a workspace entry from a FRESH config snapshot inside an editConfig
+   * transform. Mutating a pre-read snapshot entry and persisting that snapshot was a
+   * lost-update race: a stale full-config write racing removeWorkspace() resurrected
+   * the removed entry as a permanent sidebar ghost. All config mutations must re-find
+   * their target entry here (or equivalent) inside the serialized transform.
+   */
+  private findFreshWorkspaceEntry(
+    config: ProjectsConfig,
+    target: { projectPath: string; workspaceId: string; workspacePath: string }
+  ): Workspace | undefined {
+    const projectConfig = config.projects.get(target.projectPath);
+    return (
+      projectConfig?.workspaces.find((workspace) => workspace.id === target.workspaceId) ??
+      projectConfig?.workspaces.find((workspace) => workspace.path === target.workspacePath)
+    );
   }
 
   getHeartbeatSettings(workspaceId: string): WorkspaceHeartbeatSettings | null {
@@ -4595,13 +4627,30 @@ export class WorkspaceService extends EventEmitter {
         return Err(resolved.error);
       }
 
-      const { normalizedWorkspaceId, config, workspaceEntry } = resolved.data;
-      if (!workspaceEntry.heartbeat) {
+      const { normalizedWorkspaceId, projectPath, workspacePath } = resolved.data;
+      if (!resolved.data.workspaceEntry.heartbeat) {
         return Ok(undefined);
       }
 
-      delete workspaceEntry.heartbeat;
-      await this.config.saveConfig(config);
+      // Mutate inside the serialized editConfig transform, re-finding the entry from
+      // fresh config (see findFreshWorkspaceEntry). Entry gone meanwhile means the
+      // workspace was removed concurrently — unset is then trivially satisfied.
+      let removedHeartbeat = false;
+      await this.config.editConfig((freshConfig) => {
+        const entry = this.findFreshWorkspaceEntry(freshConfig, {
+          projectPath,
+          workspaceId: normalizedWorkspaceId,
+          workspacePath,
+        });
+        if (entry?.heartbeat) {
+          delete entry.heartbeat;
+          removedHeartbeat = true;
+        }
+        return freshConfig;
+      });
+      if (!removedHeartbeat) {
+        return Ok(undefined);
+      }
 
       const interactionTimestamp = Date.now();
       await this.updateRecencyTimestamp(normalizedWorkspaceId, interactionTimestamp);
@@ -4668,70 +4717,100 @@ export class WorkspaceService extends EventEmitter {
         return Err(resolved.error);
       }
 
-      const { normalizedWorkspaceId, config, workspaceEntry } = resolved.data;
-      const defaultIntervalMs = this.getHeartbeatDefaultIntervalMsFromConfig(config);
-      const currentSettings = normalizeHeartbeatSettings(
-        workspaceEntry.heartbeat,
-        defaultIntervalMs
-      );
-      const nextMessage = hasMessageUpdate
-        ? sanitizeHeartbeatMessage(settings.message)
-        : currentSettings?.message;
-      // trigger/whenBusy mirror the `message` pattern (not `contextMode`): a present key with
-      // null clears back to unset, an absent key preserves, and unset is never materialized
-      // into config so read-time defaulting stays intact (see resolveHeartbeatSchedulePolicy).
-      const nextTrigger = hasTriggerUpdate
-        ? (settings.trigger ?? undefined)
-        : currentSettings?.trigger;
-      const nextWhenBusy = hasWhenBusyUpdate
-        ? (settings.whenBusy ?? undefined)
-        : currentSettings?.whenBusy;
-      const nextEnabled = hasEnabledUpdate ? settings.enabled! : (currentSettings?.enabled ?? true);
-      const nextIntervalMs = hasIntervalUpdate
-        ? settings.intervalMs!
-        : (currentSettings?.intervalMs ?? defaultIntervalMs);
-      // Server-managed cadence-edit stamp: fixed-interval restart anchoring uses
-      // max(last persisted firing, scheduleUpdatedAt), so a heartbeat fired under the
-      // previous schedule cannot bypass this edit (HeartbeatService's
-      // deriveInitialIntervalNextEligibleAt). Only cadence-affecting fields count —
-      // resolved trigger, not raw, so an explicit no-op like null→"idle" does not
-      // re-anchor (mirroring ensureTrackedWorkspace's live re-anchor conditions).
+      const { normalizedWorkspaceId, projectPath, workspacePath } = resolved.data;
       const interactionTimestamp = Date.now();
-      const cadenceChanged =
-        currentSettings?.enabled !== nextEnabled ||
-        currentSettings?.intervalMs !== nextIntervalMs ||
-        resolveHeartbeatSchedulePolicy(currentSettings ?? undefined).trigger !==
-          resolveHeartbeatSchedulePolicy({ trigger: nextTrigger, whenBusy: nextWhenBusy }).trigger;
-      const nextScheduleUpdatedAt = cadenceChanged
-        ? interactionTimestamp
-        : currentSettings?.scheduleUpdatedAt;
-      // Keep the interval on disk even when disabled so re-enabling restores the user's choice.
-      const nextSettings: WorkspaceHeartbeatSettings = {
-        enabled: nextEnabled,
-        intervalMs: nextIntervalMs,
-        contextMode: hasContextModeUpdate
-          ? sanitizeHeartbeatContextMode(settings.contextMode)
-          : (currentSettings?.contextMode ?? HEARTBEAT_DEFAULT_CONTEXT_MODE),
-        ...(nextMessage != null ? { message: nextMessage } : {}),
-        ...(nextTrigger != null ? { trigger: nextTrigger } : {}),
-        ...(nextWhenBusy != null ? { whenBusy: nextWhenBusy } : {}),
-        ...(nextScheduleUpdatedAt != null ? { scheduleUpdatedAt: nextScheduleUpdatedAt } : {}),
-      };
+      // Merge with the FRESH entry inside the serialized editConfig transform (not the
+      // pre-read snapshot): merging against a stale entry could silently drop a concurrent
+      // heartbeat edit, and persisting the stale snapshot could resurrect concurrently
+      // removed workspaces (lost-update race). Entry gone meanwhile → Err.
+      let mergeResult: Result<{ settings: WorkspaceHeartbeatSettings; changed: boolean }, string> =
+        Err("Workspace not found");
+      await this.config.editConfig((freshConfig) => {
+        const workspaceEntry = this.findFreshWorkspaceEntry(freshConfig, {
+          projectPath,
+          workspaceId: normalizedWorkspaceId,
+          workspacePath,
+        });
+        if (!workspaceEntry) {
+          mergeResult = Err("Workspace not found");
+          return freshConfig;
+        }
 
-      const changed =
-        workspaceEntry.heartbeat?.enabled !== nextSettings.enabled ||
-        workspaceEntry.heartbeat?.intervalMs !== nextSettings.intervalMs ||
-        workspaceEntry.heartbeat?.message !== nextSettings.message ||
-        sanitizeHeartbeatContextMode(workspaceEntry.heartbeat?.contextMode) !==
-          nextSettings.contextMode ||
-        (workspaceEntry.heartbeat?.trigger ?? undefined) !== nextSettings.trigger ||
-        (workspaceEntry.heartbeat?.whenBusy ?? undefined) !== nextSettings.whenBusy;
-      if (!changed) {
-        return Ok(nextSettings);
+        const defaultIntervalMs = this.getHeartbeatDefaultIntervalMsFromConfig(freshConfig);
+        const currentSettings = normalizeHeartbeatSettings(
+          workspaceEntry.heartbeat,
+          defaultIntervalMs
+        );
+        const nextMessage = hasMessageUpdate
+          ? sanitizeHeartbeatMessage(settings.message)
+          : currentSettings?.message;
+        // trigger/whenBusy mirror the `message` pattern (not `contextMode`): a present key with
+        // null clears back to unset, an absent key preserves, and unset is never materialized
+        // into config so read-time defaulting stays intact (see resolveHeartbeatSchedulePolicy).
+        const nextTrigger = hasTriggerUpdate
+          ? (settings.trigger ?? undefined)
+          : currentSettings?.trigger;
+        const nextWhenBusy = hasWhenBusyUpdate
+          ? (settings.whenBusy ?? undefined)
+          : currentSettings?.whenBusy;
+        const nextEnabled = hasEnabledUpdate
+          ? settings.enabled!
+          : (currentSettings?.enabled ?? true);
+        const nextIntervalMs = hasIntervalUpdate
+          ? settings.intervalMs!
+          : (currentSettings?.intervalMs ?? defaultIntervalMs);
+        // Server-managed cadence-edit stamp: fixed-interval restart anchoring uses
+        // max(last persisted firing, scheduleUpdatedAt), so a heartbeat fired under the
+        // previous schedule cannot bypass this edit (HeartbeatService's
+        // deriveInitialIntervalNextEligibleAt). Only cadence-affecting fields count —
+        // resolved trigger, not raw, so an explicit no-op like null→"idle" does not
+        // re-anchor (mirroring ensureTrackedWorkspace's live re-anchor conditions).
+        const cadenceChanged =
+          currentSettings?.enabled !== nextEnabled ||
+          currentSettings?.intervalMs !== nextIntervalMs ||
+          resolveHeartbeatSchedulePolicy(currentSettings ?? undefined).trigger !==
+            resolveHeartbeatSchedulePolicy({ trigger: nextTrigger, whenBusy: nextWhenBusy })
+              .trigger;
+        const nextScheduleUpdatedAt = cadenceChanged
+          ? interactionTimestamp
+          : currentSettings?.scheduleUpdatedAt;
+        // Keep the interval on disk even when disabled so re-enabling restores the user's choice.
+        const nextSettings: WorkspaceHeartbeatSettings = {
+          enabled: nextEnabled,
+          intervalMs: nextIntervalMs,
+          contextMode: hasContextModeUpdate
+            ? sanitizeHeartbeatContextMode(settings.contextMode)
+            : (currentSettings?.contextMode ?? HEARTBEAT_DEFAULT_CONTEXT_MODE),
+          ...(nextMessage != null ? { message: nextMessage } : {}),
+          ...(nextTrigger != null ? { trigger: nextTrigger } : {}),
+          ...(nextWhenBusy != null ? { whenBusy: nextWhenBusy } : {}),
+          ...(nextScheduleUpdatedAt != null ? { scheduleUpdatedAt: nextScheduleUpdatedAt } : {}),
+        };
+
+        const changed =
+          workspaceEntry.heartbeat?.enabled !== nextSettings.enabled ||
+          workspaceEntry.heartbeat?.intervalMs !== nextSettings.intervalMs ||
+          workspaceEntry.heartbeat?.message !== nextSettings.message ||
+          sanitizeHeartbeatContextMode(workspaceEntry.heartbeat?.contextMode) !==
+            nextSettings.contextMode ||
+          (workspaceEntry.heartbeat?.trigger ?? undefined) !== nextSettings.trigger ||
+          (workspaceEntry.heartbeat?.whenBusy ?? undefined) !== nextSettings.whenBusy;
+        if (!changed) {
+          mergeResult = Ok({ settings: nextSettings, changed: false });
+          return freshConfig;
+        }
+
+        workspaceEntry.heartbeat = nextSettings;
+        mergeResult = Ok({ settings: nextSettings, changed: true });
+        return freshConfig;
+      });
+
+      if (!mergeResult.success) {
+        return Err(mergeResult.error);
       }
-
-      workspaceEntry.heartbeat = nextSettings;
-      await this.config.saveConfig(config);
+      if (!mergeResult.data.changed) {
+        return Ok(mergeResult.data.settings);
+      }
 
       // Changing heartbeat settings is a real user interaction. Persist that recency before
       // emitting metadata so restarts preserve the post-config-change first-fire deadline
@@ -4739,7 +4818,7 @@ export class WorkspaceService extends EventEmitter {
       await this.updateRecencyTimestamp(normalizedWorkspaceId, interactionTimestamp);
       await this.emitCurrentWorkspaceMetadata(normalizedWorkspaceId);
 
-      return Ok(nextSettings);
+      return Ok(mergeResult.data.settings);
     } catch (error) {
       const message = getErrorMessage(error);
       return Err(`Failed to set heartbeat settings: ${message}`);
@@ -4827,18 +4906,6 @@ export class WorkspaceService extends EventEmitter {
       }
 
       const { projectPath, workspacePath } = found;
-      const config = this.config.loadConfigOrDefault();
-      const projectConfig = config.projects.get(projectPath);
-      if (!projectConfig) {
-        return Err(`Project not found: ${projectPath}`);
-      }
-
-      const workspaceEntry =
-        projectConfig.workspaces.find((workspace) => workspace.id === normalizedWorkspaceId) ??
-        projectConfig.workspaces.find((workspace) => workspace.path === workspacePath);
-      if (!workspaceEntry) {
-        return Err("Workspace not found");
-      }
 
       // Drop the whole record when every field is null — keeps the
       // config.json minimal and makes "no override" the canonical state
@@ -4848,30 +4915,56 @@ export class WorkspaceService extends EventEmitter {
         override.defaultTurnCap == null &&
         override.alwaysRequireExplicitBudget == null;
 
-      const prior = workspaceEntry.goalDefaults;
-      if (allNull) {
-        if (prior == null) {
-          return Ok(undefined);
+      // Compare against the FRESH entry inside the serialized editConfig transform
+      // (see findFreshWorkspaceEntry): persisting a pre-read snapshot loses concurrent
+      // edits and can resurrect removed workspaces. Entry gone meanwhile → Err.
+      let writeResult: Result<{ changed: boolean }, string> = Err("Workspace not found");
+      await this.config.editConfig((freshConfig) => {
+        const workspaceEntry = this.findFreshWorkspaceEntry(freshConfig, {
+          projectPath,
+          workspaceId: normalizedWorkspaceId,
+          workspacePath,
+        });
+        if (!workspaceEntry) {
+          writeResult = Err("Workspace not found");
+          return freshConfig;
         }
-        delete workspaceEntry.goalDefaults;
-      } else {
-        const next: WorkspaceGoalDefaultsOverride = {
-          defaultBudgetCents: override.defaultBudgetCents ?? null,
-          defaultTurnCap: override.defaultTurnCap ?? null,
-          alwaysRequireExplicitBudget: override.alwaysRequireExplicitBudget ?? null,
-        };
-        const unchanged =
-          prior != null &&
-          (prior.defaultBudgetCents ?? null) === next.defaultBudgetCents &&
-          (prior.defaultTurnCap ?? null) === next.defaultTurnCap &&
-          (prior.alwaysRequireExplicitBudget ?? null) === next.alwaysRequireExplicitBudget;
-        if (unchanged) {
-          return Ok(undefined);
-        }
-        workspaceEntry.goalDefaults = next;
-      }
 
-      await this.config.saveConfig(config);
+        const prior = workspaceEntry.goalDefaults;
+        if (allNull) {
+          if (prior == null) {
+            writeResult = Ok({ changed: false });
+            return freshConfig;
+          }
+          delete workspaceEntry.goalDefaults;
+        } else {
+          const next: WorkspaceGoalDefaultsOverride = {
+            defaultBudgetCents: override.defaultBudgetCents ?? null,
+            defaultTurnCap: override.defaultTurnCap ?? null,
+            alwaysRequireExplicitBudget: override.alwaysRequireExplicitBudget ?? null,
+          };
+          const unchanged =
+            prior != null &&
+            (prior.defaultBudgetCents ?? null) === next.defaultBudgetCents &&
+            (prior.defaultTurnCap ?? null) === next.defaultTurnCap &&
+            (prior.alwaysRequireExplicitBudget ?? null) === next.alwaysRequireExplicitBudget;
+          if (unchanged) {
+            writeResult = Ok({ changed: false });
+            return freshConfig;
+          }
+          workspaceEntry.goalDefaults = next;
+        }
+
+        writeResult = Ok({ changed: true });
+        return freshConfig;
+      });
+
+      if (!writeResult.success) {
+        return Err(writeResult.error);
+      }
+      if (!writeResult.data.changed) {
+        return Ok(undefined);
+      }
       await this.emitCurrentWorkspaceMetadata(normalizedWorkspaceId);
       return Ok(undefined);
     } catch (error) {
@@ -6698,19 +6791,6 @@ export class WorkspaceService extends EventEmitter {
 
     const { projectPath, workspacePath } = found;
 
-    const config = this.config.loadConfigOrDefault();
-    const projectConfig = config.projects.get(projectPath);
-    if (!projectConfig) {
-      return Err(`Project not found: ${projectPath}`);
-    }
-
-    const workspaceEntry = projectConfig.workspaces.find((w) => w.id === workspaceId);
-    const workspaceEntryWithFallback =
-      workspaceEntry ?? projectConfig.workspaces.find((w) => w.path === workspacePath);
-    if (!workspaceEntryWithFallback) {
-      return Err("Workspace not found");
-    }
-
     const normalizedAgentId = normalizeAgentId(agentId, "");
     if (!normalizedAgentId) {
       return Err("Agent ID is required");
@@ -6720,29 +6800,53 @@ export class WorkspaceService extends EventEmitter {
     // settings bucket. Persist whatever agent ID the caller chose so legacy Ask
     // settings can fade out naturally instead of being mixed into Auto.
 
-    const prev = workspaceEntryWithFallback.aiSettingsByAgent?.[normalizedAgentId];
-    const aiSettingsChanged =
-      aiSettings != null &&
-      (prev?.model !== aiSettings.model || prev?.thinkingLevel !== aiSettings.thinkingLevel);
-    const selectedAgentChanged =
-      options?.persistSelectedAgentId === true &&
-      workspaceEntryWithFallback.agentId !== normalizedAgentId;
-    if (!aiSettingsChanged && !selectedAgentChanged) {
+    // Compare/merge against the FRESH entry inside the serialized editConfig transform
+    // (see findFreshWorkspaceEntry): persisting a pre-read snapshot loses concurrent
+    // edits and can resurrect removed workspaces. Entry gone meanwhile → Err.
+    let writeResult: Result<boolean, string> = Err("Workspace not found");
+    await this.config.editConfig((freshConfig) => {
+      const workspaceEntry = this.findFreshWorkspaceEntry(freshConfig, {
+        projectPath,
+        workspaceId,
+        workspacePath,
+      });
+      if (!workspaceEntry) {
+        writeResult = Err("Workspace not found");
+        return freshConfig;
+      }
+
+      const prev = workspaceEntry.aiSettingsByAgent?.[normalizedAgentId];
+      const aiSettingsChanged =
+        aiSettings != null &&
+        (prev?.model !== aiSettings.model || prev?.thinkingLevel !== aiSettings.thinkingLevel);
+      const selectedAgentChanged =
+        options?.persistSelectedAgentId === true && workspaceEntry.agentId !== normalizedAgentId;
+      if (!aiSettingsChanged && !selectedAgentChanged) {
+        writeResult = Ok(false);
+        return freshConfig;
+      }
+
+      if (aiSettings != null) {
+        workspaceEntry.aiSettingsByAgent = {
+          ...(workspaceEntry.aiSettingsByAgent ?? {}),
+          [normalizedAgentId]: aiSettings,
+        };
+      }
+
+      if (options?.persistSelectedAgentId === true) {
+        workspaceEntry.agentId = normalizedAgentId;
+      }
+
+      writeResult = Ok(true);
+      return freshConfig;
+    });
+
+    if (!writeResult.success) {
+      return Err(writeResult.error);
+    }
+    if (!writeResult.data) {
       return Ok(false);
     }
-
-    if (aiSettings != null) {
-      workspaceEntryWithFallback.aiSettingsByAgent = {
-        ...(workspaceEntryWithFallback.aiSettingsByAgent ?? {}),
-        [normalizedAgentId]: aiSettings,
-      };
-    }
-
-    if (options?.persistSelectedAgentId === true) {
-      workspaceEntryWithFallback.agentId = normalizedAgentId;
-    }
-
-    await this.config.saveConfig(config);
 
     if (options?.emitMetadata !== false) {
       const allMetadata = await this.config.getAllWorkspaceMetadata();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -4915,6 +4915,32 @@ export class WorkspaceService extends EventEmitter {
         override.defaultTurnCap == null &&
         override.alwaysRequireExplicitBudget == null;
 
+      // No-op fast path from a snapshot read: skip the queued write entirely when the
+      // override already matches. Race-safe — equivalent to a serialized write of the
+      // identical value landing first, and skipping cannot resurrect removed entries.
+      {
+        const snapshotEntry = this.findFreshWorkspaceEntry(this.config.loadConfigOrDefault(), {
+          projectPath,
+          workspaceId: normalizedWorkspaceId,
+          workspacePath,
+        });
+        const prior = snapshotEntry?.goalDefaults;
+        if (snapshotEntry && allNull && prior == null) {
+          return Ok(undefined);
+        }
+        if (
+          snapshotEntry &&
+          !allNull &&
+          prior != null &&
+          (prior.defaultBudgetCents ?? null) === (override.defaultBudgetCents ?? null) &&
+          (prior.defaultTurnCap ?? null) === (override.defaultTurnCap ?? null) &&
+          (prior.alwaysRequireExplicitBudget ?? null) ===
+            (override.alwaysRequireExplicitBudget ?? null)
+        ) {
+          return Ok(undefined);
+        }
+      }
+
       // Compare against the FRESH entry inside the serialized editConfig transform
       // (see findFreshWorkspaceEntry): persisting a pre-read snapshot loses concurrent
       // edits and can resurrect removed workspaces. Entry gone meanwhile → Err.
@@ -6799,6 +6825,30 @@ export class WorkspaceService extends EventEmitter {
     // Removing the built-in Ask agent should not force writes into Auto's
     // settings bucket. Persist whatever agent ID the caller chose so legacy Ask
     // settings can fade out naturally instead of being mixed into Auto.
+
+    // Hot path: this runs on every message send, so skip the queued write when a
+    // snapshot read already shows no change. Skipping is race-safe — it is equivalent
+    // to a serialized write of the identical value landing first, and not writing can
+    // never resurrect concurrently removed entries.
+    {
+      const snapshotEntry = this.findFreshWorkspaceEntry(this.config.loadConfigOrDefault(), {
+        projectPath,
+        workspaceId,
+        workspacePath,
+      });
+      if (!snapshotEntry) {
+        return Err("Workspace not found");
+      }
+      const prev = snapshotEntry.aiSettingsByAgent?.[normalizedAgentId];
+      const aiSettingsChanged =
+        aiSettings != null &&
+        (prev?.model !== aiSettings.model || prev?.thinkingLevel !== aiSettings.thinkingLevel);
+      const selectedAgentChanged =
+        options?.persistSelectedAgentId === true && snapshotEntry.agentId !== normalizedAgentId;
+      if (!aiSettingsChanged && !selectedAgentChanged) {
+        return Ok(false);
+      }
+    }
 
     // Compare/merge against the FRESH entry inside the serialized editConfig transform
     // (see findFreshWorkspaceEntry): persisting a pre-read snapshot loses concurrent


### PR DESCRIPTION
## Summary

Fixes the two root causes of "garbage" sub-agent workspaces lingering in the sidebar: (1) a lost-update race in `config.json` writes that resurrects just-removed child workspace entries, and (2) interrupted workflow-owned children that were never eligible for auto-cleanup and stayed in the active sidebar forever.

## Background

Users reported that finished/interrupted sub-agents "shockingly often" remain in the sidebar and require manual cleanup. Forensics on a live specimen confirmed two independent mechanisms:

**RC1 — config resurrection.** `Config.editConfig` serializes mutations on a queue, but several callers (heartbeat settings, goal defaults, per-agent AI settings, projectService, CLI, and two internal Config paths) wrote full pre-read snapshots via public `saveConfig`, bypassing the queue. A stale snapshot landing after a concurrent `removeWorkspace` resurrects the removed entry — a sidebar ghost pointing at an already-deleted worktree/session, with no retry path. Reproduced against the real `Config` class: with a ~1200-workspace config, a direct save racing a removal resurrected the entry in 14/17 timing probes (~3.5 ms window). The production specimen matched exactly: transcript archived into the parent (proving removal ran), worktree and session dir deleted, config entry still present — and only the first-removed of three concurrently-removed children survived.

**RC2 — interrupted workflow children.** Interrupting a workflow run (or discovering a dead run at startup) marks running children `interrupted` without a completed report. `canCleanupReportedTask` requires a completed report, so those children were permanently ineligible for cleanup. The topology gate additionally blocks reported ancestors whose only remaining children are those interrupted entries, so garbage accumulated in clusters.

## Implementation

**RC1:** `Config.saveConfig` is now private (it remains the write primitive under the `editConfig` queue). All external callers were converted to `editConfig` transforms that re-resolve their target entry from fresh config inside the transform; entry-gone-meanwhile is handled gracefully (unset -> Ok, set -> Err). Internal bypasses fixed too: `getAllWorkspaceMetadata` replays its read-time migrations inside `editConfig`, and the sync load-time migration write-back became a one-shot queued identity transform.

**RC2:** When a workflow run reaches a terminal state (`markWorkflowRunEnded`, plus the run-scoped interrupt path), `sweepEndedWorkflowRunTasks` archives interrupted-without-report workflow-owned descendants deepest-first (log-and-continue on failures; refuses lossy untracked-file auto-archive), then rechecks reported descendants and archives ancestors blocked only by archived children. A startup sweep (`archiveLeftoverTasksOfInactiveWorkflowRuns`) self-heals children of inactive runs, including historical garbage from before this fix. User-spawned (non-workflow-owned) interrupted tasks intentionally keep the current keep-for-inspection behavior. Archived-not-removed preserves inspectability and workflow resume safety (journal replay restarts incomplete steps with fresh task IDs).

## Validation

- Regression test `workspaceService.configResurrection.test.ts` verified to **fail on the pre-fix parent commit** (lost update clobbers a concurrent write) and pass post-fix; it asserts both directions of the lost update (removal survives AND the concurrent write lands).
- Post-fix resurrection probe at production scale (1200-workspace config, 17 timing probes racing `removeWorkspace` vs heartbeat writes): 0 resurrections.
- Live dogfood on a seeded dev-server sandbox replicating the production fingerprint (interrupted workflow child of a dead run + user-spawned interrupted child): startup sweep archived only the workflow child; the user child stayed active in the sidebar (verified via agent-browser snapshot + screenshot).
- `MUX_ESLINT_CONCURRENCY=1 make static-check` green; targeted suites (config, resurrection regression, heartbeat, goal defaults, taskService incl. 3 new archive-sweep tests, projectService) 469 pass / 0 fail.

## Risks

- **Config write serialization (medium severity, app-wide config writes):** converting direct saves to queued transforms changes write ordering under concurrency. Mitigated by re-resolving entries from fresh config inside each transform (no snapshot merges) and by the dual-direction regression test. The load-time migration persist is now deferred to a queued task; migrations are idempotent and re-applied on every load, so delayed persistence is safe.
- **Auto-archiving workflow children (low-medium, task lifecycle):** the sweep only touches workflow-owned, interrupted, report-less, unarchived tasks — a state that was previously permanent garbage. Known residual (P4, documented): a crash between child-archive and blocked-ancestor-archive can leave one reported ancestor active until its run is re-swept; a comment over-claims ordering for the hard-timeout mid-run sweep case (behavior itself is idempotent/benign).

---

<details>
<summary>📋 Implementation Plan</summary>

# Plan: Fix lingering sub-agent "garbage" workspaces in the sidebar

Two independent, confirmed root causes; both fixed in this change set. Net product-code estimate: **~+110 LoC** (Workstream A ≈ +30 net, Workstream B ≈ +80 net; tests excluded).

## Context (verified by code investigation)

**RC1 — lost-update resurrection via direct `saveConfig`:** `Config.editConfig` (src/node/config.ts:1412) serializes mutations on `editConfigQueue` (:676), but public `Config.saveConfig(snapshot)` (:1143, async, atomic write, **swallows write errors**) lets callers write a stale full snapshot outside the queue. A stale write racing `removeWorkspace` (:2081, correctly queued) resurrects the removed workspace entry → permanent sidebar ghost pointing at a deleted worktree/session. Reproduced 14/17 timing probes with a 1200-workspace config.

Confirmed external callers of `.saveConfig(`:
- `src/node/services/workspaceService.ts`: `unsetHeartbeatSettings` (~4604), `setHeartbeatSettings` (~4734), **plus two not in the brief**: `setWorkspaceGoalDefaults` (~4874), `persistWorkspaceAISettingsForAgent` (~6745). All use the read-snapshot → mutate nested entry → `saveConfig(config)` pattern (heartbeat paths via `resolveHeartbeatWorkspaceEntry`, :4537, which returns `{ normalizedWorkspaceId, config, workspaceEntry }` where `workspaceEntry` aliases into the snapshot).
- `src/node/services/projectService.ts`: `create` (~510), `remove` (~960, ~996, ~1093), `setIdleCompactionHours` (~1376), `assignWorkspaceToSubProject` (~1427). Note ~889: `remove` deliberately re-reads from disk to verify persistence because `saveConfig` logs-and-continues — preserve that verification behavior.
- `src/cli/run.ts` (~470) and `src/cli/workflow.ts` (~215): ephemeral isolated `Config(tempDir)` instances (no real race), converted anyway for API uniformity.
- **Internal bypasses inside Config itself** (making `saveConfig` private does not fix these):
  - `getAllWorkspaceMetadata` (src/node/config.ts:1998): `await this.saveConfig(config)` after read-time workspace migrations.
  - `loadConfigOrDefault` migration write (:1029–1038): `writeFileAtomic.sync` outside the queue when `configModified` (set by load-time migrations/normalizations).

No dynamic access (`config["saveConfig"]`), no subclasses of `Config`, and the ORPC `saveConfig` route (src/node/orpc/router.ts:1342) already uses `editConfig` — privatizing is safe.

**RC2 — interrupted workflow-owned children never auto-cleaned:**
- `terminateAllDescendantAgentTasks` (src/node/services/taskService.ts:3826) transitions running children via `applyInterruptedTaskStatus` (:1422): `taskStatus = "interrupted"`, `reportedAt = undefined`, no completed report.
- `canCleanupReportedTask` (:10288) requires `hasCompletedAgentReport` (:10304) → interrupted-without-report children are permanently ineligible.
- `markWorkflowRunEnded` (:3793–3812) — called from `WorkflowTaskServiceAdapter.onRunEnded` on terminal run states — only rechecks children **with** completed reports.
- Startup prepass in `initialize()` (:1907–1928) transitions running/awaiting_report children of inactive runs (run status not in `pending|running|backgrounded`, resolved via the parent's `WorkflowRunStore`) to the same permanent `interrupted` state.
- Topology gate `hasChildAgentTasks` (:6943, fed by `listAgentTaskWorkspaces` :6472) counts **all** config children including archived ones → an interrupted grandchild blocks a reported parent's cleanup forever.
- Workflow-owned = `findWorkflowTaskOwnerInAncestry` finds an ancestor with `workflowTask: { runId, stepId, ... }`; `canCleanupReportedTask` already exempts workflow-owned tasks from `preserveSubagentsUntilArchive` (:10351–10356).
- Archive semantics: `WorkspaceService.archive` (src/node/services/workspaceService.ts:5817) sets `archivedAt` under `editConfig`, closes sessions, snapshots untracked files, removes the managed worktree via lifecycle hooks; the sidebar filters archived entries (`WorkspaceContext.tsx:1019`). TaskService already holds a `workspaceService` reference (constructor injection; existing archive call at taskService.ts:5876).
- **Resume safety confirmed:** `workflow_resume` of an interrupted run replays the journal; for incomplete steps, `waitForAgentTask` fails with "Task not found"/"Task interrupted" and `shouldRestartUnrecoverableStartedTask` (WorkflowRunner.ts:308) restarts the step with a fresh task/workspace ID. Archived old children do not collide.

---

## Workstream A: serialize all config mutations through `editConfig`

### A1. Privatize `saveConfig`
- Change `Config.saveConfig` to `private` in `src/node/config.ts`. Keep its atomic-write + log-and-swallow error semantics unchanged (it remains `editConfig`'s write primitive).
- Add a "why" comment referencing the lost-update resurrection race (removed-workspace entries restored by stale snapshot writes).

### A2. Convert service callers to `editConfig` transforms (re-resolve entries from fresh config)
Pattern for all conversions — do **not** mutate a pre-read snapshot; re-find the target inside the transform, **derive the final next value inside the transform from the fresh entry** (a pre-read may only validate/normalize the caller's *input*; any merge with existing entry state must read the fresh entry, otherwise partial updates can still lose concurrent edits), and use closure capture for results (keeps `editConfig`'s signature untouched, minimal diff):

```ts
let result: Result<..., string> = Err("workspace removed concurrently");
await this.config.editConfig((cfg) => {
  const ws = /* re-find workspace/project in cfg */;
  if (ws) {
    const next = /* merge normalized input with FRESH ws state */;
    /* apply next */;
    result = Ok(next);
  }
  return cfg;
});
return result;
```

- **workspaceService.ts** — `setHeartbeatSettings`, `unsetHeartbeatSettings`, `setWorkspaceGoalDefaults`, `persistWorkspaceAISettingsForAgent`: keep `resolveHeartbeatWorkspaceEntry` (and analogous pre-reads) for early validation of caller input only; the entry lookup + merge + mutation all move inside the transform. Handle entry-gone-meanwhile gracefully (heartbeat unset on a vanished entry → `Ok(undefined)`; set on a vanished entry → `Err`).
- **projectService.ts** (6 sites): same conversion; re-find `projectConfig`/workspace inside the transform. `create` also recomputes `deriveProjectHierarchy` inside the transform. Preserve the ~889 read-back persistence verification in `remove` (its rationale — swallowed write errors — still holds because `editConfig` uses the same write primitive).
- **cli/run.ts, cli/workflow.ts**: trivial `editConfig` transforms (`cfg => ({ ...cfg, projects: trustOnlyProjects })`).

### A3. Fix internal Config bypasses
- `getAllWorkspaceMetadata` (:1998): factor the read-time workspace normalization into a deterministic helper; when `configModified`, persist by running that helper inside an `editConfig` transform against fresh config (idempotent re-application) instead of `saveConfig(config)`.
- `loadConfigOrDefault` sync migration write (:1029–1038): `loadConfigOrDefault` is sync, so it cannot await the queue. **Ship a one-shot queued persist** replacing the sync write-back:
  - Add `private migrationPersist: Promise<void> | null = null` on `Config`.
  - When `configModified` and `migrationPersist === null`, schedule (do not await) `this.migrationPersist = this.editConfig((cfg) => cfg)` — the identity transform re-reads disk, re-runs migrations, and writes the migrated form under the queue.
  - `.catch(log.warn)` the stored promise (no bare `void` fire-and-forget) and reset `migrationPersist = null` in `finally` so a later migration can re-schedule.
  - Migrations are idempotent and re-applied on every load, so delayed persistence is safe.
  - Emergency fallback **only** if implementation proves this re-entrant/deadlocking (load called from inside an `editConfig` transform): delete the write-back entirely (next legitimate serialized mutation persists the migrated form) and document why.

### A4. Regression tests (behavioral)
- **Primary resurrection regression — must use a formerly-unsafe public path** (a race of `removeWorkspace` vs a generic `editConfig` mutation would pass even pre-fix and prove nothing): in the workspaceService test suite, with a real `Config(tempDir)`, seed workspaces A and B; start `config.removeWorkspace("A")` un-awaited; concurrently call `WorkspaceService.setHeartbeatSettings(B, ...)` (pre-fix: stale snapshot + direct `saveConfig` → resurrects A; post-fix: serialized); await both; re-read from disk via fresh `Config(tempDir)`; assert A stays removed **and** B's heartbeat landed. Test comment documents the pre-fix interleaving. **Do not ship a one-shot race test whose pre-fix failure depends on scheduler luck**: make the CI assertion deterministic-or-stressed — use a bounded stress loop (e.g. N interleaved iterations with a large seeded config) so pre-fix failure is near-certain, and keep any purely probabilistic timing probe in the out-of-repo validation script (below), not in fragile unit assertions.
- Entry-gone-meanwhile: `setHeartbeatSettings`/`unsetHeartbeatSettings` racing `removeWorkspace` of the **same** workspace → graceful result (`Err`/`Ok(undefined)` per A2), no resurrection.
- Supplementary `src/node/config.test.ts` coverage only if a gap remains beyond the existing "serializes concurrent edits" test (:108–141); don't duplicate it.

---

## Workstream B: archive interrupted-without-report workflow-owned children

### B1. Archive sweep on workflow-run end
- Extend `markWorkflowRunEnded(workflowRunId)` (taskService.ts:3793): after the existing completed-report cleanup loop, collect workspaces with `workflowTask?.runId === workflowRunId`, `taskStatus === "interrupted"`, no completed report, and not already archived; archive each via `this.workspaceService.archive(id)`.
- **Archive failure handling:** mirror the existing TaskService archive call pattern (:5876) and handle `archive`'s *actual* return semantics — both thrown errors and `Err`/failed `Result` — logging per child and continuing the sweep; one failure must not abort it.
- **Ordering (biggest lifecycle race in this workstream):** verify the run-end hook fires **after** descendants have been interrupted. `WorkflowService.interruptRun` (WorkflowService.ts:245) updates the store to `interrupted` and calls `WorkflowTaskServiceAdapter.interruptRun` (→ `terminateAllDescendantAgentTasks`); confirm on all three terminal transitions (completed/failed/interrupted) that `onRunEnded` → `markWorkflowRunEnded` runs after that interruption completes. If `markWorkflowRunEnded` can run first (children still `running` when the sweep looks), invoke the archive sweep from the interrupt path after descendant interruption instead/in addition (race-safe: the not-already-archived + interrupted-status filter makes the sweep idempotent).
- Deeper descendants of run children are also interrupted by `terminateAllDescendantAgentTasks` — include workflow-owned descendants via ancestry (reuse `isWorkflowOwnedTaskUsingIndex`/descendant walk), archiving deepest-first so `WorkspaceService.archive` preconditions hold.
- Explicitly do **not** touch user-spawned (non-workflow-owned) interrupted tasks.

### B2. Archive on the startup prepass
- In `initialize()` after the inactive-workflow-owner prepass (:1907–1928): archive the children that `interruptTaskRecoveryForInactiveWorkflowOwner` just transitioned to `interrupted` (collect their IDs during the pass; archive after the config refresh). Per AGENTS.md startup rules, wrap in try/catch so archive failures never crash startup.
- Children already sitting in `interrupted` from a previous session (transitioned before this fix shipped, or by a pre-crash interrupt) should also be swept here: include existing `interrupted`-without-report workflow-owned children of inactive runs, so historical garbage self-heals on next launch.

### B3. Topology-gate interaction for reported ancestors
- After archiving in B1, re-run `cleanupReportedLeafTask`/`requestReportedTaskCleanupRecheck` for reported workflow-owned ancestors of the run (loop order in `markWorkflowRunEnded`: clean completed leaves first, then archive interrupted ones, then recheck remaining reported tasks of the run).
- `hasChildAgentTasks` counts archived children, so a reported parent with an archived interrupted child stays blocked. Resolve with this decision ladder (all options stay narrow — workflow-owned only; **no** global `hasChildAgentTasks` change, which risks orphaning config entries):
  1. Verify whether `WorkspaceService.remove` of a parent safely handles remaining archived descendants (no orphaned/corrupt config entries). If yes: narrow gate exception in `canCleanupReportedTask` ignoring blocking children that are workflow-owned AND interrupted-without-report AND archived (~+15–25 product LoC).
  2. If removal is not provably safe: **archive** reported workflow-owned ancestors of the ended run that are blocked *only* by archived interrupted workflow descendants — still hides the active-sidebar garbage without deleting anything (~+20–35 product LoC).
  3. Only if neither is safe: keep the gate as-is and document the exact safety blocker and residual active-sidebar consequence in a code comment at the gate (~+3–8 product LoC).

### B4. Constraints honored
- `workflow_resume` unaffected (verified: interrupted steps restart with fresh task IDs; archived children are never reused).
- No periodic timers; all triggers are event-driven (run-end, startup prepass).
- No UI changes; sidebar already filters `archivedAt`.

### B5. Tests (extend `src/node/services/taskService.test.ts`, using existing harness: `createTestConfig`, `projectWorkspace`, `saveWorkspaces`, `createWorkspaceServiceMocks`, `createTaskServiceHarness` with real HistoryService)
Assert **archived state**, not just mock calls: the `workspaceService.archive` mock must mutate config to set `archivedAt` (matching the real archive), and tests assert the resulting config/sidebar-relevant state.
- (a) Workflow run end/interrupt archives interrupted-without-report workflow-owned children: interrupted child ends with `archivedAt` set; a completed-report sibling instead goes through the existing cleanup path (not archived).
- (b) User-spawned interrupted task (no `workflowTask` in ancestry) ends with no `archivedAt` and unchanged status.
- (c) Startup prepass (model on existing tests at :9642 / :9751): children of an inactive run are transitioned to interrupted **and** archived; parent recovery still works.
- (d) Per B3's chosen rung: (1) reported parent with an archived interrupted workflow-owned child becomes cleanup-eligible, or (2) the blocked reported ancestor ends archived; for rung (3) add no tautological test — the residual is documented in code.

---

## Validation & dogfooding

### Local validation
1. Targeted tests: `bun test src/node/config.test.ts`, the workspaceService heartbeat suites, projectService tests, and `bun test src/node/services/taskService.test.ts`. Do **not** run the monolithic suite in one Bun process; QuickJS-heavy workflow tests run individually only if touched.
2. `MUX_ESLINT_CONCURRENCY=1 make static-check`.
3. Grep gate: `grep -rn "\.saveConfig(" src/ | grep -v "src/node/config.ts"` returns nothing (and inside config.ts only `editConfig`'s internal write path + privatized definition remain).

### Resurrection probe (RC1 evidence)
- Adapt the investigation's Bun timing probe (script lives in `/tmp`, not the repo): temp rootDir, ~1200-workspace config, loop ≥17 probes racing `config.removeWorkspace(A)` against the **converted public mutation path** (drive `WorkspaceService.setHeartbeatSettings` on B via the existing test harness, or the extracted editConfig-based mutation if full service construction is impractical). Expect **0 resurrections**; capture the command + output summary in the final report.

### End-to-end dogfooding (RC2, startup-prepass path)
- Headless environment: Electron GUI screenshots are environmentally blocked, so use the `dev-server-sandbox` skill: seed a temp `MUX_ROOT` whose config contains (i) a workflow-owned child in `taskStatus: "interrupted"` under an inactive run and (ii) a user-spawned interrupted task; start the sandbox dev server; connect with `agent-browser`.
- Evidence (note: the startup prepass runs before the browser can connect, so "before" evidence is the **seeded config file**, not a screenshot):
  1. Before: seeded config.json excerpt showing both interrupted entries active.
  2. After: post-start `agent-browser` sidebar screenshot **and** a short `agent-browser record start/stop` webm — both are required whenever the sandbox/browser route works (workflow-owned child hidden, user-spawned task still visible); attach via `attach_file`.
  3. Strongest proof (no UI changed in this fix): config diff showing `archivedAt` set **only** on the workflow-owned child.
- If the sandbox route proves environmentally blocked, fall back to backend evidence only (config before/after + taskService logs), stated explicitly as the fallback.

---

## Acceptance criteria
1. `Config.saveConfig` is private; grep shows zero external `.saveConfig(` callers; all former callers (incl. the two extra workspaceService sites and both internal Config bypasses) use serialized `editConfig` transforms that re-resolve entries from fresh config.
2. New regression test proves `removeWorkspace` cannot be resurrected by a concurrent config mutation, with the pre-fix interleaving documented in the test comment.
3. Workflow-owned children left `interrupted` without reports are archived when their owning run ends (all terminal transitions) or is discovered inactive at startup; user-spawned interrupted tasks keep current behavior; `workflow_resume` of interrupted runs still works.
4. Reported ancestors of ended runs are rechecked after the archive sweep; the topology-gate interaction is resolved by either a narrow workflow-owned gate exception or archiving blocked workflow-owned ancestors. Only if both are unsafe, the code comment documents the exact safety blocker and the residual active-sidebar consequence.
5. All new/changed code carries "why" comments referencing the race/lifecycle rationale.
6. `MUX_ESLINT_CONCURRENCY=1 make static-check` passes; targeted test suites pass; resurrection probe reports 0 resurrections; dogfooding evidence (screenshots or documented fallback) included in the final report.

## Risks & decision points
- **`editConfig` error semantics differ subtly from `saveConfig`?** Both funnel into the same swallowing write primitive; projectService's read-back verification is preserved, so behavior is unchanged. Verify during implementation.
- **`loadConfigOrDefault` fix re-entrancy:** the queued-persist approach must not deadlock/loop when `loadConfigOrDefault` is called from inside an `editConfig` transform; one-shot flag + fallback (delete the write-back) covers this.
- **Startup archive cost:** archive snapshots untracked files and removes worktrees; bounded by the number of stale interrupted children, wrapped in try/catch, and self-healing (retries next launch for failures).
- **Topology gate** is the only genuinely open sub-decision; the B3 ladder bounds it (verify removal safety → narrow gate exception; else ancestor archive; else documented residual), and no option touches non-workflow-owned tasks.

## Out of scope
No periodic sweeps, no PR/branch/GitHub work, no UI changes, no unrelated refactors of config/taskService.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$94.40`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=94.40 -->
