### PR TITLE
🤖 fix: avoid duplicate subagent completion responses

### DIFF
--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -14,6 +14,7 @@ import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import { Ok } from "@/common/types/result";
 import { GOAL_CONTINUATION_KIND } from "@/constants/goals";
+import { formatSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 interface AutoRetryResumeRequest {
@@ -121,6 +122,38 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(retryOptions.options.toolPolicy).toEqual([{ regex_match: ".*", action: "disable" }]);
     expect(retryOptions.options.disableWorkspaceAgents).toBe(true);
 
+    session.dispose();
+  });
+
+  test("visible completed subagent report cards do not schedule startup auto-retry", async () => {
+    const workspaceId = "startup-retry-subagent-report-card";
+    const { session, historyService, events, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const appendResult = await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage(
+        "completed-subagent-report",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: "child-task",
+          agentType: "explore",
+          status: "completed",
+          title: "Final report",
+          reportMarkdown: "Investigation complete.",
+        }),
+        { timestamp: Date.now(), synthetic: true, uiVisible: true }
+      )
+    );
+    expect(appendResult.success).toBe(true);
+
+    session.ensureStartupAutoRetryCheck();
+    const startupCheckPromise = (
+      session as unknown as { startupAutoRetryCheckPromise: Promise<void> | null }
+    ).startupAutoRetryCheckPromise;
+    await startupCheckPromise;
+
+    expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
     session.dispose();
   });
 

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -157,6 +157,87 @@ describe("AgentSession startup auto-retry recovery", () => {
     session.dispose();
   });
 
