### PR TITLE
🤖 fix: restore queued message text hierarchy

### DIFF
--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -111,7 +111,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
                 <button
                   type="button"
                   onClick={props.onEdit}
-                  className="text-muted hover:bg-hover hover:text-foreground flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors"
+                  className="text-muted hover:bg-hover hover:text-foreground flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11px] font-medium transition-colors"
                 >
                   <Pencil className="size-3" />
                   Edit
@@ -123,7 +123,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
                   type="button"
                   onClick={handleSendImmediately}
                   disabled={isSending}
-                  className="bg-pending/10 text-pending hover:bg-pending/20 flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                  className="bg-pending/10 text-pending hover:bg-pending/20 flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {isSending ? (
                     <Loader2 className="size-3 animate-spin" />


### PR DESCRIPTION
## Summary

Restores the intended hierarchy in the queued-message card by making the Edit and Send now labels smaller than the user-authored queued message.

## Background

Follow-up to #3780. The queued message body is 13px, but its 12px medium-weight actions appeared visually larger and competed with the content.

## Implementation

- reduces both queued-message action labels from 12px to 11px
- preserves the existing button dimensions, icons, colors, and touch targets

## Validation

- `bun test ./tests/ui/chat/queuedMessageBanner.test.tsx`
- `make static-check`
- measured the rendered phone story: queued message 13px; action labels 11px
- visually verified the full-app story at 1280×800 and 390×844

## Risks

Very low. This is a typography-only change scoped to two action labels.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$18.62`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=18.62 -->
