### PR TITLE
🤖 fix: clean up devtools.jsonl on archive/remove and reap orphaned session dirs

### DIFF
--- a/src/node/services/__tests__/devToolsService.test.ts
+++ b/src/node/services/__tests__/devToolsService.test.ts
@@ -402,6 +402,30 @@ describe("DevToolsService", () => {
       expect(await service.getRunWithSteps("ws-1", "run-1")).toBeNull();
       expect(await fs.readFile(getDevtoolsLogPath(sessionsDir, "ws-1"), "utf-8")).toBe("");
     });
+
+    it("removeWorkspaceData deletes the log file and in-memory state", async () => {
+      const service = new DevToolsService(createTestConfig({ sessionsDir, enabled: true }));
+      await service.createRun("ws-1", makeRun("run-1"));
+      await service.createStep("ws-1", makeStep({ id: "step-1", runId: "run-1" }));
+
+      await service.removeWorkspaceData("ws-1");
+
+      expect(await pathExists(getDevtoolsLogPath(sessionsDir, "ws-1"))).toBe(false);
+      expect(await service.getRuns("ws-1")).toEqual([]);
+      expect(await service.getRunWithSteps("ws-1", "run-1")).toBeNull();
+    });
+
+    it("removeWorkspaceData deletes stale log files even when logging is disabled", async () => {
+      // Simulate a file written while logging was enabled, then the user disabling it.
+      const logPath = getDevtoolsLogPath(sessionsDir, "ws-1");
+      await fs.mkdir(path.dirname(logPath), { recursive: true });
+      await fs.writeFile(logPath, `${JSON.stringify({ type: "run", run: makeRun("run-1") })}\n`);
+
+      const service = new DevToolsService(createTestConfig({ sessionsDir, enabled: false }));
+      await service.removeWorkspaceData("ws-1");
+
+      expect(await pathExists(logPath)).toBe(false);
+    });
   });
 
   describe("persistence", () => {

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -164,6 +164,10 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
   );
   aiService.setWorkflowResultContinuationSender(workspaceService);
   workspaceService.setMemoryConsolidationService(memoryConsolidationService);
+  if (opts.devToolsService) {
+    // DevTools debug-log cleanup when workspaces are archived/removed.
+    workspaceService.setDevToolsService(opts.devToolsService);
+  }
   workspaceService.setMCPServerManager(mcpServerManager);
   workspaceService.setWorkspaceGoalService(workspaceGoalService);
   workspaceGoalService.setOnActivityChange((workspaceId, snapshot) => {

--- a/src/node/services/devToolsService.ts
+++ b/src/node/services/devToolsService.ts
@@ -369,6 +369,41 @@ export class DevToolsService extends EventEmitter {
     this.emitWorkspaceEvent(workspaceId, { type: "cleared" });
   }
 
+  /**
+   * Remove all DevTools state for a workspace: in-memory data and the on-disk
+   * devtools.jsonl. Called when a workspace is archived or removed — debug logs
+   * grow large and are only useful for live workspaces (worst case after
+   * unarchive is an empty DevTools panel).
+   *
+   * Runs regardless of `enabled`: files written while logging was on must be
+   * cleaned up even if the user has since disabled debug logging.
+   */
+  async removeWorkspaceData(workspaceId: string): Promise<void> {
+    assert(
+      workspaceId.trim().length > 0,
+      "DevToolsService.removeWorkspaceData requires a workspaceId"
+    );
+
+    // Wait for any in-flight load to finish so it cannot repopulate state
+    // after the removal below.
+    const pendingLoad = this.loadingPromises.get(workspaceId);
+    if (pendingLoad) {
+      await pendingLoad;
+    }
+
+    // Deleting the entry (rather than clearing it in place) makes stale queued
+    // appends no-ops via the existence guard in appendToFile.
+    this.workspaces.delete(workspaceId);
+    this.pendingRunMetadata.delete(workspaceId);
+
+    // Enqueue the deletion so it serializes behind any pending appends.
+    await this.enqueueWrite(workspaceId, async () => {
+      await fs.rm(this.getSessionFilePath(workspaceId), { force: true });
+    });
+
+    this.emitWorkspaceEvent(workspaceId, { type: "cleared" });
+  }
+
   private emitWorkspaceEvent(workspaceId: string, event: DevToolsEvent): void {
     this.emit(`update:${workspaceId}`, event);
   }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3959,6 +3959,121 @@ describe("WorkspaceService initialize", () => {
     }
   });
 
+  test("removes stale orphaned session directories but keeps referenced and recent ones", async () => {
+    const { config: realConfig, historyService, cleanup } = await createTestHistoryService();
+    await realConfig.editConfig((cfg) => {
+      cfg.projects.set("/tmp/proj", {
+        workspaces: [
+          { path: "/tmp/proj/known-ws", id: "known-ws", name: "known-ws" },
+          // Legacy entry without a stable ID: its session dir is keyed by "<project>-<workspace>".
+          { path: "/tmp/proj/legacy-branch" },
+        ],
+      });
+      return cfg;
+    });
+
+    const sessionDirFor = (id: string) => path.join(realConfig.sessionsDir, id);
+    const knownDir = sessionDirFor("known-ws");
+    const legacyDir = sessionDirFor("proj-legacy-branch");
+    const staleOrphanDir = sessionDirFor("stale-orphan-ws");
+    const freshOrphanDir = sessionDirFor("fresh-orphan-ws");
+    for (const dir of [knownDir, legacyDir, staleOrphanDir, freshOrphanDir]) {
+      await fsPromises.mkdir(dir, { recursive: true });
+    }
+    // Backdate everything except the fresh orphan past the grace window, proving
+    // retention comes from config references rather than directory age.
+    const staleTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    for (const dir of [knownDir, legacyDir, staleOrphanDir]) {
+      await fsPromises.utimes(dir, staleTime, staleTime);
+    }
+
+    const aiService = {
+      on: mock(() => undefined),
+      off: mock(() => undefined),
+    } as unknown as AIService;
+    const service = createWorkspaceServiceForTest({
+      config: realConfig,
+      historyService,
+      aiService,
+      initStateManager: mockInitStateManager as InitStateManager,
+    });
+    const startupAccess = service as unknown as {
+      startStartupRecovery: (workspaceId: string) => void;
+    };
+    spyOn(startupAccess, "startStartupRecovery").mockImplementation(() => undefined);
+
+    const exists = (dir: string) =>
+      fsPromises.stat(dir).then(
+        () => true,
+        () => false
+      );
+
+    try {
+      await service.initialize();
+      expect(await exists(knownDir)).toBe(true);
+      expect(await exists(legacyDir)).toBe(true);
+      expect(await exists(freshOrphanDir)).toBe(true);
+      expect(await exists(staleOrphanDir)).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("preserves orphaned session directories when config cannot be loaded", async () => {
+    const { config: realConfig, historyService, cleanup } = await createTestHistoryService();
+    const orphanDir = path.join(realConfig.sessionsDir, "stale-orphan-ws");
+    await fsPromises.mkdir(orphanDir, { recursive: true });
+    const staleTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    await fsPromises.utimes(orphanDir, staleTime, staleTime);
+    await fsPromises.writeFile(path.join(realConfig.rootDir, "config.json"), "{invalid-json");
+
+    const aiService = {
+      on: mock(() => undefined),
+      off: mock(() => undefined),
+    } as unknown as AIService;
+    const service = createWorkspaceServiceForTest({
+      config: realConfig,
+      historyService,
+      aiService,
+      initStateManager: mockInitStateManager as InitStateManager,
+    });
+
+    try {
+      await service.initialize();
+      expect(await fsPromises.stat(orphanDir).then(() => true)).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("removes DevTools logs for archived workspaces at startup", async () => {
+    const liveWorkspace = createFrontendWorkspaceMetadata({
+      id: "live-ws",
+      name: "Live Workspace",
+    });
+    const archivedWorkspace = createFrontendWorkspaceMetadata({
+      id: "archived-ws",
+      name: "Archived Workspace",
+      archivedAt: "2026-03-20T00:00:00.000Z",
+    });
+    config.getAllWorkspaceMetadata = mock(() =>
+      Promise.resolve([liveWorkspace, archivedWorkspace])
+    ) as unknown as Config["getAllWorkspaceMetadata"];
+
+    const removeWorkspaceData = mock(() => Promise.resolve());
+    workspaceService.setDevToolsService({ removeWorkspaceData });
+
+    const startupAccess = workspaceService as unknown as {
+      startStartupRecovery: (workspaceId: string) => void;
+    };
+    spyOn(startupAccess, "startStartupRecovery").mockImplementation(() => undefined);
+
+    await workspaceService.initialize();
+
+    expect(removeWorkspaceData).toHaveBeenCalledTimes(1);
+    expect(removeWorkspaceData).toHaveBeenCalledWith("archived-ws");
+  });
+
   test("disposes transient startup-recovery sessions that go idle", async () => {
     const dispose = mock(() => undefined);
     const fakeSession = {
@@ -8831,6 +8946,34 @@ describe("WorkspaceService archive lifecycle hooks", () => {
     expect(entry?.archivedAt).toBeTruthy();
     expect(entry?.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
+  test("archive() removes DevTools data only after archivedAt is persisted", async () => {
+    const removeWorkspaceData = mock((id: string) => {
+      // devtools cleanup must run only once the archived state is durable
+      expect(id).toBe(workspaceId);
+      const entry = configState.projects.get(projectPath)?.workspaces[0];
+      expect(entry?.archivedAt).toBeTruthy();
+      return Promise.resolve();
+    });
+    workspaceService.setDevToolsService({ removeWorkspaceData });
+
+    const result = await workspaceService.archive(workspaceId);
+
+    expect(result.success).toBe(true);
+    expect(removeWorkspaceData).toHaveBeenCalledTimes(1);
+  });
+
+  test("archive() stays successful when DevTools cleanup fails", async () => {
+    workspaceService.setDevToolsService({
+      removeWorkspaceData: mock(() => Promise.reject(new Error("disk error"))),
+    });
+
+    const result = await workspaceService.archive(workspaceId);
+
+    expect(result.success).toBe(true);
+    const entry = configState.projects.get(projectPath)?.workspaces[0];
+    expect(entry?.archivedAt).toBeTruthy();
+  });
+
   test("archive() invokes descendant cleanup only after archive persistence succeeds", async () => {
     const callOrder: string[] = [];
     editConfigSpy.mockImplementation((fn: (config: ProjectsConfig) => ProjectsConfig) => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -293,6 +293,14 @@ import { getErrorMessage } from "@/common/utils/errors";
 const MAX_WORKSPACE_NAME_COLLISION_RETRIES = 3;
 
 /**
+ * Minimum age before an unreferenced session directory is treated as an orphan and
+ * deleted at startup. Protects session data written by a workspace whose config entry
+ * has not been observed yet (e.g., creation racing the sweep); true orphans are stale
+ * for far longer and get reaped on a later startup.
+ */
+const ORPHAN_SESSION_DIR_GRACE_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Base name used when /new auto-generates a branch name. Numbered suffixes
  * (`workspace-1`, `workspace-2`, ...) come from {@link generateForkBranchName}
  * so the existing fork-style numbering helpers stay the single source of truth.
@@ -2248,6 +2256,8 @@ export class WorkspaceService extends EventEmitter {
   private worktreeArchiveSnapshotService?: WorktreeArchiveSnapshotLifecycleService;
   private taskService?: TaskService;
   private workspaceGoalService?: WorkspaceGoalService;
+  /** Narrow DevTools cleanup surface; wired by coreServices when a DevToolsService exists. */
+  private devToolsService?: { removeWorkspaceData(workspaceId: string): Promise<void> };
 
   /**
    * Set the MCP server manager for tool access.
@@ -2307,6 +2317,11 @@ export class WorkspaceService extends EventEmitter {
    */
   setTaskService(taskService: TaskService): void {
     this.taskService = taskService;
+  }
+
+  /** DevTools debug-log cleanup on archive/remove; wired by coreServices. */
+  setDevToolsService(service: { removeWorkspaceData(workspaceId: string): Promise<void> }): void {
+    this.devToolsService = service;
   }
 
   private getWorktreeArchiveBehavior(): "keep" | "delete" | "snapshot" {
@@ -2390,6 +2405,12 @@ export class WorkspaceService extends EventEmitter {
         log.debug("Failed to clean orphaned scratch workdirs", { error });
       });
       const allMetadata = await this.config.getAllWorkspaceMetadata();
+      await this.cleanupOrphanSessionDirs(allMetadata).catch((error: unknown) => {
+        log.debug("Failed to clean orphaned session directories", { error });
+      });
+      await this.cleanupArchivedDevToolsLogs(allMetadata).catch((error: unknown) => {
+        log.debug("Failed to clean archived workspace DevTools logs", { error });
+      });
       let scheduledCount = 0;
       let skippedTaskCount = 0;
       let skippedArchivedCount = 0;
@@ -3450,6 +3471,90 @@ export class WorkspaceService extends EventEmitter {
         await fsPromises.rm(candidatePath, { recursive: true, force: true });
       } catch (error: unknown) {
         log.debug("Failed to clean orphaned scratch workdir", { candidatePath, error });
+      }
+    }
+  }
+
+  /**
+   * Startup sweep over the sessions directory: delete session directories whose
+   * workspace no longer exists in config at all (orphans left behind by crashed
+   * or partially-failed removals), so they stop hogging disk forever.
+   */
+  private async cleanupOrphanSessionDirs(allMetadata: FrontendWorkspaceMetadata[]): Promise<void> {
+    // Never interpret a config read failure as an empty reference set, because that
+    // would turn best-effort orphan cleanup into deletion of every workspace's session data.
+    const config = this.config.loadConfigOrDefault({ throwOnError: true });
+
+    const knownIds = new Set<string>(allMetadata.map((metadata) => metadata.id));
+    for (const [projectPath, projectConfig] of config.projects) {
+      for (const workspace of projectConfig.workspaces) {
+        if (workspace.id) {
+          knownIds.add(workspace.id);
+        }
+        // Pre-stable-ID sessions are keyed by the legacy "<project>-<workspace>" ID;
+        // keep them even if the config entry has since been migrated.
+        knownIds.add(this.config.generateLegacyId(projectPath, workspace.path));
+      }
+    }
+
+    const entries = await fsPromises
+      .readdir(this.config.sessionsDir, { withFileTypes: true })
+      .catch((error: unknown) => {
+        if (isErrnoWithCode(error, "ENOENT")) {
+          return null;
+        }
+        throw error;
+      });
+    if (entries == null) {
+      return;
+    }
+
+    const nowMs = Date.now();
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (knownIds.has(entry.name)) continue;
+
+      const candidatePath = path.join(this.config.sessionsDir, entry.name);
+      try {
+        // Grace window: never reap a directory with recent activity, so a workspace
+        // being created concurrently with this sweep cannot lose its session data.
+        const stat = await fsPromises.stat(candidatePath);
+        if (nowMs - stat.mtimeMs < ORPHAN_SESSION_DIR_GRACE_MS) continue;
+
+        // Re-check fresh config immediately before deleting (findWorkspace also
+        // resolves legacy IDs), closing the race with workspaces created after
+        // the snapshot above.
+        if (this.config.findWorkspace(entry.name)) continue;
+
+        await fsPromises.rm(candidatePath, { recursive: true, force: true });
+        log.info("Removed orphaned session directory", { workspaceId: entry.name });
+      } catch (error: unknown) {
+        log.debug("Failed to clean orphaned session directory", { candidatePath, error });
+      }
+    }
+  }
+
+  /**
+   * Startup sweep deleting devtools.jsonl for archived workspaces. Archive-time cleanup
+   * handles new archives; this retroactively heals workspaces archived before that
+   * cleanup existed (debug logs routinely dwarf all other session data).
+   */
+  private async cleanupArchivedDevToolsLogs(
+    allMetadata: FrontendWorkspaceMetadata[]
+  ): Promise<void> {
+    if (!this.devToolsService) {
+      return;
+    }
+
+    for (const metadata of allMetadata) {
+      if (!isWorkspaceArchived(metadata.archivedAt, metadata.unarchivedAt)) continue;
+      try {
+        await this.devToolsService.removeWorkspaceData(metadata.id);
+      } catch (error: unknown) {
+        log.debug("Failed to remove DevTools log for archived workspace", {
+          workspaceId: metadata.id,
+          error,
+        });
       }
     }
   }
@@ -4707,6 +4812,17 @@ export class WorkspaceService extends EventEmitter {
         await fsPromises.rm(sessionDir, { recursive: true, force: true });
       } catch (error) {
         log.error(`Failed to remove session directory for ${workspaceId}:`, error);
+      }
+
+      // The on-disk devtools.jsonl died with the session directory above; also drop any
+      // in-memory DevTools state so stale runs cannot outlive the workspace.
+      try {
+        await this.devToolsService?.removeWorkspaceData(workspaceId);
+      } catch (error) {
+        log.debug("Failed to drop DevTools state after workspace removal", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
       }
 
       // Stop MCP servers for this workspace
@@ -6473,6 +6589,19 @@ export class WorkspaceService extends EventEmitter {
             error: getErrorMessage(error),
           });
         }
+      }
+
+      // DevTools debug logs can be huge and are only useful for live workspaces; drop them
+      // once the archived state is durable (worst case after unarchive is an empty DevTools
+      // panel). Best-effort: archive stays successful even if this fails — the startup sweep
+      // in initialize() retries for archived workspaces.
+      try {
+        await this.devToolsService?.removeWorkspaceData(workspaceId);
+      } catch (error) {
+        log.debug("Failed to remove DevTools log after archive", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
       }
 
       // Emit updated metadata


### PR DESCRIPTION
## Summary

DevTools debug logs (`devtools.jsonl`) are now deleted when a workspace is archived or removed, and startup sweeps reclaim disk from orphaned session directories and from workspaces archived before this cleanup existed.

## Background

A disk audit found ~57.7 GiB of `devtools.jsonl` files across 442 archived workspaces (mux never pruned these; the worst case after unarchive is an empty DevTools panel), plus 96 orphaned session directories whose workspaces no longer exist in `~/.mux/config.json` at all (left behind by crashed or partially-failed removals).

## Implementation

- `DevToolsService.removeWorkspaceData(workspaceId)`: drops in-memory run/step state and deletes the on-disk `devtools.jsonl`. The deletion serializes behind pending appends via the existing per-workspace write queue, and deleting the in-memory entry makes stale queued appends no-ops via the existing `appendToFile` existence guards. Runs even when debug logging is disabled, so files written while logging was on still get cleaned.
- `WorkspaceService.archive()` calls it best-effort **after** `archivedAt` is durably persisted — archive never fails because of log cleanup.
- `WorkspaceService.remove()` additionally drops in-memory DevTools state (the file already dies with the session directory).
- Startup sweeps in `WorkspaceService.initialize()` (next to the existing orphan-scratch-workdir reaper):
  - **Orphan session dirs**: deletes `~/.mux/sessions/<id>` directories with no config entry. Safety rails: config read failures are never treated as an empty reference set (no mass deletion), legacy `<project>-<workspace>` session IDs are preserved for un-migrated entries, and a 24h mtime grace window plus a fresh `findWorkspace()` re-check guard against racing workspace creation.
  - **Retroactive devtools sweep**: deletes `devtools.jsonl` for currently-archived workspaces, healing archives that predate archive-time cleanup and any archive-time cleanup failures.
- Wired via a narrow `setDevToolsService()` setter in `coreServices` (same pattern as `setTaskService`). Chat history, plans, and archive snapshots are untouched.

## Validation

End-to-end dogfood with real `Config` + `DevToolsService` + `WorkspaceService` on a temp root: `initialize()` shrank an archived workspace 8.1M→4K (chat kept), removed a 4.1M stale orphan, spared a fresh orphan; `archive()` then dropped the live workspace's `devtools.jsonl` leaving only `chat.jsonl`.

## Risks

- Deletion sweeps are the main risk surface. Mitigations: orphan reaping requires a strict config load (`throwOnError`), a 24h grace window, and a per-directory fresh config re-check immediately before `rm`; devtools cleanup only ever touches `devtools.jsonl`.
- Severity if wrong: loss of debug logs (low; regenerable) or, guarded against as above, session data of a brand-new workspace.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$13.32`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=13.32 -->
