### PR TITLE
🤖 fix: wait for sibling tools before send-after-step dispatch

### DIFF
--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -450,6 +450,10 @@ export const ToolCallEndEventSchema = z.object({
   toolCallId: z.string(),
   toolName: z.string(),
   result: z.unknown(),
+  providerExecuted: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when the provider executed the tool server-side" }),
   timestamp: z.number().meta({ description: "When tool call completed (Date.now())" }),
   parentToolCallId: z.string().optional().meta({ description: "Set for nested PTC calls" }),
 });

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -99,6 +99,96 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
+  test("soft-stops after a provider-executed tool result and dispatches after abort", async () => {
+    const workspaceId = "queue-dispatch-provider-tool";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
+      () => undefined
+    );
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolName: "web_search",
+        providerExecuted: true,
+      });
+
+      expect(stopStream).toHaveBeenCalledWith(workspaceId, {
+        soft: true,
+        abortReason: "system",
+      });
+
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
+      expect(didDispatch).toBe(true);
+      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
+    } finally {
+      sendQueuedMessages.mockRestore();
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("waits for every known sibling before stopping after a provider-executed result", async () => {
+    const workspaceId = "queue-dispatch-provider-siblings";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+      aiEmitter.emit("tool-call-start", {
+        type: "tool-call-start",
+        workspaceId,
+        messageId: "assistant-1",
+        toolCallId: "provider-tool-1",
+        toolName: "web_search",
+        args: {},
+        tokens: 0,
+        timestamp: Date.now(),
+      });
+      aiEmitter.emit("tool-call-start", {
+        type: "tool-call-start",
+        workspaceId,
+        messageId: "assistant-1",
+        toolCallId: "provider-tool-2",
+        toolName: "web_search",
+        args: {},
+        tokens: 0,
+        timestamp: Date.now(),
+      });
+
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolCallId: "provider-tool-1",
+        toolName: "web_search",
+        providerExecuted: true,
+      });
+      expect(stopStream).not.toHaveBeenCalled();
+
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolCallId: "provider-tool-2",
+        toolName: "web_search",
+        providerExecuted: true,
+      });
+      expect(stopStream).toHaveBeenCalledTimes(1);
+    } finally {
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   // Heartbeat force-queue drain path: a scheduled message queued while the session is IDLE
   // (e.g. a heartbeat deferred behind active descendant tasks) must ride along with the next
   // turn and drain at its stream-end, releasing the dedupe key so the next firing can enqueue.
@@ -255,8 +345,8 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
-  test("does not send the queued message after a user abort", async () => {
-    const workspaceId = "queue-dispatch-user-abort";
+  test("hard user interrupt cancels a pending provider-tool dispatch", async () => {
+    const workspaceId = "queue-dispatch-hard-user-interrupt";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
       workspaceId,
     });
@@ -268,8 +358,17 @@ describe("AgentSession queued message tool-call dispatch", () => {
     try {
       aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
       session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
-      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "user"));
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolName: "web_search",
+        providerExecuted: true,
+      });
+      expect(stopStream).toHaveBeenCalledTimes(1);
+
+      const interruptResult = await session.interruptStream();
+      expect(interruptResult.success).toBe(true);
+      // The native soft-stop can still win the event race after the hard user interrupt.
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
 
       await new Promise((resolve) => setTimeout(resolve, 25));
       expect(sendQueuedMessages).not.toHaveBeenCalled();

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -5,15 +5,11 @@ import { createAgentSessionHarness } from "./agentSession.testHarness";
 
 const TEST_MODEL = "anthropic:claude-sonnet-4-5";
 
-function toolCallEndEvent(
-  workspaceId: string,
-  overrides?: { replay?: boolean }
-): Record<string, unknown> {
+function toolCallEndEvent(workspaceId: string): Record<string, unknown> {
   return {
     type: "tool-call-end",
     workspaceId,
     messageId: "assistant-1",
-    ...(overrides?.replay === true ? { replay: true } : {}),
     toolCallId: "tool-call-1",
     toolName: "bash",
     result: { success: true },
@@ -56,77 +52,8 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 500): Prom
 }
 
 describe("AgentSession queued message tool-call dispatch", () => {
-  test("soft-stops the current stream after a real tool call when a tool-end message is queued", async () => {
-    const workspaceId = "queue-dispatch-tool-end";
-    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
-      workspaceId,
-    });
-    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
-
-    try {
-      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
-      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
-
-      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
-
-      expect(stopStream).toHaveBeenCalledWith(workspaceId, {
-        soft: true,
-        abortReason: "system",
-      });
-    } finally {
-      stopStream.mockRestore();
-      session.dispose();
-      await cleanup();
-    }
-  });
-
-  test("does not stop the stream for turn-end queues or replayed tool events", async () => {
-    const turnEndWorkspaceId = "queue-dispatch-turn-end";
-    const turnEndHarness = await createAgentSessionHarness({ workspaceId: turnEndWorkspaceId });
-    const turnEndStopStream = spyOn(turnEndHarness.aiService, "stopStream").mockResolvedValue(
-      Ok(undefined)
-    );
-
-    try {
-      turnEndHarness.aiEmitter.emit("stream-start", streamStartEvent(turnEndWorkspaceId));
-      turnEndHarness.session.queueMessage("later", {
-        model: TEST_MODEL,
-        agentId: "exec",
-        queueDispatchMode: "turn-end",
-      });
-      turnEndHarness.aiEmitter.emit("tool-call-end", toolCallEndEvent(turnEndWorkspaceId));
-
-      expect(turnEndStopStream).not.toHaveBeenCalled();
-    } finally {
-      turnEndStopStream.mockRestore();
-      turnEndHarness.session.dispose();
-      await turnEndHarness.cleanup();
-    }
-
-    const replayWorkspaceId = "queue-dispatch-replay";
-    const replayHarness = await createAgentSessionHarness({ workspaceId: replayWorkspaceId });
-    const replayStopStream = spyOn(replayHarness.aiService, "stopStream").mockResolvedValue(
-      Ok(undefined)
-    );
-
-    try {
-      replayHarness.aiEmitter.emit("stream-start", streamStartEvent(replayWorkspaceId));
-      replayHarness.session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
-      replayHarness.aiEmitter.emit(
-        "tool-call-end",
-        toolCallEndEvent(replayWorkspaceId, { replay: true })
-      );
-
-      expect(replayStopStream).not.toHaveBeenCalled();
-    } finally {
-      replayStopStream.mockRestore();
-      replayHarness.session.dispose();
-      await replayHarness.cleanup();
-    }
-  });
-
-  test("sends the queued message after the system abort caused by tool-call dispatch", async () => {
-    const workspaceId = "queue-dispatch-after-system-abort";
+  test("waits for stream-end instead of interrupting between sibling tool results", async () => {
+    const workspaceId = "queue-dispatch-full-step";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
       workspaceId,
     });
@@ -138,75 +65,32 @@ describe("AgentSession queued message tool-call dispatch", () => {
     try {
       aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
       session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+
       aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
-
-      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
-      expect(didDispatch).toBe(true);
-      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
-    } finally {
-      sendQueuedMessages.mockRestore();
-      stopStream.mockRestore();
-      session.dispose();
-      await cleanup();
-    }
-  });
-
-  test("dispatches a turn-end replacement after editing while abort is in flight", async () => {
-    const workspaceId = "queue-dispatch-edited-replacement";
-    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
-      workspaceId,
-    });
-    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
-    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
-      () => undefined
-    );
-
-    try {
-      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
-      session.queueMessage("original follow up", { model: TEST_MODEL, agentId: "exec" });
-      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
-
-      session.clearQueue();
-      session.queueMessage("replacement follow up", {
-        model: TEST_MODEL,
-        agentId: "exec",
-        queueDispatchMode: "turn-end",
+      aiEmitter.emit("tool-call-end", {
+        ...toolCallEndEvent(workspaceId),
+        toolCallId: "tool-call-2",
       });
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
 
-      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
-      expect(didDispatch).toBe(true);
-      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
-    } finally {
-      sendQueuedMessages.mockRestore();
-      stopStream.mockRestore();
-      session.dispose();
-      await cleanup();
-    }
-  });
-
-  test("cancels a pending tool-end dispatch when a hard user interrupt starts", async () => {
-    const workspaceId = "queue-dispatch-hard-user-interrupt";
-    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
-      workspaceId,
-    });
-    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
-    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
-      () => undefined
-    );
-
-    try {
-      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
-      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
-      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
-
-      const interruptResult = await session.interruptStream();
-      expect(interruptResult.success).toBe(true);
-      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
-
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(stopStream).not.toHaveBeenCalled();
       expect(sendQueuedMessages).not.toHaveBeenCalled();
+
+      aiEmitter.emit("stream-end", {
+        type: "stream-end",
+        workspaceId,
+        messageId: "assistant-1",
+        parts: [],
+        metadata: {
+          model: TEST_MODEL,
+          contextUsage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+          providerMetadata: {},
+          finishReason: "tool-calls",
+        },
+      });
+
+      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
+      expect(didDispatch).toBe(true);
+      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
     } finally {
       sendQueuedMessages.mockRestore();
       stopStream.mockRestore();

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -361,11 +361,6 @@ export class AgentSession {
   private activePreparedTurnAbortController: AbortController | null = null;
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
-  // A tool-end queued message should preempt the current turn after the next real tool result.
-  // We keep this set until the requested stream-abort arrives, so a re-queued replacement
-  // can still dispatch even if the original queued draft was edited while the abort was in flight.
-  private queuedToolEndAbortInFlight = false;
-
   private idleWaiters: Array<() => void> = [];
   private pendingExternalManualFollowUps = 0;
   private readonly messageQueue = new MessageQueue();
@@ -3473,10 +3468,6 @@ export class AgentSession {
     // Explicit user interruption should immediately stop any pending auto-retry loop.
     this.retryManager.cancel();
 
-    if (options?.soft !== true) {
-      this.queuedToolEndAbortInFlight = false;
-    }
-
     // For hard interrupts, delete partial BEFORE stopping to prevent abort handler
     // from committing it. For soft interrupts, defer to stream-abort handler since
     // the stream continues running and would recreate the partial.
@@ -4590,10 +4581,6 @@ export class AgentSession {
       ) {
         this.onPostCompactionStateChange?.();
       }
-
-      if (payload.type === "tool-call-end" && payload.replay !== true) {
-        this.requestQueuedToolEndDispatchAfterCurrentTool();
-      }
     });
     forward("reasoning-delta", (payload) => {
       this.markActiveStreamHadAnyOutput();
@@ -4688,7 +4675,6 @@ export class AgentSession {
         );
 
         this.emitChatEvent(payload);
-        this.queuedToolEndAbortInFlight = false;
         return;
       }
 
@@ -4708,7 +4694,6 @@ export class AgentSession {
       const failedUserMessageId = this.activeStreamUserMessageId;
       const hadCompactionRequest = this.activeCompactionRequest !== undefined;
       const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
-      const isQueuedToolEndAbort = this.queuedToolEndAbortInFlight && abortReason !== "user";
       if (abortReason === "user") {
         await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
       }
@@ -4737,20 +4722,13 @@ export class AgentSession {
       if (hadCompactionRequest && !this.disposed) {
         this.clearQueue();
       }
-      // A queued tool-end dispatch deliberately soft-stops the stream (abortReason "system")
-      // to preempt the turn, so that abort is intentional rather than a failure: skip auto-retry.
-      if (!isQueuedToolEndAbort) {
-        await this.handleStreamFailureForAutoRetry({
-          type: "aborted",
-          message: abortReason,
-        });
-      }
+      await this.handleStreamFailureForAutoRetry({
+        type: "aborted",
+        message: abortReason,
+      });
       await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
       this.emitChatEvent(payload);
-      const dispatchedQueuedMessage = this.dispatchQueuedToolEndMessageAfterAbort(abortReason);
-      if (!dispatchedQueuedMessage) {
-        this.setTurnPhase(TurnPhase.IDLE);
-      }
+      this.setTurnPhase(TurnPhase.IDLE);
     });
     forward("runtime-status", (payload) => {
       if (payload.type === "runtime-status") {
@@ -4852,8 +4830,7 @@ export class AgentSession {
         // P2: if an edit is waiting, skip the queue flush so the edit truncates first.
         const hadQueuedMessages = this.hasPendingManualFollowUp();
         if (this.deferQueuedFlushUntilAfterEdit) {
-          // Clear the queued message flag so the next turn's tools don't early-return.
-          this.queuedToolEndAbortInFlight = false;
+          // Clear the queued-message signal while the edit flow owns the next dispatch.
           this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
           // Do not dispatch stream-end follow-ups while the edit flow is waiting
           // for IDLE; truncation must run before any synthetic turn resumes.
@@ -5207,48 +5184,6 @@ export class AgentSession {
     return true;
   }
 
-  private requestQueuedToolEndDispatchAfterCurrentTool(): void {
-    if (
-      this.turnPhase !== TurnPhase.STREAMING ||
-      this.queuedToolEndAbortInFlight ||
-      !this.hasQueuedMessages("tool-end")
-    ) {
-      return;
-    }
-
-    this.queuedToolEndAbortInFlight = true;
-    void this.aiService
-      .stopStream(this.workspaceId, { soft: true, abortReason: "system" })
-      .then((result) => {
-        if (!result.success) {
-          this.queuedToolEndAbortInFlight = false;
-          log.warn("Failed to stop stream for queued tool-end message dispatch", {
-            workspaceId: this.workspaceId,
-            error: result.error,
-          });
-        }
-      });
-  }
-
-  private dispatchQueuedToolEndMessageAfterAbort(
-    abortReason: StreamAbortReason | undefined
-  ): boolean {
-    if (!this.queuedToolEndAbortInFlight) {
-      return false;
-    }
-
-    const shouldDispatch =
-      abortReason !== "user" && !this.deferQueuedFlushUntilAfterEdit && this.hasQueuedMessages();
-    this.queuedToolEndAbortInFlight = false;
-
-    if (!shouldDispatch) {
-      return false;
-    }
-
-    this.sendQueuedMessages();
-    return true;
-  }
-
   async waitForPendingStreamErrorRecoveryDecision(): Promise<void> {
     await this.streamErrorRecoveryDecision?.promise;
   }
@@ -5323,7 +5258,7 @@ export class AgentSession {
 
   /**
    * Send queued messages if any exist.
-   * Called when tool execution completes, stream ends, or user clicks send immediately.
+   * Called when the current turn ends or the user chooses to send immediately.
    */
   sendQueuedMessages(): void {
     // sendQueuedMessages can race with teardown (e.g. workspace.remove) because we
@@ -5334,7 +5269,6 @@ export class AgentSession {
     }
 
     // Clear the queued message flag (even if queue is empty, to handle race conditions)
-    this.queuedToolEndAbortInFlight = false;
     this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
 
     if (!this.messageQueue.isEmpty()) {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -361,6 +361,12 @@ export class AgentSession {
   private activePreparedTurnAbortController: AbortController | null = null;
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
+  // Provider-executed tools (for example native web_search/web_fetch) complete inside one
+  // provider response, so the SDK's between-step stopWhen hook cannot preempt after them.
+  // Track known siblings and reserve soft interruption for that native-only boundary.
+  private queuedProviderToolEndAbortInFlight = false;
+  private readonly activeToolCallIds = new Set<string>();
+
   private idleWaiters: Array<() => void> = [];
   private pendingExternalManualFollowUps = 0;
   private readonly messageQueue = new MessageQueue();
@@ -3468,6 +3474,11 @@ export class AgentSession {
     // Explicit user interruption should immediately stop any pending auto-retry loop.
     this.retryManager.cancel();
 
+    if (options?.soft !== true) {
+      this.queuedProviderToolEndAbortInFlight = false;
+      this.activeToolCallIds.clear();
+    }
+
     // For hard interrupts, delete partial BEFORE stopping to prevent abort handler
     // from committing it. For soft interrupts, defer to stream-abort handler since
     // the stream continues running and would recreate the partial.
@@ -4440,6 +4451,7 @@ export class AgentSession {
   }
 
   private resetActiveStreamState(): void {
+    this.activeToolCallIds.clear();
     this.activeStreamContext = undefined;
     this.activeStreamUserMessageId = undefined;
     this.activeStreamStartedAtMs = undefined;
@@ -4451,6 +4463,7 @@ export class AgentSession {
   private async handleStreamError(data: StreamErrorPayload): Promise<void> {
     this.setTurnPhase(TurnPhase.COMPLETING);
 
+    this.queuedProviderToolEndAbortInFlight = false;
     this.clearLiveUsageState();
     const hadCompactionRequest = this.activeCompactionRequest !== undefined;
     if (
@@ -4529,6 +4542,8 @@ export class AgentSession {
     forward("stream-start", (payload) => {
       if (payload.type === "stream-start") {
         this.activeStreamStartedAtMs = payload.startTime;
+        this.queuedProviderToolEndAbortInFlight = false;
+        this.activeToolCallIds.clear();
       }
       this.setTurnPhase(TurnPhase.STREAMING);
       this.emitChatEvent(payload);
@@ -4540,6 +4555,9 @@ export class AgentSession {
     forward("tool-call-start", (payload) => {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);
+      if (payload.type === "tool-call-start" && payload.replay !== true) {
+        this.activeToolCallIds.add(payload.toolCallId);
+      }
     });
     forward("bash-output", (payload) => {
       this.markActiveStreamHadAnyOutput();
@@ -4569,7 +4587,7 @@ export class AgentSession {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);
     });
-    forward("tool-call-end", (payload) => {
+    forward("tool-call-end", async (payload) => {
       this.markActiveStreamHadAnyOutput();
       this.emitChatEvent(payload);
 
@@ -4580,6 +4598,13 @@ export class AgentSession {
         (payload.toolName === "propose_plan" || payload.toolName.startsWith("file_edit_"))
       ) {
         this.onPostCompactionStateChange?.();
+      }
+
+      if (payload.type === "tool-call-end" && payload.replay !== true) {
+        this.activeToolCallIds.delete(payload.toolCallId);
+        if (payload.providerExecuted === true && this.activeToolCallIds.size === 0) {
+          await this.requestQueuedProviderToolEndDispatch();
+        }
       }
     });
     forward("reasoning-delta", (payload) => {
@@ -4674,6 +4699,8 @@ export class AgentSession {
           this.activeStreamUserMessageId
         );
 
+        this.queuedProviderToolEndAbortInFlight = false;
+        this.activeToolCallIds.clear();
         this.emitChatEvent(payload);
         return;
       }
@@ -4694,6 +4721,8 @@ export class AgentSession {
       const failedUserMessageId = this.activeStreamUserMessageId;
       const hadCompactionRequest = this.activeCompactionRequest !== undefined;
       const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
+      const isQueuedProviderToolEndAbort =
+        this.queuedProviderToolEndAbortInFlight && abortReason !== "user";
       if (abortReason === "user") {
         await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
       }
@@ -4722,13 +4751,19 @@ export class AgentSession {
       if (hadCompactionRequest && !this.disposed) {
         this.clearQueue();
       }
-      await this.handleStreamFailureForAutoRetry({
-        type: "aborted",
-        message: abortReason,
-      });
+      if (!isQueuedProviderToolEndAbort) {
+        await this.handleStreamFailureForAutoRetry({
+          type: "aborted",
+          message: abortReason,
+        });
+      }
       await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
       this.emitChatEvent(payload);
-      this.setTurnPhase(TurnPhase.IDLE);
+      const dispatchedQueuedMessage =
+        this.dispatchQueuedProviderToolEndMessageAfterAbort(abortReason);
+      if (!dispatchedQueuedMessage) {
+        this.setTurnPhase(TurnPhase.IDLE);
+      }
     });
     forward("runtime-status", (payload) => {
       if (payload.type === "runtime-status") {
@@ -4830,6 +4865,7 @@ export class AgentSession {
         // P2: if an edit is waiting, skip the queue flush so the edit truncates first.
         const hadQueuedMessages = this.hasPendingManualFollowUp();
         if (this.deferQueuedFlushUntilAfterEdit) {
+          this.queuedProviderToolEndAbortInFlight = false;
           // Clear the queued-message signal while the edit flow owns the next dispatch.
           this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
           // Do not dispatch stream-end follow-ups while the edit flow is waiting
@@ -5184,6 +5220,49 @@ export class AgentSession {
     return true;
   }
 
+  private async requestQueuedProviderToolEndDispatch(): Promise<void> {
+    if (
+      this.turnPhase !== TurnPhase.STREAMING ||
+      this.queuedProviderToolEndAbortInFlight ||
+      this.activeToolCallIds.size > 0 ||
+      !this.hasQueuedMessages("tool-end")
+    ) {
+      return;
+    }
+
+    this.queuedProviderToolEndAbortInFlight = true;
+    const result = await this.aiService.stopStream(this.workspaceId, {
+      soft: true,
+      abortReason: "system",
+    });
+    if (!result.success) {
+      this.queuedProviderToolEndAbortInFlight = false;
+      log.warn("Failed to stop stream after provider-executed tool result", {
+        workspaceId: this.workspaceId,
+        error: result.error,
+      });
+    }
+  }
+
+  private dispatchQueuedProviderToolEndMessageAfterAbort(
+    abortReason: StreamAbortReason | undefined
+  ): boolean {
+    if (!this.queuedProviderToolEndAbortInFlight) {
+      return false;
+    }
+
+    const shouldDispatch =
+      abortReason !== "user" && !this.deferQueuedFlushUntilAfterEdit && this.hasQueuedMessages();
+    this.queuedProviderToolEndAbortInFlight = false;
+
+    if (!shouldDispatch) {
+      return false;
+    }
+
+    this.sendQueuedMessages();
+    return true;
+  }
+
   async waitForPendingStreamErrorRecoveryDecision(): Promise<void> {
     await this.streamErrorRecoveryDecision?.promise;
   }
@@ -5268,6 +5347,7 @@ export class AgentSession {
       return;
     }
 
+    this.queuedProviderToolEndAbortInFlight = false;
     // Clear the queued message flag (even if queue is empty, to handle race conditions)
     this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
 

--- a/src/node/services/mock/mockAiRouter.ts
+++ b/src/node/services/mock/mockAiRouter.ts
@@ -25,6 +25,9 @@ export interface MockAiRouterReply {
   /** Optional: if present, the mock adapter will emit a usage-delta early in the stream. */
   usage?: LanguageModelV2Usage;
 
+  /** Optional: delay before mock tool calls begin (useful for interaction-driven queue tests). */
+  toolCallDelayMs?: number;
+
   /** Optional: mock tool calls to emit before assistant text streaming. */
   toolCalls?: MockAiToolCall[];
 
@@ -182,6 +185,41 @@ function buildPermissionExecReply(): MockAiRouterReply {
           output: "patch applied\n",
           exitCode: 0,
           wall_duration_ms: 180,
+        },
+      },
+    ],
+  };
+}
+
+function buildParallelToolStepReply(): MockAiRouterReply {
+  return {
+    assistantText: "Finished both sibling tool calls before continuing.",
+    toolCallDelayMs: 10_000,
+    toolCalls: [
+      {
+        toolCallId: "tool-parallel-step-a",
+        toolName: "file_read",
+        args: { path: "parallel-step-a.txt" },
+        result: {
+          success: true,
+          file_size: 24,
+          modifiedTime: "2024-01-01T00:00:00.000Z",
+          lines_read: 1,
+          content: "1\tparallel step A complete",
+          lease: "lease-parallel-step-a",
+        },
+      },
+      {
+        toolCallId: "tool-parallel-step-b",
+        toolName: "file_read",
+        args: { path: "parallel-step-b.txt" },
+        result: {
+          success: true,
+          file_size: 24,
+          modifiedTime: "2024-01-01T00:00:00.000Z",
+          lines_read: 1,
+          content: "1\tparallel step B complete",
+          lease: "lease-parallel-step-b",
         },
       },
     ],
@@ -438,6 +476,10 @@ const defaultHandlers: MockAiRouterHandler[] = [
       hasMockMarker(request.latestUserText, "permission:exec-refactor") ||
       normalizeText(request.latestUserText) === "do it",
     respond: () => buildPermissionExecReply(),
+  },
+  {
+    match: (request) => hasMockMarker(request.latestUserText, "tool:parallel-step"),
+    respond: () => buildParallelToolStepReply(),
   },
   {
     match: (request) =>

--- a/src/node/services/mock/mockAiStreamAdapter.ts
+++ b/src/node/services/mock/mockAiStreamAdapter.ts
@@ -103,6 +103,8 @@ export function buildMockStreamEventsFromReply(
     }
   }
 
+  nextDelay += reply.toolCallDelayMs ?? 0;
+
   if (reply.toolCalls && reply.toolCalls.length > 0) {
     for (const toolCall of reply.toolCalls) {
       events.push({

--- a/src/node/services/streamManager.modelOnlyNotifications.test.ts
+++ b/src/node/services/streamManager.modelOnlyNotifications.test.ts
@@ -110,10 +110,21 @@ describe("StreamManager - model-only tool notifications", () => {
       countTokens: async () => 0,
     };
 
-    const events: Array<{ toolName?: string; result?: unknown }> = [];
-    streamManager.on("tool-call-end", (data: { toolName: string; result: unknown }) => {
-      events.push({ toolName: data.toolName, result: data.result });
-    });
+    const events: Array<{
+      toolName?: string;
+      result?: unknown;
+      providerExecuted?: boolean;
+    }> = [];
+    streamManager.on(
+      "tool-call-end",
+      (data: { toolName: string; result: unknown; providerExecuted?: boolean }) => {
+        events.push({
+          toolName: data.toolName,
+          result: data.result,
+          providerExecuted: data.providerExecuted,
+        });
+      }
+    );
 
     const mockStreamResult = {
       // eslint-disable-next-line @typescript-eslint/require-await
@@ -122,6 +133,7 @@ describe("StreamManager - model-only tool notifications", () => {
           type: "tool-result",
           toolCallId: "orphan-web-search-1",
           toolName: "web_search",
+          providerExecuted: true,
           output: {
             type: "json",
             value: [
@@ -202,5 +214,6 @@ describe("StreamManager - model-only tool notifications", () => {
 
     const toolEnd = events.find((event) => event.toolName === "web_search");
     expect(toolEnd).toBeDefined();
+    expect(toolEnd?.providerExecuted).toBe(true);
   });
 });

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1793,7 +1793,8 @@ export class StreamManager extends EventEmitter {
     toolCalls: ToolCallMap,
     toolCallId: string,
     toolName: string,
-    output: unknown
+    output: unknown,
+    providerExecuted?: boolean
   ): Promise<void> {
     // Find and update the existing tool part
     const existingPartIndex = streamInfo.parts.findIndex(
@@ -1852,6 +1853,7 @@ export class StreamManager extends EventEmitter {
       toolCallId,
       toolName,
       result: output,
+      ...(providerExecuted === true ? { providerExecuted: true } : {}),
       timestamp: completionTimestamp,
     } as ToolCallEndEvent);
   }
@@ -1862,9 +1864,18 @@ export class StreamManager extends EventEmitter {
     toolCalls: ToolCallMap,
     toolCallId: string,
     toolName: string,
-    output: unknown
+    output: unknown,
+    providerExecuted?: boolean
   ): Promise<void> {
-    await this.completeToolCall(workspaceId, streamInfo, toolCalls, toolCallId, toolName, output);
+    await this.completeToolCall(
+      workspaceId,
+      streamInfo,
+      toolCalls,
+      toolCallId,
+      toolName,
+      output,
+      providerExecuted
+    );
     await this.checkSoftCancelStream(workspaceId, streamInfo);
   }
 
@@ -2715,6 +2726,7 @@ export class StreamManager extends EventEmitter {
                   toolCallId: string;
                   toolName: string;
                   output: unknown;
+                  providerExecuted?: boolean;
                 };
 
                 // Strip encrypted content from web search results before storing
@@ -2748,7 +2760,8 @@ export class StreamManager extends EventEmitter {
                   toolCalls,
                   toolResultPart.toolCallId,
                   toolResultPart.toolName,
-                  strippedOutput
+                  strippedOutput,
+                  toolResultPart.providerExecuted
                 );
                 break;
               }
@@ -2760,6 +2773,7 @@ export class StreamManager extends EventEmitter {
                   toolCallId: string;
                   toolName: string;
                   error: unknown;
+                  providerExecuted?: boolean;
                 };
 
                 const logLevel = streamInfo.abortController.signal.aborted ? log.debug : log.error;
@@ -2786,7 +2800,8 @@ export class StreamManager extends EventEmitter {
                   toolCalls,
                   toolErrorPart.toolCallId,
                   toolErrorPart.toolName,
-                  errorOutput
+                  errorOutput,
+                  toolErrorPart.providerExecuted
                 );
                 break;
               }

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1601,6 +1601,9 @@ export class StreamManager extends EventEmitter {
 
     return [
       stepCountIs(100000),
+      // The SDK evaluates stop conditions only after every sibling tool result in the
+      // model's current step settles. Do not move this to individual tool-call-end events:
+      // that would abort the remaining calls the model emitted in the same batch.
       () => request.hasQueuedMessages?.("tool-end") ?? false,
       hasSuccessfulRequiredToolResult,
     ];

--- a/tests/ui/chat/sendModeDropdown.test.ts
+++ b/tests/ui/chat/sendModeDropdown.test.ts
@@ -197,6 +197,38 @@ describe("Send dispatch modes (mock AI router)", () => {
     }
   }, 60_000);
 
+  test("send after step waits for every tool call emitted in the current step", async () => {
+    const app = await createAppHarness({ branchPrefix: "queued-parallel-tool-step" });
+
+    try {
+      await app.chat.send("[mock:tool:parallel-step] Run both sibling tool calls");
+      await waitFor(() => {
+        const state = workspaceStore.getWorkspaceSidebarState(app.workspaceId);
+        if (!state.canInterrupt) {
+          throw new Error("Expected the source turn to be streaming before queueing");
+        }
+      });
+
+      const queuedText = "follow up after the complete tool step";
+      await app.chat.typeWithoutSending(queuedText);
+      const sendButton = await waitForSendModeMenuTrigger(app.view.container);
+      fireEvent.click(sendButton);
+      await waitFor(() => {
+        expect(app.view.container.textContent).toContain("Queued - Sending after step");
+      });
+
+      await app.chat.expectTranscriptContains("parallel-step-a.txt");
+      await app.chat.expectTranscriptContains("parallel-step-b.txt");
+      await app.chat.expectTranscriptContains(
+        "Finished both sibling tool calls before continuing."
+      );
+      await app.chat.expectTranscriptContains(`Mock response: ${queuedText}`);
+      await app.chat.expectStreamComplete();
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+
   test("pressing Enter on an empty composer sends the queued message now", async () => {
     const app = await createAppHarness({ branchPrefix: "queued-enter-send-now" });
 


### PR DESCRIPTION
## Summary

Fix **Send after step** so a queued follow-up waits for every known sibling tool call in the current step while still preempting immediately after provider-native tools such as `web_search` and `web_fetch` finish.

## Background

`AgentSession` previously soft-stopped the stream on every individual `tool-call-end`. When a model emitted multiple client-executed tools in the same step, the first completion could cancel or background remaining siblings before their results were committed.

Moving dispatch exclusively to the AI SDK `stopWhen` step boundary fixed client sibling batches, but provider-executed tools run inside a single provider response and do not create the client-tool continuation where `stopWhen` is evaluated. They therefore need a distinct native-tool boundary.

## Implementation

- Remove per-client-tool soft aborts from `AgentSession`; client tools now stop at `StreamManager`'s AI SDK completed-step boundary after all sibling results settle.
- Propagate the AI SDK's `providerExecuted` marker on `tool-call-end` events.
- Track live tool-call IDs in `AgentSession` and reserve soft preemption for a provider-executed result after every currently known sibling has completed.
- Preserve intentional-abort retry suppression, edited-queue behavior, and hard-user-interrupt cancellation for that native-only path.
- Add delayed two-tool mock coverage for the full client sibling step plus focused provider-native result, sibling, metadata, and interrupt-race tests.

## Validation

- `bun test src/node/services/agentSession.queueDispatch.test.ts`
- `bun test src/node/services/streamManager.modelOnlyNotifications.test.ts`
- `TEST_INTEGRATION=1 bun x jest tests/ui/chat/sendModeDropdown.test.ts --runInBand`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `git diff --check`

## Dogfooding

Verified the client sibling path in an isolated dev-server sandbox with Claude Opus 4.8. The model planned two sibling foreground Bash calls in one assistant step, each sleeping for 45 seconds, while a follow-up was queued in **Send after step** mode.

Observed UTC ordering:

1. Follow-up queued: `09:12:48.941`
2. Sibling A completed: `09:13:33.923`
3. At the first tool boundary, sibling B was alive and the follow-up was absent from durable history.
4. Sibling B completed: `09:14:18.953`
5. Follow-up entered durable history: `09:14:19.025` — 72 ms after sibling B completed.

Captured four progression screenshots and a continuous 103.4-second VP8 WebM recording at 1280×578 covering queueing, sibling handoff, and final dispatch. The provider-native branch is additionally locked down with deterministic event-level tests because native search/fetch execution depends on external provider behavior.

<details>
<summary>Middle-boundary process evidence</summary>

```text
/tmp/mux-after-step-video-final/markers/sibling-a.done 2026-07-13 09:13:33.923199472 +0000
second_sibling=b pid=1026746 alive=yes at 2026-07-13T09:13:34,031728440+00:00
    PID    PPID                  STARTED     ELAPSED COMMAND
1026746  979179 Mon Jul 13 09:13:33 2026       00:00 bash -c ... sleep 45 ... sibling-b.done
queued_followup_in_history=no
```

</details>

## Risks

This changes queue-dispatch timing for **Send after step** only. Client tool calls remain on the SDK's transactional step boundary; provider-native calls use a narrowly gated soft interrupt only after the emitted result is persisted and no known sibling remains active. Regression tests cover both paths and the hard-interrupt race.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `max` • Cost: `$79.65`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=max costs=79.65 -->
