### PR TITLE
🤖 refactor: remove remote PostHog feature flag evaluation

### DIFF
--- a/src/browser/contexts/ExperimentsContext.test.tsx
+++ b/src/browser/contexts/ExperimentsContext.test.tsx
@@ -1,11 +1,10 @@
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { GlobalWindow } from "happy-dom";
 import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
-import type { ExperimentValue } from "@/common/orpc/types";
 import { requireTestModule, type RecursivePartial } from "@/browser/testUtils";
 import type * as APIModule from "./API";
 import type { APIClient } from "./API";
@@ -90,8 +89,8 @@ describe("ExperimentsProvider", () => {
 
     // Broader browser runs can leave bare globals, event constructors, and timer functions pointed
     // at stale or fake implementations from earlier suites. Rebind the globals
-    // ExperimentsProvider reaches through indirectly so the polling test always exercises the fresh
-    // happy-dom window installed for this case.
+    // ExperimentsProvider reaches through indirectly so each case runs against the fresh
+    // happy-dom window installed for it.
     globalThis.localStorage = dom.localStorage;
     globalThis.location = dom.location as unknown as Location;
     globalThis.StorageEvent = dom.StorageEvent as unknown as typeof StorageEvent;
@@ -128,94 +127,6 @@ describe("ExperimentsProvider", () => {
     }
   });
 
-  test("polls getAll until remote variants are available", async () => {
-    let callCount = 0;
-
-    const getAllMock = mock(() => {
-      callCount += 1;
-
-      if (callCount === 1) {
-        return Promise.resolve({
-          [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: { value: null, source: "cache" },
-        } satisfies Record<string, ExperimentValue>);
-      }
-
-      return Promise.resolve({
-        [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: { value: "test", source: "posthog" },
-      } satisfies Record<string, ExperimentValue>);
-    });
-
-    currentClientMock = {
-      experiments: {
-        getAll: getAllMock,
-        reload: mock(() => Promise.resolve()),
-      },
-    };
-
-    let scheduledPoll: (() => void) | null = null;
-    const expectedInitialPollDelayMs = 100;
-    const scheduledPollHandle = originalSetTimeout(() => undefined, 0);
-    originalClearTimeout(scheduledPollHandle);
-
-    // Capture the provider's first poll callback so this assertion does not depend on whichever
-    // timer implementation earlier suites left behind.
-    globalThis.setTimeout = ((callback: TimerHandler, delay?: number) => {
-      if (delay === expectedInitialPollDelayMs && typeof callback === "function") {
-        const scheduledCallback = callback as () => void;
-        scheduledPoll = () => {
-          scheduledCallback();
-        };
-        return scheduledPollHandle;
-      }
-
-      return originalSetTimeout(callback, delay);
-    }) as typeof globalThis.setTimeout;
-    globalThis.clearTimeout = ((timeout: ReturnType<typeof setTimeout>) => {
-      if (timeout === scheduledPollHandle) {
-        scheduledPoll = null;
-        return;
-      }
-
-      originalClearTimeout(timeout);
-    }) as typeof globalThis.clearTimeout;
-
-    function Observer() {
-      const enabled = useExperimentValue(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
-      return <div data-testid="enabled">{String(enabled)}</div>;
-    }
-
-    const { getByTestId } = render(
-      <APIProvider client={currentClientMock as APIClient}>
-        <ExperimentsProvider>
-          <Observer />
-        </ExperimentsProvider>
-      </APIProvider>
-    );
-
-    expect(getByTestId("enabled").textContent).toBe("false");
-
-    await waitFor(() => {
-      expect(scheduledPoll).not.toBeNull();
-    });
-
-    const pollRemoteExperiments: () => void =
-      scheduledPoll ??
-      (() => {
-        throw new Error("Expected poll callback to be scheduled");
-      });
-    expect(scheduledPoll).not.toBeNull();
-
-    act(() => {
-      pollRemoteExperiments();
-    });
-
-    await waitFor(() => {
-      expect(getByTestId("enabled").textContent).toBe("true");
-    });
-
-    expect(getAllMock.mock.calls.length).toBeGreaterThanOrEqual(2);
-  });
-
   test("syncs existing local overrides to the backend on connect", async () => {
     globalThis.window.localStorage.setItem(
       getExperimentKey(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES),
@@ -225,9 +136,7 @@ describe("ExperimentsProvider", () => {
     const setOverrideMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        getAll: mock(() => Promise.resolve({} satisfies Record<string, ExperimentValue>)),
         setOverride: setOverrideMock,
-        reload: mock(() => Promise.resolve()),
       },
     };
 
@@ -275,9 +184,7 @@ describe("ExperimentsProvider", () => {
     const setOverrideMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        getAll: mock(() => Promise.resolve({} satisfies Record<string, ExperimentValue>)),
         setOverride: setOverrideMock,
-        reload: mock(() => Promise.resolve()),
       },
     };
 

--- a/src/browser/contexts/ExperimentsContext.test.tsx
+++ b/src/browser/contexts/ExperimentsContext.test.tsx
@@ -133,10 +133,10 @@ describe("ExperimentsProvider", () => {
       JSON.stringify(true)
     );
 
-    const setOverrideMock = mock(() => Promise.resolve());
+    const syncMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        setOverride: setOverrideMock,
+        sync: syncMock,
       },
     };
 
@@ -149,10 +149,30 @@ describe("ExperimentsProvider", () => {
     );
 
     await waitFor(() => {
-      expect(setOverrideMock).toHaveBeenCalledWith({
-        experimentId: EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
-        enabled: true,
+      expect(syncMock).toHaveBeenCalledWith({
+        overrides: { [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true },
       });
+    });
+  });
+
+  test("sends an empty override set when localStorage has none, clearing backend state", async () => {
+    const syncMock = mock(() => Promise.resolve());
+    currentClientMock = {
+      experiments: {
+        sync: syncMock,
+      },
+    };
+
+    render(
+      <APIProvider client={currentClientMock as APIClient}>
+        <ExperimentsProvider>
+          <div />
+        </ExperimentsProvider>
+      </APIProvider>
+    );
+
+    await waitFor(() => {
+      expect(syncMock).toHaveBeenCalledWith({ overrides: {} });
     });
   });
 
@@ -181,10 +201,10 @@ describe("ExperimentsProvider", () => {
   });
 
   test("persists backend overrides when a user toggles an experiment", async () => {
-    const setOverrideMock = mock(() => Promise.resolve());
+    const syncMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        setOverride: setOverrideMock,
+        sync: syncMock,
       },
     };
 
@@ -208,9 +228,8 @@ describe("ExperimentsProvider", () => {
     fireEvent.click(getByTestId("toggle"));
 
     await waitFor(() => {
-      expect(setOverrideMock).toHaveBeenCalledWith({
-        experimentId: EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
-        enabled: true,
+      expect(syncMock).toHaveBeenCalledWith({
+        overrides: { [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true },
       });
       expect(getByTestId("toggle").textContent).toBe("true");
     });

--- a/src/browser/contexts/ExperimentsContext.test.tsx
+++ b/src/browser/contexts/ExperimentsContext.test.tsx
@@ -133,10 +133,11 @@ describe("ExperimentsProvider", () => {
       JSON.stringify(true)
     );
 
-    const syncMock = mock(() => Promise.resolve());
+    const setOverrideMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        sync: syncMock,
+        setOverride: setOverrideMock,
+        getOverrides: mock(() => Promise.resolve({})),
       },
     };
 
@@ -149,31 +150,42 @@ describe("ExperimentsProvider", () => {
     );
 
     await waitFor(() => {
-      expect(syncMock).toHaveBeenCalledWith({
-        overrides: { [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true },
+      expect(setOverrideMock).toHaveBeenCalledWith({
+        experimentId: EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
+        enabled: true,
       });
     });
   });
 
-  test("sends an empty override set when localStorage has none, clearing backend state", async () => {
-    const syncMock = mock(() => Promise.resolve());
+  test("adopts a backend override when this client has no local state, and clears nothing", async () => {
+    const setOverrideMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        sync: syncMock,
+        setOverride: setOverrideMock,
+        getOverrides: mock(() =>
+          Promise.resolve({ [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true })
+        ),
       },
     };
 
-    render(
+    function Observer() {
+      const enabled = useExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES);
+      return <div data-testid="enabled">{String(enabled)}</div>;
+    }
+
+    const { getByTestId } = render(
       <APIProvider client={currentClientMock as APIClient}>
         <ExperimentsProvider>
-          <div />
+          <Observer />
         </ExperimentsProvider>
       </APIProvider>
     );
 
     await waitFor(() => {
-      expect(syncMock).toHaveBeenCalledWith({ overrides: {} });
+      expect(getByTestId("enabled").textContent).toBe("true");
     });
+
+    expect(setOverrideMock).not.toHaveBeenCalled();
   });
 
   test("returns false for a platform-restricted experiment on unsupported platforms", () => {
@@ -201,10 +213,11 @@ describe("ExperimentsProvider", () => {
   });
 
   test("persists backend overrides when a user toggles an experiment", async () => {
-    const syncMock = mock(() => Promise.resolve());
+    const setOverrideMock = mock(() => Promise.resolve());
     currentClientMock = {
       experiments: {
-        sync: syncMock,
+        setOverride: setOverrideMock,
+        getOverrides: mock(() => Promise.resolve({})),
       },
     };
 
@@ -228,8 +241,9 @@ describe("ExperimentsProvider", () => {
     fireEvent.click(getByTestId("toggle"));
 
     await waitFor(() => {
-      expect(syncMock).toHaveBeenCalledWith({
-        overrides: { [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true },
+      expect(setOverrideMock).toHaveBeenCalledWith({
+        experimentId: EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
+        enabled: true,
       });
       expect(getByTestId("toggle").textContent).toBe("true");
     });

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -4,8 +4,6 @@ import React, {
   useSyncExternalStore,
   useCallback,
   useEffect,
-  useRef,
-  useState,
 } from "react";
 import {
   type ExperimentId,
@@ -15,7 +13,6 @@ import {
   isExperimentSupportedOnPlatform,
 } from "@/common/constants/experiments";
 import { getStorageChangeEvent } from "@/common/constants/events";
-import type { ExperimentValue } from "@/common/orpc/types";
 import { useAPI } from "@/browser/contexts/API";
 
 /**
@@ -81,14 +78,6 @@ function getExperimentSnapshot(experimentId: ExperimentId): boolean {
   return getExperimentOverrideSnapshot(experimentId) ?? experiment.enabledByDefault;
 }
 
-/**
- * Check if user has explicitly set a local override for an experiment.
- * Returns true if there's a value in localStorage (not using default).
- */
-function hasLocalOverride(experimentId: ExperimentId): boolean {
-  return getExperimentOverrideSnapshot(experimentId) !== undefined;
-}
-
 function getExplicitLocalExperimentOverrides(): Partial<Record<ExperimentId, boolean>> {
   const overrides: Partial<Record<ExperimentId, boolean>> = {};
 
@@ -106,39 +95,6 @@ function getExplicitLocalExperimentOverrides(): Partial<Record<ExperimentId, boo
   }
 
   return overrides;
-}
-
-/**
- * Convert PostHog experiment variant to boolean enabled state.
- * For experiments with control/test variants, "test" means enabled.
- */
-function getRemoteExperimentEnabled(value: string | boolean): boolean {
-  if (typeof value === "boolean") {
-    return value;
-  }
-  return value === "test";
-}
-
-/**
- * True when any remote experiment value is still pending a background PostHog refresh.
- */
-function hasPendingRemoteExperimentValues(
-  remoteExperiments: Partial<Record<ExperimentId, ExperimentValue>>
-): boolean {
-  return Object.values(remoteExperiments).some(
-    (remote) => remote?.source === "cache" && remote.value === null
-  );
-}
-
-const REMOTE_EXPERIMENTS_POLL_INITIAL_DELAY_MS = 100;
-const REMOTE_EXPERIMENTS_POLL_MAX_DELAY_MS = 5_000;
-const REMOTE_EXPERIMENTS_POLL_MAX_ATTEMPTS = 8;
-
-function getRemoteExperimentsPollDelayMs(attempt: number): number {
-  return Math.min(
-    REMOTE_EXPERIMENTS_POLL_INITIAL_DELAY_MS * 2 ** attempt,
-    REMOTE_EXPERIMENTS_POLL_MAX_DELAY_MS
-  );
 }
 
 /**
@@ -170,8 +126,6 @@ function setExperimentState(experimentId: ExperimentId, enabled: boolean): void 
  */
 interface ExperimentsContextValue {
   setExperiment: (experimentId: ExperimentId, enabled: boolean) => void;
-  remoteExperiments: Partial<Record<ExperimentId, ExperimentValue>> | null;
-  reloadRemoteExperiments: () => Promise<void>;
 }
 
 const ExperimentsContext = createContext<ExperimentsContextValue | null>(null);
@@ -182,38 +136,6 @@ const ExperimentsContext = createContext<ExperimentsContextValue | null>(null);
  */
 export function ExperimentsProvider(props: { children: React.ReactNode }) {
   const apiState = useAPI();
-  const [remoteExperiments, setRemoteExperiments] = useState<Partial<
-    Record<ExperimentId, ExperimentValue>
-  > | null>(null);
-
-  const loadRemoteExperiments = useCallback(async () => {
-    if (apiState.status !== "connected" || !apiState.api) {
-      setRemoteExperiments(null);
-      return;
-    }
-
-    try {
-      const result = await apiState.api.experiments.getAll();
-      setRemoteExperiments(result as Partial<Record<ExperimentId, ExperimentValue>>);
-    } catch {
-      setRemoteExperiments(null);
-    }
-  }, [apiState.status, apiState.api]);
-
-  const reloadRemoteExperiments = useCallback(async () => {
-    if (apiState.status !== "connected" || !apiState.api) {
-      setRemoteExperiments(null);
-      return;
-    }
-
-    try {
-      await apiState.api.experiments.reload();
-    } catch {
-      // Best effort
-    }
-
-    await loadRemoteExperiments();
-  }, [apiState.status, apiState.api, loadRemoteExperiments]);
 
   const persistBackendOverride = useCallback(
     async (experimentId: ExperimentId, enabled: boolean | undefined) => {
@@ -229,12 +151,11 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
 
       try {
         await apiState.api.experiments.setOverride({ experimentId, enabled });
-        await loadRemoteExperiments();
       } catch {
         // Best effort
       }
     },
-    [apiState.status, apiState.api, loadRemoteExperiments]
+    [apiState.status, apiState.api]
   );
 
   const setExperiment = useCallback(
@@ -263,79 +184,16 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
             await apiState.api.experiments.setOverride({ experimentId, enabled });
           })
         );
-        await loadRemoteExperiments();
       } catch {
         // Best effort
       }
     };
 
     void syncLocalOverrides();
-  }, [apiState.status, apiState.api, loadRemoteExperiments]);
-
-  // On cold start, experiments.getAll can return { source: "cache", value: null } while
-  // ExperimentsService refreshes from PostHog in the background. Poll a few times so the
-  // renderer picks up remote variants without requiring a manual reload.
-  const remotePollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const remotePollAttemptRef = useRef(0);
-
-  const clearRemotePoll = useCallback(() => {
-    if (remotePollTimeoutRef.current === null) {
-      return;
-    }
-
-    clearTimeout(remotePollTimeoutRef.current);
-    remotePollTimeoutRef.current = null;
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      clearRemotePoll();
-    };
-  }, [clearRemotePoll]);
-
-  useEffect(() => {
-    if (apiState.status !== "connected" || !apiState.api) {
-      remotePollAttemptRef.current = 0;
-      clearRemotePoll();
-      return;
-    }
-
-    if (!remoteExperiments) {
-      remotePollAttemptRef.current = 0;
-      clearRemotePoll();
-      return;
-    }
-
-    if (!hasPendingRemoteExperimentValues(remoteExperiments)) {
-      remotePollAttemptRef.current = 0;
-      clearRemotePoll();
-      return;
-    }
-
-    if (remotePollTimeoutRef.current !== null) {
-      return;
-    }
-
-    const attempt = remotePollAttemptRef.current;
-    if (attempt >= REMOTE_EXPERIMENTS_POLL_MAX_ATTEMPTS) {
-      return;
-    }
-
-    const delayMs = getRemoteExperimentsPollDelayMs(attempt);
-    remotePollTimeoutRef.current = setTimeout(() => {
-      remotePollTimeoutRef.current = null;
-      remotePollAttemptRef.current += 1;
-      void loadRemoteExperiments();
-    }, delayMs);
-  }, [apiState.status, apiState.api, remoteExperiments, clearRemotePoll, loadRemoteExperiments]);
-  useEffect(() => {
-    void loadRemoteExperiments();
-  }, [loadRemoteExperiments]);
+  }, [apiState.status, apiState.api]);
 
   return (
-    <ExperimentsContext.Provider
-      value={{ setExperiment, remoteExperiments, reloadRemoteExperiments }}
-    >
+    <ExperimentsContext.Provider value={{ setExperiment }}>
       {props.children}
     </ExperimentsContext.Provider>
   );
@@ -346,17 +204,10 @@ export function ExperimentsProvider(props: { children: React.ReactNode }) {
  * Uses useSyncExternalStore for efficient, selective re-renders.
  * Only re-renders when THIS specific experiment changes.
  *
- * Resolution priority:
- * - If userOverridable && user has explicitly set a local value → use local
- * - If backend has an override or remote assignment → use backend value
- * - Otherwise → use local (which may be default)
- *
  * @param experimentId - The experiment to subscribe to
  * @returns Whether the experiment is enabled
  */
 export function useExperimentValue(experimentId: ExperimentId): boolean {
-  const experiment = EXPERIMENTS[experimentId];
-  const isSupported = isExperimentSupported(experimentId);
   const subscribe = useCallback(
     (callback: () => void) => subscribeToExperiment(experimentId, callback),
     [experimentId]
@@ -364,35 +215,14 @@ export function useExperimentValue(experimentId: ExperimentId): boolean {
 
   const getSnapshot = useCallback(() => getExperimentSnapshot(experimentId), [experimentId]);
 
-  const localEnabled = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-
-  const context = useContext(ExperimentsContext);
-  const remote = context?.remoteExperiments?.[experimentId];
-
-  if (!isSupported) {
-    return false;
-  }
-
-  // User-overridable: local wins if explicitly set
-  if (experiment.userOverridable && hasLocalOverride(experimentId)) {
-    return localEnabled;
-  }
-
-  // Remote assignment (if available and not disabled)
-  if (remote && remote.source !== "disabled" && remote.value !== null) {
-    return getRemoteExperimentEnabled(remote.value);
-  }
-
-  // Fallback to local (which may be default)
-  return localEnabled;
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 /**
  * Hook to read only an explicit local override for an experiment.
  *
- * Returns `undefined` when the user has not explicitly set a value in localStorage.
- * This is important for user-overridable experiments: the backend can then apply
- * the PostHog assignment instead of treating the default value as a user choice.
+ * Returns `undefined` when the user has not explicitly set a value in localStorage,
+ * which lets send options distinguish "user chose off" from "user never chose".
  */
 export function useExperimentOverrideValue(experimentId: ExperimentId): boolean | undefined {
   const isSupported = isExperimentSupported(experimentId);
@@ -421,10 +251,6 @@ export function useExperimentOverrideValue(experimentId: ExperimentId): boolean 
  * @returns Function to set experiment state
  */
 
-export function useRemoteExperimentValue(experimentId: ExperimentId): ExperimentValue | null {
-  const context = useContext(ExperimentsContext);
-  return context?.remoteExperiments?.[experimentId] ?? null;
-}
 export function useSetExperiment(): (experimentId: ExperimentId, enabled: boolean) => void {
   const context = useContext(ExperimentsContext);
   if (!context) {
@@ -459,8 +285,6 @@ export function useExperiment(experimentId: ExperimentId): [boolean, (enabled: b
  */
 export function useAllExperiments(): Record<ExperimentId, boolean> {
   const experiments = getExperimentList();
-  const context = useContext(ExperimentsContext);
-  const remoteExperiments = context?.remoteExperiments;
 
   // Subscribe to all experiments
   const subscribe = useCallback(
@@ -475,32 +299,11 @@ export function useAllExperiments(): Record<ExperimentId, boolean> {
     const result: Partial<Record<ExperimentId, boolean>> = {};
 
     for (const exp of experiments) {
-      if (!isExperimentSupported(exp.id)) {
-        result[exp.id] = false;
-        continue;
-      }
-
-      const localValue = getExperimentSnapshot(exp.id);
-      const remote = remoteExperiments?.[exp.id];
-
-      // User-overridable: local wins if explicitly set
-      if (exp.userOverridable && hasLocalOverride(exp.id)) {
-        result[exp.id] = localValue;
-        continue;
-      }
-
-      // Remote assignment (if available and not disabled)
-      if (remote && remote.source !== "disabled" && remote.value !== null) {
-        result[exp.id] = getRemoteExperimentEnabled(remote.value);
-        continue;
-      }
-
-      // Fallback to local (which may be default)
-      result[exp.id] = localValue;
+      result[exp.id] = getExperimentSnapshot(exp.id);
     }
 
     return result as Record<ExperimentId, boolean>;
-  }, [experiments, remoteExperiments]);
+  }, [experiments]);
 
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -4,12 +4,12 @@ import React, {
   useSyncExternalStore,
   useCallback,
   useEffect,
+  useState,
 } from "react";
 import {
   type ExperimentId,
   EXPERIMENTS,
   getExperimentKey,
-  getExperimentList,
   isExperimentSupportedOnPlatform,
 } from "@/common/constants/experiments";
 import { getStorageChangeEvent } from "@/common/constants/events";
@@ -65,19 +65,6 @@ function getExperimentOverrideSnapshot(experimentId: ExperimentId): boolean | un
   }
 }
 
-/**
- * Get current experiment state from localStorage.
- * Returns the stored value or the default if not set.
- */
-function getExperimentSnapshot(experimentId: ExperimentId): boolean {
-  const experiment = EXPERIMENTS[experimentId];
-  if (!isExperimentSupported(experimentId)) {
-    return false;
-  }
-
-  return getExperimentOverrideSnapshot(experimentId) ?? experiment.enabledByDefault;
-}
-
 function getExplicitLocalExperimentOverrides(): Partial<Record<ExperimentId, boolean>> {
   const overrides: Partial<Record<ExperimentId, boolean>> = {};
 
@@ -126,6 +113,7 @@ function setExperimentState(experimentId: ExperimentId, enabled: boolean): void 
  */
 interface ExperimentsContextValue {
   setExperiment: (experimentId: ExperimentId, enabled: boolean) => void;
+  backendOverrides: Partial<Record<ExperimentId, boolean>> | null;
 }
 
 const ExperimentsContext = createContext<ExperimentsContextValue | null>(null);
@@ -136,35 +124,78 @@ const ExperimentsContext = createContext<ExperimentsContextValue | null>(null);
  */
 export function ExperimentsProvider(props: { children: React.ReactNode }) {
   const apiState = useAPI();
+  const [backendOverrides, setBackendOverrides] = useState<Partial<
+    Record<ExperimentId, boolean>
+  > | null>(null);
 
-  // localStorage is the source of truth: always send the complete set so the backend
-  // mirrors exactly what Settings shows, including overrides the user has cleared.
-  const syncOverridesToBackend = useCallback(async () => {
-    if (apiState.status !== "connected" || !apiState.api) {
-      return;
-    }
+  const persistOverride = useCallback(
+    async (experimentId: ExperimentId, enabled: boolean) => {
+      if (apiState.status !== "connected" || !apiState.api) {
+        return;
+      }
 
-    try {
-      await apiState.api.experiments.sync({ overrides: getExplicitLocalExperimentOverrides() });
-    } catch {
-      // Best effort
-    }
-  }, [apiState.status, apiState.api]);
+      try {
+        await apiState.api.experiments.setOverride({ experimentId, enabled });
+      } catch {
+        // Best effort
+      }
+    },
+    [apiState.status, apiState.api]
+  );
 
   const setExperiment = useCallback(
     (experimentId: ExperimentId, enabled: boolean) => {
       setExperimentState(experimentId, enabled);
-      void syncOverridesToBackend();
+      setBackendOverrides((prev) => (prev ? { ...prev, [experimentId]: enabled } : prev));
+      void persistOverride(experimentId, enabled);
     },
-    [syncOverridesToBackend]
+    [persistOverride]
   );
 
   useEffect(() => {
-    void syncOverridesToBackend();
-  }, [syncOverridesToBackend]);
+    if (apiState.status !== "connected" || !apiState.api) {
+      setBackendOverrides(null);
+      return;
+    }
+
+    const api = apiState.api;
+    let cancelled = false;
+
+    const reconcile = async () => {
+      // Upload this client's local overrides first, then adopt the merged backend state.
+      // Uploads are per-experiment: this client's localStorage is origin-scoped and may
+      // legitimately be empty, so it must never clear overrides another client set.
+      try {
+        await Promise.all(
+          Object.entries(getExplicitLocalExperimentOverrides()).map(([experimentId, enabled]) =>
+            api.experiments.setOverride({ experimentId: experimentId as ExperimentId, enabled })
+          )
+        );
+      } catch {
+        // Best effort
+      }
+
+      try {
+        const overrides = await api.experiments.getOverrides();
+        if (!cancelled) {
+          setBackendOverrides(overrides);
+        }
+      } catch {
+        if (!cancelled) {
+          setBackendOverrides(null);
+        }
+      }
+    };
+
+    void reconcile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiState.status, apiState.api]);
 
   return (
-    <ExperimentsContext.Provider value={{ setExperiment }}>
+    <ExperimentsContext.Provider value={{ setExperiment, backendOverrides }}>
       {props.children}
     </ExperimentsContext.Provider>
   );
@@ -184,9 +215,25 @@ export function useExperimentValue(experimentId: ExperimentId): boolean {
     [experimentId]
   );
 
-  const getSnapshot = useCallback(() => getExperimentSnapshot(experimentId), [experimentId]);
+  const getSnapshot = useCallback(
+    () => getExperimentOverrideSnapshot(experimentId),
+    [experimentId]
+  );
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const localOverride = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const context = useContext(ExperimentsContext);
+
+  if (!isExperimentSupported(experimentId)) {
+    return false;
+  }
+
+  // An explicit local toggle wins, which also settles the race against an in-flight
+  // backend read: a toggle made while it loads is not overwritten when it resolves.
+  if (localOverride !== undefined) {
+    return localOverride;
+  }
+
+  return context?.backendOverrides?.[experimentId] ?? EXPERIMENTS[experimentId].enabledByDefault;
 }
 
 /**
@@ -247,34 +294,4 @@ export function useExperiment(experimentId: ExperimentId): [boolean, (enabled: b
   );
 
   return [enabled, setEnabled];
-}
-
-/**
- * Get all experiments with their current state.
- * Reactive - re-renders when any experiment changes.
- * Use sparingly; prefer useExperimentValue for single experiments.
- */
-export function useAllExperiments(): Record<ExperimentId, boolean> {
-  const experiments = getExperimentList();
-
-  // Subscribe to all experiments
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      const unsubscribes = experiments.map((exp) => subscribeToExperiment(exp.id, callback));
-      return () => unsubscribes.forEach((unsub) => unsub());
-    },
-    [experiments]
-  );
-
-  const getSnapshot = useCallback(() => {
-    const result: Partial<Record<ExperimentId, boolean>> = {};
-
-    for (const exp of experiments) {
-      result[exp.id] = getExperimentSnapshot(exp.id);
-    }
-
-    return result as Record<ExperimentId, boolean>;
-  }, [experiments]);
-
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -82,7 +82,7 @@ function getExplicitLocalExperimentOverrides(): Partial<Record<ExperimentId, boo
   const overrides: Partial<Record<ExperimentId, boolean>> = {};
 
   for (const experimentId of Object.keys(EXPERIMENTS) as ExperimentId[]) {
-    if (!EXPERIMENTS[experimentId].userOverridable || !isExperimentSupported(experimentId)) {
+    if (!isExperimentSupported(experimentId)) {
       continue;
     }
 

--- a/src/browser/contexts/ExperimentsContext.tsx
+++ b/src/browser/contexts/ExperimentsContext.tsx
@@ -137,60 +137,31 @@ const ExperimentsContext = createContext<ExperimentsContextValue | null>(null);
 export function ExperimentsProvider(props: { children: React.ReactNode }) {
   const apiState = useAPI();
 
-  const persistBackendOverride = useCallback(
-    async (experimentId: ExperimentId, enabled: boolean | undefined) => {
-      if (
-        apiState.status !== "connected" ||
-        !apiState.api ||
-        enabled === undefined ||
-        !EXPERIMENTS[experimentId].userOverridable ||
-        !isExperimentSupported(experimentId)
-      ) {
-        return;
-      }
-
-      try {
-        await apiState.api.experiments.setOverride({ experimentId, enabled });
-      } catch {
-        // Best effort
-      }
-    },
-    [apiState.status, apiState.api]
-  );
-
-  const setExperiment = useCallback(
-    (experimentId: ExperimentId, enabled: boolean) => {
-      setExperimentState(experimentId, enabled);
-      void persistBackendOverride(experimentId, enabled);
-    },
-    [persistBackendOverride]
-  );
-
-  useEffect(() => {
+  // localStorage is the source of truth: always send the complete set so the backend
+  // mirrors exactly what Settings shows, including overrides the user has cleared.
+  const syncOverridesToBackend = useCallback(async () => {
     if (apiState.status !== "connected" || !apiState.api) {
       return;
     }
 
-    const localOverrides = getExplicitLocalExperimentOverrides();
-    const syncLocalOverrides = async () => {
-      const entries = Object.entries(localOverrides) as Array<[ExperimentId, boolean]>;
-      if (entries.length === 0) {
-        return;
-      }
-
-      try {
-        await Promise.all(
-          entries.map(async ([experimentId, enabled]) => {
-            await apiState.api.experiments.setOverride({ experimentId, enabled });
-          })
-        );
-      } catch {
-        // Best effort
-      }
-    };
-
-    void syncLocalOverrides();
+    try {
+      await apiState.api.experiments.sync({ overrides: getExplicitLocalExperimentOverrides() });
+    } catch {
+      // Best effort
+    }
   }, [apiState.status, apiState.api]);
+
+  const setExperiment = useCallback(
+    (experimentId: ExperimentId, enabled: boolean) => {
+      setExperimentState(experimentId, enabled);
+      void syncOverridesToBackend();
+    },
+    [syncOverridesToBackend]
+  );
+
+  useEffect(() => {
+    void syncOverridesToBackend();
+  }, [syncOverridesToBackend]);
 
   return (
     <ExperimentsContext.Provider value={{ setExperiment }}>

--- a/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.advisor.test.tsx
@@ -165,7 +165,6 @@ void mock.module("@/browser/contexts/ExperimentsContext", () => ({
     },
   ],
   useExperimentValue: (experimentId: string) => experimentValues[experimentId] ?? false,
-  useRemoteExperimentValue: () => null,
 }));
 
 void mock.module("@/browser/hooks/useModelsFromSettings", () => ({

--- a/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.test.tsx
@@ -63,7 +63,6 @@ void mock.module("@/browser/contexts/ExperimentsContext", () => ({
     },
   ],
   useExperimentValue: (experimentId: string) => experimentValues[experimentId] ?? experimentEnabled,
-  useRemoteExperimentValue: () => null,
 }));
 
 void mock.module("@/browser/hooks/useTelemetry", () => ({

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AlertTriangle, Info } from "lucide-react";
-import {
-  useExperiment,
-  useExperimentValue,
-  useRemoteExperimentValue,
-} from "@/browser/contexts/ExperimentsContext";
+import { useExperiment, useExperimentValue } from "@/browser/contexts/ExperimentsContext";
 import {
   getExperimentList,
   getExperimentPlatformRestrictionLabel,
@@ -53,7 +49,6 @@ interface ExperimentRowProps {
 
 function ExperimentRow(props: ExperimentRowProps) {
   const [enabled, setEnabled] = useExperiment(props.experimentId);
-  const remote = useRemoteExperimentValue(props.experimentId);
   const telemetry = useTelemetry();
   const { availabilityMessage, disabled = false, onToggle, experimentId } = props;
 
@@ -65,10 +60,10 @@ function ExperimentRow(props: ExperimentRowProps) {
 
       setEnabled(value);
       // Track the override for analytics
-      telemetry.experimentOverridden(experimentId, remote?.value ?? null, value);
+      telemetry.experimentOverridden(experimentId, value);
       onToggle?.(value);
     },
-    [disabled, setEnabled, telemetry, experimentId, remote?.value, onToggle]
+    [disabled, setEnabled, telemetry, experimentId, onToggle]
   );
 
   return (

--- a/src/browser/features/Settings/Sections/ExperimentsSection.tsx
+++ b/src/browser/features/Settings/Sections/ExperimentsSection.tsx
@@ -730,10 +730,7 @@ export function ExperimentsSection() {
   const experiments = useMemo(
     () =>
       allExperiments.filter(
-        (exp) =>
-          exp.showInSettings !== false &&
-          exp.userOverridable === true &&
-          !MEMORY_SUB_EXPERIMENT_IDS.includes(exp.id)
+        (exp) => exp.showInSettings !== false && !MEMORY_SUB_EXPERIMENT_IDS.includes(exp.id)
       ),
     [allExperiments]
   );

--- a/src/browser/hooks/useExperiments.test.ts
+++ b/src/browser/hooks/useExperiments.test.ts
@@ -3,7 +3,7 @@
  *
  * Key invariant:
  * - For user-overridable experiments, absence of a localStorage entry must be treated as
- *   "no explicit override" (undefined), so the backend can apply PostHog assignment.
+ *   "no explicit override" (undefined) rather than an explicit "off".
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";

--- a/src/browser/hooks/useExperiments.ts
+++ b/src/browser/hooks/useExperiments.ts
@@ -1,7 +1,6 @@
 import { readPersistedState } from "./usePersistedState";
 import {
   type ExperimentId,
-  EXPERIMENTS,
   getExperimentKey,
   isExperimentSupportedOnPlatform,
 } from "@/common/constants/experiments";
@@ -12,7 +11,6 @@ export {
   useExperimentValue,
   useExperimentOverrideValue,
   useSetExperiment,
-  useAllExperiments,
 } from "@/browser/contexts/ExperimentsContext";
 
 /**
@@ -27,19 +25,10 @@ export {
  * override exists, so send options can distinguish "user chose off" from "user never chose".
  */
 export function isExperimentEnabled(experimentId: ExperimentId): boolean | undefined {
-  const experiment = EXPERIMENTS[experimentId];
   if (!isExperimentSupportedOnPlatform(experimentId, window.api?.platform)) {
     return false;
   }
 
-  const key = getExperimentKey(experimentId);
-
-  if (experiment.userOverridable) {
-    const stored = readPersistedState<unknown>(key, undefined);
-    return typeof stored === "boolean" ? stored : undefined;
-  }
-
-  // Non-overridable: always use default (these are local-only experiments)
-  const stored = readPersistedState<unknown>(key, experiment.enabledByDefault);
-  return typeof stored === "boolean" ? stored : experiment.enabledByDefault;
+  const stored = readPersistedState<unknown>(getExperimentKey(experimentId), undefined);
+  return typeof stored === "boolean" ? stored : undefined;
 }

--- a/src/browser/hooks/useExperiments.ts
+++ b/src/browser/hooks/useExperiments.ts
@@ -23,12 +23,8 @@ export {
  * For reactive updates in React components, use useExperimentValue (UI gating) or
  * useExperimentOverrideValue (backend send options).
  *
- * IMPORTANT: For user-overridable experiments, returns `undefined` when no explicit
- * localStorage override exists. This signals to the backend to use the PostHog
- * assignment instead of treating the default value as a user choice.
- *
- * @param experimentId - The experiment to check
- * @returns Whether the experiment is enabled, or undefined if backend should decide
+ * For user-overridable experiments, returns `undefined` when no explicit localStorage
+ * override exists, so send options can distinguish "user chose off" from "user never chose".
  */
 export function isExperimentEnabled(experimentId: ExperimentId): boolean | undefined {
   const experiment = EXPERIMENTS[experimentId];
@@ -38,8 +34,6 @@ export function isExperimentEnabled(experimentId: ExperimentId): boolean | undef
 
   const key = getExperimentKey(experimentId);
 
-  // For user-overridable experiments: only return a value if user explicitly set one.
-  // This allows the backend to use PostHog assignment when there's no override.
   if (experiment.userOverridable) {
     const stored = readPersistedState<unknown>(key, undefined);
     return typeof stored === "boolean" ? stored : undefined;

--- a/src/browser/hooks/useSendMessageOptions.ts
+++ b/src/browser/hooks/useSendMessageOptions.ts
@@ -52,7 +52,6 @@ export function useSendMessageOptions(workspaceId: string): SendMessageOptionsWi
   });
 
   // Subscribe to local override state so toggles apply immediately.
-  // If undefined, the backend will apply the PostHog assignment.
   const programmaticToolCalling = useExperimentOverrideValue(
     EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING
   );

--- a/src/browser/hooks/useTelemetry.ts
+++ b/src/browser/hooks/useTelemetry.ts
@@ -37,7 +37,7 @@ import type {
  * telemetry.commandUsed(commandType);
  * telemetry.voiceTranscription(audioDurationSecs, success);
  * telemetry.errorOccurred(errorType, context);
- * telemetry.experimentOverridden(experimentId, assignedVariant, userChoice);
+ * telemetry.experimentOverridden(experimentId, userChoice);
  * ```
  */
 export function useTelemetry() {
@@ -92,12 +92,9 @@ export function useTelemetry() {
     trackErrorOccurred(errorType, context);
   }, []);
 
-  const experimentOverridden = useCallback(
-    (experimentId: string, assignedVariant: string | boolean | null, userChoice: boolean) => {
-      trackExperimentOverridden(experimentId, assignedVariant, userChoice);
-    },
-    []
-  );
+  const experimentOverridden = useCallback((experimentId: string, userChoice: boolean) => {
+    trackExperimentOverridden(experimentId, userChoice);
+  }, []);
 
   return {
     workspaceSwitched,

--- a/src/common/constants/experiments.test.ts
+++ b/src/common/constants/experiments.test.ts
@@ -6,7 +6,6 @@ describe("experiments registry", () => {
     const experiment = EXPERIMENTS[EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES];
 
     expect(experiment.enabledByDefault).toBe(false);
-    expect(experiment.userOverridable).toBe(true);
     expect(experiment.showInSettings).toBe(true);
   });
 
@@ -19,14 +18,13 @@ describe("experiments registry", () => {
       throw new Error("Expected multi-project workspaces experiment to be registered");
     }
 
-    expect(experiment.showInSettings !== false && experiment.userOverridable === true).toBe(true);
+    expect(experiment.showInSettings).not.toBe(false);
   });
 
   test("keeps portable desktop visible in Settings while remaining opt-in", () => {
     const experiment = EXPERIMENTS[EXPERIMENT_IDS.PORTABLE_DESKTOP];
 
     expect(experiment.enabledByDefault).toBe(false);
-    expect(experiment.userOverridable).toBe(true);
     expect(experiment.showInSettings).toBe(true);
   });
 });

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -49,14 +49,6 @@ export interface ExperimentDefinition {
    * Defaults to true. Use false for invisible A/B tests.
    */
   showInSettings?: boolean;
-  /**
-   * When true, only an explicit local override (Settings toggle) can enable the
-   * experiment — remote/cached PostHog assignment is excluded from its
-   * evaluation path entirely. Use for security-sensitive experiments where
-   * "enabled" must mean deliberate local user consent (e.g. features that
-   * execute repo-controlled shell commands). Implies userOverridable.
-   */
-  localOverrideOnly?: boolean;
 }
 
 /**
@@ -214,9 +206,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     enabledByDefault: false,
     userOverridable: true,
     showInSettings: true,
-    // Executes repo-controlled shell commands: enabling must be a deliberate
-    // local user action, never a remote rollout bucket.
-    localOverrideOnly: true,
   },
   [EXPERIMENT_IDS.TIMELINE]: {
     id: EXPERIMENT_IDS.TIMELINE,

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -34,8 +34,6 @@ export interface ExperimentDefinition {
   description: string;
   /** Default state - false means disabled by default */
   enabledByDefault: boolean;
-  /** When true, the user can toggle this experiment in Settings. */
-  userOverridable?: boolean;
   /**
    * When set, the experiment is only toggleable on these platforms. On other platforms it
    * appears disabled with a message.
@@ -58,7 +56,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Programmatic Tool Calling",
     description: "Enable code_execution tool for multi-tool workflows in a sandboxed JS runtime",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE]: {
@@ -66,7 +63,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "PTC Exclusive Mode",
     description: "Replace all tools with code_execution (forces PTC usage)",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.CONFIGURABLE_BIND_URL]: {
@@ -75,7 +71,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Allow mux to listen on a non-localhost address so other devices on your LAN/VPN can connect. Anyone on your network with the auth token can access your mux API. HTTP only; use only on trusted networks (Tailscale recommended).",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.EXEC_SUBAGENT_HARD_RESTART]: {
@@ -83,7 +78,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Exec sub-agent hard restart",
     description: "Hard-restart exec sub-agents on context overflow",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.MUX_GOVERNOR]: {
@@ -91,7 +85,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Mux Governor",
     description: "Remote policy delivery for enterprise Mux Governor service",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: {
@@ -99,7 +92,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Multi-project workspaces",
     description: "Enable workspaces that can span multiple projects instead of a single project",
     enabledByDefault: false,
-    userOverridable: true,
     // Keep this visible so users can opt into the still-default-off experiment from Settings.
     showInSettings: true,
   },
@@ -108,7 +100,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Agent Browser",
     description: "Show the Browser tab in the right sidebar for live agent-browser viewing",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.ADVISOR_TOOL]: {
@@ -116,7 +107,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Advisor Tool",
     description: "Enable the experimental client-side advisor tool foundation",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: {
@@ -124,7 +114,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Workspace Heartbeats",
     description: "Persist per-workspace heartbeat settings for future background follow-ups",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.PORTABLE_DESKTOP]: {
@@ -132,7 +121,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Portable Desktop",
     description: "Enable virtual desktop sessions for GUI-based agent interactions",
     enabledByDefault: false,
-    userOverridable: true,
     platformRestriction: ["linux"],
     showInSettings: true,
   },
@@ -141,7 +129,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Dynamic Workflows",
     description: "Enable durable JavaScript workflow orchestration for delegated agent tasks",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.MEMORY]: {
@@ -150,7 +137,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Enable the agent memory tool and memory index (global / project / workspace scopes)",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   // Sub-experiment of Agent Memory (flat flag, gated on the parent at the call
@@ -162,7 +148,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     name: "Memory Hot Set",
     description: "Preload pinned and frequently used memory files into the system prompt",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   // Sub-experiment of Agent Memory (flat flag, gated on the parent at call
@@ -174,7 +159,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Background dream agent that consolidates memory files after compaction, on idle, and at archive",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.TOOL_SEARCH]: {
@@ -183,7 +167,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Defer MCP tool definitions out of the model-visible tool list until the model discovers them via the tool_catalog_search tool",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.CLAUDE_SKILLS_COMPAT]: {
@@ -192,7 +175,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Also discover Agent Skills from .claude/skills and ~/.claude/skills (read-only, lowest precedence within each scope)",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT]: {
@@ -201,7 +183,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "When you invoke a skill, whole-line !`command` directives in SKILL.md run in the workspace and are replaced with their output before the model sees the skill. Commands come from skill files, so only enable this if you trust the skills in your projects.",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
   [EXPERIMENT_IDS.TIMELINE]: {
@@ -210,7 +191,6 @@ export const EXPERIMENTS: Record<ExperimentId, ExperimentDefinition> = {
     description:
       "Record a durable birds-eye timeline per workspace: prompts, agent events, goals, heartbeats, sub-agents, and workflows",
     enabledByDefault: false,
-    userOverridable: true,
     showInSettings: true,
   },
 };

--- a/src/common/constants/experiments.ts
+++ b/src/common/constants/experiments.ts
@@ -34,10 +34,7 @@ export interface ExperimentDefinition {
   description: string;
   /** Default state - false means disabled by default */
   enabledByDefault: boolean;
-  /**
-   * When true, user can override remote PostHog assignment via Settings toggle.
-   * When false (default), remote assignment is authoritative.
-   */
+  /** When true, the user can toggle this experiment in Settings. */
   userOverridable?: boolean;
   /**
    * When set, the experiment is only toggleable on these platforms. On other platforms it

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -337,7 +337,6 @@ export {
   splashScreens,
   tasks,
   experiments,
-  ExperimentValueSchema,
   telemetry,
   TelemetryEventSchema,
   ssh,

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -136,14 +136,14 @@ import { ThinkingLevelSchema } from "../../types/thinking";
 
 // Experiments
 export const experiments = {
-  /**
-   * Replaces every backend override with the renderer's complete local state, so a
-   * cleared localStorage cannot leave an orphaned override enabling a backend gate
-   * that Settings shows as off.
-   */
-  sync: {
+  getOverrides: {
+    input: z.void(),
+    output: z.partialRecord(z.enum(EXPERIMENT_IDS), z.boolean()),
+  },
+  setOverride: {
     input: z.object({
-      overrides: z.partialRecord(z.enum(EXPERIMENT_IDS), z.boolean()),
+      experimentId: z.enum(EXPERIMENT_IDS),
+      enabled: z.boolean().nullish(),
     }),
     output: z.void(),
   },

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -135,25 +135,12 @@ import { TaskSettingsSchema } from "../../config/schemas/taskSettings";
 import { ThinkingLevelSchema } from "../../types/thinking";
 
 // Experiments
-export const ExperimentValueSchema = z.object({
-  value: z.union([z.string(), z.boolean(), z.null()]),
-  source: z.enum(["posthog", "cache", "override", "disabled"]),
-});
-
 export const experiments = {
-  getAll: {
-    input: z.void(),
-    output: z.record(z.string(), ExperimentValueSchema),
-  },
   setOverride: {
     input: z.object({
       experimentId: z.enum(EXPERIMENT_IDS),
       enabled: z.boolean().nullish(),
     }),
-    output: z.void(),
-  },
-  reload: {
-    input: z.void(),
     output: z.void(),
   },
 };

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -136,10 +136,14 @@ import { ThinkingLevelSchema } from "../../types/thinking";
 
 // Experiments
 export const experiments = {
-  setOverride: {
+  /**
+   * Replaces every backend override with the renderer's complete local state, so a
+   * cleared localStorage cannot leave an orphaned override enabling a backend gate
+   * that Settings shows as off.
+   */
+  sync: {
     input: z.object({
-      experimentId: z.enum(EXPERIMENT_IDS),
-      enabled: z.boolean().nullish(),
+      overrides: z.partialRecord(z.enum(EXPERIMENT_IDS), z.boolean()),
     }),
     output: z.void(),
   },

--- a/src/common/orpc/schemas/telemetry.ts
+++ b/src/common/orpc/schemas/telemetry.ts
@@ -224,7 +224,6 @@ const ErrorOccurredPropertiesSchema = z.object({
 
 const ExperimentOverriddenPropertiesSchema = z.object({
   experimentId: z.string(),
-  assignedVariant: z.union([z.string(), z.boolean(), z.null()]),
   userChoice: z.boolean(),
 });
 

--- a/src/common/orpc/schemas/workflow.test.ts
+++ b/src/common/orpc/schemas/workflow.test.ts
@@ -184,7 +184,6 @@ describe("workflow experiment gate", () => {
     const experiment = EXPERIMENTS[EXPERIMENT_IDS.DYNAMIC_WORKFLOWS];
 
     expect(experiment.enabledByDefault).toBe(false);
-    expect(experiment.userOverridable).toBe(true);
     expect(experiment.showInSettings).toBe(true);
   });
 });

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -65,8 +65,6 @@ export type PolicyStatus = z.infer<typeof schemas.PolicyStatusSchema>;
 export type PolicySource = z.infer<typeof schemas.PolicySourceSchema>;
 export type EffectivePolicy = z.infer<typeof schemas.EffectivePolicySchema>;
 export type PolicyRuntimeId = z.infer<typeof schemas.PolicyRuntimeIdSchema>;
-export type ExperimentValue = z.infer<typeof schemas.ExperimentValueSchema>;
-
 // Type guards for common chat message variants
 export function isCaughtUpMessage(msg: WorkspaceChatMessage): msg is CaughtUpMessage {
   return (msg as { type?: string }).type === "caught-up";

--- a/src/common/telemetry/payload.ts
+++ b/src/common/telemetry/payload.ts
@@ -351,8 +351,6 @@ export interface ErrorOccurredPayload {
 export interface ExperimentOverriddenPayload {
   /** Experiment identifier (e.g., 'agent-browser') */
   experimentId: string;
-  /** The variant PostHog assigned (null if not remote-controlled) */
-  assignedVariant: string | boolean | null;
   /** What the user chose (true = enabled, false = disabled) */
   userChoice: boolean;
 }

--- a/src/common/telemetry/tracking.ts
+++ b/src/common/telemetry/tracking.ts
@@ -182,13 +182,9 @@ export function trackErrorOccurred(
  * @param assignedVariant - What PostHog assigned (null if not remote-controlled)
  * @param userChoice - What the user chose (true = enabled, false = disabled)
  */
-export function trackExperimentOverridden(
-  experimentId: string,
-  assignedVariant: string | boolean | null,
-  userChoice: boolean
-): void {
+export function trackExperimentOverridden(experimentId: string, userChoice: boolean): void {
   trackEvent({
     event: "experiment_overridden",
-    properties: { experimentId, assignedVariant, userChoice },
+    properties: { experimentId, userChoice },
   });
 }

--- a/src/common/telemetry/tracking.ts
+++ b/src/common/telemetry/tracking.ts
@@ -178,9 +178,6 @@ export function trackErrorOccurred(
 
 /**
  * Track experiment override - when a user manually toggles an experiment
- * @param experimentId - The experiment identifier
- * @param assignedVariant - What PostHog assigned (null if not remote-controlled)
- * @param userChoice - What the user chose (true = enabled, false = disabled)
  */
 export function trackExperimentOverridden(experimentId: string, userChoice: boolean): void {
   trackEvent({

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5983,23 +5983,11 @@ export const router = (authToken?: string) => {
         }),
     },
     experiments: {
-      getAll: t
-        .input(schemas.experiments.getAll.input)
-        .output(schemas.experiments.getAll.output)
-        .handler(({ context }) => {
-          return context.experimentsService.getAll();
-        }),
       setOverride: t
         .input(schemas.experiments.setOverride.input)
         .output(schemas.experiments.setOverride.output)
         .handler(async ({ context, input }) => {
           await context.experimentsService.setOverride(input.experimentId, input.enabled);
-        }),
-      reload: t
-        .input(schemas.experiments.reload.input)
-        .output(schemas.experiments.reload.output)
-        .handler(async ({ context }) => {
-          await context.experimentsService.refreshAll();
         }),
     },
     debug: {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5983,11 +5983,17 @@ export const router = (authToken?: string) => {
         }),
     },
     experiments: {
-      sync: t
-        .input(schemas.experiments.sync.input)
-        .output(schemas.experiments.sync.output)
+      getOverrides: t
+        .input(schemas.experiments.getOverrides.input)
+        .output(schemas.experiments.getOverrides.output)
+        .handler(async ({ context }) => {
+          return await context.experimentsService.getOverrides();
+        }),
+      setOverride: t
+        .input(schemas.experiments.setOverride.input)
+        .output(schemas.experiments.setOverride.output)
         .handler(async ({ context, input }) => {
-          await context.experimentsService.syncOverrides(input.overrides);
+          await context.experimentsService.setOverride(input.experimentId, input.enabled);
         }),
     },
     debug: {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5983,11 +5983,11 @@ export const router = (authToken?: string) => {
         }),
     },
     experiments: {
-      setOverride: t
-        .input(schemas.experiments.setOverride.input)
-        .output(schemas.experiments.setOverride.output)
+      sync: t
+        .input(schemas.experiments.sync.input)
+        .output(schemas.experiments.sync.output)
         .handler(async ({ context, input }) => {
-          await context.experimentsService.setOverride(input.experimentId, input.enabled);
+          await context.experimentsService.syncOverrides(input.overrides);
         }),
     },
     debug: {

--- a/src/node/services/agentSession.agentSkillSnapshot.test.ts
+++ b/src/node/services/agentSession.agentSkillSnapshot.test.ts
@@ -680,10 +680,10 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
       // The directive has an observable side effect so we can prove it never ran.
       skillBody: "Context:\n!`touch dynamic-context-ran.marker`\nDone.",
     });
-    const isExperimentLocallyEnabled = mock(() => false);
+    const isExperimentEnabled = mock(() => false);
     const { session, messages } = await createSessionHarness({
       workspacePath,
-      aiServiceOverrides: { isExperimentLocallyEnabled },
+      aiServiceOverrides: { isExperimentEnabled },
     });
 
     const result = await session.sendMessage("use dyn", {
@@ -698,7 +698,7 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(isExperimentLocallyEnabled).toHaveBeenCalledWith(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT);
+    expect(isExperimentEnabled).toHaveBeenCalledWith(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT);
     // Body unchanged: the directive stays literal text...
     expect(getMessageText(messages[0])).toContain("!`touch dynamic-context-ran.marker`");
     // ...and no command executed (the side-effect marker must not exist).
@@ -713,7 +713,7 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     const { session, messages } = await createSessionHarness({
       workspacePath,
       aiServiceOverrides: {
-        isExperimentLocallyEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
+        isExperimentEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
       },
     });
 
@@ -747,7 +747,7 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     const { session, messages } = await createSessionHarness({
       workspacePath,
       aiServiceOverrides: {
-        isExperimentLocallyEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
+        isExperimentEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
       },
     });
 
@@ -777,7 +777,7 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     const { session, messages } = await createSessionHarness({
       workspacePath,
       aiServiceOverrides: {
-        isExperimentLocallyEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
+        isExperimentEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
       },
     });
 
@@ -806,7 +806,7 @@ describe("AgentSession.sendMessage (agent skill snapshots)", () => {
     const { session, messages } = await createSessionHarness({
       workspacePath,
       aiServiceOverrides: {
-        isExperimentLocallyEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
+        isExperimentEnabled: mock((id) => id === EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT),
       },
     });
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6370,12 +6370,9 @@ export class AgentSession {
   }): Promise<string> {
     // The typeof guard mirrors the getWorkspaceMetadata guard in
     // materializeAgentSkillSnapshots: test mocks may provide a partial AIService.
-    // isExperimentLocallyEnabled (not isExperimentEnabled): shell execution must
-    // require a deliberate local Settings toggle; a remote/cached experiment
-    // assignment must never be able to switch it on.
     if (
-      typeof this.aiService.isExperimentLocallyEnabled !== "function" ||
-      !this.aiService.isExperimentLocallyEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)
+      typeof this.aiService.isExperimentEnabled !== "function" ||
+      !this.aiService.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)
     ) {
       return args.body;
     }
@@ -6386,10 +6383,9 @@ export class AgentSession {
         // SECURITY AUDIT: this sink executes shell commands sourced from SKILL.md
         // bodies, which are repo-controlled and therefore attacker-controlled input
         // (any cloned repo can ship arbitrary skills). It is acceptable only because:
-        // (1) it is gated on an explicit LOCAL override of the default-off
-        // "skill-dynamic-context" experiment (Settings toggle); remote/cached
-        // experiment assignment can never enable it (see isExperimentLocallyEnabled),
-        // so the user has deliberately opted into skills running commands; and
+        // (1) it is gated on the default-off "skill-dynamic-context" experiment,
+        // which only an explicit local Settings toggle can enable, so the user has
+        // deliberately opted into skills running commands; and
         // (2) it runs solely on user-initiated skill invocations (slash "/skill" or
         // inline "$skill" refs) — the model-side agent_skill_read tool never reaches
         // this path — so each execution traces to a deliberate user action on a skill

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -572,16 +572,6 @@ export class AIService extends EventEmitter {
   }
 
   /**
-   * Whether the user explicitly enabled an experiment via local override.
-   * Unlike isExperimentEnabled, remote assignment can never satisfy this gate —
-   * required for security-sensitive experiments (see
-   * ExperimentsService.isExperimentLocallyEnabled).
-   */
-  isExperimentLocallyEnabled(experimentId: ExperimentId): boolean {
-    return this.experimentsService?.isExperimentLocallyEnabled(experimentId) === true;
-  }
-
-  /**
    * Build the session-segment memory context: the index snapshot advertised
    * in the memory tool description, plus the hot-memories block (pinned +
    * frequently used memory files; memory-hot-set sub-experiment). Returns

--- a/src/node/services/experimentsService.test.ts
+++ b/src/node/services/experimentsService.test.ts
@@ -45,7 +45,7 @@ describe("ExperimentsService", () => {
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(false);
 
-    await service.setOverride(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING, true);
+    await service.syncOverrides({ [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: true });
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(true);
   });
@@ -56,7 +56,7 @@ describe("ExperimentsService", () => {
       telemetryService: first.telemetryService,
       muxHome: tempDir,
     });
-    await service.setOverride(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES, true);
+    await service.syncOverrides({ [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true });
 
     expect((await readOverridesFile()).overrides).toEqual({
       [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true,
@@ -79,9 +79,9 @@ describe("ExperimentsService", () => {
   test("clearing an override disables the experiment and drops its telemetry variant", async () => {
     const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.setOverride(EXPERIMENT_IDS.MEMORY, true);
+    await service.syncOverrides({ [EXPERIMENT_IDS.MEMORY]: true });
 
-    await service.setOverride(EXPERIMENT_IDS.MEMORY, null);
+    await service.syncOverrides({});
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.MEMORY)).toBe(false);
     expect((await readOverridesFile()).overrides).toEqual({});
@@ -91,7 +91,7 @@ describe("ExperimentsService", () => {
   test("an explicit false override keeps the experiment disabled", async () => {
     const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.setOverride(EXPERIMENT_IDS.AGENT_BROWSER, false);
+    await service.syncOverrides({ [EXPERIMENT_IDS.AGENT_BROWSER]: false });
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.AGENT_BROWSER)).toBe(false);
     expect((await readOverridesFile()).overrides).toEqual({
@@ -120,7 +120,7 @@ describe("ExperimentsService", () => {
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PORTABLE_DESKTOP)).toBe(false);
 
-    await service.setOverride(EXPERIMENT_IDS.PORTABLE_DESKTOP, true);
+    await service.syncOverrides({ [EXPERIMENT_IDS.PORTABLE_DESKTOP]: true });
 
     expect((await readOverridesFile()).overrides).toEqual({});
     expect(setFeatureFlagVariant).toHaveBeenCalledWith(EXPERIMENT_IDS.PORTABLE_DESKTOP, null);
@@ -148,10 +148,37 @@ describe("ExperimentsService", () => {
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.TOOL_SEARCH)).toBe(false);
   });
 
+  test("clears a persisted override that the renderer no longer has locally", async () => {
+    await fs.writeFile(
+      path.join(tempDir, OVERRIDES_FILE),
+      JSON.stringify({
+        version: 1,
+        experiments: {},
+        overrides: { [EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT]: true },
+      }),
+      "utf-8"
+    );
+
+    const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
+    const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
+    await service.initialize();
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(true);
+
+    // A renderer with empty localStorage reports no overrides at all.
+    await service.syncOverrides({});
+
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
+    expect((await readOverridesFile()).overrides).toEqual({});
+    expect(setFeatureFlagVariant).toHaveBeenLastCalledWith(
+      EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT,
+      null
+    );
+  });
+
   test("writes an empty experiments map so older builds still read overrides", async () => {
     const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.setOverride(EXPERIMENT_IDS.TIMELINE, true);
+    await service.syncOverrides({ [EXPERIMENT_IDS.TIMELINE]: true });
 
     expect((await readOverridesFile()).experiments).toEqual({});
   });

--- a/src/node/services/experimentsService.test.ts
+++ b/src/node/services/experimentsService.test.ts
@@ -45,7 +45,7 @@ describe("ExperimentsService", () => {
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(false);
 
-    await service.syncOverrides({ [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: true });
+    await service.setOverride(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING, true);
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(true);
   });
@@ -56,7 +56,7 @@ describe("ExperimentsService", () => {
       telemetryService: first.telemetryService,
       muxHome: tempDir,
     });
-    await service.syncOverrides({ [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true });
+    await service.setOverride(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES, true);
 
     expect((await readOverridesFile()).overrides).toEqual({
       [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true,
@@ -79,9 +79,9 @@ describe("ExperimentsService", () => {
   test("clearing an override disables the experiment and drops its telemetry variant", async () => {
     const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.syncOverrides({ [EXPERIMENT_IDS.MEMORY]: true });
+    await service.setOverride(EXPERIMENT_IDS.MEMORY, true);
 
-    await service.syncOverrides({});
+    await service.setOverride(EXPERIMENT_IDS.MEMORY, null);
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.MEMORY)).toBe(false);
     expect((await readOverridesFile()).overrides).toEqual({});
@@ -91,7 +91,7 @@ describe("ExperimentsService", () => {
   test("an explicit false override keeps the experiment disabled", async () => {
     const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.syncOverrides({ [EXPERIMENT_IDS.AGENT_BROWSER]: false });
+    await service.setOverride(EXPERIMENT_IDS.AGENT_BROWSER, false);
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.AGENT_BROWSER)).toBe(false);
     expect((await readOverridesFile()).overrides).toEqual({
@@ -120,7 +120,7 @@ describe("ExperimentsService", () => {
 
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PORTABLE_DESKTOP)).toBe(false);
 
-    await service.syncOverrides({ [EXPERIMENT_IDS.PORTABLE_DESKTOP]: true });
+    await service.setOverride(EXPERIMENT_IDS.PORTABLE_DESKTOP, true);
 
     expect((await readOverridesFile()).overrides).toEqual({});
     expect(setFeatureFlagVariant).toHaveBeenCalledWith(EXPERIMENT_IDS.PORTABLE_DESKTOP, null);
@@ -148,7 +148,7 @@ describe("ExperimentsService", () => {
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.TOOL_SEARCH)).toBe(false);
   });
 
-  test("clears a persisted override that the renderer no longer has locally", async () => {
+  test("a client with empty local state does not clear overrides it never knew about", async () => {
     await fs.writeFile(
       path.join(tempDir, OVERRIDES_FILE),
       JSON.stringify({
@@ -159,26 +159,46 @@ describe("ExperimentsService", () => {
       "utf-8"
     );
 
-    const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
+    const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
     await service.initialize();
+
+    // A second renderer (different origin, so empty localStorage) uploads nothing and
+    // reads state back. It must not disable what another client persisted.
+    await service.setOverride(EXPERIMENT_IDS.AGENT_BROWSER, true);
+
+    expect(await service.getOverrides()).toEqual({
+      [EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT]: true,
+      [EXPERIMENT_IDS.AGENT_BROWSER]: true,
+    });
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(true);
+  });
 
-    // A renderer with empty localStorage reports no overrides at all.
-    await service.syncOverrides({});
-
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
-    expect((await readOverridesFile()).overrides).toEqual({});
-    expect(setFeatureFlagVariant).toHaveBeenLastCalledWith(
-      EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT,
-      null
+  test("getOverrides hides overrides for platform-unsupported experiments", async () => {
+    await fs.writeFile(
+      path.join(tempDir, OVERRIDES_FILE),
+      JSON.stringify({
+        version: 1,
+        experiments: {},
+        overrides: { [EXPERIMENT_IDS.PORTABLE_DESKTOP]: true },
+      }),
+      "utf-8"
     );
+
+    const { telemetryService } = createTelemetryService();
+    const service = new ExperimentsService({
+      telemetryService,
+      muxHome: tempDir,
+      platform: "darwin",
+    });
+
+    expect(await service.getOverrides()).toEqual({});
   });
 
   test("writes an empty experiments map so older builds still read overrides", async () => {
     const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
-    await service.syncOverrides({ [EXPERIMENT_IDS.TIMELINE]: true });
+    await service.setOverride(EXPERIMENT_IDS.TIMELINE, true);
 
     expect((await readOverridesFile()).experiments).toEqual({});
   });

--- a/src/node/services/experimentsService.test.ts
+++ b/src/node/services/experimentsService.test.ts
@@ -2,10 +2,22 @@ import { describe, expect, test, beforeEach, afterEach, mock } from "bun:test";
 import { ExperimentsService } from "./experimentsService";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import type { TelemetryService } from "./telemetryService";
-import type { PostHog } from "posthog-node";
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
+
+const OVERRIDES_FILE = "feature_flags.json";
+
+function createTelemetryService(): {
+  telemetryService: TelemetryService;
+  setFeatureFlagVariant: ReturnType<typeof mock>;
+} {
+  const setFeatureFlagVariant = mock(() => undefined);
+  return {
+    telemetryService: { setFeatureFlagVariant } as unknown as TelemetryService,
+    setFeatureFlagVariant,
+  };
+}
 
 describe("ExperimentsService", () => {
   let tempDir: string;
@@ -18,238 +30,87 @@ describe("ExperimentsService", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  test("loads cached experiment values from disk and exposes them", async () => {
-    const cacheFilePath = path.join(tempDir, "feature_flags.json");
-    await fs.writeFile(
-      cacheFilePath,
-      JSON.stringify(
-        {
-          version: 1,
-          experiments: {
-            [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: {
-              value: "test",
-              fetchedAtMs: Date.now(),
-            },
-          },
-        },
-        null,
-        2
-      ),
-      "utf-8"
-    );
+  async function readOverridesFile(): Promise<{
+    experiments?: unknown;
+    overrides?: Record<string, unknown>;
+  }> {
+    const raw = await fs.readFile(path.join(tempDir, OVERRIDES_FILE), "utf-8");
+    return JSON.parse(raw) as { experiments?: unknown; overrides?: Record<string, unknown> };
+  }
 
-    const setFeatureFlagVariant = mock(() => undefined);
-    const fakePostHog = {
-      getFeatureFlag: mock(() => Promise.resolve("test")),
-    } as unknown as PostHog;
-
-    const telemetryService = {
-      getPostHogClient: mock(() => fakePostHog),
-      getDistinctId: mock(() => "distinct-id"),
-      setFeatureFlagVariant,
-    } as unknown as TelemetryService;
-
-    const service = new ExperimentsService({
-      telemetryService,
-      muxHome: tempDir,
-      cacheTtlMs: 60 * 60 * 1000,
-    });
-
-    await service.initialize();
-
-    const values = service.getAll();
-    expect(values[EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]).toEqual({
-      value: "test",
-      source: "cache",
-    });
-
-    expect(setFeatureFlagVariant).toHaveBeenCalledWith(
-      EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING,
-      "test"
-    );
-  });
-
-  test("isExperimentLocallyEnabled requires a local override; remote/cached assignment never satisfies it", async () => {
-    const cacheFilePath = path.join(tempDir, "feature_flags.json");
-    // Seed a cached remote assignment that turns the experiment ON.
-    await fs.writeFile(
-      cacheFilePath,
-      JSON.stringify(
-        {
-          version: 1,
-          experiments: {
-            [EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT]: {
-              value: true,
-              fetchedAtMs: Date.now(),
-            },
-          },
-        },
-        null,
-        2
-      ),
-      "utf-8"
-    );
-
-    const telemetryService = {
-      getPostHogClient: mock(() => ({
-        getFeatureFlag: mock(() => Promise.resolve(true)),
-      })),
-      getDistinctId: mock(() => "distinct-id"),
-      setFeatureFlagVariant: mock(() => undefined),
-    } as unknown as TelemetryService;
-
-    const service = new ExperimentsService({
-      telemetryService,
-      muxHome: tempDir,
-      cacheTtlMs: 60 * 60 * 1000,
-    });
-    await service.initialize();
-
-    // localOverrideOnly: the cached remote assignment must be excluded from the
-    // evaluation path entirely, so BOTH gates read disabled — Settings UI and
-    // the execution gate can never disagree.
-    expect(service.getExperimentValue(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toEqual({
-      value: null,
-      source: "disabled",
-    });
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
-    expect(service.isExperimentLocallyEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
-
-    // An explicit local toggle enables both gates consistently.
-    await service.setOverride(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT, true);
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(true);
-    expect(service.isExperimentLocallyEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(true);
-
-    // Clearing the override turns both gates off again (no remote fallback).
-    await service.setOverride(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT, null);
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
-    expect(service.isExperimentLocallyEnabled(EXPERIMENT_IDS.SKILL_DYNAMIC_CONTEXT)).toBe(false);
-  });
-
-  test("refreshExperiment updates cache and writes it to disk", async () => {
-    const setFeatureFlagVariant = mock(() => undefined);
-    const fakePostHog = {
-      getFeatureFlag: mock(() => Promise.resolve("test")),
-    } as unknown as PostHog;
-
-    const telemetryService = {
-      getPostHogClient: mock(() => fakePostHog),
-      getDistinctId: mock(() => "distinct-id"),
-      setFeatureFlagVariant,
-    } as unknown as TelemetryService;
-
-    const service = new ExperimentsService({
-      telemetryService,
-      muxHome: tempDir,
-      cacheTtlMs: 0,
-    });
-
-    await service.initialize();
-    await service.refreshExperiment(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
-
-    const value = service.getExperimentValue(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
-    expect(value.value).toBe("test");
-    expect(value.source).toBe("posthog");
-
-    const cacheFilePath = path.join(tempDir, "feature_flags.json");
-    const disk = JSON.parse(await fs.readFile(cacheFilePath, "utf-8")) as unknown;
-    expect(typeof disk).toBe("object");
-
-    expect((disk as { version: unknown }).version).toBe(1);
-    expect((disk as { experiments: Record<string, unknown> }).experiments).toHaveProperty(
-      EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING
-    );
-
-    expect(setFeatureFlagVariant).toHaveBeenCalledWith(
-      EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING,
-      "test"
-    );
-  });
-
-  test("persists backend overrides and applies them before remote gating", async () => {
-    const setFeatureFlagVariant = mock(() => undefined);
-    const telemetryService = {
-      getPostHogClient: mock(() => null),
-      getDistinctId: mock(() => null),
-      setFeatureFlagVariant,
-    } as unknown as TelemetryService;
-
+  test("experiments are disabled until the user sets an override", async () => {
+    const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
     await service.initialize();
+
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(false);
+
+    await service.setOverride(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING, true);
+
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(true);
+  });
+
+  test("overrides survive a restart and re-apply their telemetry variant", async () => {
+    const first = createTelemetryService();
+    const service = new ExperimentsService({
+      telemetryService: first.telemetryService,
+      muxHome: tempDir,
+    });
     await service.setOverride(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES, true);
 
-    expect(service.getExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES)).toEqual({
-      value: true,
-      source: "override",
-    });
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES)).toBe(true);
-    expect(setFeatureFlagVariant).toHaveBeenCalledWith(
-      EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
-      true
-    );
-
-    const cacheFilePath = path.join(tempDir, "feature_flags.json");
-    const disk = JSON.parse(await fs.readFile(cacheFilePath, "utf-8")) as {
-      overrides?: Record<string, unknown>;
-    };
-    expect(disk.overrides).toEqual({
+    expect((await readOverridesFile()).overrides).toEqual({
       [EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES]: true,
     });
 
-    const reloadedSetFeatureFlagVariant = mock(() => undefined);
-    const reloadedTelemetryService = {
-      getPostHogClient: mock(() => null),
-      getDistinctId: mock(() => null),
-      setFeatureFlagVariant: reloadedSetFeatureFlagVariant,
-    } as unknown as TelemetryService;
-
-    const reloadedService = new ExperimentsService({
-      telemetryService: reloadedTelemetryService,
+    const second = createTelemetryService();
+    const reloaded = new ExperimentsService({
+      telemetryService: second.telemetryService,
       muxHome: tempDir,
     });
-    await reloadedService.initialize();
+    await reloaded.initialize();
 
-    expect(reloadedService.getExperimentValue(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES)).toEqual({
-      value: true,
-      source: "override",
-    });
-    expect(reloadedService.isExperimentEnabled(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES)).toBe(true);
-    expect(reloadedSetFeatureFlagVariant).toHaveBeenCalledWith(
+    expect(reloaded.isExperimentEnabled(EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES)).toBe(true);
+    expect(second.setFeatureFlagVariant).toHaveBeenCalledWith(
       EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES,
       true
     );
   });
 
-  test("platform-restricted experiments stay disabled on unsupported platforms", async () => {
-    const cacheFilePath = path.join(tempDir, "feature_flags.json");
+  test("clearing an override disables the experiment and drops its telemetry variant", async () => {
+    const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
+    const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
+    await service.setOverride(EXPERIMENT_IDS.MEMORY, true);
+
+    await service.setOverride(EXPERIMENT_IDS.MEMORY, null);
+
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.MEMORY)).toBe(false);
+    expect((await readOverridesFile()).overrides).toEqual({});
+    expect(setFeatureFlagVariant).toHaveBeenLastCalledWith(EXPERIMENT_IDS.MEMORY, null);
+  });
+
+  test("an explicit false override keeps the experiment disabled", async () => {
+    const { telemetryService } = createTelemetryService();
+    const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
+    await service.setOverride(EXPERIMENT_IDS.AGENT_BROWSER, false);
+
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.AGENT_BROWSER)).toBe(false);
+    expect((await readOverridesFile()).overrides).toEqual({
+      [EXPERIMENT_IDS.AGENT_BROWSER]: false,
+    });
+  });
+
+  test("platform-restricted experiments ignore overrides on unsupported platforms", async () => {
     await fs.writeFile(
-      cacheFilePath,
-      JSON.stringify(
-        {
-          version: 1,
-          experiments: {
-            [EXPERIMENT_IDS.PORTABLE_DESKTOP]: {
-              value: true,
-              fetchedAtMs: Date.now(),
-            },
-          },
-          overrides: {
-            [EXPERIMENT_IDS.PORTABLE_DESKTOP]: true,
-          },
-        },
-        null,
-        2
-      ),
+      path.join(tempDir, OVERRIDES_FILE),
+      JSON.stringify({
+        version: 1,
+        experiments: {},
+        overrides: { [EXPERIMENT_IDS.PORTABLE_DESKTOP]: true },
+      }),
       "utf-8"
     );
 
-    const setFeatureFlagVariant = mock(() => undefined);
-    const telemetryService = {
-      getPostHogClient: mock(() => null),
-      getDistinctId: mock(() => null),
-      setFeatureFlagVariant,
-    } as unknown as TelemetryService;
-
+    const { telemetryService, setFeatureFlagVariant } = createTelemetryService();
     const service = new ExperimentsService({
       telemetryService,
       muxHome: tempDir,
@@ -257,37 +118,41 @@ describe("ExperimentsService", () => {
     });
     await service.initialize();
 
-    expect(service.getExperimentValue(EXPERIMENT_IDS.PORTABLE_DESKTOP)).toEqual({
-      value: null,
-      source: "disabled",
-    });
     expect(service.isExperimentEnabled(EXPERIMENT_IDS.PORTABLE_DESKTOP)).toBe(false);
 
     await service.setOverride(EXPERIMENT_IDS.PORTABLE_DESKTOP, true);
 
-    const disk = JSON.parse(await fs.readFile(cacheFilePath, "utf-8")) as {
-      overrides?: Record<string, unknown>;
-    };
-    expect(disk.overrides).toEqual({});
+    expect((await readOverridesFile()).overrides).toEqual({});
     expect(setFeatureFlagVariant).toHaveBeenCalledWith(EXPERIMENT_IDS.PORTABLE_DESKTOP, null);
   });
 
-  test("returns disabled when telemetry is disabled", async () => {
-    const telemetryService = {
-      getPostHogClient: mock(() => null),
-      getDistinctId: mock(() => null),
-      setFeatureFlagVariant: mock(() => undefined),
-    } as unknown as TelemetryService;
+  test("overrides written by a build with remote evaluation still load", async () => {
+    await fs.writeFile(
+      path.join(tempDir, OVERRIDES_FILE),
+      JSON.stringify({
+        version: 1,
+        experiments: {
+          [EXPERIMENT_IDS.TOOL_SEARCH]: { value: "test", fetchedAtMs: Date.now() },
+        },
+        overrides: { [EXPERIMENT_IDS.AGENT_BROWSER]: true },
+      }),
+      "utf-8"
+    );
 
+    const { telemetryService } = createTelemetryService();
     const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
     await service.initialize();
 
-    const values = service.getAll();
-    expect(values[EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]).toEqual({
-      value: null,
-      source: "disabled",
-    });
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.AGENT_BROWSER)).toBe(true);
+    // A cached remote assignment must not survive as an implicit opt-in.
+    expect(service.isExperimentEnabled(EXPERIMENT_IDS.TOOL_SEARCH)).toBe(false);
+  });
 
-    expect(service.isExperimentEnabled(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING)).toBe(false);
+  test("writes an empty experiments map so older builds still read overrides", async () => {
+    const { telemetryService } = createTelemetryService();
+    const service = new ExperimentsService({ telemetryService, muxHome: tempDir });
+    await service.setOverride(EXPERIMENT_IDS.TIMELINE, true);
+
+    expect((await readOverridesFile()).experiments).toEqual({});
   });
 });

--- a/src/node/services/experimentsService.ts
+++ b/src/node/services/experimentsService.ts
@@ -78,33 +78,39 @@ export class ExperimentsService {
   }
 
   /**
-   * Replace all overrides with the renderer's complete local state. Overrides absent
-   * from `next` are cleared rather than left behind, so backend gates can never stay
-   * enabled for an experiment the user's Settings shows as off.
+   * Overrides persisted for this machine. Renderers read these so a client whose
+   * origin-scoped localStorage is empty still shows the state its backend gates use.
    */
-  async syncOverrides(next: Partial<Record<ExperimentId, boolean>>): Promise<void> {
+  async getOverrides(): Promise<Partial<Record<ExperimentId, boolean>>> {
     await this.ensureInitialized();
 
-    const previous = new Set(this.overrides.keys());
-    this.overrides.clear();
-
-    for (const [key, enabled] of Object.entries(next)) {
-      const experimentId = key as ExperimentId;
-      assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
-      if (typeof enabled !== "boolean" || !this.isExperimentSupported(experimentId)) {
-        continue;
-      }
-
-      this.overrides.set(experimentId, enabled);
-    }
-
-    for (const experimentId of previous) {
-      if (!this.overrides.has(experimentId)) {
-        this.telemetryService.setFeatureFlagVariant(experimentId, null);
-      }
-    }
-
+    const result: Partial<Record<ExperimentId, boolean>> = {};
     for (const [experimentId, enabled] of this.overrides) {
+      if (this.isExperimentSupported(experimentId)) {
+        result[experimentId] = enabled;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Update a single override. Writes are per-experiment so a client cannot clear
+   * overrides it never knew about: localStorage is origin-scoped, and a second
+   * renderer starting empty must not wipe state persisted for this machine.
+   */
+  async setOverride(
+    experimentId: ExperimentId,
+    enabled: boolean | null | undefined
+  ): Promise<void> {
+    await this.ensureInitialized();
+    assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
+
+    if (!this.isExperimentSupported(experimentId) || enabled == null) {
+      this.overrides.delete(experimentId);
+      this.telemetryService.setFeatureFlagVariant(experimentId, null);
+    } else {
+      this.overrides.set(experimentId, enabled);
       this.telemetryService.setFeatureFlagVariant(experimentId, enabled);
     }
 

--- a/src/node/services/experimentsService.ts
+++ b/src/node/services/experimentsService.ts
@@ -91,11 +91,6 @@ export class ExperimentsService {
     for (const [key, enabled] of Object.entries(next)) {
       const experimentId = key as ExperimentId;
       assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
-      assert(
-        EXPERIMENTS[experimentId].userOverridable === true,
-        `Experiment ${experimentId} does not support user overrides`
-      );
-
       if (typeof enabled !== "boolean" || !this.isExperimentSupported(experimentId)) {
         continue;
       }

--- a/src/node/services/experimentsService.ts
+++ b/src/node/services/experimentsService.ts
@@ -77,26 +77,39 @@ export class ExperimentsService {
     }
   }
 
-  async setOverride(
-    experimentId: ExperimentId,
-    enabled: boolean | null | undefined
-  ): Promise<void> {
+  /**
+   * Replace all overrides with the renderer's complete local state. Overrides absent
+   * from `next` are cleared rather than left behind, so backend gates can never stay
+   * enabled for an experiment the user's Settings shows as off.
+   */
+  async syncOverrides(next: Partial<Record<ExperimentId, boolean>>): Promise<void> {
     await this.ensureInitialized();
-    assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
-    assert(
-      EXPERIMENTS[experimentId].userOverridable === true,
-      `Experiment ${experimentId} does not support user overrides`
-    );
-    assert(
-      enabled == null || typeof enabled === "boolean",
-      `Experiment override for ${experimentId} must be boolean | null | undefined`
-    );
 
-    if (!this.isExperimentSupported(experimentId) || enabled == null) {
-      this.overrides.delete(experimentId);
-      this.telemetryService.setFeatureFlagVariant(experimentId, null);
-    } else {
+    const previous = new Set(this.overrides.keys());
+    this.overrides.clear();
+
+    for (const [key, enabled] of Object.entries(next)) {
+      const experimentId = key as ExperimentId;
+      assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
+      assert(
+        EXPERIMENTS[experimentId].userOverridable === true,
+        `Experiment ${experimentId} does not support user overrides`
+      );
+
+      if (typeof enabled !== "boolean" || !this.isExperimentSupported(experimentId)) {
+        continue;
+      }
+
       this.overrides.set(experimentId, enabled);
+    }
+
+    for (const experimentId of previous) {
+      if (!this.overrides.has(experimentId)) {
+        this.telemetryService.setFeatureFlagVariant(experimentId, null);
+      }
+    }
+
+    for (const [experimentId, enabled] of this.overrides) {
       this.telemetryService.setFeatureFlagVariant(experimentId, enabled);
     }
 

--- a/src/node/services/experimentsService.ts
+++ b/src/node/services/experimentsService.ts
@@ -5,32 +5,25 @@ import {
   type ExperimentId,
 } from "@/common/constants/experiments";
 import { getMuxHome } from "@/common/constants/paths";
-import type { ExperimentValue } from "@/common/orpc/types";
-import { log } from "@/node/services/log";
 import type { TelemetryService } from "@/node/services/telemetryService";
 
 import * as fs from "fs/promises";
 import writeFileAtomic from "write-file-atomic";
 import * as path from "path";
-import { getErrorMessage } from "@/common/utils/errors";
 
-export type { ExperimentValue };
-
-interface CachedVariant {
-  value: string | boolean;
-  fetchedAtMs: number;
-  source: "posthog" | "cache";
-}
-
-interface ExperimentsCacheFile {
+interface ExperimentsFile {
   version: 1;
-  experiments: Record<string, { value: string | boolean; fetchedAtMs: number }>;
+  /**
+   * Always written as an empty object. Builds before remote evaluation was removed
+   * abort reading this file when `experiments` is absent, which would silently drop
+   * the user's overrides on downgrade.
+   */
+  experiments: Record<string, never>;
   overrides?: Record<string, boolean>;
 }
 
-const CACHE_FILE_NAME = "feature_flags.json";
-const CACHE_FILE_VERSION = 1;
-const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;
+const OVERRIDES_FILE_NAME = "feature_flags.json";
+const OVERRIDES_FILE_VERSION = 1;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -39,37 +32,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Backend experiments service.
  *
- * Evaluates PostHog feature flags in the main process (via posthog-node) and exposes
- * the current assignments to the renderer via oRPC.
- *
- * Design goals:
- * - Never block user flows on network calls (use cached values and refresh in background)
- * - Fail closed (unknown = control/disabled)
- * - Avoid calling PostHog when telemetry is disabled
+ * Experiments are opt-in local toggles: an experiment is enabled only when the user
+ * explicitly turns it on in Settings. Overrides are persisted so main-process gates
+ * (oRPC routes, AI runtime, tool registration) agree with the renderer on every launch.
  */
 export class ExperimentsService {
   private readonly telemetryService: TelemetryService;
   private readonly muxHome: string;
-  private readonly cacheFilePath: string;
-  private readonly cacheTtlMs: number;
+  private readonly overridesFilePath: string;
   private readonly platform: NodeJS.Platform;
 
-  private readonly cachedVariants = new Map<ExperimentId, CachedVariant>();
   private readonly overrides = new Map<ExperimentId, boolean>();
-  private readonly refreshInFlight = new Map<ExperimentId, Promise<void>>();
 
-  private cacheLoaded = false;
+  private initialized = false;
 
   constructor(options: {
     telemetryService: TelemetryService;
     muxHome?: string;
-    cacheTtlMs?: number;
     platform?: NodeJS.Platform;
   }) {
     this.telemetryService = options.telemetryService;
     this.muxHome = options.muxHome ?? getMuxHome();
-    this.cacheFilePath = path.join(this.muxHome, CACHE_FILE_NAME);
-    this.cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.overridesFilePath = path.join(this.muxHome, OVERRIDES_FILE_NAME);
     this.platform = options.platform ?? process.platform;
   }
 
@@ -78,63 +62,19 @@ export class ExperimentsService {
   }
 
   async initialize(): Promise<void> {
-    if (this.cacheLoaded) {
+    if (this.initialized) {
       return;
     }
 
-    await this.loadCacheFromDisk();
-    this.cacheLoaded = true;
+    await this.loadOverridesFromDisk();
+    this.initialized = true;
 
-    // Populate telemetry properties from cache immediately so variant breakdowns
-    // are present even before a background refresh completes.
-    for (const [experimentId, cached] of this.cachedVariants) {
-      if (!this.isExperimentSupported(experimentId)) {
-        this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), null);
-        continue;
-      }
-
-      this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), cached.value);
-    }
-
-    // Renderer overrides must win over cached/remote assignments so server-side gates
-    // and telemetry reflect the same explicit user choice on fresh launches.
     for (const [experimentId, enabled] of this.overrides) {
-      if (!this.isExperimentSupported(experimentId)) {
-        this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), null);
-        continue;
-      }
-
-      this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), enabled);
+      this.telemetryService.setFeatureFlagVariant(
+        experimentId,
+        this.isExperimentSupported(experimentId) ? enabled : null
+      );
     }
-
-    // Refresh in background (best effort). We only refresh values that are stale or missing
-    // to avoid unnecessary network calls during startup.
-    if (this.isRemoteEvaluationEnabled()) {
-      for (const experimentId of Object.keys(EXPERIMENTS) as ExperimentId[]) {
-        this.maybeRefreshInBackground(experimentId);
-      }
-    }
-  }
-
-  isRemoteEvaluationEnabled(): boolean {
-    return (
-      this.telemetryService.getPostHogClient() !== null &&
-      this.telemetryService.getDistinctId() !== null
-    );
-  }
-
-  /**
-   * Return current values for all known experiments.
-   * This is used to render Settings → Experiments.
-   */
-  getAll(): Record<ExperimentId, ExperimentValue> {
-    const result: Partial<Record<ExperimentId, ExperimentValue>> = {};
-
-    for (const experimentId of Object.keys(EXPERIMENTS) as ExperimentId[]) {
-      result[experimentId] = this.getExperimentValue(experimentId);
-    }
-
-    return result as Record<ExperimentId, ExperimentValue>;
   }
 
   async setOverride(
@@ -152,238 +92,52 @@ export class ExperimentsService {
       `Experiment override for ${experimentId} must be boolean | null | undefined`
     );
 
-    if (!this.isExperimentSupported(experimentId)) {
+    if (!this.isExperimentSupported(experimentId) || enabled == null) {
       this.overrides.delete(experimentId);
-      this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), null);
-      await this.writeCacheToDisk();
-      return;
-    }
-
-    if (enabled == null) {
-      this.overrides.delete(experimentId);
-      const cached = this.cachedVariants.get(experimentId);
-      this.telemetryService.setFeatureFlagVariant(
-        this.getFlagKey(experimentId),
-        cached?.value ?? null
-      );
+      this.telemetryService.setFeatureFlagVariant(experimentId, null);
     } else {
       this.overrides.set(experimentId, enabled);
-      this.telemetryService.setFeatureFlagVariant(this.getFlagKey(experimentId), enabled);
+      this.telemetryService.setFeatureFlagVariant(experimentId, enabled);
     }
 
-    await this.writeCacheToDisk();
-  }
-
-  getExperimentValue(experimentId: ExperimentId): ExperimentValue {
-    assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
-
-    if (!this.isExperimentSupported(experimentId)) {
-      return { value: null, source: "disabled" };
-    }
-
-    const override = this.overrides.get(experimentId);
-    if (override !== undefined) {
-      if (this.isRemoteEvaluationEnabled() && !EXPERIMENTS[experimentId].localOverrideOnly) {
-        this.maybeRefreshInBackground(experimentId);
-      }
-      return { value: override, source: "override" };
-    }
-
-    // Local-override-only experiments never consult remote/cached assignment:
-    // without an explicit local toggle they read as disabled, so Settings and
-    // security gates (isExperimentLocallyEnabled) always agree.
-    if (EXPERIMENTS[experimentId].localOverrideOnly) {
-      return { value: null, source: "disabled" };
-    }
-
-    if (!this.isRemoteEvaluationEnabled()) {
-      return { value: null, source: "disabled" };
-    }
-
-    const cached = this.cachedVariants.get(experimentId);
-    if (!cached) {
-      // No cached value yet. Fail closed, but kick off a background refresh.
-      this.maybeRefreshInBackground(experimentId);
-      return { value: null, source: "cache" };
-    }
-
-    this.maybeRefreshInBackground(experimentId);
-    return { value: cached.value, source: cached.source };
+    await this.writeOverridesToDisk();
   }
 
   /**
-   * True only when the user has explicitly enabled the experiment via a local
-   * override (Settings → Experiments toggle). Remote/cached PostHog assignment
-   * can NEVER satisfy this gate. Use for security-sensitive experiments where
-   * "enabled" must mean deliberate local user consent (e.g. skill dynamic
-   * context injection, which executes repo-controlled shell commands).
+   * True only when the user has explicitly enabled the experiment in Settings.
+   * Nothing else can enable an experiment, so security-sensitive gates (e.g. skill
+   * dynamic context injection, which executes repo-controlled shell commands) can
+   * rely on this meaning deliberate local consent.
    */
-  isExperimentLocallyEnabled(experimentId: ExperimentId): boolean {
+  isExperimentEnabled(experimentId: ExperimentId): boolean {
+    assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
+
+    if (!this.isExperimentSupported(experimentId)) {
+      return false;
+    }
+
     return this.overrides.get(experimentId) === true;
   }
 
-  /**
-   * Convert an experiment assignment to a boolean gate.
-   *
-   * NOTE: This intentionally does not block on network calls.
-   */
-  isExperimentEnabled(experimentId: ExperimentId): boolean {
-    const value = this.getExperimentValue(experimentId).value;
-
-    // PostHog can return either boolean flags or string variants.
-    if (typeof value === "boolean") {
-      return value;
-    }
-
-    if (typeof value === "string") {
-      // For now, treat variant "test" as enabled for experiments with control/test variants.
-      // If we add experiments with different variant semantics, add a mapping per experiment.
-      return value === "test";
-    }
-
-    return false;
-  }
-
-  async refreshAll(): Promise<void> {
-    await this.ensureInitialized();
-
-    if (!this.isRemoteEvaluationEnabled()) {
-      return;
-    }
-
-    await Promise.all(
-      (Object.keys(EXPERIMENTS) as ExperimentId[]).map(async (experimentId) => {
-        await this.refreshExperiment(experimentId);
-      })
-    );
-  }
-
-  async refreshExperiment(experimentId: ExperimentId): Promise<void> {
-    await this.ensureInitialized();
-    assert(experimentId in EXPERIMENTS, `Unknown experimentId: ${experimentId}`);
-
-    if (!this.isExperimentSupported(experimentId) || !this.isRemoteEvaluationEnabled()) {
-      return;
-    }
-
-    const existing = this.refreshInFlight.get(experimentId);
-    if (existing) {
-      return existing;
-    }
-
-    const promise = this.refreshExperimentImpl(experimentId).finally(() => {
-      this.refreshInFlight.delete(experimentId);
-    });
-
-    this.refreshInFlight.set(experimentId, promise);
-    return promise;
-  }
-
-  private async refreshExperimentImpl(experimentId: ExperimentId): Promise<void> {
-    const client = this.telemetryService.getPostHogClient();
-    const distinctId = this.telemetryService.getDistinctId();
-    assert(client, "PostHog client must exist when remote evaluation is enabled");
-    assert(distinctId, "distinctId must exist when remote evaluation is enabled");
-
-    const flagKey = this.getFlagKey(experimentId);
-
-    try {
-      const value = await client.getFeatureFlag(flagKey, distinctId);
-      if (typeof value !== "string" && typeof value !== "boolean") {
-        return;
-      }
-
-      const cached: CachedVariant = {
-        value,
-        fetchedAtMs: Date.now(),
-        source: "posthog",
-      };
-
-      this.cachedVariants.set(experimentId, cached);
-      if (!this.overrides.has(experimentId)) {
-        this.telemetryService.setFeatureFlagVariant(flagKey, value);
-      }
-
-      await this.writeCacheToDisk();
-    } catch (error) {
-      log.debug("Failed to refresh experiment from PostHog", {
-        experimentId,
-        error: getErrorMessage(error),
-      });
-    }
-  }
-
-  private maybeRefreshInBackground(experimentId: ExperimentId): void {
-    if (!this.isExperimentSupported(experimentId)) {
-      return;
-    }
-
-    const cached = this.cachedVariants.get(experimentId);
-    if (!cached) {
-      void this.refreshExperiment(experimentId);
-      return;
-    }
-
-    if (Date.now() - cached.fetchedAtMs > this.cacheTtlMs) {
-      void this.refreshExperiment(experimentId);
-    }
-  }
-
-  private getFlagKey(experimentId: ExperimentId): string {
-    // Today, our experiment IDs are already PostHog flag keys.
-    // If that ever changes, this is the single mapping point.
-    return experimentId;
-  }
-
   private async ensureInitialized(): Promise<void> {
-    if (this.cacheLoaded) {
+    if (this.initialized) {
       return;
     }
 
     await this.initialize();
-    assert(this.cacheLoaded, "ExperimentsService failed to initialize");
+    assert(this.initialized, "ExperimentsService failed to initialize");
   }
 
-  private async loadCacheFromDisk(): Promise<void> {
+  private async loadOverridesFromDisk(): Promise<void> {
     try {
-      const raw = await fs.readFile(this.cacheFilePath, "utf-8");
+      const raw = await fs.readFile(this.overridesFilePath, "utf-8");
       const parsed = JSON.parse(raw) as unknown;
 
-      if (!isRecord(parsed)) {
+      if (!isRecord(parsed) || parsed.version !== OVERRIDES_FILE_VERSION) {
         return;
       }
 
-      const version = parsed.version;
-      const experiments = parsed.experiments;
       const overrides = parsed.overrides;
-
-      if (version !== CACHE_FILE_VERSION || !isRecord(experiments)) {
-        return;
-      }
-
-      for (const [key, value] of Object.entries(experiments)) {
-        if (!(key in EXPERIMENTS) || !isRecord(value)) {
-          continue;
-        }
-
-        const fetchedAtMs = value.fetchedAtMs;
-        const variant = value.value;
-
-        if (typeof fetchedAtMs !== "number" || !Number.isFinite(fetchedAtMs)) {
-          continue;
-        }
-
-        if (typeof variant !== "string" && typeof variant !== "boolean") {
-          continue;
-        }
-
-        this.cachedVariants.set(key as ExperimentId, {
-          value: variant,
-          fetchedAtMs,
-          source: "cache",
-        });
-      }
-
       if (!isRecord(overrides)) {
         return;
       }
@@ -396,35 +150,27 @@ export class ExperimentsService {
         this.overrides.set(key as ExperimentId, value);
       }
     } catch {
-      // Ignore missing/corrupt cache
+      // Ignore missing/corrupt overrides
     }
   }
 
-  private async writeCacheToDisk(): Promise<void> {
+  private async writeOverridesToDisk(): Promise<void> {
     try {
-      const experiments: ExperimentsCacheFile["experiments"] = {};
-      for (const [experimentId, cached] of this.cachedVariants) {
-        experiments[experimentId] = {
-          value: cached.value,
-          fetchedAtMs: cached.fetchedAtMs,
-        };
-      }
-
-      const overrides: NonNullable<ExperimentsCacheFile["overrides"]> = {};
+      const overrides: NonNullable<ExperimentsFile["overrides"]> = {};
       for (const [experimentId, enabled] of this.overrides) {
         overrides[experimentId] = enabled;
       }
 
-      const payload: ExperimentsCacheFile = {
-        version: CACHE_FILE_VERSION,
-        experiments,
+      const payload: ExperimentsFile = {
+        version: OVERRIDES_FILE_VERSION,
+        experiments: {},
         overrides,
       };
 
       await fs.mkdir(this.muxHome, { recursive: true });
-      await writeFileAtomic(this.cacheFilePath, JSON.stringify(payload, null, 2), "utf-8");
+      await writeFileAtomic(this.overridesFilePath, JSON.stringify(payload, null, 2), "utf-8");
     } catch {
-      // Ignore cache persistence failures
+      // Ignore persistence failures
     }
   }
 }

--- a/src/node/services/sessionTimingService.test.ts
+++ b/src/node/services/sessionTimingService.test.ts
@@ -8,10 +8,9 @@ import { SessionTimingService } from "./sessionTimingService";
 import type { TelemetryService } from "./telemetryService";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 
-function createMockTelemetryService(): Pick<TelemetryService, "capture" | "getFeatureFlag"> {
+function createMockTelemetryService(): Pick<TelemetryService, "capture"> {
   return {
     capture: mock(() => undefined),
-    getFeatureFlag: mock(() => Promise.resolve(undefined)),
   };
 }
 
@@ -20,7 +19,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 describe("SessionTimingService", () => {
   let tempDir: string;
   let config: Config;
-  let telemetry: Pick<TelemetryService, "capture" | "getFeatureFlag">;
+  let telemetry: Pick<TelemetryService, "capture">;
   let service: SessionTimingService;
 
   beforeEach(async () => {

--- a/src/node/services/telemetryService.ts
+++ b/src/node/services/telemetryService.ts
@@ -134,14 +134,6 @@ export class TelemetryService {
   private featureFlagVariants: Record<string, string | boolean> = {};
   private readonly muxHome: string;
 
-  getPostHogClient(): PostHog | null {
-    return this.client;
-  }
-
-  getDistinctId(): string | null {
-    return this.distinctId;
-  }
-
   /**
    * Check if telemetry is enabled.
    * Returns true only after initialize() completes and telemetry was not disabled.
@@ -275,19 +267,6 @@ export class TelemetryService {
    * Track a telemetry event.
    * Events are silently ignored when disabled.
    */
-
-  async getFeatureFlag(key: string): Promise<boolean | string | undefined> {
-    if (isTelemetryDisabledByEnv(process.env) || !this.client || !this.distinctId) {
-      return undefined;
-    }
-
-    try {
-      // `getFeatureFlag` will automatically emit $feature_flag_called.
-      return await this.client.getFeatureFlag(key, this.distinctId, { disableGeoip: true });
-    } catch {
-      return undefined;
-    }
-  }
   capture(payload: TelemetryEventPayload): void {
     if (isTelemetryDisabledByEnv(process.env) || !this.client || !this.distinctId) {
       return;


### PR DESCRIPTION
## Summary

Removes the remote PostHog feature-flag evaluation mechanism from mux. Experiments were never actually rolled out remotely: none of the experiment IDs exist as PostHog flags, so every lookup returned `undefined` and the service failed closed. Enabling an experiment has only ever been possible through the local Settings toggle, which made the whole remote path inert while still emitting `$feature_flag_called` on every launch. Local toggles and their backend sync are kept, so no gated feature changes state for any user.

## Background

PostHog data for the mux project showed `$feature_flag_called` had grown to **20.2% of all billable events** (391,465 of 1,938,370 over 90 days). Investigating the growth found the cause was not volume from real experiments:

- **2 flags** are defined in PostHog (`stats_tab_v1`, `post-compaction-context`), and neither is in `EXPERIMENT_IDS`.
- **26 keys** were being evaluated by clients, covering every entry in `EXPERIMENT_IDS`.
- Over 90 days: **390,554 calls returned null vs 904 that resolved.** `programmatic-tool-calling` alone burned 10,475 calls returning nothing.

Because `ExperimentsService` fails closed (`override ?? cachedRemote ?? null`, and the cache could never populate for an undefined flag), the remote layer could not influence any gate. All real uptake came from users toggling in Settings: 236 of 11,008 users have ever toggled anything, with keep rates between 64% and 86%.

Every experiment added to the registry permanently added roughly one wasted event per user per launch, so the cost grew with the registry rather than with usage.

Notable consequence worth stating explicitly: **no experiment has ever been remotely rolled out.** Every "experiment" is an opt-in local toggle. If anyone assumed these were staged rollouts, that assumption was wrong.

## Implementation

Three commits, ordered so the mechanical removal is reviewable on its own.

**1. Remove remote evaluation.** Deletes `client.getFeatureFlag`, the variant disk cache and its 10-minute TTL, background refresh, renderer polling with exponential backoff, the `experiments.getAll` / `experiments.reload` oRPC routes, and `TelemetryService.getFeatureFlag` / `getPostHogClient` / `getDistinctId` (which had no other production callers). `isExperimentLocallyEnabled` collapses into `isExperimentEnabled`, which now structurally means "the user opted in locally"; that is the property the `skill-dynamic-context` shell-execution gate depends on. `localOverrideOnly` is dropped because it now describes every experiment.

`feature_flags.json` still writes an empty `experiments` map, because a build from before this change aborts reading the file when that key is absent and would silently drop the user's overrides on downgrade.

**2. Keep backend overrides authoritative across clients.** Removing `getAll` dropped the renderer's fallback to backend override state, so a cleared localStorage would show a toggle as off while the persisted backend override kept the gate on. That is most consequential for `skill-dynamic-context`, whose backend gate executes repo-controlled shell commands. The fix restores the read: the renderer fetches backend overrides and displays them when it has no local override, and writes stay per-experiment so no client can clear an override it never set. Precedence is local override > backend override > default. An explicit toggle wins, which also settles the race against an in-flight read.

An earlier revision of this PR instead had the renderer replace the whole backend map on mount. Codex correctly flagged that as unsafe: localStorage is origin-scoped, so a remote browser client, another profile, or a changed port starts empty and would disable every persisted experiment just by connecting. That approach was replaced with the read-based one above.

**3. Drop `userOverridable`.** The field meant "the user can override the remote PostHog assignment". With remote evaluation gone it was `true` for all 18 experiments and every check on it was always-true branching, including an unreachable default-value path in the non-hook reader. Also removes `useAllExperiments`, which had no consumers.

Deliberately unchanged: the 18 gated features. Deleting or force-enabling them is a set of product decisions, it would flip state for the 236 users who opted in and the 55 who opted out, and one gate guards shell execution of repo-controlled commands.

## Validation

Red-green verified each new guard by toggling the implementation and confirming a genuine failure, then restoring and confirming green:

- Downgrade compatibility: writing the file without the empty `experiments` map fails the test.
- Cached-variant isolation: treating a legacy cached variant as an implicit opt-in fails the test.
- Cross-client safety: reintroducing the wipe (`overrides.clear()` inside `setOverride`) fails the test asserting a client with empty local state cannot clear overrides it never knew about.

Also ran `tests/ui/layout/rightSidebar.test.ts` (14/14), which exercises the `agent-browser` experiment tab gating end to end through the localStorage path this change preserves.

## Risks

Low regression risk to gate behavior, because the resolution path strictly narrows: previously `override ?? cachedRemote ?? null`, now `override` only. Since no flag was ever defined in PostHog, no user's cache could hold a value, so resolved state is unchanged.

One intentional behavior change at the edge: a manually seeded or hand-edited `feature_flags.json` containing a cached variant no longer enables anything. That path is now ignored by design, since a remote assignment should not survive as an implicit opt-in.

Affected product areas are the surfaces reading experiment state: Settings, right-sidebar tabs (browser, memory, timeline, workflows, desktop), slash commands and the command palette, multi-project workspaces, and AI tool registration. All read through the unchanged local toggle path.

<details>
<summary>Telemetry detail</summary>

`setFeatureFlagVariant` is intentionally kept. It attaches `$feature/<key>` super-properties to existing events rather than emitting new ones, so it costs nothing billable and it is what powers the enabled/disabled breakdown per experiment. Only `client.getFeatureFlag` produced the `$feature_flag_called` volume.

The `experiment_overridden` event drops its `assignedVariant` property, which was always `null` once remote assignment was gone. The zod schema, TS payload type, and call site were updated together.

</details>

## Pains

`posthog-js` is now an unused dependency (zero source imports), but removing it changes the Nix offline dependency cache and requires a CI round-trip to recover the new `outputHash`, since Nix is unavailable in the dev sandbox. Left out of this PR deliberately to keep the diff coherent.

One pre-existing test failure is unrelated to this change: `WorkspaceService bash monitor wakes > accepted history suppresses redelivery while wake-store reconciliation keeps failing` fails identically on the branch point (`f14eade0c`), verified on a detached worktree. It is a test mock missing `getForegroundToolCallIds` in bash-monitor code this PR does not touch.

---

_Generated with `mux` • Model: `anthropic:claude-opus-5` • Thinking: `max`_

<!-- mux-attribution: model=anthropic:claude-opus-5 thinking=max -->

