### PR TITLE
🤖 fix: inherit OpenAI OAuth support for custom models

### DIFF
--- a/src/browser/features/ChatInput/CodexOauthWarningBanner.test.tsx
+++ b/src/browser/features/ChatInput/CodexOauthWarningBanner.test.tsx
@@ -20,7 +20,7 @@ describe("CodexOauthWarningBanner", () => {
 
     const view = render(
       <CodexOauthWarningBanner
-        activeModel="openai:gpt-5.3-codex-spark"
+        requiresCodexOauth={true}
         codexOauthSet={false}
         onOpenProviders={onOpenProviders}
       />
@@ -37,7 +37,7 @@ describe("CodexOauthWarningBanner", () => {
   test("does not render when Codex OAuth is connected", () => {
     const view = render(
       <CodexOauthWarningBanner
-        activeModel="openai:gpt-5.3-codex-spark"
+        requiresCodexOauth={true}
         codexOauthSet={true}
         onOpenProviders={() => undefined}
       />
@@ -49,7 +49,7 @@ describe("CodexOauthWarningBanner", () => {
   test("does not render when Codex OAuth status is still unknown", () => {
     const view = render(
       <CodexOauthWarningBanner
-        activeModel="openai:gpt-5.3-codex-spark"
+        requiresCodexOauth={true}
         codexOauthSet={null}
         onOpenProviders={() => undefined}
       />
@@ -61,19 +61,7 @@ describe("CodexOauthWarningBanner", () => {
   test("does not render for non-required models", () => {
     const view = render(
       <CodexOauthWarningBanner
-        activeModel="openai:gpt-5.3-codex"
-        codexOauthSet={false}
-        onOpenProviders={() => undefined}
-      />
-    );
-
-    expect(view.queryByTestId("codex-oauth-warning-banner")).toBeNull();
-  });
-
-  test("does not render for non-OpenAI providers even with matching model id", () => {
-    const view = render(
-      <CodexOauthWarningBanner
-        activeModel="openrouter:gpt-5.3-codex-spark"
+        requiresCodexOauth={false}
         codexOauthSet={false}
         onOpenProviders={() => undefined}
       />

--- a/src/browser/features/ChatInput/CodexOauthWarningBanner.tsx
+++ b/src/browser/features/ChatInput/CodexOauthWarningBanner.tsx
@@ -1,20 +1,14 @@
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/browser/components/Button/Button";
-import { isCodexOauthRequiredModelId } from "@/common/constants/codexOAuth";
 
 interface Props {
-  activeModel: string;
+  requiresCodexOauth: boolean;
   codexOauthSet: boolean | null;
   onOpenProviders: () => void;
 }
 
-// Keep warning criteria coupled to the shared OAuth-required model set so UI
-// copy stays accurate when model gating changes.
 export function CodexOauthWarningBanner(props: Props) {
-  const shouldShowWarning =
-    props.activeModel.startsWith("openai:") &&
-    isCodexOauthRequiredModelId(props.activeModel) &&
-    props.codexOauthSet === false;
+  const shouldShowWarning = props.requiresCodexOauth && props.codexOauthSet === false;
 
   if (!shouldShowWarning) {
     return null;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -663,6 +663,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     defaultModel,
     setDefaultModel,
     codexOauthSet,
+    requiresCodexOauth,
   } = useModelsFromSettings();
 
   const [agentAiDefaults] = usePersistedState<AgentAiDefaults>(
@@ -3113,7 +3114,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           {creationControlsProps && <CreationControls {...creationControlsProps} />}
 
           <CodexOauthWarningBanner
-            activeModel={baseModel}
+            requiresCodexOauth={requiresCodexOauth(baseModel)}
             codexOauthSet={codexOauthSet}
             onOpenProviders={() => open("providers", { expandProvider: "openai" })}
           />

--- a/src/browser/hooks/useModelsFromSettings.test.ts
+++ b/src/browser/hooks/useModelsFromSettings.test.ts
@@ -362,7 +362,10 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
         isEnabled: true,
         isConfigured: true,
         codexOauthSet: true,
-        models: SEEDED_OPENAI_CUSTOM_MODELS,
+        models: [
+          ...SEEDED_OPENAI_CUSTOM_MODELS,
+          { id: "team-codex", mappedToModel: KNOWN_MODELS.GPT_53_CODEX.id },
+        ],
       },
     };
 
@@ -373,6 +376,7 @@ describe("useModelsFromSettings OpenAI Codex OAuth gating", () => {
     expect(result.current.models).toContain("openai:gpt-5.2-codex");
     expect(result.current.models).toContain(KNOWN_MODELS.GPT_53_CODEX.id);
     expect(result.current.models).toContain("openai:gpt-5.3-codex-spark");
+    expect(result.current.models).toContain("openai:team-codex");
     expect(result.current.models).not.toContain("openai:gpt-5.2-pro");
   });
 

--- a/src/browser/hooks/useModelsFromSettings.ts
+++ b/src/browser/hooks/useModelsFromSettings.ts
@@ -1,10 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { readPersistedString, usePersistedState } from "./usePersistedState";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
-import {
-  isCodexOauthAllowedModelId,
-  isCodexOauthRequiredModelId,
-} from "@/common/constants/codexOAuth";
+import { isCodexOauthAllowedModel, isCodexOauthRequiredModel } from "@/common/constants/codexOAuth";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import { useProvidersConfig } from "./useProvidersConfig";
 import { useRouting } from "./useRouting";
@@ -212,6 +209,8 @@ export function useModelsFromSettings() {
   const openaiApiKeySet = config === null ? null : config.openai?.apiKeySet === true;
   const codexOauthSet = config === null ? null : config.openai?.codexOauthSet === true;
 
+  const requiresCodexOauth = (modelId: string) => isCodexOauthRequiredModel(modelId, config);
+
   const providerHiddenModels = useMemo(() => {
     if (config == null) {
       return [];
@@ -249,12 +248,12 @@ export function useModelsFromSettings() {
       // fail at send time (oauth_not_connected / api_key_not_found).
       if (modelId.startsWith("openai:")) {
         if (!hasOpenaiApiKey && hasCodexOauth) {
-          return isCodexOauthAllowedModelId(modelId);
+          return isCodexOauthAllowedModel(modelId, config);
         }
         if (hasOpenaiApiKey && hasCodexOauth) {
           return true;
         }
-        return !isCodexOauthRequiredModelId(modelId);
+        return !isCodexOauthRequiredModel(modelId, config);
       }
 
       return true;
@@ -322,10 +321,10 @@ export function useModelsFromSettings() {
       }
 
       if (!hasOpenaiApiKey && hasCodexOauth) {
-        return isCodexOauthAllowedModelId(modelId);
+        return isCodexOauthAllowedModel(modelId, config);
       }
 
-      return !isCodexOauthRequiredModelId(modelId);
+      return !isCodexOauthRequiredModel(modelId, config);
     });
 
     return effectivePolicy ? next.filter((m) => isModelAllowedByPolicy(effectivePolicy, m)) : next;
@@ -436,5 +435,6 @@ export function useModelsFromSettings() {
     setDefaultModel: setDefaultModelAndPersist,
     openaiApiKeySet,
     codexOauthSet,
+    requiresCodexOauth,
   };
 }

--- a/src/common/constants/codexOAuth.test.ts
+++ b/src/common/constants/codexOAuth.test.ts
@@ -36,6 +36,8 @@ describe("codexOAuth model gating", () => {
       openai: {
         models: [
           { id: "team-codex", mappedToModel: "openai:gpt-5.3-codex" },
+          { id: "team-bare", mappedToModel: "gpt-5.3-codex" },
+          { id: "team-litellm", mappedToModel: "openai/gpt-5.3-codex" },
           { id: "team-spark", mappedToModel: "openai:gpt-5.3-codex-spark" },
         ],
       },
@@ -43,6 +45,8 @@ describe("codexOAuth model gating", () => {
 
     expect(isCodexOauthAllowedModel("openai:team-codex", config)).toBe(true);
     expect(isCodexOauthRequiredModel("openai:team-codex", config)).toBe(false);
+    expect(isCodexOauthAllowedModel("openai:team-bare", config)).toBe(true);
+    expect(isCodexOauthAllowedModel("openai:team-litellm", config)).toBe(true);
     expect(isCodexOauthAllowedModel("openai:team-spark", config)).toBe(true);
     expect(isCodexOauthRequiredModel("openai:team-spark", config)).toBe(true);
   });

--- a/src/common/constants/codexOAuth.test.ts
+++ b/src/common/constants/codexOAuth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { isCodexOauthAllowedModelId, isCodexOauthRequiredModelId } from "./codexOAuth";
+import {
+  isCodexOauthAllowedModel,
+  isCodexOauthAllowedModelId,
+  isCodexOauthRequiredModel,
+  isCodexOauthRequiredModelId,
+} from "./codexOAuth";
 
 describe("codexOAuth model gating", () => {
   it("allows GPT-5.4 mini through the Codex OAuth route", () => {
@@ -24,6 +29,32 @@ describe("codexOAuth model gating", () => {
   it("does not allow GPT-5.4 nano through the Codex OAuth route", () => {
     expect(isCodexOauthAllowedModelId("gpt-5.4-nano")).toBe(false);
     expect(isCodexOauthAllowedModelId("openai:gpt-5.4-nano")).toBe(false);
+  });
+
+  it("inherits OAuth compatibility from a mapped OpenAI model", () => {
+    const config = {
+      openai: {
+        models: [
+          { id: "team-codex", mappedToModel: "openai:gpt-5.3-codex" },
+          { id: "team-spark", mappedToModel: "openai:gpt-5.3-codex-spark" },
+        ],
+      },
+    };
+
+    expect(isCodexOauthAllowedModel("openai:team-codex", config)).toBe(true);
+    expect(isCodexOauthRequiredModel("openai:team-codex", config)).toBe(false);
+    expect(isCodexOauthAllowedModel("openai:team-spark", config)).toBe(true);
+    expect(isCodexOauthRequiredModel("openai:team-spark", config)).toBe(true);
+  });
+
+  it("does not inherit OpenAI OAuth compatibility across providers", () => {
+    const config = {
+      openrouter: {
+        models: [{ id: "team-codex", mappedToModel: "openai:gpt-5.3-codex" }],
+      },
+    };
+
+    expect(isCodexOauthAllowedModel("openrouter:team-codex", config)).toBe(false);
   });
 
   it("does not mark GPT-5.4 mini or nano as OAuth-required", () => {

--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -147,13 +147,25 @@ export function isCodexOauthRequiredModelId(modelId: string): boolean {
   return CODEX_OAUTH_REQUIRED_MODELS.has(normalizeCodexOauthModelId(modelId));
 }
 
-function isOpenAIModelString(modelId: string): boolean {
-  const separatorIndex = modelId.indexOf(":");
-  return (
-    separatorIndex > 0 &&
-    separatorIndex < modelId.length - 1 &&
-    modelId.slice(0, separatorIndex) === "openai"
-  );
+function normalizeOpenAIModelString(modelId: string): string | null {
+  const trimmedModelId = modelId.trim();
+  if (!trimmedModelId) {
+    return null;
+  }
+
+  if (trimmedModelId.startsWith("openai:")) {
+    return trimmedModelId.length > "openai:".length ? trimmedModelId : null;
+  }
+
+  if (trimmedModelId.startsWith("openai/")) {
+    return trimmedModelId.length > "openai/".length
+      ? `openai:${trimmedModelId.slice("openai/".length)}`
+      : null;
+  }
+
+  return trimmedModelId.includes(":") || trimmedModelId.includes("/")
+    ? null
+    : `openai:${trimmedModelId}`;
 }
 
 /**
@@ -161,18 +173,20 @@ function isOpenAIModelString(modelId: string): boolean {
  *
  * Custom OpenAI IDs may opt into Codex OAuth compatibility by mapping to a known
  * OpenAI model. The runtime ID is still sent to OpenAI; only capability checks
- * inherit from mappedToModel.
+ * inherit from mappedToModel. Treat-as mappings also accept the bare and
+ * LiteLLM-style OpenAI IDs supported by metadata lookups.
  */
 export function getCodexOauthCompatibilityModelId(
   modelId: string,
   providersConfig: ProviderModelsConfig | null
 ): string | null {
-  if (!isOpenAIModelString(modelId)) {
+  const runtimeModelId = normalizeOpenAIModelString(modelId);
+  if (runtimeModelId === null || !modelId.trim().startsWith("openai:")) {
     return null;
   }
 
-  const mappedModelId = resolveModelForMetadata(modelId, providersConfig);
-  return isOpenAIModelString(mappedModelId) ? mappedModelId : modelId;
+  const mappedModelId = resolveModelForMetadata(runtimeModelId, providersConfig);
+  return normalizeOpenAIModelString(mappedModelId) ?? runtimeModelId;
 }
 
 export function isCodexOauthAllowedModel(

--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -8,6 +8,11 @@
  * UI can reference the same endpoints and model gating rules.
  */
 
+import {
+  resolveModelForMetadata,
+  type ProviderModelsConfig,
+} from "@/common/utils/providers/modelEntries";
+
 // NOTE: These endpoints + params follow the OpenCode Codex OAuth guide.
 // If OpenAI changes them, keep all updates centralized here.
 
@@ -140,6 +145,50 @@ export function isCodexOauthAllowedModelId(modelId: string): boolean {
 
 export function isCodexOauthRequiredModelId(modelId: string): boolean {
   return CODEX_OAUTH_REQUIRED_MODELS.has(normalizeCodexOauthModelId(modelId));
+}
+
+function isOpenAIModelString(modelId: string): boolean {
+  const separatorIndex = modelId.indexOf(":");
+  return (
+    separatorIndex > 0 &&
+    separatorIndex < modelId.length - 1 &&
+    modelId.slice(0, separatorIndex) === "openai"
+  );
+}
+
+/**
+ * Resolve the OpenAI model whose capabilities a runtime model inherits.
+ *
+ * Custom OpenAI IDs may opt into Codex OAuth compatibility by mapping to a known
+ * OpenAI model. The runtime ID is still sent to OpenAI; only capability checks
+ * inherit from mappedToModel.
+ */
+export function getCodexOauthCompatibilityModelId(
+  modelId: string,
+  providersConfig: ProviderModelsConfig | null
+): string | null {
+  if (!isOpenAIModelString(modelId)) {
+    return null;
+  }
+
+  const mappedModelId = resolveModelForMetadata(modelId, providersConfig);
+  return isOpenAIModelString(mappedModelId) ? mappedModelId : modelId;
+}
+
+export function isCodexOauthAllowedModel(
+  modelId: string,
+  providersConfig: ProviderModelsConfig | null
+): boolean {
+  const compatibilityModelId = getCodexOauthCompatibilityModelId(modelId, providersConfig);
+  return compatibilityModelId !== null && isCodexOauthAllowedModelId(compatibilityModelId);
+}
+
+export function isCodexOauthRequiredModel(
+  modelId: string,
+  providersConfig: ProviderModelsConfig | null
+): boolean {
+  const compatibilityModelId = getCodexOauthCompatibilityModelId(modelId, providersConfig);
+  return compatibilityModelId !== null && isCodexOauthRequiredModelId(compatibilityModelId);
 }
 
 export function getCodexOauthContextWindowOverride(modelId: string): number | null {

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -77,6 +77,19 @@ describe("getEffectiveContextLimit", () => {
     expect(defaultOauthLimit).toBe(272_000);
   });
 
+  test("inherits the Codex OAuth context cap from a mapped OpenAI model", () => {
+    const limit = getEffectiveContextLimit(
+      "openai:team-gpt",
+      false,
+      providersWithOpenAI({
+        codexOauthSet: true,
+        models: [{ id: "team-gpt", mappedToModel: KNOWN_MODELS.GPT.id }],
+      })
+    );
+
+    expect(limit).toBe(272_000);
+  });
+
   test("does not apply the GPT-5.5 OAuth cap to gateway-routed models", () => {
     const limit = getEffectiveContextLimit(
       "openrouter:openai/gpt-5.5",

--- a/src/common/utils/compaction/contextLimit.ts
+++ b/src/common/utils/compaction/contextLimit.ts
@@ -6,9 +6,10 @@
  */
 
 import {
+  getCodexOauthCompatibilityModelId,
   getCodexOauthContextWindowOverride,
-  isCodexOauthAllowedModelId,
-  isCodexOauthRequiredModelId,
+  isCodexOauthAllowedModel,
+  isCodexOauthRequiredModel,
 } from "@/common/constants/codexOAuth";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { supports1MContext } from "@/common/utils/ai/models";
@@ -27,20 +28,6 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function hasNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
-}
-
-function getOpenAIProviderModelId(model: string): string | null {
-  const separatorIndex = model.indexOf(":");
-  if (separatorIndex <= 0 || separatorIndex === model.length - 1) {
-    return null;
-  }
-
-  const provider = model.slice(0, separatorIndex);
-  if (provider !== "openai") {
-    return null;
-  }
-
-  return model.slice(separatorIndex + 1);
 }
 
 function hasCodexOauthTokens(config: unknown): boolean {
@@ -83,12 +70,12 @@ function getCodexOauthContextLimit(
   model: string,
   providersConfig: ProvidersConfigMap | null
 ): number | null {
-  const modelId = getOpenAIProviderModelId(model);
-  if (!modelId || !isCodexOauthAllowedModelId(modelId)) {
+  const compatibilityModelId = getCodexOauthCompatibilityModelId(model, providersConfig);
+  if (compatibilityModelId === null || !isCodexOauthAllowedModel(model, providersConfig)) {
     return null;
   }
 
-  const oauthLimit = getCodexOauthContextWindowOverride(modelId);
+  const oauthLimit = getCodexOauthContextWindowOverride(compatibilityModelId);
   if (oauthLimit == null) {
     return null;
   }
@@ -98,7 +85,7 @@ function getCodexOauthContextLimit(
     return null;
   }
 
-  if (isCodexOauthRequiredModelId(modelId)) {
+  if (isCodexOauthRequiredModel(model, providersConfig)) {
     return oauthLimit;
   }
 

--- a/src/common/utils/providers/modelEntries.ts
+++ b/src/common/utils/providers/modelEntries.ts
@@ -1,5 +1,7 @@
-import type { ProviderModelEntry, ProvidersConfigMap } from "@/common/orpc/types";
+import type { ProviderModelEntry } from "@/common/orpc/types";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
+
+export type ProviderModelsConfig = Record<string, { models?: ProviderModelEntry[] } | undefined>;
 
 interface ParsedProviderModelId {
   provider: string;
@@ -57,7 +59,7 @@ function parseProviderModelId(fullModelId: string): ParsedProviderModelId | null
 }
 
 function findProviderModelEntry(
-  providersConfig: ProvidersConfigMap | null,
+  providersConfig: ProviderModelsConfig | null,
   provider: string,
   modelId: string
 ): ProviderModelEntry | null {
@@ -85,7 +87,7 @@ function findProviderModelEntry(
  */
 function findProviderModelEntryScoped(
   fullModelId: string,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProviderModelsConfig | null
 ): ProviderModelEntry | null {
   const rawParsed = parseProviderModelId(fullModelId);
   if (rawParsed) {
@@ -114,7 +116,7 @@ function findProviderModelEntryScoped(
 
 export function getModelContextWindowOverride(
   fullModelId: string,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProviderModelsConfig | null
 ): number | null {
   const entry = findProviderModelEntryScoped(fullModelId, providersConfig);
   return entry ? getProviderModelEntryContextWindowTokens(entry) : null;
@@ -122,7 +124,7 @@ export function getModelContextWindowOverride(
 
 export function resolveModelForMetadata(
   fullModelId: string,
-  providersConfig: ProvidersConfigMap | null
+  providersConfig: ProviderModelsConfig | null
 ): string {
   const entry = findProviderModelEntryScoped(fullModelId, providersConfig);
   return (entry ? getProviderModelEntryMappedTo(entry) : null) ?? fullModelId;

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -969,6 +969,31 @@ describe("ProviderModelFactory modelCostsIncluded", () => {
     });
   });
 
+  it("routes a custom OpenAI model through Codex OAuth when it inherits from a compatible model", async () => {
+    await withTempConfig(async (config, factory) => {
+      config.saveProvidersConfig({
+        openai: {
+          codexOauth: {
+            type: "oauth",
+            access: "test-access-token",
+            refresh: "test-refresh-token",
+            expires: Date.now() + 60_000,
+            accountId: "test-account-id",
+          },
+          models: [{ id: "team-codex", mappedToModel: KNOWN_MODELS.GPT_53_CODEX.id }],
+        },
+      });
+
+      const result = await factory.createModel("openai:team-codex");
+      expect(result.success).toBe(true);
+      if (!result.success) {
+        return;
+      }
+
+      expect(modelCostsIncluded(result.data)).toBe(true);
+    });
+  });
+
   it("does not mark gpt-5.3-codex as subscription-covered when routed through API key", async () => {
     await withTempConfig(async (config, factory) => {
       config.saveProvidersConfig({

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -14,8 +14,8 @@ import {
 } from "@/common/constants/providers";
 import {
   CODEX_ENDPOINT,
-  isCodexOauthAllowedModelId,
-  isCodexOauthRequiredModelId,
+  isCodexOauthAllowedModel,
+  isCodexOauthRequiredModel,
 } from "@/common/constants/codexOAuth";
 import { parseCodexOauthAuth } from "@/node/utils/codexOauthAuth";
 import type { Config, ProviderConfig, ProvidersConfig } from "@/node/config";
@@ -1211,8 +1211,8 @@ export class ProviderModelFactory {
       if (providerName === "openai") {
         const fullModelId = `${providerName}:${modelId}`;
 
-        const codexOauthAllowed = isCodexOauthAllowedModelId(fullModelId);
-        const codexOauthRequired = isCodexOauthRequiredModelId(fullModelId);
+        const codexOauthAllowed = isCodexOauthAllowedModel(fullModelId, providersConfig);
+        const codexOauthRequired = isCodexOauthRequiredModel(fullModelId, providersConfig);
 
         const storedCodexOauth = parseCodexOauthAuth(
           (providerConfig as { codexOauth?: unknown }).codexOauth


### PR DESCRIPTION
## Summary

Allow custom models under the OpenAI provider to inherit Codex OAuth compatibility from their configured **Treat as** (`mappedToModel`) model while preserving the custom runtime model ID sent to OpenAI.

## Background

OAuth-only OpenAI configurations currently hide arbitrary custom model IDs and reject them at runtime because OAuth eligibility is checked only against the custom ID. This prevents aliases or organization-specific model IDs from using Codex OAuth even when they intentionally inherit capabilities from a supported OpenAI model.

## Implementation

- Resolve Codex OAuth allow/require checks through `mappedToModel` for custom OpenAI models.
- Apply the inherited eligibility consistently to model-picker filtering and runtime provider routing.
- Inherit required-OAuth warnings and OAuth-specific context-window caps.
- Keep inheritance scoped to the OpenAI provider so other providers cannot gain OpenAI OAuth access through metadata mapping.
- Continue sending the custom model ID on the provider request; the mapping is used only for capabilities and auth routing.

## Validation

- Added coverage for OAuth eligibility inheritance and cross-provider isolation.
- Added model-picker coverage for an OAuth-only custom OpenAI model.
- Added runtime routing and subscription-cost coverage for a mapped custom model.
- Added OAuth context-limit inheritance coverage.
- Ran the targeted OAuth/model test suite successfully.
- Ran `make static-check NIX=` successfully. The normal `make static-check` reaches the repository's Nix formatter wrapper, which fails because its untracked temporary copy is not visible to Nix; `nix fmt -- flake.nix` succeeds directly and leaves the file unchanged.

## Risks

Low-to-moderate risk, limited to OpenAI auth selection and model visibility. Eligibility remains constrained to the existing Codex OAuth allowlist, and only custom models explicitly mapped to an allowlisted OpenAI model inherit support.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `max` • Cost: `$7.27`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=max costs=7.27 -->
