### PR TITLE
[openai] 🤖 fix: use 372K GPT-5.6 OAuth context

### DIFF
--- a/src/common/constants/codexOAuth.test.ts
+++ b/src/common/constants/codexOAuth.test.ts
@@ -23,10 +23,10 @@ describe("codexOAuth model gating", () => {
   it("allows the GPT-5.6 family through Codex OAuth without requiring it", () => {
     // Includes the bare alias: it is a servable model id (OpenAI routes it to Sol).
     const contextLimits = {
-      "gpt-5.6": 272_000,
-      "gpt-5.6-sol": 272_000,
-      "gpt-5.6-terra": 128_000,
-      "gpt-5.6-luna": 128_000,
+      "gpt-5.6": 372_000,
+      "gpt-5.6-sol": 372_000,
+      "gpt-5.6-terra": 372_000,
+      "gpt-5.6-luna": 372_000,
     } as const;
 
     for (const [model, contextLimit] of Object.entries(contextLimits)) {

--- a/src/common/constants/codexOAuth.ts
+++ b/src/common/constants/codexOAuth.ts
@@ -132,13 +132,13 @@ export const CODEX_OAUTH_REQUIRED_MODELS = new Set<string>([
  */
 const CODEX_OAUTH_CONTEXT_WINDOW_OVERRIDES: Record<string, number> = {
   // The public API exposes a 1.05M window for these models, but the ChatGPT/Codex
-  // OAuth routing layer has smaller tier-specific limits. Keep the auth-route caps
-  // separate from model metadata so API-key requests retain the full public window.
+  // model catalog publishes smaller context windows (372K for the GPT-5.6 family).
+  // Keep auth-route caps separate so API-key requests retain the full public window.
   "gpt-5.5": 272_000,
-  "gpt-5.6": 272_000,
-  "gpt-5.6-sol": 272_000,
-  "gpt-5.6-terra": 128_000,
-  "gpt-5.6-luna": 128_000,
+  "gpt-5.6": 372_000,
+  "gpt-5.6-sol": 372_000,
+  "gpt-5.6-terra": 372_000,
+  "gpt-5.6-luna": 372_000,
 };
 
 function normalizeCodexOauthModelId(modelId: string): string {

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -92,10 +92,10 @@ describe("getEffectiveContextLimit", () => {
 
   test("caps the GPT-5.6 family at each tier's Codex OAuth context window", () => {
     const contextLimits = {
-      "gpt-5.6": 272_000,
-      "gpt-5.6-sol": 272_000,
-      "gpt-5.6-terra": 128_000,
-      "gpt-5.6-luna": 128_000,
+      "gpt-5.6": 372_000,
+      "gpt-5.6-sol": 372_000,
+      "gpt-5.6-terra": 372_000,
+      "gpt-5.6-luna": 372_000,
     } as const;
 
     for (const [model, contextLimit] of Object.entries(contextLimits)) {

--- a/src/common/utils/tokens/tokenMeterUtils.test.ts
+++ b/src/common/utils/tokens/tokenMeterUtils.test.ts
@@ -100,8 +100,8 @@ describe("calculateTokenMeterData", () => {
       },
     });
 
-    expect(result.maxTokens).toBe(272_000);
-    expect(result.totalPercentage).toBeCloseTo((11_000 / 272_000) * 100);
+    expect(result.maxTokens).toBe(372_000);
+    expect(result.totalPercentage).toBeCloseTo((11_000 / 372_000) * 100);
   });
 
   test("uses Claude Sonnet 4.6's native 1M context even when the beta toggle is off", () => {


### PR DESCRIPTION
## Summary

Use the 372K context window published by OpenAI's Codex model catalog for every GPT-5.6 model routed through Codex OAuth, while preserving the public API's 1.05M window for API-key requests.

## Background

The previous OAuth-cap change used 272K for GPT-5.6/Sol and 128K for Terra/Luna. OpenAI's current `openai/codex` model catalog lists `context_window: 372000` for Sol, Terra, and Luna, and the bare `gpt-5.6` alias routes to Sol.

## Implementation

- Set the Codex OAuth context override to 372K for `gpt-5.6`, Sol, Terra, and Luna.
- Update compaction and token-meter expectations to use the catalog value.
- Retain GPT-5.5's existing 272K OAuth override.

## Risks

Low. This only changes effective context accounting for direct OpenAI requests routed through Codex OAuth. API-key and gateway-routed requests retain their existing model metadata.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `medium` • Cost: `$18.32`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=medium costs=18.32 -->
