### PR TITLE
🤖 fix: re-land waiting-on-bash-monitor indicators with a subtle pulsing blue dot

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -487,9 +487,8 @@ function renderWorkflowOnlyActivity() {
   );
 }
 
-// Idle workspace parked on an armed background bash monitor: static
-// backgrounded-blue "waiting" dot (no streaming pulse) + "Watching background
-// bash" caption.
+// Idle workspace parked on an armed background bash monitor: pulsing
+// backgrounded-blue "waiting" dot + "Watching background bash" caption.
 function renderBashMonitorWaiting() {
   const monitorWorkspace = createWorkspace({
     id: "ws-bash-monitor",

--- a/src/browser/components/AgentListItem/AgentListItem.stories.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.stories.tsx
@@ -487,12 +487,48 @@ function renderWorkflowOnlyActivity() {
   );
 }
 
+// Idle workspace parked on an armed background bash monitor: static
+// backgrounded-blue "waiting" dot (no streaming pulse) + "Watching background
+// bash" caption.
+function renderBashMonitorWaiting() {
+  const monitorWorkspace = createWorkspace({
+    id: "ws-bash-monitor",
+    name: "bash-monitor",
+    title: "Waiting on background bash monitor",
+    projectName: PROJECT_NAME,
+    projectPath: PROJECT_PATH,
+    createdAt: new Date(NOW - 6_000).toISOString(),
+  });
+
+  return (
+    <StoryScaffold
+      workspaces={[monitorWorkspace]}
+      workspaceActivitySnapshots={{
+        [monitorWorkspace.id]: {
+          recency: NOW,
+          streaming: false,
+          lastModel: null,
+          lastThinkingLevel: null,
+          activeBashMonitorCount: 1,
+        },
+      }}
+    >
+      <WorkspaceRow workspace={monitorWorkspace} />
+    </StoryScaffold>
+  );
+}
+
 // Composite gallery covering the primary single-workspace states. Replaces the
 // former FigmaStates, Selected, Active, ErrorState, Archiving, Question, and
 // Draft stories — one snapshot, all states preserved and labeled.
 export const WorkflowOnlyActivity: Story = {
   args: undefined as never,
   render: renderWorkflowOnlyActivity,
+};
+
+export const BashMonitorWaiting: Story = {
+  args: undefined as never,
+  render: renderBashMonitorWaiting,
 };
 
 export const States: Story = {

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -392,9 +392,8 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    // Waiting-on-monitor renders the backgrounded-blue dot, NOT the pulsing
-    // green streaming dot — that ambiguity confused users.
-    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    // Waiting-on-monitor renders the backgrounded-blue dot (same pulse as the
+    // active dot), NOT the green streaming dot — that ambiguity confused users.
     expect(row.querySelector(".bg-content-success")).toBeNull();
     expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByText("Watching background bash")).toBeTruthy();
@@ -429,13 +428,13 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    expect(row.querySelector(".bg-content-success")).toBeNull();
     expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Watching background bash")).toBeNull();
   });
 
