### PR TITLE
🤖 fix: onboarding wizard and narrow-viewport dogfood issues

### DIFF
--- a/src/browser/components/LeftSidebar/LeftSidebar.tsx
+++ b/src/browser/components/LeftSidebar/LeftSidebar.tsx
@@ -26,15 +26,15 @@ export function LeftSidebar(props: LeftSidebarProps) {
     ...projectSidebarProps
   } = props;
   const isDesktop = isDesktopMode();
-  // Match the CSS gate for the mobile "overlay" sidebar; we don't show a drag handle in that mode.
-  const isMobileTouch =
-    typeof window !== "undefined" &&
-    window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
+  // Match the CSS gate for the mobile "overlay" sidebar (width-only, any pointer
+  // type); we don't show a drag handle in that mode since CSS pins the width.
+  const isMobileOverlay =
+    typeof window !== "undefined" && window.matchMedia("(max-width: 768px)").matches;
 
   const handleBeforeOpenSettings = () => {
-    // Keep settings navigation escapable on touch devices by dismissing the
+    // Keep settings navigation escapable on narrow viewports by dismissing the
     // off-canvas sidebar as soon as the user opens settings from this sidebar.
-    if (!collapsed && isMobileTouch) {
+    if (!collapsed && isMobileOverlay) {
       onToggleCollapsed();
     }
   };
@@ -77,7 +77,7 @@ export function LeftSidebar(props: LeftSidebarProps) {
           onToggleCollapsed={onToggleCollapsed}
         />
 
-        {!collapsed && !isMobileTouch && onStartResize && (
+        {!collapsed && !isMobileOverlay && onStartResize && (
           <div
             data-testid="left-sidebar-resize-handle"
             className={cn(

--- a/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
+++ b/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
@@ -97,6 +97,8 @@ interface ProjectCreateFormProps {
   placeholder?: string;
   /** Hide the footer actions (submit/cancel buttons). */
   hideFooter?: boolean;
+  /** Notifies the parent when an inline error appears/clears (e.g. to hide contradictory helper text). */
+  onErrorChange?: (hasError: boolean) => void;
 }
 
 export interface ProjectCreateFormHandle {
@@ -118,13 +120,22 @@ export const ProjectCreateForm = React.forwardRef<ProjectCreateFormHandle, Proje
         ? "C:\\Users\\user\\projects\\my-project"
         : "/home/user/projects/my-project",
       hideFooter = false,
+      onErrorChange,
     },
     ref
   ) {
     const { api } = useAPI();
     const [path, setPath] = useState(initialPath ?? "");
-    const [error, setError] = useState("");
+    const [error, setErrorState] = useState("");
     const [isCreating, setIsCreating] = useState(false);
+
+    const setError = useCallback(
+      (next: string) => {
+        setErrorState(next);
+        onErrorChange?.(next.length > 0);
+      },
+      [onErrorChange]
+    );
 
     useEffect(() => {
       setPath(initialPath ?? "");
@@ -141,7 +152,7 @@ export const ProjectCreateForm = React.forwardRef<ProjectCreateFormHandle, Proje
     const reset = useCallback(() => {
       setPath("");
       setError("");
-    }, []);
+    }, [setError]);
 
     const handleCancel = useCallback(() => {
       reset();
@@ -211,7 +222,7 @@ export const ProjectCreateForm = React.forwardRef<ProjectCreateFormHandle, Proje
       } finally {
         setCreating(false);
       }
-    }, [api, isCreating, onClose, onSuccess, path, reset, setCreating]);
+    }, [api, isCreating, onClose, onSuccess, path, reset, setCreating, setError]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
@@ -297,6 +308,8 @@ interface ProjectCloneFormProps {
   onIsCreatingChange?: (isCreating: boolean) => void;
   hideFooter?: boolean;
   autoFocus?: boolean;
+  /** Notifies the parent when an inline error appears/clears (e.g. to hide contradictory helper text). */
+  onErrorChange?: (hasError: boolean) => void;
 }
 
 export interface ProjectCloneFormHandle {
@@ -375,7 +388,15 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
     const [repoUrl, setRepoUrl] = useState("");
     const [cloneParentDir, setCloneParentDir] = useState(props.defaultProjectDir);
     const [hasEditedCloneParentDir, setHasEditedCloneParentDir] = useState(false);
-    const [error, setError] = useState("");
+    const [error, setErrorState] = useState("");
+
+    const setError = useCallback(
+      (next: string) => {
+        setErrorState(next);
+        props.onErrorChange?.(next.length > 0);
+      },
+      [props]
+    );
     const [destinationExistsPath, setDestinationExistsPath] = useState<string | null>(null);
     const [isCreating, setIsCreating] = useState(false);
     const [cloneOutput, setCloneOutput] = useState("");
@@ -402,7 +423,7 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
       rawOutputRef.current = "";
       setDestinationExistsPath(null);
       setIsAddingProject(false);
-    }, [props.defaultProjectDir]);
+    }, [props.defaultProjectDir, setError]);
 
     const abortInFlightClone = useCallback(() => {
       if (!abortControllerRef.current) {
@@ -552,7 +573,7 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
           setCreating(false);
         }
       }
-    }, [api, isCreating, props, repoUrl, reset, setCreating, trimmedCloneParentDir]);
+    }, [api, isCreating, props, repoUrl, reset, setCreating, setError, trimmedCloneParentDir]);
 
     const handleAddExistingProject = useCallback(async () => {
       if (!api || !destinationExistsPath) {
@@ -593,13 +614,13 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
           setIsAddingProject(false);
         }
       }
-    }, [api, destinationExistsPath, props, reset]);
+    }, [api, destinationExistsPath, props, reset, setError]);
 
     const handleRetry = useCallback(() => {
       setError("");
       setCloneOutput("");
       rawOutputRef.current = "";
-    }, []);
+    }, [setError]);
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
@@ -794,6 +815,8 @@ interface ProjectAddFormProps {
   autoFocus?: boolean;
   hideFooter?: boolean;
   showCancelButton?: boolean;
+  /** Notifies the parent when the active form shows an inline error (e.g. to hide contradictory helper text). */
+  onErrorChange?: (hasError: boolean) => void;
 }
 
 export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddFormProps>(
@@ -871,11 +894,14 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
         }
 
         setMode(nextMode);
