### PR TITLE
🤖 fix: clean up legacy Chat with Mux config entries on load

### DIFF
--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -567,6 +567,28 @@ describe("Config", () => {
       expect(loaded.projects.has(legacyProjectPath)).toBe(false);
     });
 
+    it("survives a corrupted non-string subProjectPath on a mux-chat record", () => {
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              "/home/user/repo",
+              {
+                workspaces: [
+                  { path: "/home/user/repo/ws", id: "mux-chat", name: "chat", subProjectPath: 42 },
+                ],
+              },
+            ],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.get("/home/user/repo")?.workspaces).toHaveLength(1);
+    });
+
     it("keeps other workspaces in a system Mux project and retains the project", () => {
       const configFile = path.join(tempDir, "config.json");
       fs.writeFileSync(

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -534,6 +534,39 @@ describe("Config", () => {
       expect(loaded.projects.get("/home/user/mux")?.workspaces).toHaveLength(1);
     });
 
+    it("removes entries already merged into an ancestor project via subProjectPath", () => {
+      // An earlier load's subproject merge relocated mux-chat into the
+      // registered ~/.mux parent and left the system/Mux child empty.
+      const parentProjectPath = "/home/user/.mux";
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              parentProjectPath,
+              {
+                workspaces: [
+                  {
+                    ...legacyMuxChatWorkspace(legacyProjectPath),
+                    subProjectPath: legacyProjectPath,
+                  },
+                  { path: "/home/user/.mux/other", id: "other-ws", name: "other" },
+                ],
+              },
+            ],
+            [legacyProjectPath, { workspaces: [], projectKind: "system" }],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.get(parentProjectPath)?.workspaces.map((w) => w.id)).toEqual([
+        "other-ws",
+      ]);
+      expect(loaded.projects.has(legacyProjectPath)).toBe(false);
+    });
+
     it("keeps other workspaces in a system Mux project and retains the project", () => {
       const configFile = path.join(tempDir, "config.json");
       fs.writeFileSync(

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -451,6 +451,115 @@ describe("Config", () => {
     });
   });
 
+  describe("legacy Chat with Mux cleanup", () => {
+    const legacyProjectPath = "/home/user/.mux/system/Mux";
+
+    function legacyMuxChatWorkspace(projectPath: string) {
+      return {
+        path: projectPath,
+        id: "mux-chat",
+        name: "chat-with-mux",
+        title: "Chat with Mux",
+        agentId: "mux",
+      };
+    }
+
+    it("removes the legacy system Mux project and persists the cleanup", async () => {
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              legacyProjectPath,
+              {
+                workspaces: [legacyMuxChatWorkspace(legacyProjectPath)],
+                projectKind: "system",
+              },
+            ],
+            ["/repo", { workspaces: [] }],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.has(legacyProjectPath)).toBe(false);
+      expect(loaded.projects.has("/repo")).toBe(true);
+
+      await flushConfigEdits();
+      const persisted = fs.readFileSync(configFile, "utf-8");
+      expect(persisted).not.toContain("mux-chat");
+    });
+
+    it("removes stale entries left under other mux roots", () => {
+      const staleProjectPath = "/home/user/.mux-dev/system/Mux";
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              legacyProjectPath,
+              { workspaces: [legacyMuxChatWorkspace(legacyProjectPath)], projectKind: "system" },
+            ],
+            [
+              staleProjectPath,
+              { workspaces: [legacyMuxChatWorkspace(staleProjectPath)], projectKind: "system" },
+            ],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.size).toBe(0);
+    });
+
+    it("keeps unrelated workspaces whose id collides with mux-chat", () => {
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              "/home/user/mux",
+              {
+                workspaces: [{ path: "/home/user/mux-chat", id: "mux-chat", name: "chat" }],
+              },
+            ],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.get("/home/user/mux")?.workspaces).toHaveLength(1);
+    });
+
+    it("keeps other workspaces in a system Mux project and retains the project", () => {
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            [
+              legacyProjectPath,
+              {
+                workspaces: [
+                  legacyMuxChatWorkspace(legacyProjectPath),
+                  { path: "/home/user/other", id: "other-ws", name: "other" },
+                ],
+                projectKind: "system",
+              },
+            ],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      const workspaces = loaded.projects.get(legacyProjectPath)?.workspaces;
+      expect(workspaces?.map((w) => w.id)).toEqual(["other-ws"]);
+    });
+  });
+
   describe("modelFallbacks normalization", () => {
     it("self-heals malformed modelFallbacks on load instead of breaking sends", () => {
       const configFile = path.join(tempDir, "config.json");

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -660,6 +660,52 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
   return next;
 }
 /**
+ * The built-in Chat with Mux workspace (removed in #3123) lived in a hidden
+ * `<muxHome>/system/Mux` project. The removal shipped no config migration, so
+ * upgraded installs kept the entry: invisible in the UI (system projects are
+ * filtered out) but still swept by config-driven background jobs like
+ * AgentStatusService, which sent its stale transcript to the LLM on every
+ * launch. Drop the leftovers on load. Older builds recreate the entry on
+ * downgrade; this cleanup re-runs on the next upgrade.
+ */
+function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boolean {
+  let modified = false;
+  for (const [projectPath, projectConfig] of projects) {
+    // Match the project by path shape (basename "Mux" under "system") rather
+    // than the current root dir so stale entries from other roots (e.g. a
+    // ~/.mux entry seen by a ~/.mux-dev build) are cleaned too.
+    const isSystemMuxProjectPath =
+      path.basename(projectPath) === "Mux" && path.basename(path.dirname(projectPath)) === "system";
+    if (!isSystemMuxProjectPath) {
+      continue;
+    }
+
+    const remaining = projectConfig.workspaces.filter((workspace) => {
+      if (workspace.id !== "mux-chat") {
+        return true;
+      }
+      // Keep unrelated workspaces whose generated id happens to be "mux-chat";
+      // only entries carrying the built-in workspace's markers are legacy.
+      const looksLikeLegacyMuxChat =
+        workspace.agentId === "mux" ||
+        workspace.path === projectPath ||
+        workspace.name === "chat-with-mux" ||
+        workspace.title === "Chat with Mux";
+      return !looksLikeLegacyMuxChat;
+    });
+
+    if (remaining.length !== projectConfig.workspaces.length) {
+      projectConfig.workspaces = remaining;
+      modified = true;
+      if (remaining.length === 0) {
+        projects.delete(projectPath);
+      }
+    }
+  }
+  return modified;
+}
+
+/**
  * Config - Centralized configuration management
  *
  * Encapsulates all config paths and operations, making them dependency-injectable
@@ -888,6 +934,12 @@ export class Config {
             ];
           });
         const projectsMap = deriveProjectHierarchy(new Map<string, ProjectConfig>(normalizedPairs));
+
+        // Run before the subproject merge below so a hierarchy edge case
+        // cannot relocate a legacy workspace into a parent project first.
+        if (removeLegacyMuxChatEntries(projectsMap)) {
+          configModified = true;
+        }
 
         for (const [projectPath, projectConfig] of projectsMap) {
           const parentProjectPath = projectConfig.parentProjectPath;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -689,9 +689,12 @@ function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boole
       // an ancestor project (e.g. ~/.mux registered as a project) on an
       // earlier load, stamping subProjectPath with the original system/Mux
       // path. Match the entry in either location.
+      // typeof guard: config JSON is unvalidated at runtime, and a corrupted
+      // non-string subProjectPath would make path.basename throw, collapsing
+      // the whole config load to empty defaults.
       const legacyProjectPath = projectIsSystemMux
         ? projectPath
-        : workspace.subProjectPath != null && isSystemMuxPath(workspace.subProjectPath)
+        : typeof workspace.subProjectPath === "string" && isSystemMuxPath(workspace.subProjectPath)
           ? workspace.subProjectPath
           : null;
       if (legacyProjectPath === null) {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -671,37 +671,58 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
  * mux-chat id from orphan reaping.
  */
 function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boolean {
+  // Match by path shape (basename "Mux" under "system") rather than the
+  // current root dir so stale entries from other roots (e.g. a ~/.mux entry
+  // seen by a ~/.mux-dev build) are cleaned too.
+  const isSystemMuxPath = (candidate: string): boolean =>
+    path.basename(candidate) === "Mux" && path.basename(path.dirname(candidate)) === "system";
+
   let modified = false;
   for (const [projectPath, projectConfig] of projects) {
-    // Match the project by path shape (basename "Mux" under "system") rather
-    // than the current root dir so stale entries from other roots (e.g. a
-    // ~/.mux entry seen by a ~/.mux-dev build) are cleaned too.
-    const isSystemMuxProjectPath =
-      path.basename(projectPath) === "Mux" && path.basename(path.dirname(projectPath)) === "system";
-    if (!isSystemMuxProjectPath) {
-      continue;
-    }
+    const projectIsSystemMux = isSystemMuxPath(projectPath);
 
     const remaining = projectConfig.workspaces.filter((workspace) => {
       if (workspace.id !== "mux-chat") {
+        return true;
+      }
+      // The subproject merge below may have already relocated the entry into
+      // an ancestor project (e.g. ~/.mux registered as a project) on an
+      // earlier load, stamping subProjectPath with the original system/Mux
+      // path. Match the entry in either location.
+      const legacyProjectPath = projectIsSystemMux
+        ? projectPath
+        : workspace.subProjectPath != null && isSystemMuxPath(workspace.subProjectPath)
+          ? workspace.subProjectPath
+          : null;
+      if (legacyProjectPath === null) {
         return true;
       }
       // Keep unrelated workspaces whose generated id happens to be "mux-chat";
       // only entries carrying the built-in workspace's markers are legacy.
       const looksLikeLegacyMuxChat =
         workspace.agentId === "mux" ||
-        workspace.path === projectPath ||
+        workspace.path === legacyProjectPath ||
         workspace.name === "chat-with-mux" ||
         workspace.title === "Chat with Mux";
       return !looksLikeLegacyMuxChat;
     });
 
-    if (remaining.length !== projectConfig.workspaces.length) {
+    const removedEntries = remaining.length !== projectConfig.workspaces.length;
+    if (removedEntries) {
       projectConfig.workspaces = remaining;
       modified = true;
-      if (remaining.length === 0) {
-        projects.delete(projectPath);
-      }
+    }
+
+    // Delete the system Mux project once empty. The already-empty +
+    // projectKind check covers the shell left behind when the subproject
+    // merge relocated its only workspace into a parent project.
+    if (
+      projectIsSystemMux &&
+      remaining.length === 0 &&
+      (removedEntries || projectConfig.projectKind === "system")
+    ) {
+      projects.delete(projectPath);
+      modified = true;
     }
   }
   return modified;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -666,7 +666,9 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
  * filtered out) but still swept by config-driven background jobs like
  * AgentStatusService, which sent its stale transcript to the LLM on every
  * launch. Drop the leftovers on load. Older builds recreate the entry on
- * downgrade; this cleanup re-runs on the next upgrade.
+ * downgrade; this cleanup re-runs on the next upgrade. The workspace's session
+ * data is preserved for downgrades: cleanupOrphanSessionDirs exempts the
+ * mux-chat id from orphan reaping.
  */
 function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boolean {
   let modified = false;

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -4694,15 +4694,18 @@ describe("WorkspaceService initialize", () => {
     const sessionDirFor = (id: string) => path.join(realConfig.sessionsDir, id);
     const knownDir = sessionDirFor("known-ws");
     const legacyDir = sessionDirFor("proj-legacy-branch");
+    // Unreferenced in config (the load-time migration removed the legacy Chat
+    // with Mux entry) but exempt from reaping so downgrades keep the history.
+    const muxChatDir = sessionDirFor("mux-chat");
     const staleOrphanDir = sessionDirFor("stale-orphan-ws");
     const freshOrphanDir = sessionDirFor("fresh-orphan-ws");
-    for (const dir of [knownDir, legacyDir, staleOrphanDir, freshOrphanDir]) {
+    for (const dir of [knownDir, legacyDir, muxChatDir, staleOrphanDir, freshOrphanDir]) {
       await fsPromises.mkdir(dir, { recursive: true });
     }
     // Backdate everything except the fresh orphan past the grace window, proving
     // retention comes from config references rather than directory age.
     const staleTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
-    for (const dir of [knownDir, legacyDir, staleOrphanDir]) {
+    for (const dir of [knownDir, legacyDir, muxChatDir, staleOrphanDir]) {
       await fsPromises.utimes(dir, staleTime, staleTime);
     }
 
@@ -4731,6 +4734,7 @@ describe("WorkspaceService initialize", () => {
       await service.initialize();
       expect(await exists(knownDir)).toBe(true);
       expect(await exists(legacyDir)).toBe(true);
+      expect(await exists(muxChatDir)).toBe(true);
       expect(await exists(freshOrphanDir)).toBe(true);
       expect(await exists(staleOrphanDir)).toBe(false);
     } finally {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -3829,6 +3829,11 @@ export class WorkspaceService extends EventEmitter {
     const config = this.config.loadConfigOrDefault({ throwOnError: true });
 
     const knownIds = new Set<string>(allMetadata.map((metadata) => metadata.id));
+    // The config load-time migration (removeLegacyMuxChatEntries) drops the
+    // removed Chat with Mux workspace from config, which would make its
+    // session dir look orphaned here. Preserve the transcript: a downgraded
+    // build recreates the workspace and should find its history intact.
+    knownIds.add("mux-chat");
     for (const [projectPath, projectConfig] of config.projects) {
       for (const workspace of projectConfig.workspaces) {
         if (workspace.id) {


### PR DESCRIPTION
## Summary

Remove leftover "Chat with Mux" entries from `config.json` at load time so hidden legacy workspaces stop feeding background LLM calls.

## Background

Chat with Mux was removed in #3123 without a config migration, so upgraded installs kept the hidden `system/Mux` project with the `mux-chat` workspace. The entry is invisible in the UI (system projects are filtered in `ProjectContext`), but `AgentStatusService` sweeps every non-archived workspace in `config.json` and its transcript-hash dedup cache is in-memory only, so every app launch re-sent the stale mux-chat transcript to the status model. Observed in the field as ghost small-model calls with zero workspaces visible in the UI.

## Implementation

`removeLegacyMuxChatEntries` runs inside `Config.loadConfigOrDefault` and reuses the old self-heal predicate in reverse:

- Matches projects by path shape (basename `Mux` under `system/`) rather than the current root, so stale entries from other mux roots (e.g. a `~/.mux` entry seen by a `~/.mux-dev` build) are cleaned too.
- Removes workspaces only when `id === "mux-chat"` and they carry a legacy marker (agentId `mux`, path = project path, name `chat-with-mux`, or title `Chat with Mux`), preserving the old collision guard for unrelated generated IDs.
- Also matches entries the subproject merge already relocated into an ancestor project (e.g. a registered `~/.mux`) via their `subProjectPath`, and deletes the empty system-kind child project shell the merge left behind.
- Deletes the project when it becomes empty and persists through the existing serialized migration-persist queue.
- Runs on every load instead of behind a one-shot migration flag because a downgrade to an old build recreates the entry; re-running keeps upgrade/downgrade friction-free.

Session data under `~/.mux/sessions/mux-chat/` is deliberately preserved: `cleanupOrphanSessionDirs` exempts the `mux-chat` id from orphan reaping (it would otherwise reap the now-unreferenced dir after its 24h grace window), so a downgraded build that recreates the workspace finds its history intact.

## Validation

- Red-green: unwiring the migration call fails 3 of the 4 new tests; the collision-safety test passes either way by design (it guards against over-deletion).

## Risks

Low. The predicate requires both the legacy project path shape and workspace-level markers, so a user workspace whose generated id happens to be `mux-chat` is untouched (covered by test). The cleanup only edits config entries; no session or on-disk workspace data is deleted.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->


