### PR TITLE
🤖 fix: align composer pickers and size local workers by memory

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -737,14 +737,15 @@ export default defineConfig([
     },
   },
   {
-    // Workflow/action/runtime sources are plain JS evaluated outside the TS
-    // program (QuickJS, skill assets, or generated child-process wrappers), so
-    // type-aware rules cannot apply. Lint them with core untyped rules so typos
-    // and dead helpers fail loudly instead of becoming silent sandbox globals.
+    // Workflow/action/runtime and script helper sources are plain JS evaluated outside the TS
+    // program (QuickJS, skill assets, generated child-process wrappers, or local tooling), so
+    // type-aware rules cannot apply. Lint them with core untyped rules so typos and dead helpers
+    // fail loudly instead of becoming silent globals.
     files: [
       "src/node/builtinSkills/**/*.js",
       "src/node/builtinWorkflowActions/**/*.js",
       "src/node/workflowRuntime/*.js",
+      "scripts/lib/*.js",
     ],
     extends: [tseslint.configs.disableTypeChecked],
     languageOptions: {

--- a/fmt.mk
+++ b/fmt.mk
@@ -6,7 +6,7 @@
 .PHONY: fmt fmt-check fmt-prettier fmt-prettier-check fmt-shell fmt-shell-check fmt-nix fmt-nix-check fmt-python fmt-python-check fmt-sync-docs fmt-sync-docs-check update-flake-hash flake-hash-check
 
 # Centralized patterns - single source of truth
-PRETTIER_PATTERNS := 'src/**/*.{ts,tsx,json}' 'src/node/workflowRuntime/*.js' 'tests/**/*.ts' 'docs/**/*.mdx' 'package.json' 'tsconfig*.json' 'README.md'
+PRETTIER_PATTERNS := 'src/**/*.{ts,tsx,json}' 'src/node/workflowRuntime/*.js' 'scripts/lib/*.js' 'tests/**/*.ts' 'docs/**/*.mdx' 'package.json' 'tsconfig*.json' 'README.md'
 SHELL_SCRIPTS := scripts
 PYTHON_DIRS := benchmarks
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,18 +1,6 @@
-const os = require("node:os");
+const { workerBudgetFor } = require("./scripts/lib/worker_budget.js");
 
-// Use cgroup-aware memory when available (containers), fall back to host RAM.
-// process.constrainedMemory() returns the cgroup v2 limit (Node 19.6+),
-// or 0/undefined outside a cgroup.
-const totalMemoryBytes =
-  (typeof process.constrainedMemory === "function" &&
-    process.constrainedMemory()) ||
-  os.totalmem();
-
-const cpuWorkerCap = Math.max(1, Math.floor(os.cpus().length * 0.5));
-const memoryWorkerCap = Math.floor(
-  totalMemoryBytes / (1024 * 1024 * 1024) / 1.5,
-);
-const maxWorkers = Math.max(1, Math.min(cpuWorkerCap, memoryWorkerCap));
+const maxWorkers = workerBudgetFor("jest");
 
 /** @type {import('jest').Config} */
 module.exports = {
@@ -55,10 +43,10 @@ module.exports = {
     // This is slower but ensures compatibility
     "node_modules/(?!\\.pnpm)(?!.*)",
   ],
-  // High core-count containers with limited cgroup memory (for example 96 cores /
-  // 32 GB) can OOM if Jest uses CPU-only parallelism, so keep roughly 1.5 GB
-  // per worker.
   maxWorkers,
+  // Second line of defence behind maxWorkers: recycle a worker that is still holding most of its
+  // budget between suites instead of letting it grow into the cgroup's headroom.
+  workerIdleMemoryLimit: "4GB",
   // Force exit after tests complete to avoid hanging on lingering handles
   forceExit: true,
   // 10 minute timeout for integration tests, 10s for unit tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -44,8 +44,6 @@ module.exports = {
     "node_modules/(?!\\.pnpm)(?!.*)",
   ],
   maxWorkers,
-  // Second line of defence behind maxWorkers: recycle a worker that is still holding most of its
-  // budget between suites instead of letting it grow into the cgroup's headroom.
   workerIdleMemoryLimit: "4GB",
   // Force exit after tests complete to avoid hanging on lingering handles
   forceExit: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -44,7 +44,6 @@ module.exports = {
     "node_modules/(?!\\.pnpm)(?!.*)",
   ],
   maxWorkers,
-  workerIdleMemoryLimit: "4GB",
   // Force exit after tests complete to avoid hanging on lingering handles
   forceExit: true,
   // 10 minute timeout for integration tests, 10s for unit tests

--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -95,7 +95,7 @@ function tightestConstraint(dirs, limitFile) {
   let constraint = null;
   for (const dir of dirs) {
     const limitBytes = parseLimitBytes(readFileOrNull(path.join(dir, limitFile)));
-    if (limitBytes != null && (constraint == null || limitBytes < constraint.limitBytes)) {
+    if (limitBytes != null && (constraint == null || limitBytes <= constraint.limitBytes)) {
       constraint = { dir, limitBytes };
     }
   }

--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -15,6 +15,8 @@ const DEFAULT_PROC_SELF_CGROUP = "/proc/self/cgroup";
 // caps as absent instead of trusting them.
 const UNLIMITED_BYTES_FLOOR = 2n ** 62n;
 
+// Peak RSS measured per worker in this repo, rounded up for growth: ESLint's --concurrency lanes are
+// worker threads sharing one heap (~2.8GiB each), Jest forks processes reaching ~4.7GiB.
 const PROFILES = {
   eslint: { memoryPerWorkerGib: 4, maxWorkers: 4 },
   jest: { memoryPerWorkerGib: 6, maxWorkers: 4 },

--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -1,0 +1,223 @@
+"use strict";
+
+// Worker-pool sizing for tools that fan out across cores (ESLint, Jest).
+//
+// Agent containers can expose 96 CPUs and a 128 GiB host while capping the workspace far lower
+// through cgroup v2 (32 GiB here), and that cap can sit on an ANCESTOR cgroup while the leaf reports
+// "max". Node's process.constrainedMemory() only reads the leaf, so it answers 2^64 ("unlimited")
+// and any pool sized from it collapses to a plain CPU count. Dozens of multi-GiB workers then get
+// the whole run SIGKILLed. Hence: resolve the cap across the cgroup chain and size pools against
+// memory rather than cores.
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const BYTES_PER_GIB = 1024 ** 3;
+const DEFAULT_CGROUP_ROOT = "/sys/fs/cgroup";
+const DEFAULT_PROC_SELF_CGROUP = "/proc/self/cgroup";
+
+// cgroup v1 spells "unlimited" as a saturated integer rather than "max", so treat implausibly large
+// caps as absent instead of trusting them.
+const UNLIMITED_BYTES_FLOOR = 2n ** 62n;
+
+// Peak resident set measured per worker on this repo: ESLint runs its --concurrency lanes as worker
+// threads sharing one heap (~2.8 GiB each), Jest forks processes that reach ~4.7 GiB rendering the
+// full app. Both are rounded up to absorb the parent process and growth.
+const PROFILES = {
+  eslint: { memoryPerWorkerGib: 4, maxWorkers: 4 },
+  jest: { memoryPerWorkerGib: 6, maxWorkers: 4 },
+};
+
+const CPU_FRACTION = 0.5;
+
+function readFileOrNull(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function parseBytes(raw) {
+  if (raw == null) {
+    return null;
+  }
+  const text = raw.trim();
+  if (text === "") {
+    return null;
+  }
+  let value;
+  try {
+    value = BigInt(text);
+  } catch {
+    return null;
+  }
+  if (value < 0n) {
+    return null;
+  }
+  return value;
+}
+
+function parseLimitBytes(raw) {
+  const value = parseBytes(raw);
+  if (value == null || value === 0n || value >= UNLIMITED_BYTES_FLOOR) {
+    return null;
+  }
+  return Number(value);
+}
+
+/** Cgroup v2 directories from the leaf the process lives in up to the mount root. */
+function cgroupDirChain(options) {
+  const cgroupRoot = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
+  const raw = readFileOrNull(options.procSelfCgroup ?? DEFAULT_PROC_SELF_CGROUP);
+  const v2Line = raw
+    ?.split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith("0::"));
+  const segments = (v2Line?.slice("0::".length) ?? "").split("/").filter(Boolean);
+
+  const chain = [];
+  for (let depth = segments.length; depth >= 0; depth--) {
+    chain.push(path.join(cgroupRoot, ...segments.slice(0, depth)));
+  }
+  return chain;
+}
+
+/**
+ * The most restrictive memory cap that applies to this process, plus the directory that imposes it.
+ * Usage has to be read from that same directory: sibling workspaces sharing an ancestor cgroup are
+ * invisible from the leaf.
+ */
+function resolveMemoryConstraint(options = {}) {
+  let constraint = null;
+
+  for (const dir of cgroupDirChain(options)) {
+    const limitBytes = parseLimitBytes(readFileOrNull(path.join(dir, "memory.max")));
+    if (limitBytes != null && (constraint == null || limitBytes < constraint.limitBytes)) {
+      constraint = { dir, limitBytes };
+    }
+  }
+  if (constraint != null) {
+    return constraint;
+  }
+
+  const cgroupRoot = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
+  const v1Dir = path.join(cgroupRoot, "memory");
+  const v1Limit = parseLimitBytes(readFileOrNull(path.join(v1Dir, "memory.limit_in_bytes")));
+  return v1Limit == null ? null : { dir: v1Dir, limitBytes: v1Limit };
+}
+
+function parseMemoryStat(dir) {
+  const raw = readFileOrNull(path.join(dir, "memory.stat"));
+  if (raw == null) {
+    return null;
+  }
+
+  const values = new Map();
+  for (const line of raw.split("\n")) {
+    const [key, value] = line.trim().split(/\s+/);
+    const parsed = parseBytes(value);
+    if (key && parsed != null) {
+      values.set(key, Number(parsed));
+    }
+  }
+  return values;
+}
+
+/**
+ * Memory in the cgroup that a new worker cannot claim. memory.current is unusable on its own because
+ * it counts page cache the kernel drops on demand; anon + kernel + shmem is the floor that cannot be
+ * reclaimed, so take whichever estimate is larger.
+ */
+function readCgroupUsageBytes(dir) {
+  const stat = parseMemoryStat(dir);
+  if (stat == null) {
+    return null;
+  }
+
+  const unreclaimable =
+    (stat.get("anon") ?? 0) + (stat.get("kernel") ?? stat.get("slab") ?? 0) + (stat.get("shmem") ?? 0);
+
+  const current = parseBytes(readFileOrNull(path.join(dir, "memory.current")));
+  const inactiveFile = stat.get("inactive_file");
+  if (current != null && inactiveFile != null) {
+    return Math.max(unreclaimable, Number(current) - inactiveFile);
+  }
+  return unreclaimable;
+}
+
+function computeWorkers(input) {
+  const cpuWorkers = Math.max(1, Math.floor(input.cpuCount * CPU_FRACTION));
+
+  // Leaves room for everything the pool does not account for: the tool's own parent process, page
+  // cache it is actively reading through, and sibling workspaces starting work mid-run.
+  const reserveBytes = Math.max(2 * BYTES_PER_GIB, input.limitBytes * 0.15);
+  const usableBytes = Math.max(0, input.limitBytes - input.inUseBytes - reserveBytes);
+  const memoryWorkers = Math.floor(usableBytes / (input.memoryPerWorkerGib * BYTES_PER_GIB));
+
+  return Math.max(1, Math.min(cpuWorkers, memoryWorkers, input.maxWorkers));
+}
+
+function resolveWorkerBudget(profileName, options = {}) {
+  const profile = PROFILES[profileName];
+  if (profile == null) {
+    throw new Error(
+      `unknown worker budget profile "${profileName}" (expected one of: ${Object.keys(PROFILES).join(", ")})`
+    );
+  }
+
+  const constraint = resolveMemoryConstraint(options);
+  // Without a cgroup cap (macOS, CI VMs) there are no co-tenants to account for, and subtracting
+  // free-memory swings would make a busy laptop silently serialize its own test run.
+  const limitBytes = constraint?.limitBytes ?? os.totalmem();
+  const inUseBytes = constraint == null ? 0 : (readCgroupUsageBytes(constraint.dir) ?? 0);
+
+  const input = {
+    ...profile,
+    cpuCount: os.availableParallelism?.() ?? os.cpus().length,
+    limitBytes,
+    inUseBytes,
+  };
+  return { ...input, cgroupDir: constraint?.dir ?? null, workers: computeWorkers(input) };
+}
+
+function formatWorkerBudget(budget) {
+  const gib = (bytes) => `${(bytes / BYTES_PER_GIB).toFixed(1)}GiB`;
+  return [
+    `workers=${budget.workers}`,
+    `limit=${gib(budget.limitBytes)}`,
+    `inUse=${gib(budget.inUseBytes)}`,
+    `perWorker=${budget.memoryPerWorkerGib}GiB`,
+    `cpus=${budget.cpuCount}`,
+    `cgroup=${budget.cgroupDir ?? "none"}`,
+  ].join(" ");
+}
+
+function workerBudgetFor(profileName) {
+  const budget = resolveWorkerBudget(profileName);
+  if (process.env.MUX_WORKER_BUDGET_DEBUG) {
+    process.stderr.write(`[worker-budget] ${profileName} ${formatWorkerBudget(budget)}\n`);
+  }
+  return budget.workers;
+}
+
+module.exports = {
+  BYTES_PER_GIB,
+  PROFILES,
+  computeWorkers,
+  formatWorkerBudget,
+  readCgroupUsageBytes,
+  resolveMemoryConstraint,
+  resolveWorkerBudget,
+  workerBudgetFor,
+};
+
+if (require.main === module) {
+  const profileName = process.argv[2];
+  const budget = resolveWorkerBudget(profileName);
+  if (process.argv.includes("--debug") || process.env.MUX_WORKER_BUDGET_DEBUG) {
+    process.stderr.write(`[worker-budget] ${profileName} ${formatWorkerBudget(budget)}\n`);
+  }
+  process.stdout.write(`${budget.workers}\n`);
+}

--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -16,7 +16,7 @@ const DEFAULT_PROC_SELF_CGROUP = "/proc/self/cgroup";
 const UNLIMITED_BYTES_FLOOR = 2n ** 62n;
 
 // Peak RSS measured per worker in this repo, rounded up for growth: ESLint's --concurrency lanes are
-// worker threads sharing one heap (~2.8GiB each), Jest forks processes reaching ~4.7GiB.
+// worker threads in one process (~2.8GiB per lane), while Jest forks reach ~4.7GiB each.
 const PROFILES = {
   eslint: { memoryPerWorkerGib: 4, maxWorkers: 4 },
   jest: { memoryPerWorkerGib: 6, maxWorkers: 4 },

--- a/scripts/lib/worker_budget.js
+++ b/scripts/lib/worker_budget.js
@@ -1,13 +1,7 @@
 "use strict";
 
-// Worker-pool sizing for tools that fan out across cores (ESLint, Jest).
-//
-// Agent containers can expose 96 CPUs and a 128 GiB host while capping the workspace far lower
-// through cgroup v2 (32 GiB here), and that cap can sit on an ANCESTOR cgroup while the leaf reports
-// "max". Node's process.constrainedMemory() only reads the leaf, so it answers 2^64 ("unlimited")
-// and any pool sized from it collapses to a plain CPU count. Dozens of multi-GiB workers then get
-// the whole run SIGKILLed. Hence: resolve the cap across the cgroup chain and size pools against
-// memory rather than cores.
+// Size tool worker pools against the tightest cgroup memory cap, including ancestor caps that
+// Node's leaf-only constrainedMemory() check can miss.
 
 const fs = require("node:fs");
 const os = require("node:os");
@@ -21,9 +15,6 @@ const DEFAULT_PROC_SELF_CGROUP = "/proc/self/cgroup";
 // caps as absent instead of trusting them.
 const UNLIMITED_BYTES_FLOOR = 2n ** 62n;
 
-// Peak resident set measured per worker on this repo: ESLint runs its --concurrency lanes as worker
-// threads sharing one heap (~2.8 GiB each), Jest forks processes that reach ~4.7 GiB rendering the
-// full app. Both are rounded up to absorb the parent process and growth.
 const PROFILES = {
   eslint: { memoryPerWorkerGib: 4, maxWorkers: 4 },
   jest: { memoryPerWorkerGib: 6, maxWorkers: 4 },
@@ -67,45 +58,65 @@ function parseLimitBytes(raw) {
   return Number(value);
 }
 
-/** Cgroup v2 directories from the leaf the process lives in up to the mount root. */
-function cgroupDirChain(options) {
-  const cgroupRoot = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
-  const raw = readFileOrNull(options.procSelfCgroup ?? DEFAULT_PROC_SELF_CGROUP);
-  const v2Line = raw
-    ?.split("\n")
-    .map((line) => line.trim())
-    .find((line) => line.startsWith("0::"));
-  const segments = (v2Line?.slice("0::".length) ?? "").split("/").filter(Boolean);
-
+function dirChain(root, cgroupPath) {
+  const segments = cgroupPath.split("/").filter(Boolean);
   const chain = [];
   for (let depth = segments.length; depth >= 0; depth--) {
-    chain.push(path.join(cgroupRoot, ...segments.slice(0, depth)));
+    chain.push(path.join(root, ...segments.slice(0, depth)));
   }
   return chain;
 }
 
-/**
- * The most restrictive memory cap that applies to this process, plus the directory that imposes it.
- * Usage has to be read from that same directory: sibling workspaces sharing an ancestor cgroup are
- * invisible from the leaf.
- */
-function resolveMemoryConstraint(options = {}) {
-  let constraint = null;
+function cgroupMembership(options) {
+  const raw = readFileOrNull(options.procSelfCgroup ?? DEFAULT_PROC_SELF_CGROUP);
+  let v2Path = null;
+  let v1MemoryPath = null;
 
-  for (const dir of cgroupDirChain(options)) {
-    const limitBytes = parseLimitBytes(readFileOrNull(path.join(dir, "memory.max")));
+  for (const line of raw?.split("\n") ?? []) {
+    const match = line.trim().match(/^\d+:([^:]*):(.*)$/);
+    if (match == null) {
+      continue;
+    }
+    const controllers = match[1].split(",");
+    if (controllers.length === 1 && controllers[0] === "") {
+      v2Path = match[2];
+    } else if (controllers.includes("memory")) {
+      v1MemoryPath = match[2];
+    }
+  }
+
+  return { v2Path, v1MemoryPath };
+}
+
+// Keep the constraining directory so its ancestor-level co-tenant usage can be subtracted.
+function tightestConstraint(dirs, limitFile) {
+  let constraint = null;
+  for (const dir of dirs) {
+    const limitBytes = parseLimitBytes(readFileOrNull(path.join(dir, limitFile)));
     if (limitBytes != null && (constraint == null || limitBytes < constraint.limitBytes)) {
       constraint = { dir, limitBytes };
     }
   }
-  if (constraint != null) {
-    return constraint;
+  return constraint;
+}
+
+function resolveMemoryConstraint(options = {}) {
+  const cgroupRoot = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
+  const membership = cgroupMembership(options);
+  if (membership.v2Path != null) {
+    const constraint = tightestConstraint(dirChain(cgroupRoot, membership.v2Path), "memory.max");
+    if (constraint != null) {
+      return constraint;
+    }
   }
 
-  const cgroupRoot = options.cgroupRoot ?? DEFAULT_CGROUP_ROOT;
-  const v1Dir = path.join(cgroupRoot, "memory");
-  const v1Limit = parseLimitBytes(readFileOrNull(path.join(v1Dir, "memory.limit_in_bytes")));
-  return v1Limit == null ? null : { dir: v1Dir, limitBytes: v1Limit };
+  if (membership.v1MemoryPath == null) {
+    return null;
+  }
+  return tightestConstraint(
+    dirChain(path.join(cgroupRoot, "memory"), membership.v1MemoryPath),
+    "memory.limit_in_bytes"
+  );
 }
 
 function parseMemoryStat(dir) {
@@ -125,33 +136,34 @@ function parseMemoryStat(dir) {
   return values;
 }
 
-/**
- * Memory in the cgroup that a new worker cannot claim. memory.current is unusable on its own because
- * it counts page cache the kernel drops on demand; anon + kernel + shmem is the floor that cannot be
- * reclaimed, so take whichever estimate is larger.
- */
+// Discount inactive file cache, but use the v2 resident-memory fields as a floor when available.
 function readCgroupUsageBytes(dir) {
   const stat = parseMemoryStat(dir);
-  if (stat == null) {
+  const current = parseBytes(readFileOrNull(path.join(dir, "memory.current")));
+  if (current != null) {
+    if (stat == null) {
+      return Number(current);
+    }
+    const resident =
+      (stat.get("anon") ?? 0) +
+      (stat.get("kernel") ?? stat.get("slab") ?? 0) +
+      (stat.get("shmem") ?? 0);
+    const inactiveFile = stat.get("inactive_file");
+    return inactiveFile == null ? resident : Math.max(resident, Number(current) - inactiveFile);
+  }
+
+  const usage = parseBytes(readFileOrNull(path.join(dir, "memory.usage_in_bytes")));
+  if (usage == null) {
     return null;
   }
-
-  const unreclaimable =
-    (stat.get("anon") ?? 0) + (stat.get("kernel") ?? stat.get("slab") ?? 0) + (stat.get("shmem") ?? 0);
-
-  const current = parseBytes(readFileOrNull(path.join(dir, "memory.current")));
-  const inactiveFile = stat.get("inactive_file");
-  if (current != null && inactiveFile != null) {
-    return Math.max(unreclaimable, Number(current) - inactiveFile);
-  }
-  return unreclaimable;
+  const inactiveFile = stat?.get("total_inactive_file") ?? stat?.get("inactive_file");
+  return inactiveFile == null ? Number(usage) : Math.max(0, Number(usage) - inactiveFile);
 }
 
 function computeWorkers(input) {
   const cpuWorkers = Math.max(1, Math.floor(input.cpuCount * CPU_FRACTION));
 
-  // Leaves room for everything the pool does not account for: the tool's own parent process, page
-  // cache it is actively reading through, and sibling workspaces starting work mid-run.
+  // Preserve headroom for the parent process, active file cache, and co-tenants growing mid-run.
   const reserveBytes = Math.max(2 * BYTES_PER_GIB, input.limitBytes * 0.15);
   const usableBytes = Math.max(0, input.limitBytes - input.inUseBytes - reserveBytes);
   const memoryWorkers = Math.floor(usableBytes / (input.memoryPerWorkerGib * BYTES_PER_GIB));
@@ -168,8 +180,8 @@ function resolveWorkerBudget(profileName, options = {}) {
   }
 
   const constraint = resolveMemoryConstraint(options);
-  // Without a cgroup cap (macOS, CI VMs) there are no co-tenants to account for, and subtracting
-  // free-memory swings would make a busy laptop silently serialize its own test run.
+  // Without a cgroup cap there is no bounded co-tenant usage signal. Host free-memory swings would
+  // make a busy laptop silently serialize its own test run.
   const limitBytes = constraint?.limitBytes ?? os.totalmem();
   const inUseBytes = constraint == null ? 0 : (readCgroupUsageBytes(constraint.dir) ?? 0);
 
@@ -203,13 +215,9 @@ function workerBudgetFor(profileName) {
 }
 
 module.exports = {
-  BYTES_PER_GIB,
-  PROFILES,
   computeWorkers,
-  formatWorkerBudget,
   readCgroupUsageBytes,
   resolveMemoryConstraint,
-  resolveWorkerBudget,
   workerBudgetFor,
 };
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,6 +29,7 @@ ESLINT_PATTERNS=(
   'src/**/*.{ts,tsx}'
   'src/node/builtinSkills/**/*.js'
   'src/node/workflowRuntime/*.js'
+  'scripts/lib/*.js'
 )
 
 get_default_eslint_concurrency() {
@@ -48,7 +49,7 @@ get_default_eslint_concurrency() {
     && [[ "$concurrency" =~ ^[0-9]+$ ]] && [ "$concurrency" -gt 0 ]; then
     echo "$concurrency"
   else
-    echo 2
+    echo 1
   fi
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -31,32 +31,7 @@ ESLINT_PATTERNS=(
   'src/node/workflowRuntime/*.js'
 )
 
-get_cpu_count() {
-  local cpu_count=""
-
-  if command -v getconf >/dev/null 2>&1; then
-    cpu_count="$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)"
-  fi
-
-  if [ -z "$cpu_count" ] && command -v nproc >/dev/null 2>&1; then
-    cpu_count="$(nproc 2>/dev/null || true)"
-  fi
-
-  if [ -z "$cpu_count" ] && command -v sysctl >/dev/null 2>&1; then
-    cpu_count="$(sysctl -n hw.ncpu 2>/dev/null || true)"
-  fi
-
-  if [[ "$cpu_count" =~ ^[0-9]+$ ]] && [ "$cpu_count" -gt 0 ]; then
-    echo "$cpu_count"
-  else
-    echo 2
-  fi
-}
-
 get_default_eslint_concurrency() {
-  local cpu_count
-  local concurrency
-
   # Most local `make static-check` runs are warm-cache validation after a small
   # edit. ESLint's worker startup/merge overhead dominates that path, so keep it
   # single-process once the cache exists; cold caches still scale up for CI-like
@@ -66,18 +41,18 @@ get_default_eslint_concurrency() {
     return
   fi
 
-  cpu_count="$(get_cpu_count)"
-  concurrency=$(((cpu_count + 1) / 2))
-
-  # User rationale: local static-check should scale up on agent/desktop machines
-  # without letting ESLint's auto concurrency spawn one worker per core.
-  if [ "$concurrency" -lt 2 ]; then
-    concurrency=2
-  elif [ "$concurrency" -gt 8 ]; then
-    concurrency=8
+  # ESLint's --concurrency lanes are worker threads sharing one heap, so a cold
+  # type-aware run scales memory, not just CPU. Size it against the cgroup's
+  # actual headroom rather than the visible core count.
+  # stderr is left attached so MUX_WORKER_BUDGET_DEBUG output and any real breakage stay visible;
+  # the fallback below only covers the helper failing outright.
+  local concurrency
+  if concurrency="$(node "$SCRIPT_DIR/lib/worker_budget.js" eslint)" \
+    && [[ "$concurrency" =~ ^[0-9]+$ ]] && [ "$concurrency" -gt 0 ]; then
+    echo "$concurrency"
+  else
+    echo 2
   fi
-
-  echo "$concurrency"
 }
 
 ESLINT_CONCURRENCY="${MUX_ESLINT_CONCURRENCY:-$(get_default_eslint_concurrency)}"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -41,11 +41,8 @@ get_default_eslint_concurrency() {
     return
   fi
 
-  # ESLint's --concurrency lanes are worker threads sharing one heap, so a cold
-  # type-aware run scales memory, not just CPU. Size it against the cgroup's
-  # actual headroom rather than the visible core count.
-  # stderr is left attached so MUX_WORKER_BUDGET_DEBUG output and any real breakage stay visible;
-  # the fallback below only covers the helper failing outright.
+  # Cold type-aware runs scale memory with concurrency, so use cgroup headroom instead of visible
+  # core count. Keep stderr attached for diagnostics, and fall back only if the helper fails.
   local concurrency
   if concurrency="$(node "$SCRIPT_DIR/lib/worker_budget.js" eslint)" \
     && [[ "$concurrency" =~ ^[0-9]+$ ]] && [ "$concurrency" -gt 0 ]; then

--- a/src/browser/components/AgentModePicker/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker/AgentModePicker.tsx
@@ -389,7 +389,6 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
             COMPOSER_PICKER_PANEL_CLASS
           )}
         >
-          {/* Agent list — scrollable for long lists */}
           <div className="max-h-64 overflow-y-auto py-1">
             {!loaded && options.length === 0 ? (
               <div className="text-muted-light px-2.5 py-2 text-[11px]">Loading agents…</div>
@@ -411,7 +410,7 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
                     tabIndex={-1}
                     data-agent-id={opt.id}
                     data-testid="agent-option"
-                    className={composerPickerOptionClass({ isHighlighted, isSelected })}
+                    className={composerPickerOptionClass({ isHighlighted, isSelected }, "py-1.5")}
                     onMouseEnter={() => setHighlightedIndex(index)}
                     onClick={() => handleSelectAgent(opt.id)}
                   >

--- a/src/browser/components/AgentModePicker/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker/AgentModePicker.tsx
@@ -7,6 +7,10 @@ import { CUSTOM_EVENTS } from "@/common/constants/events";
 import type { AgentDefinitionDescriptor } from "@/common/types/agentDefinition";
 import { normalizeAgentId as normalizeStoredAgentId } from "@/common/utils/agentIds";
 import { cn } from "@/common/lib/utils";
+import {
+  COMPOSER_PICKER_PANEL_CLASS,
+  composerPickerOptionClass,
+} from "@/browser/components/composerPickerStyles";
 import { DocsLink } from "@/browser/components/DocsLink/DocsLink";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
 import { Button } from "@/browser/components/Button/Button";
@@ -380,7 +384,10 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
           tabIndex={-1}
           onKeyDown={handleDropdownKeyDown}
           // Left alignment prevents the menu from opening beyond the viewport.
-          className="bg-surface-primary border-border-light absolute bottom-full left-0 z-[1020] mb-1 min-w-52 overflow-hidden rounded border shadow-[0_4px_12px_rgba(0,0,0,0.3)] outline-none"
+          className={cn(
+            "absolute bottom-full left-0 z-[1020] mb-1 min-w-52",
+            COMPOSER_PICKER_PANEL_CLASS
+          )}
         >
           {/* Agent list — scrollable for long lists */}
           <div className="max-h-64 overflow-y-auto py-1">
@@ -404,11 +411,7 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
                     tabIndex={-1}
                     data-agent-id={opt.id}
                     data-testid="agent-option"
-                    className={cn(
-                      "flex cursor-pointer items-center gap-2.5 px-2.5 py-1.5 transition-colors duration-100",
-                      isHighlighted ? "bg-hover text-foreground" : "bg-transparent hover:bg-hover",
-                      isSelected ? "text-foreground" : "text-light hover:text-foreground"
-                    )}
+                    className={composerPickerOptionClass({ isHighlighted, isSelected })}
                     onMouseEnter={() => setHighlightedIndex(index)}
                     onClick={() => handleSelectAgent(opt.id)}
                   >
@@ -418,10 +421,7 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
                     />
                     <span
                       data-testid="agent-name"
-                      className={cn(
-                        "min-w-0 flex-1 truncate text-[11px] font-medium",
-                        isSelected && "text-accent"
-                      )}
+                      className={cn("min-w-0 flex-1 truncate", isSelected && "text-accent")}
                     >
                       {opt.name}
                     </span>

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -15,11 +15,7 @@ import React, {
 import { cn } from "@/common/lib/utils";
 import { Check, ChevronDown, Eye, Settings, ShieldCheck, Star } from "lucide-react";
 
-import {
-  COMPOSER_PICKER_DIVIDER_CLASS,
-  COMPOSER_PICKER_PANEL_CLASS,
-  composerPickerOptionClass,
-} from "../composerPickerStyles";
+import { COMPOSER_PICKER_PANEL_CLASS, composerPickerOptionClass } from "../composerPickerStyles";
 import { ProviderIcon } from "../ProviderIcon/ProviderIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { useSettings } from "@/browser/contexts/SettingsContext";
@@ -366,7 +362,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
             )}
           >
             {/* Search input */}
-            <div className={cn("border-b px-2.5 py-1.5", COMPOSER_PICKER_DIVIDER_CLASS)}>
+            <div className="border-border-light border-b px-2.5 py-1.5">
               <input
                 ref={inputRef}
                 type="text"
@@ -395,13 +391,11 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       key={model}
                       data-highlighted={index === highlightedIndex}
                       onMouseEnter={() => setHighlightedIndex(index)}
-                      className={cn(
-                        composerPickerOptionClass({
+                      className={composerPickerOptionClass(
+                        {
                           isHighlighted: index === highlightedIndex,
                           isSelected: value === model,
-                        }),
-                        // The h-5 action buttons already set this row's inner height, so it lands on
-                        // the agent picker's row height with less vertical padding.
+                        },
                         "py-1",
                         hiddenSet.has(model) && "opacity-50"
                       )}
@@ -528,9 +522,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
 
             {/* Footer actions (last row in dropdown) */}
             {(hiddenModels.length > 0 || onOpenSettings) && (
-              <div
-                className={cn("flex flex-col gap-1 border-t py-1", COMPOSER_PICKER_DIVIDER_CLASS)}
-              >
+              <div className="border-border-light flex flex-col gap-1 border-t py-1">
                 {hiddenModels.length > 0 && (
                   <button
                     type="button"

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -396,8 +396,6 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                           isHighlighted: index === highlightedIndex,
                           isSelected: value === model,
                         },
-                        // Less padding than the agent picker's rows: the h-5 action buttons here
-                        // already carry the row to the same height.
                         "py-1",
                         hiddenSet.has(model) && "opacity-50"
                       )}

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -15,6 +15,11 @@ import React, {
 import { cn } from "@/common/lib/utils";
 import { Check, ChevronDown, Eye, Settings, ShieldCheck, Star } from "lucide-react";
 
+import {
+  COMPOSER_PICKER_DIVIDER_CLASS,
+  COMPOSER_PICKER_PANEL_CLASS,
+  composerPickerOptionClass,
+} from "../composerPickerStyles";
 import { ProviderIcon } from "../ProviderIcon/ProviderIcon";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { useSettings } from "@/browser/contexts/SettingsContext";
@@ -306,7 +311,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
               type="button"
               className={cn(
                 triggerClassName,
-                "text-foreground hover:bg-hover flex cursor-pointer items-center justify-between gap-1 px-1.5 py-0.5 transition-colors duration-300"
+                "text-foreground hover:bg-hover flex cursor-pointer items-center justify-between gap-1 px-1.5 py-0.5 transition-[background-color] duration-150"
               )}
               role="combobox"
               aria-expanded={isOpen}
@@ -323,7 +328,12 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                 )}
                 <span className="min-w-0 truncate">{displayValue}</span>
               </span>
-              <ChevronDown className="text-muted h-3 w-3 shrink-0" />
+              <ChevronDown
+                className={cn(
+                  "text-muted h-3 w-3 shrink-0 transition-transform duration-150",
+                  isOpen && "rotate-180"
+                )}
+              />
             </Button>
           </TooltipTrigger>
           <TooltipContent
@@ -349,9 +359,14 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
 
         {/* Dropdown content - rendered inline for testability */}
         {isOpen && (
-          <div className="bg-dark border-border absolute bottom-full left-0 z-[1020] mb-1 w-82 overflow-hidden rounded-md border shadow-md">
+          <div
+            className={cn(
+              "absolute bottom-full left-0 z-[1020] mb-1 w-82",
+              COMPOSER_PICKER_PANEL_CLASS
+            )}
+          >
             {/* Search input */}
-            <div className="border-border border-b px-2 py-1">
+            <div className={cn("border-b px-2.5 py-1.5", COMPOSER_PICKER_DIVIDER_CLASS)}>
               <input
                 ref={inputRef}
                 type="text"
@@ -365,7 +380,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
             </div>
 
             {/* Scrollable list */}
-            <div ref={listRef} className="max-h-[280px] overflow-y-auto p-1">
+            <div ref={listRef} className="max-h-[280px] overflow-y-auto py-1">
               {filteredModels.length === 0 ? (
                 <div className="text-muted py-2 text-center text-[10px]">No matching models</div>
               ) : (
@@ -381,8 +396,13 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       data-highlighted={index === highlightedIndex}
                       onMouseEnter={() => setHighlightedIndex(index)}
                       className={cn(
-                        "flex w-full items-center gap-1.5 rounded-sm px-2 py-0.5 text-xs cursor-pointer",
-                        index === highlightedIndex ? "bg-hover" : "hover:bg-hover",
+                        composerPickerOptionClass({
+                          isHighlighted: index === highlightedIndex,
+                          isSelected: value === model,
+                        }),
+                        // The h-5 action buttons already set this row's inner height, so it lands on
+                        // the agent picker's row height with less vertical padding.
+                        "py-1",
                         hiddenSet.has(model) && "opacity-50"
                       )}
                       onClick={() => handleSelectModel(model)}
@@ -400,7 +420,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                         className="text-muted h-3 w-3 shrink-0"
                       />
                       <span className="flex min-w-0 flex-1 items-baseline gap-1">
-                        <span className="min-w-0 truncate">
+                        <span className={cn("min-w-0 truncate", value === model && "text-accent")}>
                           {formatModelDisplayName(modelName)}
                         </span>
                         {showProviderLabel && (
@@ -508,7 +528,9 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
 
             {/* Footer actions (last row in dropdown) */}
             {(hiddenModels.length > 0 || onOpenSettings) && (
-              <div className="border-border flex flex-col gap-1 border-t px-2 py-1">
+              <div
+                className={cn("flex flex-col gap-1 border-t py-1", COMPOSER_PICKER_DIVIDER_CLASS)}
+              >
                 {hiddenModels.length > 0 && (
                   <button
                     type="button"
@@ -520,14 +542,14 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       setInputValue("");
                       setHighlightedIndex(0);
                     }}
-                    className="text-muted hover:text-foreground text-[10px] transition-colors"
+                    className="text-muted hover:text-foreground px-2.5 text-left text-[10px] transition-colors"
                   >
                     {showAllModels ? "Show fewer models" : "Show all models…"}
                   </button>
                 )}
 
                 {policyEnforced && (
-                  <div className="text-muted flex items-center gap-1 text-[10px]">
+                  <div className="text-muted flex items-center gap-1 px-2.5 text-[10px]">
                     <ShieldCheck className="h-3 w-3" aria-hidden />
                     <span>Your settings are controlled by a policy.</span>
                   </div>
@@ -543,7 +565,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       onOpenSettings();
                       handleCancel();
                     }}
-                    className="text-muted hover:bg-hover hover:text-foreground flex w-full items-center justify-start gap-1.5 rounded-sm px-2 py-1 text-[11px] transition-colors"
+                    className="text-muted hover:bg-hover hover:text-foreground flex w-full items-center justify-start gap-2.5 px-2.5 py-1 text-[11px] font-medium transition-colors"
                   >
                     <Settings className="h-3 w-3 shrink-0" />
                     Model settings

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -13,7 +13,7 @@ import React, {
   forwardRef,
 } from "react";
 import { cn } from "@/common/lib/utils";
-import { Check, ChevronDown, Eye, Settings, ShieldCheck, Star } from "lucide-react";
+import { ChevronDown, Eye, Settings, ShieldCheck, Star } from "lucide-react";
 
 import { COMPOSER_PICKER_PANEL_CLASS, composerPickerOptionClass } from "../composerPickerStyles";
 import { ProviderIcon } from "../ProviderIcon/ProviderIcon";
@@ -405,15 +405,12 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                       role="option"
                       aria-selected={value === model}
                     >
-                      <Check
-                        className={cn(
-                          "h-3 w-3 shrink-0",
-                          value === model ? "opacity-100" : "opacity-0"
-                        )}
-                      />
                       <ProviderIcon
                         provider={modelProvider}
-                        className="text-muted h-3 w-3 shrink-0"
+                        className={cn(
+                          "h-3 w-3 shrink-0",
+                          value === model ? "text-accent" : "text-muted"
+                        )}
                       />
                       <span className="flex min-w-0 flex-1 items-baseline gap-1">
                         <span className={cn("min-w-0 truncate", value === model && "text-accent")}>

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -396,6 +396,8 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                           isHighlighted: index === highlightedIndex,
                           isSelected: value === model,
                         },
+                        // Less padding than the agent picker's rows: the h-5 action buttons here
+                        // already carry the row to the same height.
                         "py-1",
                         hiddenSet.has(model) && "opacity-50"
                       )}

--- a/src/browser/components/composerPickerStyles.ts
+++ b/src/browser/components/composerPickerStyles.ts
@@ -1,0 +1,19 @@
+import { cn } from "@/common/lib/utils";
+
+// The composer's inline pickers (agent mode, model) sit next to each other and open the same way, so
+// drift between their panels is immediately visible. Placement and width stay with each picker.
+export const COMPOSER_PICKER_PANEL_CLASS =
+  "bg-surface-primary border-border-light overflow-hidden rounded border shadow-[0_4px_12px_rgba(0,0,0,0.3)] outline-none";
+
+export const COMPOSER_PICKER_DIVIDER_CLASS = "border-border-light";
+
+export function composerPickerOptionClass(state: {
+  isHighlighted: boolean;
+  isSelected: boolean;
+}): string {
+  return cn(
+    "flex cursor-pointer items-center gap-2.5 px-2.5 py-1.5 text-[11px] font-medium transition-colors duration-100",
+    state.isHighlighted ? "bg-hover text-foreground" : "bg-transparent hover:bg-hover",
+    state.isSelected ? "text-foreground" : "text-light hover:text-foreground"
+  );
+}

--- a/src/browser/components/composerPickerStyles.ts
+++ b/src/browser/components/composerPickerStyles.ts
@@ -1,19 +1,19 @@
+import type { ClassValue } from "clsx";
+
 import { cn } from "@/common/lib/utils";
 
-// The composer's inline pickers (agent mode, model) sit next to each other and open the same way, so
-// drift between their panels is immediately visible. Placement and width stay with each picker.
+// Keep adjacent composer pickers visually aligned while leaving placement and width to each picker.
 export const COMPOSER_PICKER_PANEL_CLASS =
   "bg-surface-primary border-border-light overflow-hidden rounded border shadow-[0_4px_12px_rgba(0,0,0,0.3)] outline-none";
 
-export const COMPOSER_PICKER_DIVIDER_CLASS = "border-border-light";
-
-export function composerPickerOptionClass(state: {
-  isHighlighted: boolean;
-  isSelected: boolean;
-}): string {
+export function composerPickerOptionClass(
+  state: { isHighlighted: boolean; isSelected: boolean },
+  ...classNames: ClassValue[]
+): string {
   return cn(
-    "flex cursor-pointer items-center gap-2.5 px-2.5 py-1.5 text-[11px] font-medium transition-colors duration-100",
+    "flex cursor-pointer items-center gap-2.5 px-2.5 text-[11px] font-medium transition-colors duration-100",
     state.isHighlighted ? "bg-hover text-foreground" : "bg-transparent hover:bg-hover",
-    state.isSelected ? "text-foreground" : "text-light hover:text-foreground"
+    state.isSelected ? "text-foreground" : "text-light hover:text-foreground",
+    classNames
   );
 }

--- a/tests/workerBudget.test.ts
+++ b/tests/workerBudget.test.ts
@@ -12,14 +12,11 @@ interface FakeCgroup {
   procSelfCgroup: string;
 }
 
-/**
- * Builds a cgroup v2 tree on disk. `dirs` maps a cgroup path ("/" for the mount root) to the files
- * that cgroup exposes, so a test can put the memory cap on an ancestor while the leaf reports "max".
- */
 function writeFakeCgroup(
   root: string,
   leafPath: string,
-  dirs: Record<string, Record<string, string>>
+  dirs: Record<string, Record<string, string>>,
+  procLine = `0::${leafPath}`
 ): FakeCgroup {
   const cgroupRoot = path.join(root, "cgroup");
   for (const [cgroupPath, files] of Object.entries(dirs)) {
@@ -31,7 +28,7 @@ function writeFakeCgroup(
   }
 
   const procSelfCgroup = path.join(root, "proc-self-cgroup");
-  fs.writeFileSync(procSelfCgroup, `0::${leafPath}\n`);
+  fs.writeFileSync(procSelfCgroup, `${procLine}\n`);
   return { cgroupRoot, procSelfCgroup };
 }
 
@@ -83,12 +80,22 @@ describe("worker budget cgroup resolution", () => {
     expect(workerBudget.resolveMemoryConstraint(fake)).toBeNull();
   });
 
-  it("falls back to the cgroup v1 layout", () => {
-    const fake = writeFakeCgroup(tmpRoot, "/", {
-      "/memory": { "memory.limit_in_bytes": `${4 * GIB}` },
-    });
+  it("resolves a nested cgroup v1 memory limit", () => {
+    const fake = writeFakeCgroup(
+      tmpRoot,
+      "/docker/leaf",
+      {
+        "/memory": { "memory.limit_in_bytes": `${16 * GIB}` },
+        "/memory/docker": { "memory.limit_in_bytes": `${8 * GIB}` },
+        "/memory/docker/leaf": { "memory.limit_in_bytes": `${4 * GIB}` },
+      },
+      "5:cpu,memory:/docker/leaf"
+    );
 
-    expect(workerBudget.resolveMemoryConstraint(fake).limitBytes).toBe(4 * GIB);
+    const constraint = workerBudget.resolveMemoryConstraint(fake);
+
+    expect(constraint.limitBytes).toBe(4 * GIB);
+    expect(constraint.dir).toBe(path.join(fake.cgroupRoot, "memory/docker/leaf"));
   });
 
   it("reports no constraint when the host has no cgroup files", () => {
@@ -118,7 +125,6 @@ describe("worker budget usage accounting", () => {
       memoryStat({ anon: 4 * GIB, kernel: GIB, shmem: 0, inactive_file: 15 * GIB })
     );
 
-    // memory.current says 20 GiB, but 15 GiB of that is page cache the kernel drops on demand.
     expect(workerBudget.readCgroupUsageBytes(dir)).toBe(5 * GIB);
   });
 
@@ -132,6 +138,15 @@ describe("worker budget usage accounting", () => {
     );
 
     expect(workerBudget.readCgroupUsageBytes(dir)).toBe(18 * GIB);
+  });
+
+  it("subtracts reclaimable cache from cgroup v1 usage", () => {
+    const dir = path.join(tmpRoot, "cg-v1");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "memory.usage_in_bytes"), `${20 * GIB}`);
+    fs.writeFileSync(path.join(dir, "memory.stat"), memoryStat({ total_inactive_file: 15 * GIB }));
+
+    expect(workerBudget.readCgroupUsageBytes(dir)).toBe(5 * GIB);
   });
 });
 

--- a/tests/workerBudget.test.ts
+++ b/tests/workerBudget.test.ts
@@ -71,6 +71,19 @@ describe("worker budget cgroup resolution", () => {
     expect(workerBudget.resolveMemoryConstraint(fake).limitBytes).toBe(8 * GIB);
   });
 
+  it("uses the broadest usage scope when equal caps constrain multiple levels", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/parent/leaf", {
+      "/": { "memory.max": `${64 * GIB}` },
+      "/parent": { "memory.max": `${8 * GIB}` },
+      "/parent/leaf": { "memory.max": `${8 * GIB}` },
+    });
+
+    const constraint = workerBudget.resolveMemoryConstraint(fake);
+
+    expect(constraint.limitBytes).toBe(8 * GIB);
+    expect(constraint.dir).toBe(path.join(fake.cgroupRoot, "parent"));
+  });
+
   it("ignores saturated integers that stand in for 'unlimited'", () => {
     const fake = writeFakeCgroup(tmpRoot, "/leaf", {
       "/": { "memory.max": "9223372036854771712" },

--- a/tests/workerBudget.test.ts
+++ b/tests/workerBudget.test.ts
@@ -1,0 +1,164 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const workerBudget = require("../scripts/lib/worker_budget.js");
+
+const GIB = 1024 ** 3;
+
+interface FakeCgroup {
+  cgroupRoot: string;
+  procSelfCgroup: string;
+}
+
+/**
+ * Builds a cgroup v2 tree on disk. `dirs` maps a cgroup path ("/" for the mount root) to the files
+ * that cgroup exposes, so a test can put the memory cap on an ancestor while the leaf reports "max".
+ */
+function writeFakeCgroup(
+  root: string,
+  leafPath: string,
+  dirs: Record<string, Record<string, string>>
+): FakeCgroup {
+  const cgroupRoot = path.join(root, "cgroup");
+  for (const [cgroupPath, files] of Object.entries(dirs)) {
+    const dir = path.join(cgroupRoot, cgroupPath);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const [name, contents] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), contents);
+    }
+  }
+
+  const procSelfCgroup = path.join(root, "proc-self-cgroup");
+  fs.writeFileSync(procSelfCgroup, `0::${leafPath}\n`);
+  return { cgroupRoot, procSelfCgroup };
+}
+
+function memoryStat(overrides: Record<string, number>): string {
+  return Object.entries(overrides)
+    .map(([key, value]) => `${key} ${value}`)
+    .join("\n");
+}
+
+describe("worker budget cgroup resolution", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "worker-budget-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("takes the cap from the constraining ancestor when the leaf is unlimited", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/init.scope", {
+      "/": { "memory.max": `${32 * GIB}` },
+      "/init.scope": { "memory.max": "max" },
+    });
+
+    const constraint = workerBudget.resolveMemoryConstraint(fake);
+
+    expect(constraint.limitBytes).toBe(32 * GIB);
+    expect(constraint.dir).toBe(fake.cgroupRoot);
+  });
+
+  it("prefers the tightest cap when several ancestors impose one", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/parent/leaf", {
+      "/": { "memory.max": `${64 * GIB}` },
+      "/parent": { "memory.max": `${8 * GIB}` },
+      "/parent/leaf": { "memory.max": `${16 * GIB}` },
+    });
+
+    expect(workerBudget.resolveMemoryConstraint(fake).limitBytes).toBe(8 * GIB);
+  });
+
+  it("ignores saturated integers that stand in for 'unlimited'", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/leaf", {
+      "/": { "memory.max": "9223372036854771712" },
+      "/leaf": { "memory.max": "max" },
+    });
+
+    expect(workerBudget.resolveMemoryConstraint(fake)).toBeNull();
+  });
+
+  it("falls back to the cgroup v1 layout", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/", {
+      "/memory": { "memory.limit_in_bytes": `${4 * GIB}` },
+    });
+
+    expect(workerBudget.resolveMemoryConstraint(fake).limitBytes).toBe(4 * GIB);
+  });
+
+  it("reports no constraint when the host has no cgroup files", () => {
+    const fake = writeFakeCgroup(tmpRoot, "/", { "/": {} });
+
+    expect(workerBudget.resolveMemoryConstraint(fake)).toBeNull();
+  });
+});
+
+describe("worker budget usage accounting", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "worker-budget-usage-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("excludes reclaimable page cache from usage", () => {
+    const dir = path.join(tmpRoot, "cg");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "memory.current"), `${20 * GIB}`);
+    fs.writeFileSync(
+      path.join(dir, "memory.stat"),
+      memoryStat({ anon: 4 * GIB, kernel: GIB, shmem: 0, inactive_file: 15 * GIB })
+    );
+
+    // memory.current says 20 GiB, but 15 GiB of that is page cache the kernel drops on demand.
+    expect(workerBudget.readCgroupUsageBytes(dir)).toBe(5 * GIB);
+  });
+
+  it("counts file-backed memory that cannot be reclaimed", () => {
+    const dir = path.join(tmpRoot, "cg");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "memory.current"), `${20 * GIB}`);
+    fs.writeFileSync(
+      path.join(dir, "memory.stat"),
+      memoryStat({ anon: 4 * GIB, kernel: GIB, shmem: 0, inactive_file: 2 * GIB })
+    );
+
+    expect(workerBudget.readCgroupUsageBytes(dir)).toBe(18 * GIB);
+  });
+});
+
+describe("worker budget sizing", () => {
+  const base = { cpuCount: 96, memoryPerWorkerGib: 4, maxWorkers: 4 };
+
+  it("sizes against memory rather than the visible core count", () => {
+    expect(workerBudget.computeWorkers({ ...base, limitBytes: 32 * GIB, inUseBytes: 0 })).toBe(4);
+  });
+
+  it("shrinks the pool as co-tenants consume the shared cgroup", () => {
+    const workersAt = (inUseGib: number) =>
+      workerBudget.computeWorkers({ ...base, limitBytes: 32 * GIB, inUseBytes: inUseGib * GIB });
+
+    expect(workersAt(16)).toBe(2);
+    expect(workersAt(22)).toBe(1);
+  });
+
+  it("keeps one worker even when the cgroup has no headroom left", () => {
+    expect(
+      workerBudget.computeWorkers({ ...base, limitBytes: 32 * GIB, inUseBytes: 32 * GIB })
+    ).toBe(1);
+  });
+
+  it("never exceeds the core budget on small hosts", () => {
+    expect(
+      workerBudget.computeWorkers({ ...base, cpuCount: 2, limitBytes: 64 * GIB, inUseBytes: 0 })
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Aligns the model selector with the adjacent agent picker and makes local/default Jest and ESLint worker counts respect shared cgroup memory pressure.

## Background

The model selector reserved a checkmark column on every row, which shifted its leading icons away from the agent picker alignment. During validation, local lint and test runs also exhausted a 32 GiB shared cgroup because the visible 96-core host and leaf cgroup did not expose the tighter ancestor memory cap.

## Implementation

- Shares panel chrome and option-row styling between the model and agent pickers.
- Distinguishes hover with a neutral row background and selection with an accent provider icon and label, while preserving `aria-selected` and the separate default-model star.
- Walks cgroup v1 and v2 ancestors to find the effective memory constraint, accounts for broader equal-cap usage, discounts reclaimable file cache, and reserves headroom before choosing local worker counts.
- Lints and formats the new runtime helper, with a one-worker ESLint fallback if budget detection fails.

CI integration jobs still pass an explicit `--maxWorkers=100%` on fixed runners. This PR changes the default worker budget used by local commands and other invocations that do not override it.

## Validation

- `make static-check`
- `bun x jest tests/workerBudget.test.ts --runInBand --silent` (13 tests)
- `bun test ./src/browser/components/AgentModePicker/AgentModePicker.test.tsx` (5 tests)
- Storybook visual comparison of normal, hovered, selected, and selected-plus-hover model rows

## Risks

The worker profiles use measured repository workloads and may need retuning if tool memory behavior changes. CI's explicit worker override is unchanged.

> Mux prepared this PR on behalf of Mike.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `max`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=max -->