+        // The newly mounted form starts without an error, so clear any stale flag
+        // reported by the form we're switching away from.
+        props.onErrorChange?.(false);
         if (nextMode === "clone") {
           void ensureDefaultCloneDir();
         }
       },
-      [ensureDefaultCloneDir]
+      [ensureDefaultCloneDir, props]
     );
 
     useImperativeHandle(
@@ -930,6 +956,7 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
               showCancelButton={props.showCancelButton ?? false}
               autoFocus={props.autoFocus}
               onIsCreatingChange={setCreating}
+              onErrorChange={props.onErrorChange}
               hideFooter
             />
           ) : (
@@ -940,6 +967,7 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
               isOpen={props.isOpen}
               defaultProjectDir={defaultProjectDir}
               onIsCreatingChange={setCreating}
+              onErrorChange={props.onErrorChange}
               hideFooter
               autoFocus={props.autoFocus}
             />

--- a/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
+++ b/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
@@ -97,7 +97,6 @@ interface ProjectCreateFormProps {
   placeholder?: string;
   /** Hide the footer actions (submit/cancel buttons). */
   hideFooter?: boolean;
-  /** Notifies the parent when an inline error appears/clears (e.g. to hide contradictory helper text). */
   onErrorChange?: (hasError: boolean) => void;
 }
 
@@ -308,7 +307,6 @@ interface ProjectCloneFormProps {
   onIsCreatingChange?: (isCreating: boolean) => void;
   hideFooter?: boolean;
   autoFocus?: boolean;
-  /** Notifies the parent when an inline error appears/clears (e.g. to hide contradictory helper text). */
   onErrorChange?: (hasError: boolean) => void;
 }
 
@@ -395,7 +393,7 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
         setErrorState(next);
         props.onErrorChange?.(next.length > 0);
       },
