### PR TITLE
🤖 fix: refine queued message presentation

### DIFF
--- a/src/browser/features/ChatInput/ChatInput.stories.tsx
+++ b/src/browser/features/ChatInput/ChatInput.stories.tsx
@@ -45,6 +45,87 @@ export const VoiceInputNoApiKey: AppStory = {
   },
 };
 
+export const QueuedFollowUp: AppStory = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        return setupSimpleChatStory({
+          workspaceId: "ws-queued-follow-up",
+          messages: [
+            createUserMessage("msg-1", "Please audit the settings flow for regressions.", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 120_000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              "I’m reviewing the relevant components and tests now.",
+              { historySequence: 2, timestamp: STABLE_TIMESTAMP - 60_000 }
+            ),
+          ],
+          onChat: (workspaceId, emit) => {
+            // Replay the active turn after history catches up so the queued card is exercised in the
+            // same docked state users see while an agent is working.
+            setTimeout(() => {
+              emit({
+                type: "stream-start",
+                workspaceId,
+                messageId: "msg-3",
+                model: "mock-model",
+                historySequence: 3,
+                startTime: STABLE_TIMESTAMP,
+              });
+              emit({
+                type: "stream-delta",
+                workspaceId,
+                messageId: "msg-3",
+                delta: "Checking the form state and keyboard paths…",
+                tokens: 8,
+                timestamp: STABLE_TIMESTAMP,
+              });
+              emit({
+                type: "queued-message-changed",
+                workspaceId,
+                hasQueuedMessages: true,
+                queuedMessages: [
+                  "Also verify the narrow layout and make sure the action buttons stay easy to scan.",
+                ],
+                displayText:
+                  "Also verify the narrow layout and make sure the action buttons stay easy to scan.",
+                queueDispatchMode: "tool-end",
+              });
+            }, 75);
+          },
+        });
+      }}
+    />
+  ),
+  parameters: {
+    ...appMeta.parameters,
+    pixel: {
+      matrix: { themes: ["dark", "light"], viewports: ["phone", "laptop"] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const storyRoot = document.getElementById("storybook-root") ?? canvasElement;
+    await waitForChatInputAutofocusDone(storyRoot);
+    blurActiveElement();
+
+    await waitFor(() => {
+      const card = storyRoot.querySelector<HTMLElement>('[data-component="QueuedMessageCard"]');
+      if (!card) throw new Error("Queued follow-up card not rendered");
+      if (card.scrollWidth > card.clientWidth) {
+        throw new Error(
+          `Queued follow-up overflows horizontally (${card.scrollWidth}px > ${card.clientWidth}px)`
+        );
+      }
+    });
+  },
+};
+
 export const FocusedComposer: AppStory = {
   render: () => (
     <AppWithMocks

--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import type { QueuedMessage as QueuedMessageType } from "@/common/types/message";
-import { Clock3, Loader2, Pencil, Send } from "lucide-react";
+import { AlertCircle, Clock3, Loader2, Pencil, Send } from "lucide-react";
 import { ChatInputDecoration } from "@/browser/components/ChatPane/ChatInputDecoration";
 import { UserMessageContent } from "@/browser/features/Messages/UserMessageContent";
+import { getErrorMessage } from "@/common/utils/errors";
 
 interface QueuedMessageProps {
   message: QueuedMessageType;
@@ -31,6 +32,7 @@ function deriveQueuedPreview(message: QueuedMessageType): QueuedPreview {
 export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isSending, setIsSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
   const preview = deriveQueuedPreview(props.message);
   const queueStatusLabel =
     props.message.queueDispatchMode === "turn-end"
@@ -44,10 +46,15 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
   const handleSendImmediately = () => {
     if (isSending || !props.onSendImmediately) return;
     setIsSending(true);
-    // The parent owns send error reporting; this surface only tracks whether another click is safe.
+    setSendError(null);
     props.onSendImmediately().then(
       () => setIsSending(false),
-      () => setIsSending(false)
+      (error: unknown) => {
+        // Keep failures visible at the action that caused them while leaving the queued draft intact
+        // for a retry; consuming this rejection without feedback makes IPC failures look like no-ops.
+        setSendError(getErrorMessage(error));
+        setIsSending(false);
+      }
     );
   };
 
@@ -87,6 +94,16 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
               variant="queued"
             />
           </div>
+
+          {sendError && (
+            <div
+              role="alert"
+              className="border-toast-error-border/50 bg-toast-error-bg/50 text-toast-error-text flex items-start gap-1.5 border-t px-3 py-2 text-xs"
+            >
+              <AlertCircle className="mt-0.5 size-3 shrink-0" />
+              <span className="min-w-0 break-words">{sendError}</span>
+            </div>
+          )}
 
           {hasActions && (
             <div className="border-pending/10 bg-surface-secondary/60 flex flex-wrap items-center justify-end gap-1.5 border-t px-2 py-1.5">

--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import type { QueuedMessage as QueuedMessageType } from "@/common/types/message";
-import { Pencil, Send } from "lucide-react";
+import { Clock3, Loader2, Pencil, Send } from "lucide-react";
 import { ChatInputDecoration } from "@/browser/components/ChatPane/ChatInputDecoration";
 import { UserMessageContent } from "@/browser/features/Messages/UserMessageContent";
 
@@ -28,86 +28,96 @@ function deriveQueuedPreview(message: QueuedMessageType): QueuedPreview {
   };
 }
 
-export const QueuedMessage: React.FC<QueuedMessageProps> = ({
-  message,
-  className,
-  onEdit,
-  onSendImmediately,
-}) => {
+export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isSending, setIsSending] = useState(false);
-  const preview = deriveQueuedPreview(message);
+  const preview = deriveQueuedPreview(props.message);
   const queueStatusLabel =
-    message.queueDispatchMode === "turn-end" ? "Sending after turn" : "Sending after step";
+    props.message.queueDispatchMode === "turn-end"
+      ? "Sends after this turn"
+      : "Sends after this step";
 
   const handleToggle = () => {
     setIsExpanded((prev) => !prev);
   };
 
-  const handleSendImmediately = async () => {
-    if (isSending || !onSendImmediately) return;
+  const handleSendImmediately = () => {
+    if (isSending || !props.onSendImmediately) return;
     setIsSending(true);
-    try {
-      await onSendImmediately();
-    } finally {
-      setIsSending(false);
-    }
+    // The parent owns send error reporting; this surface only tracks whether another click is safe.
+    props.onSendImmediately().then(
+      () => setIsSending(false),
+      () => setIsSending(false)
+    );
   };
 
+  const hasActions = props.onEdit != null || props.onSendImmediately != null;
+
+  // Give queued follow-ups one cohesive pending surface so they read as the user's next message,
+  // not as another generic system banner stacked above the composer.
   return (
     <ChatInputDecoration
       expanded={isExpanded}
       onToggle={handleToggle}
-      className={className}
+      className={props.className}
       contentClassName="py-1.5"
       dataComponent="QueuedMessageBanner"
       summary={
         <>
-          <Send className="text-muted group-hover:text-secondary size-3.5 transition-colors" />
-          <span className="text-muted group-hover:text-secondary transition-colors">
-            Queued - {queueStatusLabel}
+          <span className="bg-pending/10 text-pending flex size-5 shrink-0 items-center justify-center rounded-full">
+            <Clock3 className="size-3" />
+          </span>
+          <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+            <span className="text-foreground font-medium">Queued</span>
+            <span className="text-muted truncate">{queueStatusLabel}</span>
           </span>
         </>
       }
       renderExpanded={() => (
         <div
-          className="border-border-medium bg-background-secondary/80 rounded-md border px-2.5 py-1.5"
+          className="border-pending/20 bg-pending/5 overflow-hidden rounded-lg border"
           data-component="QueuedMessageCard"
         >
           {/* Keep queued drafts bounded so long content never pushes the composer off-screen. */}
-          <div className="max-h-[40vh] overflow-y-auto">
+          <div className="max-h-[40vh] overflow-y-auto px-3 py-2.5">
             <UserMessageContent
               content={preview.sanitizedText || preview.fallbackLabel}
-              reviews={message.reviews}
-              fileParts={message.fileParts}
+              reviews={props.message.reviews}
+              fileParts={props.message.fileParts}
               variant="queued"
             />
           </div>
 
-          <div className="mt-1 flex flex-wrap items-center justify-end gap-x-2 gap-y-0.5">
-            {onEdit && (
-              <button
-                type="button"
-                onClick={onEdit}
-                className="text-muted hover:text-secondary flex items-center gap-1 text-xs transition-colors"
-              >
-                <Pencil className="size-3" />
-                Edit
-              </button>
-            )}
+          {hasActions && (
+            <div className="border-pending/10 bg-surface-secondary/60 flex flex-wrap items-center justify-end gap-1.5 border-t px-2 py-1.5">
+              {props.onEdit && (
+                <button
+                  type="button"
+                  onClick={props.onEdit}
+                  className="text-muted hover:bg-hover hover:text-foreground flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors"
+                >
+                  <Pencil className="size-3" />
+                  Edit
+                </button>
+              )}
 
-            {onSendImmediately && (
-              <button
-                type="button"
-                onClick={() => void handleSendImmediately()}
-                disabled={isSending}
-                className="text-muted hover:text-secondary flex items-center gap-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Send className="size-3" />
-                {isSending ? "Sending…" : "Send now"}
-              </button>
-            )}
-          </div>
+              {props.onSendImmediately && (
+                <button
+                  type="button"
+                  onClick={handleSendImmediately}
+                  disabled={isSending}
+                  className="bg-pending/10 text-pending hover:bg-pending/20 flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSending ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <Send className="size-3" />
+                  )}
+                  {isSending ? "Sending…" : "Send now"}
+                </button>
+              )}
+            </div>
+          )}
         </div>
       )}
     />

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -41,13 +41,14 @@ const markdownStyles: Record<UserMessageContentProps["variant"], React.CSSProper
     wordBreak: "break-word",
   },
   queued: {
-    color: "var(--color-subtle)",
-    fontFamily: "var(--font-monospace)",
-    fontSize: "12px",
-    lineHeight: "16px",
+    // Queued follow-ups are still user-authored prose, so keep them readable instead of
+    // styling the preview like subdued terminal output.
+    color: "var(--color-text-light)",
+    fontFamily: "inherit",
+    fontSize: "13px",
+    lineHeight: "18px",
     overflowWrap: "break-word",
     wordBreak: "break-word",
-    opacity: 0.9,
   },
 };
 

--- a/tests/ui/chat/queuedMessageBanner.test.tsx
+++ b/tests/ui/chat/queuedMessageBanner.test.tsx
@@ -66,7 +66,8 @@ describe("QueuedMessage banner", () => {
   test("renders queued preview text and step-dispatch label", () => {
     const view = render(<QueuedMessage message={createQueuedMessage()} />);
 
-    expect(view.getByText("Queued - Sending after step")).toBeTruthy();
+    expect(view.getByText("Queued")).toBeTruthy();
+    expect(view.getByText("Sends after this step")).toBeTruthy();
     expandQueuedMessage(view);
     expect(view.getByText("Review this change before sending")).toBeTruthy();
   });
@@ -76,7 +77,7 @@ describe("QueuedMessage banner", () => {
       <QueuedMessage message={createQueuedMessage({ queueDispatchMode: "turn-end" })} />
     );
 
-    expect(view.getByText("Queued - Sending after turn")).toBeTruthy();
+    expect(view.getByText("Sends after this turn")).toBeTruthy();
   });
 
   test("renders an inner queued bubble inside the banner", () => {

--- a/tests/ui/chat/queuedMessageBanner.test.tsx
+++ b/tests/ui/chat/queuedMessageBanner.test.tsx
@@ -134,6 +134,31 @@ describe("QueuedMessage banner", () => {
     });
   });
 
+  test("shows send-now failures inline and allows retry", async () => {
+    let attempt = 0;
+    const onSendImmediately = mock(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("Connection lost while interrupting");
+      }
+    });
+
+    const view = render(
+      <QueuedMessage message={createQueuedMessage()} onSendImmediately={onSendImmediately} />
+    );
+
+    fireEvent.click(view.getByText("Send now"));
+    await waitFor(() => {
+      expect(view.getByRole("alert").textContent).toContain("Connection lost while interrupting");
+    });
+
+    fireEvent.click(view.getByText("Send now"));
+    await waitFor(() => {
+      expect(onSendImmediately).toHaveBeenCalledTimes(2);
+      expect(view.queryByRole("alert")).toBeNull();
+    });
+  });
+
   test("does not render Send now button when onSendImmediately is absent", () => {
     const view = render(<QueuedMessage message={createQueuedMessage()} onEdit={mock(() => {})} />);
 

--- a/tests/ui/chat/sendModeDropdown.test.ts
+++ b/tests/ui/chat/sendModeDropdown.test.ts
@@ -214,7 +214,8 @@ describe("Send dispatch modes (mock AI router)", () => {
       const sendButton = await waitForSendModeMenuTrigger(app.view.container);
       fireEvent.click(sendButton);
       await waitFor(() => {
-        expect(app.view.container.textContent).toContain("Queued - Sending after step");
+        expect(app.view.container.textContent).toContain("Queued");
+        expect(app.view.container.textContent).toContain("Sends after this step");
       });
 
       await app.chat.expectTranscriptContains("parallel-step-a.txt");
@@ -263,7 +264,8 @@ describe("Send dispatch modes (mock AI router)", () => {
 
       await waitFor(() => {
         const textContent = app.view.container.textContent ?? "";
-        expect(textContent).toContain("Queued - Sending after turn");
+        expect(textContent).toContain("Queued");
+        expect(textContent).toContain("Sends after this turn");
         expect(textContent).toContain("Send now");
       });
 
@@ -284,7 +286,7 @@ describe("Send dispatch modes (mock AI router)", () => {
       await waitFor(
         () => {
           const textContent = app.view.container.textContent ?? "";
-          expect(textContent).not.toContain("Queued - Sending after turn");
+          expect(textContent).not.toContain("Sends after this turn");
         },
         { timeout: 30_000 }
       );


### PR DESCRIPTION
## Summary

Refines the queued follow-up shown above the composer so it reads as the user's next message rather than a generic system banner. The new presentation adds a clear pending-state marker, improves message readability, separates the Edit and Send now actions into a consistent footer, and keeps send failures visible and retryable.

## Implementation

- introduces a cohesive pending surface and clearer queued/dispatch hierarchy
- uses regular user-message typography instead of subdued monospace text
- gives Edit and Send now distinct, touch-friendly action treatments with a sending spinner
- surfaces send-now rejections inline while preserving the queued draft for retry
- adds a full-app Storybook scenario covering active streaming at phone and laptop widths
- updates integration assertions for the refined tool-end and turn-end labels

## Validation

- `env TEST_INTEGRATION=1 bun x jest tests/ui/chat/sendModeDropdown.test.ts --runInBand`
- `bun test ./tests/ui/chat/queuedMessageBanner.test.tsx`
- `make static-check`
- visually verified the full-app story at 1280×800 and 390×844 with no horizontal overflow

## Risks

Low. The change is limited to queued-message presentation and preserves existing queue, edit, collapse, and immediate-send behavior. The new error row only appears when immediate sending rejects.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$13.39`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=13.39 -->
