### PR TITLE
🤖 chore: gitignore .ruff_cache dropped by make fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,8 @@ runs/
 
 # Python
 __pycache__
+# ruff format (fmt.mk) drops its cache at the repo root
+.ruff_cache/
 
 tmpfork
 .mux-agent-cli


### PR DESCRIPTION
## Summary

Ignore `.ruff_cache/`, which `make fmt` / `make fmt-check` drop at the repo root, so workspace archiving stops prompting about lossy untracked files.

## Background

`fmt.mk` runs `uvx ruff format benchmarks` as part of `fmt-python(-check)`, which is included in `make fmt`, `make fmt-check`, and `make static-check`. Since the repo has no `pyproject.toml`/`ruff.toml`, ruff writes its cache to `./.ruff_cache/` (reproduced in a scratch dir).

The archive preflight (`worktreeArchiveSnapshotService.listUnsupportedUntrackedFiles`) lists untracked paths via `git ls-files --others --exclude-standard --directory`, so the cache dir triggers the "confirm lossy untracked files" dialog in practically every workspace that ran static checks. `workspaceService.test.ts` even uses `.ruff_cache/` as its example untracked path.

Because the preflight uses `--exclude-standard`, gitignoring the directory removes it from the prompt immediately, including for existing workspaces. Kept ruff's cache (rather than `--no-cache` in fmt.mk) for incremental format speed.

## Validation

- Created a fake `.ruff_cache/` and confirmed `git check-ignore` matches and `git ls-files --others --exclude-standard --directory` returns nothing.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$2.61`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=2.61 -->