-      [props]
+      [props.onErrorChange]
     );
     const [destinationExistsPath, setDestinationExistsPath] = useState<string | null>(null);
     const [isCreating, setIsCreating] = useState(false);
@@ -815,7 +813,6 @@ interface ProjectAddFormProps {
   autoFocus?: boolean;
   hideFooter?: boolean;
   showCancelButton?: boolean;
-  /** Notifies the parent when the active form shows an inline error (e.g. to hide contradictory helper text). */
   onErrorChange?: (hasError: boolean) => void;
 }
 
@@ -901,7 +898,7 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
           void ensureDefaultCloneDir();
         }
       },
-      [ensureDefaultCloneDir, props]
+      [ensureDefaultCloneDir, props.onErrorChange]
     );
 
     useImperativeHandle(

--- a/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
+++ b/src/browser/components/ProjectCreateModal/ProjectCreateModal.tsx
@@ -388,12 +388,13 @@ const ProjectCloneForm = React.forwardRef<ProjectCloneFormHandle, ProjectCloneFo
     const [hasEditedCloneParentDir, setHasEditedCloneParentDir] = useState(false);
     const [error, setErrorState] = useState("");
 
+    const onErrorChange = props.onErrorChange;
     const setError = useCallback(
       (next: string) => {
         setErrorState(next);
-        props.onErrorChange?.(next.length > 0);
+        onErrorChange?.(next.length > 0);
       },
-      [props.onErrorChange]
+      [onErrorChange]
     );
     const [destinationExistsPath, setDestinationExistsPath] = useState<string | null>(null);
     const [isCreating, setIsCreating] = useState(false);
@@ -884,6 +885,7 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
       void ensureDefaultCloneDir();
     }, [ensureDefaultCloneDir, mode, props.isOpen]);
 
+    const onErrorChange = props.onErrorChange;
     const handleModeChange = useCallback(
       (nextMode: string) => {
         if (nextMode !== "pick-folder" && nextMode !== "clone") {
@@ -893,12 +895,12 @@ export const ProjectAddForm = React.forwardRef<ProjectAddFormHandle, ProjectAddF
         setMode(nextMode);
         // The newly mounted form starts without an error, so clear any stale flag
         // reported by the form we're switching away from.
-        props.onErrorChange?.(false);
+        onErrorChange?.(false);
         if (nextMode === "clone") {
           void ensureDefaultCloneDir();
         }
       },
-      [ensureDefaultCloneDir, props.onErrorChange]
+      [ensureDefaultCloneDir, onErrorChange]
     );
 
     useImperativeHandle(

--- a/src/browser/features/SplashScreens/OnboardingWizardSplash.tsx
+++ b/src/browser/features/SplashScreens/OnboardingWizardSplash.tsx
@@ -1054,6 +1054,9 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
       return;
     }
     setDirection("back");
+    // Changing steps remounts the project form without its inline error, so
+    // clear the stale flag or the "click Next" nudge stays hidden on return.
+    setProjectFormHasError(false);
     setStepIndex((i) => Math.max(0, i - 1));
   };
 
@@ -1062,6 +1065,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
       return;
     }
     setDirection("forward");
+    setProjectFormHasError(false);
     setStepIndex((i) => Math.min(totalSteps - 1, i + 1));
   };
 

--- a/src/browser/features/SplashScreens/OnboardingWizardSplash.tsx
+++ b/src/browser/features/SplashScreens/OnboardingWizardSplash.tsx
@@ -210,6 +210,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
 
   const projectAddFormRef = useRef<ProjectAddFormHandle | null>(null);
   const [isProjectCreating, setIsProjectCreating] = useState(false);
