### PR TITLE
🤖 fix: refine ChatInput controls

### DIFF
--- a/src/browser/components/AgentModePicker/AgentModePicker.tsx
+++ b/src/browser/components/AgentModePicker/AgentModePicker.tsx
@@ -333,12 +333,13 @@ export const AgentModePicker: React.FC<AgentModePickerProps> = (props) => {
             }}
             style={activeStyle}
             className={cn(
-              "text-foreground border-border-light hover:bg-hover flex items-center gap-1.5 rounded-md border px-1.5 text-[11px] font-medium transition-[background-color] duration-150",
+              "text-foreground border-border-light hover:bg-hover flex items-center gap-1.5 rounded-md border px-1.5 text-[11px] font-medium transition-[background-color] duration-150 [&_svg]:size-2.5!",
               COMPOSER_CONTROL_HEIGHT_CLASS,
               activeClassName
             )}
           >
-            <TriggerIcon className="h-3 w-3 shrink-0" />
+            {/* Keep the mode glyph at the label's visual cap height so Exec reads as one aligned unit. */}
+            <TriggerIcon className="shrink-0" />
             {/* shrink-0 leaves iconOnlyHideClassName as the only thing that hides this label. Without
               it a tight row shrinks the label to a letter and an ellipsis instead. */}
             <span

--- a/src/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton.stories.tsx
+++ b/src/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton.stories.tsx
@@ -24,26 +24,6 @@ const CONTEXT_METER_DATA: TokenMeterData = {
   ],
 };
 
-const HOVER_SUMMARY_DATA: TokenMeterData = {
-  totalTokens: 130500,
-  maxTokens: 200000,
-  totalPercentage: 65.25,
-  segments: [
-    {
-      type: "input",
-      tokens: 128000,
-      percentage: 64,
-      color: TOKEN_COMPONENT_COLORS.input,
-    },
-    {
-      type: "output",
-      tokens: 2500,
-      percentage: 1.25,
-      color: TOKEN_COMPONENT_COLORS.output,
-    },
-  ],
-};
-
 const meta = {
   ...lightweightMeta,
   title: "App/Chat/Components/ContextUsageIndicator",
@@ -87,15 +67,10 @@ export const ContextMeterWithIdleCompaction: Story = {
   },
 };
 
-/**
- * Context meter hover summary tooltip.
- *
- * Captures the non-interactive one-line tooltip shown on hover so the quick
- * compaction stats remain visible even after controls moved to click-to-open.
- */
-export const ContextMeterHoverSummaryTooltip: Story = {
+/** The compact meter opens compaction settings directly without an overlapping hover tooltip. */
+export const ContextMeterOpensSettings: Story = {
   args: {
-    data: HOVER_SUMMARY_DATA,
+    data: CONTEXT_METER_DATA,
     autoCompaction: { threshold: 80, setThreshold: fn() },
     idleCompaction: { hours: 4, setHours: fn() },
   },
@@ -106,41 +81,13 @@ export const ContextMeterHoverSummaryTooltip: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const contextButton = await canvas.findByRole("button", { name: /context usage/i });
 
-    const contextButton = await waitFor(
-      () => canvas.getByRole("button", { name: /context usage/i }),
-      { interval: 50, timeout: 10000 }
-    );
+    await userEvent.click(contextButton);
 
-    await userEvent.hover(contextButton);
-
-    await waitFor(
-      () => {
-        const tooltip = document.querySelector('[role="tooltip"]');
-        if (!(tooltip instanceof HTMLElement)) {
-          throw new Error("Compaction hover summary tooltip not visible");
-        }
-
-        const text = tooltip.textContent ?? "";
-        if (!text.includes("Context ")) {
-          throw new Error("Expected context usage summary in tooltip");
-        }
-        if (!text.includes("Auto ")) {
-          throw new Error("Expected auto-compaction summary in tooltip");
-        }
-        if (!text.includes("Idle 4h")) {
-          throw new Error("Expected idle compaction summary in tooltip");
-        }
-      },
-      { interval: 50, timeout: 5000 }
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Captures the context usage hover summary tooltip with one-line stats for context, auto-compaction threshold, and idle timer.",
-      },
-    },
+    await waitFor(() => {
+      const dialog = within(document.body).getByRole("dialog");
+      within(dialog).getByText("Compaction Settings");
+    });
   },
 };

