### PR TITLE
🤖 fix: harmonize concurrent local agent warning

### DIFF
--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.stories.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.stories.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 import { ConcurrentLocalWarningDecoration } from "./ConcurrentLocalWarning.js";
@@ -12,11 +13,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const ComposerDecoration: Story = {
-  args: {
-    streamingWorkspaceName: "refactor-db",
-  },
-  render: (args) => (
+function renderComposerDecoration(args: ComponentProps<typeof ConcurrentLocalWarningDecoration>) {
+  return (
     <div className="bg-surface-primary text-light flex h-[360px] flex-col">
       <div className="min-h-0 flex-1 overflow-hidden p-4">
         <div className="mx-auto max-w-4xl space-y-4 text-sm">
@@ -38,13 +36,39 @@ export const ComposerDecoration: Story = {
         </div>
       </div>
     </div>
-  ),
+  );
+}
+
+export const ComposerDecoration: Story = {
+  args: {
+    streamingWorkspaceName: "refactor-db",
+  },
+  render: renderComposerDecoration,
   tags: ["concurrent-local-warning"],
   parameters: {
     docs: {
       description: {
         story:
           "Shows the concurrent local-agent warning pinned in the composer decoration lane, above the input and outside the transcript scroll flow.",
+      },
+    },
+  },
+};
+
+export const PhoneComposerDecoration: Story = {
+  args: {
+    streamingWorkspaceName: "long-running-local-agent",
+  },
+  render: renderComposerDecoration,
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: { matrix: { viewports: ["phone"] } },
+    docs: {
+      description: {
+        story:
+          "Pins the phone-width visual contract so the warning stays a single aligned decoration row without pushing the composer off-screen.",
       },
     },
   },

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+
+import { installDom } from "../../../../tests/ui/dom";
+import * as WorkspaceContextModule from "@/browser/contexts/WorkspaceContext";
+import type { WorkspaceContext } from "@/browser/contexts/WorkspaceContext";
+import * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
+import type { WorkspaceSidebarState, WorkspaceStore } from "@/browser/stores/WorkspaceStore";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { WORKSPACE_STREAMING_STATUS_TRANSITION_MS } from "@/constants/streaming";
+import { useConcurrentLocalStreamingWorkspaceName } from "./ConcurrentLocalWarning";
+
+const subscribers = new Set<() => void>();
+let canInterrupt = true;
+
+const fakeStore = {
+  subscribeKey: (_workspaceId: string, listener: () => void) => {
+    subscribers.add(listener);
+    return () => subscribers.delete(listener);
+  },
+  getWorkspaceSidebarState: () => {
+    const state: WorkspaceSidebarState = {
+      canInterrupt,
+      isStarting: false,
+      awaitingUserQuestion: false,
+      lastAbortReason: null,
+      currentModel: null,
+      pendingStreamModel: null,
+      recencyTimestamp: null,
+      loadedSkills: [],
+      skillLoadErrors: [],
+      agentStatus: undefined,
+      activeWorkflowRunCount: 0,
+      activeBashMonitorCount: 0,
+      terminalActiveCount: 0,
+      terminalSessionCount: 0,
+    };
+    return state;
+  },
+} as unknown as WorkspaceStore;
+
+const otherWorkspaceMetadata: FrontendWorkspaceMetadata = {
+  id: "other-workspace",
+  name: "refactor-db",
+  projectName: "mux",
+  projectPath: "/repo",
+  namedWorkspacePath: "/repo",
+  runtimeConfig: { type: "local" },
+};
+const workspaceMetadata = new Map([[otherWorkspaceMetadata.id, otherWorkspaceMetadata]]);
+
+function WarningNameProbe() {
+  const streamingWorkspaceName = useConcurrentLocalStreamingWorkspaceName({
+    workspaceId: "current-workspace",
+    projectPath: "/repo",
+    runtimeConfig: { type: "local" },
+  });
+
+  return streamingWorkspaceName === null ? null : <div>{streamingWorkspaceName}</div>;
+}
+
+function notifyWorkspaceStateChanged(): void {
+  for (const listener of subscribers) {
+    listener();
+  }
+}
+
+describe("ConcurrentLocalWarning", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+    subscribers.clear();
+    canInterrupt = true;
+    spyOn(WorkspaceStoreModule, "useWorkspaceStoreRaw").mockReturnValue(fakeStore);
+    spyOn(WorkspaceContextModule, "useWorkspaceContext").mockReturnValue({
+      workspaceMetadata,
+    } as WorkspaceContext);
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    cleanupDom?.();
+    cleanupDom = null;
+    subscribers.clear();
+  });
+
+  test("holds the warning across a brief activity handoff", async () => {
+    const result = render(<WarningNameProbe />);
+    expect(result.getByText("refactor-db")).toBeTruthy();
+
+    act(() => {
+      canInterrupt = false;
+      notifyWorkspaceStateChanged();
+    });
+
+    expect(result.getByText("refactor-db")).toBeTruthy();
+
+    await act(async () => {
+      await new Promise((resolve) =>
+        window.setTimeout(resolve, WORKSPACE_STREAMING_STATUS_TRANSITION_MS + 50)
+      );
+    });
+    await waitFor(() => expect(result.queryByText("refactor-db")).toBeNull());
+  });
+});

