### PR TITLE
🤖 fix: preserve MCP OAuth authorization-server binding across restarts

### DIFF
--- a/src/common/types/mcpOauth.ts
+++ b/src/common/types/mcpOauth.ts
@@ -27,7 +27,9 @@ export interface MCPOAuthPendingServerConfig {
 /**
  * OAuth 2.1 token response.
  *
- * Matches the shape used by @ai-sdk/mcp.
+ * Matches the shape used by @ai-sdk/mcp (OAuthTokensSchema), including the
+ * authorization-server binding fields the SDK appends via
+ * addAuthorizationServerInformationToTokens() before saveTokens().
  */
 export interface MCPOAuthTokens {
   access_token: string;
@@ -36,18 +38,34 @@ export interface MCPOAuthTokens {
   expires_in?: number;
   scope?: string;
   refresh_token?: string;
+  /**
+   * Authorization server URL these tokens were issued by.
+   *
+   * @ai-sdk/mcp auth() requires this (or the same field on clientInformation)
+   * to be present before it will use refresh_token; when missing it
+   * invalidates the stored tokens and demands interactive re-auth. Dropping
+   * it from the persisted store breaks token refresh across app restarts.
+   */
+  authorization_server?: string;
+  /** Token endpoint bound to authorization_server; required alongside it. */
+  token_endpoint?: string;
 }
 
 /**
  * OAuth dynamic client registration information.
  *
- * Matches the shape used by @ai-sdk/mcp.
+ * Matches the shape used by @ai-sdk/mcp (OAuthClientInformationSchema),
+ * including the same authorization-server binding fields as MCPOAuthTokens.
  */
 export interface MCPOAuthClientInformation {
   client_id: string;
   client_secret?: string;
   client_id_issued_at?: number;
   client_secret_expires_at?: number;
+  /** See MCPOAuthTokens.authorization_server. */
+  authorization_server?: string;
+  /** See MCPOAuthTokens.token_endpoint. */
+  token_endpoint?: string;
 }
 
 /**

--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -205,6 +205,78 @@ describe("McpOauthService store", () => {
 
     expect(await readStoreFile()).toEqual({ version: 2, entries: {} });
   });
+
+  // Regression test: @ai-sdk/mcp auth() only uses a stored refresh_token when
+  // the persisted tokens/clientInformation retain the authorization_server +
+  // token_endpoint binding it saved. Stripping them during store parsing made
+  // auth() invalidate the tokens and demand interactive re-login after every
+  // app restart.
+  test("authorization server binding survives store round-trip", async () => {
+    const populatedStore = {
+      version: 2,
+      entries: {
+        "https://example.com/": {
+          serverUrl,
+          updatedAtMs: Date.now(),
+          clientInformation: {
+            client_id: "client-id",
+            authorization_server: "https://auth.example.com/",
+            token_endpoint: "https://auth.example.com/token",
+          },
+          tokens: {
+            access_token: "access-token",
+            token_type: "Bearer",
+            refresh_token: "refresh-token",
+            authorization_server: "https://auth.example.com/",
+            token_endpoint: "https://auth.example.com/token",
+          },
+        },
+      },
+    };
+    await fs.writeFile(getStoreFilePath(muxHome), JSON.stringify(populatedStore), "utf-8");
+
+    const provider = await service.getAuthProviderForServer({ serverUrl });
+    expect(provider).toBeDefined();
+
+    const tokens = await provider!.tokens();
+    expect(tokens?.refresh_token).toBe("refresh-token");
+    expect(tokens?.authorization_server).toBe("https://auth.example.com/");
+    expect(tokens?.token_endpoint).toBe("https://auth.example.com/token");
+
+    const clientInformation = await provider!.clientInformation();
+    expect(clientInformation?.authorization_server).toBe("https://auth.example.com/");
+    expect(clientInformation?.token_endpoint).toBe("https://auth.example.com/token");
+  });
+
+  test("invalid or partial authorization server binding is dropped as a pair", async () => {
+    const populatedStore = {
+      version: 2,
+      entries: {
+        "https://example.com/": {
+          serverUrl,
+          updatedAtMs: Date.now(),
+          clientInformation: { client_id: "client-id" },
+          tokens: {
+            access_token: "access-token",
+            token_type: "Bearer",
+            refresh_token: "refresh-token",
+            // Corrupted: not a parseable URL.
+            authorization_server: "not a url",
+            token_endpoint: "https://auth.example.com/token",
+          },
+        },
+      },
+    };
+    await fs.writeFile(getStoreFilePath(muxHome), JSON.stringify(populatedStore), "utf-8");
+
+    const provider = await service.getAuthProviderForServer({ serverUrl });
+    expect(provider).toBeDefined();
+
+    const tokens = await provider!.tokens();
+    expect(tokens?.refresh_token).toBe("refresh-token");
+    expect(tokens?.authorization_server).toBeUndefined();
+    expect(tokens?.token_endpoint).toBeUndefined();
+  });
 });
 
 describe("parseBearerWwwAuthenticate", () => {

--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -248,7 +248,17 @@ describe("McpOauthService store", () => {
     expect(clientInformation?.token_endpoint).toBe("https://auth.example.com/token");
   });
 
-  test("invalid or partial authorization server binding is dropped as a pair", async () => {
+  test.each([
+    // Corrupted: not a parseable URL.
+    "not a url",
+    // Parseable but rejected by @ai-sdk/mcp's SafeUrlSchema; must be dropped
+    // for self-healing rather than surfacing as a metadata mismatch in auth().
+    "javascript:alert(1)",
+    "data:text/plain,x",
+    "vbscript:x",
+    // Parseable non-http(s) scheme: OAuth endpoints are always http(s).
+    "ftp://auth.example.com/",
+  ])("invalid authorization server binding %j is dropped as a pair", async (badUrl) => {
     const populatedStore = {
       version: 2,
       entries: {
@@ -260,8 +270,7 @@ describe("McpOauthService store", () => {
             access_token: "access-token",
             token_type: "Bearer",
             refresh_token: "refresh-token",
-            // Corrupted: not a parseable URL.
-            authorization_server: "not a url",
+            authorization_server: badUrl,
             token_endpoint: "https://auth.example.com/token",
           },
         },

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -329,6 +329,35 @@ async function fetchProtectedResourceScopes(url: URL): Promise<string[]> {
   }
 }
 
+/**
+ * Parses the @ai-sdk/mcp authorization-server binding fields
+ * (authorization_server / token_endpoint) from a stored credentials object.
+ *
+ * These MUST survive the store round-trip: auth() refuses to use a stored
+ * refresh_token without them and instead invalidates the tokens and demands
+ * interactive re-login (i.e. dropping them silently breaks token refresh
+ * after an app restart).
+ */
+function parseAuthorizationServerBinding(value: Record<string, unknown>): {
+  authorization_server?: string;
+  token_endpoint?: string;
+} {
+  // Defensive: only accept parseable URLs so a corrupted store value cannot
+  // make the SDK's normalizeUrl()/new URL() throw during auth().
+  const asUrlString = (raw: unknown): string | undefined =>
+    typeof raw === "string" && URL.canParse(raw) ? raw : undefined;
+
+  const authorizationServer = asUrlString(value.authorization_server);
+  const tokenEndpoint = asUrlString(value.token_endpoint);
+
+  // The SDK requires both to consider the binding usable; keep the pair atomic.
+  if (!authorizationServer || !tokenEndpoint) {
+    return {};
+  }
+
+  return { authorization_server: authorizationServer, token_endpoint: tokenEndpoint };
+}
+
 function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | null {
   if (!isPlainObject(value)) {
     return null;
@@ -365,6 +394,7 @@ function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | nul
           typeof clientInformationRaw.client_secret_expires_at === "number"
             ? clientInformationRaw.client_secret_expires_at
             : undefined,
+        ...parseAuthorizationServerBinding(clientInformationRaw),
       }
     : undefined;
 
@@ -383,6 +413,7 @@ function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | nul
         scope: typeof tokensRaw.scope === "string" ? tokensRaw.scope : undefined,
         refresh_token:
           typeof tokensRaw.refresh_token === "string" ? tokensRaw.refresh_token : undefined,
+        ...parseAuthorizationServerBinding(tokensRaw),
       }
     : undefined;
 

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -342,10 +342,19 @@ function parseAuthorizationServerBinding(value: Record<string, unknown>): {
   authorization_server?: string;
   token_endpoint?: string;
 } {
-  // Defensive: only accept parseable URLs so a corrupted store value cannot
-  // make the SDK's normalizeUrl()/new URL() throw during auth().
-  const asUrlString = (raw: unknown): string | undefined =>
-    typeof raw === "string" && URL.canParse(raw) ? raw : undefined;
+  // Defensive: only accept parseable http(s) URLs so a corrupted store value
+  // cannot make the SDK's normalizeUrl()/new URL() throw during auth(), and
+  // so SDK-invalid schemes (SafeUrlSchema rejects javascript:/data:/vbscript:)
+  // are dropped for self-healing instead of surfacing as a metadata mismatch.
+  // http(s)-only is stricter than SafeUrlSchema, which is fine: OAuth
+  // authorization servers and token endpoints are always fetched over http(s).
+  const asUrlString = (raw: unknown): string | undefined => {
+    if (typeof raw !== "string" || !URL.canParse(raw)) {
+      return undefined;
+    }
+    const protocol = new URL(raw).protocol;
+    return protocol === "http:" || protocol === "https:" ? raw : undefined;
+  };
 
   const authorizationServer = asUrlString(value.authorization_server);
   const tokenEndpoint = asUrlString(value.token_endpoint);


### PR DESCRIPTION
## Summary

Fixes MCP OAuth token refresh breaking after every app restart: the persisted credential store stripped the `authorization_server` / `token_endpoint` binding fields that `@ai-sdk/mcp` requires before it will use a stored `refresh_token`, causing the SDK to delete the refresh token and demand interactive re-login on the first 401.

## Background

`@ai-sdk/mcp` v2 binds saved tokens/client information to the authorization server: `auth()` appends `authorization_server` + `token_endpoint` before calling `saveTokens()` / `saveClientInformation()`, and requires them back before running the `refresh_token` grant. When the binding is missing, `auth()` calls `invalidateCredentials("tokens")` (deleting the still-valid refresh token), skips refresh entirely, and falls through to interactive authorization — which Mux's background provider intentionally rejects with "MCP OAuth login required".

Mux's `parseStoredCredentials` rebuilt tokens/client info from disk with a strict allow-list that predates these SDK fields, so they were dropped on every store load. Within one app session refresh worked (the in-memory object kept the fields by reference), but after a restart the first expired access token permanently wiped the refresh token. User-visible symptom: remote MCP servers keep asking for re-login after restarting Mux.

## Implementation

- `MCPOAuthTokens` / `MCPOAuthClientInformation` now include the SDK's optional `authorization_server` / `token_endpoint` fields, with comments flagging the allow-list coupling for future SDK upgrades.
- New `parseAuthorizationServerBinding()` helper in `mcpOauthService.ts` preserves the pair through the store round-trip. Defensive by design: values must pass `URL.canParse` (a corrupted store entry can't make the SDK's `new URL(...)` throw mid-auth), and the pair is atomic — a partial/invalid binding is dropped entirely since the SDK requires both fields.
- The write path was never broken (`saveTokens` persists the SDK's full object), so this fix **self-heals existing installs** whose on-disk store still contains the fields. Users whose refresh tokens were already invalidated by the bug need one final interactive login.

## Validation

- New regression tests: (1) binding fields survive a disk round-trip and are visible through the background provider's `tokens()` / `clientInformation()` — exactly what `auth()` consults before refreshing; (2) corrupt/partial bindings are dropped as a pair while the refresh token is kept.
- Verified against the bundled `@ai-sdk/mcp` 2.0.10 source that the persisted shape (`OAuthTokensSchema` / `OAuthClientInformationSchema`) includes both fields and that `getStoredAuthorizationServerInformation()` consults tokens first, then client info.

## Risks

Low. The change only widens what the store parser preserves; all previously-accepted stores still parse identically. Worst case for a malformed binding is the pre-existing behavior (binding dropped → interactive re-login).
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$5.66`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=5.66 -->
