### PR TITLE
🤖 feat: add Gemini 3.6 Flash as the default Gemini Flash model

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: 'Models to test (comma-separated, or "all" for opus-4-8 + gpt-5.5 + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.5-flash)'
+        description: 'Models to test (comma-separated, or "all" for opus-4-8 + gpt-5.5 + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.6-flash)'
         required: false
         default: "all"
         type: string
@@ -129,7 +129,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-4-8","openai/gpt-5.5","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.5-flash"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-4-8","openai/gpt-5.5","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.6-flash"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')

--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -29,7 +29,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |
 | Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |
 | Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |
-| Gemini 3.5 Flash       | google:gemini-3.5-flash       | `gemini-flash`                                               |         |
+| Gemini 3.6 Flash       | google:gemini-3.6-flash       | `gemini-flash`                                               |         |
 | Grok 4 1 Fast          | xai:grok-4-1-fast             | `grok`, `grok-4`, `grok-4.1`, `grok-4-1`                     |         |
 | Grok Code Fast 1       | xai:grok-code-fast-1          | `grok-code`                                                  |         |
 | DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -33,6 +33,8 @@ import {
   normalizeToCanonical,
 } from "@/common/utils/ai/models";
 import { Button } from "../Button/Button";
+import { modelMatchesQuery } from "./modelFilter";
+
 interface ModelSelectorProps {
   value: string;
   onChange: (value: string) => void;
@@ -138,7 +140,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
     const filteredModels =
       inputValue.trim() === ""
         ? baseModels
-        : baseModels.filter((model) => model.toLowerCase().includes(inputValue.toLowerCase()));
+        : baseModels.filter((model) => modelMatchesQuery(model, inputValue.toLowerCase()));
 
     // Track which models are hidden (for rendering)
     const hiddenSet = new Set(hiddenModels);

--- a/src/browser/components/ModelSelector/modelFilter.test.ts
+++ b/src/browser/components/ModelSelector/modelFilter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { modelMatchesQuery } from "./modelFilter";
+
+describe("modelMatchesQuery", () => {
+  test("matches model string substrings", () => {
+    expect(modelMatchesQuery("google:gemini-3.6-flash", "3.6")).toBe(true);
+    expect(modelMatchesQuery("google:gemini-3.6-flash", "sonnet")).toBe(false);
+  });
+
+  test("matches documented aliases that are not model string substrings", () => {
+    expect(modelMatchesQuery("google:gemini-3.6-flash", "gemini-flash")).toBe(true);
+    expect(modelMatchesQuery("deepseek:deepseek-v4-pro", "deepseek-pro")).toBe(true);
+    expect(modelMatchesQuery("xai:grok-4-1-fast", "grok-4.1")).toBe(true);
+  });
+
+  test("matches aliases for gateway-prefixed model strings", () => {
+    expect(modelMatchesQuery("mux-gateway:google/gemini-3.6-flash", "gemini-flash")).toBe(true);
+  });
+
+  test("does not match aliases belonging to other models", () => {
+    expect(modelMatchesQuery("anthropic:claude-opus-4-8", "gemini-flash")).toBe(false);
+  });
+});

--- a/src/browser/components/ModelSelector/modelFilter.ts
+++ b/src/browser/components/ModelSelector/modelFilter.ts
@@ -1,0 +1,25 @@
+/**
+ * Search matching for the ModelSelector dropdown.
+ */
+import { MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
+
+// Reverse alias map so searches match documented aliases (e.g. "gemini-flash")
+// that are not substrings of the model string.
+const ALIASES_BY_MODEL = new Map<string, string[]>();
+for (const [alias, modelId] of Object.entries(MODEL_ABBREVIATIONS)) {
+  const aliases = ALIASES_BY_MODEL.get(modelId);
+  if (aliases) {
+    aliases.push(alias);
+  } else {
+    ALIASES_BY_MODEL.set(modelId, [alias]);
+  }
+}
+
+export function modelMatchesQuery(model: string, lowerQuery: string): boolean {
+  if (model.toLowerCase().includes(lowerQuery)) return true;
+  // Aliases map to canonical provider:model ids; normalize so gateway-prefixed
+  // entries (mux-gateway:google/...) match their aliases too.
+  const aliases = ALIASES_BY_MODEL.get(normalizeToCanonical(model));
+  return aliases?.some((alias) => alias.includes(lowerQuery)) ?? false;
+}

--- a/src/common/constants/knownModels.test.ts
+++ b/src/common/constants/knownModels.test.ts
@@ -29,8 +29,8 @@ describe("Known Models Integration", () => {
     }
   });
 
-  test("gemini-flash resolves to the stable Gemini 3.5 Flash model", () => {
-    expect(MODEL_ABBREVIATIONS["gemini-flash"]).toBe("google:gemini-3.5-flash");
+  test("gemini-flash resolves to the stable Gemini 3.6 Flash model", () => {
+    expect(MODEL_ABBREVIATIONS["gemini-flash"]).toBe("google:gemini-3.6-flash");
   });
 
   test("gpt alias tracks the GPT-5.6 flagship tier alongside the tier aliases", () => {

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -173,10 +173,11 @@ const MODEL_DEFINITIONS = {
     aliases: ["gemini", "gemini-pro"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },
-  // Gemini Flash alias tracks the latest stable Flash tier.
+  // Gemini Flash alias tracks the latest stable Flash tier (3.6 Flash, GA July 21, 2026).
+  // 3.5 Flash stays usable as the custom model string `google:gemini-3.5-flash`.
   GEMINI_FLASH: {
     provider: "google",
-    providerModelId: "gemini-3.5-flash",
+    providerModelId: "gemini-3.6-flash",
     aliases: ["gemini-flash"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },

--- a/src/common/utils/ai/modelParameterOverrides.test.ts
+++ b/src/common/utils/ai/modelParameterOverrides.test.ts
@@ -481,6 +481,28 @@ describe("resolveModelParameterOverrides", () => {
     expect(result).toEqual({ standard: {} });
   });
 
+  it("strips sampling parameters for custom entries mapped to a sampling-rejecting model", () => {
+    const providersConfig = asProvidersConfig({
+      google: {
+        models: [{ id: "team-flash", mappedToModel: "google:gemini-3.6-flash" }],
+        modelParameters: {
+          "*": {
+            temperature: 0.7,
+            max_output_tokens: 4096,
+          },
+        },
+      },
+    });
+
+    const result = resolveModelParameterOverrides(providersConfig, "google", "google:team-flash");
+
+    expect(result).toEqual({
+      standard: {
+        maxOutputTokens: 4096,
+      },
+    });
+  });
+
   it("keeps sampling parameters for Gemini models that still support them", () => {
     const providersConfig = withGoogleModelParameters({
       "*": {

--- a/src/common/utils/ai/modelParameterOverrides.test.ts
+++ b/src/common/utils/ai/modelParameterOverrides.test.ts
@@ -22,6 +22,16 @@ function withOllamaModelParameters(
   });
 }
 
+function withGoogleModelParameters(
+  modelParameters: Record<string, Record<string, unknown>>
+): ProvidersConfig {
+  return asProvidersConfig({
+    google: {
+      modelParameters,
+    },
+  });
+}
+
 function asProvidersConfig(value: unknown): ProvidersConfig {
   return value as ProvidersConfig;
 }
@@ -408,6 +418,89 @@ describe("resolveModelParameterOverrides", () => {
     );
 
     expect(result).toEqual({ standard: {} });
+  });
+
+  it("strips deprecated sampling parameters for Gemini 3.6 Flash", () => {
+    const providersConfig = withGoogleModelParameters({
+      "*": {
+        max_output_tokens: 32768,
+        temperature: 0.7,
+        top_p: 0.9,
+        top_k: 40,
+      },
+    });
+
+    const result = resolveModelParameterOverrides(
+      providersConfig,
+      "google",
+      "google:gemini-3.6-flash"
+    );
+
+    expect(result).toEqual({
+      standard: {
+        maxOutputTokens: 32768,
+      },
+    });
+  });
+
+  it("strips deprecated sampling parameters for Gemini 3.5 Flash-Lite", () => {
+    const providersConfig = withGoogleModelParameters({
+      "gemini-3.5-flash-lite": {
+        temperature: 0.5,
+        seed: 42,
+      },
+    });
+
+    const result = resolveModelParameterOverrides(
+      providersConfig,
+      "google",
+      "google:gemini-3.5-flash-lite"
+    );
+
+    expect(result).toEqual({
+      standard: {
+        seed: 42,
+      },
+    });
+  });
+
+  it("strips sampling parameters based on the gateway-routed effective model", () => {
+    const providersConfig = withGoogleModelParameters({
+      "*": {
+        temperature: 0.7,
+      },
+    });
+
+    const result = resolveModelParameterOverrides(
+      providersConfig,
+      "google",
+      "google:gemini-3.6-flash",
+      "mux-gateway:google/gemini-3.6-flash"
+    );
+
+    expect(result).toEqual({ standard: {} });
+  });
+
+  it("keeps sampling parameters for Gemini models that still support them", () => {
+    const providersConfig = withGoogleModelParameters({
+      "*": {
+        temperature: 0.7,
+        top_k: 40,
+      },
+    });
+
+    const result = resolveModelParameterOverrides(
+      providersConfig,
+      "google",
+      "google:gemini-3.5-flash"
+    );
+
+    expect(result).toEqual({
+      standard: {
+        temperature: 0.7,
+        topK: 40,
+      },
+    });
   });
 
   it("treats prototype-collision keys as providerExtras", () => {

--- a/src/common/utils/ai/modelParameterOverrides.ts
+++ b/src/common/utils/ai/modelParameterOverrides.ts
@@ -6,6 +6,7 @@ import {
 import type { ProvidersConfig } from "@/common/config/schemas/providersConfig";
 import { stripModelProviderPrefixes } from "@/common/types/thinking";
 import { getModelName } from "@/common/utils/ai/models";
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { isPlainObject } from "@/common/utils/isPlainObject";
 
 export interface ResolvedModelParameterOverrides {
@@ -97,7 +98,13 @@ export function resolveModelParameterOverrides(
     providerExtras[key] = value;
   }
 
-  if (modelRejectsSamplingParameters(effectiveModelString ?? canonicalModelString)) {
+  // Resolve mappedToModel aliases so custom entries pointing at a
+  // sampling-rejecting model (e.g. team-flash -> gemini-3.6-flash) are stripped too.
+  const capabilityModelString = resolveModelForMetadata(
+    effectiveModelString ?? canonicalModelString,
+    providersConfig
+  );
+  if (modelRejectsSamplingParameters(capabilityModelString)) {
     for (const key of SAMPLING_CALL_SETTINGS) {
       delete standard[key];
     }

--- a/src/common/utils/ai/modelParameterOverrides.ts
+++ b/src/common/utils/ai/modelParameterOverrides.ts
@@ -4,12 +4,28 @@ import {
   type ResolvedCallSettingsOverrides,
 } from "@/common/config/schemas/modelParameters";
 import type { ProvidersConfig } from "@/common/config/schemas/providersConfig";
+import { stripModelProviderPrefixes } from "@/common/types/thinking";
 import { getModelName } from "@/common/utils/ai/models";
 import { isPlainObject } from "@/common/utils/isPlainObject";
 
 export interface ResolvedModelParameterOverrides {
   standard: ResolvedCallSettingsOverrides;
   providerExtras?: Record<string, unknown>;
+}
+
+const SAMPLING_CALL_SETTINGS = ["temperature", "topP", "topK"] as const;
+
+/**
+ * Gemini 3.6 Flash and Gemini 3.5 Flash-Lite deprecate the sampling parameters
+ * temperature/top_p/top_k; Google's migration guides require stripping them from
+ * generation configs, so forwarding user overrides would break existing setups
+ * (e.g. a wildcard temperature) when the gemini-flash alias repoints.
+ */
+export function modelRejectsSamplingParameters(modelString: string): boolean {
+  const bareModelId = stripModelProviderPrefixes(modelString);
+  return (
+    bareModelId.startsWith("gemini-3.6-flash") || bareModelId.startsWith("gemini-3.5-flash-lite")
+  );
 }
 
 /**
@@ -79,6 +95,12 @@ export function resolveModelParameterOverrides(
     }
 
     providerExtras[key] = value;
+  }
+
+  if (modelRejectsSamplingParameters(effectiveModelString ?? canonicalModelString)) {
+    for (const key of SAMPLING_CALL_SETTINGS) {
+      delete standard[key];
+    }
   }
 
   return {

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1456,6 +1456,27 @@ describe("buildProviderOptions - Google", () => {
     });
   });
 
+  test("maps Gemini 3.6 Flash off to minimal thinking without thoughts", () => {
+    expect(buildProviderOptions("google:gemini-3.6-flash", "off")).toEqual({
+      google: {
+        thinkingConfig: {
+          thinkingLevel: "minimal",
+        },
+      },
+    });
+  });
+
+  test("maps Gemini 3.6 Flash medium to thinkingLevel medium with thoughts", () => {
+    expect(buildProviderOptions("google:gemini-3.6-flash", "medium")).toEqual({
+      google: {
+        thinkingConfig: {
+          includeThoughts: true,
+          thinkingLevel: "medium",
+        },
+      },
+    });
+  });
+
   test("maps Gemini 3.5 Flash medium to thinkingLevel medium with thoughts", () => {
     expect(buildProviderOptions("mux-gateway:google/gemini-3.5-flash", "medium")).toEqual({
       google: {

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -599,6 +599,16 @@ describe("getThinkingPolicyForModel", () => {
     }
   });
 
+  test("returns off/low/medium/high for stable Gemini 3.6 Flash", () => {
+    for (const model of [
+      "google:gemini-3.6-flash",
+      "mux-gateway:google/gemini-3.6-flash",
+      "google:gemini-3.6-flash-001",
+    ]) {
+      expect(getThinkingPolicyForModel(model)).toEqual(["off", "low", "medium", "high"]);
+    }
+  });
+
   test("returns off/low/medium/high for stable Gemini 3.5 Flash behind OpenRouter", () => {
     expect(getThinkingPolicyForModel("openrouter:google/gemini-3.5-flash")).toEqual([
       "off",
@@ -652,6 +662,7 @@ describe("isGeminiFlashThinkingLevelModelName", () => {
   test("does not classify Gemini Flash Lite variants as Flash thinking-level chat models", () => {
     expect(isGeminiFlashThinkingLevelModelName("gemini-3-flash-lite")).toBe(false);
     expect(isGeminiFlashThinkingLevelModelName("gemini-3.5-flash-lite")).toBe(false);
+    expect(isGeminiFlashThinkingLevelModelName("gemini-3.6-flash-lite")).toBe(false);
   });
 });
 

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -42,7 +42,9 @@ export function isGeminiFlashThinkingLevelModelName(modelName: string): boolean 
   return (
     ((normalized === "gemini-3-flash" || normalized.startsWith("gemini-3-flash-")) &&
       !normalized.startsWith("gemini-3-flash-lite")) ||
-    (normalized.startsWith("gemini-3.5-flash") && !normalized.startsWith("gemini-3.5-flash-lite"))
+    (normalized.startsWith("gemini-3.5-flash") &&
+      !normalized.startsWith("gemini-3.5-flash-lite")) ||
+    (normalized.startsWith("gemini-3.6-flash") && !normalized.startsWith("gemini-3.6-flash-lite"))
   );
 }
 

--- a/src/common/utils/tokens/displayUsage.test.ts
+++ b/src/common/utils/tokens/displayUsage.test.ts
@@ -155,6 +155,39 @@ describe("createDisplayUsage", () => {
       expect(result!.cached.tokens).toBe(71600);
       // Total is approximately correct (off by 500 non-cached, acceptable for old data)
     });
+
+    test("uses outputTokens directly when smaller than reasoningTokens (reasoning-exclusive rows)", () => {
+      // Historical Gemini-via-gateway rows persisted outputTokens exclusive of
+      // reasoning (candidatesTokenCount), so output < reasoning. The display must
+      // show the text tokens, not clamp to 0.
+      const usage: LanguageModelV2Usage = {
+        inputTokens: 9416,
+        outputTokens: 1,
+        totalTokens: 9417,
+        reasoningTokens: 37,
+      };
+
+      const result = createDisplayUsage(usage, "google:gemini-3.6-flash");
+
+      expect(result).toBeDefined();
+      expect(result!.output.tokens).toBe(1);
+      expect(result!.reasoning.tokens).toBe(37);
+    });
+
+    test("still subtracts reasoning from inclusive outputTokens", () => {
+      const usage: LanguageModelV2Usage = {
+        inputTokens: 1000,
+        outputTokens: 500,
+        totalTokens: 1500,
+        reasoningTokens: 200,
+      };
+
+      const result = createDisplayUsage(usage, "openai:gpt-5.2");
+
+      expect(result).toBeDefined();
+      expect(result!.output.tokens).toBe(300);
+      expect(result!.reasoning.tokens).toBe(200);
+    });
   });
 
   test("returns undefined for undefined usage", () => {

--- a/src/common/utils/tokens/displayUsage.ts
+++ b/src/common/utils/tokens/displayUsage.ts
@@ -138,8 +138,13 @@ export function createDisplayUsage(
     (providerMetadata?.openai as { reasoningTokens?: number } | undefined)?.reasoningTokens ??
     0;
 
-  // Calculate output tokens excluding reasoning
-  const outputWithoutReasoning = Math.max(0, (usage.outputTokens ?? 0) - reasoningTokens);
+  // Calculate output tokens excluding reasoning. Inclusive semantics guarantees
+  // outputTokens >= reasoningTokens, so a smaller outputTokens means the row was
+  // persisted with reasoning-exclusive output (historical Gemini-via-gateway data);
+  // use it directly instead of clamping to 0.
+  const rawOutputTokens = usage.outputTokens ?? 0;
+  const outputWithoutReasoning =
+    rawOutputTokens >= reasoningTokens ? rawOutputTokens - reasoningTokens : rawOutputTokens;
 
   // Get model stats for cost calculation
   const modelStats = getModelStats(metadataModelOverride ?? model);

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -80,12 +80,12 @@ describe("getModelStats", () => {
     expect(stats.tiered_pricing_threshold_tokens).toBeUndefined();
   });
 
-  test("resolves Gemini 3.5 Flash with published standard pricing and limits", () => {
+  test("resolves Gemini 3.6 Flash with published standard pricing and limits", () => {
     const stats = expectStats(KNOWN_MODELS.GEMINI_FLASH.id);
     expect(stats.max_input_tokens).toBe(1048576);
     expect(stats.max_output_tokens).toBe(65536);
     expect(stats.input_cost_per_token).toBe(0.0000015);
-    expect(stats.output_cost_per_token).toBe(0.000009);
+    expect(stats.output_cost_per_token).toBe(0.0000075);
     expect(stats.cache_read_input_token_cost).toBe(0.00000015);
   });
 

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -444,6 +444,28 @@ export const modelsExtra: Record<string, ModelData> = {
     knowledge_cutoff: "2025-01",
   },
 
+  // Gemini 3.6 Flash - GA on July 21, 2026. Stable `gemini-3.6-flash` model ID with
+  // 1M context, 65K max output, $1.50/M input, $7.50/M output. Source: Google AI
+  // Gemini API model and latest-model docs as of 2026-07-21. The $0.15/M cached
+  // input rate carries over from 3.5 Flash, cross-checked against Artificial
+  // Analysis' blended rate for 3.6 Flash.
+  "gemini-3.6-flash": {
+    max_input_tokens: 1048576,
+    max_output_tokens: 65536,
+    input_cost_per_token: 0.0000015, // $1.50 per million input tokens
+    output_cost_per_token: 0.0000075, // $7.50 per million output tokens, including thinking tokens
+    cache_read_input_token_cost: 0.00000015, // $0.15 per million cached input tokens
+    litellm_provider: "vertex_ai-language-models",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_audio_input: true,
+    supports_video_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Gemini 3.1 Pro Preview - Released February 19, 2026
   // Tiered pricing: ≤200K tokens $2/M input, $12/M output; >200K tokens $4/M input, $18/M output
   // 1M input context, ~64K max output tokens

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3182,7 +3182,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Codex Mini 5.1         | openai:gpt-5.1-codex-mini     | `codex-mini`                                                 |         |",
       "| Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |",
       "| Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |",
-      "| Gemini 3.5 Flash       | google:gemini-3.5-flash       | `gemini-flash`                                               |         |",
+      "| Gemini 3.6 Flash       | google:gemini-3.6-flash       | `gemini-flash`                                               |         |",
       "| Grok 4 1 Fast          | xai:grok-4-1-fast             | `grok`, `grok-4`, `grok-4.1`, `grok-4-1`                     |         |",
       "| Grok Code Fast 1       | xai:grok-code-fast-1          | `grok-code`                                                  |         |",
       "| DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |",

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -1682,6 +1682,9 @@ export class ProviderModelFactory {
         // (e.g. { inputTokens: 123, outputTokens: 456 }), causing
         // asLanguageModelUsage to produce undefined → 0 for all token counts.
         // These wrappers detect flat usage and convert to v3 nested format.
+        // Google forwards candidatesTokenCount as flat outputTokens, which excludes
+        // thoughts; other providers report output inclusive of reasoning.
+        const usageOptions = { outputExcludesReasoning: modelId.startsWith("google/") };
         const originalDoStream = model.doStream.bind(model);
         model.doStream = async (options) => {
           const result = await originalDoStream(options);
@@ -1690,7 +1693,7 @@ export class ProviderModelFactory {
             // Type assertion safe: the transform only modifies the shape of usage/finishReason
             // fields within existing chunks, it doesn't change the stream part types.
             stream: result.stream.pipeThrough(
-              normalizeGatewayStreamUsage()
+              normalizeGatewayStreamUsage(usageOptions)
             ) as typeof result.stream,
           };
         };
@@ -1698,7 +1701,7 @@ export class ProviderModelFactory {
         const originalDoGenerate = model.doGenerate.bind(model);
         model.doGenerate = async (options) => {
           const result = await originalDoGenerate(options);
-          return normalizeGatewayGenerateResult(result);
+          return normalizeGatewayGenerateResult(result, usageOptions);
         };
 
         const configuredOpenAIStore = muxProviderOptions?.openai?.store;

--- a/src/node/utils/gatewayStreamNormalization.test.ts
+++ b/src/node/utils/gatewayStreamNormalization.test.ts
@@ -88,6 +88,28 @@ describe("flatUsageToV3", () => {
     expect(result.outputTokens.reasoning).toBe(100);
   });
 
+  it("treats output as text-only when outputExcludesReasoning is set (Google semantics)", () => {
+    const result = flatUsageToV3(
+      { inputTokens: 9431, outputTokens: 2, reasoningTokens: 308 },
+      { outputExcludesReasoning: true }
+    );
+
+    expect(result.outputTokens.total).toBe(310); // 2 + 308
+    expect(result.outputTokens.text).toBe(2);
+    expect(result.outputTokens.reasoning).toBe(308);
+  });
+
+  it("keeps output total unchanged with outputExcludesReasoning when reasoning is absent", () => {
+    const result = flatUsageToV3(
+      { inputTokens: 100, outputTokens: 50 },
+      { outputExcludesReasoning: true }
+    );
+
+    expect(result.outputTokens.total).toBe(50);
+    expect(result.outputTokens.text).toBe(50);
+    expect(result.outputTokens.reasoning).toBeUndefined();
+  });
+
   it("handles missing fields gracefully", () => {
     const result = flatUsageToV3({});
 

--- a/src/node/utils/gatewayStreamNormalization.ts
+++ b/src/node/utils/gatewayStreamNormalization.ts
@@ -33,16 +33,38 @@ export function isV3Usage(usage: unknown): usage is V3Usage {
   return typeof u.inputTokens === "object" && u.inputTokens != null;
 }
 
+/** Options for converting flat gateway usage to v3 nested format. */
+export interface FlatUsageOptions {
+  /**
+   * The gateway forwards each upstream provider's flat usage semantics as-is.
+   * OpenAI-style flat usage reports outputTokens INCLUSIVE of reasoning, but
+   * Google forwards candidatesTokenCount, which EXCLUDES thoughts. Set this for
+   * google/* gateway models so text/total are derived correctly.
+   */
+  outputExcludesReasoning?: boolean;
+}
+
 /**
  * Convert flat (v2-style) usage to v3 nested format.
  */
-export function flatUsageToV3(usage: Record<string, unknown>): V3Usage {
+export function flatUsageToV3(usage: Record<string, unknown>, options?: FlatUsageOptions): V3Usage {
   const inputTokens = typeof usage.inputTokens === "number" ? usage.inputTokens : undefined;
   const outputTokens = typeof usage.outputTokens === "number" ? usage.outputTokens : undefined;
   const cachedInputTokens =
     typeof usage.cachedInputTokens === "number" ? usage.cachedInputTokens : undefined;
   const reasoningTokens =
     typeof usage.reasoningTokens === "number" ? usage.reasoningTokens : undefined;
+
+  const outputExcludesReasoning = options?.outputExcludesReasoning === true;
+  const outputTotal =
+    outputExcludesReasoning && outputTokens != null
+      ? outputTokens + (reasoningTokens ?? 0)
+      : outputTokens;
+  const outputText = outputExcludesReasoning
+    ? outputTokens
+    : outputTokens != null && reasoningTokens != null
+      ? outputTokens - reasoningTokens
+      : undefined;
 
   return {
     inputTokens: {
@@ -55,11 +77,8 @@ export function flatUsageToV3(usage: Record<string, unknown>): V3Usage {
       cacheWrite: undefined,
     },
     outputTokens: {
-      total: outputTokens,
-      text:
-        outputTokens != null && reasoningTokens != null
-          ? outputTokens - reasoningTokens
-          : undefined,
+      total: outputTotal,
+      text: outputText,
       reasoning: reasoningTokens,
     },
     raw: usage,
@@ -84,11 +103,14 @@ export function normalizeFinishReason(fr: unknown): { unified: string; raw: unkn
  * Normalize a doGenerate result from the gateway.
  * Converts flat usage and plain-string finishReason to v3 nested format.
  */
-export function normalizeGatewayGenerateResult<T extends Record<string, unknown>>(result: T): T {
+export function normalizeGatewayGenerateResult<T extends Record<string, unknown>>(
+  result: T,
+  options?: FlatUsageOptions
+): T {
   const normalized: Record<string, unknown> = { ...result };
 
   if (result.usage != null && !isV3Usage(result.usage)) {
-    normalized.usage = flatUsageToV3(result.usage as Record<string, unknown>);
+    normalized.usage = flatUsageToV3(result.usage as Record<string, unknown>, options);
   }
 
   if (result.finishReason != null) {
@@ -104,7 +126,7 @@ export function normalizeGatewayGenerateResult<T extends Record<string, unknown>
  *
  * Only transforms "finish" events; all other chunks pass through unchanged.
  */
-export function normalizeGatewayStreamUsage(): TransformStream {
+export function normalizeGatewayStreamUsage(options?: FlatUsageOptions): TransformStream {
   return new TransformStream({
     transform(chunk: unknown, controller: TransformStreamDefaultController) {
       if (typeof chunk !== "object" || chunk == null) {
@@ -121,7 +143,7 @@ export function normalizeGatewayStreamUsage(): TransformStream {
       // Normalize usage: convert flat → v3 nested if needed
       let usage = c.usage;
       if (usage != null && !isV3Usage(usage)) {
-        usage = flatUsageToV3(usage as Record<string, unknown>);
+        usage = flatUsageToV3(usage as Record<string, unknown>, options);
       }
 
       // Normalize finishReason: convert string → { unified, raw } if needed


### PR DESCRIPTION
## Summary

Adds Gemini 3.6 Flash (GA July 21, 2026) as a known model and makes it the default for the `gemini-flash` alias. Dogfooding the change against a live sandbox surfaced and fixed two adjacent bugs: Gemini-via-gateway responses displayed Output = 0 tokens, and the model selector search could not find models by their documented aliases.

## Implementation

**Gemini 3.6 Flash support**

- `GEMINI_FLASH` known model now points at `gemini-3.6-flash`; 3.5 Flash remains usable as a custom model string.
- Thinking policy: 3.6 Flash uses the Gemini 3.x `thinkingLevel` config with off/low/medium/high, where Mux "off" maps to Google's `minimal` (same as 3.5 Flash).
- Stats: 1M context, 65K max output, $1.50/M input, $7.50/M output, $0.15/M cached input.
- Sampling overrides: Google's 3.6 migration guide requires removing `temperature`/`top_p`/`top_k`, so `resolveModelParameterOverrides` strips them for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (including gateway-routed requests). Existing `providers.jsonc` overrides keep working instead of turning into provider errors when the alias repoints.
- Docs table and builtin skill content regenerated.
- Nightly Terminal-Bench model matrix benches `google/gemini-3.6-flash` instead of 3.5 Flash.

**Gateway output-token accounting (dogfood find)**
The Mux Gateway forwards Google's flat usage where `outputTokens` is `candidatesTokenCount`, which excludes thoughts. The v3 conversion assumed reasoning-inclusive output, so the Cost panel clamped Gemini output to `max(0, output - reasoning)` = 0. Fixed at two layers:

- Ingestion: `flatUsageToV3` accepts `outputExcludesReasoning`, set for gateway `google/*` models, so persisted usage is reasoning-inclusive.
- Display self-healing: rows persisted with the old semantics (`outputTokens < reasoningTokens`) show stored output directly instead of clamping to 0.

**Model selector alias search (dogfood find)**
Searching `gemini-flash` (the documented alias) showed "No matching models" because the filter only substring-matched the model string. Extracted the matcher into `modelFilter.ts` and extended it to match known aliases, including for gateway-prefixed model strings.

## Validation

- Live dogfood in a dev-server sandbox: Gemini 3.6 Flash responses stream correctly at medium and high thinking via Mux Gateway; reasoning renders; post-fix persisted usage is reasoning-inclusive (`outputTokens: 124, reasoningTokens: 115`) and the Cost panel shows nonzero output; `gemini-flash` search finds the model.
- Full `bun test src` (10k+ pass), `make static-check` green.

## Risks

Usage accounting changes touch cost display for all providers. The display-side change only alters behavior when `outputTokens < reasoningTokens`, which inclusive semantics cannot produce, so non-Gemini paths are unaffected. The ingestion flag is scoped to gateway `google/*` model IDs.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$69.99`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=69.99 -->

