### PR TITLE
🤖 perf: reduce idle dev CPU usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ include fmt.mk
 .PHONY: ensure-deps rebuild-native mux
 .PHONY: check-eager-imports check-bundle-size check-startup
 
-# Build tools
-TSGO := bun run node_modules/@typescript/native-preview/bin/tsgo.js
+# Use the package binary instead of its internal path so native-preview can change wrappers safely.
+TSGO := bun run tsgo
 
 # Node.js version check
 REQUIRED_NODE_VERSION := 20

--- a/bun.lock
+++ b/bun.lock
@@ -142,7 +142,7 @@
         "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
         "@typescript-eslint/parser": "^8.44.1",
-        "@typescript/native-preview": "^7.0.0-dev.20251014.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260707.2",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.21",
         "babel-jest": "^30.2.0",
@@ -1527,21 +1527,21 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.48.1", "", { "dependencies": { "@typescript-eslint/types": "8.48.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20251203.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251203.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251203.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20251203.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251203.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20251203.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251203.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20251203.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-u6kHGmbkB4WQ2XjQUVq6PixV92biRclTBAq8r09L/MGzsiVREdYzf/Bf1W4aTDcDSu6UQ3hjtBR6hROQRPrMXQ=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20251203.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gMPW/y89KANC0fIqdudxwsxUOHTOyujaOGxyj4IOaFLIP+8/gofawsmdf9HVniPq4xCT7tMpiqa/b9btxJ5nGw=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20251203.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-BG/bCAZcTGNM4bQMwY4hI0l70QaxQW9qwJ04GZJL02LAnaQVai8o5X/ghU6awkXFt9CTXdXBWn+hKNb+IiHG+w=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20251203.1", "", { "os": "linux", "cpu": "arm" }, "sha512-iGrXfVUWtXgiaiVX7FhFVYFz3qFklta2kQEx0VX+km/tBVFMt+egI36tflKYuR7UE5n+0kboKldtyKgmfGrrjQ=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm" }, "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20251203.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-UGrYYbYbyjlklDubWE93E84WU6jrCGsjpJ2+/GFf4keB3IUrvg9lRqgQ3DUYW4p5kXJR+YC42HnG+OXkN+s6Pw=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20251203.1", "", { "os": "linux", "cpu": "x64" }, "sha512-s3VZtFQGktU1ph0q3v8T2tVsgTrRoiaWFknt2vrErxKnzfQgChWOlM0o7Geaj/y1dnrOGWO/cHwMCSb7vd2fgw=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2", "", { "os": "linux", "cpu": "x64" }, "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20251203.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-rcaW7Kn7Ja8J17wmc9UuOjf0LmlqPQYYnqQTdh/kj72FcK4l+8P7b1LcViQFcsOAiIcRZBKrEVZnZXNQxYdHMQ=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20251203.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+DSMCGE7VZWjYzbWDuIenBW2tUclUqAGi7pcOgGq3BpwPEqyVhdQh5ggOk087xgshBv5Wj/yAdXA9gQFAFxpEQ=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-Z7gr/DKP/qjKXzuYYpfGDczSzZcqhDb+QLyZiGmg844="; # mux-offline-cache-hash
+            outputHash = "sha256-FFlI3j+x4Hp0kgDsHcPSQIDFhQvuBSIQrbTAYBc1CEE="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",
-    "@typescript/native-preview": "^7.0.0-dev.20251014.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.21",
     "babel-jest": "^30.2.0",

--- a/scripts/build-main-watch.js
+++ b/scripts/build-main-watch.js
@@ -9,7 +9,6 @@ const fs = require("fs");
 const path = require("path");
 
 const rootDir = path.join(__dirname, "..");
-const tsgoPath = path.join(rootDir, "node_modules/@typescript/native-preview/bin/tsgo.js");
 const tscAliasPath = path.join(rootDir, "node_modules/tsc-alias/dist/bin/index.js");
 const buildCompleteStampPath = path.join(rootDir, "dist/.main-build-complete");
 
@@ -25,8 +24,8 @@ try {
     });
   }
 
