### PR TITLE
🤖 bench: target GPT-5.6 Sol and run Terminal-Bench lanes at high thinking

### DIFF
--- a/.github/workflows/nightly-terminal-bench.yml
+++ b/.github/workflows/nightly-terminal-bench.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       models:
-        description: 'Models to test (comma-separated, or "all" for opus-5 + gpt-5.5 + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.6-flash)'
+        description: 'Models to test (comma-separated, or "all" for opus-5 + gpt-5.6-sol + google/gemini-3-pro-preview + google/gemini-3-flash-preview + google/gemini-3.6-flash)'
         required: false
         default: "all"
         type: string
@@ -129,7 +129,7 @@ jobs:
           INPUT_MODELS: ${{ inputs.models }}
         run: |
           if [ "$INPUT_MODELS" = "all" ] || [ -z "$INPUT_MODELS" ]; then
-            echo 'models=["anthropic/claude-opus-5","openai/gpt-5.5","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.6-flash"]' >> "$GITHUB_OUTPUT"
+            echo 'models=["anthropic/claude-opus-5","openai/gpt-5.6-sol","google/gemini-3-pro-preview","google/gemini-3-flash-preview","google/gemini-3.6-flash"]' >> "$GITHUB_OUTPUT"
           else
             # Convert comma-separated to JSON array
             models_json=$(echo "$INPUT_MODELS" | jq -R -s -c 'split(",") | map(gsub("^\\s+|\\s+$"; ""))')
@@ -147,8 +147,7 @@ jobs:
     uses: ./.github/workflows/terminal-bench.yml
     with:
       model_name: ${{ matrix.model }}
-      # Claude Opus uses xhigh; GPT-5.5 stays high because xhigh timed out in TBench.
-      mux_run_args: "--thinking ${{ contains(matrix.model, 'claude-opus') && 'xhigh' || 'high' }}"
+      mux_run_args: "--thinking high"
       dataset: "terminal-bench@2.0"
       concurrency: "48"
       env: "daytona"

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       model_name:
-        description: "Model to use (e.g., anthropic/claude-opus-5, openai/gpt-5.5)"
+        description: "Model to use (e.g., anthropic/claude-opus-5, openai/gpt-5.6-sol)"
         required: false
         type: string
       dataset:
@@ -98,7 +98,7 @@ on:
         required: false
         type: string
       model_name:
-        description: "Model to use (e.g., anthropic/claude-opus-5, openai/gpt-5.5)"
+        description: "Model to use (e.g., anthropic/claude-opus-5, openai/gpt-5.6-sol)"
         required: false
         type: string
       mux_run_args:

--- a/.mux/skills/tbench/SKILL.md
+++ b/.mux/skills/tbench/SKILL.md
@@ -19,7 +19,7 @@ make benchmark-terminal
 make benchmark-terminal TB_TASK_NAMES="hello-world chess-best-move"
 
 # Run with specific model and xhigh thinking
-MUX_RUN_ARGS="--thinking xhigh" make benchmark-terminal TB_ARGS="--agent-kwarg model_name=anthropic/claude-opus-4-7"
+MUX_RUN_ARGS="--thinking xhigh" make benchmark-terminal TB_ARGS="--agent-kwarg model_name=anthropic/claude-opus-5"
 
 # Run on Daytona cloud (high parallelism)
 TB_ENV=daytona TB_CONCURRENCY=48 make benchmark-terminal
@@ -91,7 +91,7 @@ TB_TIMEOUT=600 make benchmark-terminal TB_SAMPLE_SIZE=5
 
 The agent adapter accepts a few Harbor kwargs (passed via `--agent-kwarg`):
 
-- `model_name`: Model to use (e.g., `anthropic/claude-opus-4-7`, `openai/gpt-5.5`)
+- `model_name`: Model to use (e.g., `anthropic/claude-opus-5`, `openai/gpt-5.6-sol`)
 - `experiments`: Experiments to enable, comma-separated (e.g., `programmatic-tool-calling`)
 
 All other `mux run` CLI flags (thinking level, mode, runtime, budget, etc.) are passed via `MUX_RUN_ARGS` — no per-flag plumbing needed.
@@ -101,12 +101,12 @@ All other `mux run` CLI flags (thinking level, mode, runtime, budget, etc.) are 
 ```bash
 # Run with model, thinking, and 1M context
 gh workflow run terminal-bench.yml \
-  -f model_name=anthropic/claude-opus-4-7 \
-  -f mux_run_args="--thinking xhigh --use-1m"
+  -f model_name=anthropic/claude-opus-5 \
+  -f mux_run_args="--thinking high --use-1m"
 
-# Run GPT-5.5 with budget cap and high thinking
+# Run GPT-5.6 Sol with budget cap and high thinking
 gh workflow run terminal-bench.yml \
-  -f model_name=openai/gpt-5.5 \
+  -f model_name=openai/gpt-5.6-sol \
   -f mux_run_args="--thinking high --budget 5.00"
 ```
 
