### PR TITLE
🤖 fix: stop mode default from clobbering the picked model on thinking change

### DIFF
--- a/src/browser/components/WorkspaceModeAISync/WorkspaceModeAISync.test.tsx
+++ b/src/browser/components/WorkspaceModeAISync/WorkspaceModeAISync.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 
 import { AgentProvider } from "@/browser/contexts/AgentContext";
@@ -201,6 +201,46 @@ describe("WorkspaceModeAISync", () => {
       expect(readPersistedState(getModelKey(workspaceId), "")).toBe(existingModel);
       expect(readPersistedState(getThinkingLevelKey(workspaceId), "off")).toBe(existingThinking);
     });
+  });
+
+  test("keeps the user's model when per-agent settings change without an agent switch", async () => {
+    const workspaceId = nextWorkspaceId();
+
+    const configuredModel = "anthropic:claude-haiku-4-5";
+    const userModel = "anthropic:claude-sonnet-4-5";
+
+    updatePersistedState(AGENT_AI_DEFAULTS_KEY, {
+      exec: { modelString: configuredModel },
+    });
+    updatePersistedState(getModelKey(workspaceId), configuredModel);
+    updatePersistedState(getThinkingLevelKey(workspaceId), "off");
+
+    renderSync({ workspaceId, agentId: "exec" });
+
+    await waitFor(() => {
+      expect(readPersistedState(getModelKey(workspaceId), "")).toBe(configuredModel);
+    });
+
+    // Picking a model writes both the model key and the per-agent settings cache.
+    act(() => {
+      updatePersistedState(getModelKey(workspaceId), userModel);
+      updatePersistedState(getWorkspaceAISettingsByAgentKey(workspaceId), {
+        exec: { model: userModel, thinkingLevel: "off" },
+      });
+    });
+
+    expect(readPersistedState(getModelKey(workspaceId), "")).toBe(userModel);
+
+    // Changing the thinking level rewrites the same per-agent cache entry.
+    act(() => {
+      updatePersistedState(getThinkingLevelKey(workspaceId), "high");
+      updatePersistedState(getWorkspaceAISettingsByAgentKey(workspaceId), {
+        exec: { model: userModel, thinkingLevel: "high" },
+      });
+    });
+
+    expect(readPersistedState(getModelKey(workspaceId), "")).toBe(userModel);
+    expect(readPersistedState(getThinkingLevelKey(workspaceId), "")).toBe("high");
   });
 
   test("does not inherit base defaults when selected agent has its own partial settings entry", async () => {

--- a/src/browser/components/WorkspaceModeAISync/WorkspaceModeAISync.tsx
+++ b/src/browser/components/WorkspaceModeAISync/WorkspaceModeAISync.tsx
@@ -31,11 +31,6 @@ export function WorkspaceModeAISync(props: { workspaceId: string }): null {
     {},
     { listener: true }
   );
-  const [workspaceByAgent] = usePersistedState<WorkspaceAISettingsCache>(
-    getWorkspaceAISettingsByAgentKey(workspaceId),
-    {},
-    { listener: true }
-  );
 
   // User request: this effect runs on mount and during background sync (defaults/config).
   // Only treat *real* agentId changes as explicit (origin "agent"); everything else is "sync"
@@ -58,6 +53,14 @@ export function WorkspaceModeAISync(props: { workspaceId: string }): null {
     // Update refs for the next run (even if no model changes).
     prevAgentIdRef.current = normalizedAgentId;
     prevWorkspaceIdRef.current = workspaceId;
+
+    // Read at call time rather than subscribing: this cache only feeds explicit agent
+    // switches, yet every model/thinking/pro-mode change rewrites it, so a subscription
+    // would re-run this effect and re-apply the mode default over the user's own pick.
+    const workspaceByAgent = readPersistedState<WorkspaceAISettingsCache>(
+      getWorkspaceAISettingsByAgentKey(workspaceId),
+      {}
+    );
 
     const existingModel = readPersistedState<string>(modelKey, fallbackModel);
     const existingThinking = readPersistedState<ThinkingLevel>(thinkingKey, "off");
@@ -94,7 +97,7 @@ export function WorkspaceModeAISync(props: { workspaceId: string }): null {
     if (existingReasoning !== resolvedReasoningMode) {
       updatePersistedState(reasoningKey, resolvedReasoningMode);
     }
-  }, [agentAiDefaults, agentId, workspaceByAgent, workspaceId]);
+  }, [agentAiDefaults, agentId, workspaceId]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

When a mode like Exec has a configured default model in Settings, changing the workspace model and then adjusting the thinking level made the model picker flash back to the mode's default and then return to the user's choice. `WorkspaceModeAISync` subscribed to the per-agent AI settings cache, so any thinking-level, model, or pro-mode change re-ran its sync effect and re-applied the configured mode default over the model the user had just picked.

## Background

`WorkspaceModeAISync` exists to apply per-mode AI settings when the active agent changes. It held a `usePersistedState(..., { listener: true })` subscription on `workspaceAiSettingsByAgent:<workspaceId>`.

That key is rewritten by every AI-settings mutation, not just agent switches: `ThinkingContext.persistAgentAiSettings` (thinking level and pro mode), the ChatInput model picker, and the command-palette thinking actions all write it. Each write notified the subscription, re-ran the effect, and because the effect had no way to distinguish "the agent changed" from "the user changed a setting for the current agent", it resolved the model from `agentAiDefaults[mode].modelString`, which takes precedence over the workspace's current model.

Captured from a live dev-server sandbox with an Exec default of `anthropic:claude-haiku-4-5` and the workspace set to `anthropic:claude-sonnet-5`, clicking "decrease thinking level" produced:

| t (ms) | key                          | value                                                    |
| ------ | ---------------------------- | -------------------------------------------------------- |
| 144367 | `thinkingLevel`              | `high`                                                   |
| 144367 | `workspaceAiSettingsByAgent` | exec → `claude-sonnet-5`                                 |
| 144377 | `model`                      | `claude-haiku-4-5` (mode default clobbers the selection) |
| 144531 | `model`                      | `claude-sonnet-5` (backend metadata sync restores it)    |

A `MutationObserver` on the picker label recorded `Haiku 4.5` at 144394 and `Sonnet 5` at 144541, i.e. the ~150ms flash.

## Implementation

The per-agent cache is only consumed as a fallback for explicit agent switches (`useWorkspaceByAgentFallback`), so the effect does not need to react to it. It is now read with `readPersistedState` at call time and removed from the effect's dependency array. Model, thinking, and pro-mode writes no longer retrigger mode sync; the effect still runs on mount, on real agent changes, and on `agentAiDefaults` background sync.

## Validation

Verified in a `dev-server-sandbox` instance via `agent-browser`, with `agentAiDefaults.exec.modelString` set to `anthropic:claude-haiku-4-5` and `Storage.prototype.setItem` instrumented to log writes to `model:<id>` / `thinkingLevel:<id>`:

- Selecting a model writes `model:<id>` exactly once (previously three writes: selection, clobber, restore).
- Six consecutive thinking-level changes produced 12 writes, none of them to `model:<id>` (previously each change clobbered and restored it).
- Exec → Plan → Exec switches still restore each mode's saved model and thinking level, confirming the explicit-switch path is unaffected.

Added a regression test in `WorkspaceModeAISync.test.tsx` that fails on `main` with `Received: "anthropic:claude-haiku-4-5"` and passes with the fix.

## Risks

Low, and scoped to per-mode AI settings sync. The behavioral change is narrow: the effect no longer re-runs when the per-agent cache changes. The residual risk is a mode switch whose settings arrive via a cache write without an accompanying `agentId` change; the existing explicit-switch tests plus the live Exec/Plan round trip cover that path. Backend-driven metadata updates still flow through `WorkspaceContext`, which is unchanged.

> Mux prepared this PR on Mike's behalf.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `max` • Cost: `$4.18`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=max costs=4.18 -->
