### PR TITLE
🤖 fix: keep scratch AI prefs through user preference pruning

### DIFF
--- a/src/browser/contexts/UserPreferencesContext.test.ts
+++ b/src/browser/contexts/UserPreferencesContext.test.ts
@@ -290,6 +290,33 @@ describe("UserPreferencesProvider bridge helpers", () => {
     });
   });
 
+  test("keeps scratch AI defaults while pruning removed projects", () => {
+    const projects = new Map([["/repo/a", { workspaces: [] }]]);
+
+    expect(
+      prunePreferenceScopes({
+        preferences: {
+          ai: {
+            projectDefaults: {
+              _scratch: { agentId: "plan", model: "anthropic:claude-x", thinkingLevel: "high" },
+              "/repo/removed": { agentId: "plan" },
+            },
+          },
+        },
+        // The scratch system project is never part of the valid project paths.
+        projectPaths: new Set(["/repo/a"]),
+        workspaceIds: new Set(),
+        userProjects: projects,
+      })
+    ).toEqual({
+      ai: {
+        projectDefaults: {
+          _scratch: { agentId: "plan", model: "anthropic:claude-x", thinkingLevel: "high" },
+        },
+      },
+    });
+  });
+
   test("retries initial hydration failures until backend config loads", async () => {
     const controller = new AbortController();
     const errors: string[] = [];

--- a/src/browser/contexts/UserPreferencesContext.tsx
+++ b/src/browser/contexts/UserPreferencesContext.tsx
@@ -20,6 +20,7 @@ import {
   readStoredUserPreferenceValue,
   removeStoredUserPreference,
 } from "@/common/preferences/userPreferencesStorage";
+import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { normalizeOrder } from "@/common/utils/projectOrdering";
 import { stableStringify } from "@/common/utils/stableStringify";
 
@@ -128,6 +129,12 @@ export function prunePreferenceScopes(params: {
       return;
     }
     for (const projectPath of Object.keys(record)) {
+      // The scratch composer persists AI prefs under the scratch system project
+      // scope, which userProjects excludes and which may not exist in config yet.
+      // Keep it valid here or pruning deletes those prefs and the picker reverts.
+      if (projectPath === SCRATCH_PROJECT_CONFIG_KEY) {
+        continue;
+      }
       if (!params.projectPaths.has(projectPath)) {
         delete record[projectPath];
       }


### PR DESCRIPTION
## Summary

Scratch-chat AI preferences (agent mode, model, thinking level) no longer get deleted by the user-preference pruning pass, fixing the scratch composer's agent picker jumping back to the previous agent and sends using fallback model settings.

## Background

The scratch composer (#3723) persists agent/model/thinking under the `_scratch` system project scope. The pruning effect in `UserPreferencesContext` treats only `userProjects` paths as valid scopes; `userProjects` filters out system projects, and the scratch project does not exist in config at all until the first scratch chat is created. Every backend preference sync therefore pruned `ai.projectDefaults["_scratch"]` and removed the matching localStorage keys, so listener-backed UI state fell back to global defaults: the picker visibly reverted within seconds and the first send used the fallback model/thinking.

## Implementation

`prunePreferenceScopes` now always keeps the `SCRATCH_PROJECT_CONFIG_KEY` scope, unconditionally rather than based on config presence, since scratch prefs are written before the first scratch chat exists. Regression test covers scratch defaults surviving while genuinely removed project scopes are still pruned.

## Validation

Dogfood UAT in a sandboxed dev server (`make dev-server-sandbox` + agent-browser): exec/plan switch in the scratch composer now sticks through backend preference sync round trips (verified `ai.projectDefaults._scratch` survives in the sandbox `config.json`), persists across reload, and a send from the composer used exactly the displayed agent/model (`agentId: plan`, `anthropic:claude-sonnet-5` in the session `chat.jsonl`). Control checks on a regular project workspace unchanged.

## Risks

Low. The change only skips pruning for one constant scope; genuinely stale project scopes are still pruned (covered by tests). Side effect: `workspaceCreation.byProject` and `review.defaultBaseByProject` entries under `_scratch` would also survive pruning, which is harmless since the scratch flow does not write them.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$627.68`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=627.68 -->
