### PR TITLE
🤖 fix: defer bash monitor wakes during task_await

### DIFF
--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -847,10 +847,10 @@ describe("BackgroundProcessManager", () => {
       let proc = await manager.getProcess(result.processId);
       for (let attempt = 0; attempt < 200; attempt++) {
         proc = await manager.getProcess(result.processId);
-        if (proc?.unfilteredReadSettled) break;
+        if (proc?.monitorWakeBlockingReadSettled) break;
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
-      expect(proc?.unfilteredReadSettled).toBeDefined();
+      expect(proc?.monitorWakeBlockingReadSettled).toBeDefined();
       expect(proc?.shownThroughOffset ?? -1).toBe(0);
 
       const settled = await manager.getSettledShownThroughOffset(result.processId);
@@ -858,6 +858,48 @@ describe("BackgroundProcessManager", () => {
       expect(read.success).toBe(true);
       // "line\n" is 5 bytes; the settled frontier reflects the completed read, not the stale 0.
       expect(settled).toBe(5);
+    });
+
+    it("waits for an in-flight filtered task_await before reporting the frontier", async () => {
+      // A monitor wake should not interrupt task_await on the same bash process. Even though a
+      // filtered await cannot advance shownThroughOffset, the delivery gate must wait for that await
+      // to settle; afterward it can deliver any matched lines that the filter did not show.
+      const result = await manager.spawn(runtime, testWorkspaceId, "sleep 3", {
+        cwd: process.cwd(),
+        displayName: "settled-filtered-task-await",
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      const controller = new AbortController();
+      const filteredRead = manager.getOutput(
+        result.processId,
+        "NOMATCH",
+        false,
+        10,
+        controller.signal,
+        testWorkspaceId,
+        "task_await"
+      );
+
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 200; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if ((proc?.getOutputCallCount ?? 0) > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      expect(proc?.getOutputCallCount).toBe(1);
+
+      const settledPromise = manager.getSettledShownThroughOffset(result.processId);
+      const settledBeforeAwait = await Promise.race([
+        settledPromise.then(() => true),
+        new Promise<boolean>((resolve) => setImmediate(() => resolve(false))),
+      ]);
+      expect(settledBeforeAwait).toBe(false);
+
+      controller.abort();
+      expect(await filteredRead).toMatchObject({ success: true, status: "interrupted" });
+      expect(await settledPromise).toBe(0);
     });
 
     it("does not block on an in-flight filtered read", async () => {

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -152,14 +152,12 @@ export interface BackgroundProcess {
    */
   shownThroughOffset: number;
   /**
-   * Resolves when the current in-flight *unfiltered* getOutput read settles (i.e. after it has
-   * advanced shownThroughOffset and returned). undefined when no unfiltered read is in flight.
-   * getSettledShownThroughOffset awaits this so the drain gate reads a settled frontier instead of
-   * racing a concurrent task_await. Filtered reads are deliberately not tracked here: they never
-   * advance shownThroughOffset and a filtered long-poll can hold the lock for the full timeout, so
-   * waiting on them would stall wake delivery for nothing.
+   * Resolves when the current read that must block same-process monitor delivery settles. This
+   * includes unfiltered reads, which may advance shownThroughOffset, and filtered task_await reads,
+   * which a monitor wake must not interrupt. Filtered reads from other callers remain untracked so
+   * they cannot delay wake delivery for output they will never mark as shown.
    */
-  unfilteredReadSettled?: Promise<void>;
+  monitorWakeBlockingReadSettled?: Promise<void>;
   /** Mutex to serialize getOutput() calls (prevents race condition when
    * parallel tool calls read from same offset before position is updated) */
   outputLock: AsyncMutex;
@@ -988,25 +986,29 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
   }
 
   /**
-   * Register an in-flight unfiltered read on the process and return a disposable that resolves +
-   * clears it when the read settles. Filtered reads get an inert disposable: they never advance the
-   * shown frontier, so wake delivery must not wait on them. See BackgroundProcess.unfilteredReadSettled.
+   * Register a read that same-process monitor delivery must wait for. Unfiltered reads participate
+   * because they can advance the shown frontier. Filtered task_await reads also participate so the
+   * wake cannot interrupt the await that is already watching this process; after the await settles,
+   * the unchanged frontier still allows filtered-out matched output to wake the agent.
    */
-  private trackUnfilteredRead(proc: BackgroundProcess, filter: string | undefined): Disposable {
-    if (filter) {
-      // Filtered read: nothing to track, so the disposable is a no-op.
+  private trackMonitorWakeBlockingRead(
+    proc: BackgroundProcess,
+    filter: string | undefined,
+    noteToolName: string | undefined
+  ): Disposable {
+    if (filter && noteToolName !== "task_await") {
       return { [Symbol.dispose]: () => undefined };
     }
     let resolve!: () => void;
     const settled = new Promise<void>((r) => {
       resolve = r;
     });
-    proc.unfilteredReadSettled = settled;
+    proc.monitorWakeBlockingReadSettled = settled;
     return {
       [Symbol.dispose]: () => {
         // A later read only starts after this one releases outputLock, so the field is still ours.
-        if (proc.unfilteredReadSettled === settled) {
-          proc.unfilteredReadSettled = undefined;
+        if (proc.monitorWakeBlockingReadSettled === settled) {
+          proc.monitorWakeBlockingReadSettled = undefined;
         }
         resolve();
       },
@@ -1014,10 +1016,11 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
   }
 
   /**
-   * The shown-frontier (shownThroughOffset) after any in-flight unfiltered read settles. Used by
-   * drainBashMonitorWakes to decide, at delivery time, whether a monitor match has already been
-   * shown to the agent by a concurrent task_await. Returns undefined for an unknown process so the
-   * drain fails open (delivers the wake) rather than silently dropping it.
+   * The shown-frontier (shownThroughOffset) after any read that blocks same-process monitor delivery
+   * settles. Used by drainBashMonitorWakes to decide, at delivery time, whether a monitor match has
+   * already been shown by a concurrent read, while also preventing a wake from interrupting an
+   * active filtered task_await. Returns undefined for an unknown process so the drain fails open
+   * (delivers the wake) rather than silently dropping it.
    *
    * `originNotAfterMs` binds the answer to the process instance that produced the wake. Process
    * IDs are derived from display_name and reclaimed across restarts, so a pending wake for a dead
@@ -1033,11 +1036,10 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     const proc = await this.getProcess(processId);
     if (!proc) return undefined;
     if (originNotAfterMs != null && proc.startTime > originNotAfterMs) return undefined;
-    // Await the current unfiltered read (if any). The matched output already exists on disk, so an
-    // unfiltered long-poll picks it up on its first iteration and returns promptly -- this does not
-    // hang on an idle process (no read in flight => field is undefined).
-    if (proc.unfilteredReadSettled) {
-      await proc.unfilteredReadSettled;
+    // Wait until a same-process task_await or frontier-advancing read settles before deciding whether
+    // to deliver. No tracked read means the frontier is already settled.
+    if (proc.monitorWakeBlockingReadSettled) {
+      await proc.monitorWakeBlockingReadSettled;
     }
     return proc.shownThroughOffset;
   }
@@ -1092,11 +1094,10 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     // the same offset before either updates the read position.
     await using _lock = await proc.outputLock.acquire();
 
-    // Register this read so the wake drain (getSettledShownThroughOffset) can await it before
-    // reading the shown-frontier, closing the race where a monitor exit-flush emits a wake for the
-    // same final line a concurrent task_await is still delivering. Filtered reads return an inert
-    // tracker: they never advance shownThroughOffset, so wake delivery must not block on them.
-    using _readTracker = this.trackUnfilteredRead(proc, filter);
+    // Register reads that same-process monitor delivery must not race. This includes filtered
+    // task_await calls even though they do not advance shownThroughOffset: the wake waits for the
+    // await to settle, then remains deliverable if its matched output was filtered out.
+    using _readTracker = this.trackMonitorWakeBlockingRead(proc, filter, noteToolName);
 
     // Track call count for polling detection
     proc.getOutputCallCount++;

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -86,6 +86,10 @@ export interface MonitorMatchPayload {
 }
 
 /** Emitted when a spawn arms a monitor; drives the persisted armed-monitor registry. */
+export type MonitorWakeDeliveryState =
+  | { status: "blocked"; readSettled: Promise<void> }
+  | { status: "settled"; shownThroughOffset: number };
+
 export interface MonitorArmedPayload {
   processId: string;
   taskId: string;
@@ -1016,32 +1020,40 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
   }
 
   /**
-   * The shown-frontier (shownThroughOffset) after any read that blocks same-process monitor delivery
-   * settles. Used by drainBashMonitorWakes to decide, at delivery time, whether a monitor match has
-   * already been shown by a concurrent read, while also preventing a wake from interrupting an
-   * active filtered task_await. Returns undefined for an unknown process so the drain fails open
-   * (delivers the wake) rather than silently dropping it.
+   * Snapshot whether same-process monitor delivery is currently blocked by an output read. Returning
+   * the blocking promise lets the workspace defer only this process's wake while continuing to
+   * deliver unrelated monitor matches from the same workspace.
    *
-   * `originNotAfterMs` binds the answer to the process instance that produced the wake. Process
-   * IDs are derived from display_name and reclaimed across restarts, so a pending wake for a dead
-   * instance could otherwise be superseded by a newer process's frontier. Callers pass the wake
-   * record's createdAt: the originating instance necessarily started before its first match created
-   * the record, so an instance whose startTime is after createdAt reused the ID and we return
-   * undefined (fail open) rather than let it suppress the prior instance's undelivered output.
+   * `originNotAfterMs` binds the answer to the process instance that produced the wake. Process IDs
+   * are reclaimed across restarts, so a newer instance must not suppress an older instance's wake.
+   */
+  async getMonitorWakeDeliveryState(
+    processId: string,
+    originNotAfterMs?: number
+  ): Promise<MonitorWakeDeliveryState | undefined> {
+    const proc = await this.getProcess(processId);
+    if (!proc) return undefined;
+    if (originNotAfterMs != null && proc.startTime > originNotAfterMs) return undefined;
+    if (proc.monitorWakeBlockingReadSettled) {
+      return { status: "blocked", readSettled: proc.monitorWakeBlockingReadSettled };
+    }
+    return { status: "settled", shownThroughOffset: proc.shownThroughOffset };
+  }
+
+  /**
+   * The shown-frontier after all same-process blocking reads settle. Kept as a convenience for
+   * callers that need the final value rather than a non-blocking delivery decision.
    */
   async getSettledShownThroughOffset(
     processId: string,
     originNotAfterMs?: number
   ): Promise<number | undefined> {
-    const proc = await this.getProcess(processId);
-    if (!proc) return undefined;
-    if (originNotAfterMs != null && proc.startTime > originNotAfterMs) return undefined;
-    // Wait until a same-process task_await or frontier-advancing read settles before deciding whether
-    // to deliver. No tracked read means the frontier is already settled.
-    if (proc.monitorWakeBlockingReadSettled) {
-      await proc.monitorWakeBlockingReadSettled;
+    while (true) {
+      const state = await this.getMonitorWakeDeliveryState(processId, originNotAfterMs);
+      if (state == null) return undefined;
+      if (state.status === "settled") return state.shownThroughOffset;
+      await state.readSettled;
     }
-    return proc.shownThroughOffset;
   }
 
   /**

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -2031,6 +2031,89 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("delivers unrelated monitor wakes while one process is blocked by task_await", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    let blockedReadReleased = false;
+    let resolveBlockedRead: () => void = () => undefined;
+    const releaseBlockedRead = () => {
+      blockedReadReleased = true;
+      resolveBlockedRead();
+    };
+    try {
+      const workspaceId = "bash-monitor-blocked-process-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-blocked",
+        taskId: "bash:proc-blocked",
+        workspaceId,
+        filter: "DONE",
+        filterExclude: false,
+        lines: ["BLOCKED done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-ready",
+        taskId: "bash:proc-ready",
+        workspaceId,
+        filter: "DONE",
+        filterExclude: false,
+        lines: ["READY done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const blockedReadSettled = new Promise<void>((resolve) => {
+        resolveBlockedRead = resolve;
+      });
+      const getMonitorWakeDeliveryState = mock((processId: string) =>
+        Promise.resolve(
+          processId === "proc-blocked" && !blockedReadReleased
+            ? ({ status: "blocked", readSettled: blockedReadSettled } as const)
+            : ({ status: "settled", shownThroughOffset: 0 } as const)
+        )
+      );
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getMonitorWakeDeliveryState,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][1]).toContain("READY done");
+      expect(sendSpy.mock.calls[0][1]).not.toContain("BLOCKED done");
+
+      releaseBlockedRead();
+      await waitForCondition(() => sendSpy.mock.calls.length === 2);
+      expect(sendSpy.mock.calls[1][1]).toContain("BLOCKED done");
+    } finally {
+      releaseBlockedRead();
+      await cleanup();
+    }
+  });
+
   test("delivers a stale-instance wake even after a reused process ID was read past the match", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1650,6 +1650,7 @@ export class WorkspaceService extends EventEmitter {
   private readonly constructedAtMs = Date.now();
   private readonly pendingBashMonitorWakeDrainsByOwner = new Map<string, Promise<void>>();
   private readonly pendingBashMonitorWakeIdleWaitsByOwner = new Map<string, Promise<void>>();
+  private readonly pendingBashMonitorWakeReadWaits = new Set<Promise<void>>();
   private readonly cancelingBashMonitorWakeKeys = new Set<string>();
   private readonly pendingBashMonitorWakeDrains = new Set<Promise<void>>();
   private readonly bashMonitorMatchListener = (
@@ -1929,6 +1930,32 @@ export class WorkspaceService extends EventEmitter {
     this.pendingBashMonitorWakeDrains.add(promise);
   }
 
+  private scheduleBashMonitorWakeDrainAfterRead(
+    ownerWorkspaceId: string,
+    readSettled: Promise<void>
+  ): void {
+    if (this.pendingBashMonitorWakeReadWaits.has(readSettled)) {
+      return;
+    }
+    this.pendingBashMonitorWakeReadWaits.add(readSettled);
+
+    const promise = readSettled
+      .catch((error: unknown) => {
+        log.debug("Bash monitor blocking read failed; retrying drain anyway", {
+          ownerWorkspaceId,
+          error,
+        });
+      })
+      .then(() => {
+        this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
+      })
+      .finally(() => {
+        this.pendingBashMonitorWakeDrains.delete(promise);
+        this.pendingBashMonitorWakeReadWaits.delete(readSettled);
+      });
+    this.pendingBashMonitorWakeDrains.add(promise);
+  }
+
   private scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId: string): void {
     if (this.pendingBashMonitorWakeIdleWaitsByOwner.has(ownerWorkspaceId)) {
       return;
@@ -2049,28 +2076,36 @@ export class WorkspaceService extends EventEmitter {
         this.bashMonitorWakeStore.markSupersededSnapshot(ownerWorkspaceId, record)
       );
 
-    // Delivery gate: the authoritative "don't re-report shown output" check. emitMonitorMatch's
-    // shownThroughOffset comparison is only a point-in-time fast path -- it can lose a race with a
-    // concurrent task_await that advances the shown-frontier just after the wake is emitted (a
-    // process printing its final line then exiting triggers an immediate exit flush that bypasses
-    // the cooldown). Here, at the moment each wake would become a transcript message, re-check its
-    // matched offset against the settled shown-frontier and drop any match already shown. Records
-    // without matchedThroughOffset (legacy on-disk) and managers without the query (partial test
-    // stubs) fail open -- the wake delivers, matching the pre-gate behavior. The record's createdAt
-    // pins the check to the instance that produced the match: process IDs are display-name-derived
-    // and reclaimed across restarts, so a fresh process that reused the ID started after createdAt,
-    // getSettledShownThroughOffset returns undefined, and the dead instance's wake still delivers.
+    // Delivery gate: re-check each match against the shown frontier immediately before sending it.
+    // If task_await is already reading that same process, defer only that record until the read
+    // settles; unrelated process wakes in this owner batch remain deliverable. Partial manager stubs
+    // without the non-blocking query retain the previous settled-frontier behavior.
+    const canQueryDeliveryState =
+      typeof this.backgroundProcessManager.getMonitorWakeDeliveryState === "function";
     const canQueryShownFrontier =
       typeof this.backgroundProcessManager.getSettledShownThroughOffset === "function";
     const deliverable: BashMonitorWakeRecord[] = [];
     const supersededByShown: BashMonitorWakeRecord[] = [];
     for (const record of pending) {
-      if (canQueryShownFrontier && record.kind === "match" && record.matchedThroughOffset != null) {
-        const shown = await this.backgroundProcessManager.getSettledShownThroughOffset(
-          record.processId,
-          Date.parse(record.createdAt)
-        );
-        if (shown != null && shown >= record.matchedThroughOffset) {
+      let shownThroughOffset: number | undefined;
+      if (record.kind === "match" && record.matchedThroughOffset != null) {
+        if (canQueryDeliveryState) {
+          const state = await this.backgroundProcessManager.getMonitorWakeDeliveryState(
+            record.processId,
+            Date.parse(record.createdAt)
+          );
+          if (state?.status === "blocked") {
+            this.scheduleBashMonitorWakeDrainAfterRead(ownerWorkspaceId, state.readSettled);
+            continue;
+          }
+          shownThroughOffset = state?.shownThroughOffset;
+        } else if (canQueryShownFrontier) {
+          shownThroughOffset = await this.backgroundProcessManager.getSettledShownThroughOffset(
+            record.processId,
+            Date.parse(record.createdAt)
+          );
+        }
+        if (shownThroughOffset != null && shownThroughOffset >= record.matchedThroughOffset) {
           supersededByShown.push(record);
           continue;
         }


### PR DESCRIPTION
## Summary

Defers a bash monitor wake while `task_await` is already waiting on the same process, preventing the wake from interrupting the wait it is meant to supplement without delaying monitor wakes from unrelated processes.

## Background

The settled shown-frontier gate only synchronized with unfiltered output reads. A filtered `task_await` was invisible to that gate, so a monitor match could enqueue a synthetic wake during the active wait. The queued wake interrupted `task_await`, and agents could repeatedly restart the wait and be interrupted by the next monitor match.

## Implementation

- Track unfiltered reads and filtered `task_await` reads as blockers for same-process monitor wake delivery.
- Expose a non-blocking delivery-state snapshot from `BackgroundProcessManager` so the workspace can defer only records for processes with active blocking reads.
- Schedule a fresh drain when that process's read settles while continuing to deliver unrelated monitor matches from the current batch.
- Reuse the shown-frontier gate after settlement: output displayed by an unfiltered await suppresses the redundant wake, while matched output hidden by a filter remains eligible for delivery.
- Add regression coverage for both the filtered-await synchronization and the unrelated-process delivery invariant.

## Risks

A monitor wake for a process can now be delayed for the duration of an active filtered `task_await` on that same process. This is intentional and bounded by the await. Wakes for other processes and filtered reads from other callers are unaffected.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$22.23`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=22.23 -->