+  test("visible completed subagent report cards do not mask recoverable assistant partials", async () => {
+    const workspaceId = "startup-retry-subagent-report-with-partial";
+    const { session, historyService, events, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("original-user", "user", "Continue the original task", {
+        timestamp: Date.now(),
+      })
+    );
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage(
+        "completed-subagent-report",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: "child-task",
+          agentType: "explore",
+          status: "completed",
+          title: "Final report",
+          reportMarkdown: "Investigation complete.",
+        }),
+        { timestamp: Date.now(), synthetic: true, uiVisible: true }
+      )
+    );
+    await historyService.writePartial(
+      workspaceId,
+      createMuxMessage("assistant-partial", "assistant", "Interrupted response", {
+        timestamp: Date.now(),
+        partial: true,
+      })
+    );
+
+    session.ensureStartupAutoRetryCheck();
+    const startupCheckPromise = (
+      session as unknown as { startupAutoRetryCheckPromise: Promise<void> | null }
+    ).startupAutoRetryCheckPromise;
+    await startupCheckPromise;
+
+    expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
+    session.dispose();
+  });
+
+  test("hidden completed subagent reports preserve the existing startup retry fallback", async () => {
+    const workspaceId = "startup-retry-hidden-subagent-report";
+    const { session, historyService, events, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("original-user", "user", "Continue the original task", {
+        timestamp: Date.now(),
+      })
+    );
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage(
+        "hidden-completed-subagent-report",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: "child-task",
+          agentType: "explore",
+          status: "completed",
+          title: "Final report",
+          reportMarkdown: "Investigation complete.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+
+    session.ensureStartupAutoRetryCheck();
+    const startupCheckPromise = (
+      session as unknown as { startupAutoRetryCheckPromise: Promise<void> | null }
+    ).startupAutoRetryCheckPromise;
+    await startupCheckPromise;
+
+    expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(true);
+    session.dispose();
+  });
+
   test("startup auto-retry reuses workspace-turn metadata from the retry user message", async () => {
     const workspaceId = "startup-retry-workspace-turn-metadata";
     const { session, historyService, aiService, cleanup } = await createSessionBundle(workspaceId);

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1357,8 +1357,14 @@ export class AgentSession {
     return metadataResult.data;
   }
 
-  private isCompletedSubagentReportMessage(message: MuxMessage): boolean {
-    if (message.role !== "user" || message.metadata?.synthetic !== true) return false;
+  private isVisibleCompletedSubagentReportMessage(message: MuxMessage): boolean {
+    if (
+      message.role !== "user" ||
+      message.metadata?.synthetic !== true ||
+      message.metadata.uiVisible !== true
+    ) {
+      return false;
+    }
     const text = message.parts
       .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
       .map((part) => part.text)
@@ -1371,7 +1377,7 @@ export class AgentSession {
       return false;
     }
 
-    if (this.isCompletedSubagentReportMessage(message)) {
+    if (this.isVisibleCompletedSubagentReportMessage(message)) {
       return false;
     }
     if (this.isSyntheticGoalPauseBoundaryMessage(message)) {
@@ -1667,10 +1673,14 @@ export class AgentSession {
     }
 
     const lastHistoryMessage = this.getLastNonSystemHistoryMessage(historyResult.data);
-    if (lastHistoryMessage && this.isCompletedSubagentReportMessage(lastHistoryMessage)) {
+    const interruptedByPartial = partial?.role === "assistant";
+    if (
+      !interruptedByPartial &&
+      lastHistoryMessage &&
+      this.isVisibleCompletedSubagentReportMessage(lastHistoryMessage)
+    ) {
       return "completed";
     }
-    const interruptedByPartial = partial?.role === "assistant";
     const interruptedByHistory =
       lastHistoryMessage?.role === "user" ||
       (lastHistoryMessage?.role === "assistant" &&

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -148,6 +148,7 @@ import { execBuffered } from "@/node/utils/runtime/helpers";
 import { renderAgentSkillSnapshotText } from "@/common/utils/agentSkills/skillSnapshot";
 import type { MemorySessionContext } from "@/node/services/memoryService";
 import { materializeFileAtMentions } from "@/node/services/fileAtMentions";
+import { parseSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { getErrorMessage } from "@/common/utils/errors";
 import { CompactionMonitor, type CompactionStatusEvent } from "./compactionMonitor";
 
@@ -1356,11 +1357,23 @@ export class AgentSession {
     return metadataResult.data;
   }
 
+  private isCompletedSubagentReportMessage(message: MuxMessage): boolean {
+    if (message.role !== "user" || message.metadata?.synthetic !== true) return false;
+    const text = message.parts
+      .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+      .map((part) => part.text)
+      .join("\n");
+    return parseSubagentReportEnvelope(text)?.status === "completed";
+  }
+
   private shouldUseUserMessageForRetry(message: MuxMessage): boolean {
     if (message.role !== "user") {
       return false;
     }
 
+    if (this.isCompletedSubagentReportMessage(message)) {
+      return false;
+    }
     if (this.isSyntheticGoalPauseBoundaryMessage(message)) {
       return false;
     }
@@ -1654,6 +1667,9 @@ export class AgentSession {
     }
 
     const lastHistoryMessage = this.getLastNonSystemHistoryMessage(historyResult.data);
+    if (lastHistoryMessage && this.isCompletedSubagentReportMessage(lastHistoryMessage)) {
+      return "completed";
+    }
     const interruptedByPartial = partial?.role === "assistant";
     const interruptedByHistory =
       lastHistoryMessage?.role === "user" ||

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2628,6 +2628,57 @@ describe("TaskService", () => {
     expect(await terminalAttentionStore.listPending(parentId)).toEqual([]);
   });
 
+  test("completed subagent wake remains when its visible terminal report card is missing", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const childId = "task-progress-missing-terminal-card";
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: childId,
+      outputDelivery: "already_injected",
+      terminalOutcome: "completed",
+    });
+
+    const sendMessage = mock(
+      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "progress-without-card",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "in_progress",
+          title: "Progress",
+          reportMarkdown: "Progress was answered but terminal persistence failed.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("progress-without-card-response", "assistant", "Progress handled.", {
+        timestamp: Date.now(),
+      })
+    );
+
+    const internal = taskService as unknown as {
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.drainTerminalAttention(parentId);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain(
+      "Background sub-agent task(s) have completed"
+    );
+  });
+
   test("completed subagent wake remains when the latest progress update has no assistant response", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -49,7 +49,10 @@ import * as forkOrchestrator from "@/node/services/utils/forkOrchestrator";
 import { Ok, Err, type Result } from "@/common/types/result";
 import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
-import { formatSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
+import {
+  formatSubagentReportEnvelope,
+  parseSubagentReportEnvelope,
+} from "@/common/utils/subagentReportEnvelope";
 import { defaultModel } from "@/common/utils/ai/models";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
@@ -63,7 +66,7 @@ import {
   WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE,
 } from "@/common/utils/workflowRunMessages";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
-import type { ProvidersConfigMap } from "@/common/orpc/types";
+import type { ProvidersConfigMap, WorkspaceChatMessage } from "@/common/orpc/types";
 import type { AIService } from "@/node/services/aiService";
 import type { WorkspaceService } from "@/node/services/workspaceService";
 import type { InitStateManager } from "@/node/services/initStateManager";
@@ -462,7 +465,9 @@ function createWorkspaceServiceMocks(
   const updateAgentStatus =
     overrides?.updateAgentStatus ?? mock((): Promise<void> => Promise.resolve());
   const isExperimentEnabled = overrides?.isExperimentEnabled ?? mock(() => false);
-  const emitChatEvent = overrides?.emitChatEvent ?? mock(() => undefined);
+  const emitChatEvent =
+    overrides?.emitChatEvent ??
+    mock((_workspaceId: string, _message: WorkspaceChatMessage) => undefined);
   const isWorkflowInvocationCurrent =
     overrides?.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true));
 
@@ -2557,6 +2562,134 @@ describe("TaskService", () => {
     expect(prompt).not.toContain("failed terminally");
     expect(prompt).toContain("wst_error");
     expect(prompt).toContain("task_await");
+  });
+
+  test("completed subagent wake is suppressed after the parent responded to its latest progress update", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const childId = "task-progress-responded";
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: childId,
+      outputDelivery: "already_injected",
+      terminalOutcome: "completed",
+    });
+
+    const sendMessage = mock(
+      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "progress-update",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "in_progress",
+          title: "Progress",
+          reportMarkdown: "Found the relevant code path.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("progress-response", "assistant", "Thanks, I have integrated that update.", {
+        timestamp: Date.now(),
+      })
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "terminal-report",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "completed",
+          title: "Final report",
+          reportMarkdown: "Investigation complete.",
+        }),
+        { timestamp: Date.now(), synthetic: true, uiVisible: true }
+      )
+    );
+
+    const internal = taskService as unknown as {
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.drainTerminalAttention(parentId);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(await terminalAttentionStore.listPending(parentId)).toEqual([]);
+  });
+
+  test("completed subagent wake remains when the latest progress update has no assistant response", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const childId = "task-progress-unanswered";
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: childId,
+      outputDelivery: "already_injected",
+      terminalOutcome: "completed",
+    });
+
+    const sendMessage = mock(
+      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
+    );
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "old-progress",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "in_progress",
+          title: "Earlier progress",
+          reportMarkdown: "An earlier update was processed.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("old-response", "assistant", "Earlier response", { timestamp: Date.now() })
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "latest-progress",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "in_progress",
+          title: "Latest progress",
+          reportMarkdown: "A newer update has not been processed yet.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+
+    const internal = taskService as unknown as {
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.drainTerminalAttention(parentId);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(String(sendMessage.mock.calls[0]?.[1])).toContain(
+      "Background sub-agent task(s) have completed"
+    );
   });
 
   test("terminal wake-up waits for queued owner turn to clear", async () => {
@@ -15862,6 +15995,75 @@ describe("TaskService", () => {
     expect(sendMessage.mock.calls[1]?.[1]).toContain("Found a second issue.");
     expect(findWorkspaceInConfig(config, childId)?.taskStatus).toBe("running");
     expect(await readSubagentReportArtifact(config.getSessionDir(parentId), childId)).toBeNull();
+  });
+
+  test("terminal report becomes a visible card without a second parent response after progress was answered", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = "parent-progress-terminal-card";
+    const childId = "child-progress-terminal-card";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId),
+        projectWorkspace(projectPath, "child", childId, {
+          name: "agent_explore_child",
+          parentWorkspaceId: parentId,
+          agentType: "explore",
+          taskStatus: "running",
+          taskAttentionPolicy: "notify_on_terminal",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    const { workspaceService, sendMessage, emitChatEvent } = createWorkspaceServiceMocks();
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "accepted-progress",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId: childId,
+          agentType: "explore",
+          status: "in_progress",
+          title: "Progress",
+          reportMarkdown: "Initial investigation complete.",
+        }),
+        { timestamp: Date.now(), synthetic: true }
+      )
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("progress-answer", "assistant", "I incorporated the progress update.", {
+        timestamp: Date.now(),
+      })
+    );
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childId,
+      messageId: "assistant-terminal-report",
+      metadata: { model: "openai:gpt-4o-mini", finishReason: "stop" },
+      parts: [{ type: "text", text: "Final investigation result." }],
+    });
+    await flushTerminalAttentionDrains(taskService);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    const parentHistory = await collectFullHistory(historyService, parentId);
+    const completedReport = parentHistory.find((message) => {
+      const text = message.parts
+        .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
+      const report = parseSubagentReportEnvelope(text);
+      return report?.taskId === childId && report.status === "completed";
+    });
+    expect(completedReport?.metadata).toMatchObject({ synthetic: true, uiVisible: true });
+    expect(emitChatEvent).toHaveBeenCalledTimes(1);
   });
 
   test("terminal reports supersede queued incremental updates for the same child", async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5040,6 +5040,74 @@ export class TaskService {
     });
   }
 