-  // Run tsgo
-  execSync(`node "${tsgoPath}" -p tsconfig.main.json`, {
+  // Use the package binary so native-preview can change its internal wrapper safely.
+  execSync("bun run tsgo -p tsconfig.main.json", {
     cwd: rootDir,
     stdio: "inherit",
     env: { ...process.env, NODE_ENV: "development" },

--- a/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
+++ b/src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx
@@ -135,6 +135,18 @@ describe("PinnedTodoList", () => {
     expect(renderResult.getByText("Add tests")).toBeTruthy();
   });
 
+  test("spins the HTML wrapper instead of the in-progress SVG", () => {
+    seedWorkspaceState("ws-composited-spinner", { todos: defaultTodos });
+
+    const renderResult = renderPinnedTodoList("ws-composited-spinner");
+    const spinner = renderResult.container.querySelector(".animate-spin");
+    const icon = spinner?.querySelector("svg");
+
+    expect(spinner?.tagName).toBe("SPAN");
+    expect(icon).toBeTruthy();
+    expect(icon?.classList.contains("animate-spin")).toBe(false);
+  });
+
   test("renders nothing when there are no todos", () => {
     seedWorkspaceState("ws-empty", { todos: [] });
 

--- a/src/browser/components/TodoList/TodoList.tsx
+++ b/src/browser/components/TodoList/TodoList.tsx
@@ -82,7 +82,13 @@ function getStatusIcon(status: TodoItem["status"]): React.ReactNode {
     case "completed":
       return <Check aria-hidden="true" className="h-3 w-3" />;
     case "in_progress":
-      return <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />;
+      return (
+        // Chromium composites transforms on this HTML wrapper; animating the SVG
+        // itself keeps the renderer main thread busy even while mux is otherwise idle.
+        <span className="inline-flex animate-spin">
+          <Loader2 aria-hidden="true" className="h-3 w-3" />
+        </span>
+      );
     case "pending":
     default:
       return <Circle aria-hidden="true" className="h-3 w-3" />;

--- a/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
+++ b/src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx
@@ -71,7 +71,8 @@ describe("WorkspaceStatusIndicator", () => {
 
     const icon = view.container.querySelector("svg");
     expect(icon).toBeTruthy();
-    expect(icon?.getAttribute("class") ?? "").toContain("animate-spin");
+    expect(icon?.getAttribute("class") ?? "").not.toContain("animate-spin");
+    expect(icon?.parentElement?.classList.contains("animate-spin")).toBe(true);
   });
 
   test("keeps the steady streaming layout free of the transient handoff slot", () => {

--- a/src/browser/components/icons/EmojiIcon/EmojiIcon.tsx
+++ b/src/browser/components/icons/EmojiIcon/EmojiIcon.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@/common/lib/utils";
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
@@ -105,5 +104,9 @@ export function EmojiIcon(props: {
   const Icon = EMOJI_TO_ICON[normalizedEmoji] ?? Sparkles;
   const shouldSpin = props.spin ?? SPINNING_EMOJI.has(normalizedEmoji);
 
-  return <Icon aria-hidden="true" className={cn(props.className, shouldSpin && "animate-spin")} />;
+  const icon = <Icon aria-hidden="true" className={props.className} />;
+
+  // Animate an HTML wrapper so Chromium can composite the transform instead of
+  // recalculating styles for a transform applied directly to the SVG.
+  return shouldSpin ? <span className="inline-flex animate-spin">{icon}</span> : icon;
 }

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -1051,10 +1051,11 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
       return null;
     }
 
-    return (
-      (selectedHunkId ? (hunks.find((hunk) => hunk.id === selectedHunkId) ?? null) : null) ??
-      hunks[0]
-    );
+    if (!selectedHunkId) {
+      return hunks[0];
+    }
+
+    return hunks.find((hunk) => hunk.id === selectedHunkId) ?? hunks[0];
   }, [hunks, selectedHunkId]);
 
   useEffect(() => {

--- a/src/browser/main.tsx
+++ b/src/browser/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { installBrowserLogCapture } from "@/browser/utils/browserLog";
 import { installWindowOpenLocalhostProxyNormalization } from "@/browser/utils/windowOpenLocalhostProxy";
+import { installInactiveAnimationPause } from "@/browser/utils/inactiveAnimations";
 import { AppLoader } from "@/browser/components/AppLoader/AppLoader";
 import { initTelemetry, trackAppStarted } from "@/common/telemetry";
 import { initTitlebarInsets } from "@/browser/hooks/useDesktopTitlebar";
@@ -12,6 +13,12 @@ try {
   installBrowserLogCapture();
 } catch {
   // Silent failure — never crash the app for logging capture
+}
+
+try {
+  installInactiveAnimationPause();
+} catch {
+  // Animation throttling is an optimization and must never block renderer startup.
 }
 
 installWindowOpenLocalhostProxyNormalization();

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2436,6 +2436,13 @@ input[type="checkbox"] {
   animation: tutorial-pulse 1.5s ease-in-out infinite;
 }
 
+/* Electron does not throttle animations merely because its window lost focus.
+   Pause persistent status animations while mux is backgrounded to avoid idle CPU burn. */
+html[data-renderer-inactive]
+  :where(.animate-spin, .animate-pulse, .workspace-status-dot-active) {
+  animation-play-state: paused !important;
+}
+
 /* Active workspace status dot pulse (animate-pulse style, slightly stronger) */
 .workspace-status-dot-active {
   animation: workspace-status-dot-pulse 1.8s cubic-bezier(0.5, 0, 0.6, 1) infinite;

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2437,17 +2437,11 @@ input[type="checkbox"] {
 }
 
 /* Electron does not throttle animations merely because its window lost focus.
-   Pause persistent status animations while mux is backgrounded to avoid idle CPU burn. */
-html[data-renderer-inactive]
-  :where(
-    .animate-spin,
-    .animate-pulse,
-    .workspace-status-dot-active,
-    .heartbeat-dot,
-    .heartbeat-trace,
-    .subagent-connector-elbow-active
-  ),
-html[data-renderer-inactive] .subagent-connector-active::before {
+   Pause every animation timeline while mux is backgrounded so new persistent
+   status effects cannot silently reintroduce idle CPU burn. */
+html[data-renderer-inactive] *,
+html[data-renderer-inactive] *::before,
+html[data-renderer-inactive] *::after {
   animation-play-state: paused !important;
 }
 

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2445,9 +2445,9 @@ html[data-renderer-inactive]
     .workspace-status-dot-active,
     .heartbeat-dot,
     .heartbeat-trace,
-    .subagent-connector-active::before,
     .subagent-connector-elbow-active
-  ) {
+  ),
+html[data-renderer-inactive] .subagent-connector-active::before {
   animation-play-state: paused !important;
 }
 

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2439,7 +2439,15 @@ input[type="checkbox"] {
 /* Electron does not throttle animations merely because its window lost focus.
    Pause persistent status animations while mux is backgrounded to avoid idle CPU burn. */
 html[data-renderer-inactive]
-  :where(.animate-spin, .animate-pulse, .workspace-status-dot-active) {
+  :where(
+    .animate-spin,
+    .animate-pulse,
+    .workspace-status-dot-active,
+    .heartbeat-dot,
+    .heartbeat-trace,
+    .subagent-connector-active::before,
+    .subagent-connector-elbow-active
+  ) {
   animation-play-state: paused !important;
 }
 

--- a/src/browser/terminal-window.tsx
+++ b/src/browser/terminal-window.tsx
@@ -5,6 +5,7 @@
  * Each window connects to a terminal session via WebSocket.
  */
 
+import { installInactiveAnimationPause } from "@/browser/utils/inactiveAnimations";
 import ReactDOM from "react-dom/client";
 import { TerminalView } from "@/browser/components/TerminalView/TerminalView";
 import { APIProvider, useAPI } from "@/browser/contexts/API";

--- a/src/browser/terminal-window.tsx
+++ b/src/browser/terminal-window.tsx
@@ -30,6 +30,12 @@ function TerminalWindowContent(props: { workspaceId: string; sessionId: string }
   );
 }
 
+try {
+  installInactiveAnimationPause();
+} catch {
+  // Animation throttling is an optimization and must never block renderer startup.
+}
+
 installWindowOpenLocalhostProxyNormalization();
 
 // Get workspace ID from query parameter

--- a/src/browser/utils/inactiveAnimations.test.ts
+++ b/src/browser/utils/inactiveAnimations.test.ts
@@ -1,0 +1,48 @@
+import "../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { installDom } from "../../../tests/ui/dom";
+import { installInactiveAnimationPause } from "./inactiveAnimations";
+
+describe("installInactiveAnimationPause", () => {
+  let cleanupDom: (() => void) | null = null;
+  let cleanupPause: (() => void) | null = null;
+  let focused = true;
+  let hidden = false;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+    focused = true;
+    hidden = false;
+    spyOn(document, "hasFocus").mockImplementation(() => focused);
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    });
+  });
+
+  afterEach(() => {
+    cleanupPause?.();
+    cleanupPause = null;
+    cleanupDom?.();
+    cleanupDom = null;
+    mock.restore();
+  });
+
+  test("tracks focus and visibility on the document root", () => {
+    cleanupPause = installInactiveAnimationPause();
+    expect(document.documentElement.hasAttribute("data-renderer-inactive")).toBe(false);
+
+    focused = false;
+    window.dispatchEvent(new window.Event("blur"));
+    expect(document.documentElement.hasAttribute("data-renderer-inactive")).toBe(true);
+
+    focused = true;
+    window.dispatchEvent(new window.Event("focus"));
+    expect(document.documentElement.hasAttribute("data-renderer-inactive")).toBe(false);
+
+    hidden = true;
+    document.dispatchEvent(new window.Event("visibilitychange"));
+    expect(document.documentElement.hasAttribute("data-renderer-inactive")).toBe(true);
+  });
+});

--- a/src/browser/utils/inactiveAnimations.ts
+++ b/src/browser/utils/inactiveAnimations.ts
@@ -1,0 +1,25 @@
+const INACTIVE_ANIMATIONS_ATTRIBUTE = "data-renderer-inactive";
+
+function syncInactiveAnimationState(): void {
+  const inactive = document.hidden || !document.hasFocus();
+  document.documentElement.toggleAttribute(INACTIVE_ANIMATIONS_ATTRIBUTE, inactive);
+}
+
+/**
+ * Pause continuous renderer animations while mux is hidden or unfocused.
+ * Chromium does not throttle an unfocused but still-visible Electron window,
+ * so leaving these running wastes CPU for background workspaces.
+ */
+export function installInactiveAnimationPause(): () => void {
+  syncInactiveAnimationState();
+
+  document.addEventListener("visibilitychange", syncInactiveAnimationState);
+  window.addEventListener("focus", syncInactiveAnimationState);
+  window.addEventListener("blur", syncInactiveAnimationState);
+
+  return () => {
+    document.removeEventListener("visibilitychange", syncInactiveAnimationState);
+    window.removeEventListener("focus", syncInactiveAnimationState);
+    window.removeEventListener("blur", syncInactiveAnimationState);
+  };
+}

--- a/src/common/types/bunTypes.d.ts
+++ b/src/common/types/bunTypes.d.ts
@@ -1,0 +1,2 @@
+// New native-preview releases require Bun's runtime declarations to be loaded explicitly.
+/// <reference types="bun" />

--- a/tests/testTypes.d.ts
+++ b/tests/testTypes.d.ts
@@ -1,0 +1,2 @@
+// New native-preview releases no longer loosely auto-load Jest's test environment.
+/// <reference types="jest" />

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -23,6 +23,9 @@
     "src/common/**/*"
   ],
   "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.testHarness.ts",
     "src/browser/**/*",
     "src/cli/debug/**/*",
     "src/node/builtinWorkflowActions/**/*",


### PR DESCRIPTION
## Summary

Reduces idle CPU usage in `make dev` by upgrading the native TypeScript watcher, removing main-thread SVG animation hotspots, and pausing persistent status animations while the Electron window is inactive.

## Background

The existing `@typescript/native-preview` watcher continuously consumed roughly 1.4 CPU cores after typechecking completed. Separately, six SVG spinners and persistent pulse animations forced about 119 style recalculations per second in the renderer. The renderer heap growth observed during the investigation remains out of scope for this PR.

## Implementation

- upgrades `@typescript/native-preview` from the December 2025 resolved build to `7.0.0-dev.20260707.2` and invokes its public `tsgo` binary
- explicitly loads Bun runtime and Jest test declarations required by the newer compiler
- excludes tests and test harnesses from the Electron main build config
- fixes the one newly reported production diagnostic in review hunk prewarming
- moves the measured todo/status spin transforms from Lucide SVGs to composited HTML wrappers
- pauses all renderer animation timelines, including pseudo-elements, while the window is hidden or unfocused

The compiler error matrix from the investigation was:

| configuration | old compiler | new compiler before declarations | new compiler after declarations |
| --- | ---: | ---: | ---: |
| `tsconfig.json` | 0 | 5630 | 1 |
| `tsconfig.main.json` | 0 | 1798 | 1 |

The declarations exposed pre-existing test-environment typing conflicts; separating Bun runtime declarations from Jest globals avoids those conflicts. The remaining production diagnostic was fixed directly.

## Validation

- `bun test src/browser/components/WorkspaceStatusIndicator/WorkspaceStatusIndicator.test.tsx src/browser/components/PinnedTodoList/PinnedTodoList.test.tsx src/browser/utils/inactiveAnimations.test.ts`
- `make typecheck`
- `make static-check`
- native watcher reached `Found 0 errors. Watching for file changes`; CPU-time delta measured over a 15-second idle window
- frozen install validated with Bun 1.3.5

## Risks

Low-to-moderate. The dependency upgrade changes a development-only compiler/watch process. The renderer changes preserve visible active animation behavior while moving transforms to compositor-friendly wrappers and pause animation timelines only while the window is inactive.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs= -->