--- a/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
+++ b/src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useSyncExternalStore } from "react";
+import React, { useMemo, useRef, useSyncExternalStore } from "react";
 import { AlertTriangle } from "lucide-react";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import { useWorkspaceStreamingStatusPhase } from "@/browser/hooks/useWorkspaceStreamingStatusPhase";
 import { CHAT_DOCK_GUTTER_CLASS } from "@/constants/layout";
 import { useChatDockColumnWidthClass } from "@/browser/components/ChatPane/chatDockColumn";
 import { cn } from "@/common/lib/utils";
@@ -46,7 +47,7 @@ export function useConcurrentLocalStreamingWorkspaceName(
     return result;
   }, [isLocalProject, props.projectPath, props.workspaceId, workspaceMetadata]);
 
-  return useSyncExternalStore(
+  const streamingWorkspaceName = useSyncExternalStore(
     (listener) => {
       const unsubscribers = otherLocalWorkspaceIds.map((id) => store.subscribeKey(id, listener));
       return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
@@ -67,6 +68,18 @@ export function useConcurrentLocalStreamingWorkspaceName(
     },
     () => null
   );
+  const lastStreamingWorkspaceNameRef = useRef(streamingWorkspaceName);
+  if (streamingWorkspaceName !== null) {
+    lastStreamingWorkspaceNameRef.current = streamingWorkspaceName;
+  }
+  const { displayPhase } = useWorkspaceStreamingStatusPhase(
+    streamingWorkspaceName === null ? null : "streaming"
+  );
+
+  // Activity snapshots can hand off through a brief idle frame between adjacent stream phases.
+  // Hold the last concrete workspace name for the same transition window used by sidebar status,
+  // so the warning does not blink while the underlying agent is still visibly working elsewhere.
+  return displayPhase === null ? null : lastStreamingWorkspaceNameRef.current;
 }
 
 interface ConcurrentLocalWarningViewProps {
@@ -76,10 +89,15 @@ interface ConcurrentLocalWarningViewProps {
 
 export const ConcurrentLocalWarningView: React.FC<ConcurrentLocalWarningViewProps> = (props) => {
   return (
-    <div className={cn("text-center text-xs text-yellow-600/80", props.className)}>
-      <AlertTriangle aria-hidden="true" className="mr-1 inline-block h-3 w-3 align-[-2px]" />
-      <span className="text-yellow-500">{props.streamingWorkspaceName}</span> is also running in
-      this project directory — agents may interfere
+    <div
+      role="status"
+      className={cn("text-muted flex h-6 items-center gap-2 text-xs leading-none", props.className)}
+    >
+      <AlertTriangle aria-hidden="true" className="text-warning size-3.5 shrink-0" />
+      <span className="min-w-0 truncate">
+        <span className="text-foreground font-medium">{props.streamingWorkspaceName}</span> is also
+        running in this project directory — agents may interfere
+      </span>
     </div>
   );
 };
@@ -90,7 +108,10 @@ export const ConcurrentLocalWarningDecoration: React.FC<ConcurrentLocalWarningVi
   const columnWidthClass = useChatDockColumnWidthClass();
 
   return (
-    <div className={cn("bg-surface-primary py-1.5", CHAT_DOCK_GUTTER_CLASS)}>
+    <div
+      className={cn("bg-surface-primary", CHAT_DOCK_GUTTER_CLASS)}
+      data-component="ConcurrentLocalWarningDecoration"
+    >
       <ConcurrentLocalWarningView
         streamingWorkspaceName={props.streamingWorkspaceName}
         className={cn(columnWidthClass, props.className)}


### PR DESCRIPTION
## Summary

Restyles the concurrent local-agent warning as a standard composer decoration row and keeps it mounted across brief activity-state handoffs, reducing visual mismatch and flicker.

## Implementation

- aligns icon, height, spacing, typography, color tokens, and transcript-column width with neighboring composer decorations
- truncates the warning cleanly at phone widths instead of wrapping or overflowing
- reuses the existing streaming-status transition hold so transient idle snapshots do not blink the warning
- adds a behavioral regression test and a Pixel-pinned phone story

## Validation

- `bun test src/browser/components/ConcurrentLocalWarning/ConcurrentLocalWarning.test.tsx`
- `make typecheck`
- `make static-check`
- visually inspected Storybook at 1200px and 390px widths

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$7.99`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=7.99 -->
