### PR TITLE
🤖 feat: GPT-5.6 explicit prompt cache breakpoints for direct OpenAI

### DIFF
--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -247,7 +247,7 @@ export function anthropicSupportsNativeXhigh(modelString: string): boolean {
  * suffixes (e.g. gpt-5.6-sol-2026-07-09) while rejecting hypothetical named
  * variants (e.g. gpt-5.6-sol-mini) and other ids (e.g. gpt-5.61).
  */
-function isGpt56FamilyModel(modelString: string): boolean {
+export function isGpt56FamilyModel(modelString: string): boolean {
   const withoutPrefix = stripModelProviderPrefixes(modelString);
   return /^gpt-5\.6(?:-(?:sol|terra|luna))?\b(?!\.)(?!-[a-z])/.test(withoutPrefix);
 }

--- a/src/common/utils/ai/cacheStrategy.test.ts
+++ b/src/common/utils/ai/cacheStrategy.test.ts
@@ -4,13 +4,33 @@ import { openai } from "@ai-sdk/openai";
 import type { ModelMessage, Tool } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import {
   supportsAnthropicCache,
   applyCacheControl,
   createCachedSystemMessage,
+  createOpenAICachedSystemMessage,
+  openaiExplicitPromptCachingAvailable,
   applyCacheControlToTools,
 } from "./cacheStrategy";
 import { markBuiltInTaskTool, isBuiltInTaskTool } from "@/node/services/tools/task";
+
+/** Direct-OpenAI providers config with API-key auth and no base URL override. */
+function openaiProvidersConfig(
+  overrides?: Partial<ProvidersConfigMap[string]>,
+  extraProviders?: ProvidersConfigMap
+): ProvidersConfigMap {
+  return {
+    openai: {
+      apiKeySet: true,
+      isEnabled: true,
+      isConfigured: true,
+      apiKeySource: "config",
+      ...overrides,
+    },
+    ...extraProviders,
+  };
+}
 
 describe("cacheStrategy", () => {
   describe("supportsAnthropicCache", () => {
@@ -229,6 +249,184 @@ describe("cacheStrategy", () => {
           },
         },
       });
+    });
+  });
+
+  describe("openaiExplicitPromptCachingAvailable", () => {
+    const config = openaiProvidersConfig();
+
+    it("accepts every GPT-5.6 tier on the direct official OpenAI route", () => {
+      for (const model of [
+        "openai:gpt-5.6",
+        "openai:gpt-5.6-sol",
+        "openai:gpt-5.6-terra",
+        "openai:gpt-5.6-luna",
+        "openai:gpt-5.6-sol-2026-07-09",
+      ]) {
+        expect(openaiExplicitPromptCachingAvailable(model, "openai", config)).toBe(true);
+      }
+    });
+
+    it("accepts openai: aliases mapped to GPT-5.6 targets", () => {
+      const aliasConfig = openaiProvidersConfig({
+        models: [{ id: "team-sol", mappedToModel: "openai:gpt-5.6-sol" }],
+      });
+      expect(openaiExplicitPromptCachingAvailable("openai:team-sol", "openai", aliasConfig)).toBe(
+        true
+      );
+    });
+
+    it("rejects aliases whose resolved target is not OpenAI GPT-5.6", () => {
+      const aliasConfig = openaiProvidersConfig({
+        models: [
+          { id: "team-old", mappedToModel: "openai:gpt-5.2" },
+          { id: "team-claude", mappedToModel: "anthropic:claude-opus-4-6" },
+          { id: "team-bare", mappedToModel: "gpt-5.6-sol" },
+        ],
+      });
+      for (const alias of ["openai:team-old", "openai:team-claude", "openai:team-bare"]) {
+        expect(openaiExplicitPromptCachingAvailable(alias, "openai", aliasConfig)).toBe(false);
+      }
+    });
+
+    it("rejects raw unprefixed and non-OpenAI-origin model strings", () => {
+      for (const model of [
+        "gpt-5.6-sol", // raw unprefixed: never infer a provider
+        "anthropic:claude-opus-4-6",
+        "openrouter:openai/gpt-5.6-sol",
+        "github-copilot:gpt-5.6-sol",
+      ]) {
+        expect(openaiExplicitPromptCachingAvailable(model, "openai", config)).toBe(false);
+      }
+    });
+
+    it("rejects older OpenAI models and near-miss ids", () => {
+      for (const model of ["openai:gpt-5.2", "openai:gpt-5.5", "openai:gpt-5.61"]) {
+        expect(openaiExplicitPromptCachingAvailable(model, "openai", config)).toBe(false);
+      }
+    });
+
+    it("rejects missing, unknown, and gateway routes", () => {
+      for (const route of [undefined, "unknown", "mux-gateway", "openrouter", "github-copilot"]) {
+        expect(openaiExplicitPromptCachingAvailable("openai:gpt-5.6-sol", route, config)).toBe(
+          false
+        );
+      }
+    });
+
+    it("rejects when Codex OAuth wins the auth path", () => {
+      // OAuth tokens without an API key: OAuth wins.
+      expect(
+        openaiExplicitPromptCachingAvailable(
+          "openai:gpt-5.6-sol",
+          "openai",
+          openaiProvidersConfig({ apiKeySet: false, apiKeySource: undefined, codexOauthSet: true })
+        )
+      ).toBe(false);
+      // OAuth tokens + API key with default precedence: OAuth still wins.
+      expect(
+        openaiExplicitPromptCachingAvailable(
+          "openai:gpt-5.6-sol",
+          "openai",
+          openaiProvidersConfig({ codexOauthSet: true })
+        )
+      ).toBe(false);
+      // Explicit apiKey precedence restores API-key routing.
+      expect(
+        openaiExplicitPromptCachingAvailable(
+          "openai:gpt-5.6-sol",
+          "openai",
+          openaiProvidersConfig({ codexOauthSet: true, codexOauthDefaultAuth: "apiKey" })
+        )
+      ).toBe(true);
+    });
+
+    it("rejects when the providers config view is unavailable", () => {
+      expect(openaiExplicitPromptCachingAvailable("openai:gpt-5.6-sol", "openai", null)).toBe(
+        false
+      );
+      expect(openaiExplicitPromptCachingAvailable("openai:gpt-5.6-sol", "openai", {})).toBe(false);
+    });
+
+    it("accepts official explicit and env-resolved base URLs", () => {
+      for (const overrides of [
+        { baseUrl: "https://api.openai.com/v1" },
+        { baseUrl: "https://api.openai.com/v1/" },
+        { baseUrl: "https://api.openai.com" },
+        { baseUrlResolved: "https://api.openai.com/v1" },
+      ]) {
+        expect(
+          openaiExplicitPromptCachingAvailable(
+            "openai:gpt-5.6-sol",
+            "openai",
+            openaiProvidersConfig(overrides)
+          )
+        ).toBe(true);
+      }
+    });
+
+    it("rejects custom, malformed, and non-HTTPS base URLs", () => {
+      for (const overrides of [
+        { baseUrl: "https://proxy.example.com/v1" },
+        { baseUrl: "http://api.openai.com/v1" },
+        { baseUrl: "https://api.openai.com:8443/v1" },
+        { baseUrl: "https://user:pass@api.openai.com/v1" },
+        { baseUrl: "https://api.openai.com/v1?beta=1" },
+        { baseUrl: "https://api.openai.com/v2" },
+        { baseUrl: "not a url" },
+        // Config-set baseUrl wins over an official env-resolved value.
+        { baseUrl: "https://proxy.example.com/v1", baseUrlResolved: "https://api.openai.com/v1" },
+        { baseUrlResolved: "http://localhost:11434/v1" },
+      ]) {
+        expect(
+          openaiExplicitPromptCachingAvailable(
+            "openai:gpt-5.6-sol",
+            "openai",
+            openaiProvidersConfig(overrides)
+          )
+        ).toBe(false);
+      }
+    });
+  });
+
+  describe("createOpenAICachedSystemMessage", () => {
+    const config = openaiProvidersConfig();
+
+    it("returns the exact typed system-message shape for eligible requests", () => {
+      const result = createOpenAICachedSystemMessage(
+        "You are a helpful assistant",
+        "openai:gpt-5.6-luna",
+        "openai",
+        config
+      );
+
+      expect(result).toEqual({
+        role: "system",
+        content: "You are a helpful assistant",
+        providerOptions: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      });
+    });
+
+    it("returns null for empty system content", () => {
+      expect(createOpenAICachedSystemMessage("", "openai:gpt-5.6-luna", "openai", config)).toBe(
+        null
+      );
+    });
+
+    it("returns null for ineligible models and routes", () => {
+      expect(
+        createOpenAICachedSystemMessage("prompt", "openai:gpt-5.2", "openai", config)
+      ).toBeNull();
+      expect(
+        createOpenAICachedSystemMessage("prompt", "openai:gpt-5.6-luna", "mux-gateway", config)
+      ).toBeNull();
+      expect(
+        createOpenAICachedSystemMessage("prompt", "openai:gpt-5.6-luna", undefined, config)
+      ).toBeNull();
     });
   });
 

