### PR TITLE
🤖 fix: keep iPad composer clicks from selecting the whole transcript

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -864,7 +864,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     [clearActiveSideQuestionScrollHold, handleScrollContainerMouseDown, isComposerDockEvent]
   );
 
-  const handleComposerDockMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleComposerDockMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.defaultPrevented || event.button !== 0) {
       return;
     }
@@ -877,7 +877,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     // does on Chromium.
     event.preventDefault();
     control.focus({ preventScroll: true });
-  }, []);
+  };
 
   const handleTranscriptTouchMove = useCallback(() => {
     clearActiveSideQuestionScrollHold();

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -92,6 +92,7 @@ import {
   ChatDockSurface,
   useChatDockColumnWidthClass,
 } from "./chatDockColumn";
+import { resolveComposerControlFocusTarget } from "./composerControlFocus";
 import { useTranscriptDensity } from "@/browser/hooks/useTranscriptDensity";
 import { useReviews } from "@/browser/hooks/useReviews";
 import { ReviewsBanner } from "../ReviewsBanner/ReviewsBanner";
@@ -862,6 +863,21 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     },
     [clearActiveSideQuestionScrollHold, handleScrollContainerMouseDown, isComposerDockEvent]
   );
+
+  const handleComposerDockMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.defaultPrevented || event.button !== 0) {
+      return;
+    }
+    const control = resolveComposerControlFocusTarget(event.target, composerDockRef.current);
+    if (!control) {
+      return;
+    }
+    // Suppressing the default keeps WebKit from walking focus up to the scrollport
+    // (see composerControlFocus); the control then takes focus the way it already
+    // does on Chromium.
+    event.preventDefault();
+    control.focus({ preventScroll: true });
+  }, []);
 
   const handleTranscriptTouchMove = useCallback(() => {
     clearActiveSideQuestionScrollHold();
@@ -1765,6 +1781,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
               <ChatDockColumnProvider value={chatTranscriptFullWidth}>
                 <div
                   ref={composerDockRef}
+                  onMouseDown={handleComposerDockMouseDown}
                   data-testid="chat-composer-dock"
                   className="bg-surface-primary sticky bottom-0 z-10 mx-[-15px] break-normal whitespace-normal"
                   style={COMPOSER_DOCK_STYLE}

--- a/src/browser/components/ChatPane/composerControlFocus.ts
+++ b/src/browser/components/ChatPane/composerControlFocus.ts
@@ -1,0 +1,23 @@
+/**
+ * Safari never focuses a `<button>` on click; WebKit hands focus to the nearest
+ * mouse-focusable ancestor instead. Here that ancestor is the `tabIndex={0}`
+ * transcript scrollport the composer dock lives inside, and focusing that
+ * container highlights the entire transcript column. Callers resolve the control
+ * the user actually pressed so they can claim focus for it.
+ */
+
+// Deliberately an allowlist: text entry and banner prose inside the dock must keep
+// the browser's native caret placement and drag-select. `role="option"` rows are
+// listed because the model/agent dropdowns build them from plain divs.
+const CONTROL_SELECTOR = 'button, a[href], [role="button"], [role="option"]';
+
+export function resolveComposerControlFocusTarget(
+  target: EventTarget | null,
+  dock: HTMLElement | null
+): HTMLElement | null {
+  if (!dock || !(target instanceof Element) || !dock.contains(target)) {
+    return null;
+  }
+  const control = target.closest<HTMLElement>(CONTROL_SELECTOR);
+  return control && dock.contains(control) ? control : null;
+}

--- a/tests/ui/chat/composerControlFocus.test.ts
+++ b/tests/ui/chat/composerControlFocus.test.ts
@@ -1,0 +1,104 @@
+import "../dom";
+
+import { fireEvent, waitFor } from "@testing-library/react";
+
+jest.mock("lottie-react", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import { preloadTestModules } from "../../ipc/setup";
+import { createAppHarness } from "../harness";
+import { resolveComposerControlFocusTarget } from "@/browser/components/ChatPane/composerControlFocus";
+
+describe("resolveComposerControlFocusTarget", () => {
+  function buildDock() {
+    const dock = document.createElement("div");
+    const control = document.createElement("button");
+    const label = document.createElement("span");
+    control.append(label);
+    const option = document.createElement("div");
+    option.setAttribute("role", "option");
+    const textarea = document.createElement("textarea");
+    const hint = document.createElement("span");
+    dock.append(control, option, textarea, hint);
+
+    const outside = document.createElement("button");
+    document.body.append(dock, outside);
+
+    return { dock, control, label, option, textarea, hint, outside };
+  }
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test("resolves the enclosing control from a nested target", () => {
+    const { dock, control, label, option } = buildDock();
+    expect(resolveComposerControlFocusTarget(label, dock)).toBe(control);
+    expect(resolveComposerControlFocusTarget(option, dock)).toBe(option);
+  });
+
+  test("ignores non-control targets and targets outside the dock", () => {
+    const { dock, textarea, hint, outside, control } = buildDock();
+    expect(resolveComposerControlFocusTarget(textarea, dock)).toBeNull();
+    expect(resolveComposerControlFocusTarget(hint, dock)).toBeNull();
+    expect(resolveComposerControlFocusTarget(outside, dock)).toBeNull();
+    expect(resolveComposerControlFocusTarget(control, null)).toBeNull();
+  });
+});
+
+describe("Composer control focus", () => {
+  beforeAll(async () => {
+    await preloadTestModules();
+  });
+
+  test("claims focus for the pressed control instead of the transcript scrollport", async () => {
+    const app = await createAppHarness({ branchPrefix: "composer-control-focus" });
+
+    try {
+      const messageWindow = app.view.container.querySelector<HTMLElement>(
+        '[data-testid="message-window"]'
+      );
+      const dock = app.view.container.querySelector<HTMLElement>(
+        '[data-testid="chat-composer-dock"]'
+      );
+      if (!messageWindow || !dock) throw new Error("Message window or composer dock not found");
+
+      // The dock lives inside a focusable scrollport, which is what lets WebKit
+      // hand it focus when a composer button is pressed.
+      expect(messageWindow.contains(dock)).toBe(true);
+      expect(messageWindow.tabIndex).toBe(0);
+
+      const trigger = dock.querySelector<HTMLElement>(
+        '[data-component="ModelSelectorGroup"] button'
+      );
+      if (!trigger) throw new Error("Model selector trigger not found");
+      const label = trigger.querySelector("span") ?? trigger;
+
+      expect(fireEvent.mouseDown(label)).toBe(false);
+      expect(document.activeElement).toBe(trigger);
+
+      const textarea = dock.querySelector("textarea");
+      if (!textarea) throw new Error("Composer textarea not found");
+      expect(fireEvent.mouseDown(textarea)).toBe(true);
+
+      // The suppressed default must not cost the picker its click.
+      fireEvent.click(trigger);
+      const options = await waitFor(() => {
+        const found = dock.querySelectorAll<HTMLElement>('[role="option"]');
+        if (found.length === 0) throw new Error("Model options did not render");
+        return found;
+      });
+
+      const option = options[0];
+      fireEvent.mouseDown(option);
+      fireEvent.click(option);
+      await waitFor(() => {
+        expect(dock.querySelectorAll('[role="option"]')).toHaveLength(0);
+      });
+    } finally {
+      await app.dispose();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

On iPad, clicking the composer model selector highlighted the entire chat transcript column. Safari does not focus a `<button>` on click, so WebKit walks up and focuses the nearest mouse-focusable ancestor instead, which here is the `tabIndex={0}` transcript scrollport the composer now lives inside. This intercepts `mousedown` on the composer dock for non-text controls, suppresses the default, and focuses the pressed control explicitly.

## Background

Reported on iPad with a Magic Keyboard trackpad, with no input focused: clicking the model pill selected the whole transcript column.

The transcript scrollport carries `tabIndex={0}` (ChatPane.tsx) so keyboard scrolling works. Since #3501 made the composer an in-flow `sticky bottom-0` dock rendered *inside* that scrollport, every composer control became a DOM descendant of a focusable container. WebKit's `HTMLFormControlElement::isMouseFocusable()` returns false on macOS/iOS, so pressing a composer button hands focus to that ancestor, and focusing a large non-editable container is what paints the column as selected.

No app code touches Selection or Range APIs, so the highlight is entirely browser-native.

## Implementation

`handleComposerDockMouseDown` on the dock element:

- bails on `event.defaultPrevented` first, so child handlers that already `preventDefault` (the ModelSelector star/settings buttons, which deliberately keep focus in the search input) still win;
- bails on non-primary buttons;
- resolves the pressed control through a small allowlist helper, then `preventDefault()` + `focus({ preventScroll: true })`.

`preventDefault` on mousedown cancels both the ancestor focus walk and the native selection start, so it addresses the failure mode either way. The explicit focus restores what Chromium already does by default, keeping behavior identical across engines.

`resolveComposerControlFocusTarget` is deliberately an allowlist (`button, a[href], [role="button"], [role="option"]`). The composer textarea and banner prose in the dock are untouched and keep native caret placement; transcript text selection is unaffected because the handler is scoped to the dock subtree, not the scrollport. `[role="option"]` is included because the model and agent dropdown rows are plain divs; `focus()` no-ops on them, which is the desired outcome since arrow-key navigation owns their highlight.

## Validation

Red-green on three independent toggles, each failing only its matching assertion:

1. removing the `onMouseDown` wiring,
2. replacing `closest()` with `matches()` so nested targets stop resolving,
3. dropping `[role="option"]` from the allowlist.

The integration test also drives the model picker open and selects an option after the interception, proving the suppressed default does not cost the picker its click.

Not verified on real hardware: the failure cannot be reproduced on Linux. Chromium focuses buttons on click, and Playwright's WebKit is the GTK port where form controls *are* mouse-focusable. The mechanism and fix are standard WebKit behavior, but visual confirmation needs an iPad.

## Risks

Low and contained. The handler only runs for `mousedown` inside the composer dock and only for allowlisted controls. The `defaultPrevented` guard preserves existing intra-dropdown focus behavior. The main regression surface would be a future dock control that relies on native mousedown focus semantics; the allowlist keeps that explicit.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=max -->
