### PR TITLE
🤖 feat: link the footer GitHub slug to the repository

### DIFF
--- a/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
@@ -84,6 +84,21 @@ const repoMetadata: FrontendWorkspaceMetadata = {
   createdAt: "2026-01-01T00:00:00.000Z",
 };
 
+function mockDetectedPR() {
+  spyOn(PRStatusStoreModule, "useWorkspacePR").mockImplementation(
+    () =>
+      ({
+        type: "github-pr",
+        url: "https://github.com/acme/widgets/pull/7",
+        owner: "acme",
+        repo: "widgets",
+        number: 7,
+        detectedAt: 0,
+        occurrenceCount: 1,
+      }) as unknown as ReturnType<typeof PRStatusStoreModule.useWorkspacePR>
+  );
+}
+
 function renderFooter(overrides?: Partial<ComponentProps<typeof WorkspaceFooterBarComponent>>) {
   return render(
     <TooltipProvider delayDuration={0}>
@@ -200,23 +215,23 @@ describe("WorkspaceFooterBar repository controls", () => {
 
   it("shows the GitHub slug instead of the project label once a PR is detected", () => {
     workspaceMetadata.set(workspaceId, repoMetadata);
-    spyOn(PRStatusStoreModule, "useWorkspacePR").mockImplementation(
-      () =>
-        ({
-          type: "github-pr",
-          url: "https://github.com/acme/widgets/pull/7",
-          owner: "acme",
-          repo: "widgets",
-          number: 7,
-          detectedAt: 0,
-          occurrenceCount: 1,
-        }) as unknown as ReturnType<typeof PRStatusStoreModule.useWorkspacePR>
-    );
+    mockDetectedPR();
 
     const { container } = renderFooter();
 
     expect(container.textContent).toContain("acme/widgets");
     expect(container.textContent).not.toContain("demo");
+  });
+
+  it("links the GitHub slug to the repository page", () => {
+    workspaceMetadata.set(workspaceId, repoMetadata);
+    mockDetectedPR();
+
+    const { getByTestId } = renderFooter();
+
+    expect(getByTestId("workspace-footer-repository").getAttribute("href")).toBe(
+      "https://github.com/acme/widgets"
+    );
   });
 
   it("falls back to the project label when no PR is detected", () => {

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -150,13 +150,25 @@ function FooterRepositoryLabel(props: { workspaceId: string; projectLabel: strin
     return <FooterProjectLabel projectLabel={props.projectLabel} />;
   }
 
+  // The slug comes from a parsed github.com PR URL, so the repo page is always this host.
+  const slug = `${workspacePR.owner}/${workspacePR.repo}`;
+
   return (
-    <span className="text-muted flex shrink-0 items-center gap-1">
-      <Github className="h-3 w-3 shrink-0" aria-hidden="true" />
-      <span className="font-mono">
-        {workspacePR.owner}/{workspacePR.repo}
-      </span>
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <a
+          href={`https://github.com/${slug}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-testid="workspace-footer-repository"
+          className="text-muted hover:bg-hover hover:text-foreground focus-visible:ring-accent flex h-5 shrink-0 items-center gap-1 rounded-md px-1.5 transition-colors focus-visible:ring-1"
+        >
+          <Github className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <span className="font-mono">{slug}</span>
+        </a>
+      </TooltipTrigger>
+      <TooltipContent side="top">Open on GitHub</TooltipContent>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
## Summary

The workspace footer already shows the GitHub `owner/repo` slug once a PR is detected on the branch, but it was inert text. This makes it a link to the repository page.

## Background

The slug arrives from `PRStatusStore`, which parses `owner`, `repo`, and `number` out of the `github.com` PR URL returned by `gh pr view`. So whenever the slug renders, we already know the exact repository it names, and the repo URL is unambiguous. The neighbouring `PR #N` badge is clickable; the slug looked identical in weight but did nothing.

## Implementation

`FooterRepositoryLabel` now renders an `<a>` to `https://github.com/{owner}/{repo}` with `target="_blank"` and `rel="noopener noreferrer"`, which the desktop main process routes through `shell.openExternal` via `setWindowOpenHandler`. Styling matches the sibling "Last prompt" pill (`h-5`, `rounded-md`, `hover:bg-hover`) so the affordance reads as interactive, and `shrink-0` is retained because the footer row scrolls horizontally.

Behaviour without a detected PR is unchanged: the footer still shows the plain project label. The frontend has no git remote URL today, so the link is scoped to the PR-detected case.

## Validation

Checked in Storybook against `App/PhoneViewports` `IPhone16ePRLinkPlacement` (which mocks `gh pr view`): the anchor resolves to `https://github.com/coder/mux`, carries `target="_blank"` and `rel="noopener noreferrer"`, and the tooltip renders on hover.

Red-green on the new unit test: removing the `href` and removing the `data-testid` each fail only that test.

## Risks

Low. One component, no state or IPC changes. Pixel snapshots containing the footer shift by a few pixels from the new padding on the slug.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=max -->