+  const [projectFormHasError, setProjectFormHasError] = useState(false);
 
   const [direction, setDirection] = useState<Direction>("forward");
 
@@ -843,6 +844,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
               autoFocus={userProjects.size === 0}
               hideFooter
               onIsCreatingChange={setIsProjectCreating}
+              onErrorChange={setProjectFormHasError}
               onSuccess={(normalizedPath, projectConfig) => {
                 addProject(normalizedPath, projectConfig);
                 updatePersistedState(getAgentsInitNudgeKey(normalizedPath), true);
@@ -852,11 +854,14 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
             />
           </div>
 
-          <p className="mt-2 text-xs">
-            {userProjects.size > 0
-              ? "Add another folder or repo, or leave this blank and click Next to continue."
-              : "Click Next to add this project."}
-          </p>
+          {/* Hide the "click Next" nudge while the form shows an error; the two contradict. */}
+          {!projectFormHasError && (
+            <p className="mt-2 text-xs">
+              {userProjects.size > 0
+                ? "Add another folder or repo, or leave this blank and click Next to continue."
+                : "Click Next to add this project."}
+            </p>
+          )}
         </>
       ),
     });
@@ -1011,6 +1016,7 @@ export function OnboardingWizardSplash(props: { onDismiss: () => void }) {
     muxGatewayLoginInProgress,
     muxGatewayLoginStatus,
     openProvidersSettings,
+    projectFormHasError,
     userProjects.size,
     providersConfig,
     refreshMuxGatewayAccountStatus,

--- a/src/browser/features/SplashScreens/SplashScreen.tsx
+++ b/src/browser/features/SplashScreens/SplashScreen.tsx
@@ -42,11 +42,18 @@ export function SplashScreen(props: SplashScreenProps) {
 
   return (
     <Dialog open onOpenChange={(open) => !open && props.onDismiss()}>
-      <DialogContent maxWidth="500px" onInteractOutside={(e) => e.preventDefault()}>
+      {/* aria-describedby={undefined}: splash bodies are rich content, not a short description. */}
+      {/* Cap height and scroll the body (footer pinned) so tall steps keep Next/Skip clickable. */}
+      <DialogContent
+        maxWidth="500px"
+        aria-describedby={undefined}
+        className="max-h-[85vh] grid-rows-[auto_minmax(0,1fr)_auto]"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{props.title}</DialogTitle>
         </DialogHeader>
-        {props.children}
+        <div className="min-h-0 overflow-y-auto">{props.children}</div>
         <DialogFooter className={props.footerClassName}>
           {props.footer ?? (
             <>

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1140,52 +1140,6 @@ body,
     min-width: 44px;
   }
 
-  /* Show mobile menu button only on touch devices */
-  .mobile-menu-btn {
-    display: inline-flex !important;
-    justify-content: flex-start !important;
-    padding-left: 12px !important;
-  }
-
-  .mobile-sticky-header:has(.mobile-menu-btn) {
-    padding-left: 0 !important;
-  }
-
-  /* Show mobile overlay only on touch devices */
-  .mobile-overlay {
-    display: block !important;
-  }
-
-  /* Mobile sidebar positioning only on touch devices */
-  .mobile-sidebar {
-    position: fixed !important;
-    left: 0 !important;
-    top: 0 !important;
-    width: 18rem !important;
-    z-index: 1000 !important;
-    transition: transform 0.3s !important;
-    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.5) !important;
-
-    /* Account for iOS safe areas (the sidebar is position: fixed) */
-    padding-top: env(safe-area-inset-top, 0px) !important;
-    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
-    padding-left: env(safe-area-inset-left, 0px) !important;
-  }
-
-  .mobile-sidebar-collapsed {
-    transform: translateX(-100%) !important;
-    box-shadow: none !important;
-  }
-
-  /* Mobile layout - stack vertically on touch devices */
-  .mobile-layout {
-    flex-direction: column !important;
-  }
-
-  .mobile-main-content {
-    width: 100% !important;
-  }
-
   /* Keep workspace header visible when keyboard opens - fixed positioning
      because iOS Safari scrolls the visual viewport, not a scroll container.
      Left/right safe-area insets ensure header content avoids notch in landscape.
@@ -1216,8 +1170,54 @@ body,
 
 /* Tailwind utility extensions for dark theme surfaces */
 
-/* Hide right sidebar on small screens so it never stacks below the chat pane. */
+/* Narrow viewports, any pointer type: the expanded sidebar overlays the main
+   pane instead of crushing it (a 288px in-flow sidebar leaves ~90px of content
+   at 375px), and the menu button provides a way to reopen it once hidden. */
 @media (max-width: 768px) {
+  .mobile-menu-btn {
+    display: inline-flex !important;
+    justify-content: flex-start !important;
+    padding-left: 12px !important;
+  }
+
+  .mobile-sticky-header:has(.mobile-menu-btn) {
+    padding-left: 0 !important;
+  }
+
+  .mobile-overlay {
+    display: block !important;
+  }
+
+  .mobile-sidebar {
+    position: fixed !important;
+    left: 0 !important;
+    top: 0 !important;
+    width: 18rem !important;
+    z-index: 1000 !important;
+    transition: transform 0.3s !important;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.5) !important;
+
+    /* Account for iOS safe areas (the sidebar is position: fixed) */
+    padding-top: env(safe-area-inset-top, 0px) !important;
+    padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+    padding-left: env(safe-area-inset-left, 0px) !important;
+  }
+
+  .mobile-sidebar-collapsed {
+    transform: translateX(-100%) !important;
+    box-shadow: none !important;
+  }
+
+  /* Stack vertically so main content gets the full viewport width */
+  .mobile-layout {
+    flex-direction: column !important;
+  }
+
+  .mobile-main-content {
+    width: 100% !important;
+  }
+
+  /* Hide right sidebar on small screens so it never stacks below the chat pane. */
   .mobile-hide-right-sidebar {
     display: none !important;
   }

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -319,6 +319,26 @@ interface FileCompletionsCacheEntry {
   refreshing?: Promise<void>;
 }
 
+/**
+ * Translate common filesystem errno failures into friendly, user-facing messages.
+ * Without this, raw Node errno strings (e.g. "EACCES: permission denied, mkdir '/x'")
+ * leak into the project-add UI. Returns null for codes we don't recognize.
+ */
+function friendlyFsError(error: unknown, action: string, targetPath: string): string | null {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  switch (code) {
+    case "EACCES":
+    case "EPERM":
+      return `Cannot ${action} "${targetPath}": permission denied`;
+    case "EROFS":
+      return `Cannot ${action} "${targetPath}": the file system is read-only`;
+    case "ENOTDIR":
+      return `Cannot ${action} "${targetPath}": part of the path is not a folder`;
+    default:
+      return null;
+  }
+}
+
 async function resolveRealProjectPath(projectPath: string): Promise<string> {
   return stripTrailingSlashes(await fsPromises.realpath(projectPath));
 }
@@ -435,6 +455,10 @@ export class ProjectService {
       } catch (error) {
         const err = error as NodeJS.ErrnoException;
         if (err.code !== "ENOENT") {
+          const friendly = friendlyFsError(error, "access", normalizedPath);
+          if (friendly) {
+            return Err(friendly);
+          }
           throw error;
         }
       }
@@ -459,7 +483,15 @@ export class ProjectService {
 
       // Create the directory if it doesn't exist (like mkdir -p). Keep the user-facing
       // path stable in config; Windows realpath may expand 8.3 short names and surprise callers.
-      await fsPromises.mkdir(normalizedPath, { recursive: true });
+      try {
+        await fsPromises.mkdir(normalizedPath, { recursive: true });
+      } catch (error) {
+        const friendly = friendlyFsError(error, "create folder", normalizedPath);
+        if (friendly) {
+          return Err(friendly);
+        }
+        throw error;
+      }
       const canonicalPath = await resolveRealProjectPath(normalizedPath);
 
       if (config.projects.has(canonicalPath)) {

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -319,13 +319,9 @@ interface FileCompletionsCacheEntry {
   refreshing?: Promise<void>;
 }
 
-/**
- * Translate common filesystem errno failures into friendly, user-facing messages.
- * Without this, raw Node errno strings (e.g. "EACCES: permission denied, mkdir '/x'")
- * leak into the project-add UI. Returns null for codes we don't recognize.
- */
+// Keep raw Node errno details out of project-add errors.
 function friendlyFsError(error: unknown, action: string, targetPath: string): string | null {
-  const code = (error as NodeJS.ErrnoException | null)?.code;
+  const code = (error as NodeJS.ErrnoException).code;
   switch (code) {
     case "EACCES":
     case "EPERM":

--- a/tests/ipc/projects/create.test.ts
+++ b/tests/ipc/projects/create.test.ts
@@ -187,12 +187,12 @@ describeIntegration("PROJECT_CREATE IPC Handler", () => {
     await fs.rm(tempProjectDir, { recursive: true, force: true });
   });
 
-  // Regression tests for friendly filesystem error mapping: raw Node errno
-  // strings (e.g. "EACCES: permission denied, mkdir '/x'") must not leak
-  // into the project-add UI.
   test.concurrent("should return a friendly error when folder creation is denied", async () => {
-    // Root bypasses permission bits, so this scenario cannot be reproduced as root.
-    if (typeof process.getuid === "function" && process.getuid() === 0) {
+    // This scenario relies on POSIX permission bits and a non-root user.
+    if (
+      process.platform === "win32" ||
+      (typeof process.getuid === "function" && process.getuid() === 0)
+    ) {
       return;
     }
 

--- a/tests/ipc/projects/create.test.ts
+++ b/tests/ipc/projects/create.test.ts
@@ -187,6 +187,61 @@ describeIntegration("PROJECT_CREATE IPC Handler", () => {
     await fs.rm(tempProjectDir, { recursive: true, force: true });
   });
 
+  // Regression tests for friendly filesystem error mapping: raw Node errno
+  // strings (e.g. "EACCES: permission denied, mkdir '/x'") must not leak
+  // into the project-add UI.
+  test.concurrent("should return a friendly error when folder creation is denied", async () => {
+    // Root bypasses permission bits, so this scenario cannot be reproduced as root.
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+
+    const env = await createTestEnvironment();
+    const tempProjectDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-project-test-"));
+    const readOnlyDir = path.join(tempProjectDir, "readonly");
+    await fs.mkdir(readOnlyDir, { mode: 0o555 });
+    const client = resolveOrpcClient(env);
+
+    try {
+      const result = await client.projects.create({
+        projectPath: path.join(readOnlyDir, "child"),
+      });
+
+      if (result.success) {
+        throw new Error("Expected failure but got success");
+      }
+      expect(result.error).toContain("permission denied");
+      expect(result.error).not.toContain("EACCES");
+    } finally {
+      await fs.chmod(readOnlyDir, 0o755);
+      await cleanupTestEnvironment(env);
+      await fs.rm(tempProjectDir, { recursive: true, force: true });
+    }
+  });
+
+  test.concurrent("should return a friendly error when the path runs through a file", async () => {
+    const env = await createTestEnvironment();
+    const tempProjectDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-project-test-"));
+    const occupiedFile = path.join(tempProjectDir, "occupied.txt");
+    await fs.writeFile(occupiedFile, "content");
+    const client = resolveOrpcClient(env);
+
+    try {
+      const result = await client.projects.create({
+        projectPath: path.join(occupiedFile, "child"),
+      });
+
+      if (result.success) {
+        throw new Error("Expected failure but got success");
+      }
+      expect(result.error).toContain("not a folder");
+      expect(result.error).not.toContain("ENOTDIR");
+    } finally {
+      await cleanupTestEnvironment(env);
+      await fs.rm(tempProjectDir, { recursive: true, force: true });
+    }
+  });
+
   test.concurrent("should create non-existent tilde path", async () => {
     const env = await createTestEnvironment();
     const tempProjectDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-project-test-"));


### PR DESCRIPTION
## Summary

Fixes the four issues found during the dogfood UAT pass of the onboarding wizard and narrow-viewport layout (1 low, 3 medium).

## Background

A full-app dogfood session on a fresh MUX_ROOT surfaced:

1. **Wizard steps taller than the viewport made Next unclickable.** At a 720px-high window, the "Multiple runtimes" step rendered an 818px dialog; the Next button's hit target fell below the viewport, so mouse clicks did nothing while Tab+Enter worked.
2. **Raw Node errno leaked into the project-add UI.** Entering an uncreatable path showed `Failed to create project: EACCES: permission denied, mkdir '/nonexistent'`, with the contradictory "Click Next to add this project." helper still visible below the error.
3. **375px viewport with an expanded sidebar crushed the main pane.** The overlay-sidebar CSS was gated on `(max-width: 768px) and (pointer: coarse)`, so a narrow non-touch window kept the 288px sidebar in-flow, leaving ~90px for content (clipped controls, overlapping labels).
4. **Radix warned about a missing dialog description** for the splash/wizard `DialogContent`.

## Implementation

- `SplashScreen`: cap the dialog at `85vh` and scroll the body while the footer stays pinned (`grid-rows-[auto_minmax(0,1fr)_auto]`), so Next/Skip remain clickable on short viewports. Declare `aria-describedby={undefined}` (existing repo pattern) since splash bodies are rich content, not a description.
- `ProjectService.create`: map `EACCES`/`EPERM`/`EROFS`/`ENOTDIR` failures from the stat/mkdir path into friendly messages (e.g. `Cannot create folder "...": permission denied`) instead of returning raw errno strings. Intentional mkdir-p auto-creation behavior is unchanged.
- `ProjectCreateForm`/`ProjectCloneForm`/`ProjectAddForm`: new optional `onErrorChange(hasError)` callback (mirrors `onIsCreatingChange`); the onboarding wizard uses it to hide the "click Next" nudge while an inline error is shown.
- `globals.css`/`LeftSidebar`: the sidebar overlay rules (fixed overlay, backdrop, off-canvas collapse, hamburger button) now gate on width only (`max-width: 768px`); touch-specific rules (44px targets, text-size adjust, sticky header) stay behind the coarse-pointer gate. Narrow non-touch windows now get the same overlay behavior phones already had, and the hamburger reopens the hidden sidebar.

## Validation

- Reproduced all four issues in a dev-server sandbox, then re-verified each fix live: hit-testing confirmed the Next button center went from off-viewport to hittable and mouse clicks advance the step; the friendly error renders with the helper text suppressed; at 375x812 the expanded sidebar overlays with a backdrop, content gets full width, and the hamburger reopens it; the Radix warning is gone on a fresh load.
- Desktop regression check at 1280x800: in-flow sidebar, resize handle present, no overlay/hamburger.
- New integration tests cover the errno mapping (permission-denied and path-through-a-file branches), asserting raw codes do not leak.

## Risks

- The width-only overlay gate changes behavior for narrow non-touch windows (previously crushed layout, now off-canvas overlay + hamburger). Touch/phone behavior and desktop-width behavior are unchanged; Chromatic phone modes use `hasTouch: true` and match the same width gate.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$79.63`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=79.63 -->