@@ -133,7 +133,7 @@ gh workflow run terminal-bench.yml \
 MUX_RUN_ARGS="--thinking high --use-1m" make benchmark-terminal
 
 # Model and experiments via TB_ARGS
-MUX_RUN_ARGS="--thinking high" make benchmark-terminal TB_ARGS="--agent-kwarg model_name=openai/gpt-5.5 --agent-kwarg experiments=programmatic-tool-calling"
+MUX_RUN_ARGS="--thinking high" make benchmark-terminal TB_ARGS="--agent-kwarg model_name=openai/gpt-5.6-sol --agent-kwarg experiments=programmatic-tool-calling"
 ```
 
 ## Monitoring local benchmark output
@@ -205,7 +205,7 @@ python3 benchmarks/terminal_bench/prepare_leaderboard_submission.py --artifacts-
 python3 benchmarks/terminal_bench/prepare_leaderboard_submission.py
 
 # Only prepare specific models
-python3 benchmarks/terminal_bench/prepare_leaderboard_submission.py --n-runs 5 --models anthropic/claude-opus-4-7
+python3 benchmarks/terminal_bench/prepare_leaderboard_submission.py --n-runs 5 --models anthropic/claude-opus-5
 ```
 
 This creates a properly structured submission folder at `leaderboard_submission/` containing:

--- a/benchmarks/terminal_bench/prepare_leaderboard_submission.py
+++ b/benchmarks/terminal_bench/prepare_leaderboard_submission.py
@@ -116,7 +116,14 @@ MODEL_METADATA = {
         "model_org_display_name": "Anthropic",
         "folder_name": "Claude-Opus-4.8",
     },
-    # Keep historical GPT metadata alongside the current GPT-5.5 bench target
+    "anthropic/claude-opus-5": {
+        "model_name": "claude-opus-5",
+        "model_provider": "anthropic",
+        "model_display_name": "Claude Opus 5",
+        "model_org_display_name": "Anthropic",
+        "folder_name": "Claude-Opus-5",
+    },
+    # Keep historical GPT metadata alongside the current GPT-5.6 Sol bench target
     # so mixed or older artifact sets still map to the canonical leaderboard names.
     "openai/gpt-5.2": {
         "model_name": "gpt-5.2",
@@ -138,6 +145,13 @@ MODEL_METADATA = {
         "model_display_name": "GPT-5.5",
         "model_org_display_name": "OpenAI",
         "folder_name": "GPT-5.5",
+    },
+    "openai/gpt-5.6-sol": {
+        "model_name": "gpt-5.6-sol",
+        "model_provider": "openai",
+        "model_display_name": "GPT-5.6 Sol",
+        "model_org_display_name": "OpenAI",
+        "folder_name": "GPT-5.6-Sol",
     },
     "openai/gpt-5-codex": {
         "model_name": "gpt-5-codex",
@@ -449,7 +463,7 @@ def main():
     parser.add_argument(
         "--models",
         nargs="+",
-        help="Only process specific models (e.g., anthropic/claude-opus-4-8, openai/gpt-5.5)",
+        help="Only process specific models (e.g., anthropic/claude-opus-5, openai/gpt-5.6-sol)",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

Updates the Terminal-Bench model targets: the nightly GPT lane moves from GPT-5.5 to GPT-5.6 Sol, and all benchmark lanes now run at `--thinking high` (Claude Opus 5 previously ran `xhigh`).

## Background

GPT-5.6 Sol replaced GPT-5.5 as the flagship OpenAI tier, and the requested bench configuration is GPT-5.6 Sol at high thinking and Claude Opus 5 at high thinking. The old per-model `xhigh`/`high` conditional in the nightly workflow is no longer needed, so it is flattened to a single `--thinking high`.

## Implementation

- `nightly-terminal-bench.yml`: default `all` matrix swaps `openai/gpt-5.5` for `openai/gpt-5.6-sol`; `mux_run_args` is now a plain `--thinking high` for every lane. Gemini lanes and the Sonnet smoke tests are unchanged.
- `terminal-bench.yml`: model example strings refreshed.
- `prepare_leaderboard_submission.py`: adds leaderboard metadata for `anthropic/claude-opus-5` (previously missing, so submission prep could not map the current Opus target) and `openai/gpt-5.6-sol`; older entries stay as historical mappings.
- `tbench` skill (and its `benchmarks/terminal_bench/README.md` symlink): example commands updated to the new targets.

## Validation

- `make static-check` green locally.
- YAML parse of both workflows and `py_compile` of the leaderboard script pass.
- Grep confirms the only remaining `gpt-5.5` references are intentional historical metadata entries.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$5.53`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=5.53 -->
