### PR TITLE
🤖 tests: bump @coder/pixel-storybook to 0.3.0

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import type { Preview } from "@storybook/react-vite";
-import { isPixel } from "@coder/pixel-storybook";
+import { isPixel } from "@coder/pixel-storybook/storyapi";
 import { ThemeProvider, type ThemeMode } from "../src/browser/contexts/ThemeContext";
 import "../src/browser/styles/globals.css";
 import {

--- a/bun.lock
+++ b/bun.lock
@@ -111,7 +111,7 @@
         "@babel/preset-env": "^7.28.5",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@coder/pixel-storybook": "0.2.2",
+        "@coder/pixel-storybook": "0.3.0",
         "@electron/rebuild": "^4.0.4",
         "@eslint/js": "^9.36.0",
         "@playwright/test": "^1.56.0",
@@ -563,7 +563,7 @@
 
     "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
-    "@coder/pixel-storybook": ["@coder/pixel-storybook@0.2.2", "", { "dependencies": { "get-port-please": "3.1.2", "jsonc-parser": "^3.3.1", "serve-handler": "6.1.7", "zod": "3.23.8" }, "peerDependencies": { "playwright-core": ">=1.47.2", "storybook": ">=8.0.0" }, "bin": { "pixel-storybook": "build/bin.js" } }, "sha512-f1dJ7FiNCdoT9VRVH6IWFnCG3VMnavtvTx/r6sZ4hzhj/rJEZv4P69J2x4XdYaMAwi+O5xbp2UQf0dNf2U9lLA=="],
+    "@coder/pixel-storybook": ["@coder/pixel-storybook@0.3.0", "", { "dependencies": { "get-port-please": "3.1.2", "jsonc-parser": "^3.3.1", "serve-handler": "6.1.7", "zod": "3.23.8" }, "peerDependencies": { "playwright-core": ">=1.47.2", "storybook": ">=8.0.0" }, "bin": { "pixel-storybook": "build/bin.js" } }, "sha512-+M3tr9lfjN/B2v3XCYDeAcz4TqZnN80Xa1ezpBS1NejsmhGf6RePWDz9ksgLmHGJ0iCmAypjbCX8BFosOfYeoA=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-FFlI3j+x4Hp0kgDsHcPSQIDFhQvuBSIQrbTAYBc1CEE="; # mux-offline-cache-hash
+            outputHash = "sha256-hK0zwN0pShMv8NlfMXud+9Jx2J32hz5+qtLMqzunZF8="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@babel/preset-env": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@coder/pixel-storybook": "0.2.2",
+    "@coder/pixel-storybook": "0.3.0",
     "@electron/rebuild": "^4.0.4",
     "@eslint/js": "^9.36.0",
     "@playwright/test": "^1.56.0",

--- a/src/browser/features/Tools/ProposePlan/ProposePlanToolCall.stories.tsx
+++ b/src/browser/features/Tools/ProposePlan/ProposePlanToolCall.stories.tsx
@@ -1,4 +1,4 @@
-import { isPixel } from "@coder/pixel-storybook";
+import { isPixel } from "@coder/pixel-storybook/storyapi";
 import { waitFor, within } from "@storybook/test";
 
 import type { AppStory } from "@/browser/stories/meta.js";


### PR DESCRIPTION
## Summary

Bumps `@coder/pixel-storybook` from 0.2.2 to 0.3.0 (latest) and adapts to its breaking export move.

## Implementation

- `package.json` / `bun.lock`: 0.2.2 -> 0.3.0
- 0.3.0 moved the story-author API to a subpath, so `isPixel` imports in `.storybook/preview.tsx` and `ProposePlanToolCall.stories.tsx` now come from `@coder/pixel-storybook/storyapi`. `ChatPane.tsx` is unaffected; it deliberately inlines the `window.__PIXEL__` check to keep this devDependency out of the production bundle.
- `flake.nix`: refreshed the Nix offline-cache `outputHash` (taken from CI's `Flake Hash Check` log, since Nix is unavailable locally)

0.3.0 also adds `--disable-partial-raster` to the capture flags, which should reduce antialiasing flake in Pixel snapshots.

## Validation

- Two Pixel runs on 0.3.0 captured all 347 stories and ended at the same pending-snapshot steady state as concurrent non-UI PRs, so the bump is visually neutral (builds [500](https://pixel.coder.com/@coder/mux/builds/500) / [501](https://pixel.coder.com/@coder/mux/builds/501))
- `bun x storybook build` green locally

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
