### PR TITLE
🤖 feat: stage arbitrary pasted/dropped files into the workspace from chat

### DIFF
--- a/src/browser/features/ChatInput/AttachFileButton.tsx
+++ b/src/browser/features/ChatInput/AttachFileButton.tsx
@@ -1,15 +1,12 @@
 /**
- * Attach file button - floats inside the chat input textarea next to the voice input button.
- * Opens a native file picker for images, SVGs, PDFs, and workspace-staged ZIPs.
+ * Attach file button that opens a native picker for any file type.
+ * Images and PDFs attach natively. Other files are saved into the workspace.
  */
 
 import React, { useRef } from "react";
 import { Paperclip } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { cn } from "@/common/lib/utils";
-
-/** Accept filter for the file picker: provider attachments plus workspace-staged ZIPs. */
-const FILE_ACCEPT = "image/*,.svg,.pdf,.zip,application/zip,application/x-zip-compressed";
 
 interface AttachFileButtonProps {
   onFiles: (files: File[]) => void;
@@ -53,14 +50,14 @@ export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <strong>Attach file</strong> — images, SVGs, PDFs, ZIPs
+          <strong>Attach any file</strong>. Images and PDFs attach directly. Other files are saved
+          to the workspace.
         </TooltipContent>
       </Tooltip>
-      {/* Hidden file input — kept outside Tooltip to avoid stray DOM children */}
+      {/* Kept outside Tooltip to avoid stray DOM children. */}
       <input
         ref={inputRef}
         type="file"
-        accept={FILE_ACCEPT}
         multiple
         className="hidden"
         onChange={handleChange}

--- a/src/browser/features/ChatInput/AttachFileButton.tsx
+++ b/src/browser/features/ChatInput/AttachFileButton.tsx
@@ -1,6 +1,7 @@
 /**
- * Attach file button that opens a native picker for any file type.
- * Images and PDFs attach natively. Other files are saved into the workspace.
+ * Attach file button that opens a native picker.
+ * Images and PDFs attach natively. When staging is available (open workspace),
+ * any other file type is accepted and saved into the workspace.
  */
 
 import React, { useRef } from "react";
@@ -8,9 +9,13 @@ import { Paperclip } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { cn } from "@/common/lib/utils";
 
+/** Picker filter for composers without workspace staging (creation/scratch). */
+const PROVIDER_FILE_ACCEPT = "image/*,.svg,.pdf";
+
 interface AttachFileButtonProps {
   onFiles: (files: File[]) => void;
   disabled?: boolean;
+  canStageFiles: boolean;
 }
 
 export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
@@ -50,14 +55,23 @@ export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <strong>Attach any file</strong>. Images and PDFs attach directly. Other files are saved
-          to the workspace.
+          {props.canStageFiles ? (
+            <>
+              <strong>Attach any file</strong>. Images and PDFs attach directly. Other files are
+              saved to the workspace.
+            </>
+          ) : (
+            <>
+              <strong>Attach file</strong>: images, SVGs, PDFs
+            </>
+          )}
         </TooltipContent>
       </Tooltip>
       {/* Kept outside Tooltip to avoid stray DOM children. */}
       <input
         ref={inputRef}
         type="file"
+        accept={props.canStageFiles ? undefined : PROVIDER_FILE_ACCEPT}
         multiple
         className="hidden"
         onChange={handleChange}

--- a/src/browser/features/ChatInput/draftAttachmentsStorage.test.ts
+++ b/src/browser/features/ChatInput/draftAttachmentsStorage.test.ts
@@ -39,7 +39,7 @@ describe("draftAttachmentsStorage", () => {
     ]);
   });
 
-  test("parsePersistedChatAttachments returns staged zip metadata without base64", () => {
+  test("parsePersistedChatAttachments returns staged file metadata without base64", () => {
     expect(
       parsePersistedChatAttachments([
         {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2035,7 +2035,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   throw new Error("Not connected to server");
                 }
                 if (workspaceId == null) {
-                  throw new Error("ZIP attachments can be added after opening a workspace.");
+                  throw new Error("Files can be staged after opening a workspace.");
                 }
                 const result = await api.workspace.stageAttachment({
                   workspaceId,
@@ -2055,6 +2055,35 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       });
     },
     [api, variant, workspaceId]
+  );
+
+  const attachFiles = useCallback(
+    (files: File[]) => {
+      const results = files.map((file) =>
+        processAttachmentFilesForComposer([file]).then(
+          (attachments) => ({ ok: true as const, attachments }),
+          (error: unknown) => ({ ok: false as const, error })
+        )
+      );
+      void Promise.all(results).then((outcomes) => {
+        const successes = outcomes.flatMap((outcome) => (outcome.ok ? outcome.attachments : []));
+        if (successes.length > 0) {
+          setAttachments((prev) => [...prev, ...successes]);
+          showResizeToast(successes);
+        }
+        for (const outcome of outcomes) {
+          if (!outcome.ok) {
+            const message =
+              outcome.error instanceof Error
+                ? outcome.error.message
+                : "Failed to process attachment";
+            console.error("Failed to process attached file:", outcome.error);
+            pushToast({ type: "error", message });
+          }
+        }
+      });
+    },
+    [processAttachmentFilesForComposer, pushToast, setAttachments, showResizeToast]
   );
 
   // Handle paste events to extract attachments
@@ -2078,26 +2107,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
       e.preventDefault(); // Prevent default paste behavior for attachments
 
-      processAttachmentFilesForComposer(attachmentFiles)
-        .then((nextAttachments) => {
-          setAttachments((prev) => [...prev, ...nextAttachments]);
-          showResizeToast(nextAttachments);
-        })
-        .catch((error) => {
-          console.error("Failed to process pasted attachment:", error);
-          pushToast({
-            type: "error",
-            message: error instanceof Error ? error.message : "Failed to process attachment",
-          });
-        });
+      attachFiles(attachmentFiles);
     },
-    [
-      editingMessageForUi,
-      processAttachmentFilesForComposer,
-      pushToast,
-      setAttachments,
-      showResizeToast,
-    ]
+    [attachFiles, editingMessageForUi, pushToast]
   );
 
   // Handle removing an attachment
@@ -2108,10 +2120,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     [setAttachments]
   );
 
-  // Handle files selected via the attach file picker.
-  // Process each file individually so unsupported files (e.g. user switched the
-  // native picker to "All files") don't reject the entire batch — valid files
-  // still get attached and only failures are toasted.
   const handleAttachFiles = (files: File[]) => {
     if (editingMessageForUi) {
       pushToast({
@@ -2120,27 +2128,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       });
       return;
     }
-    const results = files.map((file) =>
-      processAttachmentFilesForComposer([file]).then(
-        (attachments) => ({ ok: true as const, attachments }),
-        (error: unknown) => ({ ok: false as const, error })
-      )
-    );
-    void Promise.all(results).then((outcomes) => {
-      const successes = outcomes.flatMap((o) => (o.ok ? o.attachments : []));
-      if (successes.length > 0) {
-        setAttachments((prev) => [...prev, ...successes]);
-        showResizeToast(successes);
-      }
-      for (const outcome of outcomes) {
-        if (!outcome.ok) {
-          const msg =
-            outcome.error instanceof Error ? outcome.error.message : "Failed to process attachment";
-          console.error("Failed to process attached file:", outcome.error);
-          pushToast({ type: "error", message: msg });
-        }
-      }
-    });
+    attachFiles(files);
   };
 
   // Shared slash command execution for creation + workspace inputs.
@@ -2188,8 +2176,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       setToast({
         id: Date.now().toString(),
         type: "error",
-        message:
-          "This command cannot include staged ZIP attachments. Remove the ZIP or send a normal message.",
+        message: "This command cannot include staged files. Remove them or send a normal message.",
       });
       return true;
     }
@@ -2310,26 +2297,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         return;
       }
 
