### PR TITLE
🤖 feat: show per-model cost breakdown in workspace Costs tab

### DIFF
--- a/src/browser/features/RightSidebar/CostsTab.tsx
+++ b/src/browser/features/RightSidebar/CostsTab.tsx
@@ -3,8 +3,10 @@ import { useWorkspaceUsage, useWorkspaceConsumers } from "@/browser/stores/Works
 import {
   sumUsageHistory,
   formatCostWithDollar,
+  getTotalCost,
   type ChatUsageDisplay,
 } from "@/common/utils/tokens/usageAggregator";
+import { normalizeToCanonical, formatModelStringForDisplay } from "@/common/utils/ai/models";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { AGENT_AI_DEFAULTS_KEY } from "@/common/constants/storage";
 import { resolveCompactionModel } from "@/browser/utils/messages/compactionModelPreference";
@@ -82,6 +84,34 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
     if (usage.liveCostUsage) parts.push(usage.liveCostUsage);
     return parts.length > 0 ? sumUsageHistory(parts) : undefined;
   }, [usage.sessionTotal, usage.liveCostUsage]);
+
+  // Per-model session costs. Live streaming usage is not yet folded into the
+  // persisted byModel record, so merge it into the active model's bucket to
+  // keep rows consistent with the session total above.
+  const sessionModelRows = (() => {
+    const merged = new Map<string, ChatUsageDisplay>(Object.entries(usage.sessionByModel ?? {}));
+    const liveModel = usage.liveCostUsage?.model;
+    if (usage.liveCostUsage && liveModel) {
+      const key = normalizeToCanonical(liveModel);
+      const existing = merged.get(key);
+      merged.set(
+        key,
+        existing ? sumUsageHistory([existing, usage.liveCostUsage])! : usage.liveCostUsage
+      );
+    }
+    return Array.from(merged.entries())
+      .map(([model, entry]) => ({
+        model,
+        tokens:
+          entry.input.tokens +
+          entry.cached.tokens +
+          entry.cacheCreate.tokens +
+          entry.output.tokens +
+          entry.reasoning.tokens,
+        cost: getTotalCost(entry),
+      }))
+      .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0) || b.tokens - a.tokens);
+  })();
 
   const hasUsageData =
     usage &&
@@ -385,6 +415,41 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
                       })}
                     </tbody>
                   </table>
