### PR TITLE
🤖 refactor: split context sections into a Stats Context sub-tab

### DIFF
--- a/src/browser/features/RightSidebar/ContextTab.tsx
+++ b/src/browser/features/RightSidebar/ContextTab.tsx
@@ -61,7 +61,7 @@ const ContextTabComponent: React.FC<ContextTabProps> = ({ workspaceId }) => {
         </div>
       )}
 
-      {consumers.consumers.length > 0 && (
+      {(consumers.consumers.length > 0 || consumers.isCalculating) && (
         <div className="mt-4 mb-4">
           <h3 className="text-subtle m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
             Consumer Breakdown

--- a/src/browser/features/RightSidebar/ContextTab.tsx
+++ b/src/browser/features/RightSidebar/ContextTab.tsx
@@ -11,7 +11,7 @@ interface ContextTabProps {
   workspaceId: string;
 }
 
-const ContextTabComponent: React.FC<ContextTabProps> = ({ workspaceId }) => {
+export const ContextTab: React.FC<ContextTabProps> = ({ workspaceId }) => {
   const consumers = useWorkspaceConsumers(workspaceId);
 
   const postCompactionState = usePostCompactionState(workspaceId);
@@ -79,5 +79,3 @@ const ContextTabComponent: React.FC<ContextTabProps> = ({ workspaceId }) => {
     </div>
   );
 };
-
-export const ContextTab = React.memo(ContextTabComponent);

--- a/src/browser/features/RightSidebar/ContextTab.tsx
+++ b/src/browser/features/RightSidebar/ContextTab.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { useWorkspaceConsumers } from "@/browser/stores/WorkspaceStore";
+import { ConsumerBreakdown } from "./ConsumerBreakdown";
+import { FileBreakdown } from "./FileBreakdown";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
+import { PostCompactionSection } from "./PostCompactionSection";
+import { usePostCompactionState } from "@/browser/hooks/usePostCompactionState";
+import { useOptionalWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
+
+interface ContextTabProps {
+  workspaceId: string;
+}
+
+const ContextTabComponent: React.FC<ContextTabProps> = ({ workspaceId }) => {
+  const consumers = useWorkspaceConsumers(workspaceId);
+
+  const postCompactionState = usePostCompactionState(workspaceId);
+
+  // Get runtimeConfig for SSH-aware editor opening
+  const workspaceContext = useOptionalWorkspaceContext();
+  const runtimeConfig = workspaceContext?.workspaceMetadata.get(workspaceId)?.runtimeConfig;
+
+  const hasConsumerData = consumers.totalTokens > 0 || consumers.isCalculating;
+  const hasArtifacts =
+    postCompactionState.planPath !== null || postCompactionState.trackedFilePaths.length > 0;
+
+  if (!hasConsumerData && !hasArtifacts) {
+    return (
+      <div className="text-light font-primary text-[13px] leading-relaxed">
+        <div className="text-dim py-2 text-xs italic">No context details available</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-light font-primary text-[13px] leading-relaxed">
+      <PostCompactionSection
+        workspaceId={workspaceId}
+        planPath={postCompactionState.planPath}
+        trackedFilePaths={postCompactionState.trackedFilePaths}
+        excludedItems={postCompactionState.excludedItems}
+        onToggleExclusion={postCompactionState.toggleExclusion}
+        runtimeConfig={runtimeConfig}
+      />
+
+      {consumers.topFilePaths && consumers.topFilePaths.length > 0 && (
+        <div className="mt-4 mb-4">
+          <h3 className="text-subtle m-0 mb-2 flex items-center gap-1 text-xs font-semibold tracking-wide uppercase">
+            File Breakdown
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-dim cursor-help text-[10px] font-normal">ⓘ</span>
+              </TooltipTrigger>
+              <TooltipContent align="start" className="max-w-72 whitespace-normal">
+                Token usage from file_read and file_edit tools, aggregated by file path. Consider
+                splitting large files to reduce context usage.
+              </TooltipContent>
+            </Tooltip>
+          </h3>
+          <FileBreakdown files={consumers.topFilePaths} totalTokens={consumers.totalTokens} />
+        </div>
+      )}
+
+      {consumers.consumers.length > 0 && (
+        <div className="mt-4 mb-4">
+          <h3 className="text-subtle m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
+            Consumer Breakdown
+          </h3>
+          {consumers.isCalculating ? (
+            <div className="text-secondary py-2 text-xs italic">Calculating...</div>
+          ) : (
+            <ConsumerBreakdown
+              consumers={consumers.consumers}
+              totalTokens={consumers.totalTokens}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const ContextTab = React.memo(ContextTabComponent);

--- a/src/browser/features/RightSidebar/ContextUsageSection.tsx
+++ b/src/browser/features/RightSidebar/ContextUsageSection.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { useWorkspaceUsage } from "@/browser/stores/WorkspaceStore";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { AGENT_AI_DEFAULTS_KEY } from "@/common/constants/storage";
+import { resolveCompactionModel } from "@/browser/utils/messages/compactionModelPreference";
+import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
+import { useProviderOptions } from "@/browser/hooks/useProviderOptions";
+import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
+import { calculateTokenMeterData } from "@/common/utils/tokens/tokenMeterUtils";
+import { ContextUsageBar } from "./ContextUsageBar";
+import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
+import { useAutoCompactionSettings } from "@/browser/hooks/useAutoCompactionSettings";
+import { getEffectiveContextLimit } from "@/common/utils/compaction/contextLimit";
+
+interface ContextUsageSectionProps {
+  workspaceId: string;
+}
+
+/**
+ * Context usage meter with auto-compaction threshold slider.
+ * Rendered above the Stats sub-tabs so it stays visible on every sub-tab.
+ */
+const ContextUsageSectionComponent: React.FC<ContextUsageSectionProps> = ({ workspaceId }) => {
+  const usage = useWorkspaceUsage(workspaceId);
+  const [agentAiDefaults] = usePersistedState<AgentAiDefaults>(
+    AGENT_AI_DEFAULTS_KEY,
+    {},
+    {
+      listener: true,
+    }
+  );
+  const configuredCompactionModel = agentAiDefaults.compact?.modelString ?? "";
+  const { has1MContext } = useProviderOptions();
+  const pendingSendOptions = useSendMessageOptions(workspaceId);
+  const { config: providersConfig } = useProvidersConfig();
+
+  // Token counts come from usage metadata, but context limits/1M eligibility should
+  // follow the currently selected model unless a stream is actively running.
+  const contextDisplayModel = usage.liveUsage?.model ?? pendingSendOptions.baseModel;
+  // Align warning with /compact model resolution so it matches actual compaction behavior.
+  const effectiveCompactionModel =
+    resolveCompactionModel(configuredCompactionModel) ?? contextDisplayModel;
+
+  // Auto-compaction settings: threshold per-model (100 = disabled)
+  const { threshold: autoCompactThreshold, setThreshold: setAutoCompactThreshold } =
+    useAutoCompactionSettings(workspaceId, contextDisplayModel);
+
+  const contextUsage = usage.liveUsage ?? usage.lastContextUsage;
+  if (!contextUsage) {
+    return null;
+  }
+
+  const contextUsageData = calculateTokenMeterData(
+    contextUsage,
+    contextDisplayModel,
+    has1MContext(contextDisplayModel),
+    false,
+    providersConfig
+  );
+
+  // Warn when the compaction model can't fit the auto-compact threshold to avoid failures.
+  const contextWarning = (() => {
+    const maxTokens = contextUsageData.maxTokens;
+    if (!maxTokens || autoCompactThreshold >= 100 || !effectiveCompactionModel) return undefined;
+
+    const thresholdTokens = Math.round((autoCompactThreshold / 100) * maxTokens);
+    const compactionMaxTokens = getEffectiveContextLimit(
+      effectiveCompactionModel,
+      has1MContext(effectiveCompactionModel),
+      providersConfig
+    );
+
+    if (compactionMaxTokens && compactionMaxTokens < thresholdTokens) {
+      return { compactionModelMaxTokens: compactionMaxTokens, thresholdTokens };
+    }
+    return undefined;
+  })();
+
+  return (
+    <div
+      data-testid="context-usage-section"
+      className="text-light font-primary mt-2 mb-4 text-[13px] leading-relaxed"
+    >
+      <ContextUsageBar
+        testId="context-usage"
+        data={contextUsageData}
+        model={contextDisplayModel}
+        autoCompaction={{
+          threshold: autoCompactThreshold,
+          setThreshold: setAutoCompactThreshold,
+          contextWarning,
+        }}
+      />
+    </div>
+  );
+};
+
+export const ContextUsageSection = React.memo(ContextUsageSectionComponent);

--- a/src/browser/features/RightSidebar/ContextUsageSection.tsx
+++ b/src/browser/features/RightSidebar/ContextUsageSection.tsx
@@ -20,7 +20,7 @@ interface ContextUsageSectionProps {
  * Context usage meter with auto-compaction threshold slider.
  * Rendered above the Stats sub-tabs so it stays visible on every sub-tab.
  */
-const ContextUsageSectionComponent: React.FC<ContextUsageSectionProps> = ({ workspaceId }) => {
+export const ContextUsageSection: React.FC<ContextUsageSectionProps> = ({ workspaceId }) => {
   const usage = useWorkspaceUsage(workspaceId);
   const [agentAiDefaults] = usePersistedState<AgentAiDefaults>(
     AGENT_AI_DEFAULTS_KEY,
@@ -94,5 +94,3 @@ const ContextUsageSectionComponent: React.FC<ContextUsageSectionProps> = ({ work
     </div>
   );
 };
-
-export const ContextUsageSection = React.memo(ContextUsageSectionComponent);

--- a/src/browser/features/RightSidebar/CostsTab.tsx
+++ b/src/browser/features/RightSidebar/CostsTab.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useWorkspaceUsage, useWorkspaceConsumers } from "@/browser/stores/WorkspaceStore";
+import { useWorkspaceUsage } from "@/browser/stores/WorkspaceStore";
 import {
   sumUsageHistory,
   formatCostWithDollar,
@@ -8,28 +8,10 @@ import {
 } from "@/common/utils/tokens/usageAggregator";
 import { normalizeToCanonical, formatModelStringForDisplay } from "@/common/utils/ai/models";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
-import { AGENT_AI_DEFAULTS_KEY } from "@/common/constants/storage";
-import { resolveCompactionModel } from "@/browser/utils/messages/compactionModelPreference";
-import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import { ToggleGroup, type ToggleOption } from "@/browser/components/ToggleGroup/ToggleGroup";
-import { useProviderOptions } from "@/browser/hooks/useProviderOptions";
-import { useSendMessageOptions } from "@/browser/hooks/useSendMessageOptions";
-import {
-  TOKEN_COMPONENT_COLORS,
-  calculateTokenMeterData,
-  formatTokens,
-} from "@/common/utils/tokens/tokenMeterUtils";
-import { ConsumerBreakdown } from "./ConsumerBreakdown";
-import { FileBreakdown } from "./FileBreakdown";
-import { ContextUsageBar } from "./ContextUsageBar";
-import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
-import { useAutoCompactionSettings } from "@/browser/hooks/useAutoCompactionSettings";
-import { getEffectiveContextLimit } from "@/common/utils/compaction/contextLimit";
+import { TOKEN_COMPONENT_COLORS, formatTokens } from "@/common/utils/tokens/tokenMeterUtils";
 
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
-import { PostCompactionSection } from "./PostCompactionSection";
-import { usePostCompactionState } from "@/browser/hooks/usePostCompactionState";
-import { useOptionalWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 
 type ViewMode = "last-request" | "session";
 
@@ -44,37 +26,7 @@ interface CostsTabProps {
 
 const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
   const usage = useWorkspaceUsage(workspaceId);
-  const consumers = useWorkspaceConsumers(workspaceId);
   const [viewMode, setViewMode] = usePersistedState<ViewMode>("costsTab:viewMode", "session");
-  const [agentAiDefaults] = usePersistedState<AgentAiDefaults>(
-    AGENT_AI_DEFAULTS_KEY,
-    {},
-    {
-      listener: true,
-    }
-  );
-  const configuredCompactionModel = agentAiDefaults.compact?.modelString ?? "";
-  const { has1MContext } = useProviderOptions();
-  const pendingSendOptions = useSendMessageOptions(workspaceId);
-  const { config: providersConfig } = useProvidersConfig();
-
-  // Post-compaction context state for UI display
-  const postCompactionState = usePostCompactionState(workspaceId);
-
-  // Get runtimeConfig for SSH-aware editor opening
-  const workspaceContext = useOptionalWorkspaceContext();
-  const runtimeConfig = workspaceContext?.workspaceMetadata.get(workspaceId)?.runtimeConfig;
-
-  // Token counts come from usage metadata, but context limits/1M eligibility should
-  // follow the currently selected model unless a stream is actively running.
-  const contextDisplayModel = usage.liveUsage?.model ?? pendingSendOptions.baseModel;
-  // Align warning with /compact model resolution so it matches actual compaction behavior.
-  const effectiveCompactionModel =
-    resolveCompactionModel(configuredCompactionModel) ?? contextDisplayModel;
-
-  // Auto-compaction settings: threshold per-model (100 = disabled)
-  const { threshold: autoCompactThreshold, setThreshold: setAutoCompactThreshold } =
-    useAutoCompactionSettings(workspaceId, contextDisplayModel);
 
   // Session usage for cost calculation
   // Uses sessionTotal (pre-computed) + liveCostUsage (cumulative during streaming)
@@ -113,393 +65,260 @@ const CostsTabComponent: React.FC<CostsTabProps> = ({ workspaceId }) => {
       .sort((a, b) => (b.cost ?? 0) - (a.cost ?? 0) || b.tokens - a.tokens);
   })();
 
-  const hasUsageData =
-    usage &&
-    (usage.sessionTotal !== undefined ||
-      usage.lastContextUsage !== undefined ||
-      usage.liveUsage !== undefined);
-  const hasConsumerData = consumers && (consumers.totalTokens > 0 || consumers.isCalculating);
-  const hasAnyData = hasUsageData || hasConsumerData;
+  // Last Request (for Cost section): from persisted data
+  const lastRequestUsage = usage.lastRequest?.usage;
 
-  // Only show empty state if truly no data anywhere
-  if (!hasAnyData) {
+  const hasCostData = sessionUsage !== undefined || lastRequestUsage !== undefined;
+
+  if (!hasCostData) {
     return (
       <div className="text-light font-primary text-[13px] leading-relaxed">
         <div className="text-secondary px-5 py-10 text-center">
           <p>No messages yet.</p>
-          <p>Send a message to see token usage statistics.</p>
+          <p>Send a message to see cost statistics.</p>
         </div>
       </div>
     );
   }
 
-  // Last Request (for Cost section): from persisted data
-  const lastRequestUsage = usage.lastRequest?.usage;
-
   // Cost and Details table use viewMode
   const displayUsage = viewMode === "last-request" ? lastRequestUsage : sessionUsage;
 
+  const getCostPercentage = (cost: number | undefined, total: number | undefined) =>
+    total !== undefined && total > 0 && cost !== undefined ? (cost / total) * 100 : 0;
+
+  // Costs are already computed from shared model metadata when usage is recorded.
+  // Repricing again here drifts from tiered per-request accounting, especially for
+  // native 1M models and session aggregates that span multiple requests.
+  const inputCost = displayUsage?.input.cost_usd;
+  const outputCost = displayUsage?.output.cost_usd;
+  const reasoningCost = displayUsage?.reasoning.cost_usd;
+
+  // Calculate total cost (undefined if any cost is unknown)
+  const totalCost: number | undefined = displayUsage
+    ? inputCost !== undefined &&
+      displayUsage.cached.cost_usd !== undefined &&
+      displayUsage.cacheCreate.cost_usd !== undefined &&
+      outputCost !== undefined &&
+      reasoningCost !== undefined
+      ? inputCost +
+        displayUsage.cached.cost_usd +
+        displayUsage.cacheCreate.cost_usd +
+        outputCost +
+        reasoningCost
+      : undefined
+    : undefined;
+
+  // Calculate cost percentages from the shared metadata-driven costs.
+  const inputCostPercentage = getCostPercentage(inputCost, totalCost);
+  const cachedCostPercentage = getCostPercentage(displayUsage?.cached.cost_usd, totalCost);
+  const cacheCreateCostPercentage = getCostPercentage(
+    displayUsage?.cacheCreate.cost_usd,
+    totalCost
+  );
+  const outputCostPercentage = getCostPercentage(outputCost, totalCost);
+  const reasoningCostPercentage = getCostPercentage(reasoningCost, totalCost);
+
+  const components = displayUsage
+    ? [
+        {
+          name: "Cache Read",
+          tokens: displayUsage.cached.tokens,
+          cost: displayUsage.cached.cost_usd,
+          color: TOKEN_COMPONENT_COLORS.cached,
+          show: displayUsage.cached.tokens > 0,
+        },
+        {
+          name: "Cache Create",
+          tokens: displayUsage.cacheCreate.tokens,
+          cost: displayUsage.cacheCreate.cost_usd,
+          color: TOKEN_COMPONENT_COLORS.cacheCreate,
+          show: displayUsage.cacheCreate.tokens > 0,
+        },
+        {
+          name: "Input",
+          tokens: displayUsage.input.tokens,
+          cost: inputCost,
+          color: TOKEN_COMPONENT_COLORS.input,
+          show: true,
+        },
+        {
+          name: "Output",
+          tokens: displayUsage.output.tokens,
+          cost: outputCost,
+          color: TOKEN_COMPONENT_COLORS.output,
+          show: true,
+        },
+        {
+          name: "Thinking",
+          tokens: displayUsage.reasoning.tokens,
+          cost: reasoningCost,
+          color: TOKEN_COMPONENT_COLORS.thinking,
+          show: displayUsage.reasoning.tokens > 0,
+        },
+      ].filter((c) => c.show)
+    : [];
+
   return (
     <div className="text-light font-primary text-[13px] leading-relaxed">
-      {hasUsageData && (
-        <div data-testid="context-usage-section" className="mt-2 mb-5">
-          <div data-testid="context-usage-list" className="flex flex-col gap-3">
-            {(() => {
-              const contextUsage = usage.liveUsage ?? usage.lastContextUsage;
+      <div data-testid="cost-section" className="mb-6">
+        <div className="flex flex-col gap-3">
+          {totalCost !== undefined && totalCost >= 0 && (
+            <div data-testid="cost-bar" className="relative mb-2 flex flex-col gap-1">
+              <div data-testid="cost-header" className="mb-2 flex items-baseline justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="text-foreground inline-flex items-baseline gap-1 font-medium">
+                    Cost
+                  </span>
+                  <ToggleGroup
+                    options={VIEW_MODE_OPTIONS}
+                    value={viewMode}
+                    onChange={setViewMode}
+                  />
+                </div>
+                <span className="text-muted flex items-center gap-1 text-xs tabular-nums">
+                  {formatCostWithDollar(totalCost)}
+                  {displayUsage?.hasUnknownCosts && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="text-warning cursor-help">?</span>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="max-w-[200px]">
+                        Cost may be incomplete — some models in this session have unknown pricing
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </span>
+              </div>
+              <div className="relative w-full">
+                <div className="bg-border-light flex h-1.5 w-full overflow-hidden rounded-[3px]">
+                  {cachedCostPercentage > 0 && (
+                    <div
+                      className="h-full transition-[width] duration-300"
+                      style={{
+                        width: `${cachedCostPercentage}%`,
+                        background: TOKEN_COMPONENT_COLORS.cached,
+                      }}
+                    />
+                  )}
+                  {cacheCreateCostPercentage > 0 && (
+                    <div
+                      className="h-full transition-[width] duration-300"
+                      style={{
+                        width: `${cacheCreateCostPercentage}%`,
+                        background: TOKEN_COMPONENT_COLORS.cacheCreate,
+                      }}
+                    />
+                  )}
+                  <div
+                    className="h-full transition-[width] duration-300"
+                    style={{
+                      width: `${inputCostPercentage}%`,
+                      background: TOKEN_COMPONENT_COLORS.input,
+                    }}
+                  />
+                  <div
+                    className="h-full transition-[width] duration-300"
+                    style={{
+                      width: `${outputCostPercentage}%`,
+                      background: TOKEN_COMPONENT_COLORS.output,
+                    }}
+                  />
+                  {reasoningCostPercentage > 0 && (
+                    <div
+                      className="h-full transition-[width] duration-300"
+                      style={{
+                        width: `${reasoningCostPercentage}%`,
+                        background: TOKEN_COMPONENT_COLORS.thinking,
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+          <table data-testid="cost-details" className="mt-1 w-full border-collapse text-[11px]">
+            <thead>
+              <tr className="border-border-light border-b">
+                <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                  Component
+                </th>
+                <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                  Tokens
+                </th>
+                <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                  Cost
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {components.map((component) => {
+                const costDisplay = formatCostWithDollar(component.cost);
+                const isNegligible =
+                  component.cost !== undefined && component.cost > 0 && component.cost < 0.01;
 
-              const contextUsageData = contextUsage
-                ? calculateTokenMeterData(
-                    contextUsage,
-                    contextDisplayModel,
-                    has1MContext(contextDisplayModel),
-                    false,
-                    providersConfig
-                  )
-                : { segments: [], totalTokens: 0, totalPercentage: 0 };
-
-              // Warn when the compaction model can't fit the auto-compact threshold to avoid failures.
-              const contextWarning = (() => {
-                const maxTokens = contextUsageData.maxTokens;
-                if (!maxTokens || autoCompactThreshold >= 100 || !effectiveCompactionModel)
-                  return undefined;
-
-                const thresholdTokens = Math.round((autoCompactThreshold / 100) * maxTokens);
-                const compactionMaxTokens = getEffectiveContextLimit(
-                  effectiveCompactionModel,
-                  has1MContext(effectiveCompactionModel),
-                  providersConfig
+                return (
+                  <tr key={component.name}>
+                    <td className="text-foreground py-1 pr-2 [&:last-child]:pr-0 [&:last-child]:text-right">
+                      <div className="flex items-center gap-1.5">
+                        <div
+                          className="h-2 w-2 shrink-0 rounded-sm"
+                          style={{ background: component.color }}
+                        />
+                        {component.name}
+                      </div>
+                    </td>
+                    <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                      {formatTokens(component.tokens)}
+                    </td>
+                    <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                      {isNegligible ? (
+                        <span className="text-dim italic">{costDisplay}</span>
+                      ) : (
+                        costDisplay
+                      )}
+                    </td>
+                  </tr>
                 );
-
-                if (compactionMaxTokens && compactionMaxTokens < thresholdTokens) {
-                  return { compactionModelMaxTokens: compactionMaxTokens, thresholdTokens };
-                }
-                return undefined;
-              })();
-
-              return (
-                <ContextUsageBar
-                  testId="context-usage"
-                  data={contextUsageData}
-                  model={contextDisplayModel}
-                  autoCompaction={{
-                    threshold: autoCompactThreshold,
-                    setThreshold: setAutoCompactThreshold,
-                    contextWarning,
-                  }}
-                />
-              );
-            })()}
-          </div>
-          <PostCompactionSection
-            workspaceId={workspaceId}
-            planPath={postCompactionState.planPath}
-            trackedFilePaths={postCompactionState.trackedFilePaths}
-            excludedItems={postCompactionState.excludedItems}
-            onToggleExclusion={postCompactionState.toggleExclusion}
-            runtimeConfig={runtimeConfig}
-          />
-        </div>
-      )}
-
-      {hasUsageData && (
-        <div data-testid="cost-section" className="mb-6">
-          <div className="flex flex-col gap-3">
-            {(() => {
-              // Helper to calculate cost percentage
-              const getCostPercentage = (cost: number | undefined, total: number | undefined) =>
-                total !== undefined && total > 0 && cost !== undefined ? (cost / total) * 100 : 0;
-
-              // Costs are already computed from shared model metadata when usage is recorded.
-              // Repricing again here drifts from tiered per-request accounting, especially for
-              // native 1M models and session aggregates that span multiple requests.
-              const inputCost = displayUsage?.input.cost_usd;
-              const outputCost = displayUsage?.output.cost_usd;
-              const reasoningCost = displayUsage?.reasoning.cost_usd;
-
-              // Calculate total cost (undefined if any cost is unknown)
-              const totalCost: number | undefined = displayUsage
-                ? inputCost !== undefined &&
-                  displayUsage.cached.cost_usd !== undefined &&
-                  displayUsage.cacheCreate.cost_usd !== undefined &&
-                  outputCost !== undefined &&
-                  reasoningCost !== undefined
-                  ? inputCost +
-                    displayUsage.cached.cost_usd +
-                    displayUsage.cacheCreate.cost_usd +
-                    outputCost +
-                    reasoningCost
-                  : undefined
-                : undefined;
-
-              // Calculate cost percentages from the shared metadata-driven costs.
-              const inputCostPercentage = getCostPercentage(inputCost, totalCost);
-              const cachedCostPercentage = getCostPercentage(
-                displayUsage?.cached.cost_usd,
-                totalCost
-              );
-              const cacheCreateCostPercentage = getCostPercentage(
-                displayUsage?.cacheCreate.cost_usd,
-                totalCost
-              );
-              const outputCostPercentage = getCostPercentage(outputCost, totalCost);
-              const reasoningCostPercentage = getCostPercentage(reasoningCost, totalCost);
-
-              const components = displayUsage
-                ? [
-                    {
-                      name: "Cache Read",
-                      tokens: displayUsage.cached.tokens,
-                      cost: displayUsage.cached.cost_usd,
-                      color: TOKEN_COMPONENT_COLORS.cached,
-                      show: displayUsage.cached.tokens > 0,
-                    },
-                    {
-                      name: "Cache Create",
-                      tokens: displayUsage.cacheCreate.tokens,
-                      cost: displayUsage.cacheCreate.cost_usd,
-                      color: TOKEN_COMPONENT_COLORS.cacheCreate,
-                      show: displayUsage.cacheCreate.tokens > 0,
-                    },
-                    {
-                      name: "Input",
-                      tokens: displayUsage.input.tokens,
-                      cost: inputCost,
-                      color: TOKEN_COMPONENT_COLORS.input,
-                      show: true,
-                    },
-                    {
-                      name: "Output",
-                      tokens: displayUsage.output.tokens,
-                      cost: outputCost,
-                      color: TOKEN_COMPONENT_COLORS.output,
-                      show: true,
-                    },
-                    {
-                      name: "Thinking",
-                      tokens: displayUsage.reasoning.tokens,
-                      cost: reasoningCost,
-                      color: TOKEN_COMPONENT_COLORS.thinking,
-                      show: displayUsage.reasoning.tokens > 0,
-                    },
-                  ].filter((c) => c.show)
-                : [];
-
-              return (
-                <>
-                  {totalCost !== undefined && totalCost >= 0 && (
-                    <div data-testid="cost-bar" className="relative mb-2 flex flex-col gap-1">
-                      <div
-                        data-testid="cost-header"
-                        className="mb-2 flex items-baseline justify-between"
-                      >
-                        <div className="flex items-center gap-3">
-                          <span className="text-foreground inline-flex items-baseline gap-1 font-medium">
-                            Cost
-                          </span>
-                          <ToggleGroup
-                            options={VIEW_MODE_OPTIONS}
-                            value={viewMode}
-                            onChange={setViewMode}
-                          />
-                        </div>
-                        <span className="text-muted flex items-center gap-1 text-xs tabular-nums">
-                          {formatCostWithDollar(totalCost)}
-                          {displayUsage?.hasUnknownCosts && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="text-warning cursor-help">?</span>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom" className="max-w-[200px]">
-                                Cost may be incomplete — some models in this session have unknown
-                                pricing
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                        </span>
-                      </div>
-                      <div className="relative w-full">
-                        <div className="bg-border-light flex h-1.5 w-full overflow-hidden rounded-[3px]">
-                          {cachedCostPercentage > 0 && (
-                            <div
-                              className="h-full transition-[width] duration-300"
-                              style={{
-                                width: `${cachedCostPercentage}%`,
-                                background: TOKEN_COMPONENT_COLORS.cached,
-                              }}
-                            />
-                          )}
-                          {cacheCreateCostPercentage > 0 && (
-                            <div
-                              className="h-full transition-[width] duration-300"
-                              style={{
-                                width: `${cacheCreateCostPercentage}%`,
-                                background: TOKEN_COMPONENT_COLORS.cacheCreate,
-                              }}
-                            />
-                          )}
-                          <div
-                            className="h-full transition-[width] duration-300"
-                            style={{
-                              width: `${inputCostPercentage}%`,
-                              background: TOKEN_COMPONENT_COLORS.input,
-                            }}
-                          />
-                          <div
-                            className="h-full transition-[width] duration-300"
-                            style={{
-                              width: `${outputCostPercentage}%`,
-                              background: TOKEN_COMPONENT_COLORS.output,
-                            }}
-                          />
-                          {reasoningCostPercentage > 0 && (
-                            <div
-                              className="h-full transition-[width] duration-300"
-                              style={{
-                                width: `${reasoningCostPercentage}%`,
-                                background: TOKEN_COMPONENT_COLORS.thinking,
-                              }}
-                            />
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  <table
-                    data-testid="cost-details"
-                    className="mt-1 w-full border-collapse text-[11px]"
-                  >
-                    <thead>
-                      <tr className="border-border-light border-b">
-                        <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                          Component
-                        </th>
-                        <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                          Tokens
-                        </th>
-                        <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                          Cost
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {components.map((component) => {
-                        const costDisplay = formatCostWithDollar(component.cost);
-                        const isNegligible =
-                          component.cost !== undefined &&
-                          component.cost > 0 &&
-                          component.cost < 0.01;
-
-                        return (
-                          <tr key={component.name}>
-                            <td className="text-foreground py-1 pr-2 [&:last-child]:pr-0 [&:last-child]:text-right">
-                              <div className="flex items-center gap-1.5">
-                                <div
-                                  className="h-2 w-2 shrink-0 rounded-sm"
-                                  style={{ background: component.color }}
-                                />
-                                {component.name}
-                              </div>
-                            </td>
-                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
-                              {formatTokens(component.tokens)}
-                            </td>
-                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
-                              {isNegligible ? (
-                                <span className="text-dim italic">{costDisplay}</span>
-                              ) : (
-                                costDisplay
-                              )}
-                            </td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                  {viewMode === "session" && sessionModelRows.length > 0 && (
-                    <table
-                      data-testid="cost-by-model"
-                      className="mt-4 w-full border-collapse text-[11px]"
-                    >
-                      <thead>
-                        <tr className="border-border-light border-b">
-                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                            Model
-                          </th>
-                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                            Tokens
-                          </th>
-                          <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
-                            Cost
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {sessionModelRows.map((row) => (
-                          <tr key={row.model}>
-                            <td className="text-foreground max-w-0 truncate py-1 pr-2 [&:last-child]:pr-0 [&:last-child]:text-right">
-                              {formatModelStringForDisplay(row.model)}
-                            </td>
-                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
-                              {formatTokens(row.tokens)}
-                            </td>
-                            <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
-                              {formatCostWithDollar(row.cost)}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  )}
-                </>
-              );
-            })()}
-          </div>
-        </div>
-      )}
-
-      {consumers.topFilePaths && consumers.topFilePaths.length > 0 && (
-        <div className="mb-4">
-          <h3 className="text-subtle m-0 mb-2 flex items-center gap-1 text-xs font-semibold tracking-wide uppercase">
-            File Breakdown
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="text-dim cursor-help text-[10px] font-normal">ⓘ</span>
-              </TooltipTrigger>
-              <TooltipContent align="start" className="max-w-72 whitespace-normal">
-                Token usage from file_read and file_edit tools, aggregated by file path. Consider
-                splitting large files to reduce context usage.
-              </TooltipContent>
-            </Tooltip>
-          </h3>
-          <FileBreakdown files={consumers.topFilePaths} totalTokens={consumers.totalTokens} />
-        </div>
-      )}
-
-      {consumers.consumers.length > 0 && (
-        <div className="mb-4">
-          <h3 className="text-subtle m-0 mb-2 text-xs font-semibold tracking-wide uppercase">
-            Consumer Breakdown
-          </h3>
-          {consumers.isCalculating ? (
-            <div className="text-secondary py-2 text-xs italic">Calculating...</div>
-          ) : (
-            <ConsumerBreakdown
-              consumers={consumers.consumers}
-              totalTokens={consumers.totalTokens}
-            />
+              })}
+            </tbody>
+          </table>
+          {viewMode === "session" && sessionModelRows.length > 0 && (
+            <table data-testid="cost-by-model" className="mt-4 w-full border-collapse text-[11px]">
+              <thead>
+                <tr className="border-border-light border-b">
+                  <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                    Model
+                  </th>
+                  <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                    Tokens
+                  </th>
+                  <th className="text-muted py-1 pr-2 text-left font-medium [&:last-child]:pr-0 [&:last-child]:text-right">
+                    Cost
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sessionModelRows.map((row) => (
+                  <tr key={row.model}>
+                    <td className="text-foreground max-w-0 truncate py-1 pr-2 [&:last-child]:pr-0 [&:last-child]:text-right">
+                      {formatModelStringForDisplay(row.model)}
+                    </td>
+                    <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                      {formatTokens(row.tokens)}
+                    </td>
+                    <td className="text-foreground py-1 pr-2 tabular-nums [&:last-child]:pr-0 [&:last-child]:text-right">
+                      {formatCostWithDollar(row.cost)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
         </div>
-      )}
-
-      {!consumers.isCalculating &&
-        consumers.consumers.length === 0 &&
-        (!consumers.topFilePaths || consumers.topFilePaths.length === 0) && (
-          <div className="text-dim py-2 text-xs italic">No consumer data available</div>
-        )}
+      </div>
     </div>
   );
 };
 
-// Memoize to prevent re-renders when parent (AIView) re-renders during streaming
-// Only re-renders when workspaceId changes or internal hook data (usage/consumers) updates
 export const CostsTab = React.memo(CostsTabComponent);

--- a/src/browser/features/RightSidebar/PostCompactionSection.tsx
+++ b/src/browser/features/RightSidebar/PostCompactionSection.tsx
@@ -72,7 +72,7 @@ export const PostCompactionSection: React.FC<PostCompactionSectionProps> = (prop
   }
 
   return (
-    <div className="border-border-light mt-4 border-t pt-4">
+    <div className="mt-2">
       <button
         onClick={() => setCollapsed((prev) => !prev)}
         className="flex w-full items-center justify-between text-left"

--- a/src/browser/features/RightSidebar/RightSidebar.stories.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.stories.tsx
@@ -1253,11 +1253,11 @@ export const ReviewTabWithUntrackedFiles: Story = {
 };
 
 /**
- * Costs tab showing compaction model context warning.
- * When the compaction model (gpt-4o, 128k) has a smaller context window
- * than the auto-compact threshold (80% of 200k = 160k), a warning appears.
+ * Stats tab showing compaction model context warning in the always-visible
+ * context usage section. When the compaction model (gpt-4o, 128k) has a smaller
+ * context window than the auto-compact threshold (80% of 200k = 160k), a warning appears.
  */
-export const CostsTabCompactionModelWarning: Story = {
+export const CompactionModelWarning: Story = {
   render: () => (
     <RightSidebarStoryShell
       setup={() => {

--- a/src/browser/features/RightSidebar/StatsContainer.tsx
+++ b/src/browser/features/RightSidebar/StatsContainer.tsx
@@ -1,17 +1,23 @@
 /**
  * StatsContainer — unified "Stats" top-level tab with sub-tabs.
  *
+ * The context usage meter renders above the sub-tab strip so it stays visible
+ * on every sub-tab.
+ *
  * Sub-tabs:
  * - "Cost" — renders CostsTab
+ * - "Context" — renders ContextTab (artifacts + tokenizer breakdowns)
  * - "Timing" — renders TimingPanel from StatsTab
  * - "Models" — renders ModelBreakdownPanel from StatsTab
  */
 
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { CostsTab } from "./CostsTab";
+import { ContextTab } from "./ContextTab";
+import { ContextUsageSection } from "./ContextUsageSection";
 import { TimingPanel, ModelBreakdownPanel } from "./StatsTab";
 
-type StatsSubTab = "cost" | "timing" | "models";
+type StatsSubTab = "cost" | "context" | "timing" | "models";
 
 interface StatsOption {
   value: StatsSubTab;
@@ -20,6 +26,7 @@ interface StatsOption {
 
 const OPTIONS: StatsOption[] = [
   { value: "cost", label: "Cost" },
+  { value: "context", label: "Context" },
   { value: "timing", label: "Timing" },
   { value: "models", label: "Models" },
 ];
@@ -35,6 +42,7 @@ export function StatsContainer(props: StatsContainerProps) {
 
   return (
     <div>
+      <ContextUsageSection workspaceId={props.workspaceId} />
       <div className="mb-3">
         <div className="flex gap-1">
           {OPTIONS.map((option) => {
@@ -57,6 +65,7 @@ export function StatsContainer(props: StatsContainerProps) {
         </div>
       </div>
       {effectiveTab === "cost" && <CostsTab workspaceId={props.workspaceId} />}
+      {effectiveTab === "context" && <ContextTab workspaceId={props.workspaceId} />}
       {effectiveTab === "timing" && <TimingPanel workspaceId={props.workspaceId} />}
       {effectiveTab === "models" && <ModelBreakdownPanel workspaceId={props.workspaceId} />}
     </div>


### PR DESCRIPTION
## Summary

The Stats tab's Cost sub-tab crowded cost data together with context usage, post-compaction artifacts, and tokenizer breakdowns. This PR moves the context usage meter above the sub-tab strip (always visible) and splits the remaining context sections into a new Context sub-tab, leaving Cost focused on cost data only.

## Implementation

- `ContextUsageSection` (new): context usage meter, auto-compaction threshold slider, 1M context toggle, and the compaction-model warning, extracted from `CostsTab`. Rendered by `StatsContainer` above the sub-tab strip so it stays visible on every sub-tab.
- `ContextTab` (new sub-tab between Cost and Timing): post-compaction Artifacts (plan file + tracked file diffs with include/exclude toggles), File Breakdown, and tokenizer Consumer Breakdown.
- `CostsTab`: now renders only the cost bar, Session/Last Request toggle, component table, and per-model table.
- `PostCompactionSection`: dropped its top border, which assumed it sat directly below the usage bar in the old layout.
- The `CostsTabCompactionModelWarning` story became `CompactionModelWarning` since the warning now lives in the always-visible section.

## Validation

Verified in Storybook: the meter and warning stay visible on the Cost and Context sub-tabs, the Context sub-tab shows a neutral placeholder when no tokenizer data exists, and the Cost sub-tab layout is unchanged aside from the removed sections.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$11.51`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=11.51 -->
