### PR TITLE
🤖 fix: honor agent AI defaults and target workspace settings for workspace turns

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -1324,6 +1324,207 @@ describe("TaskService", () => {
     expect(sendMessageCall[2]).toMatchObject({ reasoningMode: "pro" });
   });
 
+  test("createWorkspaceTurn resolves AI settings: agent defaults on create, target settings on follow-up, explicit override wins", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, [
+      "firsthandle",
+      "firstturn",
+      "secondhandle",
+      "secondturn",
+      "thirdhandle",
+      "thirdturn",
+    ]);
+    // Owner persisted at opus/high (helper default); configured exec agent
+    // defaults differ from both the owner's persisted and live settings.
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir, {
+      agentAiDefaults: { exec: { modelString: "openai:gpt-5.2", thinkingLevel: "xhigh" } },
+    });
+
+    const createWorkspace = mock(
+      async (...args: unknown[]): Promise<Result<{ metadata: WorkspaceMetadata }>> => {
+        const tags = args[7] as Record<string, string> | undefined;
+        await config.editConfig((cfg) => {
+          const project = cfg.projects.get(projectPath);
+          assert(project, "test project must exist");
+          project.workspaces.push({
+            path: path.join(projectPath, "workspace-turn"),
+            id: "childworkspace",
+            name: "workspace-turn",
+            title: "Workspace turn",
+            createdAt: "2026-06-19T00:00:00.000Z",
+            runtimeConfig: { type: "local" },
+            tags,
+          });
+          return cfg;
+        });
+        return Ok({ metadata: createWorkspaceTurnMetadata(projectPath) });
+      }
+    );
+    const sendMessage = mock(async (...args: unknown[]): Promise<Result<void>> => {
+      const internal = args[3] as { onAccepted?: () => Promise<void> | void } | undefined;
+      await internal?.onAccepted?.();
+      return Ok(undefined);
+    });
+    const workspaceMocks = createWorkspaceServiceMocks({ create: createWorkspace, sendMessage });
+    const { taskService } = createTaskServiceHarness(config, {
+      workspaceService: workspaceMocks.workspaceService,
+    });
+
+    // Creation: configured agent defaults outrank the owner's live runtime
+    // settings (owner turned down to medium must not produce medium children).
+    const first = await taskService.createWorkspaceTurn({
+      ownerWorkspaceId: parentId,
+      prompt: "First prompt",
+      title: "Workspace turn",
+      parentRuntimeAiSettings: {
+        modelString: "anthropic:claude-sonnet-4-5",
+        thinkingLevel: "medium",
+      },
+      workspace: { mode: "new" },
+    });
+    expect(first.success).toBe(true);
+    const firstSend = sendMessage.mock.calls[0];
+    expect(firstSend[2]).toMatchObject({
+      agentId: "exec",
+      model: "openai:gpt-5.2",
+      thinkingLevel: "xhigh",
+    });
+
+    // Simulate the child's own last-used settings (persist-on-send or a manual
+    // flip inside the child workspace).
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(projectPath);
+      const child = project?.workspaces.find((workspace) => workspace.id === "childworkspace");
+      assert(child, "child workspace must exist");
+      child.aiSettingsByAgent = {
+        exec: { model: "anthropic:claude-opus-4-6", thinkingLevel: "low" },
+      };
+      return cfg;
+    });
+
+    // Follow-up: the target continues its own settings; the owner's bump to
+    // high must not drag the child along, and agent defaults no longer apply.
+    const second = await taskService.createWorkspaceTurn({
+      ownerWorkspaceId: parentId,
+      prompt: "Second prompt",
+      title: "Follow-up",
+      parentRuntimeAiSettings: {
+        modelString: "anthropic:claude-sonnet-4-5",
+        thinkingLevel: "high",
+      },
+      workspace: { mode: "existing", workspaceId: "childworkspace" },
+    });
+    expect(second.success).toBe(true);
+    const secondSend = sendMessage.mock.calls[1];
+    expect(secondSend[2]).toMatchObject({
+      model: "anthropic:claude-opus-4-6",
+      thinkingLevel: "low",
+    });
+
+    // Explicit per-launch overrides still outrank the target's own settings.
+    const third = await taskService.createWorkspaceTurn({
+      ownerWorkspaceId: parentId,
+      prompt: "Third prompt",
+      title: "Override",
+      modelString: "openai:gpt-5.3-codex",
+      thinkingLevel: "medium",
+      workspace: { mode: "existing", workspaceId: "childworkspace" },
+    });
+    expect(third.success).toBe(true);
+    const thirdSend = sendMessage.mock.calls[2];
+    expect(thirdSend[2]).toMatchObject({
+      model: "openai:gpt-5.3-codex",
+      thinkingLevel: "medium",
+    });
+  });
+
+  test("createWorkspaceTurn follow-ups do not re-inject the owner's pro mode over the target's own settings", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["firsthandle", "firstturn", "secondhandle", "secondturn"]);
+    const projectPath = await createTestProject(rootDir, "repo", { initGit: false });
+    const parentId = "1111111111";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        {
+          path: projectPath,
+          id: parentId,
+          name: "parent",
+          createdAt: new Date().toISOString(),
+          runtimeConfig: { type: "local" },
+          aiSettingsByAgent: {
+            exec: { model: "openai:gpt-5.6-sol", thinkingLevel: "high", reasoningMode: "pro" },
+          },
+        },
+      ],
+      testTaskSettings()
+    );
+
+    const createWorkspace = mock(
+      async (...args: unknown[]): Promise<Result<{ metadata: WorkspaceMetadata }>> => {
+        const tags = args[7] as Record<string, string> | undefined;
+        await config.editConfig((cfg) => {
+          const project = cfg.projects.get(projectPath);
+          assert(project, "test project must exist");
+          project.workspaces.push({
+            path: path.join(projectPath, "workspace-turn"),
+            id: "childworkspace",
+            name: "workspace-turn",
+            title: "Workspace turn",
+            createdAt: "2026-06-19T00:00:00.000Z",
+            runtimeConfig: { type: "local" },
+            tags,
+          });
+          return cfg;
+        });
+        return Ok({ metadata: createWorkspaceTurnMetadata(projectPath) });
+      }
+    );
+    const sendMessage = mock(async (...args: unknown[]): Promise<Result<void>> => {
+      const internal = args[3] as { onAccepted?: () => Promise<void> | void } | undefined;
+      await internal?.onAccepted?.();
+      return Ok(undefined);
+    });
+    const workspaceMocks = createWorkspaceServiceMocks({ create: createWorkspace, sendMessage });
+    const { taskService } = createTaskServiceHarness(config, {
+      workspaceService: workspaceMocks.workspaceService,
+    });
+
+    // Creation still inherits the owner's pro mode.
+    const first = await taskService.createWorkspaceTurn({
+      ownerWorkspaceId: parentId,
+      prompt: "First prompt",
+      title: "Workspace turn",
+      workspace: { mode: "new" },
+    });
+    expect(first.success).toBe(true);
+    const firstSend = sendMessage.mock.calls[0];
+    expect(firstSend[2]).toMatchObject({ reasoningMode: "pro" });
+
+    // The child was switched back to standard (absent = standard per
+    // WorkspaceAISettingsSchema); follow-ups must respect that.
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(projectPath);
+      const child = project?.workspaces.find((workspace) => workspace.id === "childworkspace");
+      assert(child, "child workspace must exist");
+      child.aiSettingsByAgent = {
+        exec: { model: "openai:gpt-5.6-sol", thinkingLevel: "high" },
+      };
+      return cfg;
+    });
+
+    const second = await taskService.createWorkspaceTurn({
+      ownerWorkspaceId: parentId,
+      prompt: "Second prompt",
+      title: "Follow-up",
+      workspace: { mode: "existing", workspaceId: "childworkspace" },
+    });
+    expect(second.success).toBe(true);
+    const secondSend = sendMessage.mock.calls[1];
+    expect(secondSend[2]).not.toHaveProperty("reasoningMode");
+  });
+
   test("createWorkspaceTurn rejects multi-project owners instead of dropping secondary repos", async () => {
     const config = await createTestConfig(rootDir);
     stubStableIds(config, ["handle", "turn"]);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -3107,7 +3107,13 @@ export class TaskService {
     const handleId = `${WORKSPACE_TURN_TASK_ID_PREFIX}${this.config.generateStableId()}`;
     const turnId = this.config.generateStableId();
     const createdAt = getIsoNow();
+    // Workspace turns currently always run the exec agent (see the sendMessage
+    // call below). Key every defaults/persisted-settings lookup off this so the
+    // right agent's settings follow automatically if workspace turns ever run
+    // other agents.
+    const workspaceTurnAgentId = "exec";
     let targetWorkspaceId: string;
+    let targetAiSettings: ResolvedWorkspaceAiSettings | undefined;
     let createdWorkspace = false;
     let queuedForExistingWorkspace = false;
 
@@ -3127,6 +3133,15 @@ export class TaskService {
         return Err("Task.createWorkspaceTurn: invalid_scope for existing workspace");
       }
       targetWorkspaceId = existingWorkspaceId;
+      // Follow-up sends continue the target workspace's own last-used settings
+      // (persisted on every send, or manually changed by the user in that
+      // workspace) instead of re-inheriting the owner's live settings on each
+      // message — the owner changing its model/thinking must not drag
+      // already-created children along.
+      const targetEntry = findWorkspaceEntry(cfg, existingWorkspaceId);
+      targetAiSettings = targetEntry
+        ? this.resolveWorkspaceAISettings(targetEntry.workspace, workspaceTurnAgentId)
+        : undefined;
       queuedForExistingWorkspace = this.workspaceService.isBusyForMessage(existingWorkspaceId);
       const targetHasActiveWorkspaceTurn = await this.hasActiveWorkspaceTurnForWorkspace(
         allWorkspaceTurns,
@@ -3161,10 +3176,18 @@ export class TaskService {
       createdWorkspace = true;
     }
 
+    // Per-field precedence: explicit per-launch override → target workspace's
+    // own persisted settings (mode="existing" follow-ups) → configured agent
+    // defaults (so agent-created workspaces match what the user would get
+    // creating one by hand) → owner's live runtime settings → owner's
+    // persisted settings → app default.
+    const workspaceTurnAgentDefault = cfg.agentAiDefaults?.[workspaceTurnAgentId];
     const model =
       coerceNonEmptyString(args.modelString) ??
+      coerceNonEmptyString(targetAiSettings?.model) ??
+      coerceNonEmptyString(workspaceTurnAgentDefault?.modelString) ??
       coerceNonEmptyString(args.parentRuntimeAiSettings?.modelString) ??
-      coerceNonEmptyString(parentMeta.aiSettingsByAgent?.exec?.model) ??
+      coerceNonEmptyString(parentMeta.aiSettingsByAgent?.[workspaceTurnAgentId]?.model) ??
       coerceNonEmptyString(parentMeta.aiSettings?.model) ??
       defaultModel;
     const thinkingLevel =
@@ -3176,8 +3199,10 @@ export class TaskService {
             normalizeToCanonical(model),
             this.aiService.getProvidersConfig()
           )
-        : (args.parentRuntimeAiSettings?.thinkingLevel ??
-          parentMeta.aiSettingsByAgent?.exec?.thinkingLevel ??
+        : (targetAiSettings?.thinkingLevel ??
+          workspaceTurnAgentDefault?.thinkingLevel ??
+          args.parentRuntimeAiSettings?.thinkingLevel ??
+          parentMeta.aiSettingsByAgent?.[workspaceTurnAgentId]?.thinkingLevel ??
           parentMeta.aiSettings?.thinkingLevel);
     // Per-workspace pro mode inherits alongside model/thinking; the send path
     // re-gates per model/route so this is inert for non-GPT-5.6 models.
@@ -3185,14 +3210,20 @@ export class TaskService {
     // bucket fall back to the active-agent bucket (then legacy settings) —
     // mirroring resolveTaskAISettings — or a workspace turn launched from a
     // non-exec parent agent would silently drop back to standard mode.
+    // When the target has its own persisted settings (mode="existing"), those
+    // own the choice outright — absent means standard per
+    // WorkspaceAISettingsSchema — so the owner's pro toggle is not re-injected
+    // into follow-up sends.
     const activeParentAiSettings = this.resolveWorkspaceAISettings(
       parentMeta,
       normalizeAgentId(parentMeta.agentId)
     );
     const reasoningMode = coerceOpenAIReasoningMode(
-      parentMeta.aiSettingsByAgent?.exec?.reasoningMode ??
-        activeParentAiSettings?.reasoningMode ??
-        parentMeta.aiSettings?.reasoningMode
+      targetAiSettings != null
+        ? targetAiSettings.reasoningMode
+        : (parentMeta.aiSettingsByAgent?.[workspaceTurnAgentId]?.reasoningMode ??
+            activeParentAiSettings?.reasoningMode ??
+            parentMeta.aiSettings?.reasoningMode)
     );
 
     const record: WorkspaceTurnTaskHandleRecord = {
@@ -3251,7 +3282,7 @@ export class TaskService {
       prompt,
       {
         model,
-        agentId: "exec",
+        agentId: workspaceTurnAgentId,
         ...(thinkingLevel != null ? { thinkingLevel } : {}),
         ...(reasoningMode != null ? { reasoningMode } : {}),
         muxMetadata: this.buildWorkspaceTurnMuxMetadata(record),


### PR DESCRIPTION
## Summary

Workspace turns (`task(kind: "workspace")`) now resolve model/thinking with a saner per-field precedence: explicit per-launch override → the target workspace's own persisted settings (`mode: "existing"` follow-ups) → configured `agentAiDefaults` for the agent the turn runs → owner's live runtime settings → owner's persisted settings → app default.

## Background

Two surprising behaviors when an orchestrator workspace delegates via workspace turns:

1. **Creation ignored configured agent defaults.** An orchestrator turned down to `medium` spawned `medium` children even when the user's exec default was `max` — `createWorkspaceTurn` skipped straight from the explicit override to the owner's live settings, unlike sub-agent tasks (`resolveTaskAISettings`), which already consult `subagentAiDefaults`/`agentAiDefaults` first. Agent-created workspaces now match what the user would get creating the same workspace by hand.
2. **Follow-ups dragged children along.** Every `mode: "existing"` message re-inherited the owner's *current* settings and persisted them onto the child (persist-on-send), so bumping the orchestrator to `high` silently flipped all of its children to `high`, clobbering any level the user had deliberately set on a child. Follow-ups now continue the target workspace's own last-used settings, mirroring how a workspace behaves when the user sends a message in it directly.

## Implementation

- All lookups key off a single `workspaceTurnAgentId` constant (`exec` today, including the previously hardcoded `sendMessage` agent id), so if workspace turns ever run other agents, that agent's defaults follow automatically.
- Pro `reasoningMode` follows the same ownership rule: creation still inherits the owner's toggle, but once the target has its own persisted settings, follow-ups respect them outright (absent = standard per `WorkspaceAISettingsSchema`) instead of re-injecting the owner's choice.
- Explicit `model`/`thinking` args still outrank everything and persist onto the child via the existing persist-on-send path; for unchanged follow-ups that persist becomes a no-op writing back identical values.

## Validation

- New test walks the full precedence chain end-to-end: agent defaults beat owner runtime on create; the child's own settings beat both on follow-up; explicit override beats the child's settings.
- New test covers pro-mode ownership: inherited on create, not re-injected on follow-up after the child switched back to standard.
- Full `taskService.test.ts` suite (293) and `tools/task.test.ts` (28) pass; `make static-check` green.

## Risks

Behavioral change for orchestrator workflows: the accidental "turn the orchestrator down to spawn cheap children" trick no longer works when an exec agent default is configured — economizing children now requires an explicit `thinking:` arg on the task call (this is the intended semantics). Blast radius is confined to workspace-turn AI-settings resolution; regular sub-agent tasks and UI-created workspaces are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$11.66`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=11.66 -->