-  test("active streaming keeps the pulsing dot even with an armed monitor", () => {
+  test("active streaming keeps the green dot even with an armed monitor", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       canInterrupt: true,
       activeBashMonitorCount: 1,
@@ -443,7 +442,9 @@ describe("AgentListItem", () => {
 
     const { row } = renderWorkspaceItem();
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    // Real streaming outranks the waiting-on-monitor blue.
+    expect(row.querySelector(".bg-content-success")).toBeTruthy();
+    expect(row.querySelector(".bg-backgrounded")).toBeNull();
   });
 
   test("shows active delegated workflow work on idle workspace rows", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -392,7 +392,11 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    // Waiting-on-monitor renders the backgrounded-blue dot, NOT the pulsing
+    // green streaming dot — that ambiguity confused users.
+    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    expect(row.querySelector(".bg-content-success")).toBeNull();
+    expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByText("Watching background bash")).toBeTruthy();
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
@@ -416,7 +420,7 @@ describe("AgentListItem", () => {
     expect(rowView.queryByTestId(`workspace-delegated-activity-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
 
-  test("keeps sidebar status text while an armed monitor drives the active dot", () => {
+  test("keeps sidebar status text while an armed monitor drives the waiting dot", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       activeBashMonitorCount: 1,
       agentStatus: { emoji: "⌛", message: "Awaiting PR readiness check" },
@@ -425,9 +429,21 @@ describe("AgentListItem", () => {
     const { row } = renderWorkspaceItem();
     const rowView = within(row);
 
-    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
+    expect(row.querySelector(".workspace-status-dot-active")).toBeNull();
+    expect(row.querySelector(".bg-backgrounded")).toBeTruthy();
     expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
     expect(rowView.queryByText("Watching background bash")).toBeNull();
+  });
+
+  test("active streaming keeps the pulsing dot even with an armed monitor", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({
+      canInterrupt: true,
+      activeBashMonitorCount: 1,
+    });
+
+    const { row } = renderWorkspaceItem();
+
+    expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
   });
 
   test("shows active delegated workflow work on idle workspace rows", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -172,6 +172,7 @@ function getVisualState(opts: {
   isWorking: boolean;
   isStarting: boolean;
   hasActiveDelegatedWork: boolean;
+  isWaitingOnBashMonitor: boolean;
   isUnread: boolean;
   isSelected: boolean;
   hasError: boolean;
@@ -187,6 +188,12 @@ function getVisualState(opts: {
   }
   if (opts.isWorking || opts.isStarting || opts.isInitializing || opts.hasActiveDelegatedWork) {
     return "active";
+  }
+  // Idle but an armed background bash monitor will wake the agent: keep the row
+  // live (not "finished") without the streaming pulse, so users can tell parked
+  // wake-waiting apart from active streaming. Real work above wins.
+  if (opts.isWaitingOnBashMonitor) {
+    return "waiting";
   }
   // Avoid unread flicker for the currently selected workspace while last-read
   // timestamps catch up on the next render.
@@ -653,7 +660,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const hasError = lastAbortReason?.reason === "system";
   const hasActiveWorkflowRun = activeWorkflowRunCount > 0;
   // An armed background bash monitor means the workspace is still waiting to be
-  // woken, so keep the row on the active dot instead of letting it look finished.
+  // woken, so keep the row live (distinct "waiting" dot) instead of letting it
+  // look finished — but don't let it masquerade as active streaming.
   const hasActiveBashMonitor = activeBashMonitorCount > 0;
   const hasActiveDelegatedWork = (delegatedActivity?.activeCount ?? 0) > 0;
   const delegatedStatusText = delegatedActivity
@@ -683,7 +691,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     isArchiving: isArchiving === true,
     isWorking,
     isStarting: displayStreamingStatusPhase === "starting",
-    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun || hasActiveBashMonitor,
+    hasActiveDelegatedWork: hasActiveDelegatedWork || hasActiveWorkflowRun,
+    isWaitingOnBashMonitor: hasActiveBashMonitor,
     isUnread,
     isSelected,
     hasError,

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -5,7 +5,11 @@ import { cn } from "@/common/lib/utils";
 
 // Shared sidebar status language: agent rows and task-group headers render the
 // same dot states so grouped rows read as native parts of the agent tree.
-export type VisualState = "active" | "idle" | "seen" | "hidden" | "error" | "question";
+// "waiting" = parked but will resume on its own (e.g. armed background bash
+// monitor): rendered in the shared "backgrounded" soft blue (no pulse) so it
+// reads as waiting on background work rather than actively streaming or
+// finished — the same token background-process badges use.
+export type VisualState = "active" | "waiting" | "idle" | "seen" | "hidden" | "error" | "question";
 
 export const LEADING_SLOT_CONTAINER_STYLE = {
   width: SIDEBAR_LEADING_SLOT_SIZE_PX,
@@ -53,6 +57,7 @@ export function StatusDot(props: {
         "block h-3 w-3",
         props.state === "active" &&
           "bg-content-success border-surface-green workspace-status-dot-active",
+        props.state === "waiting" && "bg-backgrounded border-backgrounded/25",
         usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
         props.state === "idle" &&
           props.isSubAgent !== true &&

--- a/src/browser/components/AgentListItem/StatusDot.tsx
+++ b/src/browser/components/AgentListItem/StatusDot.tsx
@@ -6,9 +6,12 @@ import { cn } from "@/common/lib/utils";
 // Shared sidebar status language: agent rows and task-group headers render the
 // same dot states so grouped rows read as native parts of the agent tree.
 // "waiting" = parked but will resume on its own (e.g. armed background bash
-// monitor): rendered in the shared "backgrounded" soft blue (no pulse) so it
-// reads as waiting on background work rather than actively streaming or
-// finished — the same token background-process badges use.
+// monitor): same pulse and geometry as "active", but in the shared
+// "backgrounded" soft blue (the token background-process badges use) so it
+// reads as live-but-waiting rather than actively streaming or finished. The
+// border must stay a near-background surface tint (like the green dot's) so
+// only the small core reads as colored — a colored/translucent border makes
+// the whole 12px circle read as the dot.
 export type VisualState = "active" | "waiting" | "idle" | "seen" | "hidden" | "error" | "question";
 
 export const LEADING_SLOT_CONTAINER_STYLE = {
@@ -57,7 +60,8 @@ export function StatusDot(props: {
         "block h-3 w-3",
         props.state === "active" &&
           "bg-content-success border-surface-green workspace-status-dot-active",
-        props.state === "waiting" && "bg-backgrounded border-backgrounded/25",
+        props.state === "waiting" &&
+          "bg-backgrounded border-surface-sky workspace-status-dot-active",
         usesSubAgentConnectorDot && "bg-border-light border-border-light h-2 w-2",
         props.state === "idle" &&
           props.isSubAgent !== true &&

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -417,6 +417,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     isTranscriptCaughtUp,
     hasOlderHistory,
     loadingOlderHistory,
+    activeBashMonitorCount,
   } = workspaceState;
   const shouldShowPinnedTodoList = workspaceState.todos.length > 0;
   const shouldShowReviewsBanner = reviews.reviews.length > 0;
@@ -1015,6 +1016,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const hasInterruptedStream = interruption?.hasInterruptedStream ?? false;
   const shouldShowStreamingBarrier = isStreamStarting || canInterrupt;
+  // An armed background bash monitor means the turn ended but the agent will be
+  // woken on matching output. Keep the barrier mounted so StreamingBarrier can
+  // show its "waiting on monitor" state instead of the chat looking idle.
+  const shouldMountStreamingBarrier = shouldShowStreamingBarrier || activeBashMonitorCount > 0;
   // Keep rendering cached transcript rows during incremental catch-up so workspace switches
   // feel stable, but active stream-start/interrupt states should keep their barrier visible
   // instead of flashing full-height transcript placeholders. The skeleton additionally holds
@@ -1025,12 +1030,14 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       isHydratingTranscript,
       chatViewDataReady,
       hasRenderableMessages: deferredMessages.length > 0,
-      shouldShowStreamingBarrier,
+      // Any mounted barrier (including waiting-on-monitor) counts: a cleared
+      // transcript with an armed monitor must not flash placeholders under it.
+      shouldShowStreamingBarrier: shouldMountStreamingBarrier,
     });
   const showEmptyTranscriptPlaceholder =
     deferredMessages.length === 0 &&
     !showTranscriptHydrationPlaceholder &&
-    !shouldShowStreamingBarrier;
+    !shouldMountStreamingBarrier;
   const showRetryBarrier =
     !isHydratingTranscript && !shouldShowStreamingBarrier && hasInterruptedStream;
   const isAutoRetryActive =
@@ -1095,7 +1102,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       })
     );
   }
-  if (shouldShowStreamingBarrier) {
+  if (shouldMountStreamingBarrier) {
     transcriptTailItems.push(
       createTranscriptTailStackItem({
         key: "streaming-barrier",

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
@@ -16,6 +16,7 @@ interface MockWorkspaceState {
   pendingStreamStartTime: number | null;
   pendingStreamModel: string | null;
   runtimeStatus: { phase: string; detail?: string } | null;
+  activeBashMonitorCount: number;
 }
 
 function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): MockWorkspaceState {
@@ -28,6 +29,7 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
     pendingStreamStartTime: null,
     pendingStreamModel: null,
     runtimeStatus: null,
+    activeBashMonitorCount: 0,
     ...overrides,
   };
 
@@ -411,5 +413,44 @@ describe("StreamingBarrier", () => {
 
     expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
     expect(view.getByText("type a message to respond")).toBeTruthy();
+  });
+
+  test("idle workspace with an armed bash monitor shows the waiting state without a stop control", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: false,
+      activeBashMonitorCount: 1,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    // Shown immediately (not debounced) so the stream-end -> waiting handoff
+    // doesn't flash an empty transcript tail.
+    expect(view.getByText("Waiting on background bash monitor...")).toBeTruthy();
+    // Nothing to interrupt — the hint is informational, not a cancel control.
+    expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
+    expect(view.getByText("agent wakes on matching output")).toBeTruthy();
+  });
+
+  test("idle workspace without armed monitors renders nothing", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: false,
+      activeBashMonitorCount: 0,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    expect(view.container.textContent).toBe("");
+  });
+
+  test("active streaming takes precedence over an armed bash monitor", () => {
+    currentWorkspaceState = createWorkspaceState({
+      canInterrupt: true,
+      activeBashMonitorCount: 2,
+    });
+
+    const view = render(<StreamingBarrier workspaceId="ws-1" />);
+
+    expect(view.getByText("gpt-4o-mini streaming...")).toBeTruthy();
+    expect(view.getByRole("button", { name: "Stop streaming" })).toBeTruthy();
   });
 });

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.test.tsx
@@ -429,6 +429,8 @@ describe("StreamingBarrier", () => {
     // Nothing to interrupt — the hint is informational, not a cancel control.
     expect(view.queryByRole("button", { name: "Stop streaming" })).toBeNull();
     expect(view.getByText("agent wakes on matching output")).toBeTruthy();
+    // Not streaming-bound: no reserved token-stats slot (frees narrow panes).
+    expect(view.queryByTestId("streaming-barrier-stats")).toBeNull();
   });
 
   test("idle workspace without armed monitors renders nothing", () => {

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -20,7 +20,8 @@ type StreamingPhase =
   | "interrupting" // User triggered interrupt, waiting for stream-abort
   | "streaming" // Normal streaming
   | "compacting" // Compaction in progress
-  | "awaiting-input"; // ask_user_question waiting for response
+  | "awaiting-input" // ask_user_question waiting for response
+  | "waiting-on-monitor"; // Turn ended; armed background bash monitor will wake the agent
 
 interface StreamingBarrierProps {
   workspaceId: string;
@@ -161,12 +162,16 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
     currentModel,
     pendingStreamModel,
     runtimeStatus,
+    activeBashMonitorCount,
   } = workspaceState;
 
   // Compute streaming phase
   const phase: StreamingPhase | null = (() => {
     if (isStarting) return "starting";
-    if (!canInterrupt) return null;
+    // No active stream: normally hide the barrier, but if an armed background
+    // bash monitor is still watching output, the agent will be woken on match.
+    // Surface that so the idle chat doesn't read as "done" or stalled.
+    if (!canInterrupt) return activeBashMonitorCount > 0 ? "waiting-on-monitor" : null;
     if (aggregator?.hasInterruptingStream()) return "interrupting";
     if (awaitingUserQuestion) return "awaiting-input";
     if (isCompacting) return "compacting";
@@ -221,6 +226,10 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
         return modelName ? `${modelName} compacting...` : "compacting...";
       case "streaming":
         return modelName ? `${modelName} streaming...` : "streaming...";
+      case "waiting-on-monitor":
+        return activeBashMonitorCount === 1
+          ? "Waiting on background bash monitor..."
+          : `Waiting on ${activeBashMonitorCount} background bash monitors...`;
     }
   })();
   const statusText = useStabilizedStreamingStatusText(workspaceId, phase, rawStatusText);
@@ -236,6 +245,8 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
         return "";
       case "awaiting-input":
         return "type a message to respond";
+      case "waiting-on-monitor":
+        return "agent wakes on matching output";
       case "starting":
       case "compacting":
       case "streaming":

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrier.tsx
@@ -301,6 +301,11 @@ export const StreamingBarrier: React.FC<StreamingBarrierProps> = ({
       cancelText={cancelText}
       onCancel={canTapCancel ? handleCancelClick : undefined}
       cancelShortcutText={canTapCancel ? interruptKeybind : undefined}
+      // Waiting-on-monitor is not streaming-bound: drop the reserved stats slot
+      // and let the informational hint hide in narrow panes so the barrier fits
+      // phone-width transcripts (the label alone carries the state).
+      reserveStatsSlot={phase !== "waiting-on-monitor"}
+      hideHintOnNarrow={phase === "waiting-on-monitor"}
       className={className}
       hintElement={
         showCompactionHint ? (

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
@@ -78,3 +78,15 @@ export const Streaming: Story = {
     tps: 73,
   },
 };
+
+/**
+ * Idle turn that is waiting on an armed background bash monitor. There is no
+ * active stream, so the stop control is replaced by an informational hint and
+ * the token-stats slot stays hidden.
+ */
+export const WaitingOnBackgroundBashMonitor: Story = {
+  args: {
+    statusText: "Waiting on background bash monitor...",
+    cancelText: "agent wakes on matching output",
+  },
+};

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.stories.tsx
@@ -82,11 +82,35 @@ export const Streaming: Story = {
 /**
  * Idle turn that is waiting on an armed background bash monitor. There is no
  * active stream, so the stop control is replaced by an informational hint and
- * the token-stats slot stays hidden.
+ * the token-stats slot is not rendered.
  */
 export const WaitingOnBackgroundBashMonitor: Story = {
   args: {
     statusText: "Waiting on background bash monitor...",
     cancelText: "agent wakes on matching output",
+    reserveStatsSlot: false,
+    hideHintOnNarrow: true,
   },
+};
+
+/**
+ * Same waiting state in a phone-width pane: the low-priority hint hides via the
+ * barrier's own container query so the row cannot overflow horizontally. The
+ * fixed-width wrapper drives the container query directly, so this contract
+ * holds in the Storybook test-runner and Chromatic without viewport modes.
+ */
+export const WaitingOnBackgroundBashMonitorNarrow: Story = {
+  args: {
+    statusText: "Waiting on background bash monitor...",
+    cancelText: "agent wakes on matching output",
+    reserveStatsSlot: false,
+    hideHintOnNarrow: true,
+  },
+  render: (args) => (
+    <div className="bg-background flex min-h-screen items-start p-6">
+      <div className="w-[320px] rounded-md border border-[var(--color-border-medium)] bg-[var(--color-card)] p-4">
+        <StreamingBarrierView {...args} />
+      </div>
+    </div>
+  ),
 };

--- a/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.tsx
+++ b/src/browser/features/Messages/ChatBarrier/StreamingBarrierView.tsx
@@ -17,6 +17,18 @@ export interface StreamingBarrierViewProps {
   className?: string;
   /** Optional hint element shown after status (e.g., settings link) */
   hintElement?: React.ReactNode;
+  /**
+   * Reserve the token-stats slot (default true). Streaming-bound phases keep it
+   * so the starting -> streaming transition doesn't reflow the row; idle phases
+   * (e.g. waiting on a bash monitor) skip it to fit narrow panes.
+   */
+  reserveStatsSlot?: boolean;
+  /**
+   * Hide the plain-text cancel hint when the barrier's container is narrow.
+   * Use for low-priority informational hints that would overflow phone-width
+   * transcripts; keep instructional hints (e.g. awaiting-input) always visible.
+   */
+  hideHintOnNarrow?: boolean;
 }
 
 /**
@@ -27,29 +39,34 @@ export interface StreamingBarrierViewProps {
  */
 export const StreamingBarrierView: React.FC<StreamingBarrierViewProps> = (props) => {
   return (
-    <div className={`flex items-center justify-between gap-4 ${props.className ?? ""}`}>
+    // @container scopes the narrow-hint query to the barrier's own width, so it
+    // tracks the chat pane (which can be narrow on wide desktops), not the viewport.
+    <div className={`@container flex items-center justify-between gap-4 ${props.className ?? ""}`}>
       <div className="flex flex-1 items-center gap-2">
         <BaseBarrier text={props.statusText} color="var(--color-assistant-border)" animate />
         {props.hintElement}
-        {/* Always render the stats slot so the row geometry is identical across the
-            starting -> streaming transition; only its visibility toggles. Previously
-            this slot mounted exactly when streaming began, reflowing the row (layout
-            flash). Reserving it (with placeholder values) keeps the layout stable. */}
-        <span
-          data-testid="streaming-barrier-stats"
-          aria-hidden={props.tokenCount === undefined}
-          className={cn(
-            "text-assistant-border counter-nums-mono inline-flex min-w-[14ch] items-baseline justify-end text-[11px] whitespace-nowrap select-none",
-            props.tokenCount === undefined && "invisible"
-          )}
-        >
-          <span>~{(props.tokenCount ?? 0).toLocaleString()} tokens</span>
-          <span className="text-dim ml-1 inline-flex min-w-[7ch] items-baseline justify-end gap-1">
-            <span>@</span>
-            <span>{props.tps !== undefined && props.tps > 0 ? props.tps : "--"}</span>
-            <span>t/s</span>
+        {/* Render the stats slot for streaming-bound phases so the row geometry is
+            identical across the starting -> streaming transition; only its visibility
+            toggles. Previously this slot mounted exactly when streaming began,
+            reflowing the row (layout flash). Reserving it (with placeholder values)
+            keeps the layout stable. */}
+        {props.reserveStatsSlot !== false && (
+          <span
+            data-testid="streaming-barrier-stats"
+            aria-hidden={props.tokenCount === undefined}
+            className={cn(
+              "text-assistant-border counter-nums-mono inline-flex min-w-[14ch] items-baseline justify-end text-[11px] whitespace-nowrap select-none",
+              props.tokenCount === undefined && "invisible"
+            )}
+          >
+            <span>~{(props.tokenCount ?? 0).toLocaleString()} tokens</span>
+            <span className="text-dim ml-1 inline-flex min-w-[7ch] items-baseline justify-end gap-1">
+              <span>@</span>
+              <span>{props.tps !== undefined && props.tps > 0 ? props.tps : "--"}</span>
+              <span>t/s</span>
+            </span>
           </span>
-        </span>
+        )}
       </div>
       <div className="ml-auto">
         {props.onCancel && props.cancelText.length > 0 ? (
@@ -70,7 +87,14 @@ export const StreamingBarrierView: React.FC<StreamingBarrierViewProps> = (props)
             </button>
           </TooltipIfPresent>
         ) : (
-          <span className="text-muted text-[11px] whitespace-nowrap select-none">
+          <span
+            className={cn(
+              "text-muted text-[11px] whitespace-nowrap select-none",
+              // Low-priority hints yield to the status label in narrow panes
+              // instead of forcing horizontal overflow.
+              props.hideHintOnNarrow && "hidden @md:inline"
+            )}
+          >
             {props.cancelText}
           </span>
         )}


### PR DESCRIPTION
## Summary

Re-lands #3697 (distinct waiting-on-bash-monitor indicators in chat and sidebar), which was reverted on `main` (09a1857fa1) because the sidebar's blue waiting dot rendered far too large. The dot is now the same size/geometry as the green streaming dot and shares its pulse animation, in the `--color-backgrounded` soft blue.

## Background

The original PR gave idle-but-waiting-on-monitor workspaces a blue sidebar dot styled `bg-backgrounded border-backgrounded/25`. The `StatusDot` circle is 12px with a 3.5px border; the green active dot uses a near-background surface tint for that border (`border-surface-green`), so only its small core reads as colored. The translucent blue border made the entire 12px circle read as blue — visually enormous next to its siblings, prompting the revert.

## Implementation

First commit is a clean `git revert` of the revert (restoring #3697 verbatim); the second commit applies the fix on top:

- `StatusDot` waiting state is now `bg-backgrounded border-surface-sky workspace-status-dot-active`: the `--color-surface-sky` border is the same near-background surface treatment the green/question dots use (defined in all four themes), so the visible blue core matches the green core's size, and the shared `workspace-status-dot-pulse` opacity animation now runs on it too.
- Tests updated: since the pulse class is shared between active and waiting, assertions distinguish the states by color token (`bg-content-success` vs `bg-backgrounded`) instead of by animation class.

Everything else from #3697 (chat-pane waiting barrier, empty-transcript gating, stories) is unchanged.

## Risks

Low, same envelope as #3697: zero armed monitors reproduces prior behavior exactly, and streaming/error/question states still outrank the waiting dot. The only new surface is the dot styling itself, now built from the same tokens/animation as the existing active dot.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `high`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=high -->
