### PR TITLE
🤖 fix: archive all sidebar variants

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -1226,7 +1226,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(parentRow.getAttribute("aria-describedby")).toBe("workspace-status-description-parent");
   });
 
-  test("renders variants groups with a shared row and labeled members when expanded", async () => {
+  test("archives a variants group from its context menu and renders labeled members when expanded", async () => {
     window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
 
     const singleProjectRefs = [
@@ -1322,7 +1322,22 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(view.queryByTestId(agentItemTestId("child-1"))).toBeNull();
     expect(view.queryByTestId(agentItemTestId("child-2"))).toBeNull();
 
-    fireEvent.click(groupRow);
+    fireEvent.contextMenu(groupRow, { clientX: 120, clientY: 80 });
+    const archiveAllVariants = view.getByRole("button", { name: /Archive all variants/ });
+    fireEvent.click(archiveAllVariants);
+
+    await waitFor(() => {
+      expect(preflightArchiveWorkspaceMock).toHaveBeenCalledTimes(2);
+      expect(archiveWorkspaceActionMock).toHaveBeenCalledTimes(2);
+    });
+    expect(preflightArchiveWorkspaceMock).toHaveBeenNthCalledWith(1, "child-1");
+    expect(preflightArchiveWorkspaceMock).toHaveBeenNthCalledWith(2, "child-2");
+    expect(archiveWorkspaceActionMock).toHaveBeenNthCalledWith(1, "child-1", undefined);
+    expect(archiveWorkspaceActionMock).toHaveBeenNthCalledWith(2, "child-2", undefined);
+
+    if (groupRow.getAttribute("aria-expanded") !== "true") {
+      fireEvent.click(groupRow);
+    }
 
     await waitFor(() => {
       expect(view.getByText("frontend · Split review")).toBeTruthy();

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -1335,6 +1335,18 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
     expect(archiveWorkspaceActionMock).toHaveBeenNthCalledWith(1, "child-1", undefined);
     expect(archiveWorkspaceActionMock).toHaveBeenNthCalledWith(2, "child-2", undefined);
 
+    archiveWorkspaceActionMock.mockClear();
+    archiveWorkspaceActionMock.mockImplementationOnce(() =>
+      Promise.resolve({ success: false as const, error: "archive failed" })
+    );
+    fireEvent.contextMenu(groupRow, { clientX: 120, clientY: 80 });
+    fireEvent.click(view.getByRole("button", { name: /Archive all variants/ }));
+
+    await waitFor(() => {
+      expect(archiveWorkspaceActionMock).toHaveBeenCalledTimes(1);
+    });
+    expect(archiveWorkspaceActionMock).toHaveBeenCalledWith("child-1", undefined);
+
     if (groupRow.getAttribute("aria-expanded") !== "true") {
       fireEvent.click(groupRow);
     }

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -955,15 +955,26 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const workspaceForkError = usePopoverError();
   const workspaceStopRuntimeError = usePopoverError();
   const workspaceRemoveError = usePopoverError();
-  const [archiveConfirmation, setArchiveConfirmation] = useState<{
-    workspaceId: string;
-    displayTitle: string;
-    buttonElement?: HTMLElement;
-    /** When set, the confirmation warns about permanent deletion of untracked files. */
-    untrackedPaths?: string[];
-    /** Whether the workspace has an active stream that will be interrupted. */
-    isStreaming?: boolean;
-  } | null>(null);
+  const [archiveConfirmation, setArchiveConfirmation] = useState<
+    | {
+        kind: "workspace";
+        workspaceId: string;
+        displayTitle: string;
+        buttonElement?: HTMLElement;
+        /** When set, the confirmation warns about permanent deletion of untracked files. */
+        untrackedPaths?: string[];
+        /** Whether the workspace has an active stream that will be interrupted. */
+        isStreaming?: boolean;
+      }
+    | {
+        kind: "variant-group";
+        title: string;
+        buttonElement: HTMLElement;
+        members: Array<{ workspaceId: string; untrackedPaths?: string[] }>;
+        isStreaming: boolean;
+      }
+    | null
+  >(null);
   const [deleteConfirmation, setDeleteConfirmation] = useState<{
     projectPath: string;
     projectName: string;
@@ -1136,6 +1147,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           const awaitingUserQuestion = aggregator?.hasAwaitingUserQuestion() ?? false;
           const isStreaming = (hasActiveStreams || isStarting) && !awaitingUserQuestion;
           setArchiveConfirmation({
+            kind: "workspace",
             workspaceId,
             displayTitle,
             buttonElement,
@@ -1160,6 +1172,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                 const metadata = workspaceStore.getWorkspaceMetadata(workspaceId);
                 const displayTitle = metadata?.title ?? metadata?.name ?? workspaceId;
                 setArchiveConfirmation({
+                  kind: "workspace",
                   workspaceId,
                   displayTitle,
                   buttonElement,
@@ -1267,6 +1280,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       if (isStreaming || untrackedPaths) {
         // Show a single combined confirmation dialog for streaming + untracked-file warnings.
         setArchiveConfirmation({
+          kind: "workspace",
           workspaceId,
           displayTitle,
           buttonElement,
@@ -1287,6 +1301,54 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     ]
   );
 
+  const handleArchiveVariantGroup = useCallback(
+    async (title: string, members: FrontendWorkspaceMetadata[], buttonElement: HTMLElement) => {
+      const preparedMembers: Array<{ workspaceId: string; untrackedPaths?: string[] }> = [];
+      let isStreaming = false;
+
+      // Preflight the whole group before changing anything. A partial archive would
+      // leave a variants row in a surprising half-deleted state.
+      for (const member of members) {
+        const preflight = await preflightArchiveWorkspace(member.id);
+        if (!preflight.success) {
+          workspaceArchiveError.showError(
+            member.id,
+            preflight.error ?? "Failed to check archive readiness"
+          );
+          return;
+        }
+
+        preparedMembers.push({
+          workspaceId: member.id,
+          untrackedPaths:
+            preflight.data?.kind === "confirm-lossy-untracked-files"
+              ? preflight.data.paths
+              : undefined,
+        });
+        isStreaming ||= hasActiveStream(member.id);
+      }
+
+      const hasUntrackedPaths = preparedMembers.some(
+        (member) => member.untrackedPaths != null && member.untrackedPaths.length > 0
+      );
+      if (isStreaming || hasUntrackedPaths) {
+        setArchiveConfirmation({
+          kind: "variant-group",
+          title,
+          buttonElement,
+          members: preparedMembers,
+          isStreaming,
+        });
+        return;
+      }
+
+      for (const member of preparedMembers) {
+        await performArchiveWorkspace(member.workspaceId, buttonElement);
+      }
+    },
+    [hasActiveStream, performArchiveWorkspace, preflightArchiveWorkspace, workspaceArchiveError]
+  );
+
   const handleArchiveWorkspaceConfirm = useCallback(async () => {
     if (!archiveConfirmation) {
       return;
@@ -1294,6 +1356,17 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
     const confirmation = archiveConfirmation;
     setArchiveConfirmation(null);
+    if (confirmation.kind === "variant-group") {
+      for (const member of confirmation.members) {
+        await performArchiveWorkspace(
+          member.workspaceId,
+          confirmation.buttonElement,
+          member.untrackedPaths
+        );
+      }
+      return;
+    }
+
     await performArchiveWorkspace(
       confirmation.workspaceId,
       confirmation.buttonElement,
@@ -1889,6 +1962,17 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     userProjects,
     workspaceStore,
   ]);
+
+  const archiveConfirmationIsVariantGroup = archiveConfirmation?.kind === "variant-group";
+  const variantGroupUntrackedPaths = archiveConfirmationIsVariantGroup
+    ? archiveConfirmation.members.flatMap((member) => member.untrackedPaths ?? [])
+    : [];
+  const archiveConfirmationUntrackedPaths = archiveConfirmationIsVariantGroup
+    ? variantGroupUntrackedPaths.length > 0
+      ? variantGroupUntrackedPaths
+      : undefined
+    : archiveConfirmation?.untrackedPaths;
+  const archiveConfirmationIsStreaming = archiveConfirmation?.isStreaming ?? false;
 
   return (
     <TitleEditProvider onUpdateTitle={onUpdateTitle}>
@@ -2588,6 +2672,16 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                       onToggle={() => {
                                         toggleTaskGroupExpansion(group.storageKey, isExpanded);
                                       }}
+                                      onArchiveAll={
+                                        group.kind === "variants"
+                                          ? (buttonElement) =>
+                                              handleArchiveVariantGroup(
+                                                group.title,
+                                                group.allMembers,
+                                                buttonElement
+                                              )
+                                          : undefined
+                                      }
                                     />
                                   );
 
@@ -3240,22 +3334,32 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           <ConfirmationModal
             isOpen={archiveConfirmation !== null}
             title={
-              archiveConfirmation?.untrackedPaths
-                ? "Archive workspace with untracked files?"
-                : archiveConfirmation
-                  ? `Archive "${archiveConfirmation.displayTitle}" while streaming?`
-                  : "Archive chat?"
+              archiveConfirmationIsVariantGroup
+                ? `Archive all variants for "${archiveConfirmation.title}"?`
+                : archiveConfirmationUntrackedPaths
+                  ? "Archive workspace with untracked files?"
+                  : archiveConfirmation
+                    ? `Archive "${archiveConfirmation.displayTitle}" while streaming?`
+                    : "Archive chat?"
             }
-            description={buildArchiveConfirmDescription(
-              archiveConfirmation?.isStreaming ?? false,
-              archiveConfirmation?.untrackedPaths
-            )}
+            description={
+              archiveConfirmationIsVariantGroup
+                ? `${archiveConfirmation.members.length} variant chats will be archived together.`
+                : buildArchiveConfirmDescription(
+                    archiveConfirmationIsStreaming,
+                    archiveConfirmationUntrackedPaths
+                  )
+            }
             warning={buildArchiveConfirmWarning(
-              archiveConfirmation?.isStreaming ?? false,
-              archiveConfirmation?.untrackedPaths
+              archiveConfirmationIsStreaming,
+              archiveConfirmationUntrackedPaths
             )}
             confirmLabel={
-              archiveConfirmation?.untrackedPaths ? "Archive and delete files" : "Archive"
+              archiveConfirmationUntrackedPaths
+                ? "Archive and delete files"
+                : archiveConfirmationIsVariantGroup
+                  ? "Archive all"
+                  : "Archive"
             }
             confirmVariant="destructive"
             onConfirm={handleArchiveWorkspaceConfirm}

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1156,7 +1156,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
             // interruption warning again when the archive attempt has not yet been confirmed.
             isStreaming: acknowledgedUntrackedPaths == null ? isStreaming : false,
           });
-          return;
+          return false;
         }
         if (!result.success) {
           if (acknowledgedUntrackedPaths != null) {
@@ -1187,7 +1187,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                     return (hasActiveStreams || isStarting) && !awaitingUserQuestion;
                   })(),
                 });
-                return;
+                return false;
               }
             }
           }
@@ -1198,7 +1198,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           // left-sidebar row that may be far from their current focus. Use the shared toast fallback
           // position so archive errors match other top-right UI error surfaces.
           workspaceArchiveError.showError(workspaceId, error);
+          return false;
         }
+        return true;
       } finally {
         // Clear archiving state
         setArchivingWorkspaceIds((prev) => {
@@ -1343,7 +1345,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       }
 
       for (const member of preparedMembers) {
-        await performArchiveWorkspace(member.workspaceId, buttonElement);
+        const archived = await performArchiveWorkspace(member.workspaceId, buttonElement);
+        if (!archived) {
+          return;
+        }
       }
     },
     [hasActiveStream, performArchiveWorkspace, preflightArchiveWorkspace, workspaceArchiveError]
@@ -1358,11 +1363,14 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     setArchiveConfirmation(null);
     if (confirmation.kind === "variant-group") {
       for (const member of confirmation.members) {
-        await performArchiveWorkspace(
+        const archived = await performArchiveWorkspace(
           member.workspaceId,
           confirmation.buttonElement,
           member.untrackedPaths
         );
+        if (!archived) {
+          return;
+        }
       }
       return;
     }

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
@@ -1,7 +1,7 @@
 import "../../../../tests/ui/dom";
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 import { TaskGroupListItem } from "./TaskGroupListItem";
 
@@ -62,6 +62,23 @@ describe("TaskGroupListItem", () => {
       "text-content-success"
     );
     expect(groupRow.textContent).toContain("1 queued");
+  });
+
+  test("handles the archive shortcut without triggering native window handlers", () => {
+    const onWindowKeydown = mock(() => undefined);
+    const onArchiveAll = mock(() => Promise.resolve());
+    window.addEventListener("keydown", onWindowKeydown);
+    const view = renderTaskGroup({ kind: "variants", onArchiveAll });
+
+    fireEvent.keyDown(view.getByTestId("task-group-best-of-demo"), {
+      key: "Backspace",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    window.removeEventListener("keydown", onWindowKeydown);
+
+    expect(onArchiveAll).toHaveBeenCalledTimes(1);
+    expect(onWindowKeydown).not.toHaveBeenCalled();
   });
 
   test("aggregates member state into the shared status-dot language", () => {

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
@@ -64,6 +64,22 @@ describe("TaskGroupListItem", () => {
     expect(groupRow.textContent).toContain("1 queued");
   });
 
+  test("ignores keyboard events from nested menu controls", () => {
+    const onToggle = mock(() => undefined);
+    const view = renderTaskGroup({
+      kind: "variants",
+      onArchiveAll: () => Promise.resolve(),
+      onToggle,
+    });
+    fireEvent.contextMenu(view.getByTestId("task-group-best-of-demo"));
+
+    fireEvent.keyDown(view.getByRole("button", { name: /Archive all variants/ }), {
+      key: "Enter",
+    });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
   test("handles the archive shortcut without triggering native window handlers", () => {
     const onWindowKeydown = mock(() => undefined);
     const onArchiveAll = mock(() => Promise.resolve());

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
@@ -64,20 +64,28 @@ describe("TaskGroupListItem", () => {
     expect(groupRow.textContent).toContain("1 queued");
   });
 
-  test("ignores keyboard events from nested menu controls", () => {
+  test("handles menu shortcuts without toggling the group or reaching window handlers", () => {
+    const onWindowKeydown = mock(() => undefined);
+    const onArchiveAll = mock(() => Promise.resolve());
     const onToggle = mock(() => undefined);
-    const view = renderTaskGroup({
-      kind: "variants",
-      onArchiveAll: () => Promise.resolve(),
-      onToggle,
-    });
+    window.addEventListener("keydown", onWindowKeydown);
+    const view = renderTaskGroup({ kind: "variants", onArchiveAll, onToggle });
     fireEvent.contextMenu(view.getByTestId("task-group-best-of-demo"));
+    const menuItem = view.getByRole("button", { name: /Archive all variants/ });
 
-    fireEvent.keyDown(view.getByRole("button", { name: /Archive all variants/ }), {
-      key: "Enter",
-    });
-
+    fireEvent.keyDown(menuItem, { key: "Enter" });
     expect(onToggle).not.toHaveBeenCalled();
+    onWindowKeydown.mockClear();
+
+    fireEvent.keyDown(menuItem, {
+      key: "Backspace",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    window.removeEventListener("keydown", onWindowKeydown);
+
+    expect(onArchiveAll).toHaveBeenCalledTimes(1);
+    expect(onWindowKeydown).not.toHaveBeenCalled();
   });
 
   test("handles the archive shortcut without triggering native window handlers", () => {

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/browser/components/PositionedMenu/PositionedMenu";
 import { getSidebarItemPaddingLeft } from "@/browser/components/sidebarItemLayout";
 import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
+import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
 import { cn } from "@/common/lib/utils";
 import {
@@ -105,6 +106,7 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
         }
         if (props.onArchiveAll && matchesKeybind(event, KEYBINDS.ARCHIVE_WORKSPACE)) {
           event.preventDefault();
+          stopKeyboardPropagation(event);
           props.onArchiveAll(event.currentTarget).catch(() => {
             // The sidebar owner surfaces archive failures through its shared error UI.
           });

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -99,6 +99,11 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
       }}
       onContextMenu={props.onArchiveAll ? contextMenu.onContextMenu : undefined}
       onKeyDown={(event) => {
+        // Portaled menu events still bubble through the React tree. Only the row
+        // itself owns expansion and archive shortcuts.
+        if (event.target !== event.currentTarget) {
+          return;
+        }
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           props.onToggle();

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -99,22 +99,22 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
       }}
       onContextMenu={props.onArchiveAll ? contextMenu.onContextMenu : undefined}
       onKeyDown={(event) => {
-        // Portaled menu events still bubble through the React tree. Only the row
-        // itself owns expansion and archive shortcuts.
-        if (event.target !== event.currentTarget) {
-          return;
-        }
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          props.onToggle();
-          return;
-        }
+        // Portaled menu events still bubble through the React tree. Handle the
+        // shared archive shortcut first, then limit row-only keys to the row.
         if (props.onArchiveAll && matchesKeybind(event, KEYBINDS.ARCHIVE_WORKSPACE)) {
           event.preventDefault();
           stopKeyboardPropagation(event);
           props.onArchiveAll(event.currentTarget).catch(() => {
             // The sidebar owner surfaces archive failures through its shared error UI.
           });
+          return;
+        }
+        if (event.target !== event.currentTarget) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          props.onToggle();
         }
       }}
     >

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -1,7 +1,14 @@
 import { ChevronRight, Layers3, Workflow } from "lucide-react";
 
 import { StatusDot, type VisualState } from "@/browser/components/AgentListItem/StatusDot";
+import { ArchiveIcon } from "@/browser/components/icons/ArchiveIcon/ArchiveIcon";
+import {
+  PositionedMenu,
+  PositionedMenuItem,
+} from "@/browser/components/PositionedMenu/PositionedMenu";
 import { getSidebarItemPaddingLeft } from "@/browser/components/sidebarItemLayout";
+import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
+import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
 import { cn } from "@/common/lib/utils";
 import {
   formatSidebarTaskGroupHeader,
@@ -24,6 +31,8 @@ interface TaskGroupListItemProps {
   isExpanded: boolean;
   isSelected: boolean;
   onToggle: () => void;
+  /** Variant groups archive as one unit so users do not have to expand and remove each chat. */
+  onArchiveAll?: (buttonElement: HTMLElement) => Promise<void>;
 }
 
 /**
@@ -43,6 +52,7 @@ function getAggregateVisualState(props: TaskGroupListItemProps): VisualState {
 }
 
 export function TaskGroupListItem(props: TaskGroupListItemProps) {
+  const contextMenu = useContextMenuPosition();
   const hasRunningWork = props.runningCount > 0;
   const aggregateState = getAggregateVisualState(props);
   const statusDescriptionId = `task-group-status-${props.groupId}`;
@@ -86,10 +96,18 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
       onClick={() => {
         props.onToggle();
       }}
+      onContextMenu={props.onArchiveAll ? contextMenu.onContextMenu : undefined}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           props.onToggle();
+          return;
+        }
+        if (props.onArchiveAll && matchesKeybind(event, KEYBINDS.ARCHIVE_WORKSPACE)) {
+          event.preventDefault();
+          props.onArchiveAll(event.currentTarget).catch(() => {
+            // The sidebar owner surfaces archive failures through its shared error UI.
+          });
         }
       }}
     >
@@ -153,6 +171,26 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
           )}
         </div>
       </div>
+      {props.onArchiveAll && (
+        <PositionedMenu
+          open={contextMenu.isOpen}
+          onOpenChange={contextMenu.onOpenChange}
+          position={contextMenu.position}
+        >
+          <PositionedMenuItem
+            icon={<ArchiveIcon className="h-4 w-4 shrink-0" />}
+            label="Archive all variants"
+            shortcut={formatKeybind(KEYBINDS.ARCHIVE_WORKSPACE)}
+            variant="destructive"
+            onClick={(event) => {
+              contextMenu.close();
+              props.onArchiveAll?.(event.currentTarget).catch(() => {
+                // The sidebar owner surfaces archive failures through its shared error UI.
+              });
+            }}
+          />
+        </PositionedMenu>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a context menu action to variant group rows in the sidebar so all variants can be archived together without expanding the group and archiving each chat individually.

## Implementation

- adds an **Archive all variants** action on right-click and supports the existing archive keyboard shortcut when the group row is focused
- preflights every variant before changing the group to avoid leaving it partially archived
- combines streaming and untracked-file warnings into one group confirmation
- archives each member through the existing workspace archive path
- adds UI coverage for opening the group context menu and archiving every member

## Risks

Low and limited to sidebar variant-group archive behavior. Individual workspace archive behavior continues to use the existing preflight, confirmation, and error handling paths.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `medium` • Cost: `$13.98`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=medium costs=13.98 -->
