### PR TITLE
🤖 fix: apply OpenAI's GPT-5.6 Luna and Terra price cut

### DIFF
--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -104,7 +104,7 @@ const MODEL_DEFINITIONS = {
     tokenizerOverride: "openai/gpt-5",
   },
   // GPT-5.6 Terra - balanced everyday tier, released July 9, 2026.
-  // GPT-5.5-class quality at half the cost: $2.50/M input, $15/M output; 1.05M context.
+  // GPT-5.5-class quality at a fraction of the cost: $2/M input, $12/M output; 1.05M context.
   GPT_56_TERRA: {
     provider: "openai",
     providerModelId: "gpt-5.6-terra",
@@ -112,7 +112,7 @@ const MODEL_DEFINITIONS = {
     tokenizerOverride: "openai/gpt-5",
   },
   // GPT-5.6 Luna - fastest, most cost-efficient tier, released July 9, 2026.
-  // $1/M input, $6/M output; 1.05M context (GA model page; 400K was a stale launch value).
+  // $0.20/M input, $1.20/M output; 1.05M context (GA model page; 400K was a stale launch value).
   GPT_56_LUNA: {
     provider: "openai",
     providerModelId: "gpt-5.6-luna",

--- a/src/common/utils/tokens/displayUsage.test.ts
+++ b/src/common/utils/tokens/displayUsage.test.ts
@@ -243,12 +243,13 @@ describe("createDisplayUsage", () => {
     expect(result!.input.tokens).toBe(500);
     expect(result!.cached.tokens).toBe(100000);
     expect(result!.cacheCreate.tokens).toBe(5000);
-    // Luna base rates: $1/M input, $0.10/M cache read (0.1x), $1.25/M cache
-    // write (1.25x), $6/M output.
-    expect(result!.input.cost_usd).toBeCloseTo(0.0005);
-    expect(result!.cached.cost_usd).toBeCloseTo(0.01);
-    expect(result!.cacheCreate.cost_usd).toBeCloseTo(0.00625);
-    expect(result!.output.cost_usd).toBeCloseTo(0.006);
+    // Luna base rates: $0.20/M input, $0.02/M cache read (0.1x), $0.25/M cache
+    // write (1.25x), $1.20/M output. These land near 1e-3, so the default
+    // toBeCloseTo precision of 2 would accept any of them; pin it explicitly.
+    expect(result!.input.cost_usd).toBeCloseTo(0.0001, 10);
+    expect(result!.cached.cost_usd).toBeCloseTo(0.002, 10);
+    expect(result!.cacheCreate.cost_usd).toBeCloseTo(0.00125, 10);
+    expect(result!.output.cost_usd).toBeCloseTo(0.0012, 10);
   });
 
   describe("tiered long-context pricing", () => {

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -42,8 +42,8 @@ describe("getModelStats", () => {
   test.each([
     // [model, input, output, cacheRead, cacheCreation]
     ["openai:gpt-5.6-sol", 0.000005, 0.00003, 0.0000005, 0.00000625],
-    ["openai:gpt-5.6-terra", 0.0000025, 0.000015, 0.00000025, 0.000003125],
-    ["openai:gpt-5.6-luna", 0.000001, 0.000006, 0.0000001, 0.00000125],
+    ["openai:gpt-5.6-terra", 0.000002, 0.000012, 0.0000002, 0.0000025],
+    ["openai:gpt-5.6-luna", 0.0000002, 0.0000012, 0.00000002, 0.00000025],
   ] as const)(
     "resolves %s with the GA pricing and limits",
     (model, input, output, cacheRead, cacheCreation) => {

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -300,20 +300,21 @@ export const modelsExtra: Record<string, ModelData> = {
 
   // GPT-5.6 Terra - Released July 9, 2026 (balanced everyday tier).
   // GA docs: 1.05M context window, 128K max output, Feb 16 2026 cutoff (family).
-  // Base pricing: $2.50/M input, $15/M output, $0.25/M cached input; cache
-  // writes 1.25x the active input rate ($3.125/M base). Same 272K long-context
-  // tier as Sol (2x input / 1.5x output for the full request).
+  // Base pricing (OpenAI's July 30, 2026 price cut): $2/M input, $12/M output,
+  // $0.20/M cached input; cache writes 1.25x the active input rate ($2.50/M
+  // base). Same 272K long-context tier as Sol (2x input / 1.5x output for the
+  // full request).
   "gpt-5.6-terra": {
     max_input_tokens: 1050000,
     max_output_tokens: 128000,
-    input_cost_per_token: 0.0000025, // $2.50 per million input tokens (<272K prompt tokens)
-    input_cost_per_token_above_200k_tokens: 0.000005, // $5 per million input tokens (>272K)
-    output_cost_per_token: 0.000015, // $15 per million output tokens (<272K prompt tokens)
-    output_cost_per_token_above_200k_tokens: 0.0000225, // $22.50 per million output tokens (>272K)
-    cache_read_input_token_cost: 0.00000025, // $0.25 per million cached input tokens (<272K)
-    cache_read_input_token_cost_above_200k_tokens: 0.0000005, // $0.50 per million cached input tokens (>272K)
-    cache_creation_input_token_cost: 0.000003125, // $3.125 per million tokens (1.25x input)
-    cache_creation_input_token_cost_above_200k_tokens: 0.00000625, // $6.25 per million tokens (1.25x long-context input)
+    input_cost_per_token: 0.000002, // $2 per million input tokens (<272K prompt tokens)
+    input_cost_per_token_above_200k_tokens: 0.000004, // $4 per million input tokens (>272K)
+    output_cost_per_token: 0.000012, // $12 per million output tokens (<272K prompt tokens)
+    output_cost_per_token_above_200k_tokens: 0.000018, // $18 per million output tokens (>272K)
+    cache_read_input_token_cost: 0.0000002, // $0.20 per million cached input tokens (<272K)
+    cache_read_input_token_cost_above_200k_tokens: 0.0000004, // $0.40 per million cached input tokens (>272K)
+    cache_creation_input_token_cost: 0.0000025, // $2.50 per million tokens (1.25x input)
+    cache_creation_input_token_cost_above_200k_tokens: 0.000005, // $5 per million tokens (1.25x long-context input)
     tiered_pricing_threshold_tokens: 272000, // OpenAI's published boundary is 272K (field names say 200K)
     litellm_provider: "openai",
     mode: "chat",
@@ -327,20 +328,21 @@ export const modelsExtra: Record<string, ModelData> = {
   // GPT-5.6 Luna - Released July 9, 2026 (fastest, most cost-efficient tier).
   // GA model page: 1.05M context window (the 400K figure was a stale launch
   // value that caused premature compaction), 128K max output, Feb 16 2026 cutoff.
-  // Base pricing: $1/M input, $6/M output, $0.10/M cached input; cache writes
-  // 1.25x the active input rate ($1.25/M base). Same 272K long-context tier as
-  // Sol (2x input / 1.5x output for the full request).
+  // Base pricing (OpenAI's July 30, 2026 price cut): $0.20/M input, $1.20/M
+  // output, $0.02/M cached input; cache writes 1.25x the active input rate
+  // ($0.25/M base). Same 272K long-context tier as Sol (2x input / 1.5x output
+  // for the full request).
   "gpt-5.6-luna": {
     max_input_tokens: 1050000,
     max_output_tokens: 128000,
-    input_cost_per_token: 0.000001, // $1 per million input tokens (<272K prompt tokens)
-    input_cost_per_token_above_200k_tokens: 0.000002, // $2 per million input tokens (>272K)
-    output_cost_per_token: 0.000006, // $6 per million output tokens (<272K prompt tokens)
-    output_cost_per_token_above_200k_tokens: 0.000009, // $9 per million output tokens (>272K)
-    cache_read_input_token_cost: 0.0000001, // $0.10 per million cached input tokens (<272K)
-    cache_read_input_token_cost_above_200k_tokens: 0.0000002, // $0.20 per million cached input tokens (>272K)
-    cache_creation_input_token_cost: 0.00000125, // $1.25 per million tokens (1.25x input)
-    cache_creation_input_token_cost_above_200k_tokens: 0.0000025, // $2.50 per million tokens (1.25x long-context input)
+    input_cost_per_token: 0.0000002, // $0.20 per million input tokens (<272K prompt tokens)
+    input_cost_per_token_above_200k_tokens: 0.0000004, // $0.40 per million input tokens (>272K)
+    output_cost_per_token: 0.0000012, // $1.20 per million output tokens (<272K prompt tokens)
+    output_cost_per_token_above_200k_tokens: 0.0000018, // $1.80 per million output tokens (>272K)
+    cache_read_input_token_cost: 0.00000002, // $0.02 per million cached input tokens (<272K)
+    cache_read_input_token_cost_above_200k_tokens: 0.00000004, // $0.04 per million cached input tokens (>272K)
+    cache_creation_input_token_cost: 0.00000025, // $0.25 per million tokens (1.25x input)
+    cache_creation_input_token_cost_above_200k_tokens: 0.0000005, // $0.50 per million tokens (1.25x long-context input)
     tiered_pricing_threshold_tokens: 272000, // OpenAI's published boundary is 272K (field names say 200K)
     litellm_provider: "openai",
     mode: "chat",


### PR DESCRIPTION
## Summary

Applies OpenAI's July 30, 2026 API price cut for GPT-5.6 Luna (80% cheaper) and Terra (20% cheaper) to Mux's hand-maintained model pricing table. Sol is unchanged.

## Background

OpenAI [lowered Luna and Terra API pricing](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/) effective July 30, 2026: Terra to $2/M input and $12/M output, Luna to $0.20/M input and $1.20/M output.

Mux does not pick this up automatically. `scripts/update_models.ts` syncs pricing from upstream LiteLLM into `models.json`, but our committed snapshot has no GPT-5.6 entries, so Sol/Terra/Luna are served from `models-extra.ts`, the hand-maintained override table that `getModelStats` consults *before* `models.json`. Until this change, every Luna and Terra cost readout in the app was overstated by up to 5x.

## Implementation

Base input/output rates come from OpenAI's announcement. Derived rates follow the multipliers already documented for this family:

- Cached input: 0.1x input (OpenAI's 90% cached-input discount)
- Cache writes: 1.25x the active input rate
- Above the 272K long-context boundary: 2x input, 1.5x output, applied to the whole request (cache reads and writes scale with the input tier)

| Field | Terra | Luna |
|---|---|---|
| input | $2.50 -> $2.00 /M | $1.00 -> $0.20 /M |
| output | $15.00 -> $12.00 /M | $6.00 -> $1.20 /M |
| cached read | $0.25 -> $0.20 /M | $0.10 -> $0.02 /M |
| cache write | $3.125 -> $2.50 /M | $1.25 -> $0.25 /M |

Context window (1.05M), max output (128K), and the 272K boundary are unchanged.

`knownModels.ts` carried the old rates in comments beside each model definition; those are updated so the two sources do not disagree.

## Validation

**Cross-checked against upstream LiteLLM.** Upstream has since published `gpt-5.6-luna` and `gpt-5.6-terra`, and all eight base values here match it exactly (input, output, cached read, cache write for both models), as do context window and max output. This is an independent confirmation of the four rates that had to be derived rather than read off the announcement.

**The entries stay in `models-extra.ts` despite now existing upstream.** LiteLLM ships `null` for every long-context field (`*_above_200k_tokens`) and for `tiered_pricing_threshold_tokens`, so deleting our overrides would silently drop the 272K tier and under-bill large prompts. The tier is still live on the new bases: requests above 272K input tokens bill at 2x input / 1.5x output for the entire request.

**Test precision fix.** The pre-existing Luna cost-math assertions in `displayUsage.test.ts` were passing vacuously: all four expected values sit at or below 1e-3, and `toBeCloseTo`'s default precision of 2 accepts anything within 0.005, so they held even against the old rates that were 5x higher. They are pinned to precision 10 so the test actually constrains the rates.

Confirmed no Storybook story renders GPT-5.6 per-token prices, so no visual baselines move.

## Risks

Low blast radius: data-only change to a lookup table, no logic touched.

One user-visible side effect: costs are recomputed from stored token counts at display time via `createDisplayUsage` / `recomputeUsageCosts` rather than read from a persisted dollar amount, so historical Luna and Terra sessions will re-price at the new lower rates in the costs UI. That matches how previous pricing corrections in this table have behaved.

## Follow-up (not in this PR)

Our `models.json` snapshot is stale relative to upstream LiteLLM, which now carries the whole GPT-5.6 family. Re-running `scripts/update_models.ts` would touch pricing for many unrelated models and deserves its own PR and review; it would not change behavior for these two models, since `models-extra.ts` takes precedence and holds strictly richer data.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=max -->