-      processAttachmentFilesForComposer(attachmentFiles)
-        .then((nextAttachments) => {
-          setAttachments((prev) => [...prev, ...nextAttachments]);
-          showResizeToast(nextAttachments);
-        })
-        .catch((error) => {
-          console.error("Failed to process dropped attachment:", error);
-          pushToast({
-            type: "error",
-            message: error instanceof Error ? error.message : "Failed to process attachment",
-          });
-        });
+      attachFiles(attachmentFiles);
     },
-    [
-      editingMessageForUi,
-      processAttachmentFilesForComposer,
-      pushToast,
-      setAttachments,
-      showResizeToast,
-    ]
+    [attachFiles, editingMessageForUi, pushToast]
   );
 
   // Handle suggestion selection

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -3365,6 +3365,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                   <AttachFileButton
                     onFiles={handleAttachFiles}
                     disabled={disabled || sendInFlightBlocksInput || !!editingMessageForUi}
+                    canStageFiles={variant === "workspace"}
                   />
                   <VoiceInputButton
                     state={voiceInput.state}

--- a/src/browser/features/ChatInput/stagedAttachments.test.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.test.ts
@@ -7,24 +7,48 @@ import {
 } from "./stagedAttachments";
 
 describe("stagedAttachments", () => {
-  test("builds a staged-file notice with filename, type, size, and path", () => {
+  test("round-trips markdown and CSV staged attachments through the notice", () => {
     const notice = buildStagedAttachmentNotice([
       {
         kind: "staged",
-        id: "zip-1",
-        filename: "archive.zip",
-        mediaType: "application/zip",
-        sizeBytes: 12_345,
-        stagedPath: ".mux/user-attachments/id/archive.zip",
+        id: "md-1",
+        filename: "notes.md",
+        mediaType: "text/markdown",
+        sizeBytes: 12,
+        stagedPath: ".mux/user-attachments/id/notes.md",
+      },
+      {
+        kind: "staged",
+        id: "csv-1",
+        filename: "data.csv",
+        mediaType: "text/csv",
+        sizeBytes: 34,
+        stagedPath: ".mux/user-attachments/id/data.csv",
       },
     ]);
 
-    expect(notice).toContain("<attached-files>");
-    expect(notice).toContain("`archive.zip` (`application/zip`, 12.1 KB)");
-    expect(notice).toContain("`.mux/user-attachments/id/archive.zip`");
+    expect(parseStagedAttachmentNotice(notice)).toEqual({
+      text: "",
+      attachments: [
+        {
+          filename: "notes.md",
+          mediaType: "text/markdown",
+          sizeLabel: "12 B",
+          sizeBytes: 12,
+          stagedPath: ".mux/user-attachments/id/notes.md",
+        },
+        {
+          filename: "data.csv",
+          mediaType: "text/csv",
+          sizeLabel: "34 B",
+          sizeBytes: 34,
+          stagedPath: ".mux/user-attachments/id/data.csv",
+        },
+      ],
+    });
   });
 
-  test("allows zip-only sends by returning the notice as message text", () => {
+  test("allows file-only sends by returning the notice as message text", () => {
     const message = appendStagedAttachmentNotice("", [
       {
         kind: "staged",

--- a/src/browser/features/Messages/UserMessageContent.staged.test.tsx
+++ b/src/browser/features/Messages/UserMessageContent.staged.test.tsx
@@ -10,11 +10,11 @@ import { UserMessageContent } from "./UserMessageContent";
 
 const STAGED_ATTACHMENT: StagedChatAttachment = {
   kind: "staged",
-  id: "zip-1",
-  filename: "archive.zip",
-  mediaType: "application/zip",
+  id: "md-1",
+  filename: "notes.md",
+  mediaType: "text/markdown",
   sizeBytes: 12_345,
-  stagedPath: ".mux/user-attachments/id/archive.zip",
+  stagedPath: ".mux/user-attachments/id/notes.md",
 };
 
 describe("UserMessageContent staged attachment rendering", () => {
@@ -32,7 +32,7 @@ describe("UserMessageContent staged attachment rendering", () => {
 
   test("hides the model-only staged attachment notice and renders a download chip", () => {
     const downloads: unknown[] = [];
-    const content = appendStagedAttachmentNotice("Inspect this archive.", [STAGED_ATTACHMENT]);
+    const content = appendStagedAttachmentNotice("Inspect these notes.", [STAGED_ATTACHMENT]);
 
     const view = render(
       <UserMessageContent
@@ -44,20 +44,20 @@ describe("UserMessageContent staged attachment rendering", () => {
 
     expect(view.queryByText(/<attached-files>/)).toBeNull();
     expect(view.queryByText(/workspace filesystem/)).toBeNull();
-    expect(view.getByText("Inspect this archive.")).toBeTruthy();
+    expect(view.getByText("Inspect these notes.")).toBeTruthy();
 
-    const chip = view.getByRole("button", { name: /download archive\.zip/i });
-    expect(chip.textContent).toContain("archive.zip");
+    const chip = view.getByRole("button", { name: /download notes\.md/i });
+    expect(chip.textContent).toContain("notes.md");
     expect(chip.textContent).toContain("12.1 KB");
 
     fireEvent.click(chip);
     expect(downloads).toEqual([
       {
-        filename: "archive.zip",
-        mediaType: "application/zip",
+        filename: "notes.md",
+        mediaType: "text/markdown",
         sizeLabel: "12.1 KB",
         sizeBytes: 12_390,
-        stagedPath: ".mux/user-attachments/id/archive.zip",
+        stagedPath: ".mux/user-attachments/id/notes.md",
       },
     ]);
   });

--- a/src/browser/utils/attachmentsHandling.test.ts
+++ b/src/browser/utils/attachmentsHandling.test.ts
@@ -1,4 +1,5 @@
 import { MAX_SVG_TEXT_CHARS } from "@/common/constants/imageAttachments";
+import { MAX_STAGED_ATTACHMENT_SIZE_BYTES } from "@/common/constants/stagedAttachments";
 import { afterAll, describe, expect, test } from "@jest/globals";
 
 import {
@@ -111,129 +112,46 @@ describe("attachmentsHandling", () => {
   });
 
   describe("extractAttachmentsFromClipboard", () => {
-    test("extracts image files from clipboard items", () => {
-      // Mock clipboard items
-      const mockFile = new File(["fake image"], "test.png", { type: "image/png" });
-
+    test("extracts arbitrary file items without treating clipboard text as a file", () => {
+      const image = new File(["image"], "test.png", { type: "image/png" });
+      const text = new File(["text"], "notes.txt", { type: "text/plain" });
       const mockItems = [
-        {
-          type: "image/png",
-          getAsFile: () => mockFile,
-        },
-        {
-          type: "text/plain",
-          getAsFile: () => null,
-        },
+        { kind: "file", getAsFile: () => image },
+        { kind: "file", getAsFile: () => text },
+        { kind: "string", getAsFile: () => null },
       ] as unknown as DataTransferItemList;
 
-      const files = extractAttachmentsFromClipboard(mockItems);
-
-      expect(files).toHaveLength(1);
-      expect(files[0]).toBe(mockFile);
-    });
-
-    test("ignores non-image items", () => {
-      const mockItems: DataTransferItemList = [
-        {
-          type: "text/plain",
-          getAsFile: () => new File(["text"], "test.txt", { type: "text/plain" }),
-        },
-        {
-          type: "text/html",
-          getAsFile: () => new File(["<p>html</p>"], "test.html", { type: "text/html" }),
-        },
-      ] as unknown as DataTransferItemList;
-
-      const files = extractAttachmentsFromClipboard(mockItems);
-
-      expect(files).toHaveLength(0);
-    });
-
-    test("handles multiple images", () => {
-      const mockFile1 = new File(["fake image 1"], "test1.png", { type: "image/png" });
-      const mockFile2 = new File(["fake image 2"], "test2.jpg", { type: "image/jpeg" });
-
-      const mockItems = [
-        {
-          type: "image/png",
-          getAsFile: () => mockFile1,
-        },
-        {
-          type: "image/jpeg",
-          getAsFile: () => mockFile2,
-        },
-      ] as unknown as DataTransferItemList;
-
-      const files = extractAttachmentsFromClipboard(mockItems);
-
-      expect(files).toHaveLength(2);
-      expect(files).toContain(mockFile1);
-      expect(files).toContain(mockFile2);
+      expect(extractAttachmentsFromClipboard(mockItems)).toEqual([image, text]);
     });
   });
 
   describe("extractAttachmentsFromDrop", () => {
-    test("extracts image files from DataTransfer", () => {
-      const mockFile1 = new File(["image 1"], "test1.png", { type: "image/png" });
-      const mockFile2 = new File(["text"], "test.txt", { type: "text/plain" });
-      const mockFile3 = new File(["image 2"], "test2.jpg", { type: "image/jpeg" });
+    test("extracts arbitrary dropped files", () => {
+      const image = new File(["image"], "test.png", { type: "image/png" });
+      const text = new File(["text"], "notes.txt", { type: "text/plain" });
+      const binary = new File(["binary"], "data.bin", { type: "" });
+      const mockDataTransfer = { files: [image, text, binary] };
 
-      const mockDataTransfer = {
-        files: [mockFile1, mockFile2, mockFile3],
-      };
-
-      const files = extractAttachmentsFromDrop(mockDataTransfer as unknown as DataTransfer);
-
-      expect(files).toHaveLength(2);
-      expect(files).toContain(mockFile1);
-      expect(files).toContain(mockFile3);
-      expect(files).not.toContain(mockFile2);
-    });
-
-    test("returns empty array when no images", () => {
-      const mockFile = new File(["text"], "test.txt", { type: "text/plain" });
-
-      const mockDataTransfer = {
-        files: [mockFile],
-      };
-
-      const files = extractAttachmentsFromDrop(mockDataTransfer as unknown as DataTransfer);
-
-      expect(files).toHaveLength(0);
-    });
-
-    test("accepts files with supported extensions when MIME type is empty (macOS drag-drop)", () => {
-      const mockFile1 = new File(["image"], "photo.png", { type: "" }); // Empty type
-      const mockFile2 = new File(["image"], "picture.jpg", { type: "" }); // Empty type
-      const mockFile3 = new File(["pdf"], "doc.pdf", { type: "" }); // Empty type
-      const mockFile4 = new File(["text"], "document.txt", { type: "" }); // Empty type, unsupported
-
-      const mockDataTransfer = {
-        files: [mockFile1, mockFile2, mockFile3, mockFile4],
-      };
-
-      const files = extractAttachmentsFromDrop(mockDataTransfer as unknown as DataTransfer);
-
-      expect(files).toHaveLength(3);
-      expect(files).toContain(mockFile1);
-      expect(files).toContain(mockFile2);
-      expect(files).toContain(mockFile3);
-      expect(files).not.toContain(mockFile4);
+      expect(extractAttachmentsFromDrop(mockDataTransfer as unknown as DataTransfer)).toEqual([
+        image,
+        text,
+        binary,
+      ]);
     });
   });
 
   describe("staged attachments", () => {
-    test("stages zip files through the provided callback", async () => {
-      const file = new File(["zip bytes"], "archive.zip", { type: "" });
+    test("stages arbitrary files through the provided callback", async () => {
+      const file = new File(["markdown"], "notes.md", { type: "text/markdown" });
 
       const attachments = await processAttachmentFiles([file], {
-        stageAttachment: (zipFile, dataBase64) => {
-          expect(dataBase64).toBe("emlwIGJ5dGVz");
+        stageAttachment: (stagedFile, dataBase64) => {
+          expect(dataBase64).toBe("bWFya2Rvd24=");
           return Promise.resolve({
-            filename: zipFile.name,
-            mediaType: "application/zip",
-            sizeBytes: zipFile.size,
-            stagedPath: `.mux/user-attachments/id/${zipFile.name}`,
+            filename: stagedFile.name,
+            mediaType: stagedFile.type,
+            sizeBytes: stagedFile.size,
+            stagedPath: `.mux/user-attachments/id/${stagedFile.name}`,
           });
         },
       });
@@ -242,24 +160,49 @@ describe("attachmentsHandling", () => {
         {
           kind: "staged",
           id: expect.stringMatching(/^\d+-[a-z0-9]+$/),
-          filename: "archive.zip",
-          mediaType: "application/zip",
-          sizeBytes: 9,
-          stagedPath: ".mux/user-attachments/id/archive.zip",
+          filename: "notes.md",
+          mediaType: "text/markdown",
+          sizeBytes: 8,
+          stagedPath: ".mux/user-attachments/id/notes.md",
         },
       ]);
     });
 
-    test("does not convert staged zip attachments to provider file parts", () => {
+    test("rejects oversized files before reading or staging them", async () => {
+      let read = false;
+      let staged = false;
+      const file = {
+        name: "large.bin",
+        type: "",
+        size: MAX_STAGED_ATTACHMENT_SIZE_BYTES + 1,
+        arrayBuffer: () => {
+          read = true;
+          return Promise.reject(new Error("should not read"));
+        },
+      } as unknown as File;
+
+      await expect(
+        processAttachmentFiles([file], {
+          stageAttachment: () => {
+            staged = true;
+            return Promise.reject(new Error("should not stage"));
+          },
+        })
+      ).rejects.toThrow("cannot be staged");
+      expect(read).toBe(false);
+      expect(staged).toBe(false);
+    });
+
+    test("does not convert staged attachments to provider file parts", () => {
       expect(
         chatAttachmentsToFileParts([
           {
             kind: "staged",
-            id: "zip-1",
-            filename: "archive.zip",
-            mediaType: "application/zip",
+            id: "file-1",
+            filename: "notes.md",
+            mediaType: "text/markdown",
             sizeBytes: 1,
-            stagedPath: ".mux/user-attachments/id/archive.zip",
+            stagedPath: ".mux/user-attachments/id/notes.md",
           },
         ])
       ).toEqual([]);
@@ -267,26 +210,52 @@ describe("attachmentsHandling", () => {
   });
 
   describe("processAttachmentFiles", () => {
-    test("converts multiple files to attachments", async () => {
-      const file1 = new File(["image 1"], "test1.png", { type: "image/png" });
-      const file2 = new File(["image 2"], "test2.jpg", { type: "image/jpeg" });
+    test("routes provider-native files before the staged fallback", async () => {
+      const image = new File(["image"], "photo.png", { type: "image/png" });
+      const pdf = new File(["pdf"], "document.pdf", { type: "application/pdf" });
 
-      const attachments = await processAttachmentFiles([file1, file2]);
+      const attachments = await processAttachmentFiles([image, pdf], {
+        stageAttachment: () => Promise.reject(new Error("provider file was staged")),
+      });
 
-      expect(attachments).toHaveLength(2);
-      if (attachments[0].kind !== "provider" || attachments[1].kind !== "provider") {
-        throw new Error("Expected provider attachments");
-      }
-      expect(attachments[0].mediaType).toBe("image/png");
-      expect(attachments[1].mediaType).toBe("image/jpeg");
-      expect(attachments[0].url).toContain("data:image/png;base64,");
-      expect(attachments[1].url).toContain("data:image/jpeg;base64,");
+      expect(attachments.map((attachment) => attachment.kind)).toEqual(["provider", "provider"]);
+      expect(attachments.map((attachment) => attachment.mediaType)).toEqual([
+        "image/png",
+        "application/pdf",
+      ]);
+    });
+
+    test("routes mixed arbitrary files independently", async () => {
+      const image = new File(["image"], "photo.png", { type: "image/png" });
+      const markdown = new File(["md"], "notes.md", { type: "text/markdown" });
+      const csv = new File(["csv"], "data.csv", { type: "text/csv" });
+      const binary = new File(["bin"], "data.bin", { type: "" });
+      const stagedNames: string[] = [];
+
+      const attachments = await processAttachmentFiles([image, markdown, csv, binary], {
+        stageAttachment: (file) => {
+          stagedNames.push(file.name);
+          const mediaType = file.type || "application/octet-stream";
+          return Promise.resolve({
+            filename: file.name,
+            mediaType,
+            sizeBytes: file.size,
+            stagedPath: `.mux/user-attachments/id/${file.name}`,
+          });
+        },
+      });
+
+      expect(attachments.map((attachment) => attachment.kind)).toEqual([
+        "provider",
+        "staged",
+        "staged",
+        "staged",
+      ]);
+      expect(stagedNames).toEqual(["notes.md", "data.csv", "data.bin"]);
     });
 
     test("handles empty array", async () => {
-      const attachments = await processAttachmentFiles([]);
-
-      expect(attachments).toHaveLength(0);
+      expect(await processAttachmentFiles([])).toEqual([]);
     });
   });
 });

--- a/src/browser/utils/attachmentsHandling.ts
+++ b/src/browser/utils/attachmentsHandling.ts
@@ -1,10 +1,7 @@
 import type { FilePart } from "@/common/orpc/types";
 import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
 import { MAX_STAGED_ATTACHMENT_SIZE_BYTES } from "@/common/constants/stagedAttachments";
-import {
-  getSupportedAttachmentMediaType,
-  getSupportedStagedAttachmentMediaType,
-} from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import { getSupportedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import type { ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
 import { resizeImageIfNeeded } from "@/browser/utils/imageResize";
 
@@ -44,7 +41,7 @@ export function chatAttachmentsToFileParts(
 
   return attachments.flatMap((attachment, index) => {
     if (attachment.kind === "staged") {
-      // Staged ZIPs live in the workspace filesystem and must never be sent as provider file parts.
+      // Staged files live in the workspace filesystem and must never be sent as provider file parts.
       return [];
     }
 
@@ -78,21 +75,6 @@ export function chatAttachmentsToFileParts(
   });
 }
 
-function getSupportedStagedMediaType(file: File): string | null {
-  return getSupportedStagedAttachmentMediaType({
-    mediaType: file.type !== "" ? file.type : null,
-    filename: file.name,
-  });
-}
-
-// True when a file is accepted as either a provider attachment or a staged (ZIP) attachment.
-// Shared by the clipboard/drop extractors so both stay in sync on what counts as attachable.
-// Both getters return a non-empty media-type string or null, so `!= null` matches the prior
-// truthiness checks the extractors inlined.
-function isSupportedAttachmentFile(file: File): boolean {
-  return getSupportedMediaType(file) != null || getSupportedStagedMediaType(file) != null;
-}
-
 function fileBytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 0x8000;
@@ -106,13 +88,9 @@ async function fileToStagedChatAttachment(
   file: File,
   stageAttachment: (file: File, dataBase64: string) => Promise<StageAttachmentResult>
 ): Promise<ChatAttachment> {
-  const mediaType = getSupportedStagedMediaType(file);
-  if (mediaType == null) {
-    throw new Error(`Unsupported attachment type: ${file.type || file.name}`);
-  }
   if (file.size > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
     throw new Error(
-      `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+      `Attachments larger than ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes cannot be staged.`
     );
   }
 
@@ -204,36 +182,20 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
 }
 
 /**
- * Extract supported attachment files from clipboard items.
+ * Extract attachment files from clipboard items.
  */
 export function extractAttachmentsFromClipboard(items: DataTransferItemList): File[] {
-  const files: File[] = [];
-
-  for (const item of Array.from(items)) {
-    const file = item?.getAsFile();
-    if (!file) continue;
-
-    if (isSupportedAttachmentFile(file)) {
-      files.push(file);
-    }
-  }
-
-  return files;
+  return Array.from(items).flatMap((item) => {
+    const file = item.kind === "file" ? item.getAsFile() : null;
+    return file == null ? [] : [file];
+  });
 }
 
 /**
- * Extract supported attachment files from drag and drop DataTransfer.
+ * Extract attachment files from drag and drop DataTransfer.
  */
 export function extractAttachmentsFromDrop(dataTransfer: DataTransfer): File[] {
-  const files: File[] = [];
-
-  for (const file of Array.from(dataTransfer.files)) {
-    if (isSupportedAttachmentFile(file)) {
-      files.push(file);
-    }
-  }
-
-  return files;
+  return Array.from(dataTransfer.files);
 }
 
 /**
@@ -245,13 +207,14 @@ export async function processAttachmentFiles(
 ): Promise<ChatAttachment[]> {
   return await Promise.all(
     files.map((file) => {
-      if (getSupportedStagedMediaType(file) != null) {
-        if (!options.stageAttachment) {
-          throw new Error("ZIP attachments can be added after opening a workspace.");
-        }
-        return fileToStagedChatAttachment(file, options.stageAttachment);
+      // Provider-native formats must win because every file is eligible for workspace staging.
+      if (getSupportedMediaType(file) != null) {
+        return fileToChatAttachment(file);
       }
-      return fileToChatAttachment(file);
+      if (!options.stageAttachment) {
+        throw new Error("Files can be staged after opening a workspace.");
+      }
+      return fileToStagedChatAttachment(file, options.stageAttachment);
     })
   );
 }

--- a/src/browser/utils/attachmentsHandling.ts
+++ b/src/browser/utils/attachmentsHandling.ts
@@ -198,16 +198,13 @@ export function extractAttachmentsFromDrop(dataTransfer: DataTransfer): File[] {
   return Array.from(dataTransfer.files);
 }
 
-/**
- * Processes multiple attachment files and converts them to chat attachments.
- */
 export async function processAttachmentFiles(
   files: File[],
   options: ProcessAttachmentOptions = {}
 ): Promise<ChatAttachment[]> {
   return await Promise.all(
     files.map((file) => {
-      // Provider-native formats must win because every file is eligible for workspace staging.
+      // Prefer provider-native formats before the optional workspace staging fallback.
       if (getSupportedMediaType(file) != null) {
         return fileToChatAttachment(file);
       }

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -65,7 +65,7 @@ describe("canEditDisplayedUserMessage", () => {
     expect(canEditDisplayedUserMessage(userMessage({ isSideQuestion: true }))).toBe(false);
   });
 
-  test("restores staged ZIPs as attachments when editing sent messages", () => {
+  test("restores staged files as attachments when editing sent messages", () => {
     const content = appendStagedAttachmentNotice("Inspect this archive.", [STAGED_ATTACHMENT]);
 
     const pending = buildPendingFromDisplayed(userMessage({ content, historyId: "history-1" }));
@@ -80,7 +80,7 @@ describe("canEditDisplayedUserMessage", () => {
     ]);
   });
 
-  test("restores staged ZIPs as attachments when normalizing queued messages", () => {
+  test("restores staged files as attachments when normalizing queued messages", () => {
     const queued: QueuedMessage = {
       id: "queued-1",
       content: appendStagedAttachmentNotice("Queued archive.", [STAGED_ATTACHMENT]),
@@ -97,7 +97,7 @@ describe("canEditDisplayedUserMessage", () => {
     ]);
   });
 
-  test("restores staged ZIPs from restore-to-input payloads with attachments", () => {
+  test("restores staged files from restore-to-input payloads with attachments", () => {
     const filePart = {
       url: "data:text/plain;base64,ZGF0YQ==",
       mediaType: "text/plain",
@@ -130,7 +130,7 @@ describe("canEditDisplayedUserMessage", () => {
     });
   });
 
-  test("restores staged ZIPs from compaction follow-up content", () => {
+  test("restores staged files from compaction follow-up content", () => {
     const followUp: CompactionFollowUpRequest = {
       text: appendStagedAttachmentNotice("Continue after compaction.", [STAGED_ATTACHMENT]),
       model: "claude-sonnet-4-5",

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -814,7 +814,7 @@ function stripStagedDraftAttachments(value: string): string {
       return value;
     }
     // Forked worktrees do not share staged draft files. Keep provider attachments, but drop
-    // workspace-local staged ZIP chips so the fork cannot point at missing source-worktree paths.
+    // workspace-local staged file chips so the fork cannot point at missing source-worktree paths.
     return JSON.stringify(parsed.filter((attachment) => !isStagedPersistedAttachment(attachment)));
   } catch {
     return value;

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
@@ -6,16 +6,62 @@ import {
 } from "./supportedAttachmentMediaTypes";
 
 describe("supportedAttachmentMediaTypes", () => {
-  test("classifies zip files as staged attachments without making them provider attachments", () => {
-    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBeNull();
-    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBe(
-      "application/zip"
+  test("keeps images and PDFs as provider attachments", () => {
+    expect(getSupportedAttachmentMediaType({ mediaType: "image/png", filename: "photo.png" })).toBe(
+      "image/png"
     );
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "document.pdf" })).toBe(
+      "application/pdf"
+    );
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "notes.md" })).toBeNull();
+  });
+
+  test("infers common staged attachment media types from extensions", () => {
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "notes.md" })).toBe(
+      "text/markdown"
+    );
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "notes.txt" })).toBe(
+      "text/plain"
+    );
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "data.csv" })).toBe(
+      "text/csv"
+    );
+  });
+
+  test("falls back to application/octet-stream for unknown files", () => {
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "data.bin" })).toBe(
+      "application/octet-stream"
+    );
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "README" })).toBe(
+      "application/octet-stream"
+    );
+  });
+
+  test("normalizes provided media types and canonicalizes zip aliases", () => {
+    expect(
+      getSupportedStagedAttachmentMediaType({
+        mediaType: " Text/Plain; Charset=UTF-8 ",
+        filename: "x",
+      })
+    ).toBe("text/plain");
     expect(
       getSupportedStagedAttachmentMediaType({
         mediaType: "application/x-zip-compressed",
         filename: "archive",
       })
     ).toBe("application/zip");
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBeNull();
+  });
+
+  test("replaces unsafe media types with application/octet-stream", () => {
+    expect(
+      getSupportedStagedAttachmentMediaType({ mediaType: "text/`plain", filename: "notes.md" })
+    ).toBe("application/octet-stream");
+    expect(
+      getSupportedStagedAttachmentMediaType({ mediaType: "text/(plain)", filename: "notes.md" })
+    ).toBe("application/octet-stream");
+    expect(
+      getSupportedStagedAttachmentMediaType({ mediaType: `text/${"a".repeat(100)}`, filename: "x" })
+    ).toBe("application/octet-stream");
   });
 });

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -16,6 +16,22 @@ const EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
   pdf: PDF_MEDIA_TYPE,
 };
 
+const STAGED_EXTENSION_TO_MEDIA_TYPE: Record<string, string> = {
+  md: MARKDOWN_MEDIA_TYPE,
+  txt: "text/plain",
+  csv: "text/csv",
+  json: "application/json",
+  log: "text/plain",
+  yaml: "application/yaml",
+  yml: "application/yaml",
+  xml: "application/xml",
+  zip: ZIP_MEDIA_TYPE,
+};
+
+const DEFAULT_STAGED_MEDIA_TYPE = "application/octet-stream";
+const MAX_STAGED_MEDIA_TYPE_LENGTH = 100;
+const MEDIA_TYPE_PATTERN = /^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/u;
+
 export function normalizeAttachmentMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
 }
@@ -49,25 +65,39 @@ export function getSupportedAttachmentMediaType(args: {
   return isSupportedAttachmentMediaType(normalized) ? normalized : null;
 }
 
+function sanitizeStagedAttachmentMediaType(mediaType: string): string | null {
+  const normalized = normalizeAttachmentMediaType(mediaType);
+  if (
+    normalized.length === 0 ||
+    normalized.length > MAX_STAGED_MEDIA_TYPE_LENGTH ||
+    !MEDIA_TYPE_PATTERN.test(normalized)
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
 export function isSupportedStagedAttachmentMediaType(mediaType: string): boolean {
   const normalized = normalizeAttachmentMediaType(mediaType);
-  return ZIP_MEDIA_TYPES.includes(normalized as (typeof ZIP_MEDIA_TYPES)[number]);
+  return (
+    ZIP_MEDIA_TYPES.includes(normalized as (typeof ZIP_MEDIA_TYPES)[number]) ||
+    sanitizeStagedAttachmentMediaType(normalized) != null
+  );
 }
 
 export function getSupportedStagedAttachmentMediaType(args: {
   mediaType?: string | null;
   filename?: string | null;
-}): string | null {
+}): string {
   const trimmedMediaType = args.mediaType?.trim();
-  const mediaType =
-    trimmedMediaType != null && trimmedMediaType.length > 0 ? trimmedMediaType : null;
-  if (mediaType != null && isSupportedStagedAttachmentMediaType(mediaType)) {
-    return ZIP_MEDIA_TYPE;
+  if (trimmedMediaType != null && trimmedMediaType.length > 0) {
+    const normalized = normalizeAttachmentMediaType(trimmedMediaType);
+    if (ZIP_MEDIA_TYPES.includes(normalized as (typeof ZIP_MEDIA_TYPES)[number])) {
+      return ZIP_MEDIA_TYPE;
+    }
+    return sanitizeStagedAttachmentMediaType(normalized) ?? DEFAULT_STAGED_MEDIA_TYPE;
   }
 
-  if (args.filename?.toLowerCase().endsWith(".zip") === true) {
-    return ZIP_MEDIA_TYPE;
-  }
-
-  return null;
+  const ext = args.filename?.toLowerCase().split(".").pop() ?? "";
+  return STAGED_EXTENSION_TO_MEDIA_TYPE[ext] ?? DEFAULT_STAGED_MEDIA_TYPE;
 }

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -11,6 +11,7 @@ import {
   copyStagedWorkspaceAttachments,
   extractStagedAttachmentPathsFromText,
   readStagedWorkspaceAttachment,
+  sanitizeStagedFilename,
   stageWorkspaceAttachment,
 } from "./stageWorkspaceAttachment";
 
@@ -28,53 +29,68 @@ afterEach(async () => {
 });
 
 describe("stageWorkspaceAttachment", () => {
-  test("writes zip bytes under the staged attachment directory and keeps git clean", async () => {
+  test("writes arbitrary files under the staged attachment directory and keeps git clean", async () => {
     const repo = await makeTempDir("mux-stage-attachment-");
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
     const runtime = new LocalRuntime(repo);
-    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 1, 2, 3]);
+    const cases = [
+      { filename: "../../notes.md", mediaType: "text/markdown", bytes: Buffer.from("markdown") },
+      { filename: "data.csv", mediaType: "text/csv", bytes: Buffer.from("a,b") },
+      { filename: "payload.bin", mediaType: "", bytes: Buffer.from([0, 1, 2]) },
+    ];
 
-    const result = await stageWorkspaceAttachment({
-      runtime,
-      workspacePath: repo,
-      filename: "../../archive.zip",
-      mediaType: "application/zip",
-      sizeBytes: bytes.byteLength,
-      dataBase64: Buffer.from(bytes).toString("base64"),
-    });
+    for (const item of cases) {
+      const result = await stageWorkspaceAttachment({
+        runtime,
+        workspacePath: repo,
+        filename: item.filename,
+        mediaType: item.mediaType,
+        sizeBytes: item.bytes.byteLength,
+        dataBase64: item.bytes.toString("base64"),
+      });
 
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.filename).toBe("archive.zip");
-    expect(result.data.stagedPath).toStartWith(`${STAGED_ATTACHMENT_DIR}/`);
-    expect(await readFile(path.join(repo, result.data.stagedPath))).toEqual(Buffer.from(bytes));
+      expect(result.success).toBe(true);
+      if (!result.success) continue;
+      expect(result.data.filename).toBe(path.basename(item.filename));
+      expect(result.data.stagedPath).toStartWith(`${STAGED_ATTACHMENT_DIR}/`);
+      expect(await readFile(path.join(repo, result.data.stagedPath))).toEqual(item.bytes);
+    }
+
     const status = execFileSync("git", ["status", "--porcelain"], { cwd: repo, encoding: "utf8" });
     expect(status).toBe("");
   });
 
-  test("reads staged zip bytes for download and rejects paths outside staging", async () => {
+  test("reads staged files for download and rejects paths outside staging", async () => {
     const repo = await makeTempDir("mux-stage-attachment-download-");
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
     const runtime = new LocalRuntime(repo);
-    const bytes = Buffer.from("zip bytes");
+    const bytes = Buffer.from("markdown");
 
     const staged = await stageWorkspaceAttachment({
       runtime,
       workspacePath: repo,
-      filename: "archive.zip",
-      mediaType: "application/zip",
+      filename: "notes.md",
+      mediaType: "text/markdown",
       sizeBytes: bytes.byteLength,
       dataBase64: bytes.toString("base64"),
     });
     expect(staged.success).toBe(true);
     if (!staged.success) return;
 
-    const invalidDownload = await readStagedWorkspaceAttachment({
-      runtime,
-      workspacePath: repo,
-      stagedPath: "../README.md",
-    });
-    expect(invalidDownload).toEqual({ success: false, error: "Invalid staged attachment path." });
+    for (const stagedPath of [
+      "../README.md",
+      "/.mux/user-attachments/id/notes.md",
+      ".mux/user-attachments/../notes.md",
+      ".mux/user-attachments/id//notes.md",
+      ".mux/user-attachments/id/",
+    ]) {
+      const invalidDownload = await readStagedWorkspaceAttachment({
+        runtime,
+        workspacePath: repo,
+        stagedPath,
+      });
+      expect(invalidDownload).toEqual({ success: false, error: "Invalid staged attachment path." });
+    }
 
     const downloaded = await readStagedWorkspaceAttachment({
       runtime,
@@ -85,23 +101,32 @@ describe("stageWorkspaceAttachment", () => {
     expect(downloaded).toEqual({
       success: true,
       data: {
-        filename: "archive.zip",
-        mediaType: "application/zip",
+        filename: "notes.md",
+        mediaType: "text/markdown",
         sizeBytes: bytes.byteLength,
         dataBase64: bytes.toString("base64"),
       },
     });
   });
 
-  test("stages zip files in non-git workspaces", async () => {
+  test("sanitizes staged filenames while preserving extensions", () => {
+    expect(sanitizeStagedFilename("../../notes.md")).toBe("notes.md");
+    expect(sanitizeStagedFilename("..\\..\\bad\u0000name?.csv")).toBe("badname-.csv");
+    expect(sanitizeStagedFilename("...env")).toBe("env");
+    expect(sanitizeStagedFilename("...\u0000")).toBe("attachment");
+    expect(sanitizeStagedFilename(`${"a".repeat(140)}.txt`)).toHaveLength(120);
+    expect(sanitizeStagedFilename(`${"a".repeat(140)}.txt`)).toEndWith(".txt");
+  });
+
+  test("stages files in non-git workspaces", async () => {
     const dir = await makeTempDir("mux-stage-attachment-nongit-");
     const runtime = new LocalRuntime(dir);
-    const bytes = Buffer.from("zip");
+    const bytes = Buffer.from("text");
 
     const result = await stageWorkspaceAttachment({
       runtime,
       workspacePath: dir,
-      filename: "archive.zip",
+      filename: "notes.txt",
       mediaType: "",
       sizeBytes: bytes.byteLength,
       dataBase64: bytes.toString("base64"),
@@ -109,10 +134,40 @@ describe("stageWorkspaceAttachment", () => {
 
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(await readFile(path.join(dir, result.data.stagedPath), "utf8")).toBe("zip");
+    expect(result.data.mediaType).toBe("text/plain");
+    expect(await readFile(path.join(dir, result.data.stagedPath), "utf8")).toBe("text");
   });
 
-  test("copies staged zip attachments into a fork target and keeps git clean", async () => {
+  test("lists and copies non-zip staged files", async () => {
+    const sourceDir = await makeTempDir("mux-stage-attachment-list-source-");
+    const targetDir = await makeTempDir("mux-stage-attachment-list-target-");
+    const sourceRuntime = new LocalRuntime(sourceDir);
+    const targetRuntime = new LocalRuntime(targetDir);
+    const bytes = Buffer.from("notes");
+
+    const staged = await stageWorkspaceAttachment({
+      runtime: sourceRuntime,
+      workspacePath: sourceDir,
+      filename: "notes.md",
+      mediaType: "text/markdown",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) return;
+
+    const copied = await copyStagedWorkspaceAttachments({
+      sourceRuntime,
+      targetRuntime,
+      sourceWorkspacePath: sourceDir,
+      targetWorkspacePath: targetDir,
+    });
+
+    expect(copied).toEqual({ success: true, data: undefined });
+    expect(await readFile(path.join(targetDir, staged.data.stagedPath))).toEqual(bytes);
+  });
+
+  test("copies selected staged attachments into a fork target and keeps git clean", async () => {
     const sourceRepo = await makeTempDir("mux-stage-attachment-copy-source-");
     const targetRepo = await makeTempDir("mux-stage-attachment-copy-target-");
     execFileSync("git", ["init", "-b", "main"], { cwd: sourceRepo, stdio: "ignore" });
@@ -167,7 +222,7 @@ describe("stageWorkspaceAttachment", () => {
     expect(status).toBe("");
   });
 
-  test("skips stale referenced staged zip attachments during fork copy", async () => {
+  test("skips stale referenced staged attachments during fork copy", async () => {
     const sourceRepo = await makeTempDir("mux-stage-attachment-stale-source-");
     const targetRepo = await makeTempDir("mux-stage-attachment-stale-target-");
     execFileSync("git", ["init", "-b", "main"], { cwd: sourceRepo, stdio: "ignore" });
@@ -199,13 +254,14 @@ describe("stageWorkspaceAttachment", () => {
     expect(await readFile(path.join(targetRepo, staged.data.stagedPath))).toEqual(bytes);
   });
 
-  test("extracts referenced staged attachment paths from persisted text", () => {
+  test("extracts current and legacy staged attachment paths from persisted text", () => {
     const text =
-      "before `.mux/user-attachments/one/ARCHIVE.ZIP` middle `.mux/user-attachments/two/future.zip` after";
+      "before `.mux/user-attachments/one/notes.md` middle `.mux/user-attachments/two/data.csv` legacy `.mux/user-attachments/three/ARCHIVE.ZIP` after";
 
     expect(extractStagedAttachmentPathsFromText(text)).toEqual([
-      ".mux/user-attachments/one/ARCHIVE.ZIP",
-      ".mux/user-attachments/two/future.zip",
+      ".mux/user-attachments/one/notes.md",
+      ".mux/user-attachments/two/data.csv",
+      ".mux/user-attachments/three/ARCHIVE.ZIP",
     ]);
   });
 
@@ -229,7 +285,7 @@ describe("stageWorkspaceAttachment", () => {
     ).toEqual([]);
   });
 
-  test("rejects invalid payloads before writing", async () => {
+  test("rejects mismatched payload sizes before writing", async () => {
     const repo = await makeTempDir("mux-stage-attachment-invalid-");
     execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
     const runtime = new LocalRuntime(repo);
@@ -239,7 +295,7 @@ describe("stageWorkspaceAttachment", () => {
       workspacePath: repo,
       filename: "archive.txt",
       mediaType: "text/plain",
-      sizeBytes: 3,
+      sizeBytes: 4,
       dataBase64: Buffer.from("zip").toString("base64"),
     });
 

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -4,7 +4,6 @@ import { randomUUID } from "node:crypto";
 import {
   MAX_STAGED_ATTACHMENT_SIZE_BYTES,
   STAGED_ATTACHMENT_DIR,
-  ZIP_MEDIA_TYPE,
 } from "@/common/constants/stagedAttachments";
 import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
@@ -43,15 +42,12 @@ export async function stageWorkspaceAttachment(input: {
       mediaType: input.mediaType,
       filename: input.filename,
     });
-    if (mediaType == null) {
-      return Err("Only .zip attachments can be staged.");
-    }
     if (!Number.isInteger(input.sizeBytes) || input.sizeBytes < 0) {
       return Err("Attachment size is invalid.");
     }
     if (input.sizeBytes > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
       return Err(
-        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+        `Attachments larger than ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes cannot be staged.`
       );
     }
 
@@ -61,11 +57,11 @@ export async function stageWorkspaceAttachment(input: {
     }
     if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
       return Err(
-        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+        `Attachments larger than ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes cannot be staged.`
       );
     }
 
-    const filename = sanitizeZipFilename(input.filename);
+    const filename = sanitizeStagedFilename(input.filename);
     const excludeResult = await ensureGitInfoExclude({
       runtime: input.runtime,
       workspacePath: input.workspacePath,
@@ -80,7 +76,7 @@ export async function stageWorkspaceAttachment(input: {
     await input.runtime.ensureDir(`${input.workspacePath}/${stagedDir}`);
     await writeBytes(input.runtime, `${input.workspacePath}/${stagedPath}`, bytes);
 
-    return Ok({ filename, mediaType: ZIP_MEDIA_TYPE, sizeBytes: bytes.byteLength, stagedPath });
+    return Ok({ filename, mediaType, sizeBytes: bytes.byteLength, stagedPath });
   } catch (error) {
     return Err(getErrorMessage(error));
   }
@@ -103,13 +99,14 @@ export async function readStagedWorkspaceAttachment(input: {
     );
     if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
       return Err(
-        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+        `Attachments larger than ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes cannot be staged.`
       );
     }
 
+    const filename = stagedPath.split("/").pop() ?? "attachment";
     return Ok({
-      filename: stagedPath.split("/").pop() ?? "attachment.zip",
-      mediaType: ZIP_MEDIA_TYPE,
+      filename,
+      mediaType: getSupportedStagedAttachmentMediaType({ filename }),
       sizeBytes: bytes.byteLength,
       dataBase64: bytes.toString("base64"),
     });
@@ -165,7 +162,7 @@ export async function copyStagedWorkspaceAttachments(input: {
       }
       if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
         return Err(
-          `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+          `Attachments larger than ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes cannot be staged.`
         );
       }
       await input.targetRuntime.ensureDir(
@@ -182,7 +179,7 @@ export async function copyStagedWorkspaceAttachments(input: {
 
 export function extractStagedAttachmentPathsFromText(text: string): string[] {
   const paths = new Set<string>();
-  const pattern = /`(?<path>\.mux\/user-attachments\/[^`]+?\.zip)`/giu;
+  const pattern = /`(?<path>\.mux\/user-attachments\/[^`]+)`/gu;
   for (const match of text.matchAll(pattern)) {
     const stagedPath = match.groups?.path ? normalizeReadableStagedPath(match.groups.path) : null;
     if (stagedPath != null) {
@@ -192,7 +189,7 @@ export function extractStagedAttachmentPathsFromText(text: string): string[] {
   return [...paths];
 }
 
-export function sanitizeZipFilename(filename: string): string {
+export function sanitizeStagedFilename(filename: string): string {
   const rawBase = filename.split(/[\\/]/u).pop()?.trim() ?? "";
   const withoutControls = Array.from(rawBase)
     .filter((char) => {
@@ -201,27 +198,34 @@ export function sanitizeZipFilename(filename: string): string {
     })
     .join("");
   const safeChars = withoutControls.replace(/[^A-Za-z0-9._ -]/gu, "-").replace(/^\.+/u, "");
-  const withExtension = safeChars.toLowerCase().endsWith(".zip") ? safeChars : `${safeChars}.zip`;
-  const fallback =
-    withExtension === ".zip" || withExtension.trim().length === 0
-      ? "attachment.zip"
-      : withExtension;
+  const fallback = safeChars.trim().length === 0 ? "attachment" : safeChars;
   if (fallback.length <= 120) {
     return fallback;
   }
-  const stem = fallback.slice(0, 116).replace(/\.+$/u, "") || "attachment";
-  return `${stem}.zip`;
+
+  const extensionIndex = fallback.lastIndexOf(".");
+  const extension = extensionIndex > 0 ? fallback.slice(extensionIndex) : "";
+  if (extension.length === 0 || extension.length >= 120) {
+    return fallback.slice(0, 120).replace(/\.+$/u, "") || "attachment";
+  }
+  const stem = fallback
+    .slice(0, extensionIndex)
+    .slice(0, 120 - extension.length)
+    .replace(/\.+$/u, "");
+  return `${stem || "attachment"}${extension}`.slice(0, 120);
 }
 
 function normalizeReadableStagedPath(stagedPath: string): string | null {
-  const normalized = stagedPath.replace(/\\/gu, "/").replace(/^\/+/, "");
+  const normalized = stagedPath.replace(/\\/gu, "/");
+  const segments = normalized.split("/");
   if (
     normalized.length === 0 ||
+    normalized.startsWith("/") ||
     normalized.includes("\0") ||
     normalized.includes("//") ||
-    normalized.split("/").includes("..") ||
+    segments.includes("..") ||
     !normalized.startsWith(`${STAGED_ATTACHMENT_DIR}/`) ||
-    !normalized.toLowerCase().endsWith(".zip")
+    (segments.at(-1)?.length ?? 0) === 0
   ) {
     return null;
   }
@@ -245,7 +249,7 @@ async function listStagedAttachmentPaths(
 ): Promise<Result<string[], string>> {
   const result = await execBuffered(
     runtime,
-    `if [ ! -d ${shellQuote(STAGED_ATTACHMENT_DIR)} ]; then exit 0; fi; find ${shellQuote(STAGED_ATTACHMENT_DIR)} -type f -iname '*.zip' -print`,
+    `if [ ! -d ${shellQuote(STAGED_ATTACHMENT_DIR)} ]; then exit 0; fi; find ${shellQuote(STAGED_ATTACHMENT_DIR)} -type f -print`,
     { cwd: workspacePath, timeout: 30 }
   );
   if (result.exitCode !== 0) {


### PR DESCRIPTION
## Summary

Pasting, dropping, or picking any file type in the chat input now works. Images and PDFs keep the existing native provider attachment behavior. Every other file (.md, .txt, .csv, binaries, unknown extensions) is staged into the workspace at `.mux/user-attachments/<uuid>/<name>` and the outgoing message carries the existing generated `<attached-files>` notice pointing the agent at the path.

## Background

The chat input previously discarded all non-image/PDF/ZIP files during clipboard/drop extraction, so text files like `.md` or `.csv` could not be attached at all. The ZIP staged-attachment pipeline already provided exactly the needed mechanism (workspace write through the Runtime abstraction, git-excluded dir, composer chips, draft persistence, hidden notice, fork copying, edit/failure restoration), so this change generalizes it from ZIP-only to arbitrary files.

## Implementation

- Classification (`supportedAttachmentMediaTypes.ts`): provider check (image/PDF) is unchanged and evaluated first; everything else resolves to a staged media type via browser MIME, a small text extension map, or `application/octet-stream`. Staged MIME strings are validated against an RFC-style pattern (and length-capped) before landing in the notice, since the notice is backtick-delimited and reparsed.
- Browser: extractors accept all files; `processAttachmentFiles` routes provider-first with staged fallback; paste/drop/picker share one per-file handler so a single oversized or unreadable file toasts an error without rejecting the rest of the batch.
- Node (`stageWorkspaceAttachment.ts`): ZIP-only gates removed; the sanitizer preserves the original extension; staged-path normalization, history-text path extraction (fork copying), and directory listing accept any file under `.mux/user-attachments/` while keeping all traversal checks; download MIME is inferred from the extension. Legacy `.zip` paths still parse.
- File picker: `accept` filter removed.

Kept as-is: the 10 MiB cap for all staged files, the staged directory, the notice format, and the ORPC schema (already generic).

## Validation

- Dogfood UAT in a sandboxed dev-server with a live model: dropped/pasted/picked `.md`, `.txt`, `.csv`, extension-less binary, PNG, PDF, ZIP, a mixed PNG+md drop, an 11 MiB oversize batch, text-only paste fall-through, failed-send composer restoration, and the no-workspace creation view. The agent read a staged file by its notice path and echoed the content. Long-filename chip verified at 375px with no overflow.

## Risks

Medium-touch area: attachment classification and the staged path validation feed both send and fork-copy flows. Regressions would surface as wrongly-staged images/PDFs (guarded by the provider-first routing test), broken fork copying of staged files (covered by non-zip + legacy-zip path tests), or rejected uploads. Traversal checks on staged paths are unchanged in strictness.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$36.68`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=36.68 -->
