### PR TITLE
🤖 fix: avoid subagent report interruption flash

### DIFF
--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -3,6 +3,7 @@ import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
 import { createMuxMessage, type DisplayedMessage } from "@/common/types/message";
 import { formatSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { buildWorkflowRunCardMessage } from "@/common/utils/workflowRunMessages";
+import { getInterruptionContext } from "@/common/utils/messages/retryEligibility";
 import { shouldNotifyOnResponseComplete } from "./responseCompletionMetadata";
 import { MAX_HISTORY_HIDDEN_SEGMENTS } from "./transcriptTruncationPlan";
 import { StreamingMessageAggregator } from "./StreamingMessageAggregator";
@@ -541,11 +542,13 @@ describe("StreamingMessageAggregator", () => {
       });
 
       expect(aggregator.getPendingStreamStartTime()).toBeNull();
-      expect(aggregator.getDisplayedMessages().at(-1)).toMatchObject({
+      const displayedMessages = aggregator.getDisplayedMessages();
+      expect(displayedMessages.at(-1)).toMatchObject({
         type: "user",
         id: "report-1",
         isSynthetic: true,
       });
+      expect(getInterruptionContext(displayedMessages).hasInterruptedStream).toBe(false);
     });
 
     test("renders persisted workflow slash invocation before workflow card", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -547,8 +547,45 @@ describe("StreamingMessageAggregator", () => {
         type: "user",
         id: "report-1",
         isSynthetic: true,
+        isUiVisible: true,
       });
       expect(getInterruptionContext(displayedMessages).hasInterruptedStream).toBe(false);
+    });
+
+    test("keeps hidden completed subagent reports in the retry lifecycle", () => {
+      withDebugLlmRequestEnabled(() => {
+        const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
+        aggregator.loadHistoricalMessages(
+          [
+            createMuxMessage(
+              "report-1",
+              "user",
+              formatSubagentReportEnvelope({
+                taskId: "task-1",
+                agentType: "explore",
+                status: "completed",
+                title: "Investigation complete",
+                reportMarkdown: "The child finished successfully.",
+              }),
+              {
+                timestamp: 1,
+                historySequence: 1,
+                synthetic: true,
+              }
+            ),
+          ],
+          false
+        );
+
+        const displayedMessages = aggregator.getDisplayedMessages();
+        expect(displayedMessages.at(-1)).toMatchObject({
+          type: "user",
+          id: "report-1",
+          isSynthetic: true,
+          isUiVisible: undefined,
+        });
+        expect(getInterruptionContext(displayedMessages).hasInterruptedStream).toBe(true);
+      });
     });
 
     test("renders persisted workflow slash invocation before workflow card", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
 import { createMuxMessage, type DisplayedMessage } from "@/common/types/message";
+import { formatSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { buildWorkflowRunCardMessage } from "@/common/utils/workflowRunMessages";
 import { shouldNotifyOnResponseComplete } from "./responseCompletionMetadata";
 import { MAX_HISTORY_HIDDEN_SEGMENTS } from "./transcriptTruncationPlan";
@@ -504,6 +505,47 @@ describe("StreamingMessageAggregator", () => {
       expect(userMessages[0]?.isSynthetic).toBe(true);
       expect(userMessages[1]?.content).toBe("hello");
       expect(userMessages[1]?.isSynthetic).toBeUndefined();
+    });
+
+    test("does not start a parent response for a visible completed subagent report", () => {
+      const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
+      aggregator.loadHistoricalMessages(
+        [
+          createMuxMessage("assistant-1", "assistant", "I incorporated the progress update.", {
+            timestamp: 1,
+            historySequence: 1,
+          }),
+        ],
+        false
+      );
+
+      aggregator.handleMessage({
+        ...createMuxMessage(
+          "report-1",
+          "user",
+          formatSubagentReportEnvelope({
+            taskId: "task-1",
+            agentType: "explore",
+            status: "completed",
+            title: "Investigation complete",
+            reportMarkdown: "The child finished successfully.",
+          }),
+          {
+            timestamp: 2,
+            historySequence: 2,
+            synthetic: true,
+            uiVisible: true,
+          }
+        ),
+        type: "message",
+      });
+
+      expect(aggregator.getPendingStreamStartTime()).toBeNull();
+      expect(aggregator.getDisplayedMessages().at(-1)).toMatchObject({
+        type: "user",
+        id: "report-1",
+        isSynthetic: true,
+      });
     });
 
     test("renders persisted workflow slash invocation before workflow card", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -36,7 +36,7 @@ import type {
 } from "@/common/types/tools";
 import type { AssistedReviewHunk } from "@/common/types/review";
 import { formatAssistedFilter, parseAssistedFilter } from "@/common/utils/review/assistedReview";
-import { parseSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
+import { isCompletedSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { completeInProgressTodoItems } from "@/common/utils/todoList";
 import { AgentSkillReadToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import { getToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
@@ -93,7 +93,7 @@ function isDisplayOnlyCompletedSubagentReport(message: MuxMessage): boolean {
     return false;
   }
 
-  return parseSubagentReportEnvelope(getTextPartContent(message.parts))?.status === "completed";
+  return isCompletedSubagentReportEnvelope(getTextPartContent(message.parts));
 }
 
 // Maximum number of messages to display in the DOM for performance

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -36,6 +36,7 @@ import type {
 } from "@/common/types/tools";
 import type { AssistedReviewHunk } from "@/common/types/review";
 import { formatAssistedFilter, parseAssistedFilter } from "@/common/utils/review/assistedReview";
+import { parseSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { completeInProgressTodoItems } from "@/common/utils/todoList";
 import { AgentSkillReadToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import { getToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
@@ -82,6 +83,18 @@ import {
   isSideQuestionUserMessage as isSideQuestionUserMuxMessage,
 } from "@/common/utils/messages/sideQuestion";
 import { isWorkflowResultMessage } from "@/common/utils/workflowRunMessages";
+
+function isDisplayOnlyCompletedSubagentReport(message: MuxMessage): boolean {
+  if (
+    message.role !== "user" ||
+    message.metadata?.synthetic !== true ||
+    message.metadata.uiVisible !== true
+  ) {
+    return false;
+  }
+
+  return parseSubagentReportEnvelope(getTextPartContent(message.parts))?.status === "completed";
+}
 
 // Maximum number of messages to display in the DOM for performance
 // Full history is still maintained internally for token counting and stats
@@ -3060,6 +3073,13 @@ export class StreamingMessageAggregator {
     this.maybeTrackLoadedSkillFromAgentSkillSnapshot(incomingMessage.metadata?.agentSkillSnapshot);
 
     if (incomingMessage.role !== "user" || isSideQuestionUserMuxMessage(incomingMessage)) {
+      return;
+    }
+
+    if (isDisplayOnlyCompletedSubagentReport(incomingMessage)) {
+      // A terminal report card is appended for visibility after the parent already answered the
+      // progress update. It intentionally starts no new parent turn, so preserve the idle lifecycle
+      // instead of briefly presenting the card as an interrupted user request.
       return;
     }
 

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -308,6 +308,7 @@ function buildUserDisplayedMessages(options: {
       fileParts: fileParts.length > 0 ? fileParts : undefined,
       historySequence,
       isSynthetic: message.metadata?.synthetic === true ? true : undefined,
+      isUiVisible: message.metadata?.uiVisible === true ? true : undefined,
       isGoalContinuation: message.metadata?.kind === GOAL_CONTINUATION_KIND ? true : undefined,
       isBudgetLimitWrapup: message.metadata?.kind === GOAL_BUDGET_LIMIT_KIND ? true : undefined,
       timestamp: baseTimestamp,

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -750,6 +750,8 @@ export type DisplayedMessage =
       fileParts?: FilePart[]; // Optional attachments
       historySequence: number; // Global ordering across all messages
       isSynthetic?: boolean;
+      /** True only for synthetic messages intentionally rendered in the normal transcript. */
+      isUiVisible?: boolean;
       timestamp?: number;
       /** True for synthetic user turns created by the active-goal continuation loop. */
       isGoalContinuation?: boolean;

--- a/src/common/utils/messages/retryEligibility.ts
+++ b/src/common/utils/messages/retryEligibility.ts
@@ -1,6 +1,7 @@
 import type { DisplayedMessage } from "@/common/types/message";
 import type { StreamErrorType } from "@/common/types/errors";
 import type { RuntimeStatusEvent, StreamAbortReasonSnapshot } from "@/common/types/stream";
+import { isCompletedSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 
 /**
  * Debug flag to force all errors to be retryable.
@@ -141,12 +142,24 @@ export function getLastNonDecorativeMessage(
  * Decorative rows and /btw side-branch rows are persisted in the transcript but
  * must not become the retry candidate for the main agent.
  */
+function isDisplayOnlyCompletedSubagentReport(message: DisplayedMessage): boolean {
+  return (
+    message.type === "user" &&
+    message.isSynthetic === true &&
+    isCompletedSubagentReportEnvelope(message.content)
+  );
+}
+
 export function getLastMainRetryCandidateMessage(
   messages: DisplayedMessage[]
 ): DisplayedMessage | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
     const candidate = messages[i];
-    if (isDecorativeTranscriptMessage(candidate) || isSideQuestionTranscriptMessage(candidate)) {
+    if (
+      isDecorativeTranscriptMessage(candidate) ||
+      isSideQuestionTranscriptMessage(candidate) ||
+      isDisplayOnlyCompletedSubagentReport(candidate)
+    ) {
       continue;
     }
     return candidate;

--- a/src/common/utils/messages/retryEligibility.ts
+++ b/src/common/utils/messages/retryEligibility.ts
@@ -146,6 +146,7 @@ function isDisplayOnlyCompletedSubagentReport(message: DisplayedMessage): boolea
   return (
     message.type === "user" &&
     message.isSynthetic === true &&
+    message.isUiVisible === true &&
     isCompletedSubagentReportEnvelope(message.content)
   );
 }

--- a/src/common/utils/subagentReportEnvelope.ts
+++ b/src/common/utils/subagentReportEnvelope.ts
@@ -133,3 +133,7 @@ export function parseSubagentReportEnvelope(content: string): SubagentReportEnve
   if (!root) return null;
   return parseJsonEnvelope(root[1]) ?? parseLegacyEnvelope(root[1]);
 }
+
+export function isCompletedSubagentReportEnvelope(content: string): boolean {
+  return parseSubagentReportEnvelope(content)?.status === "completed";
+}


### PR DESCRIPTION
## Summary

Prevents a completed subagent report card from briefly putting the parent workspace into a phantom response lifecycle and flashing the **Stream interrupted** barrier.

## Background

When a parent had already answered an incremental subagent progress update, the terminal report was appended as a visible synthetic user message without starting another parent response. The frontend treated that display-only card as a new main-thread request, both setting pending-stream state and selecting it as an unanswered retry candidate even though no stream would follow.

## Implementation

- detect visible synthetic completed subagent report envelopes in the streaming message aggregator
- keep rendering the report card while preserving the parent workspace's existing idle stream lifecycle
- exclude display-only completed report cards from main-turn retry candidate selection
- add a regression test proving the card remains visible without pending-stream or interrupted-retry state

## Validation

- `bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts src/common/utils/messages/retryEligibility.test.ts`
- `make static-check`

## Risks

Low. The exception is limited to completed subagent report envelopes explicitly marked synthetic and UI-visible; regular user messages and hidden report prompts retain the existing stream-start behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high -->
