### PR TITLE
🤖 fix: keep workspace-turn handles running through auto-retryable stream errors

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -382,6 +382,7 @@ function createWorkspaceServiceMocks(
     hasQueuedMessages: ReturnType<typeof mock>;
     isBusyForMessage: ReturnType<typeof mock>;
     hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
+    hasPendingAutoRetry: ReturnType<typeof mock>;
     waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
     waitForIdle: ReturnType<typeof mock>;
     waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
@@ -409,6 +410,7 @@ function createWorkspaceServiceMocks(
   waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
   waitForIdle: ReturnType<typeof mock>;
   hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
+  hasPendingAutoRetry: ReturnType<typeof mock>;
   waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
   archive: ReturnType<typeof mock>;
   deleteWorktree: ReturnType<typeof mock>;
@@ -435,6 +437,7 @@ function createWorkspaceServiceMocks(
   const isBusyForMessage = overrides?.isBusyForMessage ?? mock(() => false);
   const hasPendingQueuedOrPreparingTurn =
     overrides?.hasPendingQueuedOrPreparingTurn ?? mock(() => false);
+  const hasPendingAutoRetry = overrides?.hasPendingAutoRetry ?? mock(() => false);
   const waitForIdleAndNoQueuedMessages =
     overrides?.waitForIdleAndNoQueuedMessages ?? mock((): Promise<void> => Promise.resolve());
   const waitForIdle = overrides?.waitForIdle ?? mock((): Promise<void> => Promise.resolve());
@@ -477,6 +480,7 @@ function createWorkspaceServiceMocks(
       hasQueuedWorkspaceTurn,
       hasQueuedMessages,
       hasPendingQueuedOrPreparingTurn,
+      hasPendingAutoRetry,
       waitForIdleAndNoQueuedMessages,
       waitForIdle,
       waitForPendingStreamErrorRecoveryDecision,
@@ -500,6 +504,7 @@ function createWorkspaceServiceMocks(
     hasQueuedMessages,
     isBusyForMessage,
     hasPendingQueuedOrPreparingTurn,
+    hasPendingAutoRetry,
     waitForIdleAndNoQueuedMessages,
     waitForIdle,
     waitForPendingStreamErrorRecoveryDecision,
@@ -640,6 +645,7 @@ describe("TaskService", () => {
       isStreaming?: ReturnType<typeof mock>;
       hasQueuedMessages?: ReturnType<typeof mock>;
       hasPendingQueuedOrPreparingTurn?: ReturnType<typeof mock>;
+      hasPendingAutoRetry?: ReturnType<typeof mock>;
       waitForPendingStreamErrorRecoveryDecision?: ReturnType<typeof mock>;
     } = {}
   ) {
@@ -676,6 +682,9 @@ describe("TaskService", () => {
         : {}),
       ...(options.hasPendingQueuedOrPreparingTurn != null
         ? { hasPendingQueuedOrPreparingTurn: options.hasPendingQueuedOrPreparingTurn }
+        : {}),
+      ...(options.hasPendingAutoRetry != null
+        ? { hasPendingAutoRetry: options.hasPendingAutoRetry }
         : {}),
       ...(options.waitForPendingStreamErrorRecoveryDecision != null
         ? {
@@ -3915,7 +3924,7 @@ describe("TaskService", () => {
   // falsely reporting the turn as failed to the parent.
   test("workspace-turn auto-retryable stream errors stay running while retry is pending", async () => {
     let retryDecisionAwaited = false;
-    const hasPendingQueuedOrPreparingTurn = mock(
+    const hasPendingAutoRetry = mock(
       (workspaceId: string) => retryDecisionAwaited && workspaceId === "childworkspace"
     );
     const waitForPendingStreamErrorRecoveryDecision = mock((): Promise<void> => {
@@ -3923,7 +3932,7 @@ describe("TaskService", () => {
       return Promise.resolve();
     });
     const { parentId, taskService } = await startWorkspaceTurnForTest({
-      hasPendingQueuedOrPreparingTurn,
+      hasPendingAutoRetry,
       waitForPendingStreamErrorRecoveryDecision,
     });
     const internal = taskService as unknown as {
@@ -3955,6 +3964,35 @@ describe("TaskService", () => {
       type: "error",
       workspaceId: "childworkspace",
       messageId: "msg_truncated_exhausted",
+      error: "Anthropic stream closed unexpectedly before the response completed.",
+      errorType: "stream_truncated",
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "error",
+      workspaceId: "childworkspace",
+      error: "Anthropic stream closed unexpectedly before the response completed.",
+    });
+  });
+
+  // Codex review: unrelated queued manual messages must not keep the handle
+  // running for auto-retryable errors — they start a different turn, so the
+  // failed turn would never resume. Only an actual pending auto-retry counts.
+  test("workspace-turn auto-retryable stream errors with only queued messages mark the handle failed", async () => {
+    const hasPendingQueuedOrPreparingTurn = mock(() => true);
+    const hasPendingAutoRetry = mock(() => false);
+    const { parentId, taskService } = await startWorkspaceTurnForTest({
+      hasPendingQueuedOrPreparingTurn,
+      hasPendingAutoRetry,
+    });
+    const internal = taskService as unknown as {
+      handleTaskStreamError: (event: ErrorEvent) => Promise<void>;
+    };
+
+    await internal.handleTaskStreamError({
+      type: "error",
+      workspaceId: "childworkspace",
+      messageId: "msg_truncated_queued_only",
       error: "Anthropic stream closed unexpectedly before the response completed.",
       errorType: "stream_truncated",
     });

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3909,6 +3909,63 @@ describe("TaskService", () => {
     });
   });
 
+  // Regression: stream_truncated (a transient provider drop) previously fell
+  // outside the recoverable allowlist and terminally settled the handle even
+  // though the child session had already scheduled an in-session auto-retry,
+  // falsely reporting the turn as failed to the parent.
+  test("workspace-turn auto-retryable stream errors stay running while retry is pending", async () => {
+    let retryDecisionAwaited = false;
+    const hasPendingQueuedOrPreparingTurn = mock(
+      (workspaceId: string) => retryDecisionAwaited && workspaceId === "childworkspace"
+    );
+    const waitForPendingStreamErrorRecoveryDecision = mock((): Promise<void> => {
+      retryDecisionAwaited = true;
+      return Promise.resolve();
+    });
+    const { parentId, taskService } = await startWorkspaceTurnForTest({
+      hasPendingQueuedOrPreparingTurn,
+      waitForPendingStreamErrorRecoveryDecision,
+    });
+    const internal = taskService as unknown as {
+      handleTaskStreamError: (event: ErrorEvent) => Promise<void>;
+    };
+
+    await internal.handleTaskStreamError({
+      type: "error",
+      workspaceId: "childworkspace",
+      messageId: "msg_truncated",
+      error: "Anthropic stream closed unexpectedly before the response completed.",
+      errorType: "stream_truncated",
+    });
+
+    expect(waitForPendingStreamErrorRecoveryDecision).toHaveBeenCalledWith("childworkspace");
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "running",
+      workspaceId: "childworkspace",
+    });
+  });
+
+  test("workspace-turn auto-retryable stream errors without a pending retry mark the handle failed", async () => {
+    const { parentId, taskService } = await startWorkspaceTurnForTest();
+    const internal = taskService as unknown as {
+      handleTaskStreamError: (event: ErrorEvent) => Promise<void>;
+    };
+
+    await internal.handleTaskStreamError({
+      type: "error",
+      workspaceId: "childworkspace",
+      messageId: "msg_truncated_exhausted",
+      error: "Anthropic stream closed unexpectedly before the response completed.",
+      errorType: "stream_truncated",
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "error",
+      workspaceId: "childworkspace",
+      error: "Anthropic stream closed unexpectedly before the response completed.",
+    });
+  });
+
   test("workspace-turn exhausted recoverable stream errors mark the handle failed", async () => {
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8840,12 +8840,22 @@ export class TaskService {
     return records.toReversed().find((record) => record.workspaceId === workspaceId) ?? null;
   }
 
-  private async hasRecoverableWorkspaceTurnRetryInFlight(workspaceId: string): Promise<boolean> {
+  private async hasRecoverableWorkspaceTurnRetryInFlight(
+    workspaceId: string,
+    options: { requireAutoRetry: boolean }
+  ): Promise<boolean> {
     await this.workspaceService.waitForPendingStreamErrorRecoveryDecision(workspaceId);
-    return (
-      this.aiService.isStreaming(workspaceId) ||
-      this.workspaceService.hasPendingQueuedOrPreparingTurn(workspaceId)
-    );
+    if (this.aiService.isStreaming(workspaceId)) {
+      return true;
+    }
+    // Auto-retryable stream errors recover only through an actual scheduled
+    // auto-retry. Unrelated queued manual messages must not keep the handle
+    // running: they would start a different turn, leaving the parent awaiting a
+    // turn that already failed (or settling it from an uncorrelated
+    // stream-end).
+    return options.requireAutoRetry
+      ? this.workspaceService.hasPendingAutoRetry(workspaceId)
+      : this.workspaceService.hasPendingQueuedOrPreparingTurn(workspaceId);
   }
 
   private async finalizeWorkspaceTurnFromStreamError(event: ErrorEvent): Promise<boolean> {
@@ -8853,10 +8863,17 @@ export class TaskService {
     if (record == null) {
       return false;
     }
+    // Explicit in-session recovery cases (aborted, context_exceeded) may
+    // continue through queued/preparing turns; auto-retryable errors require a
+    // pending auto-retry of the same turn.
+    const explicitRecovery =
+      event.errorType != null && WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS.has(event.errorType);
     if (
       event.errorType != null &&
       isWorkspaceTurnRecoverableStreamError(event.errorType) &&
-      (await this.hasRecoverableWorkspaceTurnRetryInFlight(record.workspaceId))
+      (await this.hasRecoverableWorkspaceTurnRetryInFlight(record.workspaceId, {
+        requireAutoRetry: !explicitRecovery,
+      }))
     ) {
       return true;
     }

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -676,11 +676,38 @@ const MAX_CONSECUTIVE_PARENT_AUTO_RESUMES = 3;
  */
 const MAX_TASK_RECOVERY_ATTEMPTS = 5;
 
+/**
+ * Stream errors classified non-retryable by RetryManager that nevertheless have
+ * in-session recovery paths for workspace turns (queued continuation after a
+ * soft abort, compaction retry on context overflow). All auto-retryable errors
+ * (e.g. stream_truncated, network, server_error) are additionally treated as
+ * recoverable by isWorkspaceTurnRecoverableStreamError below, because the child
+ * session schedules an in-session auto-retry for them.
+ */
 const WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS: ReadonlySet<StreamErrorType> = new Set([
   "aborted",
   "context_exceeded",
-  "runtime_start_failed",
 ]);
+
+/**
+ * A workspace-turn stream error may resolve without parent intervention when
+ * the child can still make progress on its own. The caller must still confirm
+ * a retry/continuation is actually in flight
+ * (hasRecoverableWorkspaceTurnRetryInFlight) before leaving the handle running;
+ * exhausted or user-disabled auto-retry settles the handle terminally.
+ *
+ * Gating on isNonRetryableStreamError (instead of a narrow allowlist) keeps
+ * this aligned with RetryManager: previously a transient provider drop
+ * (stream_truncated) terminally settled the handle and falsely reported the
+ * turn as failed to the parent, even though the child auto-retried and
+ * continued the same turn seconds later.
+ */
+function isWorkspaceTurnRecoverableStreamError(errorType: StreamErrorType): boolean {
+  return (
+    WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS.has(errorType) ||
+    !isNonRetryableStreamError({ type: errorType })
+  );
+}
 
 /**
  * Provider-terminal stream errors that settle a child task even while it is
@@ -8828,7 +8855,7 @@ export class TaskService {
     }
     if (
       event.errorType != null &&
-      WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS.has(event.errorType) &&
+      isWorkspaceTurnRecoverableStreamError(event.errorType) &&
       (await this.hasRecoverableWorkspaceTurnRetryInFlight(record.workspaceId))
     ) {
       return true;

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8914,6 +8914,18 @@ export class WorkspaceService extends EventEmitter {
   }
 
   /**
+   * Narrow check for an actual scheduled/starting auto-retry, excluding queued
+   * manual messages and preparing turns. Callers that must distinguish "the
+   * same turn will resume on its own" from "some other queued work exists"
+   * (e.g. workspace-turn stream-error settlement) need this instead of
+   * hasPendingQueuedOrPreparingTurn.
+   */
+  hasPendingAutoRetry(workspaceId: string): boolean {
+    const session = this.sessions.get(workspaceId.trim());
+    return session?.hasPendingAutoRetry() ?? false;
+  }
+
+  /**
    * Best-effort delete of plan files (new + legacy paths) for a workspace.
    *
    * Why best-effort: plan files may not exist yet, or deletion may fail due to permissions.


### PR DESCRIPTION
## Summary

Workspace-turn task handles (`task(kind="workspace")`) were terminally settled as `error` the moment the child hit **any** stream error outside a narrow allowlist — including transient, auto-retryable transport drops like `stream_truncated`. The parent then received a false "turn reached terminal state" wake and a `task_await` error result, even though the child auto-retried seconds later and kept working on the same turn. This PR gates the recoverable-error check on the same classification RetryManager uses, so handles stay `running` while a child auto-retry is actually in flight.

## Background

Observed live: a parent spawned two workspace turns; both children hit a single Anthropic-side stream drop (`stream_truncated`) at the same second. `finalizeWorkspaceTurnFromStreamError` settled both handles as terminal `error` ("Anthropic stream closed unexpectedly… Mux will retry automatically when possible") and woke the parent, while both children auto-retried 3 seconds later and continued their original turns. The parent, believing them dead, injected duplicate "Resume" turns into the still-running workspaces, and the original turns' real completions could no longer be reported through their already-settled handles.

Root cause: `WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS` (`aborted`, `context_exceeded`, `runtime_start_failed`) was inverted relative to actual retry semantics — none of the auto-retryable error types (`stream_truncated`, `network`, `server_error`, `rate_limit`, …) were in it, so the `&&`-chained retry-in-flight check (`hasRecoverableWorkspaceTurnRetryInFlight`) was short-circuited and never consulted. That check would have returned true: the child session schedules its auto-retry timer before the error event is emitted, and the parent-side check awaits the child's recovery decision (`waitForPendingStreamErrorRecoveryDecision`) before inspecting `hasPendingAutoRetry()`.

## Implementation

- New `isWorkspaceTurnRecoverableStreamError(errorType)`: recoverable when the error is auto-retryable per `isNonRetryableStreamError` (RetryManager's single source of truth), **or** in the explicit set of non-retryable errors with in-session recovery paths (`aborted`, `context_exceeded`). `runtime_start_failed` left the explicit set because it is already auto-retryable.
- `hasRecoverableWorkspaceTurnRetryInFlight` remains the arbiter: it deterministically distinguishes "auto-retry pending" from "genuinely dead" (exhausted retries, user-disabled auto-retry), so terminal settlement still happens when no recovery is in flight.

## Validation

- Red-test verified: the new regression test (`stream_truncated` + pending retry → handle stays `running`) fails against the old allowlist-only predicate and passes with the fix.
- Counterpart test proves `stream_truncated` with **no** retry in flight still settles the handle as `error`.
- Full `taskService.test.ts` suite (290 tests) and `make static-check` pass locally.

## Risks

Low-to-moderate, scoped to workspace-turn handle settlement. The behavior shift: transient stream errors no longer settle handles when a retry is pending — if a child's retry later exhausts, the terminal `error` settlement arrives from the final failed attempt (whose error event finds no retry in flight) rather than the first. Pre-existing settlement paths for non-retryable errors, user aborts, and no-retry-in-flight cases are covered by existing tests, which all pass unchanged.
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$6.07`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=6.07 -->