--- a/src/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton.tsx
+++ b/src/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton.tsx
@@ -10,7 +10,6 @@ import { Switch } from "../Switch/Switch";
 import { formatTokens, type TokenMeterData } from "@/common/utils/tokens/tokenMeterUtils";
 import { cn } from "@/common/lib/utils";
 import { Toggle1MContext } from "../Toggle1MContext/Toggle1MContext";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip/Tooltip";
 import { COMPOSER_COMPACT_HIDE_CLASS, COMPOSER_CONTROL_HEIGHT_CLASS } from "@/constants/layout";
 
 /** Compact threshold tick mark for the button view */
@@ -207,96 +206,62 @@ export const ContextUsageIndicatorButton: React.FC<ContextUsageIndicatorButtonPr
     ? `${Math.round(data.totalPercentage)}%`
     : formatTokens(data.totalTokens);
 
-  const hoverUsageSummary = data.maxTokens
-    ? `Context ${formatTokens(data.totalTokens)} / ${formatTokens(data.maxTokens)} (${data.totalPercentage.toFixed(1)}%)`
-    : `Context ${formatTokens(data.totalTokens)} (unknown limit)`;
-  const hoverAutoSummary = autoCompaction
-    ? autoCompaction.threshold < 100
-      ? `Auto ${autoCompaction.threshold}%`
-      : "Auto off"
-    : null;
-  const hoverIdleSummary = idleCompaction
-    ? isIdleCompactionEnabled
-      ? `Idle ${idleHours}h`
-      : "Idle off"
-    : null;
-  const hoverSummary = [hoverUsageSummary, hoverAutoSummary, hoverIdleSummary]
-    .filter((part): part is string => part !== null)
-    .join(" · ");
-
   return (
     <Dialog>
-      {/*
-        Keep a hover-only one-line summary so users can quickly see compaction stats
-        without reopening the full click-based settings dialog.
-      */}
-      <Tooltip delayDuration={200} disableHoverableContent>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <button
-              aria-label={ariaLabel}
-              aria-haspopup="dialog"
-              className={cn(
-                "border-border-light hover:bg-hover focus-visible:ring-accent flex cursor-pointer items-center gap-1.5 rounded-md border px-1.5 focus-visible:ring-1",
-                COMPOSER_CONTROL_HEIGHT_CLASS
-              )}
-              type="button"
+      <DialogTrigger asChild>
+        <button
+          aria-label={ariaLabel}
+          aria-haspopup="dialog"
+          className={cn(
+            "border-border-light hover:bg-hover focus-visible:ring-accent flex cursor-pointer items-center gap-1.5 rounded-md border px-1.5 focus-visible:ring-1",
+            COMPOSER_CONTROL_HEIGHT_CLASS
+          )}
+          type="button"
+        >
+          {/* Keep this control scannable: usage is already conveyed by the meter + percentage, and
+            click opens the detailed compaction settings without a competing hover interaction. */}
+          {isIdleCompactionEnabled && (
+            <span className={COMPOSER_COMPACT_HIDE_CLASS}>
+              <Hourglass className="text-muted h-3 w-3" />
+            </span>
+          )}
+
+          {/* Narrow composers keep the percentage only: a 56px meter reads as an empty bar at
+            low usage while starving the model and agent labels next to it. */}
+          {data.totalTokens > 0 ? (
+            <div
+              data-context-usage-meter
+              className={cn("relative h-3 w-14", COMPOSER_COMPACT_HIDE_CLASS)}
             >
-              {/* Idle compaction indicator */}
-              {isIdleCompactionEnabled && (
-                <span
-                  title={`Auto-compact after ${idleHours}h idle`}
-                  className={COMPOSER_COMPACT_HIDE_CLASS}
-                >
-                  <Hourglass className="text-muted h-3 w-3" />
-                </span>
+              <TokenMeter
+                segments={data.segments}
+                orientation="horizontal"
+                className="h-3"
+                trackClassName="bg-surface-quaternary"
+              />
+              {isAutoCompactionEnabled && (
+                <CompactThresholdIndicator threshold={autoCompaction.threshold} />
               )}
-
-              <span className={cn("text-muted text-[11px]", COMPOSER_COMPACT_HIDE_CLASS)}>
-                Context
-              </span>
-
-              {/* Narrow composers keep the percentage only: a 56px meter reads as an empty bar at
-                low usage while starving the model and agent labels next to it. */}
-              {data.totalTokens > 0 ? (
-                <div
-                  data-context-usage-meter
-                  className={cn("relative h-3 w-14", COMPOSER_COMPACT_HIDE_CLASS)}
-                >
-                  <TokenMeter
-                    segments={data.segments}
-                    orientation="horizontal"
-                    className="h-3"
-                    trackClassName="bg-surface-quaternary"
-                  />
-                  {isAutoCompactionEnabled && (
-                    <CompactThresholdIndicator threshold={autoCompaction.threshold} />
-                  )}
-                </div>
-              ) : (
-                /* Empty meter placeholder - allows access to settings with no usage */
-                <div
-                  data-context-usage-meter
-                  className={cn(
-                    "bg-surface-quaternary relative h-3 w-14 rounded-full",
-                    COMPOSER_COMPACT_HIDE_CLASS
-                  )}
-                />
+            </div>
+          ) : (
+            /* Empty meter placeholder - allows access to settings with no usage */
+            <div
+              data-context-usage-meter
+              className={cn(
+                "bg-surface-quaternary relative h-3 w-14 rounded-full",
+                COMPOSER_COMPACT_HIDE_CLASS
               )}
+            />
+          )}
 
-              <span
-                data-context-usage-percent
-                className="text-muted counter-nums text-[10px] font-medium"
-              >
-                {compactLabel}
-              </span>
-            </button>
-          </DialogTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="top" showArrow={false} className="whitespace-nowrap">
-          {hoverSummary}
-        </TooltipContent>
-      </Tooltip>
+          <span
+            data-context-usage-percent
+            className="text-muted counter-nums text-[10px] font-medium"
+          >
+            {compactLabel}
+          </span>
+        </button>
+      </DialogTrigger>
 
       {/*
         Keep compaction controls in a dialog so auto + idle settings stay open

--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -27,6 +27,7 @@ import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { formatModelDisplayName } from "@/common/utils/ai/modelDisplay";
 import { formatProviderDisplayName } from "@/common/utils/providers/customProviders";
 import {
+  formatCompactModelStringForDisplay,
   formatModelStringForDisplay,
   getExplicitGatewayPrefix,
   getModelName,
@@ -287,6 +288,9 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
     const displayValue = hasValue
       ? formatModelStringForDisplay(canonicalValue)
       : (emptyLabel ?? "");
+    const compactDisplayValue = hasValue
+      ? formatCompactModelStringForDisplay(canonicalValue)
+      : displayValue;
 
     // Explicit gateway selections short-circuit route resolution: the user
     // intentionally pinned a gateway, so display that gateway directly instead
@@ -322,7 +326,24 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
                     className="h-3 w-3 shrink-0 opacity-70"
                   />
                 )}
-                <span className="min-w-0 truncate">{displayValue}</span>
+                {compactDisplayValue === displayValue ? (
+                  <span className="min-w-0 truncate">{displayValue}</span>
+                ) : (
+                  <>
+                    <span
+                      data-model-label="full"
+                      className="min-w-0 truncate [@container(max-width:500px)]:hidden"
+                    >
+                      {displayValue}
+                    </span>
+                    <span
+                      data-model-label="compact"
+                      className="hidden min-w-0 truncate [@container(max-width:500px)]:block"
+                    >
+                      {compactDisplayValue}
+                    </span>
+                  </>
+                )}
               </span>
               <ChevronDown
                 className={cn(

--- a/src/browser/features/ChatInput/ChatInput.stories.tsx
+++ b/src/browser/features/ChatInput/ChatInput.stories.tsx
@@ -165,6 +165,25 @@ export const NarrowControlRowCollapse: AppStory = {
       }
     };
 
+    const fullModelLabel = storyRoot.querySelector<HTMLElement>('[data-model-label="full"]');
+    const compactModelLabel = storyRoot.querySelector<HTMLElement>('[data-model-label="compact"]');
+    if (!fullModelLabel || !compactModelLabel) {
+      throw new Error("Responsive model labels not rendered");
+    }
+    const assertCompactModelLabel = () => {
+      if (fullModelLabel.getBoundingClientRect().width > 0) {
+        throw new Error("Full GPT family label should hide on a constrained composer row");
+      }
+      if (compactModelLabel.getBoundingClientRect().width === 0) {
+        throw new Error("Compact model tier should be visible on a constrained composer row");
+      }
+      if (compactModelLabel.innerText.trim() !== "Sol") {
+        throw new Error(
+          `Expected constrained GPT tier label "Sol", got "${compactModelLabel.innerText}"`
+        );
+      }
+    };
+
     await resizeRowInto(400, 300, 341);
     await waitFor(() => {
       if (agentTrigger.innerText.trim() !== "") {
@@ -177,6 +196,7 @@ export const NarrowControlRowCollapse: AppStory = {
       }
       if (meterVisible()) throw new Error("Context meter should be hidden on an icon-only row");
       if (proVisible()) throw new Error("PRO chip should be hidden on the tightest row");
+      assertCompactModelLabel();
       assertNoOverflow("tightest");
     });
 
@@ -188,6 +208,7 @@ export const NarrowControlRowCollapse: AppStory = {
         );
       }
       if (!proVisible()) throw new Error("PRO chip should return once the row clears 340px");
+      assertCompactModelLabel();
       assertNoOverflow("pro-returns");
     });
 
@@ -201,6 +222,7 @@ export const NarrowControlRowCollapse: AppStory = {
         );
       }
       assertNoOverflow("phone-width");
+      assertCompactModelLabel();
 
       const modelName = storyRoot.querySelector<HTMLElement>(
         '[data-component="ModelSelectorGroup"] button span'
@@ -225,18 +247,25 @@ export const NarrowControlRowCollapse: AppStory = {
       }
       if (meterVisible()) throw new Error("Context meter should stay hidden at or below 500px");
       if (!proVisible()) throw new Error("PRO chip should stay visible above 340px");
+      assertCompactModelLabel();
       assertNoOverflow("agent-label-returns");
     });
 
     await resizeRowInto(640, 505, 1200);
     await waitFor(() => {
-      if (!contextTrigger.innerText.includes("Context")) {
+      if (!/^\d+%$/.test(contextTrigger.innerText.trim())) {
         throw new Error(
-          `Context pill should regain its label above 500px, showing "${contextTrigger.innerText}"`
+          `Context control should keep its concise percentage label, showing "${contextTrigger.innerText}"`
         );
       }
       if (!meterVisible()) throw new Error("Context meter should be visible above 500px");
       assertNoOverflow("full-detail");
+      if (fullModelLabel.getBoundingClientRect().width === 0) {
+        throw new Error("Full model label should return once the composer row clears 500px");
+      }
+      if (compactModelLabel.getBoundingClientRect().width > 0) {
+        throw new Error("Compact model label should hide once the full label has room");
+      }
 
       // Checked here rather than on a narrow row because a narrow row is under flex-shrink pressure,
       // which trims a fixed width down to roughly its content width and hides the difference. With

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -3532,7 +3532,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                 </div>
 
                 <div
-                  className="flex shrink-0 items-center justify-end gap-1.5"
+                  className="flex shrink-0 items-center justify-end gap-1"
                   data-component="ModelControls"
                 >
                   {/* Attach and voice sit below the textarea rather than in an absolute overlay so
@@ -3580,7 +3580,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                           size="xs"
                           variant="ghost"
                           className={cn(
-                            "inline-flex h-8 w-8 items-center justify-center rounded-full p-0 font-medium transition-colors duration-200",
+                            // Keep the filled action compact so it reads as an icon button, not a
+                            // second bordered control competing with the picker groups.
+                            "inline-flex h-7 w-7 items-center justify-center rounded-full p-0 font-medium transition-colors duration-200",
                             // Pin text colors because the ghost variant otherwise overrides the glyph.
                             canSend
                               ? "bg-composer-send hover:bg-composer-send text-composer-send-foreground hover:text-composer-send-foreground hover:opacity-90"
@@ -3588,7 +3590,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                             "[@media(hover:none)_and_(pointer:coarse)]:h-9 [@media(hover:none)_and_(pointer:coarse)]:w-9 [@media(hover:none)_and_(pointer:coarse)]:text-sm"
                           )}
                         >
-                          <SendHorizontal className="h-4 w-4" strokeWidth={2.5} />
+                          <SendHorizontal className="h-3.5 w-3.5" strokeWidth={2.5} />
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent align="start" className="max-w-80 whitespace-normal">

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -65,9 +65,11 @@
     --color-ask-mode-light: hsl(246 100% 85%);
     --color-ask-mode-alpha: hsla(246 100% 68% / 0.1);
 
-    --color-exec-mode: hsl(268.56 94.04% 55.19%);
-    --color-exec-mode-hover: hsl(268.56 94.04% 67%);
-    --color-exec-mode-light: hsl(268.56 94.04% 78%);
+    /* Preserve the prior purple hue, but raise its lightness so the Exec label stays legible on the
+      redesigned dark composer surface. */
+    --color-exec-mode: hsl(268.56 90% 68%);
+    --color-exec-mode-hover: hsl(268.56 90% 75%);
+    --color-exec-mode-light: hsl(268.56 90% 82%);
 
     /* Edit mode: amber/gold for editing warnings and barriers */
     --color-edit-mode: hsl(38 80% 45%);

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -65,9 +65,9 @@
     --color-ask-mode-light: hsl(246 100% 85%);
     --color-ask-mode-alpha: hsla(246 100% 68% / 0.1);
 
-    --color-exec-mode: hsl(187.7 75% 79.6%);
-    --color-exec-mode-hover: hsl(187.7 75% 88%);
-    --color-exec-mode-light: hsl(187.7 75% 93%);
+    --color-exec-mode: hsl(268.56 94.04% 55.19%);
+    --color-exec-mode-hover: hsl(268.56 94.04% 67%);
+    --color-exec-mode-light: hsl(268.56 94.04% 78%);
 
     /* Edit mode: amber/gold for editing warnings and barriers */
     --color-edit-mode: hsl(38 80% 45%);
@@ -372,10 +372,9 @@
   --color-ask-mode-light: hsl(246 100% 85%);
   --color-ask-mode-alpha: hsla(246 100% 68% / 0.08);
 
-  /* Same hue as the dark-theme teal, darkened: that pale value fails contrast on white. */
-  --color-exec-mode: hsl(187.7 75% 30%);
-  --color-exec-mode-hover: hsl(187.7 75% 38%);
-  --color-exec-mode-light: hsl(187.7 75% 48%);
+  --color-exec-mode: hsl(268.56 94.04% 55.19%);
+  --color-exec-mode-hover: hsl(268.56 94.04% 67%);
+  --color-exec-mode-light: hsl(268.56 94.04% 78%);
 
   --color-pending: hsl(30 100% 64%);
 
@@ -619,14 +618,12 @@
   --color-plan-mode-light: color-mix(in srgb, var(--color-plan-mode), white 42%);
   --color-plan-mode-alpha: hsl(from var(--color-plan-mode) h s l / 0.08);
 
-  /* Literal purple rather than var(--color-exec-mode): keeps Ask distinct from plan blue. */
-  --color-ask-mode: color-mix(in srgb, #5e409d 62%, var(--color-plan-mode)); /* Flexoki purple-600 */
+  --color-ask-mode: color-mix(in srgb, var(--color-exec-mode) 62%, var(--color-plan-mode)); /* Blend between plan and exec */
   --color-ask-mode-hover: color-mix(in srgb, var(--color-ask-mode), white 18%);
   --color-ask-mode-light: color-mix(in srgb, var(--color-ask-mode), white 42%);
   --color-ask-mode-alpha: hsl(from var(--color-ask-mode) h s l / 0.08);
 
-  /* Not the canonical cyan-600 for light themes: --color-task-mode already uses that step. */
-  --color-exec-mode: #164f4a; /* Flexoki cyan-800 */
+  --color-exec-mode: #5e409d; /* Flexoki purple-600 */
   --color-exec-mode-hover: color-mix(in srgb, var(--color-exec-mode), white 18%);
   --color-exec-mode-light: color-mix(in srgb, var(--color-exec-mode), white 42%);
 
@@ -855,14 +852,12 @@
   --color-plan-mode-light: color-mix(in srgb, var(--color-plan-mode), white 22%);
   --color-plan-mode-alpha: hsl(from var(--color-plan-mode) h s l / 0.12);
 
-  /* Literal purple rather than var(--color-exec-mode): keeps Ask distinct from plan blue. */
-  --color-ask-mode: color-mix(in srgb, #8b7ec8 62%, var(--color-plan-mode)); /* Flexoki purple-400 */
+  --color-ask-mode: color-mix(in srgb, var(--color-exec-mode) 62%, var(--color-plan-mode)); /* Blend between plan and exec */
   --color-ask-mode-hover: color-mix(in srgb, var(--color-ask-mode), white 10%);
   --color-ask-mode-light: color-mix(in srgb, var(--color-ask-mode), white 22%);
   --color-ask-mode-alpha: hsl(from var(--color-ask-mode) h s l / 0.12);
 
-  /* Not the canonical cyan-400 for dark themes: --color-task-mode already uses that step. */
-  --color-exec-mode: #a2dece; /* Flexoki cyan-150 */
+  --color-exec-mode: #8b7ec8; /* Flexoki purple-400 */
   --color-exec-mode-hover: color-mix(in srgb, var(--color-exec-mode), white 10%);
   --color-exec-mode-light: color-mix(in srgb, var(--color-exec-mode), white 22%);
 

--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { formatModelDisplayName } from "./modelDisplay";
+import { formatCompactModelDisplayName, formatModelDisplayName } from "./modelDisplay";
+
+describe("formatCompactModelDisplayName", () => {
+  test("keeps the distinguishing GPT-5.6 tier in constrained labels", () => {
+    expect(formatCompactModelDisplayName("gpt-5.6-sol")).toBe("Sol");
+    expect(formatCompactModelDisplayName("gpt-5.6-terra-20260709")).toBe("Terra");
+    expect(formatCompactModelDisplayName("gpt-5.6-luna-2026-07-09")).toBe("Luna");
+  });
+
+  test("falls back to the full display name when no shorter label is clearer", () => {
+    expect(formatCompactModelDisplayName("claude-opus-5")).toBe("Opus 5");
+    expect(formatCompactModelDisplayName("gpt-5.3-codex-spark")).toBe("Spark 5.3");
+  });
+});
 
 describe("formatModelDisplayName", () => {
   describe("Claude models", () => {

--- a/src/common/utils/ai/modelDisplay.ts
+++ b/src/common/utils/ai/modelDisplay.ts
@@ -4,6 +4,20 @@
 
 import { capitalize } from "../capitalize";
 
+/** Compact labels preserve the distinguishing model tier when the shared family prefix would truncate it. */
+export function formatCompactModelDisplayName(modelName: string): string {
+  // GPT-5.6's durable tier name carries more information than the shared family prefix when the
+  // composer is space-constrained. Keep the full model name everywhere else.
+  const gptTierMatch = /^gpt-\d+(?:\.\d+)?-(sol|terra|luna)(?:-\d{8}|-\d{4}-\d{2}-\d{2})?$/.exec(
+    modelName.toLowerCase()
+  );
+  if (gptTierMatch) {
+    return capitalize(gptTierMatch[1]);
+  }
+
+  return formatModelDisplayName(modelName);
+}
+
 /**
  * Format a model name for display with proper capitalization and spacing.
  *

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -4,7 +4,7 @@
 
 import { DEFAULT_MODEL, MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 import { PROVIDER_DEFINITIONS, type ProviderName } from "@/common/constants/providers";
-import { formatModelDisplayName } from "./modelDisplay";
+import { formatCompactModelDisplayName, formatModelDisplayName } from "./modelDisplay";
 
 export const defaultModel = DEFAULT_MODEL;
 
@@ -135,6 +135,10 @@ export function getModelName(modelString: string): string {
  */
 export function formatModelStringForDisplay(modelString: string): string {
   return formatModelDisplayName(getModelName(modelString));
+}
+
+export function formatCompactModelStringForDisplay(modelString: string): string {
+  return formatCompactModelDisplayName(getModelName(modelString));
 }
 
 /**


### PR DESCRIPTION
## Summary

Refines the redesigned ChatInput controls so the composer is clearer and tighter across desktop and mobile: restores the prior Exec purple palette, reduces the send action and mode glyph, shows GPT-5.6 tier names such as `Sol` in constrained rows, and simplifies the context control to a meter plus percentage with a direct click-to-settings interaction.

## Implementation

- Restored the pre-redesign Exec color tokens across the default and Flexoki themes.
- Tightened the send-button cluster while preserving the larger touch target on coarse-pointer devices.
- Added responsive model labels so GPT-5.6 Sol/Terra/Luna retain their distinguishing tier name when space is constrained.
- Removed the redundant `Context` text and competing hover summary; clicking the meter continues to open compaction settings.
- Reduced the agent-mode glyph to align visually with its label.

## Validation

- `make static-check`
- `bun run typecheck`
- `bun test src/browser/components/AgentModePicker/AgentModePicker.test.tsx src/common/utils/ai/modelDisplay.test.ts src/common/utils/ai/models.test.ts`
- `bun x jest tests/ui/chat/composerControlFocus.test.ts --runInBand`
- Storybook interaction coverage for the ChatInput and phone viewport stories
- Playwright visual-contract check at 1200px and 390px for responsive model labels, context interaction, icon/send sizing, and overflow

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$10.87`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=10.87 -->