+  private async findProgressRespondedTaskIds(
+    ownerWorkspaceId: string,
+    candidateTaskIds: ReadonlySet<string>
+  ): Promise<Set<string>> {
+    if (candidateTaskIds.size === 0) return new Set<string>();
+
+    const awaitingResponse = new Set<string>();
+    const responded = new Set<string>();
+    // The duplicate-ending decision only depends on the active context epoch. If compaction already
+    // summarized an older progress turn, retain the terminal wake rather than scanning lifetime history.
+    const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
+    if (!historyResult.success) {
+      log.warn("Failed to inspect progress wake responses", {
+        ownerWorkspaceId,
+        error: historyResult.error,
+      });
+      return new Set<string>();
+    }
+    for (const message of historyResult.data) {
+      if (message.role === "user" && message.metadata?.synthetic === true) {
+        const text = message.parts
+          .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+          .map((part) => part.text)
+          .join("\n");
+        const report = parseSubagentReportEnvelope(text);
+        if (report?.status === "in_progress" && candidateTaskIds.has(report.taskId)) {
+          // A newer update requires a newer assistant response before terminal handoff can be
+          // suppressed. This avoids hiding a final result behind an unprocessed progress update.
+          awaitingResponse.add(report.taskId);
+          responded.delete(report.taskId);
+        }
+        continue;
+      }
+
+      if (message.role === "assistant" && message.metadata?.partial !== true) {
+        for (const taskId of awaitingResponse) {
+          responded.add(taskId);
+        }
+        awaitingResponse.clear();
+      }
+    }
+    return responded;
+  }
+
+  private async hasAcceptedSubagentProgressReport(
+    ownerWorkspaceId: string,
+    taskId: string
+  ): Promise<boolean> {
+    const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
+    if (!historyResult.success) {
+      log.warn("Failed to inspect accepted subagent progress reports", {
+        ownerWorkspaceId,
+        taskId,
+        error: historyResult.error,
+      });
+      return false;
+    }
+    return historyResult.data.some((message) => {
+      if (message.role !== "user" || message.metadata?.synthetic !== true) return false;
+      const text = message.parts
+        .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+        .map((part) => part.text)
+        .join("\n");
+      const report = parseSubagentReportEnvelope(text);
+      return report?.taskId === taskId && report.status === "in_progress";
+    });
+  }
+
   /**
    * Drain pending terminal notifications for one owner workspace: defer (leave pending) when the
    * owner is busy/queued/preparing, otherwise send one coalesced synthetic wake-up and mark the
@@ -5084,12 +5152,52 @@ export class TaskService {
       return;
     }
 
-    const injectedNotifications = pending.filter((n) => n.outputDelivery === "already_injected");
+    const suppressibleTaskIds = new Set(
+      pending
+        .filter(
+          (notification) =>
+            notification.sourceKind === "agent_task" &&
+            notification.outputDelivery === "already_injected" &&
+            notification.terminalOutcome === "completed"
+        )
+        .map((notification) => notification.sourceId)
+    );
+    const respondedProgressTaskIds = await this.findProgressRespondedTaskIds(
+      ownerWorkspaceId,
+      suppressibleTaskIds
+    );
+    const effectivePending: TerminalAttentionNotification[] = [];
+    for (const notification of pending) {
+      if (
+        notification.sourceKind === "agent_task" &&
+        respondedProgressTaskIds.has(notification.sourceId)
+      ) {
+        // The parent already produced a response to this child's latest progress wake. The terminal
+        // report is persisted as a visible card, so another generic model turn would create a second
+        // ending without adding context. Keep failures and first/only completions unchanged.
+        try {
+          await this.terminalAttentionStore.markDelivered(ownerWorkspaceId, notification.id);
+        } catch (error) {
+          log.error("Failed to consume redundant subagent completion wake", {
+            ownerWorkspaceId,
+            taskId: notification.sourceId,
+            error,
+          });
+        }
+        continue;
+      }
+      effectivePending.push(notification);
+    }
+    if (effectivePending.length === 0) return;
+
+    const injectedNotifications = effectivePending.filter(
+      (n) => n.outputDelivery === "already_injected"
+    );
     const injectedTaskIds = injectedNotifications.map((n) => n.sourceId);
-    const awaitHandleIds = pending
+    const awaitHandleIds = effectivePending
       .filter((n) => n.outputDelivery === "requires_task_await")
       .map((n) => n.sourceId);
-    const workflowNotifications = pending.filter(
+    const workflowNotifications = effectivePending.filter(
       (n) => n.outputDelivery === "workflow_result_context"
     );
     const anyInjectedFailure = injectedNotifications.some(
@@ -5124,13 +5232,13 @@ export class TaskService {
     const prompt = promptSections.join("\n\n");
 
     const markPendingDelivered = async () => {
-      for (const notification of pending) {
+      for (const notification of effectivePending) {
         await this.terminalAttentionStore.markDelivered(ownerWorkspaceId, notification.id);
       }
     };
 
     const markPendingForRetry = async () => {
-      for (const notification of pending) {
+      for (const notification of effectivePending) {
         await this.terminalAttentionStore.markPending(ownerWorkspaceId, notification.id);
       }
     };
@@ -10585,11 +10693,16 @@ export class TaskService {
       });
     }
 
+    const hadAcceptedProgressReport = await this.hasAcceptedSubagentProgressReport(
+      parentWorkspaceId,
+      childWorkspaceId
+    );
     await this.deliverReportToParent(
       parentWorkspaceId,
       childWorkspaceId,
       latestChildEntry,
-      reportArgs
+      reportArgs,
+      { uiVisible: hadAcceptedProgressReport }
     );
 
     // Resolve foreground waiters.
@@ -11146,7 +11259,8 @@ export class TaskService {
       title?: string;
       structuredOutput?: unknown;
       planFilePath?: string;
-    }
+    },
+    options?: { uiVisible?: boolean }
   ): Promise<void> {
     assert(
       childWorkspaceId.length > 0,
@@ -11161,7 +11275,8 @@ export class TaskService {
           parentWorkspaceId,
           childWorkspaceId,
           childEntry,
-          report
+          report,
+          options
         );
       });
     } else {
@@ -11169,7 +11284,8 @@ export class TaskService {
         parentWorkspaceId,
         childWorkspaceId,
         childEntry,
-        report
+        report,
+        options
       );
     }
 
@@ -11187,7 +11303,8 @@ export class TaskService {
       title?: string;
       structuredOutput?: unknown;
       planFilePath?: string;
-    }
+    },
+    options?: { uiVisible?: boolean }
   ): Promise<readonly string[]> {
     const agentType = coerceNonEmptyString(childEntry?.workspace.agentType) ?? "agent";
 
@@ -11280,12 +11397,19 @@ export class TaskService {
     const reportMessage = createMuxMessage(messageId, "user", reportContent, {
       timestamp: Date.now(),
       synthetic: true,
+      ...(options?.uiVisible === true ? { uiVisible: true } : {}),
     });
 
     const appendResult = await this.historyService.appendToHistory(
       parentWorkspaceId,
       reportMessage
     );
+    if (appendResult.success && options?.uiVisible === true) {
+      this.workspaceService.emitChatEvent(parentWorkspaceId, {
+        ...reportMessage,
+        type: "message",
+      });
+    }
     if (!appendResult.success) {
       log.error("Failed to append synthetic subagent report to parent history", {
         parentWorkspaceId,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5046,6 +5046,7 @@ export class TaskService {
   ): Promise<Set<string>> {
     if (candidateTaskIds.size === 0) return new Set<string>();
 
+    const visibleCompletedReports = new Set<string>();
     const awaitingResponse = new Set<string>();
     const responded = new Set<string>();
     // The duplicate-ending decision only depends on the active context epoch. If compaction already
@@ -5065,6 +5066,13 @@ export class TaskService {
           .map((part) => part.text)
           .join("\n");
         const report = parseSubagentReportEnvelope(text);
+        if (
+          report?.status === "completed" &&
+          message.metadata?.uiVisible === true &&
+          candidateTaskIds.has(report.taskId)
+        ) {
+          visibleCompletedReports.add(report.taskId);
+        }
         if (report?.status === "in_progress" && candidateTaskIds.has(report.taskId)) {
           // A newer update requires a newer assistant response before terminal handoff can be
           // suppressed. This avoids hiding a final result behind an unprocessed progress update.
@@ -5081,7 +5089,7 @@ export class TaskService {
         awaitingResponse.clear();
       }
     }
-    return responded;
+    return new Set([...responded].filter((taskId) => visibleCompletedReports.has(taskId)));
   }
 
   private async hasAcceptedSubagentProgressReport(


### PR DESCRIPTION
## Summary

Prevents background sub-agent completion from triggering a second, redundant assistant ending when the parent already responded to that child’s latest incremental progress update.

## Background

`agent_report` progress updates are themselves synthetic wake turns. After the parent responds, the child’s terminal report is injected into history and the terminal-attention notifier currently sends another generic prompt beginning “Background sub-agent task(s) have completed… Write the final response now.” That forces another model response even though the chat already reached a natural conclusion, creating confusing double endings.

## Implementation

- Inspect the active context epoch before delivering completed agent-task attention.
- Suppress only successful completion wakes where the parent has an assistant response after that child’s latest `in_progress` report.
- Keep the terminal report visible by persisting it with `uiVisible: true` and emitting the live report card event.
- Preserve the generic terminal wake when the latest progress update has not been answered, when no progress update exists, and for failures, workspace turns, and workflow results.
- Track the latest progress report rather than any historical update, so a newer unprocessed progress message still receives a terminal handoff.

## Validation

- Full `src/node/services/taskService.test.ts` suite: 327 passing tests.
- Targeted terminal-attention, progress-report, and report-card tests.
- `make static-check`.

## Risks

Low-to-moderate and scoped to successful background sub-agent terminal attention. The suppression decision fails open: history read failures, compaction that moves the progress turn out of the active context, or an unanswered latest update retain the existing completion wake.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$272.47`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=272.47 -->
