### PR TITLE
🤖 chore: bump @coder/pixel-storybook to 0.2.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
         "@babel/preset-env": "^7.28.5",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@coder/pixel-storybook": "0.2.1",
+        "@coder/pixel-storybook": "0.2.2",
         "@electron/rebuild": "^4.0.4",
         "@eslint/js": "^9.36.0",
         "@playwright/test": "^1.56.0",
@@ -563,7 +563,7 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
-    "@coder/pixel-storybook": ["@coder/pixel-storybook@0.2.1", "", { "dependencies": { "get-port-please": "3.1.2", "jsonc-parser": "^3.3.1", "serve-handler": "6.1.7", "zod": "3.23.8" }, "peerDependencies": { "playwright-core": ">=1.47.2", "storybook": ">=8.0.0" }, "bin": { "pixel-storybook": "build/bin.js" } }, "sha512-o4EIY5JcLr+U/URGwfTQ1s0rs2jp4CfdOG94kHABLVD6wFEwUDyl52LX8utx6ArOkxuixbe3NMUTdxWU33fqLw=="],
+    "@coder/pixel-storybook": ["@coder/pixel-storybook@0.2.2", "", { "dependencies": { "get-port-please": "3.1.2", "jsonc-parser": "^3.3.1", "serve-handler": "6.1.7", "zod": "3.23.8" }, "peerDependencies": { "playwright-core": ">=1.47.2", "storybook": ">=8.0.0" }, "bin": { "pixel-storybook": "build/bin.js" } }, "sha512-f1dJ7FiNCdoT9VRVH6IWFnCG3VMnavtvTx/r6sZ4hzhj/rJEZv4P69J2x4XdYaMAwi+O5xbp2UQf0dNf2U9lLA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-OzBNhFDq9TWcHNfEGI5SpOVvin9WVzi9SvsG34G267A="; # mux-offline-cache-hash
+            outputHash = "sha256-Z7gr/DKP/qjKXzuYYpfGDczSzZcqhDb+QLyZiGmg844="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@babel/preset-env": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@coder/pixel-storybook": "0.2.1",
+    "@coder/pixel-storybook": "0.2.2",
     "@electron/rebuild": "^4.0.4",
     "@eslint/js": "^9.36.0",
     "@playwright/test": "^1.56.0",


### PR DESCRIPTION
## Summary

Bump `@coder/pixel-storybook` from 0.2.1 to 0.2.2.

## Background

0.2.2 ships two changes:

- coder/pixel-storybook#55: snapshot display names now include the story name, so multiple stories from one CSF file no longer collapse into a single dashboard group. This re-keys all snapshot groups, so the first Pixel build on this PR reports everything as new snapshots.
- coder/pixel-storybook#56: screenshots are held in memory instead of round-tripping through disk. Internal change, no config impact (we only set env vars in `pixel.yml`).

Also updates the Nix offline dep cache hash in `flake.nix` for the lockfile change.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$1.76`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=1.76 -->
