### PR TITLE
🤖 fix: reclaim the mobile bottom band and move the PR badge to the header

### DIFF
--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1251,7 +1251,11 @@ function AppInner() {
 
   return (
     <>
-      <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
+      {/* Narrow viewports hand the bottom inset to the chat column's last row instead: this box
+          clips overflow, so reserving the inset here strands dead space under the workspace footer
+          bar that no child can paint into. Safe because the sidebar is position: fixed with its own
+          inset at these widths and the right sidebar is hidden. */}
+      <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)] [@media(max-width:768px)]:pb-0">
         <LeftSidebar
           collapsed={sidebarCollapsed}
           onToggleCollapsed={handleToggleSidebar}

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1251,10 +1251,10 @@ function AppInner() {
 
   return (
     <>
-      {/* Narrow viewports hand the bottom inset to the chat column's last row instead: this box
-          clips overflow, so reserving the inset here strands dead space under the workspace footer
-          bar that no child can paint into. Safe because the sidebar is position: fixed with its own
-          inset at these widths and the right sidebar is hidden. */}
+      {/* Narrow layouts let the main column run to the screen edge and leave the bottom inset to
+          whichever row holds controls there (WorkspaceFooterBar): this box clips overflow, so a
+          child cannot paint into its padding, and the reserved band reads as dead space. The
+          sidebar is position: fixed with its own inset at these widths. */}
       <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)] [@media(max-width:768px)]:pb-0">
         <LeftSidebar
           collapsed={sidebarCollapsed}

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef, useState } from "react";
 import { useRouter } from "./contexts/RouterContext";
 import { useLocation, useNavigate } from "react-router-dom";
 import "./styles/globals.css";
+import { cn } from "@/common/lib/utils";
 import { useWorkspaceContext, toWorkspaceSelection } from "./contexts/WorkspaceContext";
 import { useProjectContext } from "./contexts/ProjectContext";
 import type { WorkspaceSelection } from "./components/ProjectSidebar/ProjectSidebar";
@@ -1237,6 +1238,13 @@ function AppInner() {
     };
   }, [setSelectedWorkspace, workspaceStore]);
 
