### PR TITLE
🤖 feat: apply mid-turn thinking-level changes at the next model step

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -77,6 +77,7 @@ import { useTelemetry } from "./hooks/useTelemetry";
 import { getRuntimeTypeForTelemetry } from "@/common/telemetry";
 import { useStartWorkspaceCreation } from "./hooks/useStartWorkspaceCreation";
 import { useAPI } from "@/browser/contexts/API";
+import { requestActiveTurnThinkingLevel } from "@/browser/utils/activeTurnThinking";
 import {
   clearPendingWorkspaceAiSettings,
   markPendingWorkspaceAiSettings,
@@ -534,6 +535,10 @@ function AppInner() {
             clearPendingWorkspaceAiSettings(workspaceId, normalizedAgentId);
             // Best-effort only.
           });
+
+        // Mid-turn change: also apply to the active turn's next model step so
+        // the palette/keybind path behaves like the slider (ThinkingProvider).
+        requestActiveTurnThinkingLevel(api, workspaceId, normalized);
       }
 
       // Dispatch toast notification event for UI feedback

--- a/src/browser/contexts/ThinkingContext.test.tsx
+++ b/src/browser/contexts/ThinkingContext.test.tsx
@@ -590,6 +590,81 @@ describe("ThinkingContext", () => {
     }
   });
 
+  test("requests a mid-turn override for the active workspace turn on slider changes", async () => {
+    const workspaceId = "ws-set-thinking-mid-turn";
+    const setActiveTurnThinkingLevel = mock<
+      (args: {
+        workspaceId: string;
+        thinkingLevel: ThinkingLevel;
+      }) => Promise<{ success: true; data: { accepted: boolean } }>
+    >(() => Promise.resolve({ success: true as const, data: { accepted: true } }));
+    currentClientMock = {
+      workspace: {
+        updateAgentAISettings: mock(() =>
+          Promise.resolve({ success: true as const, data: undefined })
+        ),
+        setActiveTurnThinkingLevel,
+      },
+    };
+
+    setWorkspaceMetadata(createWorkspaceMetadata({ id: workspaceId }));
+
+    const view = renderWithWorkspaceMetadata({
+      workspaceId,
+      modelOverride: null,
+      children: (
+        <ThinkingProvider workspaceId={workspaceId}>
+          <ThinkingSetterComponent />
+        </ThinkingProvider>
+      ),
+    });
+
+    const button = await view.findByTestId("set-thinking-medium", undefined, METADATA_WAIT_OPTIONS);
+    act(() => {
+      button.click();
+    });
+
+    await waitFor(() => {
+      expect(setActiveTurnThinkingLevel).toHaveBeenCalledWith({
+        workspaceId,
+        thinkingLevel: "medium",
+      });
+    }, METADATA_WAIT_OPTIONS);
+  });
+
+  test("does not request a mid-turn override in project scope (no workspaceId)", async () => {
+    const projectPath = "/Users/dev/mid-turn-scope";
+    const setActiveTurnThinkingLevel = mock(() =>
+      Promise.resolve({ success: true as const, data: { accepted: false } })
+    );
+    currentClientMock = {
+      workspace: { setActiveTurnThinkingLevel },
+    };
+
+    const view = renderWithAPI(
+      <ThinkingProvider projectPath={projectPath}>
+        <ThinkingSetterComponent />
+      </ThinkingProvider>
+    );
+
+    const button = await view.findByTestId("set-thinking-medium", undefined, METADATA_WAIT_OPTIONS);
+    act(() => {
+      button.click();
+    });
+
+    // Project/global scopes have no active turn to override; the route must
+    // not fire (persisted settings alone drive the next turn).
+    await waitFor(() => {
+      expect(
+        readPersistedState<ThinkingLevel | null>(
+          getThinkingLevelKey(getProjectScopeId(projectPath)),
+          null
+        )
+      ).toBe("medium");
+    }, METADATA_WAIT_OPTIONS);
+    expect(setActiveTurnThinkingLevel).not.toHaveBeenCalled();
+  });
+
   test("cycles thinking level via keybind in project-scoped (creation) flow", async () => {
     const projectPath = "/Users/dev/my-project";
 

--- a/src/browser/contexts/ThinkingContext.tsx
+++ b/src/browser/contexts/ThinkingContext.tsx
@@ -226,12 +226,24 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
         thinkingLevel: level,
         reasoningMode: getCurrentReasoningMode(),
       });
+      // Mid-turn change: also request the new level for the active turn's next
+      // model step. No streaming gate here — the backend no-ops cheaply when
+      // idle, and gating on store state would break non-workspace mounts.
+      if (props.workspaceId) {
+        api?.workspace
+          .setActiveTurnThinkingLevel({ workspaceId: props.workspaceId, thinkingLevel: level })
+          .catch(() => {
+            // Best-effort: no active stream / transient IPC failure.
+          });
+      }
     },
     [
+      api,
       defaultModel,
       getCurrentReasoningMode,
       metadataSettings.model,
       persistAgentAiSettings,
+      props.workspaceId,
       scopeId,
       setThinkingLevelInternal,
     ]

--- a/src/browser/contexts/ThinkingContext.tsx
+++ b/src/browser/contexts/ThinkingContext.tsx
@@ -27,6 +27,7 @@ import { enforceThinkingPolicy, getAvailableThinkingLevels } from "@/common/util
 import { useMinThinkingLevels } from "@/browser/hooks/useMinThinkingLevels";
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import { useAPI } from "@/browser/contexts/API";
+import { requestActiveTurnThinkingLevel } from "@/browser/utils/activeTurnThinking";
 import {
   clearPendingWorkspaceAiSettings,
   getWorkspaceAiSettingsFromMetadata,
@@ -227,14 +228,10 @@ export const ThinkingProvider: React.FC<ThinkingProviderProps> = (props) => {
         reasoningMode: getCurrentReasoningMode(),
       });
       // Mid-turn change: also request the new level for the active turn's next
-      // model step. No streaming gate here — the backend no-ops cheaply when
-      // idle, and gating on store state would break non-workspace mounts.
+      // model step. Non-workspace (project/global) mounts have no workspaceId
+      // and skip this inside the helper.
       if (props.workspaceId) {
-        api?.workspace
-          .setActiveTurnThinkingLevel({ workspaceId: props.workspaceId, thinkingLevel: level })
-          .catch(() => {
-            // Best-effort: no active stream / transient IPC failure.
-          });
+        requestActiveTurnThinkingLevel(api, props.workspaceId, level);
       }
     },
     [

--- a/src/browser/utils/activeTurnThinking.ts
+++ b/src/browser/utils/activeTurnThinking.ts
@@ -1,0 +1,25 @@
+import type { APIClient } from "@/browser/contexts/API";
+import type { ThinkingLevel } from "@/common/types/thinking";
+
+/**
+ * Best-effort request to apply a thinking-level change to the active turn's
+ * NEXT model step (mid-turn override). Shared by every UI path that changes a
+ * workspace's thinking level (slider, keybinds, command palette) so they all
+ * behave identically during a stream.
+ *
+ * No streaming gate on purpose: the backend no-ops cheaply (accepted: false)
+ * when the workspace is idle or unknown, and the persisted workspace setting
+ * (updated separately by callers) still covers future turns.
+ */
+export function requestActiveTurnThinkingLevel(
+  api: APIClient | null | undefined,
+  workspaceId: string,
+  thinkingLevel: ThinkingLevel
+): void {
+  if (!api || !workspaceId) {
+    return;
+  }
+  api.workspace.setActiveTurnThinkingLevel({ workspaceId, thinkingLevel }).catch(() => {
+    // Best-effort: transient IPC failure loses only the mid-turn nudge.
+  });
+}

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1202,6 +1202,17 @@ export const workspace = {
     }),
     output: ResultSchema(z.void(), z.string()),
   },