--- a/src/common/utils/ai/cacheStrategy.ts
+++ b/src/common/utils/ai/cacheStrategy.ts
@@ -1,7 +1,11 @@
-import { tool as createTool, type ModelMessage, type Tool } from "ai";
+import { tool as createTool, type ModelMessage, type SystemModelMessage, type Tool } from "ai";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
+import { isGpt56FamilyModel } from "@/common/types/thinking";
 import assert from "@/common/utils/assert";
 import { cloneToolPreservingDescriptors } from "@/common/utils/tools/cloneToolPreservingDescriptors";
-import { normalizeToCanonical } from "./models";
+import { wouldRouteOpenAIThroughCodexOauth } from "@/common/utils/providers/codexOauthRouting";
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
+import { getExplicitGatewayPrefix, normalizeToCanonical } from "./models";
 
 /**
  * Anthropic prompt cache TTL value.
@@ -133,6 +137,140 @@ export function createCachedSystemMessage(
     content: systemContent,
     providerOptions: cacheTtl ? anthropicCacheControl(cacheTtl) : ANTHROPIC_CACHE_CONTROL,
   };
+}
+
+/**
+ * Whether an official-endpoint host check passes for direct OpenAI explicit
+ * prompt caching. Absence of any override means the SDK's official default;
+ * any configured value must resolve to the canonical https://api.openai.com
+ * endpoint (root or /v1 path, default port, no credentials/query/hash).
+ */
+function isOfficialOpenAIBaseUrl(baseUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return false;
+  }
+
+  return (
+    url.protocol === "https:" &&
+    url.hostname === "api.openai.com" &&
+    url.port === "" &&
+    url.username === "" &&
+    url.password === "" &&
+    url.search === "" &&
+    url.hash === "" &&
+    (url.pathname === "/" || url.pathname === "/v1" || url.pathname === "/v1/")
+  );
+}
+
+/**
+ * Route-aware eligibility for GPT-5.6 explicit prompt cache breakpoints.
+ *
+ * Explicit breakpoints (and the Chat Completions promptCacheKey extension) are
+ * only known to work on the official direct OpenAI API with API-key auth, so
+ * every branch fails closed until proven eligible:
+ * - the request model's parsed origin must be exactly `openai` (raw unprefixed
+ *   strings and non-OpenAI namespaces never infer a provider here);
+ * - mapped aliases resolve through resolveModelForMetadata and the resolved
+ *   capability target must itself be an OpenAI GPT-5.6-family model;
+ * - the backend-resolved route provider must be exactly "openai" — missing,
+ *   legacy, gateway, or unknown route metadata fails closed;
+ * - Codex OAuth precedence (mirrored by wouldRouteOpenAIThroughCodexOauth)
+ *   fails closed because the ChatGPT backend strips these fields;
+ * - a configured custom base URL fails closed unless it is the official
+ *   endpoint. Transport-level HTTP proxy env vars are not endpoint overrides
+ *   and stay outside this check.
+ */
+export function openaiExplicitPromptCachingAvailable(
+  modelString: string,
+  routeProvider: string | undefined,
+  providersConfig: ProvidersConfigMap | null
+): boolean {
+  if (routeProvider !== "openai") {
+    return false;
+  }
+
+  // Explicit gateway namespaces (e.g. openrouter:openai/gpt-5.6) fail closed
+  // even though they canonicalize to an openai: origin — the request namespace
+  // itself must be OpenAI.
+  if (getExplicitGatewayPrefix(modelString) != null) {
+    return false;
+  }
+
+  const normalized = normalizeToCanonical(modelString);
+  const [origin, modelName] = normalized.split(":", 2);
+  if (origin !== "openai" || !modelName) {
+    return false;
+  }
+
+  // Mapped aliases inherit eligibility only when the resolved capability
+  // target is also an OpenAI GPT-5.6-family model.
+  const capabilityModel = resolveModelForMetadata(normalized, providersConfig);
+  const [capabilityOrigin, capabilityModelName] = capabilityModel.split(":", 2);
+  if (capabilityOrigin !== "openai" || !capabilityModelName) {
+    return false;
+  }
+  if (!isGpt56FamilyModel(capabilityModel)) {
+    return false;
+  }
+
+  // Without a providers config view we cannot verify auth precedence or the
+  // active endpoint, so eligibility cannot be established.
+  const openaiConfig = providersConfig?.openai;
+  if (openaiConfig == null) {
+    return false;
+  }
+
+  if (wouldRouteOpenAIThroughCodexOauth(normalized, providersConfig)) {
+    return false;
+  }
+
+  // baseUrl is the config-set value (which wins over env in the provider
+  // factory); baseUrlResolved carries the active env value when config is
+  // unset. Absence of both means the SDK's official default endpoint.
+  const activeBaseUrl = openaiConfig.baseUrl ?? openaiConfig.baseUrlResolved;
+  if (activeBaseUrl != null && !isOfficialOpenAIBaseUrl(activeBaseUrl)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Create a structured system message carrying one explicit GPT-5.6 prompt
+ * cache breakpoint at the end of Mux's stable system/developer instructions.
+ *
+ * The AI SDK reads message-level providerOptions.openai.promptCacheBreakpoint
+ * on system messages (string content — not a content-part array) and
+ * serializes it to a `prompt_cache_breakpoint` content block on both the
+ * Responses and Chat Completions wire formats. Request-wide caching stays
+ * implicit (no promptCacheOptions), preserving OpenAI's automatic
+ * latest-message breakpoint alongside this stable-prefix one.
+ */
+export function createOpenAICachedSystemMessage(
+  systemContent: string,
+  modelString: string,
+  routeProvider: string | undefined,
+  providersConfig: ProvidersConfigMap | null
+): SystemModelMessage | null {
+  if (
+    !systemContent ||
+    !openaiExplicitPromptCachingAvailable(modelString, routeProvider, providersConfig)
+  ) {
+    return null;
+  }
+
+  return {
+    role: "system",
+    content: systemContent,
+    providerOptions: {
+      openai: {
+        promptCacheBreakpoint: { mode: "explicit" },
+      },
+    },
+  } satisfies SystemModelMessage;
 }
 
 /**

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -3,9 +3,10 @@
  */
 
 import { createOpenAI, type OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
-import { generateText } from "ai";
+import { generateText, streamText } from "ai";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { createMuxMessage } from "@/common/types/message";
+import { createOpenAICachedSystemMessage } from "./cacheStrategy";
 import { describe, test, expect, mock } from "bun:test";
 import {
   buildProviderOptions,
@@ -558,6 +559,145 @@ describe("buildProviderOptions - OpenAI", () => {
     });
   });
 
+  describe("GPT-5.6 Chat Completions promptCacheKey", () => {
+    const chatWireFormat = { openai: { wireFormat: "chatCompletions" as const } };
+    const directOpenAIConfig: ProvidersConfigMap = {
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+    };
+
+    function buildChatOptions(
+      model: string,
+      opts?: {
+        providersConfig?: ProvidersConfigMap;
+        routeProvider?: Parameters<typeof buildProviderOptions>[8];
+      }
+    ): OpenAIResponsesProviderOptions | undefined {
+      return getOpenAIOptions(
+        buildProviderOptions(
+          model,
+          "medium",
+          undefined,
+          undefined,
+          chatWireFormat,
+          "workspace-1",
+          undefined,
+          opts?.providersConfig ?? directOpenAIConfig,
+          opts?.routeProvider,
+          "project-scope"
+        )
+      );
+    }
+
+    test("direct GPT-5.6 Chat Completions receives the stable cache key", () => {
+      const openai = buildChatOptions("openai:gpt-5.6-luna", { routeProvider: "openai" });
+
+      expect(openai?.promptCacheKey).toBe("mux-v1-project-scope");
+      // Responses-only fields stay omitted on Chat Completions.
+      expect(openai?.truncation).toBeUndefined();
+      expect(openai?.include).toBeUndefined();
+      expect(openai?.reasoningSummary).toBeUndefined();
+    });
+
+    test("mapped GPT-5.6 aliases inherit the cache key; non-GPT-5.6 aliases do not", () => {
+      const aliasConfig: ProvidersConfigMap = {
+        openai: {
+          apiKeySet: true,
+          isEnabled: true,
+          isConfigured: true,
+          models: [
+            { id: "team-sol", mappedToModel: "openai:gpt-5.6-sol" },
+            { id: "team-old", mappedToModel: "openai:gpt-5.2" },
+          ],
+        },
+      };
+
+      expect(
+        buildChatOptions("openai:team-sol", {
+          providersConfig: aliasConfig,
+          routeProvider: "openai",
+        })?.promptCacheKey
+      ).toBe("mux-v1-project-scope");
+      expect(
+        buildChatOptions("openai:team-old", {
+          providersConfig: aliasConfig,
+          routeProvider: "openai",
+        })?.promptCacheKey
+      ).toBeUndefined();
+    });
+
+    test("older models, missing routes, gateways, Codex OAuth, and custom endpoints get no key", () => {
+      // Older model on the eligible route.
+      expect(
+        buildChatOptions("openai:gpt-5.2", { routeProvider: "openai" })?.promptCacheKey
+      ).toBeUndefined();
+      // Missing route metadata fails closed.
+      expect(buildChatOptions("openai:gpt-5.6-luna")?.promptCacheKey).toBeUndefined();
+      // Passthrough gateway route fails closed.
+      expect(
+        buildChatOptions("openai:gpt-5.6-luna", { routeProvider: "mux-gateway" })?.promptCacheKey
+      ).toBeUndefined();
+      // Codex OAuth wins the auth path.
+      expect(
+        buildChatOptions("openai:gpt-5.6-luna", {
+          routeProvider: "openai",
+          providersConfig: {
+            openai: { apiKeySet: false, isEnabled: true, isConfigured: true, codexOauthSet: true },
+          },
+        })?.promptCacheKey
+      ).toBeUndefined();
+      // Custom base URL fails closed.
+      expect(
+        buildChatOptions("openai:gpt-5.6-luna", {
+          routeProvider: "openai",
+          providersConfig: {
+            openai: {
+              apiKeySet: true,
+              isEnabled: true,
+              isConfigured: true,
+              baseUrl: "https://proxy.example.com/v1",
+            },
+          },
+        })?.promptCacheKey
+      ).toBeUndefined();
+    });
+
+    test("GPT-5.6 Responses keeps the legacy broader key behavior unchanged", () => {
+      // Route-absent Responses request: legacy behavior still derives the key.
+      const routeAbsent = getOpenAIOptions(
+        buildProviderOptions(
+          "openai:gpt-5.6-luna",
+          "medium",
+          undefined,
+          undefined,
+          undefined,
+          "workspace-1",
+          undefined,
+          undefined,
+          undefined,
+          "project-scope"
+        )
+      );
+      expect(routeAbsent?.promptCacheKey).toBe("mux-v1-project-scope");
+
+      // Passthrough gateway Responses request: legacy behavior still applies.
+      const passthrough = getOpenAIOptions(
+        buildProviderOptions(
+          "mux-gateway:openai/gpt-5.6-luna",
+          "medium",
+          undefined,
+          undefined,
+          undefined,
+          "workspace-1",
+          undefined,
+          undefined,
+          "mux-gateway",
+          "project-scope"
+        )
+      );
+      expect(passthrough?.promptCacheKey).toBe("mux-v1-project-scope");
+    });
+  });
+
   describe("route provider format selection", () => {
     test("uses the transforming route provider format for gateway-routed OpenAI models", () => {
       const result = buildProviderOptions(
@@ -951,6 +1091,191 @@ describe("buildProviderOptions - OpenAI", () => {
         mode: "pro",
       });
       expect(capturedBodies[1].reasoning_effort).toBe("max");
+    });
+  });
+
+  describe("GPT-5.6 explicit prompt caching serialization", () => {
+    // Production-path wire test: createOpenAI + capture fetch + streamText
+    // (the same streaming parser Mux uses), not intermediate TS objects.
+    const providersConfig: ProvidersConfigMap = {
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+    };
+
+    function sseResponse(events: unknown[]): Response {
+      const body =
+        events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("") + "data: [DONE]\n\n";
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }
+
+    // Synthetic usage: 1200 input = 48 uncached + 1024 cache-read + 128 cache-write.
+    const responsesSse = [
+      {
+        type: "response.created",
+        response: { id: "resp_1", created_at: 0, model: "gpt-5.6-luna" },
+      },
+      {
+        type: "response.completed",
+        response: {
+          usage: {
+            input_tokens: 1200,
+            input_tokens_details: { cached_tokens: 1024, cache_write_tokens: 128 },
+            output_tokens: 5,
+            output_tokens_details: { reasoning_tokens: 0 },
+          },
+        },
+      },
+    ];
+    const chatCompletionsSse = [
+      {
+        id: "chat_1",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "gpt-5.6-luna",
+        choices: [{ index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: null }],
+      },
+      {
+        id: "chat_1",
+        object: "chat.completion.chunk",
+        created: 0,
+        model: "gpt-5.6-luna",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+        usage: {
+          prompt_tokens: 1200,
+          completion_tokens: 5,
+          total_tokens: 1205,
+          prompt_tokens_details: { cached_tokens: 1024, cache_write_tokens: 128 },
+        },
+      },
+    ];
+
+    test("serializes the breakpoint and cache key without disabling implicit mode on both wire formats", async () => {
+      const capturedBodies: Array<Record<string, unknown>> = [];
+      const captureFetch = Object.assign(
+        (
+          input: Parameters<typeof fetch>[0],
+          init?: Parameters<typeof fetch>[1]
+        ): Promise<Response> => {
+          if (typeof init?.body !== "string") {
+            throw new Error("Expected the OpenAI provider to send a JSON string body");
+          }
+          capturedBodies.push(JSON.parse(init.body) as Record<string, unknown>);
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          return Promise.resolve(
+            sseResponse(url.endsWith("/responses") ? responsesSse : chatCompletionsSse)
+          );
+        },
+        { preconnect: fetch.preconnect.bind(fetch) }
+      );
+      const openai = createOpenAI({ apiKey: "test", fetch: captureFetch });
+
+      // Production system-message shape from the cache strategy helper.
+      const cachedSystem = createOpenAICachedSystemMessage(
+        "You are Mux.",
+        "openai:gpt-5.6-luna",
+        "openai",
+        providersConfig
+      );
+      if (!cachedSystem) {
+        throw new Error("Expected an eligible cached system message");
+      }
+
+      const responsesOptions = getOpenAIOptions(
+        buildProviderOptions(
+          "openai:gpt-5.6-luna",
+          "medium",
+          undefined,
+          undefined,
+          undefined,
+          "workspace-1",
+          undefined,
+          providersConfig,
+          "openai",
+          "test-scope"
+        )
+      );
+      const chatOptions = getOpenAIOptions(
+        buildProviderOptions(
+          "openai:gpt-5.6-luna",
+          "medium",
+          undefined,
+          undefined,
+          { openai: { wireFormat: "chatCompletions" } },
+          "workspace-1",
+          undefined,
+          providersConfig,
+          "openai",
+          "test-scope"
+        )
+      );
+      if (!responsesOptions || !chatOptions) {
+        throw new Error("Expected OpenAI provider options for both wire formats");
+      }
+
+      const responsesResult = streamText({
+        model: openai.responses("gpt-5.6-luna"),
+        system: cachedSystem,
+        prompt: "hi",
+        providerOptions: { openai: responsesOptions },
+        maxRetries: 0,
+      });
+      for await (const _part of responsesResult.fullStream) {
+        // Fully consume the stream so usage resolves through the SSE parser.
+      }
+      const responsesUsage = await responsesResult.usage;
+
+      const chatResult = streamText({
+        model: openai.chat("gpt-5.6-luna"),
+        system: cachedSystem,
+        prompt: "hi",
+        providerOptions: { openai: chatOptions },
+        maxRetries: 0,
+      });
+      for await (const _part of chatResult.fullStream) {
+        // Fully consume the stream so usage resolves through the SSE parser.
+      }
+      const chatUsage = await chatResult.usage;
+
+      // Responses wire format: input_text block carrying the breakpoint.
+      const responsesBody = capturedBodies[0];
+      const responsesInput = responsesBody.input as Array<Record<string, unknown>>;
+      const responsesSystem = responsesInput.find(
+        (message) => message.role === "system" || message.role === "developer"
+      );
+      expect(responsesSystem?.content).toEqual([
+        {
+          type: "input_text",
+          text: "You are Mux.",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+      ]);
+      expect(responsesBody.prompt_cache_key).toBe("mux-v1-test-scope");
+      expect(responsesBody.prompt_cache_options).toBeUndefined();
+
+      // Chat Completions wire format: text block carrying the breakpoint.
+      const chatBody = capturedBodies[1];
+      const chatMessages = chatBody.messages as Array<Record<string, unknown>>;
+      const chatSystem = chatMessages.find(
+        (message) => message.role === "system" || message.role === "developer"
+      );
+      expect(chatSystem?.content).toEqual([
+        {
+          type: "text",
+          text: "You are Mux.",
+          prompt_cache_breakpoint: { mode: "explicit" },
+        },
+      ]);
+      expect(chatBody.prompt_cache_key).toBe("mux-v1-test-scope");
+      expect(chatBody.prompt_cache_options).toBeUndefined();
+
+      // Both parsers expose cache reads and writes on nested v7 usage details.
+      expect(responsesUsage.inputTokenDetails?.cacheReadTokens).toBe(1024);
+      expect(responsesUsage.inputTokenDetails?.cacheWriteTokens).toBe(128);
+      expect(chatUsage.inputTokenDetails?.cacheReadTokens).toBe(1024);
+      expect(chatUsage.inputTokenDetails?.cacheWriteTokens).toBe(128);
     });
   });
 

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -26,6 +26,7 @@ import {
   OPENROUTER_REASONING_EFFORT,
 } from "@/common/types/thinking";
 import { isGeminiFlashThinkingLevelModelName } from "@/common/utils/thinking/policy";
+import { openaiExplicitPromptCachingAvailable } from "@/common/utils/ai/cacheStrategy";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { log } from "@/node/services/log";
 import type { MuxMessage } from "@/common/types/message";
@@ -408,6 +409,16 @@ export function buildProviderOptions(
           // See: https://sdk.vercel.ai/providers/ai-sdk-providers/openai#responses-models
           ...(promptCacheKey && { promptCacheKey }),
         }),
+        // Chat Completions gets the same stable routing key only for GPT-5.6
+        // on the direct official OpenAI API (the stricter explicit-caching
+        // gate). The broader legacy Responses behavior above stays unchanged.
+        ...(!isResponses &&
+          promptCacheKey &&
+          openaiExplicitPromptCachingAvailable(
+            modelString,
+            routeProvider,
+            providersConfig ?? null
+          ) && { promptCacheKey }),
         // Conditionally add reasoning configuration
         ...(reasoningEffort && {
           reasoningEffort,

--- a/src/common/utils/tokens/displayUsage.test.ts
+++ b/src/common/utils/tokens/displayUsage.test.ts
@@ -190,6 +190,34 @@ describe("createDisplayUsage", () => {
     expect(result!.cached.tokens).toBe(0);
   });
 
+  test("separates GPT-5.6 input, cache reads, and cache writes with 0.1x read / 1.25x write rates", () => {
+    // OpenAI explicit-caching accounting: inputTokens is inclusive of cache
+    // reads and writes; writes arrive through the legacy provider-neutral
+    // `anthropic.cacheCreationInputTokens` metadata key (withCacheWriteMetadata
+    // re-injects it from AI SDK 7 usage.inputTokenDetails.cacheWriteTokens).
+    const usage: LanguageModelV2Usage = {
+      inputTokens: 105500, // 500 uncached + 100000 cache-read + 5000 cache-write
+      outputTokens: 1000,
+      totalTokens: 106500,
+      cachedInputTokens: 100000,
+    };
+
+    const result = createDisplayUsage(usage, "openai:gpt-5.6-luna", {
+      anthropic: { cacheCreationInputTokens: 5000 },
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.input.tokens).toBe(500);
+    expect(result!.cached.tokens).toBe(100000);
+    expect(result!.cacheCreate.tokens).toBe(5000);
+    // Luna base rates: $1/M input, $0.10/M cache read (0.1x), $1.25/M cache
+    // write (1.25x), $6/M output.
+    expect(result!.input.cost_usd).toBeCloseTo(0.0005);
+    expect(result!.cached.cost_usd).toBeCloseTo(0.01);
+    expect(result!.cacheCreate.cost_usd).toBeCloseTo(0.00625);
+    expect(result!.output.cost_usd).toBeCloseTo(0.006);
+  });
+
   describe("tiered long-context pricing", () => {
     test("keeps GPT-5.5 on base rates at the published 272K boundary", () => {
       const usage: LanguageModelV2Usage = {

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -1622,6 +1622,150 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
     );
   });
 
+  // GPT-5.6 Chat Completions explicit-caching seam: fallback provider options
+  // and route metadata must be rebuilt from the fallback model/route so cache
+  // fields cannot leak across routes in either direction.
+  function stubPerModelRouteResolution(service: AIService): void {
+    const providerModelFactory = Reflect.get(service, "providerModelFactory") as
+      | ProviderModelFactory
+      | undefined;
+    if (!providerModelFactory) {
+      throw new Error("Expected AIService.providerModelFactory in fallback route test");
+    }
+    spyOn(providerModelFactory, "resolveAndCreateModel").mockImplementation(
+      (requestedModelString) => {
+        const isGateway = requestedModelString.startsWith("mux-gateway:");
+        const canonicalModelString = isGateway
+          ? requestedModelString.replace("mux-gateway:openai/", "openai:")
+          : requestedModelString;
+        return Promise.resolve({
+          success: true,
+          data: {
+            model: Object.create(null) as LanguageModel,
+            effectiveModelString: requestedModelString,
+            canonicalModelString,
+            canonicalProviderName: "openai" as ProviderName,
+            canonicalModelId: canonicalModelString.split(":")[1] ?? canonicalModelString,
+            routedThroughGateway: isGateway,
+            routeProvider: (isGateway ? "mux-gateway" : "openai") as ProviderName,
+          },
+        });
+      }
+    );
+
+    const providerService = Reflect.get(service, "providerService") as ProviderService | undefined;
+    if (!providerService) {
+      throw new Error("Expected AIService.providerService in fallback route test");
+    }
+    spyOn(providerService, "getConfig").mockReturnValue({
+      openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+    });
+  }
+
+  async function runChatCompletionsFallback(options: {
+    tempDirName: string;
+    workspaceId: string;
+    sourceModel: string;
+    fallbackModel: string;
+  }): Promise<{
+    primaryOpenAIOptions: Record<string, unknown>;
+    primaryInitialMetadata: Record<string, unknown>;
+    preparedOpenAIOptions: Record<string, unknown>;
+    preparedMetadataPatch: Record<string, unknown>;
+  }> {
+    using muxHome = new DisposableTempDir(options.tempDirName);
+    const projectPath = path.join(muxHome.path, "project");
+    await fs.mkdir(projectPath, { recursive: true });
+    await writeMainConfig(muxHome.path, {
+      modelFallbacks: {
+        [options.sourceModel]: { models: [options.fallbackModel] },
+      },
+    });
+
+    const metadata = createLocalWorkspaceMetadata(options.workspaceId, projectPath);
+    const harness = createHarness(muxHome.path, metadata, { useRequestedModelString: true });
+    stubPerModelRouteResolution(harness.service);
+
+    const result = await harness.service.streamMessage({
+      messages: [createMuxMessage("latest-user", "user", "fix the issue")],
+      workspaceId: options.workspaceId,
+      modelString: options.sourceModel,
+      thinkingLevel: "off",
+      muxProviderOptions: { openai: { wireFormat: "chatCompletions" } },
+    });
+    expect(result.success).toBe(true);
+    expect(harness.startStreamCalls).toHaveLength(1);
+
+    const startStreamArgs = harness.startStreamCalls[0];
+    const modelFallback = startStreamArgs[START_STREAM_MODEL_FALLBACK_INDEX] as
+      | ModelFallbackOptions
+      | undefined;
+    if (!modelFallback) {
+      throw new Error("Expected modelFallback options on startStream");
+    }
+
+    const prepared = await modelFallback.prepare(options.fallbackModel);
+    expect(prepared.success).toBe(true);
+    if (!prepared.success) {
+      throw new Error(prepared.error);
+    }
+
+    const preparedOpenAIOptions = (prepared.data.providerOptions as { openai?: unknown })
+      ?.openai as Record<string, unknown>;
+    expect(preparedOpenAIOptions).toBeDefined();
+
+    return {
+      primaryOpenAIOptions: openAIOptionsFromStartStreamCall(startStreamArgs),
+      primaryInitialMetadata: initialMetadataFromStartStreamCall(startStreamArgs),
+      preparedOpenAIOptions,
+      preparedMetadataPatch: (prepared.data.initialMetadataPatch ?? {}) as Record<string, unknown>,
+    };
+  }
+
+  it("drops the Chat Completions cache key when an eligible source falls back to a gateway route", async () => {
+    const {
+      primaryOpenAIOptions,
+      primaryInitialMetadata,
+      preparedOpenAIOptions,
+      preparedMetadataPatch,
+    } = await runChatCompletionsFallback({
+      tempDirName: "ai-service-fallback-cache-key-drop",
+      workspaceId: "workspace-fallback-cache-key-drop",
+      sourceModel: "openai:gpt-5.6-luna",
+      fallbackModel: "mux-gateway:openai/gpt-5.6-sol",
+    });
+
+    // Source: direct official OpenAI GPT-5.6 Chat Completions gets the key.
+    expect(primaryOpenAIOptions.promptCacheKey).toStartWith("mux-v1-");
+    expect(primaryInitialMetadata.routeProvider).toBe("openai");
+    // Fallback: gateway route — the rebuilt options must not carry the key.
+    expect(preparedOpenAIOptions.promptCacheKey).toBeUndefined();
+    expect(preparedMetadataPatch.routeProvider).toBe("mux-gateway");
+    expect(preparedMetadataPatch.routedThroughGateway).toBe(true);
+  });
+
+  it("adds the Chat Completions cache key when a gateway source falls back to direct OpenAI", async () => {
+    const {
+      primaryOpenAIOptions,
+      primaryInitialMetadata,
+      preparedOpenAIOptions,
+      preparedMetadataPatch,
+    } = await runChatCompletionsFallback({
+      tempDirName: "ai-service-fallback-cache-key-add",
+      workspaceId: "workspace-fallback-cache-key-add",
+      sourceModel: "mux-gateway:openai/gpt-5.6-luna",
+      fallbackModel: "openai:gpt-5.6-sol",
+    });
+
+    // Source: gateway-routed GPT-5.6 Chat Completions gets no key.
+    expect(primaryOpenAIOptions.promptCacheKey).toBeUndefined();
+    expect(primaryInitialMetadata.routeProvider).toBe("mux-gateway");
+    // Fallback: direct official OpenAI — the rebuilt options carry the key.
+    expect(preparedOpenAIOptions.promptCacheKey).toStartWith("mux-v1-");
+    expect(preparedMetadataPatch.routeProvider).toBe("openai");
+    expect(preparedMetadataPatch.routedThroughGateway).toBe(false);
+  });
+
   it("drops reasoning-only continuations before adding interrupted sentinels for non-Anthropic fallbacks", () => {
     const continuationAssistant: MuxMessage = {
       id: "assistant-reasoning-only",

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -4,6 +4,7 @@ import { existsSync } from "node:fs";
 import * as path from "node:path";
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
 import type { CompletedMessagePart, WorkflowRunAttachedEvent } from "@/common/types/stream";
 import { Ok, Err } from "@/common/types/result";
@@ -589,6 +590,7 @@ describe("StreamManager - Anthropic cache TTL overrides", () => {
       modelString,
       messages,
       "You are a helpful assistant",
+      undefined, // routeProvider
       tools,
       providerOptions,
       undefined,
@@ -647,6 +649,189 @@ describe("StreamManager - Anthropic cache TTL overrides", () => {
       type: "ephemeral",
       ttl: "1h",
     });
+  });
+});
+
+describe("StreamManager - OpenAI GPT-5.6 cached system instructions", () => {
+  interface StreamRequestConfigForTests {
+    messages: ModelMessage[];
+    system?: string | { role: string; content: string; providerOptions?: unknown };
+  }
+
+  type BuildStreamRequestConfig = (...args: unknown[]) => StreamRequestConfigForTests;
+
+  const eligibleProvidersConfig: ProvidersConfigMap = {
+    openai: { apiKeySet: true, isEnabled: true, isConfigured: true },
+  };
+
+  const structuredSystem = {
+    role: "system",
+    content: "You are a helpful assistant",
+    providerOptions: { openai: { promptCacheBreakpoint: { mode: "explicit" } } },
+  };
+
+  function buildRequestForRoute(
+    providersConfig: ProvidersConfigMap | null,
+    routeProvider: string | undefined,
+    modelString = "openai:gpt-5.6-luna"
+  ): StreamRequestConfigForTests {
+    const streamManager = new StreamManager(historyService, undefined, () => providersConfig);
+    const buildRequestConfig = getPrivateMethodForTests<BuildStreamRequestConfig>(
+      streamManager,
+      "buildStreamRequestConfig"
+    );
+    // .call: the transform reads this.getProvidersConfig for route eligibility.
+    return buildRequestConfig.call(
+      streamManager,
+      createTestLanguageModel(),
+      modelString,
+      [{ role: "user", content: "hello" }],
+      "You are a helpful assistant",
+      routeProvider
+    );
+  }
+
+  test("direct GPT-5.6 replaces the system string with a structured cached message", () => {
+    const request = buildRequestForRoute(eligibleProvidersConfig, "openai");
+
+    expect(request.system).toEqual(structuredSystem);
+    // Unlike the Anthropic transform, messages stay untouched (no prepend).
+    expect(request.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  test("ineligible routes and endpoints preserve the original system string", () => {
+    // Missing route metadata (legacy/test-stub) fails closed.
+    expect(buildRequestForRoute(eligibleProvidersConfig, undefined).system).toBe(
+      "You are a helpful assistant"
+    );
+    // Gateway routes fail closed.
+    expect(buildRequestForRoute(eligibleProvidersConfig, "mux-gateway").system).toBe(
+      "You are a helpful assistant"
+    );
+    // Custom base URLs fail closed.
+    expect(
+      buildRequestForRoute(
+        {
+          openai: {
+            ...eligibleProvidersConfig.openai,
+            baseUrl: "https://proxy.example.com/v1",
+          },
+        },
+        "openai"
+      ).system
+    ).toBe("You are a helpful assistant");
+    // Non-GPT-5.6 models keep the plain string.
+    expect(buildRequestForRoute(eligibleProvidersConfig, "openai", "openai:gpt-5.2").system).toBe(
+      "You are a helpful assistant"
+    );
+  });
+
+  // The fallback swap must evaluate the fallback's freshly-resolved route
+  // (initialMetadataPatch.routeProvider), not the stale source metadata that
+  // streamInfo.initialMetadata still holds when the swapped request is built.
+  async function runRefusalFallbackForTests(options: {
+    workspaceId: string;
+    staleRouteProvider: string;
+    initialMetadataPatch?: Record<string, unknown>;
+  }): Promise<Record<string, unknown>> {
+    const streamManager = new StreamManager(
+      historyService,
+      undefined,
+      () => eligibleProvidersConfig
+    );
+    streamManager.on("error", () => undefined);
+    Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+
+    const messageId = `${options.workspaceId}-message`;
+    const historySequence = 1;
+    await appendPartialAssistantForTests(options.workspaceId, messageId, historySequence);
+    const processStreamWithCleanup = getProcessStreamWithCleanupForTests(streamManager);
+
+    const createStreamResult = mock(() =>
+      createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "text-delta", text: "fallback answer" };
+          yield { type: "finish", finishReason: "stop" };
+        })()
+      )
+    );
+    expect(Reflect.set(streamManager, "createStreamResult", createStreamResult)).toBe(true);
+
+    const prepare = mock((nextModelString: string, _options?: ModelFallbackPrepareOptions) =>
+      Promise.resolve(
+        Ok({
+          model: createTestLanguageModel("fallback-model"),
+          modelString: nextModelString,
+          messages: [],
+          system: "You are a helpful assistant",
+          tools: undefined,
+          thinkingLevel: "off",
+          ...(options.initialMetadataPatch
+            ? { initialMetadataPatch: options.initialMetadataPatch }
+            : {}),
+        })
+      )
+    );
+
+    const startTime = Date.now() - 250;
+    const streamInfo = createStreamInfoForTests({
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "finish", finishReason: "content-filter", rawFinishReason: "refusal" };
+        })(),
+        { inputTokens: 10, outputTokens: 0, totalTokens: 10 }
+      ),
+      messageId,
+      startTime,
+      lastPartTimestamp: startTime,
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      historySequence,
+      initialMetadata: { agentId: "plan", routeProvider: options.staleRouteProvider },
+      request: { model: createTestLanguageModel(), messages: [], providerOptions: undefined },
+      modelFallback: {
+        options: { chain: ["openai:gpt-5.6-luna"], prepare },
+        requestedModel: KNOWN_MODELS.SONNET.id,
+        refusedModels: [],
+        original: { maxOutputTokens: undefined },
+      },
+    });
+
+    await processStreamWithCleanup.call(
+      streamManager,
+      options.workspaceId,
+      streamInfo,
+      historySequence
+    );
+    expect(prepare).toHaveBeenCalledTimes(1);
+    return streamInfo.request as Record<string, unknown>;
+  }
+
+  test("fallback swap applies the cached system when the route patch resolves to direct OpenAI", async () => {
+    const request = await runRefusalFallbackForTests({
+      workspaceId: "gpt56-fallback-eligible-workspace",
+      staleRouteProvider: "mux-gateway",
+      initialMetadataPatch: { routedThroughGateway: false, routeProvider: "openai" },
+    });
+
+    expect(request.system).toEqual(structuredSystem);
+  });
+
+  test("fallback swap keeps the plain system string when the route patch omits the route", async () => {
+    // Stale source metadata says direct OpenAI, but the fallback prepare could
+    // not resolve a route — the transform must fail closed on the patch.
+    const request = await runRefusalFallbackForTests({
+      workspaceId: "gpt56-fallback-ineligible-workspace",
+      staleRouteProvider: "openai",
+      initialMetadataPatch: { routedThroughGateway: false },
+    });
+
+    expect(request.system).toBe("You are a helpful assistant");
   });
 });
 
@@ -772,6 +957,7 @@ describe("StreamManager - sequential tool execution", () => {
       KNOWN_MODELS.SONNET.id,
       [{ role: "user", content: "hello" }],
       "system",
+      undefined, // routeProvider
       tools,
       undefined,
       undefined,
@@ -879,6 +1065,7 @@ describe("StreamManager - call settings overrides", () => {
       modelString,
       messages,
       "system",
+      undefined, // routeProvider
       undefined,
       undefined,
       options.maxOutputTokens,
@@ -980,6 +1167,7 @@ describe("StreamManager - call settings overrides", () => {
       modelString,
       messages,
       "system",
+      undefined, // routeProvider
       undefined,
       undefined,
       undefined,
@@ -4838,6 +5026,7 @@ describe("StreamManager - tool search activeTools scoping", () => {
       KNOWN_MODELS.SONNET.id,
       messages,
       "system",
+      undefined, // routeProvider
       undefined,
       undefined,
       undefined,

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -5,6 +5,7 @@ import {
   streamText,
   stepCountIs,
   type ModelMessage,
+  type SystemModelMessage,
   type LanguageModel,
   type Tool,
   type ToolSet,
@@ -59,6 +60,7 @@ import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import type { Runtime } from "@/node/runtime/Runtime";
 import {
   createCachedSystemMessage,
+  createOpenAICachedSystemMessage,
   applyCacheControlToTools,
   type AnthropicCacheTtl,
 } from "@/common/utils/ai/cacheStrategy";
@@ -161,7 +163,13 @@ interface StepMessageTracker {
 interface StreamRequestConfig {
   model: LanguageModel;
   messages: ModelMessage[];
-  system?: string;
+  /**
+   * System instructions for streamText. Direct official OpenAI GPT-5.6
+   * requests carry a structured SystemModelMessage with an explicit prompt
+   * cache breakpoint (createOpenAICachedSystemMessage); everything else keeps
+   * the plain string.
+   */
+  system?: string | SystemModelMessage;
   tools?: Record<string, Tool>;
   providerOptions?: Record<string, unknown>;
   /** Per-request HTTP headers (e.g., anthropic-beta for 1M context). */
@@ -1457,6 +1465,10 @@ export class StreamManager extends EventEmitter {
     modelString: string,
     messages: ModelMessage[],
     system: string,
+    // Backend-resolved route provider (initialMetadata.routeProvider for the
+    // primary request, initialMetadataPatch.routeProvider for fallbacks).
+    // Missing route metadata fails closed for OpenAI explicit prompt caching.
+    routeProvider?: string,
     tools?: Record<string, Tool>,
     providerOptions?: Record<string, unknown>,
     maxOutputTokens?: number,
@@ -1474,7 +1486,7 @@ export class StreamManager extends EventEmitter {
     // Apply cache control for Anthropic models
     let finalMessages = messages;
     let finalTools = tools;
-    let finalSystem: string | undefined = system;
+    let finalSystem: string | SystemModelMessage | undefined = system;
     const anthropicCacheTtl =
       anthropicCacheTtlOverride ?? getAnthropicCacheTtl(finalProviderOptions);
 
@@ -1485,6 +1497,23 @@ export class StreamManager extends EventEmitter {
       // Note: Must be undefined, not empty string, to avoid Anthropic API error
       finalMessages = [cachedSystemMessage, ...messages];
       finalSystem = undefined;
+    } else {
+      // Direct official OpenAI GPT-5.6: put one explicit prompt cache
+      // breakpoint at the end of the stable system instructions. The system
+      // stays in streamText's `system` argument (as a structured message);
+      // request-wide caching remains implicit so OpenAI keeps placing its
+      // automatic latest-message breakpoint. Ineligible routes (gateways,
+      // Codex OAuth, custom base URLs, missing route metadata) keep the
+      // original string.
+      const openaiCachedSystem = createOpenAICachedSystemMessage(
+        system,
+        modelString,
+        routeProvider,
+        this.getProvidersConfig()
+      );
+      if (openaiCachedSystem) {
+        finalSystem = openaiCachedSystem;
+      }
     }
 
     // Apply cache control to tools for Anthropic models
@@ -1671,6 +1700,7 @@ export class StreamManager extends EventEmitter {
       modelString,
       messages,
       system,
+      initialMetadata?.routeProvider,
       tools,
       providerOptions,
       maxOutputTokens,
@@ -2328,6 +2358,10 @@ export class StreamManager extends EventEmitter {
       prepared.data.modelString,
       prepared.data.messages,
       prepared.data.system,
+      // Use the fallback's freshly-resolved route (not stale source metadata,
+      // which streamInfo.initialMetadata still holds at this point) so the
+      // OpenAI cached-system transform evaluates the fallback route.
+      prepared.data.initialMetadataPatch?.routeProvider,
       prepared.data.tools,
       prepared.data.providerOptions,
       fallbackState.original.maxOutputTokens,


### PR DESCRIPTION
## Summary

Adds hybrid prompt caching for official, direct-OpenAI GPT-5.6-family requests: one explicit `prompt_cache_breakpoint` at the end of Mux's stable system/developer instructions, plus the project-scoped `prompt_cache_key` on eligible Chat Completions requests. Request-wide caching stays implicit (no `promptCacheOptions`), so OpenAI keeps placing its automatic latest-message breakpoint for growing conversations and tool loops.

## Background

GPT-5.6 (via `@ai-sdk/openai` 4.0.11) supports explicit content-level cache breakpoints. Mux's system prefix is stable across turns and context resets within a workspace, so pinning one explicit breakpoint at that boundary lets a fresh context (e.g. after **Reset Context, Preserve History**) reuse the cached instruction prefix instead of re-writing it — while implicit mode continues to cover the conversation tail.

## Implementation

- **`openaiExplicitPromptCachingAvailable`** (`cacheStrategy.ts`): fail-closed eligibility gate — request namespace and resolved alias target must both be `openai:` GPT-5.6-family, route provider must be exactly `openai`, Codex OAuth precedence fails closed (`wouldRouteOpenAIThroughCodexOauth`), and any configured base URL must be the official `https://api.openai.com` endpoint (root or `/v1`). Gateways, custom endpoints, and missing route metadata all fail closed.
- **`createOpenAICachedSystemMessage`**: returns a structured `SystemModelMessage` with message-level `providerOptions.openai.promptCacheBreakpoint: { mode: "explicit" }`; the SDK serializes it to an `input_text` (Responses) / `text` (Chat Completions) block.
- **`streamManager.buildStreamRequestConfig`** now takes the resolved route: `initialMetadata.routeProvider` for primary requests and `initialMetadataPatch.routeProvider` for refusal-fallback rebuilds, so cache metadata cannot leak across routes in either direction. `StreamRequestConfig.system` widened to `string | SystemModelMessage`; the Anthropic cached-system path is untouched.
- **Chat Completions `promptCacheKey`** (`providerOptions.ts`): added only behind the stricter gate. The legacy Responses key spread (including its broader route-absent/passthrough behavior) is byte-for-byte unchanged.

## Validation

- Wire-level tests (`createOpenAI` + capture fetch + `streamText` over synthetic SSE) prove breakpoint + cache-key serialization on both wire formats, absence of `prompt_cache_options`, and that `cached_tokens`/`cache_write_tokens` surface as `inputTokenDetails.cacheReadTokens`/`cacheWriteTokens` through the streaming parser.
- Live dogfooding on `gpt-5.6-luna` (official API key, isolated desktop sandbox):
  - **Responses:** first request wrote 14,445 cache tokens; after **Reset Context, Preserve History**, the raw request proved all isolation invariants (no pre-reset turns, no `previous_response_id`, unchanged `prompt_cache_key`, byte-identical system SHA-256) and read **14,410** cached tokens — explicit stable-prefix reuse. A follow-up read 14,429 (implicit latest-message reuse retained). Cost tab shows distinct cache-read/create rows priced at 0.1×/1.25×.
  - **Chat Completions:** breakpoint (`text` block) + key serialize on the live wire; write 10,145 and same-conversation read 10,082 confirmed. Cross-conversation explicit-prefix reads stayed 0 over ~8 min of retries despite byte-identical prefixes — an OpenAI-side CC behavior, not a request-shape defect (Responses, Mux's default, shows full reuse).
  - A first attempt silently routed via mux-gateway and the gate correctly failed closed (no breakpoint emitted) — live proof of the fail-closed design.
- Live constraint noted: GPT-5.6 Chat Completions rejects function tools with `reasoning_effort != none`, so the CC flow was validated with thinking off. Pre-existing behavior, unrelated to this change.

## Risks

- **Low, tightly scoped:** the only behavioral changes for existing routes are (a) direct-OpenAI GPT-5.6 system prompts become structured messages with a breakpoint, and (b) direct-OpenAI GPT-5.6 Chat Completions gain `prompt_cache_key`. All other models, routes (gateways, Codex OAuth, custom endpoints), and Anthropic cache behavior are unchanged and covered by fail-closed tests.
- Refusal-fallback rebuilds re-evaluate eligibility from the fallback route patch, tested in both eligible→ineligible and ineligible→eligible directions.

---

<details>
<summary>📋 Implementation Plan</summary>

# GPT-5.6 explicit prompt caching

## Goal

Add GPT-5.6 explicit stable-prefix cache breakpoints while retaining OpenAI's implicit latest-message caching, then verify request shape, token accounting, and real cache reuse without changing non-GPT-5.6 routes.

## Current state

- Branch is rebased onto `origin/main` at `1d6e0caa5`.
- `@ai-sdk/openai` is now `4.0.11`, which supports `promptCacheOptions`, content-part `promptCacheBreakpoint`, and `cache_write_tokens` parsing.
- Mux already supplies a stable project-scoped `promptCacheKey` for OpenAI Responses requests and already normalizes cache reads/writes through the usage pipeline.
- Anthropic has separate explicit cache-control transforms; the OpenAI implementation should share only provider-neutral mechanics where that reduces duplication, not Anthropic wire semantics.
- Direct production OpenAI routing resolves to `routeProvider: "openai"`; missing route metadata is a legacy/test-stub case and should fail closed for the new fields.
- `StreamManager` already receives the safe `ProviderService.getConfig()` map, including effective base-URL and OAuth-source metadata, and `AIService` already rebuilds fallback system/provider options from the fallback model and route.

## Recommended approach

Use hybrid caching for eligible **official, direct OpenAI GPT-5.6-family** requests:

1. Keep request-wide mode implicit by omitting `promptCacheOptions`; GPT-5.6 already defaults to implicit mode and a 30-minute minimum TTL.
2. Add exactly one explicit breakpoint at the end of Mux's stable system/developer instructions.
3. Preserve OpenAI's automatic latest-message breakpoint so growing conversations and tool loops continue to reuse their prior prefixes.
4. Continue the existing project-scoped `promptCacheKey` behavior for Responses, and add the same key to eligible Chat Completions requests.
5. Fail closed for Codex OAuth, gateways, custom OpenAI-compatible providers, and non-official OpenAI base URLs until those routes are verified independently.

**Estimated net product-code change:** approximately **+65 to +95 LoC**. Test-only changes are excluded.

## Scope and non-goals

### In scope

- The GPT-5.6 base ID plus Sol, Terra, and Luna as canonical direct-OpenAI model strings (`openai:gpt-5.6...` at the implementation call sites), including supported date-suffixed IDs and `openai:` aliases mapped to those targets. Raw unprefixed strings are normalized before these call sites; the new capability helper itself does not infer a provider and fails closed when the model origin is missing or non-OpenAI.
- Both OpenAI Responses and Chat Completions wire formats when the resolved route is the official OpenAI API using API-key authentication.
- Main streams and refusal fallbacks rebuilt by `StreamManager`.
- Existing cache-read/write accounting, cost display, DevTools telemetry, and analytics ingestion.

### Out of scope

- `promptCacheOptions.mode: "explicit"`; explicit-only mode would disable the useful automatic latest-message breakpoint.
- Explicit breakpoints on conversation turns, tool calls, tool results, files, or individual tools.
- Cache-key format changes, per-agent sharding, or new cache settings in the UI.
- Enabling the feature through Codex OAuth, Mux Gateway, OpenRouter, GitHub Copilot, Azure/OpenAI-compatible endpoints, or a configured custom OpenAI base URL.
- Sanitizing hand-authored `providerExtras.promptCacheKey` values; that generic expert escape hatch is pre-existing behavior, while this plan governs only fields generated by Mux.
- Changing the legacy internal `providerMetadata.anthropic.cacheCreationInputTokens` persistence key; it already carries provider-neutral AI SDK cache-write usage through the current pricing pipeline despite the historical name.

## Implementation plan

Implement each phase test-first: add the failing behavioral assertion, make the smallest production change that satisfies it, then run the phase gate before continuing.

### Phase 1 — Add a route-aware GPT-5.6 cache capability

1. In `src/common/types/thinking.ts`, export the existing `isGpt56FamilyModel` matcher instead of duplicating its model-ID regex.
2. In `src/common/utils/ai/cacheStrategy.ts`, add one pure `openaiExplicitPromptCachingAvailable(modelString, routeProvider, providersConfig: ProvidersConfigMap)` helper that:
   - accepts the canonical model-string shapes already supplied by `AIService` (`openai:<model-id>` for direct built-ins and `openai:` aliases); require the request model's parsed origin to be exactly `openai`, so raw unprefixed inputs and non-OpenAI namespaces fail closed instead of relying on default-provider inference;
   - resolves `mappedToModel` aliases through `resolveModelForMetadata`, independently requires the resolved capability target's origin to be `openai`, and only then applies the GPT-5.6 family predicate to the target model ID;
   - requires the backend-resolved route provider to be exactly `openai`; missing, legacy, gateway, or unknown route metadata fails closed even though older provider-option paths are more permissive;
   - reuses `wouldRouteOpenAIThroughCodexOauth` for API-key/OAuth precedence instead of duplicating provider-factory auth logic;
   - reads the safe `openai.baseUrl` / `baseUrlResolved` view already returned by `ProviderService.getConfig()`: absence of both means the SDK's official default, otherwise resolve the active value with `baseUrl` precedence and require HTTPS host `api.openai.com`, no credentials/query/hash/non-default port, and only the root or `/v1` path with an optional trailing slash;
   - rejects malformed or non-official endpoint values and otherwise fails closed whenever eligibility cannot be established. Transport-level HTTP proxy environment variables are not endpoint overrides and stay outside this check.
3. Add `createOpenAICachedSystemMessage`, returning the exact AI SDK 7 input shape—message-level provider options with string content, not a content-part array:

   ```ts
   const cachedSystem = {
     role: "system",
     content: systemContent,
     providerOptions: {
       openai: {
         promptCacheBreakpoint: { mode: "explicit" },
       },
     },
   } satisfies SystemModelMessage;
   ```

   Return `null` for an empty system prompt or an ineligible route. Keep Anthropic cache-control helpers and wire semantics unchanged.

**Quality gate:** extend `src/common/utils/ai/cacheStrategy.test.ts` to cover the actual production shapes (`openai:gpt-5.6...` and `openai:` mapped aliases), every GPT-5.6 tier, rejection of raw unprefixed and non-OpenAI-origin strings, aliases whose resolved target is not OpenAI GPT-5.6, older models, missing/unknown/gateway routes, Codex OAuth precedence, no URL override, official explicit and `baseUrlResolved` URLs, custom/malformed/non-HTTPS URLs, empty system text, and the exact typed system-message shape.

### Phase 2 — Attach the breakpoint at the system-instructions boundary

1. In `src/node/services/streamManager.ts`, widen only `StreamRequestConfig.system` to `string | SystemModelMessage | undefined`; keep `PreparedModelFallback.system` and public/startup inputs as strings.
2. Add an explicit resolved-route argument to `buildStreamRequestConfig` and let the builder use its existing `getProvidersConfig()` callback for endpoint/auth eligibility; do not add another provider-resolution path.
3. For the primary request, pass the already-resolved `initialMetadata?.routeProvider` from `createStreamAtomically`.
4. Preserve the existing `AIService` fallback rebuild: it already recreates the fallback system, messages, tools, headers, and provider options from `next.canonicalModelString` / `next.routeProvider`. Before `streamInfo.initialMetadata` is patched, pass `prepared.data.initialMetadataPatch?.routeProvider` directly into the fallback `buildStreamRequestConfig` call so the new system transform evaluates the fallback route rather than stale source metadata.
5. Inside `buildStreamRequestConfig`:
   - preserve the current Anthropic path, which moves a cached system message into `messages` and clears `system`;
   - otherwise call `createOpenAICachedSystemMessage` with the model, safe provider config, and resolved route;
   - when eligible, keep `messages` unchanged and replace the `system` string with the structured `SystemModelMessage` accepted by AI SDK 7;
   - do not add request-level `promptCacheOptions`, because omitted mode and TTL preserve hybrid implicit + explicit caching with the provider default lifetime.
6. Leave the existing unconditional `allowSystemInMessages: true` behavior unchanged. OpenAI's structured instructions remain in the `system` argument and do not require a new compatibility switch.

**Quality gate:** extend `src/node/services/streamManager.test.ts` to prove direct GPT-5.6 produces structured cached instructions, ineligible routes/endpoints preserve the original string, Anthropic behavior remains unchanged, and the fallback route patch controls the transformed fallback system. Extend `src/node/services/aiService.test.ts` only at the existing fallback seam to prove fallback provider options and route metadata are freshly built from the fallback model/route, including eligible→ineligible and ineligible→eligible Chat Completions cases.

### Phase 3 — Supply the routing key on GPT-5.6 Chat Completions

1. In `src/common/utils/ai/providerOptions.ts`, reuse the same exact-route/auth/endpoint eligibility helper for the new Chat Completions behavior.
2. Keep the existing Responses `promptCacheKey` spread and scope exactly where it is. Its current route-absent, passthrough-gateway, Codex OAuth, and custom-endpoint behavior is legacy behavior and must not be moved behind the stricter helper in this patch.
3. For Chat Completions only, add the existing project/workspace-derived `promptCacheKey` when the request is eligible for direct official GPT-5.6 explicit caching. Continue omitting Responses-only fields such as `truncation`, `include`, and reasoning summaries from Chat Completions.
4. Do not emit `promptCacheOptions`; the provider defaults are the intended policy.

**Quality gate:** extend `src/common/utils/ai/providerOptions.test.ts` so direct GPT-5.6 Chat Completions with `routeProvider: "openai"` receives the cache key, while older models, mapped non-GPT-5.6 aliases, missing/unknown routes, gateways, Codex OAuth, and custom endpoints do not. Retain existing Responses assertions and add a GPT-5.6 Responses regression proving the legacy key remains unchanged for route-absent and passthrough cases.

### Phase 4 — Prove SDK serialization and accounting behavior

1. Add deterministic production-path tests using `createOpenAI`, a non-networked capture fetch, and `streamText` for both provider formats, following the existing serialization pattern in `src/common/utils/ai/providerOptions.test.ts`:
   - Responses must serialize the structured system instructions to an `input_text` block with `prompt_cache_breakpoint`;
   - Chat Completions must serialize them to a `text` block with the same breakpoint;
   - both eligible formats must include `prompt_cache_key`;
   - neither format should contain `prompt_cache_options` or disable implicit mode;
   - set `maxRetries: 0`, return minimal valid SSE, fully consume each stream, and await the public `usage` result so the test exercises the same streaming parser used by Mux rather than relying on `generateText` parser sharing.
2. Put synthetic `cached_tokens` and `cache_write_tokens` in the final usage-bearing Chat Completions chunk and in the Responses `response.completed.response.usage` event, then assert AI SDK 4.0.11 exposes both as `inputTokenDetails.cacheReadTokens` and `cacheWriteTokens` for each wire format.
3. Extend `src/common/utils/tokens/displayUsage.test.ts` with a GPT-5.6 case proving Mux separates ordinary input, cache reads, and cache writes and applies the configured 0.1× read and 1.25× write prices. Do not rewrite the already-covered normalization pipeline.

**Quality gate:** run the focused suites before broader checks:

```bash
bun test \
  src/common/utils/ai/cacheStrategy.test.ts \
  src/common/utils/ai/providerOptions.test.ts \
  src/node/services/streamManager.test.ts \
  src/node/services/aiService.test.ts \
  src/common/utils/tokens/displayUsage.test.ts
make typecheck
```

### Phase 5 — Full validation

1. Run formatting, lint, typechecking, and the relevant test suite through the repository targets:

   ```bash
   MUX_ESLINT_CONCURRENCY=1 make static-check
   ```

2. Re-run the focused tests in a fresh Bun process if the broad check exposes QuickJS/resource instability unrelated to these files.
3. Inspect the final diff and confirm no provider config schema, UI, analytics schema, or Anthropic cache behavior changed.

## Dogfooding and evidence

Use a live official OpenAI API-key route because custom base URLs are intentionally excluded and a mock endpoint would not exercise the production eligibility gate. Use `gpt-5.6-luna` to minimize cost.

### Setup

1. Confirm an OpenAI API key with GPT-5.6 access is available, Codex OAuth is not the selected auth path, and the OpenAI provider has no custom base URL.
2. Start an isolated desktop with provider settings copied into a temporary root:

   ```bash
   MUX_E2E=1 KEEP_SANDBOX=1 ELECTRON_DEBUG_PORT=9223 make dev-desktop-sandbox
   ```

3. Connect `agent-browser` to the Electron CDP port, enable **Settings → General → API Debug Logs**, and open the Right Sidebar **DevTools** and **Cost** tabs.
4. Use one workspace so its workspace environment block and full system prompt remain byte-identical. Save a sanitized copy of the first raw request and a SHA-256 of its system/developer text. After the first request, use the command palette action **Reset Context, Preserve History** to create a durable context boundary without changing the workspace or cache key. The post-reset raw request—not the cache counter alone—must prove that the prior conversation was sliced out before treating the next read as explicit stable-prefix reuse. Run requests sequentially and wait for each stream-end signal before continuing.

### Responses flow

1. Start a recording before model selection and preserve it through the DevTools/Cost inspection:

   ```bash
   mkdir -p /tmp/mux-gpt56-cache/{screenshots,videos}
   agent-browser --session gpt56-cache connect 9223
   agent-browser --session gpt56-cache record start /tmp/mux-gpt56-cache/videos/responses-cache.webm
   ```

2. In workspace A, select `gpt-5.6-luna` on the Responses wire format and send a short-output prompt. Wait for the explicit stream-end signal, not a fixed sleep.
3. Capture the DevTools request showing:
   - a stable `prompt_cache_key`;
   - one system/developer content block containing `prompt_cache_breakpoint: { mode: "explicit" }`;
   - no `prompt_cache_options.mode: "explicit"`.
4. Capture the first response's nonzero **Cache write** value.
5. Invoke **Reset Context, Preserve History** in the same workspace, then send a different first user message. Capture the sanitized post-reset raw request and verify all four isolation invariants before interpreting the usage result: no pre-reset user/assistant/tool messages remain in `input`; no `previous_response_id` wire field (or camel-case `previousResponseId` metadata field) is present; `prompt_cache_key` is unchanged; and the system/developer block plus its `prompt_cache_breakpoint` is byte-identical or has the same SHA-256 as the first request. Then capture a nonzero **Cache read** value; with those invariants established, the hit demonstrates stable instruction-prefix reuse rather than implicit reuse of the prior conversation.
6. Send one follow-up in the new context and capture the longer cached prefix expected from the retained implicit latest-message breakpoint. Treat latency as supporting evidence only; token counters plus the raw-request isolation checks are the acceptance signal.
7. Capture the Cost tab showing distinct uncached input, cache-read, and cache-write token/cost rows, then stop the recording.

### Chat Completions flow

1. Switch the direct OpenAI provider to Chat Completions and repeat the first request → context reset → unrelated request → follow-up sequence at low request rate.
2. Capture a request screenshot proving both `prompt_cache_key` and the system content breakpoint are serialized in the Chat Completions body.
3. For the post-reset Chat Completions request, repeat the same isolation proof against `messages`: no pre-reset turns, no previous-response identifier in raw request or metadata, unchanged cache key, and byte/hash-identical developer/system content.
4. Capture at least one cache write and one later cache read, then record the full flow to `/tmp/mux-gpt56-cache/videos/chat-completions-cache.webm`.

### Evidence requirements

- Annotated screenshots for the Responses request marker, initial cache write, same-workspace post-reset cache read, Cost-tab breakdown, and Chat Completions request marker/read.
- Sanitized pre/post-reset request extracts for each wire format (or screenshots of those extracts) showing the active message list, absence of previous-response identifiers, unchanged cache key, and matching system/developer SHA-256 values.
- One watchable `.webm` per wire format, with pauses around request inspection and token results.
- Inspect every artifact for API keys, authorization headers, private repository content, or other secrets before attaching it with `attach_file`.
- If a live key/model is unavailable, report dogfooding as blocked rather than substituting a custom endpoint that bypasses the production gate.

## Acceptance criteria

- Official direct OpenAI GPT-5.6 Responses and Chat Completions requests serialize one explicit breakpoint at the stable system/developer boundary and carry the stable cache key.
- Request-wide caching remains implicit; no code emits explicit-only mode or redundant TTL configuration.
- After a same-workspace durable context reset, the raw request proves that pre-reset turns and previous-response identifiers are absent while the cache key and system/developer bytes remain unchanged; only then does a nonzero cache read establish stable-prefix reuse, and a follow-up turn retains growing-conversation reuse.
- Older OpenAI models, gateways, Codex OAuth, custom providers/base URLs, missing/unknown routes, and non-OpenAI models receive no new Mux-generated message breakpoint or Chat Completions cache key.
- Existing Responses `promptCacheKey` behavior remains byte-for-byte unchanged, including its broader legacy route behavior.
- Mapped aliases inherit eligibility only when both the request namespace and resolved capability target are OpenAI, the target is GPT-5.6-family, and the resolved route/auth/base URL identify the official direct OpenAI API.
- Refusal fallback rebuilds reevaluate capability and route, preventing provider-specific cache metadata from leaking across models.
- Cache reads and writes reach DevTools, cost display, persisted usage, and analytics with GPT-5.6 pricing; no migration or provider-specific accounting rewrite is required.
- Focused tests, `make typecheck`, and `MUX_ESLINT_CONCURRENCY=1 make static-check` pass.
- Desktop dogfooding produces sanitized screenshots and video for both wire formats, or records the exact external credential/access blocker.

## Risks and mitigations

- **Unsupported endpoint fields:** fail closed for OAuth, gateways, custom providers, and custom base URLs.
- **SDK serialization drift:** the capture-fetch wire test verifies both API formats rather than only testing intermediate TypeScript objects.
- **Cache writes without reuse:** use one stable breakpoint, preserve implicit mode, and verify a same-workspace post-boundary read before declaring success.
- **Prefixes below 1,024 tokens:** dogfood with Mux's normal full instruction prefix and confirm actual cache-write tokens; do not infer success from request shape alone.
- **Hot project cache keys:** keep the existing key format in this patch and avoid concurrent dogfood traffic. If production telemetry later shows hot keys, handle deterministic sharding as a separate change.
- **Misleading legacy metadata name:** retain the functioning persisted shape to avoid a broad migration; document it in the implementation comment and cover OpenAI pricing behavior with a regression test.

## Rollback

Removing the OpenAI structured-system transform and the Chat Completions key extension restores today's automatic-only behavior. Existing Responses cache keys, Anthropic cache control, persisted usage, and pricing remain intact, so rollback requires no data migration.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$205.62`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=205.62 -->