+  // Non-null only while the workspace view is the visible route, which is also the only route whose
+  // last row (WorkspaceFooterBar) can own the bottom safe-area inset.
+  const activeWorkspaceMetadata =
+    !isAnalyticsOpen && !currentSettingsSection && selectedWorkspace
+      ? workspaceMetadata.get(selectedWorkspace.workspaceId)
+      : undefined;
+
   // Show auth modal if authentication is required
   if (status === "auth_required") {
     return (
@@ -1251,11 +1259,17 @@ function AppInner() {
 
   return (
     <>
-      {/* Narrow layouts let the main column run to the screen edge and leave the bottom inset to
-          whichever row holds controls there (WorkspaceFooterBar): this box clips overflow, so a
-          child cannot paint into its padding, and the reserved band reads as dead space. The
-          sidebar is position: fixed with its own inset at these widths. */}
-      <div className="bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)] [@media(max-width:768px)]:pb-0">
+      {/* On a narrow workspace view the footer bar takes over the bottom inset: this box clips
+          overflow, so nothing can paint into its padding and the reserved band reads as dead space
+          under the bar. Every other route keeps the inset here because none of them ends in a
+          control row that could reserve its own. The sidebar is position: fixed with its own inset
+          at these widths. */}
+      <div
+        className={cn(
+          "bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]",
+          activeWorkspaceMetadata && "[@media(max-width:768px)]:pb-0"
+        )}
+      >
         <LeftSidebar
           collapsed={sidebarCollapsed}
           onToggleCollapsed={handleToggleSidebar}
@@ -1282,7 +1296,7 @@ function AppInner() {
               />
             ) : selectedWorkspace ? (
               (() => {
-                const currentMetadata = workspaceMetadata.get(selectedWorkspace.workspaceId);
+                const currentMetadata = activeWorkspaceMetadata;
                 // Guard: Don't render AIView if workspace metadata not found.
                 // This can happen when selectedWorkspace (from localStorage) refers to a
                 // deleted workspace, or during a race condition on reload before the

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -2,7 +2,6 @@ import { useEffect, useCallback, useRef, useState } from "react";
 import { useRouter } from "./contexts/RouterContext";
 import { useLocation, useNavigate } from "react-router-dom";
 import "./styles/globals.css";
-import { cn } from "@/common/lib/utils";
 import { useWorkspaceContext, toWorkspaceSelection } from "./contexts/WorkspaceContext";
 import { useProjectContext } from "./contexts/ProjectContext";
 import type { WorkspaceSelection } from "./components/ProjectSidebar/ProjectSidebar";
@@ -1238,13 +1237,6 @@ function AppInner() {
     };
   }, [setSelectedWorkspace, workspaceStore]);
 
-  // Non-null only while the workspace view is the visible route, which is also the only route whose
-  // last row (WorkspaceFooterBar) can own the bottom safe-area inset.
-  const activeWorkspaceMetadata =
-    !isAnalyticsOpen && !currentSettingsSection && selectedWorkspace
-      ? workspaceMetadata.get(selectedWorkspace.workspaceId)
-      : undefined;
-
   // Show auth modal if authentication is required
   if (status === "auth_required") {
     return (
@@ -1259,17 +1251,10 @@ function AppInner() {
 
   return (
     <>
-      {/* On a narrow workspace view the footer bar takes over the bottom inset: this box clips
-          overflow, so nothing can paint into its padding and the reserved band reads as dead space
-          under the bar. Every other route keeps the inset here because none of them ends in a
-          control row that could reserve its own. The sidebar is position: fixed with its own inset
-          at these widths. */}
-      <div
-        className={cn(
-          "bg-surface-primary mobile-layout flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]",
-          activeWorkspaceMetadata && "[@media(max-width:768px)]:pb-0"
-        )}
-      >
+      {/* mobile-bottom-inset-host: narrow layouts give this box's bottom inset up to a column that
+          reserves its own clearance, keyed off the column rather than the route so surfaces without
+          one still get it here. The sidebar is position: fixed with its own inset at these widths. */}
+      <div className="bg-surface-primary mobile-layout mobile-bottom-inset-host flex h-full overflow-hidden pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[min(env(safe-area-inset-bottom,0px),40px)] pl-[env(safe-area-inset-left)]">
         <LeftSidebar
           collapsed={sidebarCollapsed}
           onToggleCollapsed={handleToggleSidebar}
@@ -1296,7 +1281,7 @@ function AppInner() {
               />
             ) : selectedWorkspace ? (
               (() => {
-                const currentMetadata = activeWorkspaceMetadata;
+                const currentMetadata = workspaceMetadata.get(selectedWorkspace.workspaceId);
                 // Guard: Don't render AIView if workspace metadata not found.
                 // This can happen when selectedWorkspace (from localStorage) refers to a
                 // deleted workspace, or during a race condition on reload before the

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -300,6 +300,10 @@ export const ChatPane: React.FC<ChatPaneProps> = (props) => {
       <div
         ref={chatAreaRef}
         aria-hidden={immersiveHidden || undefined}
+        // Tells the app root that this column ends in a row (WorkspaceFooterBar) which reserves the
+        // bottom safe-area inset itself. Dropped while hidden so the inset stays with the root for
+        // whatever replaces the column.
+        data-bottom-inset-owner={immersiveHidden ? undefined : true}
         className={cn(
           "bg-surface-primary relative flex min-w-96 flex-1 flex-col",
           // Immersive review overlays the entire workspace, so hiding the chat pane removes

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -280,11 +280,13 @@ export const WorkspaceFooterBar: React.FC<WorkspaceFooterBarProps> = (props) => 
     : null;
 
   return (
-    // As the chat column's last row, this bar owns the mobile bottom inset: padding clears the
-    // home indicator, and the negative margin lets its fill reach the screen edge.
+    // At narrow widths the app root drops its bottom inset so this bar reaches the screen edge, and
+    // this row owns the inset instead: a small clearance for the home indicator rather than the full
+    // inset, which is the band of empty space we are reclaiming. Wider viewports still get their
+    // clearance from the root.
     <footer
       data-testid="workspace-footer-bar"
-      className="bg-sidebar border-border-light mb-[calc(-1*min(env(safe-area-inset-bottom,0px),40px))] shrink-0 border-t pb-[min(env(safe-area-inset-bottom,0px),40px)]"
+      className="bg-sidebar border-border-light shrink-0 border-t [@media(max-width:768px)]:pb-[min(env(safe-area-inset-bottom,0px),8px)]"
     >
       {/* min-h rather than a fixed height: mobile raises these buttons to 44px touch targets, and a
         capped row would clip them along the same axis overflow-x-auto makes scrollable. */}
@@ -296,7 +298,12 @@ export const WorkspaceFooterBar: React.FC<WorkspaceFooterBarProps> = (props) => 
           workspaceName={props.workspaceName}
           tooltipSide="top"
         />
-        <WorkspaceLinks workspaceId={props.workspaceId} />
+        {/* User request: on narrow viewports the PR badge moves to the workspace header, where it
+            cannot scroll out of view with this row. */}
+        <WorkspaceLinks
+          workspaceId={props.workspaceId}
+          className="[@media(max-width:768px)]:hidden"
+        />
         {hasRepository && (
           <>
             <WorkspaceDriftIndicator

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -280,10 +280,9 @@ export const WorkspaceFooterBar: React.FC<WorkspaceFooterBarProps> = (props) => 
     : null;
 
   return (
-    // At narrow widths the app root drops its bottom inset so this bar reaches the screen edge, and
-    // this row owns the inset instead: a small clearance for the home indicator rather than the full
-    // inset, which is the band of empty space we are reclaiming. Wider viewports still get their
-    // clearance from the root.
+    // Narrow layouts drop the app root's bottom inset, so this row owns it: a capped clearance for
+    // the home indicator instead of the full inset, whose reserved band is the empty space we are
+    // reclaiming. Wider layouts still take their clearance from the root.
     <footer
       data-testid="workspace-footer-bar"
       className="bg-sidebar border-border-light shrink-0 border-t [@media(max-width:768px)]:pb-[min(env(safe-area-inset-bottom,0px),8px)]"
@@ -298,8 +297,7 @@ export const WorkspaceFooterBar: React.FC<WorkspaceFooterBarProps> = (props) => 
           workspaceName={props.workspaceName}
           tooltipSide="top"
         />
-        {/* User request: on narrow viewports the PR badge moves to the workspace header, where it
-            cannot scroll out of view with this row. */}
+        {/* Narrow layouts show it in the header, where it cannot scroll out of view with this row. */}
         <WorkspaceLinks
           workspaceId={props.workspaceId}
           className="[@media(max-width:768px)]:hidden"

--- a/src/browser/components/PRLinkBadge/PRLinkBadge.tsx
+++ b/src/browser/components/PRLinkBadge/PRLinkBadge.tsx
@@ -1,7 +1,3 @@
-/**
- * PR link badge component for displaying GitHub PR status in header.
- */
-
 import {
   ExternalLink,
   GitPullRequest,

--- a/src/browser/components/PRLinkBadge/PRLinkBadge.tsx
+++ b/src/browser/components/PRLinkBadge/PRLinkBadge.tsx
@@ -20,6 +20,7 @@ import { cn } from "@/common/lib/utils";
 interface PRLinkBadgeProps {
   prLink: GitHubPRLinkWithStatus;
   onRefresh?: () => void;
+  className?: string;
 }
 
 /**
@@ -180,7 +181,7 @@ export function getTooltipContent(prLink: GitHubPRLinkWithStatus): string {
   return lines.join("\n");
 }
 
-export function PRLinkBadge({ prLink }: PRLinkBadgeProps) {
+export function PRLinkBadge({ prLink, className }: PRLinkBadgeProps) {
   const colorClass = getStatusColorClass(prLink);
   // Show pulse effect when refreshing with cached status (optimistic UI)
   const isRefreshing = prLink.loading && prLink.status != null;
@@ -192,9 +193,12 @@ export function PRLinkBadge({ prLink }: PRLinkBadgeProps) {
           variant="ghost"
           size="sm"
           className={cn(
-            "h-6 gap-1 px-2 text-xs font-medium",
+            // shrink-0 because the mobile touch-target rule puts an explicit `min-width` on links,
+            // replacing the flex min-content floor and letting the label spill over its neighbour.
+            "h-6 shrink-0 gap-1 px-2 text-xs font-medium",
             colorClass,
-            isRefreshing && "animate-pulse"
+            isRefreshing && "animate-pulse",
+            className
           )}
           asChild
         >

--- a/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
+++ b/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
@@ -1,7 +1,4 @@
-/**
- * Component to display the PR badge in the workspace header.
- * PR is detected from the workspace's current branch via `gh pr view`.
- */
+/** The PR is detected from the workspace's current branch via `gh pr view`. */
 
 import { useWorkspacePR } from "@/browser/stores/PRStatusStore";
 import { PRLinkBadge } from "../PRLinkBadge/PRLinkBadge";

--- a/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
+++ b/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
@@ -8,14 +8,16 @@ import { PRLinkBadge } from "../PRLinkBadge/PRLinkBadge";
 
 interface WorkspaceLinksProps {
   workspaceId: string;
+  /** Applied to the badge itself so callers can hide it without leaving an empty flex item. */
+  className?: string;
 }
 
-export function WorkspaceLinks({ workspaceId }: WorkspaceLinksProps) {
+export function WorkspaceLinks({ workspaceId, className }: WorkspaceLinksProps) {
   const workspacePR = useWorkspacePR(workspaceId);
 
   if (!workspacePR) {
     return null;
   }
 
-  return <PRLinkBadge prLink={workspacePR} />;
+  return <PRLinkBadge prLink={workspacePR} className={className} />;
 }

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -37,6 +37,7 @@ import { WorkspaceActionsMenuContent } from "../WorkspaceActionsMenuContent/Work
 import { WorkspaceTerminalIcon } from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
 
 import { SkillIndicator } from "../SkillIndicator/SkillIndicator";
+import { WorkspaceLinks } from "../WorkspaceLinks/WorkspaceLinks";
 import { useAPI } from "@/browser/contexts/API";
 import { useAgent } from "@/browser/contexts/AgentContext";
 
@@ -556,6 +557,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
         </Popover>
       </div>
       <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
+        {/* The footer info bar hides its PR badge at this width, so the header carries it there. */}
+        <WorkspaceLinks
+          workspaceId={workspaceId}
+          className="hidden [@media(max-width:768px)]:inline-flex"
+        />
         <Popover open={notificationPopoverOpen} onOpenChange={setNotificationPopoverOpen}>
           <Tooltip {...(notificationPopoverOpen ? { open: false } : {})}>
             <TooltipTrigger asChild>

--- a/src/browser/stories/App.phoneViewports.stories.tsx
+++ b/src/browser/stories/App.phoneViewports.stories.tsx
@@ -404,6 +404,11 @@ export const IPhone17ProMaxTouchReviewImmersive: AppStory = {
         if (canvas.queryByRole("heading", { name: "Notes" })) {
           throw new Error("Touch immersive mode should hide the desktop notes sidebar.");
         }
+        // The chat column is hidden here, so it must not keep claiming the bottom safe-area inset
+        // the app root would otherwise reserve for this view's own scroll area.
+        if (document.querySelectorAll("[data-bottom-inset-owner]").length > 0) {
+          throw new Error("Immersive review left the bottom safe-area inset unowned.");
+        }
       },
       { timeout: 10_000 }
     );

--- a/src/browser/stories/App.phoneViewports.stories.tsx
+++ b/src/browser/stories/App.phoneViewports.stories.tsx
@@ -12,7 +12,7 @@ import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { LEFT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
-import { MOBILE_TOUCH_TARGET_PX } from "@/constants/layout";
+import { MOBILE_TOUCH_TARGET_PX, NARROW_VIEWPORT_MAX_WIDTH_PX } from "@/constants/layout";
 
 import { appMeta, AppWithMocks, PIXEL_DISABLED, type AppStory } from "./meta.js";
 import { createAssistantMessage, createUserMessage } from "./mocks/messages";
@@ -103,6 +103,28 @@ index 1111111..2222222 100644
 `;
 const TOUCH_REVIEW_IMMERSIVE_NUMSTAT = "2\t0\tsrc/mobile/review.tsx";
 
+const PR_LINK_URL = "https://github.com/coder/mux/pull/3753";
+const PR_DETECTION_JSON = JSON.stringify({
+  number: 3753,
+  url: PR_LINK_URL,
+  state: "OPEN",
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  title: "Redesign the workspace chrome",
+  isDraft: false,
+  headRefName: "feature/mobile-chrome",
+  baseRefName: "main",
+  statusCheckRollup: [],
+});
+
+function countVisiblePRLinks(containerTestId: string): number {
+  return [
+    ...document.querySelectorAll<HTMLElement>(
+      `[data-testid="${containerTestId}"] a[href="${PR_LINK_URL}"]`
+    ),
+  ].filter((link) => link.getBoundingClientRect().width > 0).length;
+}
+
 export default {
   ...appMeta,
   title: "App/PhoneViewports",
@@ -137,6 +159,61 @@ export const IPhone16e: AppStory = {
   },
   play: async ({ canvasElement }) => {
     await stabilizePhoneViewportStory(canvasElement);
+  },
+};
+
+/**
+ * The PR badge lives in the footer info bar on wide viewports and in the workspace header on narrow
+ * ones. Pixel captures the narrow placement; the play assertion covers whichever side the ambient
+ * viewport selects, so the test-runner exercises the wide placement.
+ */
+export const IPhone16ePRLinkPlacement: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          workspaceId: "ws-iphone-16e-pr-link",
+          workspaceName: "mobile-pr",
+          projectName: "mux",
+          messages: [...MESSAGES],
+          executeBash: (_workspaceId, script) =>
+            Promise.resolve({
+              success: true as const,
+              // Empty output for anything else falls through to the git status executor.
+              output: script.includes("gh pr view") ? PR_DETECTION_JSON : "",
+              exitCode: 0,
+              wall_duration_ms: 5,
+            }),
+        })
+      }
+    />
+  ),
+  decorators: [IPhone16eDecorator],
+  parameters: {
+    ...appMeta.parameters,
+    pixel: {
+      matrix: { themes: ["dark", "light"], viewports: ["phone"] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    await stabilizePhoneViewportStory(canvasElement);
+
+    const narrow = window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
+    await waitFor(
+      () => {
+        const inHeader = countVisiblePRLinks("workspace-menu-bar");
+        const inFooter = countVisiblePRLinks("workspace-footer-bar");
+        const [expectedHeader, expectedFooter] = narrow ? [1, 0] : [0, 1];
+        if (inHeader !== expectedHeader || inFooter !== expectedFooter) {
+          throw new Error(
+            `At ${window.innerWidth}px the PR link belongs ${
+              narrow ? "in the header" : "in the footer"
+            }, but ${inHeader} were visible in the header and ${inFooter} in the footer`
+          );
+        }
+      },
+      { timeout: 10_000 }
+    );
   },
 };
 

--- a/src/browser/stories/App.phoneViewports.stories.tsx
+++ b/src/browser/stories/App.phoneViewports.stories.tsx
@@ -168,6 +168,11 @@ export const IPhone16e: AppStory = {
  * viewport selects, so the test-runner exercises the wide placement.
  */
 export const IPhone16ePRLinkPlacement: AppStory = {
+  // Mirrors the Pixel phone variant: the fixed-width decorator does not move `window.innerWidth`, so
+  // without this a local reviewer would see the wide placement in a story framed as a phone.
+  globals: {
+    viewport: { value: "mobile2", isRotated: false },
+  },
   render: () => (
     <AppWithMocks
       setup={() =>

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1203,6 +1203,14 @@ body,
     padding-left: 0 !important;
   }
 
+  /* Hand the bottom inset to a column that reserves its own clearance (see ChatPane and
+     WorkspaceFooterBar). This box clips overflow, so a child can never paint into its padding, and
+     the reserved band reads as dead space under the footer bar. Surfaces without such a column
+     (immersive review, settings, creation, loading shells) keep the inset here. */
+  .mobile-bottom-inset-host:has([data-bottom-inset-owner]) {
+    padding-bottom: 0 !important;
+  }
+
   .mobile-overlay {
     display: block !important;
   }

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -11,6 +11,11 @@ export const CREATION_COLUMN_MAX_WIDTH_CLASS = "max-w-[67rem]";
 // reproduce that environment, which Storybook and Pixel cannot: neither emulates `pointer: coarse`.
 export const MOBILE_TOUCH_TARGET_PX = 44;
 
+// Width at or below which the app switches to its narrow layout (overlaying sidebar, PR badge in the
+// workspace header instead of the footer info bar). Tailwind arbitrary variants cannot read a TS
+// constant, so `[@media(max-width:768px)]` class strings repeat this literal.
+export const NARROW_VIEWPORT_MAX_WIDTH_PX = 768;
+
 // Keep composer controls aligned without relying on individual component defaults. This is a floor,
 // not a fixed height: mobile raises touch targets to MOBILE_TOUCH_TARGET_PX, and a pill that caps
 // its height would clip the controls inside it instead of growing with them.


### PR DESCRIPTION
## Summary

On phones the workspace footer info bar stranded a band of empty space below it, and its PR badge overlapped the drift toggle. This hands the bottom safe-area inset to the chat column so the footer bar reaches the screen edge with a small home-indicator clearance, and moves the PR badge into the workspace header below 768px.

## Background

Reported from an iPhone against the chrome redesign in #3753.

The footer bar was written to own the mobile bottom inset: a negative margin was supposed to pull its fill down to the screen edge while its own padding kept the controls clear of the home indicator. That never worked. `.mobile-main-content`, `.mobile-layout`, and the workspace shell all set `overflow: hidden` and end at the app root's *content* edge, so anything the footer painted inside the root's `pb-[env(safe-area-inset-bottom)]` was clipped. The result was a ~34pt band under the bar in the root's own fill, which reads as dead space.

The overlapping PR badge is a separate mobile-only bug: the touch-target rule in `globals.css` puts an explicit `min-width: 44px` on every link, which replaces the flex min-content floor, so the badge could shrink to 44px inside the footer's scrolling row while its label spilled over the next item.

## Implementation

- **Inset ownership**: since the padding holder cannot be an ancestor of the row that wants the space, ownership is declared by the column rather than inferred from the route. `ChatPane` marks itself `data-bottom-inset-owner` while visible (dropped when immersive review hides it), and `globals.css` drops the root's bottom padding at narrow widths via `.mobile-bottom-inset-host:has([data-bottom-inset-owner])`. Immersive review, the loading placeholder, settings, analytics, creation, and the root shells keep the inset with no route knowledge in `App`, and any future footerless workspace surface inherits the safe default.
- **`WorkspaceFooterBar`**: no negative margin; at narrow widths it reserves an 8px-capped clearance. Its fill genuinely reaches the screen edge, and ~26pt comes back to the transcript.
- **`WorkspaceMenuBar`**: renders the PR badge below 768px; the footer copy hides at the same width. Duplicate-and-hide via CSS rather than a width hook, so there is no resize state and the hidden copy leaves the accessibility tree. `WorkspaceLinks` forwards a `className` to the badge itself so hiding it does not leave an empty flex item behind in a `gap-2` row.
- **`PRLinkBadge`**: `shrink-0`, fixing the overlap for any row that holds it.

## Validation

`env(safe-area-inset-bottom)` is 0 in a desktop browser, so the band this PR removes is invisible to normal Storybook checks. Measured over CDP (`Emulation.setSafeAreaInsetsOverride` with bottom 34px, plus touch emulation and mobile device metrics):

| state | root `padding-bottom` | owners | evidence |
| --- | --- | --- | --- |
| workspace chat, before | 34px | n/a | footer fill clipped at y=810, controls end at y=810 |
| workspace chat, after | 0px | 1 | footer fill to y=844, controls end at y=836 |
| immersive review, 440x956 | 34px | 0 | immersive view ends at y=922 |
| project creation, 390x844 | 34px | 0 | column ends at y=810 |

Wide touch (1024px, same insets) is unchanged: the root keeps its inset, the footer reserves nothing, and the row still ends at the column's content edge. Light theme has no colour seam at the bottom edge, because the footer's own fill covers the clearance.

Two story assertions, both red-green verified:

- `IPhone16ePRLinkPlacement`: exactly one PR link is visible, in the header when the viewport matches the narrow query and in the footer otherwise. Un-hiding the header copy fails with `At 1280px the PR link belongs in the footer, but 1 were visible in the header and 1 in the footer`. Pixel captures the narrow placement; the test-runner runs at desktop width and covers the wide placement.
- `IPhone17ProMaxTouchReviewImmersive`: while immersive review is open, nothing claims `data-bottom-inset-owner`. Making the attribute unconditional fails with `Immersive review left the bottom safe-area inset unowned.` This one holds without an inset override because it tests the handoff, not the resolved padding.

## Risks

Footer controls now sit 8px above the physical edge rather than 34pt, so their bottom sliver overlaps the home-indicator strip. The indicator itself is a ~5pt pill within the bottom ~13pt, the strip is reserved for edge-swipe drags rather than taps, and touch targets there are 44px tall, so taps on the labels still land. Raising or removing the `pb-[min(env(safe-area-inset-bottom,0px),8px)]` cap is a one-line change if it reads badly on device.

Two surfaces now subscribe to `PRStatusStore` for the same workspace. The store keys its cache and refresh batching by workspace id, so this adds a subscriber rather than a second `gh pr view`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=xhigh -->