+  // Mid-turn thinking change: request that the active turn's NEXT model step
+  // uses this level. `accepted: false` (success) = no turn active — persisted
+  // settings already cover the next turn. `accepted: true` = the level applies
+  // to the current turn's next step if one occurs (expires silently otherwise).
+  setActiveTurnThinkingLevel: {
+    input: z.object({
+      workspaceId: z.string(),
+      thinkingLevel: ThinkingLevelSchema,
+    }),
+    output: ResultSchema(z.object({ accepted: z.boolean() }), z.string()),
+  },
   preflightArchive: {
     input: z.object({ workspaceId: z.string() }),
     output: ResultSchema(ArchivePreflightResultSchema, z.string()),

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -168,14 +168,8 @@ export const ANTHROPIC_THINKING_BUDGETS: Record<ThinkingLevel, number> = {
 
 /**
  * Anthropic effort type - matches SDK's AnthropicProviderOptions["effort"].
- *
- * Note: Opus 4.7 and Sonnet 5 introduced a native "xhigh" effort level in the API,
- * but the SDK's Zod validator still rejects "xhigh". Mux handles this by sending
- * "max" through the SDK and rewriting `output_config.effort` to "xhigh" in a fetch
- * wrapper for native-xhigh Anthropic models when the user selected the xhigh ThinkingLevel.
- * See `wrapFetchWithAnthropicCacheControl` and `buildRequestHeaders`.
  */
-export type AnthropicEffortLevel = "low" | "medium" | "high" | "max";
+export type AnthropicEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 /**
  * Anthropic effort parameter mapping (Opus 4.5+)
@@ -183,22 +177,38 @@ export type AnthropicEffortLevel = "low" | "medium" | "high" | "max";
  * The effort parameter controls how much computational work the model applies.
  * - Opus 4.5 supports: low, medium, high (policy clamps xhigh → high)
  * - Opus 4.6 supports: low, medium, high, max (xhigh maps to "max" effort)
- * - Opus 4.7+ and Sonnet 5+ support: low, medium, high, xhigh, max (xhigh requires wire override)
+ * - Opus 4.7+ and Sonnet 5+ support: low, medium, high, xhigh, max (native xhigh)
  *
- * Because the @ai-sdk/anthropic Zod schema doesn't accept "xhigh" yet, we send
- * "max" through the SDK for native-xhigh Anthropic models and rewrite
- * `output_config.effort` to "xhigh" in the Anthropic fetch wrapper.
+ * The table keeps `xhigh: "max"` as the non-native fallback; `getAnthropicEffort`
+ * upgrades it to the native "xhigh" wire value on models that support it.
+ *
+ * SDK coupling note: explicit `providerOptions.anthropic.effort` values flow
+ * verbatim into `output_config.effort` as of @ai-sdk/anthropic 4.0.11 (its Zod
+ * schema accepts "xhigh"; its `supportsXhighEffort` model gating applies only to
+ * the SDK's top-level `reasoning` CallOption mapping, which Mux does not use).
+ * Re-verify this pass-through on major SDK upgrades.
  */
 const ANTHROPIC_EFFORT: Record<ThinkingLevel, AnthropicEffortLevel> = {
   off: "low",
   low: "low",
   medium: "medium",
   high: "high",
-  xhigh: "max", // SDK placeholder; fetch wrapper rewrites to "xhigh" on native-xhigh models
+  xhigh: "max", // Non-native fallback; native-xhigh models get "xhigh" via getAnthropicEffort
   max: "max",
 };
 
-export function getAnthropicEffort(level: ThinkingLevel): AnthropicEffortLevel {
+/**
+ * Model-aware Anthropic effort resolution: `xhigh` maps to the native "xhigh"
+ * wire value only on models that support it (Opus 4.7+, Sonnet 5+, Mythos);
+ * everywhere else it falls back to "max" per the table above.
+ */
+export function getAnthropicEffort(
+  level: ThinkingLevel,
+  capabilityModel: string
+): AnthropicEffortLevel {
+  if (level === "xhigh" && anthropicSupportsNativeXhigh(capabilityModel)) {
+    return "xhigh";
+  }
   return ANTHROPIC_EFFORT[level];
 }
 

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -16,7 +16,6 @@ import {
   preserveAnthropic1MContextForFollowUp,
   resolveProviderOptionsNamespaceKey,
   ANTHROPIC_1M_CONTEXT_HEADER,
-  MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER,
   MUX_WORKSPACE_ID_HEADER,
 } from "./providerOptions";
 
@@ -111,7 +110,9 @@ describe("buildProviderOptions - Anthropic", () => {
     });
   });
 
-  for (const model of ["claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-5"] as const) {
+  // Non-native-xhigh adaptive models: xhigh falls back to "max" effort and
+  // adaptive thinking carries no `display` field.
+  for (const model of ["claude-opus-4-6", "claude-sonnet-4-6"] as const) {
     describe(`${model} (adaptive thinking + effort)`, () => {
       for (const { thinking, expectedThinking, effort } of [
         { thinking: "medium", expectedThinking: { type: "adaptive" }, effort: "medium" },
@@ -134,12 +135,49 @@ describe("buildProviderOptions - Anthropic", () => {
     });
   }
 
+  // Native-xhigh models (Opus 4.7+ / Sonnet 5+): xhigh is a distinct native
+  // effort and adaptive thinking requires `display: "summarized"` to return
+  // thinking content.
+  for (const model of ["claude-opus-4-7", "claude-sonnet-5"] as const) {
+    describe(`${model} (native xhigh effort + summarized display)`, () => {
+      for (const { thinking, expectedThinking, effort } of [
+        {
+          thinking: "medium",
+          expectedThinking: { type: "adaptive", display: "summarized" },
+          effort: "medium",
+        },
+        {
+          thinking: "xhigh",
+          expectedThinking: { type: "adaptive", display: "summarized" },
+          effort: "xhigh",
+        },
+        {
+          thinking: "max",
+          expectedThinking: { type: "adaptive", display: "summarized" },
+          effort: "max",
+        },
+        { thinking: "off", expectedThinking: { type: "disabled" }, effort: "low" },
+      ] as const) {
+        test(`maps ${thinking} to ${effort} effort`, () => {
+          const anthropic = anthropicProviderOptions(
+            buildProviderOptions(`anthropic:${model}`, thinking)
+          );
+
+          expect(anthropic.thinking).toEqual(expectedThinking);
+          expect(anthropic.effort).toBe(effort);
+        });
+      }
+    });
+  }
+
   describe("claude-fable-5 (Mythos-class: API rejects disabled thinking)", () => {
     test("maps medium to adaptive thinking like other adaptive models", () => {
       const anthropic = anthropicProviderOptions(
         buildProviderOptions("anthropic:claude-fable-5", "medium")
       );
-      expect(anthropic.thinking).toEqual({ type: "adaptive" });
+      // Mythos-class models are native-xhigh tier, so adaptive thinking carries
+      // the summarized display flag.
+      expect(anthropic.thinking).toEqual({ type: "adaptive", display: "summarized" });
       expect(anthropic.effort).toBe("medium");
     });
 
@@ -1590,67 +1628,12 @@ describe("buildRequestHeaders", () => {
     });
   }
 
-  describe("Opus 4.7+ xhigh effort override", () => {
-    for (const { name, model, routeProvider, thinkingLevel, expected } of [
-      {
-        name: "emits override header when thinkingLevel=xhigh for Opus 4.7",
-        model: "anthropic:claude-opus-4-7",
-        routeProvider: undefined,
-        thinkingLevel: "xhigh",
-        expected: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
-      },
-      {
-        name: "emits override header for gateway-routed Opus 4.7 with xhigh (passthrough)",
-        model: "mux-gateway:anthropic/claude-opus-4-7",
-        routeProvider: "mux-gateway",
-        thinkingLevel: "xhigh",
-        expected: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
-      },
-      {
-        name: "emits override header for Opus 4.8",
-        model: "anthropic:claude-opus-4-8",
-        routeProvider: undefined,
-        thinkingLevel: "xhigh",
-        expected: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
-      },
-      {
-        // Sonnet 5 added native xhigh for the Sonnet tier, so it needs the wire rewrite too.
-        name: "emits override header for Sonnet 5",
-        model: "anthropic:claude-sonnet-5",
-        routeProvider: undefined,
-        thinkingLevel: "xhigh",
-        expected: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
-      },
-      {
-        name: "does not emit override header for Opus 4.7 with thinkingLevel=max",
-        model: "anthropic:claude-opus-4-7",
-        routeProvider: undefined,
-        thinkingLevel: "max",
-        expected: undefined,
-      },
-      {
-        name: "does not emit override header for Opus 4.6 with xhigh",
-        // Opus 4.6 maps xhigh -> "max" effort; SDK accepts "max" so no wire rewrite needed.
-        model: "anthropic:claude-opus-4-6",
-        routeProvider: undefined,
-        thinkingLevel: "xhigh",
-        expected: undefined,
-      },
-      {
-        name: "does not emit override header for non-passthrough gateway (openrouter)",
-        // Non-passthrough gateways must not receive this Mux-internal header.
-        model: "anthropic:claude-opus-4-7",
-        routeProvider: "openrouter",
-        thinkingLevel: "xhigh",
-        expected: undefined,
-      },
-    ] as const) {
-      test(name, () => {
-        expect(
-          buildRequestHeaders(model, undefined, undefined, undefined, routeProvider, thinkingLevel)
-        ).toEqual(expected);
-      });
-    }
+  // Native xhigh effort no longer needs a Mux-internal override header: the
+  // SDK accepts effort "xhigh" directly (see buildProviderOptions tests above),
+  // so buildRequestHeaders is thinking-level-independent.
+  test("does not emit any Mux-internal effort header for native-xhigh models", () => {
+    expect(buildRequestHeaders("anthropic:claude-opus-4-7")).toBeUndefined();
+    expect(buildRequestHeaders("anthropic:claude-sonnet-5")).toBeUndefined();
   });
 
   describe("openaiProModeAvailable", () => {

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -43,15 +43,6 @@ export { resolveProviderOptionsNamespaceKey } from "./models";
 export { openaiProModeAvailable } from "./proMode";
 
 /**
- * Request header used to override Anthropic's `output_config.effort` at the
- * wire level. The @ai-sdk/anthropic Zod schema rejects "xhigh", so for
- * Opus 4.7+ with xhigh ThinkingLevel we send "max" through the SDK and ask the
- * fetch wrapper to rewrite it to "xhigh" via this header (which is then stripped
- * before the request reaches Anthropic).
- */
-export const MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER = "x-mux-anthropic-effort";
-
-/**
  * OpenRouter reasoning options
  * @see https://openrouter.ai/docs/use-cases/reasoning-tokens
  */
@@ -281,11 +272,9 @@ export function buildProviderOptions(
     const usesAdaptiveThinking = isOpus46 || supportsNativeXhigh || isSonnet46;
 
     if (isOpus45 || usesAdaptiveThinking) {
-      // Map to SDK-accepted effort. For Opus 4.7+ / Sonnet 5+ with xhigh ThinkingLevel, the
-      // SDK gets "max" as a placeholder and the Anthropic fetch wrapper rewrites
-      // `output_config.effort` to "xhigh" via the X-Mux-Anthropic-Effort header
-      // (added in buildRequestHeaders).
-      const effortLevel = getAnthropicEffort(effectiveThinking);
+      // Model-aware effort: native-xhigh models (Opus 4.7+ / Sonnet 5+ / Mythos)
+      // get the native "xhigh" wire value; other adaptive models keep xhigh → "max".
+      const effortLevel = getAnthropicEffort(effectiveThinking, capabilityModel);
       const budgetTokens = ANTHROPIC_THINKING_BUDGETS[effectiveThinking];
       // Opus 4.6+ / Sonnet 4.6 / Sonnet 5: adaptive thinking when on, disabled when off
       // Opus 4.5: enabled thinking with budgetTokens ceiling (only when not "off")
@@ -293,12 +282,19 @@ export function buildProviderOptions(
       // excludes "off" for them and AIService clamps the effective level via
       // resolveEffectiveThinkingLevel, so "off" should not reach here — but if a stray
       // path does, omit `thinking` (API defaults to adaptive) rather than hard-erroring.
+      //
+      // Native-xhigh models require `thinking.display: "summarized"` to return
+      // thinking content on adaptive requests; non-native adaptive models
+      // (Opus 4.6 / Sonnet 4.6) must not receive `display`.
+      // See https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#summarized-thinking
       const thinking: AnthropicProviderOptions["thinking"] = usesAdaptiveThinking
         ? effectiveThinking === "off"
           ? anthropicRejectsDisabledThinking(capabilityModel)
             ? undefined
             : { type: "disabled" }
-          : { type: "adaptive" }
+          : supportsNativeXhigh
+            ? { type: "adaptive", display: "summarized" }
+            : { type: "adaptive" }
         : budgetTokens > 0
           ? { type: "enabled", budgetTokens }
           : undefined;
@@ -309,10 +305,6 @@ export function buildProviderOptions(
         thinkingLevel: effectiveThinking,
       });
 
-      // Note: Opus 4.7+ requires `thinking.display: "summarized"` to receive
-      // thinking content, but the SDK's Zod schema strips unknown keys so we
-      // can't add it here. The Anthropic fetch wrapper injects `display` on the
-      // wire for Opus 4.7+ adaptive thinking requests.
       const anthropicOptions: AnthropicProviderOptions = {
         disableParallelToolUse: false,
         sendReasoning: true,
@@ -614,8 +606,7 @@ export function buildRequestHeaders(
   muxProviderOptions?: MuxProviderOptions,
   workspaceId?: string,
   providersConfig?: ProvidersConfigMap | null,
-  routeProvider?: ProviderName,
-  thinkingLevel?: ThinkingLevel
+  routeProvider?: ProviderName
 ): Record<string, string> | undefined {
   const headers: Record<string, string> = {};
 
@@ -636,23 +627,6 @@ export function buildRequestHeaders(
     isAnthropic1MEffectivelyEnabled(modelString, muxProviderOptions, providersConfig)
   ) {
     headers["anthropic-beta"] = ANTHROPIC_1M_CONTEXT_HEADER;
-  }
-
-  // Native-xhigh Anthropic models use an "xhigh" effort level that the
-  // @ai-sdk/anthropic Zod schema doesn't accept yet. Emit a Mux-internal header
-  // so the Anthropic fetch wrapper can rewrite `output_config.effort` to "xhigh" on the wire.
-  //
-  // Only emit when the route will pass through our Anthropic fetch wrapper
-  // (direct Anthropic or passthrough gateways like mux-gateway). Non-passthrough
-  // gateways (OpenRouter, Bedrock, github-copilot) must not see this header —
-  // they would forward it externally verbatim and strict proxies may reject it.
-  if (
-    origin === "anthropic" &&
-    routePassesHeaders &&
-    thinkingLevel === "xhigh" &&
-    anthropicSupportsNativeXhigh(modelString)
-  ) {
-    headers[MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER] = "xhigh";
   }
 
   return Object.keys(headers).length > 0 ? headers : undefined;

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -9,6 +9,7 @@ import {
   resolveMinimumThinkingLevel,
   resolveEffectiveThinkingLevel,
   getAvailableThinkingLevels,
+  isXaiGrokFastVariantSwap,
 } from "./policy";
 
 describe("getThinkingPolicyForModel", () => {
@@ -920,5 +921,18 @@ describe("enforceThinkingPolicy with a minimum floor", () => {
 
   test("omitting the floor preserves legacy capability-only behavior", () => {
     expect(enforceThinkingPolicy("anthropic:claude-sonnet-4-5", "off")).toBe("off");
+  });
+});
+
+describe("isXaiGrokFastVariantSwap", () => {
+  test("flags only off<->on transitions on xai:grok-4-1-fast", () => {
+    // off <-> non-off swaps the underlying reasoning/non-reasoning variant.
+    expect(isXaiGrokFastVariantSwap("xai:grok-4-1-fast", "off", "high")).toBe(true);
+    expect(isXaiGrokFastVariantSwap("xai:grok-4-1-fast", "high", "off")).toBe(true);
+    // non-off -> non-off stays on the reasoning variant (no swap).
+    expect(isXaiGrokFastVariantSwap("xai:grok-4-1-fast", "low", "high")).toBe(false);
+    // Other models never swap instances on thinking-level changes.
+    expect(isXaiGrokFastVariantSwap("xai:grok-4-1-fast-reasoning", "off", "high")).toBe(false);
+    expect(isXaiGrokFastVariantSwap("anthropic:claude-sonnet-4-5", "off", "high")).toBe(false);
   });
 });

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -348,6 +348,25 @@ export function enforceThinkingPolicy(
   return closest;
 }
 /**
+ * Whether a thinking-level transition would swap the underlying model instance
+ * for xAI's grok-4-1-fast (providerModelFactory maps off → non-reasoning and
+ * non-off → reasoning variants at model creation). Such transitions cannot be
+ * applied to an in-flight stream via provider options, so mid-turn overrides
+ * skip them (the persisted setting still applies to the next turn).
+ */
+export function isXaiGrokFastVariantSwap(
+  modelString: string,
+  currentLevel: ThinkingLevel,
+  nextLevel: ThinkingLevel
+): boolean {
+  const [provider, modelId] = modelString.trim().toLowerCase().split(":", 2);
+  if (provider !== "xai" || modelId !== "grok-4-1-fast") {
+    return false;
+  }
+  return (currentLevel === "off") !== (nextLevel === "off");
+}
+
+/**
  * Resolve a parsed thinking input to a concrete ThinkingLevel for a given model.
  *
  * Named levels are returned as-is (the backend's enforceThinkingPolicy will

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -4095,6 +4095,15 @@ export const router = (authToken?: string) => {
             input.aiSettings
           );
         }),
+      setActiveTurnThinkingLevel: t
+        .input(schemas.workspace.setActiveTurnThinkingLevel.input)
+        .output(schemas.workspace.setActiveTurnThinkingLevel.output)
+        .handler(({ context, input }) => {
+          return context.workspaceService.setActiveTurnThinkingLevel(
+            input.workspaceId,
+            input.thinkingLevel
+          );
+        }),
       updateTitle: t
         .input(schemas.workspace.updateTitle.input)
         .output(schemas.workspace.updateTitle.output)

--- a/src/node/services/agentSession.thinkingOverride.test.ts
+++ b/src/node/services/agentSession.thinkingOverride.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, mock } from "bun:test";
+
+import type { MuxMessage } from "@/common/types/message";
+import { Ok, Err } from "@/common/types/result";
+import type { AIService, StreamMessageOptions } from "@/node/services/aiService";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+import type { ActiveTurnThinkingOverride } from "./thinkingOverride";
+
+const MODEL = "anthropic:claude-sonnet-4-5";
+
+describe("AgentSession.setActiveTurnThinkingLevel", () => {
+  it("reports accepted:false while idle (persisted settings cover the next turn)", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "thinking-override-idle",
+    });
+    try {
+      expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  it("accepts writes during PREPARING and streaming, threads the holder to the stream, and expires it on turn end", async () => {
+    const capturedHolders: Array<ActiveTurnThinkingOverride | undefined> = [];
+    const capturedPendingAtStreamStart: Array<string | undefined> = [];
+    let sessionRef: {
+      setActiveTurnThinkingLevel: (level: "low" | "high" | "medium") => { accepted: boolean };
+    } | null = null;
+
+    const streamMessage = mock((opts: StreamMessageOptions) => {
+      capturedHolders.push(opts.activeTurnThinkingOverride);
+      capturedPendingAtStreamStart.push(opts.activeTurnThinkingOverride?.pending);
+      // Simulate a slider change while the stream is active: both writes must
+      // land in the SAME holder object the stream received (last write wins).
+      const first = sessionRef?.setActiveTurnThinkingLevel("high");
+      const second = sessionRef?.setActiveTurnThinkingLevel("low");
+      expect(first).toEqual({ accepted: true });
+      expect(second).toEqual({ accepted: true });
+      expect(opts.activeTurnThinkingOverride?.pending).toBe("low");
+      return Promise.resolve(Ok(undefined));
+    });
+
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "thinking-override-active",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+    sessionRef = session;
+
+    try {
+      const result = await session.sendMessage("hello", { model: MODEL, agentId: "exec" });
+      expect(result.success).toBe(true);
+      expect(streamMessage.mock.calls).toHaveLength(1);
+      expect(capturedHolders[0]).toBeDefined();
+
+      // The turn ended (mocked stream resolved without events -> IDLE): the
+      // holder expired, so late writes fall back to persisted settings.
+      await session.waitForIdle();
+      expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
+
+      // A follow-up turn gets a FRESH holder with no inherited pending level.
+      const second = await session.sendMessage("again", { model: MODEL, agentId: "exec" });
+      expect(second.success).toBe(true);
+      expect(capturedHolders[1]).toBeDefined();
+      expect(capturedHolders[1]).not.toBe(capturedHolders[0]);
+      expect(capturedPendingAtStreamStart[1]).toBeUndefined();
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  it("delivers a change made during the PREPARING window to the turn's stream options", async () => {
+    let pendingSeenByStream: string | undefined;
+    const streamMessage = mock((opts: StreamMessageOptions) => {
+      pendingSeenByStream = opts.activeTurnThinkingOverride?.pending;
+      return Promise.resolve(Ok(undefined));
+    });
+
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "thinking-override-preparing",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+
+    try {
+      // onAccepted runs after the holder is created but before the stream
+      // starts — exactly the PREPARING window a fast slider change can hit.
+      const result = await session.sendMessage(
+        "hello",
+        { model: MODEL, agentId: "exec" },
+        {
+          onAccepted: () => {
+            expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: true });
+          },
+        }
+      );
+      expect(result.success).toBe(true);
+      expect(streamMessage.mock.calls).toHaveLength(1);
+      // The pre-stream write reaches the turn's first provider request via the
+      // holder (prepareStep runs before step 1).
+      expect(pendingSeenByStream).toBe("high");
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  it("clears the holder when a pre-stream failure aborts the accepted turn", async () => {
+    const streamMessage = mock((_opts: StreamMessageOptions) =>
+      Promise.resolve(Err({ type: "unknown" as const, raw: "startup failed" }))
+    );
+
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "thinking-override-prestream-failure",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+
+    try {
+      const result = await session.sendMessage("hello", { model: MODEL, agentId: "exec" });
+      expect(result.success).toBe(false);
+      await session.waitForIdle();
+      expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  it("clears the holder when an onAccepted failure aborts the turn before streaming", async () => {
+    const streamMessage = mock((_history: MuxMessage[]) => Promise.resolve(Ok(undefined)));
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "thinking-override-onaccepted-failure",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+
+    try {
+      const result = await session.sendMessage(
+        "hello",
+        { model: MODEL, agentId: "exec" },
+        {
+          onAccepted: () => {
+            throw new Error("acceptance hook failed");
+          },
+        }
+      );
+      expect(result.success).toBe(false);
+      // The stream never started; the holder must not leak into idle state.
+      expect(streamMessage.mock.calls).toHaveLength(0);
+      expect(session.setActiveTurnThinkingLevel("high")).toEqual({ accepted: false });
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+});

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -60,6 +60,7 @@ import {
   type ThinkingLevel,
 } from "@/common/types/thinking";
 import { enforceThinkingPolicy, resolveMinimumThinkingLevel } from "@/common/utils/thinking/policy";
+import type { ActiveTurnThinkingOverride } from "@/node/services/thinkingOverride";
 import {
   createMuxMessage,
   dedupeAgentSkillRefs,
@@ -359,6 +360,14 @@ export class AgentSession {
   private disposed = false;
   private turnPhase: TurnPhase = TurnPhase.IDLE;
   private activePreparedTurnAbortController: AbortController | null = null;
+  /**
+   * Per-turn holder for mid-turn thinking-level overrides. Created when a turn
+   * is durably accepted (before any await that could let the renderer's slider
+   * route race in), threaded by reference into StreamManager, and cleared when
+   * the turn ends (setTurnPhase → IDLE). Null while idle: the slider route then
+   * reports accepted:false and persisted settings cover the next turn.
+   */
+  private activeTurnThinkingOverride: ActiveTurnThinkingOverride | null = null;
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
   // Provider-executed tools (for example native web_search/web_fetch) complete inside one
@@ -2806,6 +2815,13 @@ export class AgentSession {
       return Ok(undefined);
     }
 
+    // Turn durably accepted + options finalized: open the mid-turn thinking
+    // override window BEFORE the user-message emit / onAccepted / any further
+    // await, so a slider change during PREPARING (runtime warmup, model
+    // creation) lands in the holder the stream's prepareStep will read.
+    const turnThinkingOverride: ActiveTurnThinkingOverride = {};
+    this.activeTurnThinkingOverride = turnThinkingOverride;
+
     // Emit snapshots only for immediately-sent turns. On on-send compaction paths,
     // snapshots are deferred with the follow-up message to avoid duplicate ephemeral
     // snapshot rows that were never persisted.
@@ -2848,6 +2864,11 @@ export class AgentSession {
     try {
       await internal?.onAccepted?.();
     } catch (error) {
+      // Pre-stream failure: identity-guarded so a replacement turn's holder
+      // (created while this one unwound) is never cleared by mistake.
+      if (this.activeTurnThinkingOverride === turnThinkingOverride) {
+        this.activeTurnThinkingOverride = null;
+      }
       return Err(createUnknownSendMessageError(getErrorMessage(error)));
     }
 
@@ -2887,7 +2908,8 @@ export class AgentSession {
           undefined,
           agentInitiated,
           preparedTurnAbortController.signal,
-          goalKind
+          goalKind,
+          turnThinkingOverride
         );
       } finally {
         // Success should advance via stream events; if startup never emitted any, don't leave the
@@ -2963,6 +2985,10 @@ export class AgentSession {
     // accept its options, even if startup fails before the stream fully begins.
     this.setAutoRetryResumeState(optionsForStream, internal?.agentInitiated, internal?.goalKind);
     this.setTurnPhase(TurnPhase.PREPARING);
+    // Open the mid-turn thinking override window for the resumed turn (after
+    // setTurnPhase(PREPARING), which clears the holder on the IDLE transition).
+    const turnThinkingOverride: ActiveTurnThinkingOverride = {};
+    this.activeTurnThinkingOverride = turnThinkingOverride;
     try {
       // Must await here so the finally block runs after streaming completes,
       // not immediately when the Promise is returned.
@@ -2973,7 +2999,8 @@ export class AgentSession {
         undefined,
         internal?.agentInitiated,
         undefined,
-        internal?.goalKind
+        internal?.goalKind,
+        turnThinkingOverride
       );
       if (!result.success) {
         return result;
@@ -3507,7 +3534,11 @@ export class AgentSession {
     disablePostCompactionAttachments?: boolean,
     agentInitiated?: boolean,
     abortSignal?: AbortSignal,
-    goalKind?: GoalSyntheticMessageKind
+    goalKind?: GoalSyntheticMessageKind,
+    // Session-owned per-turn holder for mid-turn thinking changes. Passed
+    // explicitly (not read from the field) so a preempted turn can never pick
+    // up its replacement's holder. Absent for internal retry paths.
+    activeTurnThinkingOverride?: ActiveTurnThinkingOverride
   ): Promise<Result<void, SendMessageError>> {
     const isStartupAbortRequested = (): boolean => abortSignal?.aborted === true;
 
@@ -3692,6 +3723,10 @@ export class AgentSession {
       disableWorkspaceAgents: options?.disableWorkspaceAgents,
       hasQueuedMessages: this.hasQueuedMessages.bind(this),
       openaiTruncationModeOverride,
+      // Mid-turn thinking overrides clamp against the same floor as the
+      // send-time level above (single source of truth for the floor).
+      minThinkingLevel,
+      activeTurnThinkingOverride,
     });
 
     if (!streamResult.success) {
@@ -5014,6 +5049,10 @@ export class AgentSession {
     this.emitStreamLifecycleIfChanged();
 
     if (next === TurnPhase.IDLE) {
+      // Turn ended: expire any mid-turn thinking override. Safe unconditionally
+      // because a replacement turn (e.g. an edit) only creates its holder after
+      // the preempted turn has already been transitioned to IDLE.
+      this.activeTurnThinkingOverride = null;
       const waiters = this.idleWaiters;
       this.idleWaiters = [];
       for (const resolve of waiters) {
@@ -5024,6 +5063,23 @@ export class AgentSession {
 
   isBusy(): boolean {
     return this.turnPhase !== TurnPhase.IDLE;
+  }
+
+  /**
+   * Mid-turn thinking change: request that the active turn's next model step
+   * uses `level`. Returns accepted:false when no turn is active — the caller
+   * already persisted the setting, which covers the next turn. Last write wins
+   * across consecutive calls; the pending value expires silently if the turn
+   * ends before another model step occurs.
+   */
+  setActiveTurnThinkingLevel(level: ThinkingLevel): { accepted: boolean } {
+    this.assertNotDisposed("setActiveTurnThinkingLevel");
+    const holder = this.activeTurnThinkingOverride;
+    if (!holder) {
+      return { accepted: false };
+    }
+    holder.pending = level;
+    return { accepted: true };
   }
 
   isPreparingTurn(): boolean {

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -57,6 +57,10 @@ import type {
 import { log } from "./log";
 import type { SessionUsageService } from "./sessionUsageService";
 import type { ModelFallbackOptions, StreamManager } from "./streamManager";
+import type {
+  ActiveTurnThinkingOverride,
+  RebuildProviderOptionsForThinkingLevel,
+} from "./thinkingOverride";
 import { ExperimentsService } from "./experimentsService";
 import type { DevToolsService } from "./devToolsService";
 import { TelemetryService } from "@/node/services/telemetryService";
@@ -2954,6 +2958,161 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         model: event.model,
       })
     );
+  });
+
+  describe("mid-turn thinking override rebuild closure", () => {
+    const START_STREAM_THINKING_OVERRIDE_STATE_INDEX = 26;
+    const START_STREAM_THINKING_REBUILD_INDEX = 27;
+
+    function getThinkingOverrideStartStreamArgs(harness: StreamMessageHarness): {
+      holder: unknown;
+      rebuild: RebuildProviderOptionsForThinkingLevel;
+    } {
+      expect(harness.startStreamCalls).toHaveLength(1);
+      const call = harness.startStreamCalls[0];
+      if (!call) {
+        throw new Error("Expected streamManager.startStream call arguments");
+      }
+      const holder = call[START_STREAM_THINKING_OVERRIDE_STATE_INDEX];
+      const rebuild = call[START_STREAM_THINKING_REBUILD_INDEX];
+      expect(typeof rebuild).toBe("function");
+      return { holder, rebuild: rebuild as RebuildProviderOptionsForThinkingLevel };
+    }
+
+    it("threads the session holder by reference and rebuilds options through the same pipeline", async () => {
+      using muxHome = new DisposableTempDir("ai-service-thinking-override");
+      const projectPath = path.join(muxHome.path, "project");
+      await fs.mkdir(projectPath, { recursive: true });
+
+      const workspaceId = "workspace-thinking-override";
+      const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
+      const harness = createHarness(muxHome.path, metadata, {
+        useRequestedModelString: true,
+        canonicalProviderName: "anthropic",
+      });
+
+      const sessionHolder: ActiveTurnThinkingOverride = {};
+      const result = await harness.service.streamMessage({
+        messages: [createMuxMessage("latest-user", "user", "hello")],
+        workspaceId,
+        // Budget-token Anthropic model (no adaptive effort): level changes show
+        // up as thinking.budgetTokens differences.
+        modelString: "anthropic:claude-sonnet-4-5",
+        thinkingLevel: "low",
+        minThinkingLevel: "off",
+        activeTurnThinkingOverride: sessionHolder,
+      });
+      expect(result.success).toBe(true);
+
+      const { holder, rebuild } = getThinkingOverrideStartStreamArgs(harness);
+      // Same object: AgentSession's setter writes must be visible to prepareStep.
+      expect(holder).toBe(sessionHolder);
+
+      // No-op: requested level equals the current effective level.
+      expect(rebuild("low")).toBeNull();
+
+      // Real transition: rebuilt provider options reflect the new level.
+      const rebuilt = rebuild("high");
+      expect(rebuilt?.effectiveLevel).toBe("high");
+      const anthropic = rebuilt?.providerOptions.anthropic as
+        | { thinking?: { type: string; budgetTokens?: number } }
+        | undefined;
+      expect(anthropic?.thinking).toEqual({ type: "enabled", budgetTokens: 20000 });
+
+      // The closure diffs against the LIVE level, not the send-time one:
+      // repeating the applied level is now a no-op.
+      expect(rebuild("high")).toBeNull();
+    });
+
+    it("clamps mid-turn requests against the session-provided floor", async () => {
+      using muxHome = new DisposableTempDir("ai-service-thinking-floor");
+      const projectPath = path.join(muxHome.path, "project");
+      await fs.mkdir(projectPath, { recursive: true });
+
+      const workspaceId = "workspace-thinking-floor";
+      const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
+      const harness = createHarness(muxHome.path, metadata, {
+        useRequestedModelString: true,
+        canonicalProviderName: "anthropic",
+      });
+
+      const result = await harness.service.streamMessage({
+        messages: [createMuxMessage("latest-user", "user", "hello")],
+        workspaceId,
+        modelString: KNOWN_MODELS.SONNET.id,
+        thinkingLevel: "medium",
+        minThinkingLevel: "medium",
+        activeTurnThinkingOverride: {},
+      });
+      expect(result.success).toBe(true);
+
+      const { rebuild } = getThinkingOverrideStartStreamArgs(harness);
+      // Below-floor requests clamp up to the floor, which equals the current
+      // level here — so they must be treated as no-ops, not as downgrades.
+      expect(rebuild("off")).toBeNull();
+      expect(rebuild("low")).toBeNull();
+      // Above-floor requests still apply.
+      expect(rebuild("high")?.effectiveLevel).toBe("high");
+    });
+
+    it("applies Anthropic native-xhigh transitions as plain provider-option rebuilds", async () => {
+      using muxHome = new DisposableTempDir("ai-service-thinking-xhigh");
+      const projectPath = path.join(muxHome.path, "project");
+      await fs.mkdir(projectPath, { recursive: true });
+
+      const workspaceId = "workspace-thinking-xhigh";
+      const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
+      const harness = createHarness(muxHome.path, metadata, {
+        useRequestedModelString: true,
+        canonicalProviderName: "anthropic",
+      });
+
+      const result = await harness.service.streamMessage({
+        messages: [createMuxMessage("latest-user", "user", "hello")],
+        workspaceId,
+        modelString: "anthropic:claude-opus-4-7",
+        thinkingLevel: "high",
+        activeTurnThinkingOverride: {},
+      });
+      expect(result.success).toBe(true);
+
+      const { rebuild } = getThinkingOverrideStartStreamArgs(harness);
+      const rebuilt = rebuild("xhigh");
+      expect(rebuilt?.effectiveLevel).toBe("xhigh");
+      const anthropic = rebuilt?.providerOptions.anthropic as
+        | { effort?: string; thinking?: unknown }
+        | undefined;
+      // Post-wire-hack: the native effort flows directly via provider options.
+      expect(anthropic?.effort).toBe("xhigh");
+      expect(anthropic?.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    });
+
+    it("skips the grok-4-1-fast off<->on transition (model-instance swap)", async () => {
+      using muxHome = new DisposableTempDir("ai-service-thinking-grok");
+      const projectPath = path.join(muxHome.path, "project");
+      await fs.mkdir(projectPath, { recursive: true });
+
+      const workspaceId = "workspace-thinking-grok";
+      const metadata = createLocalWorkspaceMetadata(workspaceId, projectPath);
+      const harness = createHarness(muxHome.path, metadata, {
+        useRequestedModelString: true,
+        canonicalProviderName: "xai" as ProviderName,
+      });
+
+      const result = await harness.service.streamMessage({
+        messages: [createMuxMessage("latest-user", "user", "hello")],
+        workspaceId,
+        modelString: "xai:grok-4-1-fast",
+        thinkingLevel: "off",
+        activeTurnThinkingOverride: {},
+      });
+      expect(result.success).toBe(true);
+
+      const { rebuild } = getThinkingOverrideStartStreamArgs(harness);
+      // off -> high selects a different model instance at creation time; the
+      // in-flight stream cannot express it via provider options.
+      expect(rebuild("high")).toBeNull();
+    });
   });
 });
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -116,9 +116,14 @@ import {
 } from "@/common/types/thinking";
 import {
   enforceThinkingPolicy,
+  isXaiGrokFastVariantSwap,
   resolveEffectiveThinkingLevel,
   resolveMinimumThinkingLevel,
 } from "@/common/utils/thinking/policy";
+import type {
+  ActiveTurnThinkingOverride,
+  RebuildProviderOptionsForThinkingLevel,
+} from "@/node/services/thinkingOverride";
 
 import type {
   ErrorEvent,
@@ -269,6 +274,19 @@ export interface StreamMessageOptions {
   hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
   muxMetadata?: MuxMessageMetadata;
   openaiTruncationModeOverride?: "auto" | "disabled";
+  /**
+   * Model floor already resolved by AgentSession (config.json
+   * minThinkingLevelByModel → resolveMinimumThinkingLevel). Passed down so
+   * mid-turn overrides clamp against the same floor as the send-time level;
+   * internal callers may omit it (re-resolved from defaults).
+   */
+  minThinkingLevel?: ThinkingLevel;
+  /**
+   * Session-owned per-turn holder for mid-turn thinking-level overrides.
+   * When absent (compaction, sub-agent paths), the feature is inert for the
+   * stream. See src/node/services/thinkingOverride.ts.
+   */
+  activeTurnThinkingOverride?: ActiveTurnThinkingOverride;
 }
 
 /**
@@ -1027,6 +1045,8 @@ export class AIService extends EventEmitter {
       hasQueuedMessages,
       openaiTruncationModeOverride,
       muxMetadata,
+      minThinkingLevel: providedMinThinkingLevel,
+      activeTurnThinkingOverride,
     } = opts;
     // Support interrupts during startup (before StreamManager emits stream-start).
     // We register an AbortController up-front and let stopStream() abort it.
@@ -2432,21 +2452,29 @@ export class AIService extends EventEmitter {
       // Recursive merge within the provider namespace preserves non-conflicting nested
       // subfields (e.g., user reasoning.max_tokens alongside Mux reasoning.enabled).
       // Mux-built values win on leaf conflicts for safety of thinking/reasoning/cache.
+      // Shared by the initial build and mid-turn thinking-level rebuilds so both
+      // produce identically-shaped options.
       const providerOptionsNamespaceKey = resolveProviderOptionsNamespaceKey(
         canonicalProviderName,
         routeProvider
       );
-      const muxProviderNamespace = (providerOptions as Record<string, unknown>)?.[
-        providerOptionsNamespaceKey
-      ];
-      const mergedProviderOptions = resolvedOverrides.providerExtras
-        ? {
-            ...providerOptions,
-            [providerOptionsNamespaceKey]: isPlainObject(muxProviderNamespace)
-              ? mergeProviderExtrasUnderMux(resolvedOverrides.providerExtras, muxProviderNamespace)
-              : resolvedOverrides.providerExtras,
-          }
-        : providerOptions;
+      const mergeModelParameterExtras = (
+        builtOptions: Record<string, unknown>
+      ): Record<string, unknown> => {
+        if (!resolvedOverrides.providerExtras) {
+          return builtOptions;
+        }
+        const muxProviderNamespace = builtOptions[providerOptionsNamespaceKey];
+        return {
+          ...builtOptions,
+          [providerOptionsNamespaceKey]: isPlainObject(muxProviderNamespace)
+            ? mergeProviderExtrasUnderMux(resolvedOverrides.providerExtras, muxProviderNamespace)
+            : resolvedOverrides.providerExtras,
+        };
+      };
+      const mergedProviderOptions = mergeModelParameterExtras(
+        providerOptions as Record<string, unknown>
+      );
 
       recordStartupPhaseTiming("buildRequestConfigMs", buildRequestConfigStartedAt);
 
@@ -2456,6 +2484,63 @@ export class AIService extends EventEmitter {
           resolvedOverrides
         );
       }
+
+      // --- Mid-turn thinking-level override support ---
+      // Floor resolved by AgentSession when present; internal callers fall back
+      // to the model default so clamping never loosens below policy.
+      const minThinkingLevel =
+        providedMinThinkingLevel ??
+        resolveMinimumThinkingLevel(modelString, undefined, this.providerService.getConfig());
+      // Rebuilds provider options for a new level using the exact same pipeline
+      // as the initial build (policy clamp → resolveEffectiveThinkingLevel →
+      // buildProviderOptions → providers.jsonc extras merge). Consumed by
+      // StreamManager's prepareStep; `null` ⇒ skip (no-op or model-swap level).
+      const currentEffectiveLevelRef = { current: effectiveThinkingLevel };
+      const rebuildProviderOptionsForThinkingLevel: RebuildProviderOptionsForThinkingLevel = (
+        level
+      ) => {
+        const clamped = enforceThinkingPolicy(
+          modelString,
+          level,
+          minThinkingLevel,
+          this.providerService.getConfig()
+        );
+        const effective = resolveEffectiveThinkingLevel(
+          modelString,
+          clamped,
+          this.providerService.getConfig()
+        );
+        if (effective === currentEffectiveLevelRef.current) {
+          return null;
+        }
+        // off ↔ non-off on grok-4-1-fast selects a different model instance —
+        // not expressible via provider options on the in-flight stream.
+        if (
+          isXaiGrokFastVariantSwap(
+            canonicalModelString,
+            currentEffectiveLevelRef.current,
+            effective
+          )
+        ) {
+          return null;
+        }
+        const rebuilt = buildProviderOptions(
+          modelString,
+          effective,
+          providerRequestMessages,
+          (id) => this.streamManager.isResponseIdLost(id),
+          effectiveMuxProviderOptions,
+          workspaceId,
+          truncationMode,
+          this.providerService.getConfig(),
+          routeProvider,
+          promptCacheScope,
+          reasoningMode
+        );
+        const merged = mergeModelParameterExtras(rebuilt as Record<string, unknown>);
+        currentEffectiveLevelRef.current = effective;
+        return { effectiveLevel: effective, providerOptions: merged };
+      };
 
       // Debug dump: Log the complete LLM request when MUX_DEBUG_LLM_REQUEST is set
       if (process.env.MUX_DEBUG_LLM_REQUEST === "1") {
@@ -2576,16 +2661,19 @@ export class AIService extends EventEmitter {
                 // clamped level may violate the next model's policy/floor (the
                 // providerOptions builders require a policy-valid level, e.g. an
                 // "off" source level on a fixed-effort model like gpt-5-pro).
+                // A mid-turn thinking override folded in by StreamManager wins
+                // over the send-time level.
+                const nextMinThinkingLevel = resolveMinimumThinkingLevel(
+                  nextModelString,
+                  this.config.loadConfigOrDefault().minThinkingLevelByModel?.[
+                    normalizeToCanonical(nextModelString)
+                  ],
+                  this.providerService.getConfig()
+                );
                 const nextThinkingLevel = enforceThinkingPolicy(
                   nextModelString,
-                  effectiveThinkingLevel,
-                  resolveMinimumThinkingLevel(
-                    nextModelString,
-                    this.config.loadConfigOrDefault().minThinkingLevelByModel?.[
-                      normalizeToCanonical(nextModelString)
-                    ],
-                    this.providerService.getConfig()
-                  ),
+                  prepareOptions?.thinkingLevelOverride ?? effectiveThinkingLevel,
+                  nextMinThinkingLevel,
                   this.providerService.getConfig()
                 );
 
@@ -2748,20 +2836,76 @@ export class AIService extends EventEmitter {
                     next.canonicalProviderName,
                     next.routeProvider
                   );
-                  const nextMuxNamespace = (nextProviderOptions as Record<string, unknown>)?.[
-                    nextNamespaceKey
-                  ];
-                  const nextMergedProviderOptions = nextOverrides.providerExtras
-                    ? {
-                        ...nextProviderOptions,
-                        [nextNamespaceKey]: isPlainObject(nextMuxNamespace)
-                          ? mergeProviderExtrasUnderMux(
-                              nextOverrides.providerExtras,
-                              nextMuxNamespace
-                            )
-                          : nextOverrides.providerExtras,
+                  // Mirrors mergeModelParameterExtras for the fallback model;
+                  // shared by this baseline build and mid-turn rebuilds below.
+                  const mergeNextModelParameterExtras = (
+                    builtOptions: Record<string, unknown>
+                  ): Record<string, unknown> => {
+                    if (!nextOverrides.providerExtras) {
+                      return builtOptions;
+                    }
+                    const nextMuxNamespace = builtOptions[nextNamespaceKey];
+                    return {
+                      ...builtOptions,
+                      [nextNamespaceKey]: isPlainObject(nextMuxNamespace)
+                        ? mergeProviderExtrasUnderMux(
+                            nextOverrides.providerExtras,
+                            nextMuxNamespace
+                          )
+                        : nextOverrides.providerExtras,
+                    };
+                  };
+                  const nextMergedProviderOptions = mergeNextModelParameterExtras(
+                    nextProviderOptions as Record<string, unknown>
+                  );
+
+                  // Rebuild closure bound to the FALLBACK model so mid-turn
+                  // thinking changes keep working after the hop.
+                  const nextCurrentEffectiveLevelRef = { current: nextThinkingLevel };
+                  const rebuildNextProviderOptionsForThinkingLevel: RebuildProviderOptionsForThinkingLevel =
+                    (level) => {
+                      const clamped = enforceThinkingPolicy(
+                        next.canonicalModelString,
+                        level,
+                        nextMinThinkingLevel,
+                        this.providerService.getConfig()
+                      );
+                      const effective = resolveEffectiveThinkingLevel(
+                        next.canonicalModelString,
+                        clamped,
+                        this.providerService.getConfig()
+                      );
+                      if (effective === nextCurrentEffectiveLevelRef.current) {
+                        return null;
                       }
-                    : nextProviderOptions;
+                      if (
+                        isXaiGrokFastVariantSwap(
+                          next.canonicalModelString,
+                          nextCurrentEffectiveLevelRef.current,
+                          effective
+                        )
+                      ) {
+                        return null;
+                      }
+                      const rebuilt = buildProviderOptions(
+                        next.canonicalModelString,
+                        effective,
+                        nextProviderRequestMessages,
+                        (id) => this.streamManager.isResponseIdLost(id),
+                        effectiveMuxProviderOptions,
+                        workspaceId,
+                        truncationMode,
+                        this.providerService.getConfig(),
+                        next.routeProvider,
+                        promptCacheScope,
+                        reasoningMode
+                      );
+                      const merged = mergeNextModelParameterExtras(
+                        rebuilt as Record<string, unknown>
+                      );
+                      nextCurrentEffectiveLevelRef.current = effective;
+                      return { effectiveLevel: effective, providerOptions: merged };
+                    };
 
                   return Ok({
                     model: next.model,
@@ -2774,6 +2918,8 @@ export class AIService extends EventEmitter {
                     callSettingsOverrides: nextOverrides.standard,
                     anthropicCacheTtl: effectiveMuxProviderOptions.anthropic?.cacheTtl ?? undefined,
                     thinkingLevel: nextThinkingLevel,
+                    rebuildProviderOptionsForThinkingLevel:
+                      rebuildNextProviderOptionsForThinkingLevel,
                     initialMetadataPatch: {
                       routedThroughGateway: next.routedThroughGateway,
                       ...(next.routeProvider != null ? { routeProvider: next.routeProvider } : {}),
@@ -2841,7 +2987,9 @@ export class AIService extends EventEmitter {
           : undefined,
         runtimeTempDir,
         modelFallback,
-        toolSearchRuntime?.state
+        toolSearchRuntime?.state,
+        activeTurnThinkingOverride,
+        rebuildProviderOptionsForThinkingLevel
       );
       recordStartupPhaseTiming("startStreamMs", startStreamStartedAt);
 

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2416,8 +2416,7 @@ export class AIService extends EventEmitter {
         effectiveMuxProviderOptions,
         workspaceId,
         this.providerService.getConfig(),
-        routeProvider,
-        effectiveThinkingLevel
+        routeProvider
       );
 
       // --- Model parameter overrides from providers.jsonc ---
@@ -2729,8 +2728,7 @@ export class AIService extends EventEmitter {
                     effectiveMuxProviderOptions,
                     workspaceId,
                     this.providerService.getConfig(),
-                    next.routeProvider,
-                    nextThinkingLevel
+                    next.routeProvider
                   );
                   if (pendingRunMetadataId != null) {
                     // Keep DevTools run correlation on fallback requests too.

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -21,7 +21,6 @@ import {
   resolveOpenAIWebSocketResponsesUrl,
   wrapFetchWithAnthropicCacheControl,
 } from "./providerModelFactory";
-import { MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER } from "@/common/utils/ai/providerOptions";
 import { hasLanguageModelCleanup } from "./languageModelCleanup";
 import type { DevToolsService } from "./devToolsService";
 import { CodexOauthService } from "./codexOauthService";
@@ -1634,82 +1633,44 @@ function parseSentBody(call: CapturedFetchCall): Record<string, unknown> {
   return JSON.parse(call.init.body as string) as Record<string, unknown>;
 }
 
-describe("wrapFetchWithAnthropicCacheControl — Opus 4.7+ / Sonnet 5+ wire transforms", () => {
-  for (const model of ["claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-5"] as const) {
-    it(`injects thinking.display=summarized for ${model} adaptive thinking`, async () => {
-      const { calls, fakeFetch } = createCapturingFetch();
-      const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
-      const body = JSON.stringify({
-        model,
-        thinking: { type: "adaptive" },
-        output_config: { effort: "medium" },
-      });
-      await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
-      expect(calls.length).toBe(1);
-      const sent = parseSentBody(calls[0]);
-      expect(sent.thinking).toEqual({ type: "adaptive", display: "summarized" });
-    });
-  }
-
-  it("preserves a user-supplied display value on Opus 4.7", async () => {
+// Effort "xhigh" and thinking.display flow through the SDK directly as of
+// @ai-sdk/anthropic 4.0.11 (see buildProviderOptions), so the wrapper must NOT
+// rewrite reasoning fields — it only normalizes cache_control.
+describe("wrapFetchWithAnthropicCacheControl — reasoning fields pass through unchanged", () => {
+  it("passes native xhigh effort and summarized display through on the direct body", async () => {
     const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
+    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch, null, {
+      injectCacheControl: false,
+    });
     const body = JSON.stringify({
       model: "claude-opus-4-7",
-      thinking: { type: "adaptive", display: "omitted" },
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: "xhigh" },
     });
     await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
-    const sent = parseSentBody(calls[0]) as { thinking: { display: string } };
-    expect(sent.thinking.display).toBe("omitted");
+    expect(calls.length).toBe(1);
+    const sent = parseSentBody(calls[0]);
+    expect(sent.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(sent.output_config).toEqual({ effort: "xhigh" });
   });
 
-  it("rewrites output_config.effort to xhigh when override header is present", async () => {
+  it("does not inject display or rewrite effort for adaptive requests without them", async () => {
     const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
-    const body = JSON.stringify({
-      model: "claude-opus-4-7",
-      thinking: { type: "adaptive" },
-      output_config: { effort: "max" },
+    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch, null, {
+      injectCacheControl: false,
     });
-    await wrapped("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      body,
-      headers: { [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh" },
-    });
-    const sent = parseSentBody(calls[0]) as { output_config: { effort: string } };
-    expect(sent.output_config.effort).toBe("xhigh");
-    // Override header is stripped before forwarding
-    const outHeaders = new Headers(calls[0].init.headers);
-    expect(outHeaders.get(MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER)).toBeNull();
-  });
-
-  it("does not inject display for Opus 4.6 adaptive thinking", async () => {
-    const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
     const body = JSON.stringify({
       model: "claude-opus-4-6",
       thinking: { type: "adaptive" },
+      output_config: { effort: "max" },
     });
     await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
     const sent = parseSentBody(calls[0]);
     expect(sent.thinking).toEqual({ type: "adaptive" });
+    expect(sent.output_config).toEqual({ effort: "max" });
   });
 
-  it("does not inject display when thinking is disabled", async () => {
-    const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch);
-    const body = JSON.stringify({
-      model: "claude-opus-4-7",
-      thinking: { type: "disabled" },
-    });
-    await wrapped("https://api.anthropic.com/v1/messages", { method: "POST", body });
-    const sent = parseSentBody(calls[0]);
-    expect(sent.thinking).toEqual({ type: "disabled" });
-  });
-});
-
-describe("wrapFetchWithAnthropicCacheControl — gateway (AI SDK) body shape", () => {
-  it("injects display=summarized into providerOptions.anthropic.thinking for Opus 4.7 via gateway", async () => {
+  it("passes gateway (AI SDK) body providerOptions through unchanged", async () => {
     const { calls, fakeFetch } = createCapturingFetch();
     const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch, null, {
       injectCacheControl: false,
@@ -1717,7 +1678,7 @@ describe("wrapFetchWithAnthropicCacheControl — gateway (AI SDK) body shape", (
     const body = JSON.stringify({
       prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
       providerOptions: {
-        anthropic: { thinking: { type: "adaptive" }, effort: "medium" },
+        anthropic: { thinking: { type: "adaptive", display: "summarized" }, effort: "xhigh" },
       },
     });
     await wrapped("https://gateway.example.com/v1/language-model", {
@@ -1726,36 +1687,12 @@ describe("wrapFetchWithAnthropicCacheControl — gateway (AI SDK) body shape", (
       headers: { "ai-model-id": "anthropic/claude-opus-4-7" },
     });
     const sent = parseSentBody(calls[0]) as {
-      providerOptions: { anthropic: { thinking: unknown } };
+      providerOptions: { anthropic: { thinking: unknown; effort: string } };
     };
     expect(sent.providerOptions.anthropic.thinking).toEqual({
       type: "adaptive",
       display: "summarized",
     });
-  });
-
-  it("rewrites providerOptions.anthropic.effort to xhigh via gateway", async () => {
-    const { calls, fakeFetch } = createCapturingFetch();
-    const wrapped = wrapFetchWithAnthropicCacheControl(fakeFetch, null, {
-      injectCacheControl: false,
-    });
-    const body = JSON.stringify({
-      prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
-      providerOptions: {
-        anthropic: { thinking: { type: "adaptive" }, effort: "max" },
-      },
-    });
-    await wrapped("https://gateway.example.com/v1/language-model", {
-      method: "POST",
-      body,
-      headers: {
-        "ai-model-id": "anthropic/claude-opus-4-7",
-        [MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER]: "xhigh",
-      },
-    });
-    const sent = parseSentBody(calls[0]) as {
-      providerOptions: { anthropic: { effort: string } };
-    };
     expect(sent.providerOptions.anthropic.effort).toBe("xhigh");
   });
 });

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -3,7 +3,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { XaiProviderOptions } from "@ai-sdk/xai";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { wrapLanguageModel, type LanguageModel } from "ai";
-import { anthropicSupportsNativeXhigh, type ThinkingLevel } from "@/common/types/thinking";
+import type { ThinkingLevel } from "@/common/types/thinking";
 import { Ok, Err } from "@/common/types/result";
 import type { Result } from "@/common/types/result";
 import type { SendMessageError } from "@/common/types/errors";
@@ -49,10 +49,7 @@ import {
 } from "@/node/services/languageModelCleanup";
 import { createOpenAIWebSocketTransportFetch } from "@/node/services/openAIWebSocketTransportFetch";
 import { log } from "@/node/services/log";
-import {
-  MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER,
-  resolveProviderOptionsNamespaceKey,
-} from "@/common/utils/ai/providerOptions";
+import { resolveProviderOptionsNamespaceKey } from "@/common/utils/ai/providerOptions";
 import { resolveRoute, type RouteContext } from "@/common/routing";
 import {
   getExplicitGatewayPrefix as getExplicitGatewayProvider,
@@ -337,66 +334,8 @@ export function wrapFetchWithAnthropicCacheControl(
       return baseFetch(input, init);
     }
 
-    // Detect and strip Mux-internal headers before forwarding.
-    const incomingHeaders = new Headers(init.headers);
-    const effortOverride = incomingHeaders.get(MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER);
-    let headersModified = false;
-    if (effortOverride != null) {
-      incomingHeaders.delete(MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER);
-      headersModified = true;
-    }
-
     try {
       const json = JSON.parse(init.body) as Record<string, unknown>;
-
-      // Native-xhigh adaptive-thinking models (Opus 4.7+ and Sonnet 5+) require
-      // `thinking.display: "summarized"` to return thinking content in the response.
-      // Inject it on the wire for any adaptive thinking request targeting those models.
-      // See https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#summarized-thinking
-      //
-      // Two body shapes to handle:
-      // - Direct Anthropic API:   `{ model, thinking: { type: "adaptive" }, output_config }`
-      // - AI SDK gateway (mux-gateway): `{ prompt, providerOptions: { anthropic: { thinking } } }`
-      //   with the model exposed via the ai-model-id header.
-      const directModel = typeof json.model === "string" ? json.model : "";
-      const headerModelId = incomingHeaders.get("ai-model-id") ?? "";
-      // Reuse the shared native-xhigh detector so the wire-level regex stays in
-      // one place (src/common/types/thinking.ts) — it also normalizes provider
-      // prefixes (e.g., `anthropic/claude-opus-4-7`, `anthropic/claude-sonnet-5`).
-      const targetsNativeXhighModel = [directModel, headerModelId].some(
-        anthropicSupportsNativeXhigh
-      );
-
-      const directThinking = isRecord(json.thinking) ? json.thinking : undefined;
-      const providerOpts = isRecord(json.providerOptions) ? json.providerOptions : undefined;
-      const anthropicOpts =
-        providerOpts && isRecord(providerOpts.anthropic) ? providerOpts.anthropic : undefined;
-      const gatewayThinking =
-        anthropicOpts && isRecord(anthropicOpts.thinking) ? anthropicOpts.thinking : undefined;
-
-      if (targetsNativeXhighModel) {
-        if (directThinking?.type === "adaptive") {
-          directThinking.display ??= "summarized";
-          log.debug("Anthropic wrapper: injected thinking.display=summarized (direct body)");
-        }
-        if (gatewayThinking?.type === "adaptive") {
-          gatewayThinking.display ??= "summarized";
-          log.debug("Anthropic wrapper: injected thinking.display=summarized (gateway body)");
-        }
-      }
-
-      // Native-xhigh Anthropic models use an "xhigh" effort level. The @ai-sdk/anthropic
-      // Zod schema still rejects "xhigh", so providerOptions sends "max" through
-      // the SDK and we rewrite effort here based on the Mux-internal override
-      // header — for both direct and gateway body shapes.
-      if (effortOverride) {
-        if (isRecord(json.output_config)) {
-          json.output_config.effort = effortOverride;
-        }
-        if (anthropicOpts) {
-          anthropicOpts.effort = effortOverride;
-        }
-      }
 
       // Inject cache_control on the last tool if tools array exists.
       // If the SDK already populated cache_control, preserve it but override ttl
@@ -444,15 +383,11 @@ export function wrapFetchWithAnthropicCacheControl(
 
       // Update body with modified JSON
       const newBody = JSON.stringify(json);
-      const outHeaders = incomingHeaders;
+      const outHeaders = new Headers(init.headers);
       outHeaders.delete("content-length"); // Body size changed
       return baseFetch(input, { ...init, headers: outHeaders, body: newBody });
     } catch {
-      // If JSON parsing fails we can't touch the body, but we still need to
-      // strip Mux-internal headers if any were present so Anthropic doesn't see them.
-      if (headersModified) {
-        return baseFetch(input, { ...init, headers: incomingHeaders });
-      }
+      // If JSON parsing fails we can't touch the body; forward unchanged.
       return baseFetch(input, init);
     }
   };
@@ -1202,8 +1137,7 @@ export class ProviderModelFactory {
         // Use getProviderFetch to preserve any user-configured custom fetch (e.g., proxies)
         const baseFetch = getProviderFetch(providerConfig);
         const disableBeta = muxProviderOptions?.anthropic?.disableBetaFeatures === true;
-        // Always wrap to apply Opus 4.7+ wire-level transforms (display + effort
-        // override); skip cache_control injection when beta features are off.
+        // Wrap for cache_control normalization; skip injection when beta features are off.
         const fetchWithCacheControl = wrapFetchWithAnthropicCacheControl(
           baseFetch,
           effectiveAnthropicCacheTtl,
@@ -1716,8 +1650,8 @@ export class ProviderModelFactory {
         const baseFetch = getProviderFetch(providerConfig);
         const isAnthropicModel = modelId.startsWith("anthropic/");
         const disableBeta = muxProviderOptions?.anthropic?.disableBetaFeatures === true;
-        // For Anthropic models via gateway, always wrap to apply Opus 4.7+ wire
-        // transforms; skip cache_control injection when beta features are off.
+        // For Anthropic models via gateway, wrap for cache_control normalization;
+        // skip injection when beta features are off.
         const fetchWithCacheControl = isAnthropicModel
           ? wrapFetchWithAnthropicCacheControl(baseFetch, effectiveAnthropicCacheTtl, {
               injectCacheControl: !disableBeta,

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -5436,6 +5436,7 @@ describe("StreamManager - mid-turn thinking override", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // onToolExecutionStart
       state,
       rebuild
     );

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -15,6 +15,10 @@ import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import type { ToolSearchStreamState } from "@/common/utils/tools/toolCatalog";
 import { StreamManager, type ModelFallbackPrepareOptions } from "./streamManager";
+import type {
+  ActiveTurnThinkingOverride,
+  RebuildProviderOptionsForThinkingLevel,
+} from "./thinkingOverride";
 import { stripEncryptedContent } from "@/node/utils/messages/stripEncryptedContent";
 import * as aiSdk from "ai";
 import {
@@ -5213,5 +5217,330 @@ describe("StreamManager - tool search activeTools scoping", () => {
     // Same reference, not a copy — tool_search.execute mutations must be
     // visible to prepareStep.
     expect(request.toolSearchState).toBe(toolSearchState);
+  });
+});
+
+describe("StreamManager - mid-turn thinking override", () => {
+  interface OverrideRequestForTests {
+    model: unknown;
+    messages: ModelMessage[];
+    system?: string;
+    providerOptions?: Record<string, unknown>;
+    thinkingOverrideState?: ActiveTurnThinkingOverride;
+    rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel;
+  }
+
+  type BuildStreamRequestConfig = (...args: unknown[]) => OverrideRequestForTests;
+  type CreateStreamResult = (
+    request: OverrideRequestForTests,
+    abortController: AbortController
+  ) => unknown;
+  type CapturedPrepareStep = (options: { messages: ModelMessage[] }) => Promise<
+    | {
+        messages?: ModelMessage[];
+        activeTools?: string[];
+        providerOptions?: Record<string, unknown>;
+      }
+    | undefined
+  >;
+
+  const model = createAnthropic({ apiKey: "test" })("claude-sonnet-4-5");
+  const messages: ModelMessage[] = [{ role: "user", content: "hello" }];
+
+  function getRequestHelpers(streamManager: StreamManager): {
+    buildRequestConfig: BuildStreamRequestConfig;
+    createStreamResult: CreateStreamResult;
+  } {
+    const buildRequestConfig = Reflect.get(streamManager, "buildStreamRequestConfig") as
+      | ((...args: unknown[]) => OverrideRequestForTests)
+      | undefined;
+    const createStreamResultMethod = Reflect.get(streamManager, "createStreamResult") as
+      | CreateStreamResult
+      | undefined;
+    expect(typeof buildRequestConfig).toBe("function");
+    expect(typeof createStreamResultMethod).toBe("function");
+    if (!buildRequestConfig || !createStreamResultMethod) {
+      throw new Error("Expected StreamManager private helpers to exist");
+    }
+    return {
+      buildRequestConfig: (...args) => buildRequestConfig.apply(streamManager, args),
+      createStreamResult: (request, abortController) =>
+        createStreamResultMethod.call(streamManager, request, abortController),
+    };
+  }
+
+  function setupStreamTextSpy() {
+    return spyOn(aiSdk, "streamText").mockReturnValue({
+      fullStream: (async function* asyncGenerator() {
+        yield* [] as unknown[];
+        await Promise.resolve();
+      })(),
+      usage: Promise.resolve(undefined),
+      providerMetadata: Promise.resolve(undefined),
+      totalUsage: Promise.resolve(undefined),
+      steps: Promise.resolve([]),
+    } as unknown as ReturnType<typeof aiSdk.streamText>);
+  }
+
+  function capturePrepareStep(
+    streamTextSpy: ReturnType<typeof setupStreamTextSpy>
+  ): CapturedPrepareStep {
+    const prepareStep = streamTextSpy.mock.calls[0]?.[0]?.prepareStep as
+      | CapturedPrepareStep
+      | undefined;
+    expect(typeof prepareStep).toBe("function");
+    if (!prepareStep) {
+      throw new Error("Expected prepareStep to be captured");
+    }
+    return prepareStep;
+  }
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("applies a pending override in place: same object identity, old keys deleted, sink invoked", async () => {
+    const streamManager = new StreamManager(historyService);
+    const { createStreamResult } = getRequestHelpers(streamManager);
+    const streamTextSpy = setupStreamTextSpy();
+
+    const appliedLevels: string[] = [];
+    const state: ActiveTurnThinkingOverride = {
+      pending: "high",
+      onApplied: (level) => appliedLevels.push(level),
+    };
+    const originalProviderOptions: Record<string, unknown> = {
+      anthropic: { effort: "low", thinking: { type: "enabled", budgetTokens: 4000 } },
+      staleNamespace: { key: "must-be-deleted" },
+    };
+    const rebuilt = { anthropic: { effort: "high", thinking: { type: "enabled" } } };
+    const rebuild = mock((level: string) =>
+      level === "high" ? { effectiveLevel: "high" as const, providerOptions: rebuilt } : null
+    );
+
+    const request: OverrideRequestForTests = {
+      model,
+      messages,
+      system: "system",
+      providerOptions: originalProviderOptions,
+      thinkingOverrideState: state,
+      rebuildProviderOptionsForThinkingLevel:
+        rebuild as unknown as RebuildProviderOptionsForThinkingLevel,
+    };
+    createStreamResult(request, new AbortController());
+    const prepareStep = capturePrepareStep(streamTextSpy);
+
+    const step = await prepareStep({ messages });
+    // Rebuilt options are returned for the step (defense in depth) …
+    expect(step?.providerOptions).toEqual(rebuilt);
+    // … and the live request object is replaced IN PLACE (same identity),
+    // deleting keys the SDK's deep-merge could never remove.
+    expect(request.providerOptions).toBe(originalProviderOptions);
+    expect(request.providerOptions).toEqual(rebuilt);
+    expect("staleNamespace" in originalProviderOptions).toBe(false);
+    // Consume-once bookkeeping + metadata sink.
+    expect(state.pending).toBeUndefined();
+    expect(state.applied).toBe("high");
+    expect(appliedLevels).toEqual(["high"]);
+    // Without a new pending value the next step is a no-op again.
+    expect(await prepareStep({ messages })).toBeUndefined();
+    expect(rebuild).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears pending without touching options when the rebuild reports not-applicable", async () => {
+    const streamManager = new StreamManager(historyService);
+    const { createStreamResult } = getRequestHelpers(streamManager);
+    const streamTextSpy = setupStreamTextSpy();
+
+    const state: ActiveTurnThinkingOverride = { pending: "off" };
+    const originalProviderOptions: Record<string, unknown> = { xai: { some: "config" } };
+    const rebuild = mock(() => null);
+
+    const request: OverrideRequestForTests = {
+      model,
+      messages,
+      system: "system",
+      providerOptions: originalProviderOptions,
+      thinkingOverrideState: state,
+      rebuildProviderOptionsForThinkingLevel:
+        rebuild as unknown as RebuildProviderOptionsForThinkingLevel,
+    };
+    createStreamResult(request, new AbortController());
+    const prepareStep = capturePrepareStep(streamTextSpy);
+
+    expect(await prepareStep({ messages })).toBeUndefined();
+    expect(request.providerOptions).toEqual({ xai: { some: "config" } });
+    // Consume-once: a skipped application must not retry on every later step.
+    expect(state.pending).toBeUndefined();
+    expect(state.applied).toBeUndefined();
+    expect(await prepareStep({ messages })).toBeUndefined();
+    expect(rebuild).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays byte-identical to the feature-off behavior when no override state exists", async () => {
+    const streamManager = new StreamManager(historyService);
+    const { createStreamResult } = getRequestHelpers(streamManager);
+    const streamTextSpy = setupStreamTextSpy();
+
+    createStreamResult({ model, messages, system: "system" }, new AbortController());
+    const prepareStep = capturePrepareStep(streamTextSpy);
+    expect(await prepareStep({ messages })).toBeUndefined();
+  });
+
+  test("buildStreamRequestConfig normalizes providerOptions to a stable mutable object only when a rebuild closure exists", () => {
+    const streamManager = new StreamManager(historyService);
+    const { buildRequestConfig, createStreamResult } = getRequestHelpers(streamManager);
+    const streamTextSpy = setupStreamTextSpy();
+
+    const state: ActiveTurnThinkingOverride = {};
+    const rebuild: RebuildProviderOptionsForThinkingLevel = () => null;
+
+    // Without the closure, an absent providerOptions stays absent (no behavior change).
+    const plainRequest = buildRequestConfig(
+      model,
+      KNOWN_MODELS.SONNET.id,
+      messages,
+      "system",
+      undefined, // routeProvider
+      undefined, // tools
+      undefined, // providerOptions
+      undefined, // maxOutputTokens
+      undefined, // callSettingsOverrides
+      undefined, // toolPolicy
+      undefined, // hasQueuedMessages
+      undefined, // headers
+      undefined, // anthropicCacheTtlOverride
+      undefined, // onChunk
+      undefined, // onStepMessages
+      undefined // toolSearchState
+    );
+    expect(plainRequest.providerOptions).toBeUndefined();
+
+    // With the closure, undefined normalizes to a mutable object whose identity
+    // is exactly what streamText() captures — otherwise in-place mutation at
+    // prepareStep time would be unobservable to the SDK's per-step merge.
+    const request = buildRequestConfig(
+      model,
+      KNOWN_MODELS.SONNET.id,
+      messages,
+      "system",
+      undefined,
+      undefined,
+      undefined, // providerOptions intentionally absent
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      state,
+      rebuild
+    );
+    expect(request.providerOptions).toEqual({});
+    expect(request.thinkingOverrideState).toBe(state);
+    expect(request.rebuildProviderOptionsForThinkingLevel).toBe(rebuild);
+
+    createStreamResult(request, new AbortController());
+    const streamTextArgs = streamTextSpy.mock.calls[0]?.[0];
+    expect(streamTextArgs?.providerOptions).toBe(
+      request.providerOptions as NonNullable<typeof streamTextArgs>["providerOptions"]
+    );
+  });
+
+  test("model fallback folds the pending override into prepare() and rebinds holder + closure on the swapped request", async () => {
+    const streamManager = new StreamManager(historyService);
+    Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+
+    const workspaceId = "thinking-fallback-workspace";
+    const messageId = "thinking-fallback-message";
+    const historySequence = 1;
+    const fallbackModel = KNOWN_MODELS.GPT.id;
+
+    await appendPartialAssistantForTests(workspaceId, messageId, historySequence);
+    const processStreamWithCleanup = getProcessStreamWithCleanupForTests(streamManager);
+
+    const capturedNextRequests: OverrideRequestForTests[] = [];
+    const createStreamResult = mock((request: OverrideRequestForTests) => {
+      capturedNextRequests.push(request);
+      return createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "text-delta", text: "fallback answer" };
+          yield { type: "finish", finishReason: "stop" };
+        })(),
+        { inputTokens: 5, outputTokens: 3, totalTokens: 8 }
+      );
+    });
+    expect(Reflect.set(streamManager, "createStreamResult", createStreamResult)).toBe(true);
+
+    const fallbackLanguageModel = createTestLanguageModel("fallback-model");
+    const fallbackRebuild: RebuildProviderOptionsForThinkingLevel = () => null;
+    const prepare = mock((nextModelString: string, options?: ModelFallbackPrepareOptions) => {
+      expect(options?.thinkingLevelOverride).toBe("high");
+      return Promise.resolve(
+        Ok({
+          model: fallbackLanguageModel,
+          modelString: nextModelString,
+          messages: [],
+          system: "fallback system",
+          tools: undefined,
+          thinkingLevel: "high",
+          rebuildProviderOptionsForThinkingLevel: fallbackRebuild,
+        })
+      );
+    });
+
+    // Pending override that never got a next step on the refusing stream: the
+    // fallback hop must not silently revert it.
+    const holder: ActiveTurnThinkingOverride = { pending: "high" };
+    const startTime = Date.now() - 250;
+    const streamInfo = createStreamInfoForTests({
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "finish", finishReason: "content-filter", rawFinishReason: "refusal" };
+        })(),
+        { inputTokens: 10, outputTokens: 0, totalTokens: 10 }
+      ),
+      messageId,
+      startTime,
+      lastPartTimestamp: startTime,
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      historySequence,
+      runtime: LOCAL_TEST_RUNTIME,
+      request: {
+        model: createTestLanguageModel("refused-model"),
+        messages: [],
+        providerOptions: undefined,
+        thinkingOverrideState: holder,
+      },
+      modelFallback: {
+        options: { chain: [fallbackModel], prepare },
+        requestedModel: KNOWN_MODELS.SONNET.id,
+        refusedModels: [],
+        original: { maxOutputTokens: undefined },
+      },
+    });
+
+    await processStreamWithCleanup.call(streamManager, workspaceId, streamInfo, historySequence);
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    // Pending was folded into the fallback baseline (consumed, kept as applied
+    // for potential second hops).
+    expect(holder.pending).toBeUndefined();
+    expect(holder.applied).toBe("high");
+    // The swapped request carries the SAME holder (the session setter keeps
+    // working) and the fallback-bound rebuild closure.
+    expect(createStreamResult).toHaveBeenCalledTimes(1);
+    const nextRequest = capturedNextRequests[0];
+    expect(nextRequest?.thinkingOverrideState).toBe(holder);
+    expect(nextRequest?.rebuildProviderOptionsForThinkingLevel).toBe(fallbackRebuild);
   });
 });

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import { EventEmitter } from "events";
 import * as path from "path";
 import { PlatformPaths } from "@/common/utils/paths";
@@ -14,6 +15,7 @@ import {
   RetryError,
 } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
+import type { ProviderOptions } from "@ai-sdk/provider-utils";
 import type { Result } from "@/common/types/result";
 import assert from "@/common/utils/assert";
 import { Ok, Err } from "@/common/types/result";
@@ -32,6 +34,10 @@ import type {
 import type { SendMessageError, StreamErrorType } from "@/common/types/errors";
 import type { MuxMetadata, MuxMessage, PersistedToolModelUsage } from "@/common/types/message";
 import type { ThinkingLevel } from "@/common/types/thinking";
+import type {
+  ActiveTurnThinkingOverride,
+  RebuildProviderOptionsForThinkingLevel,
+} from "@/node/services/thinkingOverride";
 import type { NestedToolCall } from "@/common/orpc/schemas/message";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
 import {
@@ -190,6 +196,19 @@ interface StreamRequestConfig {
    * `activeTools`. Absent when the feature is inactive.
    */
   toolSearchState?: ToolSearchStreamState;
+  /**
+   * Mid-turn thinking override holder — the SESSION'S object, by reference
+   * (never created inside StreamManager: a locally-created object would be
+   * invisible to AgentSession.setActiveTurnThinkingLevel). prepareStep
+   * consumes `pending` before every model step.
+   */
+  thinkingOverrideState?: ActiveTurnThinkingOverride;
+  /**
+   * Closure built by AIService that re-runs the effective-level pipeline
+   * (policy clamp + resolveEffectiveThinkingLevel) and rebuilds provider
+   * options for the stream's model. `null` ⇒ not applicable / no-op.
+   */
+  rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel;
 }
 
 /**
@@ -220,6 +239,12 @@ export interface PreparedModelFallback {
   thinkingLevel?: string;
   /** Route attribution corrections (routedThroughGateway, routeProvider, costsIncluded). */
   initialMetadataPatch?: Partial<MuxMetadata>;
+  /**
+   * Rebuild closure bound to the FALLBACK model so mid-turn thinking changes
+   * keep working after a fallback hop (the source model's closure would build
+   * options for the wrong model).
+   */
+  rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel;
 }
 
 export interface ModelFallbackPrepareOptions {
@@ -229,6 +254,12 @@ export interface ModelFallbackPrepareOptions {
    * receives it so provider-message preparation cannot mutate live UI parts.
    */
   continuation?: { assistantMessage: MuxMessage };
+  /**
+   * Mid-turn thinking level to fold into the fallback's baseline: pending (not
+   * yet applied) or already-applied override from the refused stream. The
+   * fallback prepare re-clamps it for the next model.
+   */
+  thinkingLevelOverride?: ThinkingLevel;
 }
 
 export interface ModelFallbackOptions {
@@ -1573,9 +1604,16 @@ export class StreamManager extends EventEmitter {
     onChunk?: StreamTextOnChunk,
     onStepMessages?: (messages: ModelMessage[]) => void,
     toolSearchState?: ToolSearchStreamState,
-    onToolExecutionStart?: (toolCallId: string) => void
+    onToolExecutionStart?: (toolCallId: string) => void,
+    thinkingOverrideState?: ActiveTurnThinkingOverride,
+    rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel
   ): StreamRequestConfig {
-    const finalProviderOptions = providerOptions;
+    // Mid-turn thinking overrides mutate providerOptions IN PLACE (the SDK's
+    // per-step deep-merge reads the object passed at streamText() time, so
+    // identity must stay stable). An initially-undefined value would make that
+    // mutation unobservable — normalize to a guaranteed mutable object.
+    const finalProviderOptions =
+      rebuildProviderOptionsForThinkingLevel != null ? (providerOptions ?? {}) : providerOptions;
 
     // Apply cache control for Anthropic models
     let finalMessages = messages;
@@ -1648,6 +1686,8 @@ export class StreamManager extends EventEmitter {
       onStepMessages,
       toolPolicy,
       toolSearchState,
+      thinkingOverrideState,
+      rebuildProviderOptionsForThinkingLevel,
     };
   }
 
@@ -1703,6 +1743,57 @@ export class StreamManager extends EventEmitter {
     ];
   }
 
+  /**
+   * Consume a pending mid-turn thinking-level override for the next step.
+   *
+   * Consume-once: `pending` is always cleared (a failed/no-op application must
+   * not retry on every subsequent step). On success the CONTENT of
+   * `request.providerOptions` is replaced in place — object identity is
+   * preserved because the SDK's per-step deep-merge reads the reference passed
+   * at streamText() time, and deep-merge alone cannot delete keys (e.g. the
+   * Anthropic `thinking` object when moving to "off").
+   *
+   * Returns the rebuilt options (for the prepareStep return value) or
+   * undefined when there is nothing to apply.
+   */
+  private applyPendingThinkingOverride(
+    request: StreamRequestConfig
+  ): Record<string, unknown> | undefined {
+    const state = request.thinkingOverrideState;
+    const pending = state?.pending;
+    if (state == null || pending == null) {
+      return undefined;
+    }
+    state.pending = undefined;
+    const rebuild = request.rebuildProviderOptionsForThinkingLevel;
+    if (rebuild == null) {
+      return undefined;
+    }
+    const rebuilt = rebuild(pending);
+    if (rebuilt == null) {
+      log.debug("Mid-turn thinking override skipped (not applicable / no-op)", {
+        requestedLevel: pending,
+        appliedLevel: state.applied,
+      });
+      return undefined;
+    }
+    const target = request.providerOptions;
+    // buildStreamRequestConfig normalizes providerOptions to a stable object
+    // whenever a rebuild closure is present, so target must exist here.
+    assert(target != null, "providerOptions must be normalized when a rebuild closure is present");
+    for (const key of Object.keys(target)) {
+      delete target[key];
+    }
+    Object.assign(target, rebuilt.providerOptions);
+    state.applied = rebuilt.effectiveLevel;
+    state.onApplied?.(rebuilt.effectiveLevel);
+    log.debug("Mid-turn thinking override applied", {
+      requestedLevel: pending,
+      effectiveLevel: rebuilt.effectiveLevel,
+    });
+    return rebuilt.providerOptions;
+  }
+
   private createStreamResult(
     request: StreamRequestConfig,
     abortController: AbortController,
@@ -1740,10 +1831,25 @@ export class StreamManager extends EventEmitter {
         // undefined when the feature is inactive, keeping the return value
         // byte-identical to the pre-feature behavior.
         const activeTools = computeActiveToolNames(request.toolSearchState);
-        if (rewritten === stepMessages && activeTools === undefined) return undefined;
+        // Mid-turn thinking-level change: consume a pending override before
+        // this step's provider request is built.
+        const thinkingOverride = this.applyPendingThinkingOverride(request);
+        if (
+          rewritten === stepMessages &&
+          activeTools === undefined &&
+          thinkingOverride === undefined
+        ) {
+          return undefined;
+        }
         return {
           ...(rewritten === stepMessages ? {} : { messages: rewritten }),
           ...(activeTools !== undefined ? { activeTools } : {}),
+          // Defense in depth: the in-place request mutation is authoritative
+          // (per-step deep-merge cannot delete keys); returning the rebuilt
+          // options also covers any future SDK options snapshotting.
+          ...(thinkingOverride !== undefined
+            ? { providerOptions: thinkingOverride as ProviderOptions }
+            : {}),
         };
       },
       onChunk: request.onChunk,
@@ -1786,7 +1892,9 @@ export class StreamManager extends EventEmitter {
     onChunk?: StreamTextOnChunk,
     onStepMessages?: (messages: ModelMessage[]) => void,
     modelFallback?: ModelFallbackOptions,
-    toolSearchState?: ToolSearchStreamState
+    toolSearchState?: ToolSearchStreamState,
+    thinkingOverrideState?: ActiveTurnThinkingOverride,
+    rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel
   ): WorkspaceStreamInfo {
     // abortController is created and linked to the caller-provided abortSignal in startStream().
 
@@ -1809,7 +1917,9 @@ export class StreamManager extends EventEmitter {
       onChunk,
       onStepMessages,
       toolSearchState,
-      (toolCallId) => this.handleToolExecutionStart(workspaceId, messageId, toolCallId)
+      (toolCallId) => this.handleToolExecutionStart(workspaceId, messageId, toolCallId),
+      thinkingOverrideState,
+      rebuildProviderOptionsForThinkingLevel
     );
 
     // Start streaming - this can throw immediately if API key is missing
@@ -1871,6 +1981,19 @@ export class StreamManager extends EventEmitter {
       cumulativeUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
       cumulativeProviderMetadata: undefined,
     };
+
+    // Mid-turn thinking override: route applied levels into this stream's
+    // metadata (partials, stream-end, final assistant message). Wired before
+    // any step can run; the catch-up sync covers a holder that already applied
+    // a level (e.g. re-attachment on retry paths).
+    if (request.thinkingOverrideState) {
+      request.thinkingOverrideState.onApplied = (level) => {
+        streamInfo.thinkingLevel = level;
+      };
+      if (request.thinkingOverrideState.applied) {
+        streamInfo.thinkingLevel = request.thinkingOverrideState.applied;
+      }
+    }
 
     // Atomically register the stream
     this.workspaceStreams.set(workspaceId, streamInfo);
@@ -2436,14 +2559,28 @@ export class StreamManager extends EventEmitter {
     // it would be categorized as a retryable api/unknown error and re-enter the
     // unbounded auto-retry loop this feature exists to prevent. Aborts rethrow so
     // a user interrupt during prepare stays an abort instead of a refusal.
+    // Fold a mid-turn thinking override (pending or already applied) into the
+    // fallback's baseline so the hop doesn't silently revert the user's
+    // mid-turn change. Pending is cleared here — prepare() re-clamps it for
+    // the fallback model and bakes it into the rebuilt provider options.
+    const overrideHolder = streamInfo.request.thinkingOverrideState;
+    const thinkingLevelOverride = overrideHolder?.pending ?? overrideHolder?.applied;
+    if (overrideHolder?.pending != null) {
+      overrideHolder.pending = undefined;
+    }
+    if (overrideHolder != null && thinkingLevelOverride != null) {
+      // Keep the override visible to later hops: prepare() bakes it into this
+      // hop's baseline, but a second hop re-folds from `applied`.
+      overrideHolder.applied = thinkingLevelOverride;
+    }
     let prepared: Result<PreparedModelFallback, string>;
     try {
-      prepared = await fallbackState.options.prepare(
-        nextModelString,
-        continuation?.success === true
+      prepared = await fallbackState.options.prepare(nextModelString, {
+        ...(continuation?.success === true
           ? { continuation: { assistantMessage: continuation.data } }
-          : undefined
-      );
+          : {}),
+        ...(thinkingLevelOverride != null ? { thinkingLevelOverride } : {}),
+      });
     } catch (error) {
       if (streamInfo.abortController.signal.aborted) {
         throw error;
@@ -2485,7 +2622,12 @@ export class StreamManager extends EventEmitter {
       // Same state object: aiService's fallback prepare() rebuilt it in place
       // against the fallback toolset, so prepareStep keeps reading live state.
       streamInfo.request.toolSearchState,
-      (toolCallId) => this.handleToolExecutionStart(workspaceId, streamInfo.messageId, toolCallId)
+      (toolCallId) => this.handleToolExecutionStart(workspaceId, streamInfo.messageId, toolCallId),
+      // Same holder object (the session's setter keeps working across the
+      // hop) with a closure bound to the FALLBACK model. Attached before
+      // createStreamResult below in case the SDK eagerly prepares step 1.
+      streamInfo.request.thinkingOverrideState,
+      prepared.data.rebuildProviderOptionsForThinkingLevel
     );
     // createStreamResult may eagerly prepare the first fallback step and update
     // latestMessages. Clear stale source-step messages before starting it so a
@@ -3935,7 +4077,9 @@ export class StreamManager extends EventEmitter {
     onStepMessages?: (messages: ModelMessage[]) => void,
     providedRuntimeTempDir?: string,
     modelFallback?: ModelFallbackOptions,
-    toolSearchState?: ToolSearchStreamState
+    toolSearchState?: ToolSearchStreamState,
+    thinkingOverrideState?: ActiveTurnThinkingOverride,
+    rebuildProviderOptionsForThinkingLevel?: RebuildProviderOptionsForThinkingLevel
   ): Promise<Result<StreamToken, SendMessageError>> {
     const typedWorkspaceId = workspaceId as WorkspaceId;
 
@@ -4019,7 +4163,9 @@ export class StreamManager extends EventEmitter {
           onChunk,
           onStepMessages,
           modelFallback,
-          toolSearchState
+          toolSearchState,
+          thinkingOverrideState,
+          rebuildProviderOptionsForThinkingLevel
         );
 
         // Guard against a narrow race:

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import { EventEmitter } from "events";
 import * as path from "path";
 import { PlatformPaths } from "@/common/utils/paths";

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2573,14 +2573,18 @@ export class StreamManager extends EventEmitter {
       // hop's baseline, but a second hop re-folds from `applied`.
       overrideHolder.applied = thinkingLevelOverride;
     }
+    const prepareCallOptions: ModelFallbackPrepareOptions | undefined =
+      continuation?.success === true || thinkingLevelOverride != null
+        ? {
+            ...(continuation?.success === true
+              ? { continuation: { assistantMessage: continuation.data } }
+              : {}),
+            ...(thinkingLevelOverride != null ? { thinkingLevelOverride } : {}),
+          }
+        : undefined;
     let prepared: Result<PreparedModelFallback, string>;
     try {
-      prepared = await fallbackState.options.prepare(nextModelString, {
-        ...(continuation?.success === true
-          ? { continuation: { assistantMessage: continuation.data } }
-          : {}),
-        ...(thinkingLevelOverride != null ? { thinkingLevelOverride } : {}),
-      });
+      prepared = await fallbackState.options.prepare(nextModelString, prepareCallOptions);
     } catch (error) {
       if (streamInfo.abortController.signal.aborted) {
         throw error;

--- a/src/node/services/thinkingOverride.ts
+++ b/src/node/services/thinkingOverride.ts
@@ -1,0 +1,40 @@
+/**
+ * Mid-turn thinking-level override state.
+ *
+ * One holder object is created per turn by AgentSession (at durable turn
+ * acceptance) and threaded BY REFERENCE down through AIService into
+ * StreamManager's request config — the same shared-mutable-state pattern as
+ * ToolSearchStreamState. The renderer's thinking slider writes `pending` via
+ * AgentSession.setActiveTurnThinkingLevel; StreamManager consumes it at the
+ * next prepareStep (which runs before every model step, including step 1, so
+ * changes during the PREPARING window apply to the turn's first request).
+ *
+ * Node-runtime-local: carries a callback, so it does not belong in
+ * src/common/types (never crosses IPC).
+ */
+import type { ThinkingLevel } from "@/common/types/thinking";
+
+export interface ActiveTurnThinkingOverride {
+  /** Raw level requested mid-turn; consumed at the next prepareStep (incl. step 1). */
+  pending?: ThinkingLevel;
+  /** Effective level after the most recent successful application. */
+  applied?: ThinkingLevel;
+  /** Sink wired by StreamManager to the owning streamInfo (metadata). */
+  onApplied?: (level: ThinkingLevel) => void;
+}
+
+/**
+ * Result of rebuilding provider options for a mid-turn thinking-level change.
+ * `null` from the rebuild closure means "not applicable / no-op" (e.g. the
+ * clamped level equals the current one, or the transition would require a
+ * different model instance) — the pending override is then dropped for this
+ * turn and the persisted setting still covers the next turn.
+ */
+export interface RebuiltThinkingProviderOptions {
+  effectiveLevel: ThinkingLevel;
+  providerOptions: Record<string, unknown>;
+}
+
+export type RebuildProviderOptionsForThinkingLevel = (
+  level: ThinkingLevel
+) => RebuiltThinkingProviderOptions | null;

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -218,6 +218,16 @@ function createFrontendWorkspaceMetadata(
   };
 }
 
+describe("WorkspaceService.setActiveTurnThinkingLevel", () => {
+  test("returns accepted:false when the workspace has no session", () => {
+    const workspaceService = createWorkspaceServiceForTest({ config: {} });
+    // No session was ever created for this workspace: nothing is running, so
+    // the mid-turn override is a no-op and persisted settings cover the next turn.
+    const result = workspaceService.setActiveTurnThinkingLevel("unknown-workspace", "high");
+    expect(result).toEqual(Ok({ accepted: false }));
+  });
+});
+
 describe("WorkspaceService bash monitor wakes", () => {
   test("sends a synthetic wake and marks the record delivered when monitor output matches", async () => {
     const { config, cleanup } = await createTestHistoryService();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -7125,6 +7125,27 @@ export class WorkspaceService extends EventEmitter {
     }
   }
 
+  /**
+   * Mid-turn thinking change: forward the requested level to the workspace's
+   * active turn (if any). Deliberately `sessions.get`, not getOrCreateSession —
+   * creating a session to tell it "change the turn you don't have" is pointless;
+   * persisted settings already cover the next turn.
+   */
+  setActiveTurnThinkingLevel(
+    workspaceId: string,
+    level: ThinkingLevel
+  ): Result<{ accepted: boolean }, string> {
+    try {
+      const session = this.sessions.get(workspaceId.trim());
+      if (!session) {
+        return Ok({ accepted: false });
+      }
+      return Ok(session.setActiveTurnThinkingLevel(level));
+    } catch (error) {
+      return Err(`Failed to set active-turn thinking level: ${getErrorMessage(error)}`);
+    }
+  }
+
   async fork(
     sourceWorkspaceId: string,
     newName?: string,


### PR DESCRIPTION
## Summary

Changing the thinking/reasoning slider during an active turn now applies to the **next model step** (the next provider request after the current tool execution), instead of only taking effect on the next user message. Idle-time changes behave exactly as before.

## Background

Each assistant turn spans multiple provider requests separated by tool executions, and long agentic turns can run for many minutes. Previously the thinking level was frozen at send time, so lowering effort on an obviously-mechanical stretch (or raising it when the agent got stuck) required interrupting the stream. Provider APIs are stateless per request — nothing prevents per-step reasoning changes; Mux just never rebuilt provider options mid-turn.

As a prerequisite, the Anthropic xhigh wire hack (header-marker + fetch-wrapper body rewrite) is removed: the installed `@ai-sdk/anthropic` passes `effort: "xhigh"` and adaptive `thinking.display` through provider options directly, so mid-turn rebuilds produce correct wire output without a parallel hack path.

## Implementation

- **Per-turn override holder** (`src/node/services/thinkingOverride.ts`): a small mutable `{ pending, applied, onApplied }` object created by `AgentSession` once a turn is durably accepted, shared by reference through AIService into StreamManager. Created before any async startup work, which closes the race where a slider change lands while the turn is still PREPARING (applies to its first request).
- **New ORPC route** `workspace.setActiveTurnThinkingLevel`: writes `pending` (last-write-wins) on the live session; returns `accepted: false` when idle/unknown. The frontend `ThinkingContext` fires it best-effort after the existing persistence path, so workspace-setting semantics are unchanged.
- **Consumption in `prepareStep`** (StreamManager): the pending level is consumed exactly once per change; provider options are rebuilt via an AIService-owned closure that repeats the send-time pipeline (min-level floor → policy clamp → effective-level resolution → provider options → `providers.jsonc` extras). The live `request.providerOptions` object is mutated **in place** because the AI SDK deep-merges per-step options and cannot remove stale nested keys (e.g. Anthropic `thinking` on a → off transition); the rebuilt options are also returned from `prepareStep` as defense in depth.
- **Model fallback** rebinds the same holder with a closure bound to the fallback model; same-stream retries preserve holder and mutated options.
- Out of scope (persisted setting still applies next turn): xAI `grok-4-1-fast` off↔non-off (requires a model-instance swap), model changes, OpenAI Pro `reasoningMode`, ACP sessions.

## Validation

Dogfooded against the live Anthropic API (direct route) in a dev-server sandbox, with per-step wire evidence from `devtools.jsonl` (`rawRequest.thinking` / `.output_config`, steps identified by message-count progression within one turn):

- **low → high mid-turn** (Sonnet 4.5): `budget_tokens` 4000 → 20000 at the next step.
- **high → off mid-turn**: `thinking` key deleted from subsequent requests, zero API errors (in-place deletion path).
- **off → medium mid-turn**: `thinking` added mid-turn.
- **max → xhigh mid-turn** (Sonnet 5, adaptive): `output_config.effort` "max" → "xhigh".
- **Post-turn slider change**: route returns `accepted: false`; only the persisted setting updates.
- **Phase 0 gate**: steady-state native xhigh sends `output_config.effort` + `thinking: {type: "adaptive", display: "summarized"}` directly — no effort header, no fetch-wrapper rewrite.
- Persisted assistant `metadata.thinkingLevel` reflects the final applied level in every scenario; UI verified at 375px width.

## Risks

- **StreamManager `prepareStep`** is on the hot path of every stream. The override branch is a cheap early-out when no holder/pending exists; regression risk concentrates in multi-step turns with a mid-turn change (mitigated by consume-once tests, fallback/retry tests, and live dogfooding above).
- **In-place `providerOptions` mutation** relies on the SDK reading the object captured at `streamText()` time. If a future SDK snapshot-copies options, the `prepareStep` return value covers it (asserted by test).
- **Anthropic xhigh hack removal** changes the wire path for existing xhigh users of Opus 4.6/Sonnet 4.6 (non-native `max` fallback) and native models; both shapes are covered by provider-option tests and were dogfooded live.

---

<details>
<summary>📋 Implementation Plan</summary>

# Mid-turn thinking-level changes: apply at the next model step

## Goal

When the user changes the thinking/reasoning slider while a turn is streaming, the new level should take effect at the **next model step** of the active stream (a "step" = one provider request; steps are separated by tool executions). Today the level is captured once at send time and is fixed for the whole turn.

Chosen semantics (per user): **auto-apply at next step** — no separate "Apply now" button, no interrupt/continue. Changing the slider mid-turn both (a) persists the workspace setting as today and (b) requests a next-step override on the active stream.

## Verified current behavior (evidence)

- Send path captures `thinkingLevel` in `SendMessageOptions` (`src/browser/hooks/useSendMessageOptions.ts`); backend clamps once via `enforceThinkingPolicy` in `AgentSession` (`src/node/services/agentSession.ts:3616-3640`, floor = `config.json` `minThinkingLevelByModel` → `resolveMinimumThinkingLevel`).
- `AIService.streamMessage` builds `providerOptions` once (`buildProviderOptions`, `src/node/services/aiService.ts:2393-2405`) and merges `providers.jsonc` extras (`:2422-2449`), then calls `StreamManager.startStream` with the fixed level (`:2800-2832`).
- `streamText()` is invoked once per stream (`StreamManager.createStreamResult`, `src/node/services/streamManager.ts:1617-1660`) with `providerOptions: request.providerOptions`. Its `prepareStep` hook already returns per-step overrides (messages, `activeTools`) and follows the shared-mutable-state precedent of `toolSearchState`.
- AI SDK 7 (`ai@7.0.19`): `prepareStep` may return per-step `providerOptions`, which are **deep-merged** (`mergeObjects`) with the request-level options each step (`node_modules/ai/src/generate-text/stream-text.ts:1861-1864`). Omitted keys survive; `undefined` cannot delete a key. `PrepareStepResult` has **no `headers` field**.
- The SDK reads the outer `providerOptions` reference on every step (`mergeObjects(providerOptions, …)`), so in-place mutation of `streamInfo.request.providerOptions` is visible to subsequent steps.
- Slider chain: `ThinkingSlider` → `useThinkingLevel` → `ThinkingContext.setThinkingLevel` (`src/browser/contexts/ThinkingContext.tsx:219-238`) → `persistAgentAiSettings` → `api.workspace.updateAgentAISettings`. Nothing reaches the active stream.
- Precedent for renderer→in-flight-stream mutation: `api.workspace.interruptStream` → `WorkspaceService.interruptStream` (`workspaceService.ts:8308-8381`) → `getOrCreateSession(workspaceId)` → `AgentSession.interruptStream` → `AIService.stopStream` → `StreamManager.stopStream`.
- Metadata: `streamInfo.thinkingLevel` feeds partials (`streamManager.ts:2223-2225`), stream-end metadata (`:3059-3061`) and the persisted assistant message; the model-fallback path already mutates it mid-stream (`:2425-2428`).
- **Anthropic xhigh wire hack is obsolete** (verified against installed `@ai-sdk/anthropic@4.0.11` source):
  - The hack's own comments state it existed because the SDK Zod schema "doesn't accept xhigh yet" (`src/common/types/thinking.ts:188-190`, `providerOptions.ts:641-648`); introduced with Opus 4.7 (#3180), extended for Sonnet 5 (#3664). Mux sends `effort: "max"` through the SDK plus `x-mux-anthropic-effort: xhigh`, and the Anthropic fetch wrapper rewrites `output_config.effort` on the wire (`providerModelFactory.ts:342-401`).
  - SDK 4.0.11 now accepts it: `effort: z.enum(['low','medium','high','xhigh','max'])` (`anthropic-language-model-options.ts:209`). Explicit provider options bypass the SDK's `supportsXhighEffort` model gating — that gating only applies to the SDK's top-level `reasoning` CallOption mapping, which Mux does not use; explicit `anthropicOptions.effort` flows verbatim into `output_config.effort` (`anthropic-language-model.ts:398-465`). This also covers Mythos (absent from the SDK capability table) exactly like today's wrapper rewrite.
  - Same for `thinking.display`: the SDK schema now has `display: z.enum(['omitted','summarized'])` on adaptive thinking and forwards it (`anthropic-language-model-options.ts:95-102`, `anthropic-language-model.ts:433-457`), so the wrapper's `display ??= "summarized"` injection is also expressible directly in provider options.
  - Route safety: the anthropic options branch runs iff `formatProvider === "anthropic"`, which is the **same condition** as `routePassesHeaders` (`resolveProviderOptionsNamespaceKey(origin, routeProvider) === origin`). So every route that emits anthropic `effort` today also gets the header + wrapper rewrite — direct and mux-gateway requests already carry `"xhigh"` (and `display`) on the wire in production. Sending them directly via provider options is **wire-field equivalent** (same Anthropic body fields; the mux-internal header disappears, but the wrapper stripped it before upstream anyway). Non-passthrough gateways (OpenRouter/copilot) use different provider-options branches and are unaffected.
  - All Anthropic request builders go through `buildProviderOptions` (main stream `aiService.ts:2393`, fallback `:2710`, advisor `tools/advisor.ts:159`), so no other path depends on the wrapper rewrites.

## Design overview

Core primitive: a **session-owned, per-turn live holder** (one object per turn, shared by reference down the whole pipeline — same pattern as `toolSearchState`):

```ts
interface ActiveTurnThinkingOverride {
  /** Raw level requested mid-turn; consumed at the next prepareStep (incl. step 1). */
  pending?: ThinkingLevel;
  /** Effective level after the most recent successful application. */
  applied?: ThinkingLevel;
  /** Sink wired by StreamManager to the owning streamInfo (metadata). */
  onApplied?: (level: ThinkingLevel) => void;
}
```

```text
ThinkingContext.setThinkingLevel (mid-turn)
  ├─ persistAgentAiSettings(...)                     (unchanged; future turns)
  └─ api.workspace.setActiveTurnThinkingLevel        (new, fire-and-forget)
       → router → WorkspaceService → sessions.get(id)?.setActiveTurnThinkingLevel(level)
            └─ session.activeTurnThinkingOverride != null (turn active: PREPARING or STREAMING)
                 ? holder.pending = level → { accepted: true }
                 : { accepted: false }    (idle: persisted settings already cover next turn)

AgentSession turn lifecycle
  ├─ turn durably accepted, options finalized (sendMessage / resumeStream): create holder
  │    BEFORE the user-message emit / onAccepted / any await, then
  │    pass explicitly into streamWithHistory → StreamMessageOptions
  │    → AIService → buildStreamRequestConfig → request.thinkingOverrideState (same object)
  └─ turn end (setTurnPhase→IDLE, interrupt, dispose): identity-guarded clear
       (if (this.activeTurnThinkingOverride === holder) … = null) — pending expires

StreamManager prepareStep (runs before EVERY step, including step 1 —
so a change during PREPARING/startup applies to the turn's first provider request)
  ├─ pending? → rebuildForLevel(pending)   // closure supplied by AIService
  │     ├─ policy clamp + resolveEffectiveThinkingLevel for the STREAM's model
  │     ├─ not applicable / no-op → clear pending, keep current level
  │     └─ applicable →
  │           • in-place replace streamInfo.request.providerOptions content
  │           • state.applied = effectiveLevel; state.onApplied(effectiveLevel)
  │             (onApplied sets streamInfo.thinkingLevel → partials/final metadata)
  │           • return { providerOptions: rebuilt } from prepareStep (defense in depth)
  └─ no pending → existing behavior
```

Why both in-place mutation **and** a per-step return: the SDK deep-merge cannot delete keys (e.g. Anthropic `thinking` object when moving to `off`), so mutating the live request object is the authoritative mechanism; returning the rebuilt options from `prepareStep` is redundant-but-harmless insurance if the SDK ever changes how it snapshots options.

Why a session-owned holder instead of a StreamManager setter: a slider change during AIService startup (model creation, MCP setup — seconds) would miss a not-yet-registered stream. With the holder created at turn start and threaded down by reference, writes land in the same object `prepareStep` reads, closing the PREPARING window with zero extra consumption points; and because `prepareStep` also runs before step 1, no special pre-stream handling is needed.

## Scope rules (what can/cannot switch mid-turn)

Applied inside the rebuild closure; when a transition is not applicable, the pending override is dropped for this turn (the new level still applies to the next turn via persisted settings, exactly as today):

1. **Clamp first**: target level is clamped with `enforceThinkingPolicy(streamModel, target, minThinkingLevel, providersConfig)`. If clamped target == currently effective level → no-op.
2. **xAI `grok-4-1-fast`**: `off` ↔ non-`off` selects a different model instance (`providerModelFactory.ts:2014-2020`) → skipped. (Non-off↔non-off is a no-op on xAI anyway — no effort field in provider options.)
3. Everything else applies at the next step: OpenAI `reasoningEffort`, **all Anthropic levels including into/out of native `xhigh`** (after Phase 0 removes the header hack — effort becomes pure provider options), Anthropic off↔on via in-place replacement, Google `thinkingConfig`, OpenRouter `reasoning`.

After Phase 0, `buildRequestHeaders` is thinking-level-independent (the only remaining conditional header is the 1M-context beta, keyed on model+config), so `prepareStep`'s inability to change headers no longer constrains any level transition.

Out of scope (v1): OpenAI Pro `reasoningMode` toggle mid-turn; model changes mid-turn; already-queued messages (they keep the options captured at queue time); an explicit "Apply now" interrupt+continue action; ACP sessions; emitting a dedicated chat event for the change (metadata carries the final level; can be added later if requested).

Known cosmetic limitation: the already-emitted `stream-start` event keeps the initial level, so `WorkspaceStore.currentThinkingLevel` shows the starting level until stream end. The persisted assistant message metadata reflects the **last applied** level.

---

## Implementation

### Phase 0 — Remove the Anthropic xhigh wire hack (~ −50 LoC)

Prerequisite refactor that makes Anthropic effort a pure provider-options concern (wire-field-equivalent output, verified above), unblocking mid-turn xhigh transitions and deleting two wrapper rewrites.

The refactor must stay **model-aware**: today the wire-level `"xhigh"` and `display` are applied only when `anthropicSupportsNativeXhigh(model)` matches (header gating + wrapper detection). The provider-options replacement mirrors exactly that gating so non-native adaptive models (Opus 4.6 / Sonnet 4.6: `effort: "max"`, **no** `display`) keep identical request fields:

1. `src/common/types/thinking.ts`:
   - `AnthropicEffortLevel` gains `"xhigh"`. `getAnthropicEffort` becomes model-aware: `getAnthropicEffort(level, capabilityModel)` returns `"xhigh"` only when `level === "xhigh" && anthropicSupportsNativeXhigh(capabilityModel)`, else the current mapping (xhigh→`"max"`). The `ANTHROPIC_EFFORT` table itself keeps `xhigh: "max"` as the non-native fallback.
   - Replace the stale "SDK doesn't accept xhigh yet" comment with the new rationale (explicit provider options pass through verbatim as of `@ai-sdk/anthropic@4.0.11`; add an upgrade-coupling note: the SDK's `supportsXhighEffort` gating applies only to top-level `reasoning` mapping — re-verify on major SDK upgrades).
2. `src/common/utils/ai/providerOptions.ts`:
   - Anthropic adaptive branch: pass `capabilityModel` to `getAnthropicEffort`, and set `thinking: { type: "adaptive", display: "summarized" }` **only when `anthropicSupportsNativeXhigh(capabilityModel)`** (matching the wrapper's `targetsNativeXhighModel` condition; other adaptive models keep `{ type: "adaptive" }` with no `display`, as today). Drop the stale comment.
   - `buildRequestHeaders`: delete the xhigh header branch and the now-unused `thinkingLevel` parameter (update both call sites, `aiService.ts:2413-2420` and `:2726`); delete the `MUX_ANTHROPIC_EFFORT_OVERRIDE_HEADER` export.
3. `src/node/services/providerModelFactory.ts` (Anthropic fetch wrapper): remove the effort-override header handling and the `display ??=` injection block (incl. the `targetsNativeXhighModel` detection that exists solely for them). Cache-control injection stays untouched.
4. Update existing tests: `providerOptions.test.ts` (effort mapping/xhigh header assertions), `providerModelFactory.test.ts` (wrapper rewrite tests → assert pass-through/no rewrite). Add assertions for both sides of the gate:
   - native-xhigh model at xhigh → `effort: "xhigh"` + `thinking.display: "summarized"`;
   - non-native adaptive model (e.g. Opus 4.6) at its ladder top → `effort` unchanged from today (`"max"`/clamped) and **no** `display` field.
5. Gate: targeted tests + one manual devtools.jsonl check that a steady-state xhigh request is **wire-field equivalent** to today: same Anthropic body fields (`output_config.effort`, `thinking.display`), with the mux-internal header gone (it was stripped before reaching Anthropic anyway, so upstream requests are unchanged).

Keep this phase a separate commit so it can be reverted independently of the mid-turn feature.

### Phase 1 — StreamManager: consume the holder in prepareStep (~65 LoC)

`src/node/services/streamManager.ts`

1. Type: `ActiveTurnThinkingOverride` lives in a small **node-local** shared module (e.g. `src/node/services/thinkingOverride.ts`) — it carries a callback and is node runtime state, not IPC/shared data, so it does not belong in `src/common/types/`.
2. Extend `StreamRequestConfig` with:
   - `thinkingOverrideState?: ActiveTurnThinkingOverride` — **the session's holder, by reference; never created inside StreamManager** (a locally-created object would be invisible to the session's setter).
   - `rebuildProviderOptionsForThinkingLevel?: (level: ThinkingLevel) => { effectiveLevel: ThinkingLevel; providerOptions: Record<string, unknown> } | null`
     (closure built by AIService; `null` ⇒ not applicable / no-op per scope rules)
3. Thread both through `buildStreamRequestConfig` → `createStreamAtomically` → `startStream` params (same plumbing as `onChunk` / `toolSearchState`).
4. **Stable providerOptions object**: in `buildStreamRequestConfig`, when a rebuild closure is present, normalize `providerOptions` to a guaranteed mutable object (`const finalProviderOptions = providerOptions ?? {}`) before it is captured by `streamText()`. Without this, an initially-`undefined` options value would make later in-place mutation unobservable (the SDK closes over the value passed at creation). Unit-test this identity behavior.
5. In `createStreamResult`'s `prepareStep` (before the existing `if (rewritten === stepMessages && activeTools === undefined) return undefined;` early-return), add:
   ```ts
   const thinkingOverride = applyPendingThinkingOverride(request); // helper below
   ```
   and include `...(thinkingOverride ? { providerOptions: thinkingOverride } : {})` in the returned object (adjust the early-return condition accordingly). Because `prepareStep` runs before **every** step including the first, a change made during AIService startup is applied to the turn's first provider request.
6. New private helper `applyPendingThinkingOverride(request)`:
   - reads `request.thinkingOverrideState?.pending`; returns `undefined` if unset;
   - always clears `pending` (consume-once; a failed/no-op application must not retry every step);
   - calls `request.rebuildProviderOptionsForThinkingLevel(pending)`; on `null` → `log.debug` (include workspace, from/to level, skip reason) + return `undefined`;
   - **in-place** replaces the contents of `request.providerOptions` (delete own keys, `Object.assign` the rebuilt object — object identity preserved) so the SDK's per-step deep-merge and all retry paths observe it;
   - sets `state.applied = effectiveLevel`, invokes `state.onApplied?.(effectiveLevel)`, returns the rebuilt options object.
7. Wire the metadata sink in `createStreamAtomically`, immediately after `streamInfo` is constructed (and **before** any code path can trigger a step):
   ```ts
   if (request.thinkingOverrideState) {
     request.thinkingOverrideState.onApplied = (level) => { streamInfo.thinkingLevel = level; };
     if (request.thinkingOverrideState.applied) streamInfo.thinkingLevel = request.thinkingOverrideState.applied;
   }
   ```
   (The catch-up sync covers re-attachment of a holder that already applied a level.) Partial writes (`:2223`), stream-end metadata (`:3059`), and the final assistant message then pick up the new level with no polling in the process loop. Note: `createStreamResult` is called before `streamInfo` exists (`:1698-1727`); the SDK does not invoke `prepareStep` synchronously during `streamText()` construction, but the catch-up sync makes ordering safe regardless.
8. No StreamManager setter method is needed — the session writes to the shared holder directly (see Phase 3).
9. Retry/fallback interplay:
   - **Empty-output retry & previousResponseId retry**: both reuse/spread `streamInfo.request`, so the mutated `providerOptions`, holder reference, closure, and `onApplied` sink carry forward automatically (`streamManager.ts:2484-2521`, `:3540-3589`). No changes needed beyond confirming in tests.
   - **Model fallback** (`:2331-2445`): the fallback prepare context (second argument of `ModelFallbackOptions.prepare`, currently `{ continuation?: … }`) gains `thinkingLevelOverride?: ThinkingLevel`, populated from `request.thinkingOverrideState?.pending ?? request.thinkingOverrideState?.applied` (then clear `pending` — it is folded into the fallback's baseline). `PreparedModelFallback` (`prepared.data`) gains the fallback-model-bound `rebuildProviderOptionsForThinkingLevel`. `nextRequest` is built with the **same holder object** (so the session setter keeps working) and the new closure — both attached in `buildStreamRequestConfig(...)` **before** `createStreamResult(nextRequest, …)` is called, in case the SDK eagerly prepares the first fallback step; `onApplied` still points at the same `streamInfo`, so no re-wiring is required.

### Phase 2 — AIService: rebuild closure (+ fallback) (~70 LoC)

`src/node/services/aiService.ts` (inside `streamMessage`, after `mergedProviderOptions` is computed at ~`:2449`)

1. Build the closure, capturing everything already in scope. It must reproduce the **exact initial effective-level pipeline** (AgentSession floor clamp → AIService `resolveEffectiveThinkingLevel`, `:1097-1101`), not just `enforceThinkingPolicy`:
   ```ts
   const rebuildProviderOptionsForThinkingLevel = (level: ThinkingLevel) => {
     const clamped = enforceThinkingPolicy(modelString, level, minThinkingLevel, providersConfig);
     const effective = resolveEffectiveThinkingLevel(modelString, clamped, this.providerService.getConfig());
     if (effective === currentEffectiveLevelRef.current) return null;          // no-op
     if (isXaiGrokFastVariantSwap(modelString, currentEffectiveLevelRef.current, effective)) return null;
     const rebuilt = buildProviderOptions(modelString, effective, providerRequestMessages,
       (id) => this.streamManager.isResponseIdLost(id), effectiveMuxProviderOptions,
       workspaceId, truncationMode, this.providerService.getConfig(), routeProvider,
       promptCacheScope, reasoningMode);
     const merged = mergeModelParameterExtras(rebuilt); // shared helper, see note below
     currentEffectiveLevelRef.current = effective;
     return { effectiveLevel: effective, providerOptions: merged };
   };
   ```
   Notes:
   - `minThinkingLevel`: `AgentSession` already computes the floor at `:3616-3640`; pass it down via a new optional `StreamMessageOptions.minThinkingLevel` field instead of re-resolving in AIService (single source of truth). Fallback when absent (internal callers): `resolveMinimumThinkingLevel(modelString, undefined, providersConfig)`.
   - `currentEffectiveLevelRef` is a tiny `{ current: ThinkingLevel }` initialized to `effectiveThinkingLevel` so consecutive overrides diff against the live level, not the send-time one.
   - Factor the extras-merge at `:2431-2449` into a local `mergeModelParameterExtras(options)` used by both the initial build and the closure (DRY, no behavior change).
   - The grok skip predicate is a small pure helper colocated in `src/common/utils/thinking/policy.ts` (literal `grok-4-1-fast` check mirroring `providerModelFactory.ts:2016`). No Anthropic predicate is needed after Phase 0.
2. New optional `StreamMessageOptions` fields: `minThinkingLevel?: ThinkingLevel` and `activeTurnThinkingOverride?: ActiveTurnThinkingOverride` (the session holder). Pass the holder and `rebuildProviderOptionsForThinkingLevel` into `startStream` (new params, adjacent to `onChunk`). When no holder is supplied (internal callers: compaction, sub-agent paths that don't need it yet), the feature is inert for that stream.
3. Fallback prepare (`:2575-2765`): accept the new `thinkingLevelOverride` context field from StreamManager; compute `nextThinkingLevel = resolveEffectiveThinkingLevel(nextModelString, enforceThinkingPolicy(nextModelString, thinkingLevelOverride ?? effectiveThinkingLevel, minThinkingLevelForNextModel, …), …)`, and include a **new closure bound to the fallback model** (with its own `currentEffectiveLevelRef` initialized to `nextThinkingLevel`) in the returned `prepared.data` so mid-turn changes keep working after a fallback hop.

### Phase 3 — ORPC route + session holder lifecycle (~55 LoC)

1. `src/common/orpc/schemas/api.ts` — add to the `workspace` namespace (near `updateAgentAISettings`), using the repo-standard `Result` wrapper like sibling mutating routes:
   ```ts
   setActiveTurnThinkingLevel: {
     input: z.object({ workspaceId: z.string(), thinkingLevel: ThinkingLevelSchema }),
     output: ResultSchema(z.object({ accepted: z.boolean() }), z.string()),
   },
   ```
   `accepted: false` (success) = nothing active to override — persisted settings still cover the next turn. `accepted: true` = the level will be used for the current turn's next model step **if one occurs**; it expires silently otherwise. Errors are reserved for invalid input/disposed session.
2. `src/node/orpc/router.ts` — handler mirroring `updateAgentAISettings`'s shape, calling `context.workspaceService.setActiveTurnThinkingLevel(input.workspaceId, input.thinkingLevel)`.
3. `src/node/services/workspaceService.ts`:
   ```ts
   setActiveTurnThinkingLevel(workspaceId: string, level: ThinkingLevel): Result<{ accepted: boolean }, string> {
     const session = this.sessions.get(workspaceId.trim());
     if (!session) return Ok({ accepted: false });   // no session ⇒ nothing running
     return Ok(session.setActiveTurnThinkingLevel(level));
   }
   ```
   (Deliberately `sessions.get`, not `getOrCreateSession` — creating a session to tell it "change the turn you don't have" is pointless.)
4. `src/node/services/agentSession.ts` — owns the holder lifecycle:
   - New private field `activeTurnThinkingOverride: ActiveTurnThinkingOverride | null = null`.
   - **Create after the user-message append/persistence succeeds and `optionsForStream` is finalized — before emitting the user-message chat event, before `internal.onAccepted`, and before any other await/callback** that could let the renderer's slider route arrive. NOT inside `streamWithHistory` (which runs only after runtime warmup). Concretely: in `sendMessage`, just ahead of the `emitChatEvent({ …userMessage })` block (`:2820-2828`, well before `setTurnPhase(TurnPhase.PREPARING)`; covers normal, edit, and queued-dispatch turns), and at `resumeStream`'s equivalent point after its options are finalized. Assign `this.activeTurnThinkingOverride = holder` and pass `holder` **explicitly as a parameter** into `streamWithHistory`, which forwards it (plus `minThinkingLevel`) via the new `StreamMessageOptions` fields into `aiService.streamMessage`.
   - **Pre-stream failure cleanup**: any path that returns after holder creation without reaching a stream (`onAccepted` throws, startup abort via `preparedTurnAbortController`, `streamWithHistory` error) must identity-clear the holder (`if (this.activeTurnThinkingOverride === holder) this.activeTurnThinkingOverride = null`) — the existing `startPreparedStream` finally-block that resets PREPARING→IDLE is the natural place.
   - **Setter**:
     ```ts
     setActiveTurnThinkingLevel(level: ThinkingLevel): { accepted: boolean } {
       this.assertNotDisposed("setActiveTurnThinkingLevel");
       const holder = this.activeTurnThinkingOverride;
       if (!holder) return { accepted: false }; // idle: persisted settings cover the next turn
       holder.pending = level;                   // last write wins
       return { accepted: true };
     }
     ```
     The holder exists exactly while a turn is active (PREPARING through STREAMING), so no `isBusy()` heuristics are needed — and messages sitting in the queue are untouched (they dispatch later with their own captured options and a fresh holder).
   - **Clear with an identity guard** wherever the turn ends — `if (this.activeTurnThinkingOverride === holder) this.activeTurnThinkingOverride = null;` — in the turn's completion/abort paths (`setTurnPhase`→`IDLE` bookkeeping, `interruptStream`, `dispose()`). The identity guard ensures a stale aborted turn's cleanup (e.g. an edit preempting a PREPARING turn) cannot clear the replacement turn's holder.
   - Note: because `prepareStep` runs before step 1, a change landing during PREPARING/startup is applied to the first provider request via the normal pending path — no separate consumption point in `streamWithHistory` is needed.

### Phase 4 — Frontend wiring (~12 LoC)

`src/browser/contexts/ThinkingContext.tsx`, inside `setThinkingLevel` (`:219-238`), after `persistAgentAiSettings(...)`:

```ts
if (props.workspaceId) {
  api?.workspace
    .setActiveTurnThinkingLevel({ workspaceId: props.workspaceId, thinkingLevel: level })
    .catch(() => {/* best-effort: no active stream / transient IPC failure */});
}
```

- No renderer gating on "is streaming" — the backend no-ops cheaply when idle, and gating via `useWorkspaceState(workspaceId).canInterrupt` would break Storybook/test mounts of `ThinkingProvider` that have no registered store workspace.
- Keybind path (`INCREASE_THINKING`/`DECREASE_THINKING`) already funnels through `setThinkingLevel`, so it inherits the behavior.
- One-shot `/model+level` sends and `setReasoningMode` are untouched.

### Phase 5 — Tests (~150 LoC test code; not counted in product LoC)

1. `src/node/services/streamManager.test.ts` (follow the tool-search suite pattern: `spyOn(aiSdk, "streamText")`, capture `prepareStep` from `mock.calls[0][0]`, invoke directly):
   - pending override → `prepareStep` returns rebuilt `providerOptions`, `request.providerOptions` is replaced **in place** (same object identity, old provider-namespace keys gone), `pending` cleared, `applied` recorded, `onApplied` invoked (streamInfo.thinkingLevel updated).
   - initially-`undefined` providerOptions: request config normalizes to a stable object so `streamText` receives the same reference that later mutation targets (identity assertion).
   - rebuild returns `null` → no `providerOptions` in the step result, `pending` cleared (no retry storm), request options untouched.
   - accepted-but-no-next-step: pending set after the final step → stream ends normally, final metadata keeps the last **applied** (or original) level, no leak into a later stream.
   - empty-output retry / previousResponseId retry: after application, re-created stream still carries mutated options (assert on `streamInfo.request.providerOptions`).
   - model fallback: `prepare` receives `thinkingLevelOverride` equal to the pending/applied level; `nextRequest` reuses the **same holder object** and gets the fallback-bound closure attached before `createStreamResult` runs.
2. `src/node/services/aiService.test.ts`: closure behavior — clamps to floor then applies `resolveEffectiveThinkingLevel`, no-op when effective == current, skips xAI grok-4-1-fast off↔on, applies Anthropic transitions into/out of `xhigh` as plain rebuilds, produces merged extras identical in shape to the initial build for a plain level change.
3. `src/node/services/agentSession.*.test.ts` / `workspaceService.test.ts`:
   - `setActiveTurnThinkingLevel` → `{ accepted: false }` when idle (no holder) and for unknown workspace; `{ accepted: true }` while a turn is active; last-write-wins on consecutive calls (holder.pending reflects the last level).
   - holder lifecycle: created immediately after durable acceptance/options finalization (before emit/onAccepted/any await), identity-cleared on pre-stream failure / turn end / interrupt / dispose (a post-turn setter call returns `accepted: false`); an edit-preempted turn's cleanup does not clear the replacement turn's holder.
   - PREPARING window: turn durably accepted, **before** `setTurnPhase(PREPARING)` / `streamWithHistory` / stream registration → slider route writes `pending` → the turn's first provider request consumes it (assert via captured `prepareStep`); pre-stream failure after holder creation identity-clears the holder.
   - queued messages are NOT retroactively changed: queue a follow-up mid-turn, change the level, let the queue dispatch → the follow-up turn streams with its captured options (fresh holder, no inherited pending).
4. `src/browser/contexts/ThinkingContext.test.tsx`: `setThinkingLevel` fires `api.workspace.setActiveTurnThinkingLevel` with the workspaceId and level; NOT fired when the provider has no `workspaceId` (project/global scope).

No tautological tests: every assertion above exercises branching (queued vs not, applied vs skipped, merge-deletion semantics), not copy.

### Phase 6 — Validation gates & dogfooding

Local gates (run between phases, not only at the end):

- After Phase 0: `bun test src/common/utils/ai/providerOptions.test.ts src/node/services/providerModelFactory.test.ts` + manual xhigh wire-bytes regression check (step 0 below).
- After Phase 1–2: `bun test src/node/services/streamManager.test.ts src/node/services/aiService.test.ts` (targeted; QuickJS-heavy suites excluded as usual).
- After Phase 3–4: `MUX_ESLINT_CONCURRENCY=1 make static-check` + `bun test src/browser/contexts/ThinkingContext.test.tsx`.

Dogfooding (evidence required; use `dev-server-sandbox` skill + `agent-browser`):

0. **Phase 0 regression check**: on an Anthropic native-xhigh model at steady xhigh (no mid-turn change), capture one request in `devtools.jsonl` and diff `output_config.effort` + `thinking.display` against a pre-change capture — must match (`"xhigh"` / `"summarized"`), and the `x-mux-anthropic-effort` header must be absent from `update.requestHeaders`. Also capture one Opus/Sonnet 4.6 request at its top level — `effort` unchanged and no `display` field.
1. Start a sandboxed dev server (`dev-server-sandbox` skill); ensure a **direct** provider route (disable sandbox gateway block or set `routePriority: ["direct"]`) so `devtools.jsonl` shows wire-level requests.
2. Enable API Debug Logs. In a test workspace, send a prompt guaranteed to run several tool steps (e.g. "read these 3 files then summarize") with thinking = low.
3. While the agent is mid-tool, move the slider to high (screenshot the slider + streaming state via `agent-browser screenshot`).
4. After the turn: inspect `~/.mux/sessions/<ws>/devtools.jsonl` `step-update.update.rawRequest` entries — step N (pre-change) must show the low reasoning config, step N+1 the high config (e.g. OpenAI `reasoning.effort`, Anthropic `thinking.budget_tokens`/`output_config.effort`). Capture the two JSON excerpts.
5. Verify the persisted assistant message metadata (`chat.jsonl`) has `thinkingLevel: "high"` (last applied).
6. Repeat once on an Anthropic model for the off→high in-place-replacement case (key deletion path), and once for high→xhigh on a native-xhigh model (`output_config.effort` flips to `"xhigh"` mid-turn — the transition Phase 0 unblocked).
7. Mobile check (repo rule): capture a ~375px-wide viewport screenshot of the chat footer with the slider mid-turn — no layout change is expected, but narrow-viewport verification is mandatory for UI-adjacent changes.
8. Record a screen capture of the slider change mid-turn (ffmpeg x11grab per repo notes; compress with libvpx to fit the 10MB attach limit). If recording is environmentally blocked, document the exact blocker and rely on the step-by-step screenshots + devtools excerpts.
9. Attach all screenshots/video via `attach_file` and include the two rawRequest JSON excerpts in the summary.

## Risks & mitigations

| Risk | Mitigation |
| --- | --- |
| SDK deep-merge can't delete keys (off-transitions) | In-place mutation of the live `request.providerOptions` object is authoritative; per-step return is only defense-in-depth. Unit test asserts old namespace keys are gone. |
| SDK later snapshots/clones providerOptions at `streamText()` time | Per-step returned `providerOptions` still overrides conflicting leaves; add a code comment flagging the coupling for SDK upgrades (like the MCP OAuth note). |
| Prompt-cache churn (Anthropic breakpoints / OpenAI implicit caching are level-independent; only reasoning params change) | No cache keys are touched by the rebuild (same `promptCacheKey`/scope captured). Verified: `buildProviderOptions` derives caching from workspace/scope, not level. |
| `prepareProviderRequestMessages` used the send-time level for Anthropic reasoning-part replay | Mid-turn steps use the SDK's accumulated step messages, not re-prepared history; divergence only affects reasoning-part filtering of *old* history within the same turn. Accept + document as v1 limitation in a code comment. |
| Fallback/retry paths dropping the override | Explicit carry-through (Phase 1.9 / Phase 2.3) + tests. |
| Model-swap (grok off↔on) transitions silently doing the wrong thing | Explicit skip predicate + debug log; level then applies next turn exactly as today. |
| Phase 0: SDK upgrade re-introduces effort gating for explicit provider options | Coupling comment at `ANTHROPIC_EFFORT` (like the MCP OAuth note); Phase 0 test asserts `effort: "xhigh"` survives to the request; wire-field regression check in dogfooding. |
| Phase 0: mux-gateway rejects direct `xhigh`/`display` in provider options | Already receiving these exact values today via the wrapper rewrite of the gateway body shape — proven in production; regression check covers it. |
| Phase 0: over-broad mapping sends `xhigh`/`display` to non-native models (Opus/Sonnet 4.6) | Model-aware gating on `anthropicSupportsNativeXhigh(capabilityModel)` in both `getAnthropicEffort` and the `display` field, mirroring today's header/wrapper conditions; both-sides-of-the-gate unit tests + 4.6 dogfooding capture. |
| Slider change lands during PREPARING / AIService startup (stream not yet registered) and is lost | Session-owned per-turn holder created at turn start and threaded down by reference; `prepareStep` runs before step 1, so the first provider request already honors it (Phase 3.4). |
| Initially-`undefined` providerOptions makes in-place mutation invisible to the SDK | Normalize to a stable object in `buildStreamRequestConfig` (Phase 1.4) + identity unit test. |
| Override bleeding into queued follow-up turns | Holder is per-turn and cleared at turn end; queued messages dispatch with their own captured options + fresh holder. Regression test in Phase 5.3. |

## Net LoC estimate (product code)

| Phase | Est. net LoC |
| --- | --- |
| 0 Remove xhigh wire hack | ~ −50 |
| 1 StreamManager | ~65 |
| 2 AIService | ~70 |
| 3 ORPC/session holder lifecycle | ~55 |
| 4 Frontend | ~12 |
| **Total** | **~150 net** (upper bound ~200 with type plumbing overhead) |

## Acceptance criteria

1. Changing the thinking slider during an active multi-step turn changes the reasoning parameters of the next provider request within the same turn (verified in `devtools.jsonl`).
2. Changing the slider when idle behaves exactly as today (persisted settings only; route returns `accepted: false`).
3. A change during the PREPARING window (turn accepted, stream not yet started) applies to that turn's first model request.
4. Clamping: a mid-turn request below the model floor / above the ceiling applies the clamped effective level; a no-op change leaves the request untouched.
5. Anthropic transitions into/out of native `xhigh` apply mid-turn; steady-state requests are wire-field equivalent to pre-refactor (native-xhigh: `output_config.effort: "xhigh"` + `thinking.display: "summarized"`; non-native adaptive: unchanged `effort`, no `display`; no `x-mux-anthropic-effort` header anywhere).
6. The one excluded transition (xAI grok-4-1-fast off↔on) does not alter the in-flight stream and still applies on the next turn.
7. Final assistant message metadata records the last applied level; interrupted/error partials also carry it.
8. Empty-output retry, previousResponseId retry, and model fallback preserve the applied override.
9. All targeted tests + `make static-check` pass.

</details>

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$150.32`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=150.32 -->