+                  {viewMode === "session" && sessionModelRows.length > 0 && (
+                    <table
+                      data-testid="cost-by-model"
+                      className="mt-4 w-full border-collapse text-[11px]"
+                    >
+                      <thead>
+                        <tr className="border-border-light border-b">
+                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                            Model
+                          </th>
+                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                            Tokens
+                          </th>
+                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                            Cost
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {sessionModelRows.map((row) => (
+                          <tr key={row.model}>
+                            <td className="text-foreground max-w-0 truncate py-1 pr-2 [&:last-child]:pr-0 [&:last-child]:text-right">
+                              {formatModelStringForDisplay(row.model)}
+                            </td>
+                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                              {formatTokens(row.tokens)}
+                            </td>
+                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                              {formatCostWithDollar(row.cost)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
                 </>
               );
             })()}

--- a/src/browser/features/RightSidebar/RightSidebar.stories.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.stories.tsx
@@ -342,6 +342,72 @@ export const CostsTabWithCacheCreate: Story = {
 };
 
 /**
+ * Costs tab with multiple models used in one session.
+ * The per-model breakdown table lists each model's tokens and cost.
+ */
+export const CostsTabMultiModel: Story = {
+  render: () => (
+    <RightSidebarStoryShell
+      setup={() => {
+        localStorage.setItem(RIGHT_SIDEBAR_TAB_KEY, JSON.stringify("costs"));
+        localStorage.setItem("costsTab:viewMode", JSON.stringify("session"));
+        localStorage.setItem("statsContainer:subTab", JSON.stringify("cost"));
+        localStorage.setItem(RIGHT_SIDEBAR_WIDTH_KEY, "400");
+        localStorage.removeItem(getRightSidebarLayoutKey("ws-multi-model"));
+
+        const client = setupSimpleChatStory({
+          workspaceId: "ws-multi-model",
+          workspaceName: "feature/multi-model",
+          projectName: "my-app",
+          messages: [
+            createUserMessage("msg-1", "Plan and implement the parser", { historySequence: 1 }),
+            createAssistantMessage("msg-2", "Done: plan reviewed and parser implemented.", {
+              historySequence: 2,
+            }),
+          ],
+          sessionUsage: {
+            byModel: {
+              "anthropic:claude-opus-4-6": {
+                input: { tokens: 12000, cost_usd: 0.18 },
+                cached: { tokens: 240000, cost_usd: 0.36 },
+                cacheCreate: { tokens: 80000, cost_usd: 1.5 },
+                output: { tokens: 9000, cost_usd: 0.675 },
+                reasoning: { tokens: 4000, cost_usd: 0.3 },
+                model: "anthropic:claude-opus-4-6",
+              },
+              "openai:gpt-5.2": {
+                input: { tokens: 30000, cost_usd: 0.0525 },
+                cached: { tokens: 50000, cost_usd: 0.021875 },
+                cacheCreate: { tokens: 0, cost_usd: 0 },
+                output: { tokens: 6000, cost_usd: 0.084 },
+                reasoning: { tokens: 8000, cost_usd: 0.112 },
+                model: "openai:gpt-5.2",
+              },
+            },
+            version: 1,
+          },
+        });
+        expandRightSidebar();
+        return client;
+      }}
+    >
+      <RightSidebarStoryContent workspaceId="ws-multi-model" />
+    </RightSidebarStoryShell>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Session usage is fetched async via WorkspaceStore; wait for the
+    // per-model breakdown rows to render.
+    await waitFor(() => {
+      const byModel = canvas.getByTestId("cost-by-model");
+      within(byModel).getByText("Opus 4.6");
+      within(byModel).getByText("GPT-5.2");
+    });
+  },
+};
+
+/**
  * Review tab selected - click switches from Costs to Review tab
  * Verifies per-tab width persistence: starts at Costs width (350px), switches to Review width (700px)
  */

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -208,6 +208,8 @@ type DerivedState = Record<string, number>;
 export interface WorkspaceUsageState {
   /** Pre-computed session total (sum of all models) */
   sessionTotal?: ChatUsageDisplay;
+  /** Session usage per canonical model string (source of sessionTotal) */
+  sessionByModel?: Record<string, ChatUsageDisplay>;
   /** Last completed request (persisted) */
   lastRequest?: {
     model: string;
@@ -2442,6 +2444,13 @@ export class WorkspaceStore {
           ? sumUsageHistory(Object.values(sessionData.byModel))
           : undefined;
 
+      // Shallow copy: byModel is mutated in place on stream-end, so a fresh
+      // record keeps memoized consumers from reading stale snapshots.
+      const sessionByModel =
+        sessionData && Object.keys(sessionData.byModel).length > 0
+          ? { ...sessionData.byModel }
+          : undefined;
+
       // Last request from persisted data
       const lastRequest = sessionData?.lastRequest;
 
@@ -2533,7 +2542,15 @@ export class WorkspaceStore {
             )
           : undefined;
 
-      return { sessionTotal, lastRequest, lastContextUsage, totalTokens, liveUsage, liveCostUsage };
+      return {
+        sessionTotal,
+        sessionByModel,
+        lastRequest,
+        lastContextUsage,
+        totalTokens,
+        liveUsage,
+        liveCostUsage,
+      };
     });
   }
 


### PR DESCRIPTION
## Summary

Adds a per-model cost breakdown table to the workspace Costs tab (Stats → Cost, Session view), so multi-model sessions show where tokens and spend went per model.

## Background

Session cost was only shown as component totals (input/output/cache), with no visibility into which model consumed them. Sessions that mix models (tool-invoked models, sub-agent roll-ups, mid-session model switches) had no per-model attribution. The per-model data already existed in `session-usage.json` (`byModel`); it was summed into `sessionTotal` and discarded.

## Implementation

- `WorkspaceStore`: `WorkspaceUsageState` now exposes `sessionByModel`, a fresh shallow copy of the per-canonical-model usage record already loaded from `session-usage.json` (copied per recompute because the underlying record is mutated in place on stream-end).
- `CostsTab`: new Model / Tokens / Cost table below the component table, Session view only (Last Request is single-model by definition). Live streaming usage is merged into the active model's bucket the same way the displayed session total already merges it, so model rows always sum to the header total. Rows sort by cost, then tokens, descending; names render via `formatModelStringForDisplay`.
- Storybook: `CostsTabMultiModel` story with a play assertion that both model rows render.

## Validation

- UAT against a sandboxed dev server with real API calls across two models (Haiku 4.5 + GPT-5.4 Nano): verified Session breakdown rows sum to the header total, the table hides in Last Request view, rows stay consistent mid-stream while usage grows live, and reload renders identical values from pure disk state matching `session-usage.json`.

## Risks

Low. Read-only UI addition fed by existing usage data; no changes to usage accounting or persistence. Worst case is a display inconsistency in the new table itself.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$20.48`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=20.48 -->
