### PR TITLE
🤖 fix: retract already-shown bash monitor wakes

### DIFF
--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -7,6 +7,7 @@ import {
   type MonitorArmedPayload,
   type MonitorMatchPayload,
   type MonitorStoppedPayload,
+  type OutputShownPayload,
 } from "./backgroundProcessManager";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 import type { Runtime } from "@/node/runtime/Runtime";
@@ -859,6 +860,37 @@ describe("BackgroundProcessManager", () => {
       expect(incompleteLineBytes).toBeGreaterThan(0);
       expect(incompleteLineBytes).toBeLessThanOrEqual(1_000_000);
     });
+  });
+
+  it("emits output:shown when an unfiltered read advances the shown frontier", async () => {
+    const shownEvents: Array<{ workspaceId: string; payload: OutputShownPayload }> = [];
+    manager.on("output:shown", (workspaceId, payload) => {
+      shownEvents.push({ workspaceId, payload });
+    });
+
+    const result = await manager.spawn(runtime, testWorkspaceId, "printf 'line\\n'", {
+      cwd: process.cwd(),
+      displayName: "shown-event",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const proc = await manager.getProcess(result.processId);
+    expect(proc).not.toBeNull();
+    if (proc == null) return;
+
+    const output = await manager.getOutput(result.processId, undefined, false, 1);
+    expect(output.success).toBe(true);
+    expect(shownEvents).toEqual([
+      {
+        workspaceId: testWorkspaceId,
+        payload: {
+          processId: result.processId,
+          processStartTime: proc.startTime,
+          shownThroughOffset: 5,
+        },
+      },
+    ]);
   });
 
   describe("getSettledShownThroughOffset", () => {

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -90,6 +90,12 @@ export type MonitorWakeDeliveryState =
   | { status: "blocked"; readSettled: Promise<void> }
   | { status: "settled"; shownThroughOffset: number };
 
+export interface OutputShownPayload {
+  processId: string;
+  processStartTime: number;
+  shownThroughOffset: number;
+}
+
 export interface MonitorArmedPayload {
   processId: string;
   taskId: string;
@@ -212,6 +218,7 @@ export interface ForegroundProcess {
  */
 export interface BackgroundProcessManagerEvents {
   change: [workspaceId: string];
+  "output:shown": [workspaceId: string, payload: OutputShownPayload];
   "monitor:match": [workspaceId: string, payload: MonitorMatchPayload];
   "monitor:armed": [workspaceId: string, payload: MonitorArmedPayload];
   "monitor:stopped": [workspaceId: string, payload: MonitorStoppedPayload];
@@ -1310,6 +1317,8 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     proc.incompleteLineBuffer =
       currentStatus === "running" && !hasTrailingNewline ? allLines[allLines.length - 1] : "";
 
+    const shownThroughOffsetBeforeRead = proc.shownThroughOffset;
+
     // Advance the monitor's "shown through" mark only on unfiltered reads. A filtered read may have
     // dropped matched lines, so it must not count as having shown them. End-of-last-complete-line =
     // read cursor minus the trailing fragment we just buffered (cleared, hence 0, on exit). Offsets
@@ -1335,6 +1344,16 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     );
 
     const filteredOutput = applyFilter(linesToReturn);
+
+    if (proc.shownThroughOffset > shownThroughOffsetBeforeRead) {
+      // A wake can queue between sequential task_await reads. Notify the workspace after each
+      // frontier advance so it can retract that queued wake before the next turn accepts it.
+      this.emit("output:shown", proc.workspaceId, {
+        processId: proc.id,
+        processStartTime: proc.startTime,
+        shownThroughOffset: proc.shownThroughOffset,
+      });
+    }
 
     // Suggest filter_exclude if polling too frequently on a running process
     const shouldSuggestFilterExclude =

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -617,7 +617,7 @@ describe("WorkspaceService bash monitor wakes", () => {
       });
 
       const seedWakeStore = new BashMonitorWakeStore(config);
-      await seedWakeStore.enqueueOrMergePending({
+      const shownRecord = await seedWakeStore.enqueueOrMergePending({
         processId: "proc-shown",
         taskId: "bash:proc-shown",
         workspaceId,
@@ -681,14 +681,21 @@ describe("WorkspaceService bash monitor wakes", () => {
 
       (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
         processId: "proc-shown",
-        processStartTime: 0,
+        processStartTime: Date.parse(shownRecord.createdAt) + 1,
+        shownThroughOffset: 100,
+      });
+      expect(removeQueuedSpy).not.toHaveBeenCalled();
+
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "proc-shown",
+        processStartTime: Date.parse(shownRecord.createdAt),
         shownThroughOffset: 99,
       });
       expect(removeQueuedSpy).not.toHaveBeenCalled();
 
       (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
         processId: "proc-shown",
-        processStartTime: 0,
+        processStartTime: Date.parse(shownRecord.createdAt),
         shownThroughOffset: 100,
       });
 
@@ -701,10 +708,11 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
-  test("does not retract an older queued wake when a newer process reuses its ID", async () => {
+  test("retains an earlier shown event while a later frontier query is pending", async () => {
     const { config, cleanup } = await createTestHistoryService();
+    const releaseSecondCheck = createDeferred<void>();
     try {
-      const workspaceId = "bash-monitor-shown-reused-id";
+      const workspaceId = "bash-monitor-shown-during-gate";
       const projectPath = path.join(config.rootDir, "project");
       await config.addWorkspace(projectPath, {
         id: workspaceId,
@@ -715,70 +723,10 @@ describe("WorkspaceService bash monitor wakes", () => {
         runtimeConfig: { type: "local" },
       });
 
-      const seedWakeStore = new BashMonitorWakeStore(config);
-      const staleRecord = await seedWakeStore.enqueueOrMergePending({
-        processId: "reused-proc",
-        taskId: "bash:reused-proc",
-        workspaceId,
-        filter: "FAILED",
-        filterExclude: false,
-        lines: ["FAILED stale"],
-        totalMatches: 1,
-        timestamp: Date.now(),
-        matchedThroughOffset: 100,
-      });
-
-      const backgroundProcessManager = Object.assign(new EventEmitter(), {
-        cleanup: mock(() => Promise.resolve()),
-        getForegroundToolCallIds: mock(() => []),
-        // The normal delivery gate cannot bind this old wake to the newer live process, so it
-        // deliberately fails open and lets the wake queue.
-        getMonitorWakeDeliveryState: mock(() => Promise.resolve(undefined)),
-      }) as unknown as BackgroundProcessManager & EventEmitter;
-      const workspaceService = createWorkspaceServiceForTest({
-        config,
-        backgroundProcessManager,
-        aiService: createMockAIService({ isStreaming: mock(() => true) }),
-      });
-      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
-      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
-      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
-      const removeQueuedSpy = spyOn(workspaceService, "removeQueuedMessagesByDedupeKeyPrefix");
-
-      await waitForCondition(() => sendSpy.mock.calls.length === 1);
-      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
-        processId: "reused-proc",
-        processStartTime: Date.parse(staleRecord.createdAt) + 1,
-        shownThroughOffset: 100,
-      });
-      await drainPendingDispatches();
-
-      expect(removeQueuedSpy).not.toHaveBeenCalled();
-      expect(await seedWakeStore.listPending(workspaceId)).toHaveLength(1);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  test("retries shown-output cancellation when queue insertion is still preparing", async () => {
-    const { config, cleanup } = await createTestHistoryService();
-    const releaseFirstSend = createDeferred<void>();
-    try {
-      const workspaceId = "bash-monitor-shown-queue-preparing";
-      const projectPath = path.join(config.rootDir, "project");
-      await config.addWorkspace(projectPath, {
-        id: workspaceId,
-        name: workspaceId,
-        projectName: "project",
-        projectPath,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        runtimeConfig: { type: "local" },
-      });
-
-      const seedWakeStore = new BashMonitorWakeStore(config);
-      const shownRecord = await seedWakeStore.enqueueOrMergePending({
-        processId: "proc-shown",
-        taskId: "bash:proc-shown",
+      const wakeStore = new BashMonitorWakeStore(config);
+      const shownRecord = await wakeStore.enqueueOrMergePending({
+        processId: "a-shown",
+        taskId: "bash:a-shown",
         workspaceId,
         filter: "FAILED",
         filterExclude: false,
@@ -787,9 +735,9 @@ describe("WorkspaceService bash monitor wakes", () => {
         timestamp: Date.now(),
         matchedThroughOffset: 100,
       });
-      await seedWakeStore.enqueueOrMergePending({
-        processId: "proc-unshown",
-        taskId: "bash:proc-unshown",
+      await wakeStore.enqueueOrMergePending({
+        processId: "b-unshown",
+        taskId: "bash:b-unshown",
         workspaceId,
         filter: "FAILED",
         filterExclude: false,
@@ -799,9 +747,20 @@ describe("WorkspaceService bash monitor wakes", () => {
         matchedThroughOffset: 200,
       });
 
+      const secondCheckStarted = createDeferred<void>();
+      let firstOutputShown = false;
+      const getDeliveryState = mock(async (processId: string) => {
+        if (processId === "a-shown") {
+          return { status: "settled" as const, shownThroughOffset: firstOutputShown ? 100 : 0 };
+        }
+        secondCheckStarted.resolve();
+        await releaseSecondCheck.promise;
+        return { status: "settled" as const, shownThroughOffset: 0 };
+      });
       const backgroundProcessManager = Object.assign(new EventEmitter(), {
         cleanup: mock(() => Promise.resolve()),
         getForegroundToolCallIds: mock(() => []),
+        getMonitorWakeDeliveryState: getDeliveryState,
       }) as unknown as BackgroundProcessManager & EventEmitter;
       const workspaceService = createWorkspaceServiceForTest({
         config,
@@ -810,146 +769,31 @@ describe("WorkspaceService bash monitor wakes", () => {
       });
       spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
       spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
-
-      type SendInternal = NonNullable<Parameters<WorkspaceService["sendMessage"]>[3]>;
-      let firstSendInternal: SendInternal | undefined;
-      let sendCount = 0;
-      const firstSendStarted = createDeferred<void>();
       const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
         async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
-          sendCount += 1;
-          if (sendCount === 1) {
-            firstSendInternal = args[3];
-            firstSendStarted.resolve();
-            await releaseFirstSend.promise;
-            return Ok(undefined);
-          }
           await args[3]?.onAccepted?.();
           return Ok(undefined);
         }
       );
-      let removalAttempts = 0;
-      const removeQueuedSpy = spyOn(
-        workspaceService,
-        "removeQueuedMessagesByDedupeKeyPrefix"
-      ).mockImplementation((_ownerWorkspaceId, _prefix, options) => {
-        removalAttempts += 1;
-        if (removalAttempts === 1) {
-          // The first attempt races before sendMessage has inserted its queue entry.
-          return Ok(0);
-        }
-        void firstSendInternal?.onCanceled?.(options?.cancelReason ?? "canceled");
-        return Ok(1);
-      });
 
-      await firstSendStarted.promise;
-      expect(sendSpy.mock.calls[0][1]).toContain("FAILED shown");
+      await secondCheckStarted.promise;
+      firstOutputShown = true;
+      backgroundProcessManager.emit("output:shown", workspaceId, {
+        processId: "a-shown",
+        processStartTime: Date.parse(shownRecord.createdAt),
+        shownThroughOffset: 100,
+      });
+      releaseSecondCheck.resolve();
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][1]).not.toContain("FAILED shown");
       expect(sendSpy.mock.calls[0][1]).toContain("FAILED unshown");
-
-      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
-        processId: "proc-shown",
-        processStartTime: Date.parse(shownRecord.createdAt),
-        shownThroughOffset: 100,
-      });
-      await waitForCondition(() => removeQueuedSpy.mock.calls.length === 1);
-      expect(firstSendInternal?.cancelSignal?.aborted).toBe(true);
-
-      releaseFirstSend.resolve();
-      await waitForCondition(() => removeQueuedSpy.mock.calls.length === 2);
-      await waitForCondition(() => sendSpy.mock.calls.length === 2);
-      expect(sendSpy.mock.calls[1][1]).not.toContain("FAILED shown");
-      expect(sendSpy.mock.calls[1][1]).toContain("FAILED unshown");
+      expect(getDeliveryState.mock.calls.slice(0, 2).map(([processId]) => processId)).toEqual([
+        "a-shown",
+        "b-unshown",
+      ]);
     } finally {
-      releaseFirstSend.resolve();
-      await cleanup();
-    }
-  });
-
-  test("aborts a dequeued preparing wake after its matched output is shown", async () => {
-    const { config, cleanup } = await createTestHistoryService();
-    try {
-      const workspaceId = "bash-monitor-shown-dequeued-preparing";
-      const projectPath = path.join(config.rootDir, "project");
-      await config.addWorkspace(projectPath, {
-        id: workspaceId,
-        name: workspaceId,
-        projectName: "project",
-        projectPath,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        runtimeConfig: { type: "local" },
-      });
-
-      const seedWakeStore = new BashMonitorWakeStore(config);
-      const shownRecord = await seedWakeStore.enqueueOrMergePending({
-        processId: "proc-preparing",
-        taskId: "bash:proc-preparing",
-        workspaceId,
-        filter: "FAILED",
-        filterExclude: false,
-        lines: ["FAILED preparing"],
-        totalMatches: 1,
-        timestamp: Date.now(),
-        matchedThroughOffset: 100,
-      });
-
-      const backgroundProcessManager = Object.assign(new EventEmitter(), {
-        cleanup: mock(() => Promise.resolve()),
-        getForegroundToolCallIds: mock(() => []),
-      }) as unknown as BackgroundProcessManager & EventEmitter;
-      const workspaceService = createWorkspaceServiceForTest({
-        config,
-        backgroundProcessManager,
-        aiService: createMockAIService({ isStreaming: mock(() => true) }),
-      });
-      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
-      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
-
-      const preparingStarted = createDeferred<void>();
-      const preparingCanceled = createDeferred<void>();
-      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
-        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
-          const internal = args[3];
-          if (internal?.cancelSignal == null) {
-            throw new Error("Expected monitor wake cancellation signal");
-          }
-          const signal = internal.cancelSignal;
-          preparingStarted.resolve();
-          await new Promise<void>((resolve) => {
-            if (signal.aborted) {
-              resolve();
-              return;
-            }
-            signal.addEventListener("abort", () => resolve(), { once: true });
-          });
-          await internal.onCanceled?.(
-            typeof signal.reason === "string" ? signal.reason : "preparing wake canceled"
-          );
-          if (internal.cancelState != null) {
-            internal.cancelState.canceledBeforeAcceptance = true;
-          }
-          preparingCanceled.resolve();
-          return Ok(undefined);
-        }
-      );
-      const removeQueuedSpy = spyOn(
-        workspaceService,
-        "removeQueuedMessagesByDedupeKeyPrefix"
-      ).mockReturnValue(Ok(0));
-
-      await preparingStarted.promise;
-      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
-        processId: "proc-preparing",
-        processStartTime: Date.parse(shownRecord.createdAt),
-        shownThroughOffset: 100,
-      });
-
-      await preparingCanceled.promise;
-      await waitForCondition(
-        async () => (await seedWakeStore.listPending(workspaceId)).length === 0
-      );
-      expect(removeQueuedSpy).toHaveBeenCalled();
-      expect(sendSpy).toHaveBeenCalledTimes(1);
-    } finally {
+      releaseSecondCheck.resolve();
       await cleanup();
     }
   });

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -602,6 +602,358 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("retracts a queued monitor wake once a later unfiltered read shows its match", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-shown-after-queue";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-shown",
+        taskId: "bash:proc-shown",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED shown"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-unshown",
+        taskId: "bash:proc-unshown",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED unshown"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 200,
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getForegroundToolCallIds: mock(() => []),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      let queueHasPendingMonitorWake = false;
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockImplementation(
+        () => queueHasPendingMonitorWake
+      );
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      type SendInternal = NonNullable<Parameters<WorkspaceService["sendMessage"]>[3]>;
+      let onCanceled: SendInternal["onCanceled"] | undefined;
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          onCanceled = args[3]?.onCanceled;
+          queueHasPendingMonitorWake = true;
+          return Promise.resolve(Ok(undefined));
+        }
+      );
+      const removeQueuedSpy = spyOn(
+        workspaceService,
+        "removeQueuedMessagesByDedupeKeyPrefix"
+      ).mockImplementation((_ownerWorkspaceId, _prefix, options) => {
+        queueHasPendingMonitorWake = false;
+        void onCanceled?.(options?.cancelReason ?? "canceled");
+        return Ok(1);
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED shown");
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED unshown");
+
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "proc-shown",
+        processStartTime: 0,
+        shownThroughOffset: 99,
+      });
+      expect(removeQueuedSpy).not.toHaveBeenCalled();
+
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "proc-shown",
+        processStartTime: 0,
+        shownThroughOffset: 100,
+      });
+
+      await waitForCondition(() => removeQueuedSpy.mock.calls.length === 1);
+      await waitForCondition(() => sendSpy.mock.calls.length === 2);
+      expect(sendSpy.mock.calls[1][1]).not.toContain("FAILED shown");
+      expect(sendSpy.mock.calls[1][1]).toContain("FAILED unshown");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("does not retract an older queued wake when a newer process reuses its ID", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-shown-reused-id";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      const staleRecord = await seedWakeStore.enqueueOrMergePending({
+        processId: "reused-proc",
+        taskId: "bash:reused-proc",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED stale"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getForegroundToolCallIds: mock(() => []),
+        // The normal delivery gate cannot bind this old wake to the newer live process, so it
+        // deliberately fails open and lets the wake queue.
+        getMonitorWakeDeliveryState: mock(() => Promise.resolve(undefined)),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
+      const removeQueuedSpy = spyOn(workspaceService, "removeQueuedMessagesByDedupeKeyPrefix");
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "reused-proc",
+        processStartTime: Date.parse(staleRecord.createdAt) + 1,
+        shownThroughOffset: 100,
+      });
+      await drainPendingDispatches();
+
+      expect(removeQueuedSpy).not.toHaveBeenCalled();
+      expect(await seedWakeStore.listPending(workspaceId)).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("retries shown-output cancellation when queue insertion is still preparing", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    const releaseFirstSend = createDeferred<void>();
+    try {
+      const workspaceId = "bash-monitor-shown-queue-preparing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      const shownRecord = await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-shown",
+        taskId: "bash:proc-shown",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED shown"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+      await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-unshown",
+        taskId: "bash:proc-unshown",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED unshown"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 200,
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getForegroundToolCallIds: mock(() => []),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+
+      type SendInternal = NonNullable<Parameters<WorkspaceService["sendMessage"]>[3]>;
+      let firstSendInternal: SendInternal | undefined;
+      let sendCount = 0;
+      const firstSendStarted = createDeferred<void>();
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          sendCount += 1;
+          if (sendCount === 1) {
+            firstSendInternal = args[3];
+            firstSendStarted.resolve();
+            await releaseFirstSend.promise;
+            return Ok(undefined);
+          }
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+      let removalAttempts = 0;
+      const removeQueuedSpy = spyOn(
+        workspaceService,
+        "removeQueuedMessagesByDedupeKeyPrefix"
+      ).mockImplementation((_ownerWorkspaceId, _prefix, options) => {
+        removalAttempts += 1;
+        if (removalAttempts === 1) {
+          // The first attempt races before sendMessage has inserted its queue entry.
+          return Ok(0);
+        }
+        void firstSendInternal?.onCanceled?.(options?.cancelReason ?? "canceled");
+        return Ok(1);
+      });
+
+      await firstSendStarted.promise;
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED shown");
+      expect(sendSpy.mock.calls[0][1]).toContain("FAILED unshown");
+
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "proc-shown",
+        processStartTime: Date.parse(shownRecord.createdAt),
+        shownThroughOffset: 100,
+      });
+      await waitForCondition(() => removeQueuedSpy.mock.calls.length === 1);
+      expect(firstSendInternal?.cancelSignal?.aborted).toBe(true);
+
+      releaseFirstSend.resolve();
+      await waitForCondition(() => removeQueuedSpy.mock.calls.length === 2);
+      await waitForCondition(() => sendSpy.mock.calls.length === 2);
+      expect(sendSpy.mock.calls[1][1]).not.toContain("FAILED shown");
+      expect(sendSpy.mock.calls[1][1]).toContain("FAILED unshown");
+    } finally {
+      releaseFirstSend.resolve();
+      await cleanup();
+    }
+  });
+
+  test("aborts a dequeued preparing wake after its matched output is shown", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-shown-dequeued-preparing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedWakeStore = new BashMonitorWakeStore(config);
+      const shownRecord = await seedWakeStore.enqueueOrMergePending({
+        processId: "proc-preparing",
+        taskId: "bash:proc-preparing",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED preparing"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getForegroundToolCallIds: mock(() => []),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+
+      const preparingStarted = createDeferred<void>();
+      const preparingCanceled = createDeferred<void>();
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          const internal = args[3];
+          if (internal?.cancelSignal == null) {
+            throw new Error("Expected monitor wake cancellation signal");
+          }
+          const signal = internal.cancelSignal;
+          preparingStarted.resolve();
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              resolve();
+              return;
+            }
+            signal.addEventListener("abort", () => resolve(), { once: true });
+          });
+          await internal.onCanceled?.(
+            typeof signal.reason === "string" ? signal.reason : "preparing wake canceled"
+          );
+          if (internal.cancelState != null) {
+            internal.cancelState.canceledBeforeAcceptance = true;
+          }
+          preparingCanceled.resolve();
+          return Ok(undefined);
+        }
+      );
+      const removeQueuedSpy = spyOn(
+        workspaceService,
+        "removeQueuedMessagesByDedupeKeyPrefix"
+      ).mockReturnValue(Ok(0));
+
+      await preparingStarted.promise;
+      (backgroundProcessManager as EventEmitter).emit("output:shown", workspaceId, {
+        processId: "proc-preparing",
+        processStartTime: Date.parse(shownRecord.createdAt),
+        shownThroughOffset: 100,
+      });
+
+      await preparingCanceled.promise;
+      await waitForCondition(
+        async () => (await seedWakeStore.listPending(workspaceId)).length === 0
+      );
+      expect(removeQueuedSpy).toHaveBeenCalled();
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("converts stale armed-monitor registry records into monitor-lost wakes at startup", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -798,6 +798,62 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("unregisters pending wakes when a delivery-state query fails", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-delivery-gate-failure";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const wakeStore = new BashMonitorWakeStore(config);
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-failed-gate",
+        taskId: "bash:proc-failed-gate",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED gate"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 100,
+      });
+
+      const getDeliveryState = mock(() => Promise.reject(new Error("delivery gate failed")));
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        getForegroundToolCallIds: mock(() => []),
+        getMonitorWakeDeliveryState: getDeliveryState,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
+
+      await waitForCondition(() => getDeliveryState.mock.calls.length === 1);
+      await drainPendingDispatches();
+      backgroundProcessManager.emit("monitor:stopped", workspaceId, {
+        processId: "proc-failed-gate",
+        reason: "canceled",
+      });
+
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+      expect(sendSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("converts stale armed-monitor registry records into monitor-lost wakes at startup", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -639,8 +639,7 @@ const BASH_MONITOR_SHOWN_QUEUE_REASON =
 interface QueuedBashMonitorWakeCancellation {
   abortController: AbortController;
   dispatchState: { canceledBeforeAcceptance: boolean };
-  canceledProcessKeys: Set<string>;
-  shownProcessKeys: Set<string>;
+  invalidatedProcessKeys: Set<string>;
   matchedOutputByProcess: Map<string, { matchedThroughOffset: number; originNotAfterMs: number }>;
 }
 
@@ -1759,7 +1758,7 @@ export class WorkspaceService extends EventEmitter {
       ) {
         continue;
       }
-      cancellation.shownProcessKeys.add(processKey);
+      cancellation.invalidatedProcessKeys.add(processKey);
       cancellation.abortController.abort(BASH_MONITOR_SHOWN_QUEUE_REASON);
       this.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, queueKey, {
         cancelReason: BASH_MONITOR_SHOWN_QUEUE_REASON,
@@ -1824,7 +1823,7 @@ export class WorkspaceService extends EventEmitter {
       // between the monitor stopping and the persisted/queued cleanup below.
       this.canceledBashMonitorKeys.add(processKey);
       for (const [queueKey, cancellation] of trackedWakeCancellations ?? []) {
-        cancellation.canceledProcessKeys.add(processKey);
+        cancellation.invalidatedProcessKeys.add(processKey);
         cancellation.abortController.abort(BASH_MONITOR_CANCELED_QUEUE_REASON);
         this.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, queueKey, {
           cancelReason: BASH_MONITOR_CANCELED_QUEUE_REASON,
@@ -2123,8 +2122,7 @@ export class WorkspaceService extends EventEmitter {
     const cancellation: QueuedBashMonitorWakeCancellation = {
       abortController: new AbortController(),
       dispatchState: { canceledBeforeAcceptance: false },
-      canceledProcessKeys: new Set<string>(),
-      shownProcessKeys: new Set<string>(),
+      invalidatedProcessKeys: new Set<string>(),
       matchedOutputByProcess: new Map(),
     };
     for (const record of records) {
@@ -2395,6 +2393,19 @@ export class WorkspaceService extends EventEmitter {
         this.bashMonitorWakeStore.markSupersededSnapshot(ownerWorkspaceId, record)
       );
 
+    // Register every pending match before the first frontier query. If an earlier process becomes
+    // shown while a later query awaits, the existing cancellation object retains that fact.
+    const { queueKey, cancellation } = this.registerQueuedBashMonitorWake(
+      ownerWorkspaceId,
+      pending
+    );
+    let queueKeyRegistered = true;
+    const unregisterQueueKey = (): void => {
+      if (!queueKeyRegistered) return;
+      queueKeyRegistered = false;
+      this.unregisterQueuedBashMonitorWake(ownerWorkspaceId, pending, queueKey);
+    };
+
     // Delivery gate: re-check each match against the shown frontier immediately before sending it.
     // If task_await is already reading that same process, defer only that record until the read
     // settles; unrelated process wakes in this owner batch remain deliverable. Partial manager stubs
@@ -2431,8 +2442,32 @@ export class WorkspaceService extends EventEmitter {
       }
       deliverable.push(record);
     }
-    if (supersededByShown.length > 0) {
-      await markSupersededSnapshots(supersededByShown);
+    const supersededBeforeSend = new Map(
+      supersededByShown.map((record) => [record.id, record] as const)
+    );
+    if (supersededBeforeSend.size > 0) {
+      await markSupersededSnapshots([...supersededBeforeSend.values()]);
+    }
+    if (cancellation.abortController.signal.aborted) {
+      // Stop accepting new invalidations, then include every event retained while the gate awaited.
+      unregisterQueueKey();
+      const newlyInvalidated = pending.filter(
+        (record) =>
+          !supersededBeforeSend.has(record.id) &&
+          cancellation.invalidatedProcessKeys.has(
+            this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
+          )
+      );
+      for (const record of newlyInvalidated) {
+        supersededBeforeSend.set(record.id, record);
+      }
+      if (newlyInvalidated.length > 0) {
+        await markSupersededSnapshots(newlyInvalidated);
+      }
+      if (supersededBeforeSend.size < pending.length) {
+        this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
+      }
+      return;
     }
     // Cancellation can land while the shown-frontier checks above await I/O. Drop those records
     // before constructing the prompt, while allowing unrelated process wakes in the batch through.
@@ -2447,18 +2482,11 @@ export class WorkspaceService extends EventEmitter {
         await this.bashMonitorWakeStore.markSuperseded(ownerWorkspaceId, record.id);
       }
     }
-    if (deliverable.length === 0) return;
+    if (deliverable.length === 0) {
+      unregisterQueueKey();
+      return;
+    }
 
-    const { queueKey, cancellation } = this.registerQueuedBashMonitorWake(
-      ownerWorkspaceId,
-      deliverable
-    );
-    let queueKeyRegistered = true;
-    const unregisterQueueKey = (): void => {
-      if (!queueKeyRegistered) return;
-      queueKeyRegistered = false;
-      this.unregisterQueuedBashMonitorWake(ownerWorkspaceId, deliverable, queueKey);
-    };
     const prompt = buildBashMonitorWakePrompt(deliverable);
     const retryAfterIdleIfBusy = (reason: string): void => {
       if (
@@ -2548,20 +2576,16 @@ export class WorkspaceService extends EventEmitter {
           cancellationCallbackHandled = true;
           unregisterQueueKey();
           if (delivered) return;
-          const canceledProcessKeys =
-            reason === BASH_MONITOR_CANCELED_QUEUE_REASON
-              ? cancellation.canceledProcessKeys
-              : reason === BASH_MONITOR_SHOWN_QUEUE_REASON
-                ? cancellation.shownProcessKeys
-                : undefined;
-          const canceledRecords =
-            canceledProcessKeys == null
-              ? deliverable
-              : deliverable.filter((record) =>
-                  canceledProcessKeys.has(
-                    this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
-                  )
-                );
+          const wakeInvalidated =
+            reason === BASH_MONITOR_CANCELED_QUEUE_REASON ||
+            reason === BASH_MONITOR_SHOWN_QUEUE_REASON;
+          const canceledRecords = wakeInvalidated
+            ? deliverable.filter((record) =>
+                cancellation.invalidatedProcessKeys.has(
+                  this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
+                )
+              )
+            : deliverable;
           const cancelingKeys = canceledRecords.map((record) =>
             this.bashMonitorWakeKey(ownerWorkspaceId, record.id)
           );

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -245,6 +245,7 @@ import type {
   MonitorArmedPayload,
   MonitorMatchPayload,
   MonitorStoppedPayload,
+  OutputShownPayload,
 } from "@/node/services/backgroundProcessManager";
 import { BashMonitorRegistryStore } from "@/node/services/bashMonitorRegistryStore";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
@@ -632,11 +633,15 @@ const IDLE_ONLY_BUSY_SKIP_MESSAGE = "Workspace is busy; idle-only send was skipp
 const BASH_MONITOR_WAKE_QUEUE_KEY_PREFIX = "bash-monitor-wake:";
 const BASH_MONITOR_CANCELED_QUEUE_REASON =
   "Background bash monitor was explicitly canceled before its wake dispatched.";
+const BASH_MONITOR_SHOWN_QUEUE_REASON =
+  "Background bash monitor output was already shown before its wake dispatched.";
 
 interface QueuedBashMonitorWakeCancellation {
   abortController: AbortController;
   dispatchState: { canceledBeforeAcceptance: boolean };
   canceledProcessKeys: Set<string>;
+  shownProcessKeys: Set<string>;
+  matchedOutputByProcess: Map<string, { matchedThroughOffset: number; originNotAfterMs: number }>;
 }
 
 async function waitForAgentSessionIdle(session: AgentSession, signal?: AbortSignal): Promise<void> {
@@ -1736,6 +1741,31 @@ export class WorkspaceService extends EventEmitter {
     Map<string, QueuedBashMonitorWakeCancellation>
   >();
   private nextBashMonitorWakeQueueKey = 0;
+  private readonly bashOutputShownListener = (
+    workspaceId: string,
+    payload: OutputShownPayload
+  ): void => {
+    const processKey = this.bashMonitorProcessKey(workspaceId, payload.processId);
+    for (const [queueKey, cancellation] of this.queuedBashMonitorWakeKeysByProcess.get(
+      processKey
+    ) ?? []) {
+      // Process IDs are reusable across restarts. Match the existing delivery gate's createdAt
+      // generation bound so output from a newer process cannot supersede an older pending wake.
+      const matchedOutput = cancellation.matchedOutputByProcess.get(processKey);
+      if (
+        matchedOutput == null ||
+        payload.processStartTime > matchedOutput.originNotAfterMs ||
+        payload.shownThroughOffset < matchedOutput.matchedThroughOffset
+      ) {
+        continue;
+      }
+      cancellation.shownProcessKeys.add(processKey);
+      cancellation.abortController.abort(BASH_MONITOR_SHOWN_QUEUE_REASON);
+      this.removeQueuedMessagesByDedupeKeyPrefix(workspaceId, queueKey, {
+        cancelReason: BASH_MONITOR_SHOWN_QUEUE_REASON,
+      });
+    }
+  };
   private readonly bashMonitorMatchListener = (
     _workspaceId: string,
     payload: MonitorMatchPayload
@@ -1953,6 +1983,7 @@ export class WorkspaceService extends EventEmitter {
     this.bashMonitorWakeStore = new BashMonitorWakeStore(config);
     this.bashMonitorRegistryStore = new BashMonitorRegistryStore(config);
     if (typeof this.backgroundProcessManager.on === "function") {
+      this.backgroundProcessManager.on("output:shown", this.bashOutputShownListener);
       this.backgroundProcessManager.on("monitor:match", this.bashMonitorMatchListener);
       this.backgroundProcessManager.on("monitor:armed", this.bashMonitorArmedListener);
       this.backgroundProcessManager.on("monitor:stopped", this.bashMonitorStoppedListener);
@@ -2093,9 +2124,24 @@ export class WorkspaceService extends EventEmitter {
       abortController: new AbortController(),
       dispatchState: { canceledBeforeAcceptance: false },
       canceledProcessKeys: new Set<string>(),
+      shownProcessKeys: new Set<string>(),
+      matchedOutputByProcess: new Map(),
     };
     for (const record of records) {
       const processKey = this.bashMonitorProcessKey(ownerWorkspaceId, record.processId);
+      if (record.kind === "match" && record.matchedThroughOffset != null) {
+        const previous = cancellation.matchedOutputByProcess.get(processKey);
+        cancellation.matchedOutputByProcess.set(processKey, {
+          matchedThroughOffset: Math.max(
+            previous?.matchedThroughOffset ?? 0,
+            record.matchedThroughOffset
+          ),
+          originNotAfterMs: Math.min(
+            previous?.originNotAfterMs ?? Number.POSITIVE_INFINITY,
+            Date.parse(record.createdAt)
+          ),
+        });
+      }
       const queueKeys =
         this.queuedBashMonitorWakeKeysByProcess.get(processKey) ??
         new Map<string, QueuedBashMonitorWakeCancellation>();
@@ -2502,14 +2548,20 @@ export class WorkspaceService extends EventEmitter {
           cancellationCallbackHandled = true;
           unregisterQueueKey();
           if (delivered) return;
-          const canceledRecords =
+          const canceledProcessKeys =
             reason === BASH_MONITOR_CANCELED_QUEUE_REASON
-              ? deliverable.filter((record) =>
-                  cancellation.canceledProcessKeys.has(
+              ? cancellation.canceledProcessKeys
+              : reason === BASH_MONITOR_SHOWN_QUEUE_REASON
+                ? cancellation.shownProcessKeys
+                : undefined;
+          const canceledRecords =
+            canceledProcessKeys == null
+              ? deliverable
+              : deliverable.filter((record) =>
+                  canceledProcessKeys.has(
                     this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
                   )
-                )
-              : deliverable;
+                );
           const cancelingKeys = canceledRecords.map((record) =>
             this.bashMonitorWakeKey(ownerWorkspaceId, record.id)
           );
@@ -2542,9 +2594,11 @@ export class WorkspaceService extends EventEmitter {
     if (!accepted && cancellation.abortController.signal.aborted) {
       // Cancellation may have raced the async preparation inside sendMessage and attempted queue
       // removal before the entry existed. Retry after sendMessage returns from the enqueue path.
-      this.removeQueuedMessagesByDedupeKeyPrefix(ownerWorkspaceId, queueKey, {
-        cancelReason: BASH_MONITOR_CANCELED_QUEUE_REASON,
-      });
+      const cancelReason =
+        typeof cancellation.abortController.signal.reason === "string"
+          ? cancellation.abortController.signal.reason
+          : BASH_MONITOR_CANCELED_QUEUE_REASON;
+      this.removeQueuedMessagesByDedupeKeyPrefix(ownerWorkspaceId, queueKey, { cancelReason });
     }
 
     if (!sendResult.success) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2406,88 +2406,94 @@ export class WorkspaceService extends EventEmitter {
       this.unregisterQueuedBashMonitorWake(ownerWorkspaceId, pending, queueKey);
     };
 
-    // Delivery gate: re-check each match against the shown frontier immediately before sending it.
-    // If task_await is already reading that same process, defer only that record until the read
-    // settles; unrelated process wakes in this owner batch remain deliverable. Partial manager stubs
-    // without the non-blocking query retain the previous settled-frontier behavior.
-    const canQueryDeliveryState =
-      typeof this.backgroundProcessManager.getMonitorWakeDeliveryState === "function";
-    const canQueryShownFrontier =
-      typeof this.backgroundProcessManager.getSettledShownThroughOffset === "function";
     const deliverable: BashMonitorWakeRecord[] = [];
-    const supersededByShown: BashMonitorWakeRecord[] = [];
-    for (const record of pending) {
-      let shownThroughOffset: number | undefined;
-      if (record.kind === "match" && record.matchedThroughOffset != null) {
-        if (canQueryDeliveryState) {
-          const state = await this.backgroundProcessManager.getMonitorWakeDeliveryState(
-            record.processId,
-            Date.parse(record.createdAt)
-          );
-          if (state?.status === "blocked") {
-            this.scheduleBashMonitorWakeDrainAfterRead(ownerWorkspaceId, state.readSettled);
+    let prompt: string;
+    try {
+      // Delivery gate: re-check each match against the shown frontier immediately before sending it.
+      // If task_await is already reading that same process, defer only that record until the read
+      // settles; unrelated process wakes in this owner batch remain deliverable. Partial manager stubs
+      // without the non-blocking query retain the previous settled-frontier behavior.
+      const canQueryDeliveryState =
+        typeof this.backgroundProcessManager.getMonitorWakeDeliveryState === "function";
+      const canQueryShownFrontier =
+        typeof this.backgroundProcessManager.getSettledShownThroughOffset === "function";
+      const supersededByShown: BashMonitorWakeRecord[] = [];
+      for (const record of pending) {
+        let shownThroughOffset: number | undefined;
+        if (record.kind === "match" && record.matchedThroughOffset != null) {
+          if (canQueryDeliveryState) {
+            const state = await this.backgroundProcessManager.getMonitorWakeDeliveryState(
+              record.processId,
+              Date.parse(record.createdAt)
+            );
+            if (state?.status === "blocked") {
+              this.scheduleBashMonitorWakeDrainAfterRead(ownerWorkspaceId, state.readSettled);
+              continue;
+            }
+            shownThroughOffset = state?.shownThroughOffset;
+          } else if (canQueryShownFrontier) {
+            shownThroughOffset = await this.backgroundProcessManager.getSettledShownThroughOffset(
+              record.processId,
+              Date.parse(record.createdAt)
+            );
+          }
+          if (shownThroughOffset != null && shownThroughOffset >= record.matchedThroughOffset) {
+            supersededByShown.push(record);
             continue;
           }
-          shownThroughOffset = state?.shownThroughOffset;
-        } else if (canQueryShownFrontier) {
-          shownThroughOffset = await this.backgroundProcessManager.getSettledShownThroughOffset(
-            record.processId,
-            Date.parse(record.createdAt)
-          );
         }
-        if (shownThroughOffset != null && shownThroughOffset >= record.matchedThroughOffset) {
-          supersededByShown.push(record);
-          continue;
-        }
+        deliverable.push(record);
       }
-      deliverable.push(record);
-    }
-    const supersededBeforeSend = new Map(
-      supersededByShown.map((record) => [record.id, record] as const)
-    );
-    if (supersededBeforeSend.size > 0) {
-      await markSupersededSnapshots([...supersededBeforeSend.values()]);
-    }
-    if (cancellation.abortController.signal.aborted) {
-      // Stop accepting new invalidations, then include every event retained while the gate awaited.
-      unregisterQueueKey();
-      const newlyInvalidated = pending.filter(
-        (record) =>
-          !supersededBeforeSend.has(record.id) &&
-          cancellation.invalidatedProcessKeys.has(
+      const supersededBeforeSend = new Map(
+        supersededByShown.map((record) => [record.id, record] as const)
+      );
+      if (supersededBeforeSend.size > 0) {
+        await markSupersededSnapshots([...supersededBeforeSend.values()]);
+      }
+      if (cancellation.abortController.signal.aborted) {
+        // Stop accepting new invalidations, then include every event retained while the gate awaited.
+        unregisterQueueKey();
+        const newlyInvalidated = pending.filter(
+          (record) =>
+            !supersededBeforeSend.has(record.id) &&
+            cancellation.invalidatedProcessKeys.has(
+              this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
+            )
+        );
+        for (const record of newlyInvalidated) {
+          supersededBeforeSend.set(record.id, record);
+        }
+        if (newlyInvalidated.length > 0) {
+          await markSupersededSnapshots(newlyInvalidated);
+        }
+        if (supersededBeforeSend.size < pending.length) {
+          this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
+        }
+        return;
+      }
+      // Cancellation can land while the shown-frontier checks above await I/O. Drop those records
+      // before constructing the prompt, while allowing unrelated process wakes in the batch through.
+      for (let index = deliverable.length - 1; index >= 0; index--) {
+        const record = deliverable[index];
+        if (
+          this.canceledBashMonitorKeys.has(
             this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
           )
-      );
-      for (const record of newlyInvalidated) {
-        supersededBeforeSend.set(record.id, record);
+        ) {
+          deliverable.splice(index, 1);
+          await this.bashMonitorWakeStore.markSuperseded(ownerWorkspaceId, record.id);
+        }
       }
-      if (newlyInvalidated.length > 0) {
-        await markSupersededSnapshots(newlyInvalidated);
+      if (deliverable.length === 0) {
+        unregisterQueueKey();
+        return;
       }
-      if (supersededBeforeSend.size < pending.length) {
-        this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
-      }
-      return;
-    }
-    // Cancellation can land while the shown-frontier checks above await I/O. Drop those records
-    // before constructing the prompt, while allowing unrelated process wakes in the batch through.
-    for (let index = deliverable.length - 1; index >= 0; index--) {
-      const record = deliverable[index];
-      if (
-        this.canceledBashMonitorKeys.has(
-          this.bashMonitorProcessKey(ownerWorkspaceId, record.processId)
-        )
-      ) {
-        deliverable.splice(index, 1);
-        await this.bashMonitorWakeStore.markSuperseded(ownerWorkspaceId, record.id);
-      }
-    }
-    if (deliverable.length === 0) {
-      unregisterQueueKey();
-      return;
-    }
 
-    const prompt = buildBashMonitorWakePrompt(deliverable);
+      prompt = buildBashMonitorWakePrompt(deliverable);
+    } catch (error) {
+      unregisterQueueKey();
+      throw error;
+    }
     const retryAfterIdleIfBusy = (reason: string): void => {
       if (
         this.isBusyForMessage(ownerWorkspaceId) ||


### PR DESCRIPTION
## Summary

Prevent background bash monitor wakes from dispatching after `task_await` has already shown the matched output.

## Background

The existing delivery gate handled a read that was already active when a wake drain began. A separate race remained for multi-process batches: an earlier process could become shown while the drain awaited a later process's delivery-state query. Because queue cancellation was registered only after those queries, the `output:shown` event was lost and the stale synthetic wake could dispatch.

## Implementation

`BackgroundProcessManager` emits `output:shown` whenever an unfiltered read advances a process's shown-output frontier. `WorkspaceService` now registers every pending wake with the existing cancellation path before the first asynchronous delivery-state query. If output becomes shown during the gate, the retained cancellation state supersedes that record and rebuilds the batch with only still-eligible wakes.

The generation guard uses the existing wake creation time and live process start time. Output from a newer process that reuses the same ID cannot suppress an older pending wake.

## Risks

The change is limited to synthetic background-monitor wake scheduling. A regression could cause a duplicate or missed monitor wake, but it does not affect the underlying bash process or its output.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `N/A`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=N/A -->
