### PR TITLE
🤖 perf: fix recent visual regressions

### DIFF
--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -13,8 +13,8 @@ import { isMultiProject } from "@/common/utils/multiProject";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import {
   useWorkspaceLastUserPrompt,
+  useWorkspaceRoundedStreamingTps,
   useWorkspaceSidebarState,
-  useWorkspaceStreamingStats,
   useWorkspaceUsage,
 } from "@/browser/stores/WorkspaceStore";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
@@ -182,10 +182,10 @@ function FooterProjectLabel(props: { projectLabel: string }) {
 /** Subscribe at the leaf so streaming deltas do not re-render the transcript subtree. */
 function FooterUsageStats(props: { workspaceId: string }) {
   const usage = useWorkspaceUsage(props.workspaceId);
-  const streamingStats = useWorkspaceStreamingStats(props.workspaceId);
+  // Chrome only paints a rounded value; keep identical provider chunks from committing/layouting it.
+  const roundedTps = useWorkspaceRoundedStreamingTps(props.workspaceId);
 
-  const showTps = streamingStats !== null && streamingStats.tps > 0;
-  if (usage.totalTokens <= 0 && !showTps) {
+  if (usage.totalTokens <= 0 && roundedTps === null) {
     return null;
   }
 
@@ -194,9 +194,9 @@ function FooterUsageStats(props: { workspaceId: string }) {
       <span className="text-foreground counter-nums">
         {formatTokens(usage.totalTokens)} <span className="text-muted">tok</span>
       </span>
-      {showTps && (
+      {roundedTps !== null && (
         <span className="text-foreground counter-nums">
-          {Math.round(streamingStats.tps)} <span className="text-muted">t/s</span>
+          {roundedTps} <span className="text-muted">t/s</span>
         </span>
       )}
     </span>

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/browser/contexts/WorkspaceContext";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import {
-  showAllMessages,
+  pinTimelineRevealTarget,
   useWorkspaceStoreRaw,
   useWorkspaceTimeline,
   type HistoryLoadResult,
@@ -496,9 +496,9 @@ function TimelinePreviewCard(props: {
         return;
       }
 
-      // Expanding the display cap can make an already-loaded target renderable, so re-resolve before
-      // paging history: otherwise a target hidden only by the cap reports "Too far back".
-      showAllMessages(props.workspaceId);
+      // Keep only the reveal target outside the normal transcript window. Disabling the cap here
+      // would leave every historical row mounted for the rest of the workspace session.
+      pinTimelineRevealTarget(props.workspaceId, target);
       target = resolveRevealTarget(anchor);
       if (isRevealTargetLoaded(target)) {
         dispatchReveal(target);

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -496,9 +496,11 @@ function TimelinePreviewCard(props: {
         return;
       }
 
-      // Keep only the reveal target outside the normal transcript window. Disabling the cap here
-      // would leave every historical row mounted for the rest of the workspace session.
-      pinTimelineRevealTarget(props.workspaceId, target);
+      // Keep only a resolved reveal target outside the normal transcript window. A sequence-only
+      // anchor may need history paging before it has an ID, so do not reject it before that loop.
+      if (target.messageId != null || target.toolCallId != null) {
+        pinTimelineRevealTarget(props.workspaceId, target);
+      }
       target = resolveRevealTarget(anchor);
       if (isRevealTargetLoaded(target)) {
         dispatchReveal(target);
@@ -522,6 +524,9 @@ function TimelinePreviewCard(props: {
         }
 
         target = resolveRevealTarget(anchor);
+        if (target.messageId != null || target.toolCallId != null) {
+          pinTimelineRevealTarget(props.workspaceId, target);
+        }
         if (isRevealTargetLoaded(target)) {
           dispatchReveal(target);
           setRevealState("idle");

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5808,6 +5808,15 @@ describe("WorkspaceStore", () => {
       ]);
     });
 
+    it("normalizes queued live batches that arrive oldest-first", () => {
+      const queuedLive = [event(5), event(6)];
+      const retained = [event(4), event(3), event(2)];
+
+      expect(mergeTimelineEvents(queuedLive, retained).map((item) => item.seq)).toEqual([
+        6, 5, 4, 3, 2,
+      ]);
+    });
+
     it("appends older pages without reordering retained history", () => {
       const retained = [event(6), event(5), event(4)];
       const older = [event(3), event(2)];

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -26,7 +26,7 @@ import {
 } from "@/common/constants/storage";
 import type { TodoItem } from "@/common/types/tools";
 import { buildStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
-import { WorkspaceStore } from "./WorkspaceStore";
+import { mergeTimelineEvents, WorkspaceStore } from "./WorkspaceStore";
 import type { ResponseCompleteEvent } from "@/browser/utils/messages/responseCompletionMetadata";
 
 interface LoadMoreResponse {
@@ -5789,6 +5789,39 @@ describe("WorkspaceStore", () => {
     });
   });
 
+  describe("mergeTimelineEvents", () => {
+    const event = (seq: number) => ({
+      v: 1 as const,
+      seq,
+      id: `event-${seq}`,
+      ts: seq,
+      kind: "turn.completed",
+      source: { system: "workspace" as const },
+    });
+
+    it("prepends newer live batches without reordering retained history", () => {
+      const newest = [event(6), event(5)];
+      const retained = [event(4), event(3), event(2)];
+
+      expect(mergeTimelineEvents(newest, retained).map((item) => item.seq)).toEqual([
+        6, 5, 4, 3, 2,
+      ]);
+    });
+
+    it("appends older pages without reordering retained history", () => {
+      const retained = [event(6), event(5), event(4)];
+      const older = [event(3), event(2)];
+
+      expect(mergeTimelineEvents(retained, older).map((item) => item.seq)).toEqual([6, 5, 4, 3, 2]);
+    });
+
+    it("falls back to dedupe and ordering for overlapping batches", () => {
+      expect(
+        mergeTimelineEvents([event(5), event(3)], [event(4), event(3)]).map((item) => item.seq)
+      ).toEqual([5, 4, 3]);
+    });
+  });
+
   describe("getWorkspaceLastUserPrompt", () => {
     const seedUserMessages = (workspaceId: string, rows: Array<{ id: string; text: string }>) => {
       const rawStore = getInternal<{
@@ -5858,6 +5891,39 @@ describe("WorkspaceStore", () => {
       seedUserMessages(workspaceId, [{ id: "u1", text: "" }]);
 
       expect(store.getWorkspaceLastUserPrompt(workspaceId)).toBeNull();
+    });
+
+    it("does not invalidate the footer prompt projection for assistant stream deltas", () => {
+      const workspaceId = "last-prompt-stream-deltas";
+      createAndAddWorkspace(store, workspaceId);
+      seedUserMessages(workspaceId, [{ id: "u1", text: "first prompt" }]);
+      const listener = mock(() => undefined);
+      const unsubscribe = store.subscribeLastUserPrompt(workspaceId, listener);
+      const snapshot = store.getWorkspaceLastUserPromptSnapshot(workspaceId);
+
+      const rawStore = getInternal<{
+        handleChatMessage: (workspaceId: string, data: WorkspaceChatMessage) => void;
+      }>(store);
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: "assistant-1",
+        model: "claude-haiku-3.5",
+        historySequence: 2,
+        startTime: 2_000,
+      });
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-delta",
+        workspaceId,
+        messageId: "assistant-1",
+        delta: "working",
+        tokens: 2,
+        timestamp: 2_100,
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(store.getWorkspaceLastUserPromptSnapshot(workspaceId)).toBe(snapshot);
+      unsubscribe();
     });
 
     it("holds the history epoch steady while messages stream in", () => {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -102,23 +102,33 @@ export function mergeTimelineEvents(
   fallback: TimelineEvent[]
 ): TimelineEvent[] {
   if (preferred.length === 0) return fallback;
-  if (fallback.length === 0) return preferred;
+  if (fallback.length === 0) {
+    return preferred.every((event, index) => index === 0 || preferred[index - 1].seq > event.seq)
+      ? preferred
+      : preferred.toSorted((a, b) => b.seq - a.seq);
+  }
 
-  // Timeline pages and live batches are already newest-first. Keep the common non-overlapping paths
-  // linear and allocation-light instead of rebuilding an ID set and sorting the whole retained feed.
-  const preferredOldest = preferred[preferred.length - 1];
+  // Pages are newest-first, but live events queued while the initial snapshot is built can arrive as
+  // one oldest-first batch. Normalize only that uncommon case before taking the linear fast paths.
+  const orderedPreferred = preferred.every(
+    (event, index) => index === 0 || preferred[index - 1].seq > event.seq
+  )
+    ? preferred
+    : preferred.toSorted((a, b) => b.seq - a.seq);
+
+  const preferredOldest = orderedPreferred[orderedPreferred.length - 1];
   const fallbackNewest = fallback[0];
   if (preferredOldest && fallbackNewest && preferredOldest.seq > fallbackNewest.seq) {
-    return [...preferred, ...fallback];
+    return [...orderedPreferred, ...fallback];
   }
   const fallbackOldest = fallback[fallback.length - 1];
-  const preferredNewest = preferred[0];
+  const preferredNewest = orderedPreferred[0];
   if (fallbackOldest && preferredNewest && fallbackOldest.seq > preferredNewest.seq) {
-    return [...fallback, ...preferred];
+    return [...fallback, ...orderedPreferred];
   }
 
-  const preferredIds = new Set(preferred.map((event) => event.id));
-  return [...preferred, ...fallback.filter((event) => !preferredIds.has(event.id))].toSorted(
+  const preferredIds = new Set(orderedPreferred.map((event) => event.id));
+  return [...orderedPreferred, ...fallback.filter((event) => !preferredIds.has(event.id))].toSorted(
     (a, b) => b.seq - a.seq
   );
 }

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -97,14 +97,36 @@ import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessage
 /** Stable empty reference returned when a workspace has no assisted hunks; keeps useSyncExternalStore snapshot identity stable. */
 const EMPTY_ASSISTED_REVIEW: AssistedReviewHunk[] = [];
 
-function mergeTimelineEvents(
+export function mergeTimelineEvents(
   preferred: TimelineEvent[],
   fallback: TimelineEvent[]
 ): TimelineEvent[] {
+  if (preferred.length === 0) return fallback;
+  if (fallback.length === 0) return preferred;
+
+  // Timeline pages and live batches are already newest-first. Keep the common non-overlapping paths
+  // linear and allocation-light instead of rebuilding an ID set and sorting the whole retained feed.
+  const preferredOldest = preferred[preferred.length - 1];
+  const fallbackNewest = fallback[0];
+  if (preferredOldest && fallbackNewest && preferredOldest.seq > fallbackNewest.seq) {
+    return [...preferred, ...fallback];
+  }
+  const fallbackOldest = fallback[fallback.length - 1];
+  const preferredNewest = preferred[0];
+  if (fallbackOldest && preferredNewest && fallbackOldest.seq > preferredNewest.seq) {
+    return [...fallback, ...preferred];
+  }
+
   const preferredIds = new Set(preferred.map((event) => event.id));
   return [...preferred, ...fallback.filter((event) => !preferredIds.has(event.id))].toSorted(
     (a, b) => b.seq - a.seq
   );
+}
+
+interface WorkspaceLastUserPromptSnapshot {
+  displayed: string | null;
+  historyEpoch: number;
+  isCaughtUp: boolean;
 }
 
 export interface WorkspaceTimelineSnapshot {
@@ -656,6 +678,9 @@ export class WorkspaceStore {
 
   // Derived aggregate state (computed from multiple workspaces)
   private derived = new MapStore<string, DerivedState>();
+
+  // The footer's last-prompt projection changes only on transcript/history mutations, not deltas.
+  private lastUserPromptStore = new MapStore<string, WorkspaceLastUserPromptSnapshot>();
 
   // Usage and consumer stores (two-store approach for CostsTab optimization)
   private usageStore = new MapStore<string, WorkspaceUsageState>();
@@ -1455,6 +1480,7 @@ export class WorkspaceStore {
     transient.replayingHistory = false;
     transient.historicalMessages.length = 0;
     transient.pendingStreamEvents.length = 0;
+    this.lastUserPromptStore.bump(workspaceId);
   }
 
   private ensureActiveOnChatSubscription(): void {
@@ -1629,6 +1655,11 @@ export class WorkspaceStore {
       const charsPerSec = tps * APPROX_CHARS_PER_TOKEN;
       return { tokenCount, tps, charsPerSec };
     });
+  }
+
+  getWorkspaceRoundedStreamingTps(workspaceId: string): number | null {
+    const stats = this.getWorkspaceStreamingStats(workspaceId);
+    return stats != null && stats.tps > 0 ? Math.round(stats.tps) : null;
   }
 
   subscribeStreamingStats(workspaceId: string, listener: () => void): () => void {
@@ -2472,6 +2503,9 @@ export class WorkspaceStore {
         hasOlder: result.hasOlder,
         loading: false,
       });
+      if (historicalMessages.length > 0) {
+        this.lastUserPromptStore.bump(workspaceId);
+      }
       return "loaded";
     } catch (error) {
       console.error(`[WorkspaceStore] Failed to load older history for ${workspaceId}:`, error);
@@ -2574,6 +2608,18 @@ export class WorkspaceStore {
     }
 
     return null;
+  }
+
+  getWorkspaceLastUserPromptSnapshot(workspaceId: string): WorkspaceLastUserPromptSnapshot {
+    return this.lastUserPromptStore.get(workspaceId, () => ({
+      displayed: this.getWorkspaceLastUserPrompt(workspaceId),
+      historyEpoch: this.getWorkspaceHistoryEpoch(workspaceId),
+      isCaughtUp: this.isWorkspaceTranscriptCaughtUp(workspaceId),
+    }));
+  }
+
+  subscribeLastUserPrompt(workspaceId: string, listener: () => void): () => void {
+    return this.lastUserPromptStore.subscribeKey(workspaceId, listener);
   }
 
   async fetchLastUserPromptFromHistory(workspaceId: string): Promise<string | null> {
@@ -3688,6 +3734,7 @@ export class WorkspaceStore {
 
     this.historyPagination.set(workspaceId, createInitialHistoryPaginationState());
 
+    this.lastUserPromptStore.bump(workspaceId);
     this.states.bump(workspaceId);
     this.checkAndBumpRecencyIfChanged();
   }
@@ -4078,6 +4125,8 @@ export class WorkspaceStore {
     this.cancelPendingIdleBump(workspaceId);
     this.cancelPendingStreamingBump(workspaceId);
     this.streamingStatsStore.delete(workspaceId);
+    this.lastUserPromptStore.bump(workspaceId);
+    this.lastUserPromptStore.delete(workspaceId);
 
     if (this.activeWorkspaceId === workspaceId) {
       this.activeWorkspaceId = null;
@@ -4469,6 +4518,7 @@ export class WorkspaceStore {
       // Mark as caught up
       transient.caughtUp = true;
       transient.isHydratingTranscript = false;
+      this.lastUserPromptStore.bump(workspaceId);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged(); // Messages loaded, update recency
 
@@ -4585,6 +4635,7 @@ export class WorkspaceStore {
     if (isDeleteMessage(data)) {
       applyWorkspaceChatEventToAggregator(aggregator, data);
       this.cleanupStaleLiveToolState(workspaceId, aggregator);
+      this.lastUserPromptStore.bump(workspaceId);
       this.states.bump(workspaceId);
       this.checkAndBumpRecencyIfChanged();
       this.usageStore.bump(workspaceId);
@@ -4726,6 +4777,8 @@ export class WorkspaceStore {
           this.historyPagination.set(workspaceId, this.deriveHistoryPaginationState(aggregator));
         }
 
+        // Whole messages can change the last human prompt; token/tool deltas cannot.
+        this.lastUserPromptStore.bump(workspaceId);
         this.states.bump(workspaceId);
         this.usageStore.bump(workspaceId);
         this.checkAndBumpRecencyIfChanged();
@@ -4869,20 +4922,9 @@ export function useActiveGoalCount(): number {
 
 export function useWorkspaceLastUserPrompt(workspaceId: string): string | null {
   const store = getStoreInstance();
-
-  const displayed = useSyncExternalStore(
-    (listener) => store.subscribeKey(workspaceId, listener),
-    () => store.getWorkspaceLastUserPrompt(workspaceId)
-  );
-  // The fallback scans full history, so streaming deltas must not invalidate it.
-  const historyEpoch = useSyncExternalStore(
-    (listener) => store.subscribeKey(workspaceId, listener),
-    () => store.getWorkspaceHistoryEpoch(workspaceId)
-  );
-  // Wait for catch-up because empty replay state is not yet authoritative.
-  const isCaughtUp = useSyncExternalStore(
-    (listener) => store.subscribeKey(workspaceId, listener),
-    () => store.isWorkspaceTranscriptCaughtUp(workspaceId)
+  const { displayed, historyEpoch, isCaughtUp } = useSyncExternalStore(
+    (listener) => store.subscribeLastUserPrompt(workspaceId, listener),
+    () => store.getWorkspaceLastUserPromptSnapshot(workspaceId)
   );
 
   // Compaction can hide the latest user prompt behind the replay boundary.
@@ -5093,6 +5135,19 @@ export function useWorkspaceAggregator(
   return store.getAggregator(workspaceId);
 }
 
+/** Keep a Timeline reveal target renderable while preserving transcript DOM capping. */
+export function pinTimelineRevealTarget(
+  workspaceId: string,
+  target: { messageId?: string; toolCallId?: string }
+): void {
+  const store = getStoreInstance();
+  const aggregator = store.getAggregator(workspaceId);
+  if (aggregator) {
+    aggregator.setTranscriptRevealTarget(target);
+    store.bumpState(workspaceId);
+  }
+}
+
 /**
  * Disable the displayed message cap for a workspace and trigger a re-render.
  * Used by HistoryHiddenMessage “Load all”.
@@ -5172,15 +5227,25 @@ export function useWorkspaceActivityHydrated(): boolean {
   return useSyncExternalStore(store.subscribeActivityHydrated, store.isActivityHydrated);
 }
 
+/** Rounded chrome value: identical raw-stat updates keep the snapshot primitive stable. */
+export function useWorkspaceRoundedStreamingTps(workspaceId: string): number | null {
+  const store = getStoreInstance();
+  const subscribe = useCallback(
+    (listener: () => void) => store.subscribeStreamingStats(workspaceId, listener),
+    [store, workspaceId]
+  );
+  const getSnapshot = useCallback(
+    () => store.getWorkspaceRoundedStreamingTps(workspaceId),
+    [store, workspaceId]
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
 /**
- * Hook for the live token-count / TPS pill during streaming.
+ * Hook for full-resolution live token-count / TPS stats during streaming.
  *
- * Subscribed as a separate leaf so the streaming pill can update on every
- * coalesced stream-delta WITHOUT cascading a re-render through the entire
- * chat subtree. Returns null when no stream is active.
- *
- * This is the cure for the "TPS makes WorkspaceState unstable" jitter source —
- * see {@link WorkspaceStreamingStats}.
+ * Subscribed as a separate leaf so smoothing-sensitive consumers can update on every
+ * coalesced stream-delta WITHOUT cascading a re-render through the entire chat subtree.
  */
 export function useWorkspaceStreamingStats(workspaceId: string): WorkspaceStreamingStats | null {
   const store = getStoreInstance();

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -5230,15 +5230,10 @@ export function useWorkspaceActivityHydrated(): boolean {
 /** Rounded chrome value: identical raw-stat updates keep the snapshot primitive stable. */
 export function useWorkspaceRoundedStreamingTps(workspaceId: string): number | null {
   const store = getStoreInstance();
-  const subscribe = useCallback(
+  return useSyncExternalStore(
     (listener: () => void) => store.subscribeStreamingStats(workspaceId, listener),
-    [store, workspaceId]
+    () => store.getWorkspaceRoundedStreamingTps(workspaceId)
   );
-  const getSnapshot = useCallback(
-    () => store.getWorkspaceRoundedStreamingTps(workspaceId),
-    [store, workspaceId]
-  );
-  return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 /**

--- a/src/browser/stores/useWorkspaceLastUserPrompt.test.tsx
+++ b/src/browser/stores/useWorkspaceLastUserPrompt.test.tsx
@@ -23,14 +23,19 @@ describe("useWorkspaceLastUserPrompt", () => {
     const storeHook = renderHook(() => useWorkspaceStoreRaw());
     const store = storeHook.result.current;
     let caughtUp = options.caughtUp;
+    let snapshot = { displayed: null, historyEpoch: 1, isCaughtUp: caughtUp };
 
-    spyOn(store, "getWorkspaceLastUserPrompt").mockReturnValue(null);
-    spyOn(store, "getWorkspaceHistoryEpoch").mockReturnValue(1);
-    spyOn(store, "isWorkspaceTranscriptCaughtUp").mockImplementation(() => caughtUp);
+    spyOn(store, "getWorkspaceLastUserPromptSnapshot").mockImplementation(() => snapshot);
     const fetchPrompt = mock(() => Promise.resolve("prompt from disk"));
     spyOn(store, "fetchLastUserPromptFromHistory").mockImplementation(fetchPrompt);
 
-    return { fetchPrompt, setCaughtUp: (value: boolean) => (caughtUp = value) };
+    return {
+      fetchPrompt,
+      setCaughtUp: (value: boolean) => {
+        caughtUp = value;
+        snapshot = { ...snapshot, isCaughtUp: caughtUp };
+      },
+    };
   }
 
   it("does not scan history while the transcript is still hydrating", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -732,6 +732,15 @@ describe("StreamingMessageAggregator", () => {
       expect(assistantMessages.length).toBeLessThan(100);
       expect(assistantMessages.length).toBeGreaterThan(0);
 
+      // A Timeline reveal may pin one old row, but must not disable the transcript cap.
+      aggregator.setTranscriptRevealTarget({ messageId: "a0" });
+      const withRevealTarget = aggregator.getDisplayedMessages();
+      expect(
+        withRevealTarget.some((message) => "historyId" in message && message.historyId === "a0")
+      ).toBe(true);
+      expect(withRevealTarget.some((message) => message.type === "history-hidden")).toBe(true);
+      expect(withRevealTarget.length).toBeLessThan(400);
+
       // Enable showAllMessages to see full history
       aggregator.setShowAllMessages(true);
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -452,6 +452,11 @@ interface SideQuestionInterrupt {
   sideQuestionAnswerMsg?: MuxMessage;
 }
 
+export interface TranscriptRevealTarget {
+  messageId?: string;
+  toolCallId?: string;
+}
+
 export class StreamingMessageAggregator {
   private messages = new Map<string, MuxMessage>();
   private activeStreams = new Map<string, StreamingContext>();
@@ -532,6 +537,9 @@ export class StreamingMessageAggregator {
 
   // Last URL set via status_set - kept in memory to reuse when later calls omit url
   private lastStatusUrl: string | undefined = undefined;
+
+  // Keep the most recently revealed Timeline row renderable without disabling transcript capping.
+  private transcriptRevealTarget: TranscriptRevealTarget | null = null;
 
   // Whether to disable DOM message capping for this workspace.
   // Controlled via the HistoryHiddenMessage “Load all” button.
@@ -672,6 +680,23 @@ export class StreamingMessageAggregator {
   setUnarchivedAt(unarchivedAt: string | undefined): void {
     this.unarchivedAt = unarchivedAt;
     this.updateRecency();
+  }
+
+  /** Pin one Timeline target into the capped transcript projection. */
+  setTranscriptRevealTarget(target: TranscriptRevealTarget): void {
+    assert(
+      typeof target.messageId === "string" || typeof target.toolCallId === "string",
+      "setTranscriptRevealTarget requires a messageId or toolCallId"
+    );
+    const currentTarget = this.transcriptRevealTarget;
+    if (
+      currentTarget?.messageId === target.messageId &&
+      currentTarget?.toolCallId === target.toolCallId
+    ) {
+      return;
+    }
+    this.transcriptRevealTarget = target;
+    this.invalidateCache();
   }
 
   /**
@@ -3663,10 +3688,20 @@ export class StreamingMessageAggregator {
       // and materialize omission runs as explicit history-hidden marker rows.
       // Full history is still maintained internally for token counting.
       if (!this.showAllMessages && displayedMessages.length > MAX_DISPLAYED_MESSAGES) {
+        const revealTarget = this.transcriptRevealTarget;
         const truncationPlan = buildTranscriptTruncationPlan({
           displayedMessages,
           maxDisplayedMessages: MAX_DISPLAYED_MESSAGES,
           alwaysKeepMessageTypes: ALWAYS_KEEP_MESSAGE_TYPES,
+          shouldAlwaysKeepMessage: revealTarget
+            ? (message) =>
+                (revealTarget.toolCallId != null &&
+                  message.type === "tool" &&
+                  message.toolCallId === revealTarget.toolCallId) ||
+                (revealTarget.messageId != null &&
+                  "historyId" in message &&
+                  message.historyId === revealTarget.messageId)
+            : undefined,
         });
 
         resultMessages =

--- a/src/browser/utils/messages/transcriptTruncationPlan.ts
+++ b/src/browser/utils/messages/transcriptTruncationPlan.ts
@@ -30,6 +30,8 @@ export interface BuildTranscriptTruncationPlanArgs {
   displayedMessages: DisplayedMessage[];
   maxDisplayedMessages: number;
   alwaysKeepMessageTypes: Set<DisplayedMessage["type"]>;
+  /** Preserve a specific old row (for example a Timeline reveal) without disabling the DOM cap. */
+  shouldAlwaysKeepMessage?: (message: DisplayedMessage) => boolean;
   maxHiddenSegments?: number;
 }
 
@@ -47,7 +49,8 @@ interface OmissionRunState {
 
 function collectOmissions(
   oldMessages: DisplayedMessage[],
-  alwaysKeepMessageTypes: Set<DisplayedMessage["type"]>
+  alwaysKeepMessageTypes: Set<DisplayedMessage["type"]>,
+  shouldAlwaysKeepMessage?: (message: DisplayedMessage) => boolean
 ): CollectedOmissions {
   const keptOldMessages: DisplayedMessage[] = [];
   const segments: OmissionSegment[] = [];
@@ -55,7 +58,7 @@ function collectOmissions(
   let activeRun: OmissionRunState | null = null;
 
   for (const message of oldMessages) {
-    if (alwaysKeepMessageTypes.has(message.type)) {
+    if (alwaysKeepMessageTypes.has(message.type) || shouldAlwaysKeepMessage?.(message) === true) {
       if (activeRun !== null) {
         segments.push(activeRun);
         activeRun = null;
@@ -192,7 +195,11 @@ export function buildTranscriptTruncationPlan(
   const recentMessages = args.displayedMessages.slice(-args.maxDisplayedMessages);
   const oldMessages = args.displayedMessages.slice(0, -args.maxDisplayedMessages);
 
-  const omissionCollection = collectOmissions(oldMessages, args.alwaysKeepMessageTypes);
+  const omissionCollection = collectOmissions(
+    oldMessages,
+    args.alwaysKeepMessageTypes,
+    args.shouldAlwaysKeepMessage
+  );
   if (omissionCollection.hiddenCount === 0) {
     return {
       rows: [...omissionCollection.keptOldMessages, ...recentMessages],

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -6,7 +6,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { APIContext } from "@/browser/contexts/API";
 import { TimelinePanel } from "@/browser/features/RightSidebar/Timeline/TimelinePanel";
 import {
-  showAllMessages,
+  pinTimelineRevealTarget,
   useWorkspaceStoreRaw,
   useWorkspaceTimeline,
   type WorkspaceTimelineSnapshot,
@@ -18,7 +18,7 @@ import { BACKGROUND_WORK_WAKE_OPENINGS } from "@/common/utils/machineTurnPrompts
 import { installDom } from "../dom";
 
 jest.mock("@/browser/stores/WorkspaceStore", () => ({
-  showAllMessages: jest.fn(),
+  pinTimelineRevealTarget: jest.fn(),
   useWorkspaceStoreRaw: jest.fn(),
   useWorkspaceTimeline: jest.fn(),
 }));
@@ -26,7 +26,7 @@ jest.mock("@/browser/stores/WorkspaceStore", () => ({
 const WORKSPACE_ID = "timeline-test-workspace";
 const BASE_TIMESTAMP = Date.UTC(2026, 6, 27, 12, 0, 0);
 
-const mockShowAllMessages = jest.mocked(showAllMessages);
+const mockPinTimelineRevealTarget = jest.mocked(pinTimelineRevealTarget);
 const mockUseWorkspaceStoreRaw = jest.mocked(useWorkspaceStoreRaw);
 const mockUseWorkspaceTimeline = jest.mocked(useWorkspaceTimeline);
 
@@ -118,7 +118,7 @@ describe("TimelinePanel", () => {
   beforeEach(() => {
     cleanupDom = installDom();
     localStorage.clear();
-    mockShowAllMessages.mockReset();
+    mockPinTimelineRevealTarget.mockReset();
     mockUseWorkspaceStoreRaw.mockReset();
     mockUseWorkspaceTimeline.mockReset();
   });
@@ -325,16 +325,19 @@ describe("TimelinePanel", () => {
 
     expect(loadOlderHistory).toHaveBeenCalledTimes(10);
     expect(loadOlderHistory).toHaveBeenCalledWith(WORKSPACE_ID);
-    expect(mockShowAllMessages).toHaveBeenCalledWith(WORKSPACE_ID);
+    expect(mockPinTimelineRevealTarget).toHaveBeenCalledWith(WORKSPACE_ID, {
+      messageId: "missing-message",
+      toolCallId: undefined,
+    });
   });
 
-  test("reveals a target that expanding the display cap makes renderable", async () => {
+  test("reveals a target that pinning into the capped projection makes renderable", async () => {
     const event = makeEvent("anchored", "turn.completed", 1, {
       anchor: { messageId: "capped-message" },
     });
-    // No older history to page, so the only way to reach the target is the cap expansion.
+    // No older history to page, so the only way to reach the target is the pinned projection.
     const view = renderTimeline({ events: [event], hasOlderHistory: false });
-    mockShowAllMessages.mockImplementation(() => {
+    mockPinTimelineRevealTarget.mockImplementation(() => {
       view.workspaceState.messages = [{ historyId: "capped-message" }];
     });
     const revealed: unknown[] = [];
@@ -350,6 +353,41 @@ describe("TimelinePanel", () => {
         if (revealed.length === 0) throw new Error("Reveal was not dispatched");
       });
       expect(view.queryByTestId("timeline-reveal-not-found")).toBeNull();
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
+  test("pages sequence-only anchors before pinning their resolved message", async () => {
+    const loadOlderHistory = jest.fn<Promise<"loaded">, [string]>().mockResolvedValue("loaded");
+    const event = makeEvent("sequence-anchor", "turn.completed", 1, {
+      anchor: { historySequence: 42 },
+    });
+    const view = renderTimeline({ events: [event], loadOlderHistory });
+    loadOlderHistory.mockImplementation(async () => {
+      view.workspaceState.muxMessages = [
+        { id: "resolved-message", metadata: { historySequence: 42 } },
+      ];
+      view.workspaceState.messages = [{ historyId: "resolved-message" }];
+      return "loaded";
+    });
+    const revealed: unknown[] = [];
+    const listener = (revealEvent: Event) => revealed.push(revealEvent);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      fireEvent.click(view.container.querySelector('[data-timeline-event-id="sequence-anchor"]')!);
+      const revealButton = await waitFor(() => view.getByTestId("timeline-reveal"));
+      fireEvent.click(revealButton);
+
+      await waitFor(() => {
+        if (revealed.length === 0) throw new Error("Reveal was not dispatched");
+      });
+      expect(loadOlderHistory).toHaveBeenCalledTimes(1);
+      expect(mockPinTimelineRevealTarget).toHaveBeenCalledWith(WORKSPACE_ID, {
+        messageId: "resolved-message",
+        toolCallId: undefined,
+      });
     } finally {
       window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
     }


### PR DESCRIPTION
## Summary

Fixes several renderer regressions introduced by the recent workspace chrome and Timeline redesigns: Timeline reveals now preserve the transcript DOM cap, footer status projections no longer recompute/commit for irrelevant stream chunks, and ordered Timeline batches avoid full-feed sorting on the common path.

## Background

The new always-mounted footer and Timeline reveal flow added work to high-frequency renderer paths. Long-running workspaces could permanently mount their full transcript after one reveal, scan for the last user prompt on every streaming state bump, repaint rounded TPS even when its visible value was unchanged, and sort every retained Timeline event for normal live appends and older-page loads.

## Implementation

- Pin only the requested Timeline message/tool row into the capped transcript projection instead of globally enabling “show all”.
- Move the footer’s last-user-prompt projection to a dedicated keyed store that is invalidated by whole-message/history mutations, not token/tool deltas.
- Expose a primitive rounded-TPS snapshot for chrome while preserving full-resolution streaming stats for smoothing-sensitive consumers.
- Fast-path non-overlapping newest-first Timeline batches as ordered concatenations; retain the dedupe/sort fallback for overlapping data.

## Validation

- Targeted `StreamingMessageAggregator`, `WorkspaceStore`, and last-prompt hook tests pass.
- `make static-check` passes.
- Full `make test` completed 10,213 passing tests; seven unrelated tests failed in two pre-existing areas, and both failing files passed immediately when rerun in isolation:
  - `GitStatusIndicatorView.test.tsx`
  - `MemoryTab.test.tsx`

## Risks

Low-to-moderate renderer risk. The changes are localized to transcript projection, footer selectors, and Timeline merging. Overlapping/out-of-order Timeline batches retain the previous general merge behavior, and tests cover capped reveal behavior plus ordered and overlapping merge cases.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$44.23`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=44.23 -->


