### PR TITLE
🤖 fix: distinct waiting-on-bash-monitor indicators in chat and sidebar

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -487,12 +487,47 @@ function renderWorkflowOnlyActivity() {
   );
 }
 
+// Idle workspace parked on an armed background bash monitor: static green
+// "waiting" dot (no streaming pulse) + "Watching background bash" caption.
+function renderBashMonitorWaiting() {
+  const monitorWorkspace = createWorkspace({
+    id: "ws-bash-monitor",
+    name: "bash-monitor",
+    title: "Waiting on background bash monitor",
+    projectName: PROJECT_NAME,
+    projectPath: PROJECT_PATH,
+    createdAt: new Date(NOW - 6_000).toISOString(),
+  });
+
+  return (
+    <StoryScaffold
+      workspaces={[monitorWorkspace]}
+      workspaceActivitySnapshots={{
+        [monitorWorkspace.id]: {
+          recency: NOW,
+          streaming: false,
+          lastModel: null,
+          lastThinkingLevel: null,
+          activeBashMonitorCount: 1,
+        },
+      }}
+    >
+      <WorkspaceRow workspace={monitorWorkspace} />
+    </StoryScaffold>
+  );
+}
+
 // Composite gallery covering the primary single-workspace states. Replaces the
 // former FigmaStates, Selected, Active, ErrorState, Archiving, Question, and
 // Draft stories — one snapshot, all states preserved and labeled.
 export const WorkflowOnlyActivity: Story = {
   args: undefined as never,
   render: renderWorkflowOnlyActivity,
+};
+
+export const BashMonitorWaiting: Story = {
+  args: undefined as never,
+  render: renderBashMonitorWaiting,
 };
 
 export const States: Story = {

--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -488,7 +488,7 @@ function renderWorkflowOnlyActivity() {
 }
 
 // Idle workspace parked on an armed background bash monitor: static
-// pending-orange "waiting" dot (no streaming pulse) + "Watching background
+// backgrounded-blue "waiting" dot (no streaming pulse) + "Watching background
 // bash" caption.
 function renderBashMonitorWaiting() {
   const monitorWorkspace = createWorkspace({

--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -487,8 +487,9 @@ function renderWorkflowOnlyActivity() {
   );
 }
 
-// Idle workspace parked on an armed background bash monitor: static green
-// "waiting" dot (no streaming pulse) + "Watching background bash" caption.
+// Idle workspace parked on an armed background bash monitor: static
+// pending-orange "waiting" dot (no streaming pulse) + "Watching background
+// bash" caption.
 function renderBashMonitorWaiting() {
   const monitorWorkspace = createWorkspace({
     id: "ws-bash-monitor",

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -392,10 +392,11 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    // Waiting-on-monitor keeps the live green dot but must NOT pulse like an
-    // actively streaming workspace — that ambiguity confused users.
+    // Waiting-on-monitor renders the pending-orange dot, NOT the pulsing green
+    // streaming dot — that ambiguity confused users.
     expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
-    expect(row.querySelector(".bg-content-success")).toBeTruthy();
+    expect(row.querySelector(".bg-content-success")).toBeNull();
+    expect(row.querySelector(".bg-pending")).toBeTruthy();
     expect(rowView.getByText("Watching background bash")).toBeTruthy();
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
@@ -429,7 +430,7 @@ describe("AgentListItem", () => {
     const rowView = within(row);
 
     expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
-    expect(row.querySelector(".bg-content-success")).toBeTruthy();
+    expect(row.querySelector(".bg-pending")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Watching background bash")).toBeNull();
   });

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -392,11 +392,11 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    // Waiting-on-monitor renders the pending-orange dot, NOT the pulsing green
-    // streaming dot — that ambiguity confused users.
+    // Waiting-on-monitor renders the backgrounded-blue dot, NOT the pulsing
+    // green streaming dot — that ambiguity confused users.
     expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
     expect(row.querySelector(".bg-content-success")).toBeNull();
-    expect(row.querySelector(".bg-pending")).toBeTruthy();
+    expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByText("Watching background bash")).toBeTruthy();
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
@@ -430,7 +430,7 @@ describe("AgentListItem", () => {
     const rowView = within(row);
 
     expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
-    expect(row.querySelector(".bg-pending")).toBeTruthy();
+    expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Watching background bash")).toBeNull();
   });

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -392,7 +392,10 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    // Waiting-on-monitor keeps the live green dot but must NOT pulse like an
+    // actively streaming workspace — that ambiguity confused users.
+    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    expect(row.querySelector(".bg-content-success")).toBeTruthy();
     expect(rowView.getByText("Watching background bash")).toBeTruthy();
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
@@ -416,7 +419,7 @@ describe("AgentListItem", () => {
     expect(rowView.queryByTestId(`workspace-delegated-activity-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
 
-  test("keeps sidebar status text while an armed monitor drives the active dot", () => {
+  test("keeps sidebar status text while an armed monitor drives the waiting dot", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       activeBashMonitorCount: 1,
       agentStatus: { emoji: "⌛", message: "Awaiting PR readiness check" },
@@ -425,9 +428,21 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    expect(row.querySelector(".bg-content-success")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Watching background bash")).toBeNull();
+  });
+
+  test("active streaming keeps the pulsing dot even with an armed monitor", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({
+      canInterrupt: true,
+      activeBashMonitorCount: 1,
+    });
+
+    const { row } = renderWorkspaceItem();
+
+    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
   });
 
   test("shows active delegated workflow work on idle workspace rows", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -172,6 +172,7 @@ function getVisualState(opts: {
   isWorking: boolean;
   isStarting: boolean;
   hasActiveDelegatedWork: boolean;
+  isWaitingOnBashMonitor: boolean;
   isUnread: boolean;
   isSelected: boolean;
   hasError: boolean;
@@ -187,6 +188,12 @@ function getVisualState(opts: {
   }
   if (opts.isWorking || opts.isStarting || opts.isInitializing || opts.hasActiveDelegatedWork) {
     return "active";
+  }
+  // Idle but an armed background bash monitor will wake the agent: keep the row
+  // live (not "finished") without the streaming pulse, so users can tell parked
+  // wake-waiting apart from active streaming. Real work above wins.
+  if (opts.isWaitingOnBashMonitor) {
+    return "waiting";
   }
   // Avoid unread flicker for the currently selected workspace while last-read
   // timestamps catch up on the next render.
@@ -653,7 +660,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const hasError = lastAbortReason?.reason === "system";
   const hasActiveWorkflowRun = activeWorkflowRunCount > 0;
   // An armed background bash monitor means the workspace is still waiting to be
-  // woken, so keep the row on the active dot instead of letting it look finished.
+  // woken, so keep the row live (distinct "waiting" dot) instead of letting it
+  // look finished — but don't let it masquerade as active streaming.
   const hasActiveBashMonitor = activeBashMonitorCount > 0;
   const hasActiveDelegatedWork = (delegatedActivity?.activeCount ?? 0) > 0;
   const delegatedStatusText = delegatedActivity
@@ -683,7 +691,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     isArchiving: isArchiving === true,
     isWorking,
     isStarting: displayStreamingStatusPhase === "starting",
-    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun || hasActiveBashMonitor,
+    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun,
+    isWaitingOnBashMonitor: hasActiveBashMonitor,
     isUnread,
     isSelected,
     hasError,

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -6,8 +6,8 @@ import { cn } from "@/common/lib/utils";
 // Shared sidebar status language: agent rows and task-group headers render the
 // same dot states so grouped rows read as native parts of the agent tree.
 // "waiting" = parked but will resume on its own (e.g. armed background bash
-// monitor): still live, so it keeps the active green, but without the pulse so
-// it doesn't read as actively streaming.
+// monitor): rendered in the shared "pending" orange (no pulse) so it reads as
+// waiting rather than actively streaming or finished.
 export type VisualState = "active" | "waiting" | "idle" | "seen" | "hidden" | "error" | "question";
 
 export const LEADING_SLOT_CONTAINER_STYLE = {
@@ -56,7 +56,7 @@ export function StatusDot(props: {
         "block h-3 w-3",
         props.state === "active" &&
           "bg-content-success border-surface-green workspace-status-dot-active",
-        props.state === "waiting" && "bg-content-success border-surface-green",
+        props.state === "waiting" && "bg-pending border-pending/25",
         usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
         props.state === "idle" &&
           props.isSubAgent !== true &&

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -6,8 +6,9 @@ import { cn } from "@/common/lib/utils";
 // Shared sidebar status language: agent rows and task-group headers render the
 // same dot states so grouped rows read as native parts of the agent tree.
 // "waiting" = parked but will resume on its own (e.g. armed background bash
-// monitor): rendered in the shared "pending" orange (no pulse) so it reads as
-// waiting rather than actively streaming or finished.
+// monitor): rendered in the shared "backgrounded" soft blue (no pulse) so it
+// reads as waiting on background work rather than actively streaming or
+// finished — the same token background-process badges use.
 export type VisualState = "active" | "waiting" | "idle" | "seen" | "hidden" | "error" | "question";
 
 export const LEADING_SLOT_CONTAINER_STYLE = {
@@ -56,7 +57,7 @@ export function StatusDot(props: {
         "block h-3 w-3",
         props.state === "active" &&
           "bg-content-success border-surface-green workspace-status-dot-active",
-        props.state === "waiting" && "bg-pending border-pending/25",
+        props.state === "waiting" && "bg-backgrounded border-backgrounded/25",
         usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
         props.state === "idle" &&
           props.isSubAgent !== true &&

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/common/lib/utils";
 
 // Shared sidebar status language: agent rows and task-group headers render the
 // same dot states so grouped rows read as native parts of the agent tree.
-export type VisualState = "active" | "idle" | "seen" | "hidden" | "error" | "question";
+// "waiting" = parked but will resume on its own (e.g. armed background bash
+// monitor): still live, so it keeps the active green, but without the pulse so
+// it doesn't read as actively streaming.
+export type VisualState = "active" | "waiting" | "idle" | "seen" | "hidden" | "error" | "question";
 
 export const LEADING_SLOT_CONTAINER_STYLE = {
   width: SIDEBAR_LEADING_SLOT_SIZE_PX,
@@ -53,6 +56,7 @@ export function StatusDot(props: {
         "block h-3 w-3",
         props.state === "active" &&
           "bg-content-success border-surface-green workspace-status-dot-active",
+        props.state === "waiting" && "bg-content-success border-surface-green",
         usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
         props.state === "idle" &&
           props.isSubAgent !== true &&

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -417,6 +417,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     isTranscriptCaughtUp,
     hasOlderHistory,
     loadingOlderHistory,
+    activeBashMonitorCount,
   } = workspaceState;
   const shouldShowPinnedTodoList = workspaceState.todos.length > 0;
   const shouldShowReviewsBanner = reviews.reviews.length > 0;
@@ -1015,6 +1016,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const hasInterruptedStream = interruption?.hasInterruptedStream ?? false;
   const shouldShowStreamingBarrier = isStreamStarting || canInterrupt;
+  // An armed background bash monitor means the turn ended but the agent will be
+  // woken on matching output. Keep the barrier mounted so StreamingBarrier can
+  // show its "waiting on monitor" state instead of the chat looking idle.
+  const shouldMountStreamingBarrier = shouldShowStreamingBarrier || activeBashMonitorCount > 0;
   // Keep rendering cached transcript rows during incremental catch-up so workspace switches
   // feel stable, but active stream-start/interrupt states should keep their barrier visible
   // instead of flashing full-height transcript placeholders. The skeleton additionally holds
@@ -1095,7 +1100,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       })
     );
   }
-  if (shouldShowStreamingBarrier) {
+  if (shouldMountStreamingBarrier) {
     transcriptTailItems.push(
       createTranscriptTailStackItem({
         key: "streaming-barrier",

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1030,12 +1030,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       isHydratingTranscript,
       chatViewDataReady,
       hasRenderableMessages: deferredMessages.length > 0,
-      shouldShowStreamingBarrier,
+      // Any mounted barrier (including waiting-on-monitor) counts: a cleared
+      // transcript with an armed monitor must not flash placeholders under it.
+      shouldShowStreamingBarrier: shouldMountStreamingBarrier,
     });
   const showEmptyTranscriptPlaceholder =
     deferredMessages.length === 0 &&
     !showTranscriptHydrationPlaceholder &&
-    !shouldShowStreamingBarrier;
+    !shouldMountStreamingBarrier;
   const showRetryBarrier =
     !isHydratingTranscript && !shouldShowStreamingBarrier && hasInterruptedStream;
   const isAutoRetryActive =

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
@@ -16,6 +16,7 @@ interface MockWorkspaceState {
   pendingStreamStartTime: number | null;
   pendingStreamModel: string | null;
   runtimeStatus: { phase: string; detail?: string } | null;
+  activeBashMonitorCount: number;
 }
 
 function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): MockWorkspaceState {
@@ -28,6 +29,7 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
     pendingStreamStartTime: null,
     pendingStreamModel: null,
     runtimeStatus: null,
+    activeBashMonitorCount: 0,
     ...overrides,
   };
 
@@ -411,5 +413,44 @@ describe("StreamingBarrier", () => {
 
     expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
     expect(view.getByText("type a message to respond")).toBeTruthy();
+  });
+
+  test("idle workspace with an armed bash monitor shows the waiting state without a stop control", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: false,
+      activeBashMonitorCount: 1,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    // Shown immediately (not debounced) so the stream-end -> waiting handoff
+    // doesn't flash an empty transcript tail.
+    expect(view.getByText("Waiting on background bash monitor...")).toBeTruthy();
+    // Nothing to interrupt — the hint is informational, not a cancel control.
+    expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
+    expect(view.getByText("agent wakes on matching output")).toBeTruthy();
+  });
+
+  test("idle workspace without armed monitors renders nothing", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: false,
+      activeBashMonitorCount: 0,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    expect(view.container.textContent).toBe("");
+  });
+
+  test("active streaming takes precedence over an armed bash monitor", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: true,
+      activeBashMonitorCount: 2,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    expect(view.getByText("gpt-4o-mini streaming...")).toBeTruthy();
+    expect(view.getByRole("button", { name: "Stop streaming" })).toBeTruthy();
   });
 });

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -20,7 +20,8 @@ type StreamingPhase =
   | "interrupting" // User triggered interrupt, waiting for stream-abort
   | "streaming" // Normal streaming
   | "compacting" // Compaction in progress
-  | "awaiting-input"; // ask_user_question waiting for response
+  | "awaiting-input" // ask_user_question waiting for response
+  | "waiting-on-monitor"; // Turn ended; armed background bash monitor will wake the agent
 
 interface StreamingBarrierProps {
   workspaceId: string;
@@ -161,12 +162,16 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
     currentModel,
     pendingStreamModel,
     runtimeStatus,
+    activeBashMonitorCount,
   } = workspaceState;
 
   // Compute streaming phase
   const phase: StreamingPhase | null = (() => {
     if (isStarting) return "starting";
-    if (!canInterrupt) return null;
+    // No active stream: normally hide the barrier, but if an armed background
+    // bash monitor is still watching output, the agent will be woken on match.
+    // Surface that so the idle chat doesn't read as "done" or stalled.
+    if (!canInterrupt) return activeBashMonitorCount > 0 ? "waiting-on-monitor" : null;
     if (aggregator?.hasInterruptingStream()) return "interrupting";
     if (awaitingUserQuestion) return "awaiting-input";
     if (isCompacting) return "compacting";
@@ -221,6 +226,10 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
         return modelName ? `${modelName} compacting...` : "compacting...";
       case "streaming":
         return modelName ? `${modelName} streaming...` : "streaming...";
+      case "waiting-on-monitor":
+        return activeBashMonitorCount === 1
+          ? "Waiting on background bash monitor..."
+          : `Waiting on ${activeBashMonitorCount} background bash monitors...`;
     }
   })();
   const statusText = useStabilizedStreamingStatusText(workspaceId, phase, rawStatusText);
@@ -236,6 +245,8 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
         return "";
       case "awaiting-input":
         return "type a message to respond";
+      case "waiting-on-monitor":
+        return "agent wakes on matching output";
       case "starting":
       case "compacting":
       case "streaming":

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
@@ -78,3 +78,15 @@ export const Streaming: Story = {
     tps: 73,
   },
 };
+
+/**
+ * Idle turn that is waiting on an armed background bash monitor. There is no
+ * active stream, so the stop control is replaced by an informational hint and
+ * the token-stats slot stays hidden.
+ */
+export const WaitingOnBackgroundBashMonitor: Story = {
+  args: {
+    statusText: "Waiting on background bash monitor...",
+    cancelText: "agent wakes on matching output",
+  },
+};


### PR DESCRIPTION
## Summary

When a turn ends while a background bash monitor is still armed, both the chat pane and the workspace sidebar now show a distinct "waiting on monitor" state instead of looking like active streaming (or going blank), so users don't mistake the wake-waiting state for a running or finished conversation.

## Background

Background bash processes spawned with a `monitor` block wake the workspace when matching output lands. Previously:

- The **chat pane** hid the streaming barrier as soon as the stream ended — the transcript looked idle even though the agent was deliberately parked waiting for a wake.
- The **sidebar** funneled armed monitors into the same `"active"` visual state as live streams, so a waiting workspace showed the identical pulsing green dot as an actively streaming one.

Both read as "still streaming" or "done," causing user confusion.

## Implementation

**Chat pane**

- `StreamingBarrier` gains a `waiting-on-monitor` phase, entered when no stream is active (`!canInterrupt`, not starting) and `WorkspaceState.activeBashMonitorCount > 0` — the count is already plumbed from `BackgroundProcessManager` via workspace activity snapshots, so no backend/IPC changes were needed.
- The phase renders informational copy ("agent wakes on matching output") in place of the Stop control, hides token stats, and is not debounced so the stream-end → waiting handoff is immediate.
- `ChatPane` keeps the barrier mounted while a monitor is armed (`shouldMountStreamingBarrier`); reveal/hydration logic is unchanged.

**Sidebar**

- `StatusDot` gains a `"waiting"` visual state: a static dot in the shared `--color-backgrounded` soft blue (the token background-process badges already use, no `workspace-status-dot-active` pulse), so parked wake-waiting is visually distinct from both the pulsing-green streaming state and the finished/idle states.
- `AgentListItem.getVisualState` maps armed monitors to `"waiting"` via a dedicated `isWaitingOnBashMonitor` flag instead of piggybacking on `hasActiveDelegatedWork`; real work (streaming/starting/delegated/workflow) still wins and keeps the pulsing dot.
- The existing "Watching background bash" caption is unchanged.

Added unit tests (chat: waiting state shown/hidden/precedence; sidebar: static-vs-pulsing dot assertions) and Storybook stories for both surfaces.

## Risks

Low. Active streaming/interrupting/awaiting-input states take precedence over the new states, and with zero armed monitors behavior is byte-for-byte the prior logic. Worst case is a lingering waiting indicator if a monitor count fails to clear, which would equally affect the pre-existing sidebar caption.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high -->


