### PR TITLE
🤖 fix: tighten task completion badge

### DIFF
--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -270,6 +270,12 @@ The same compact report typography applies to incremental agent findings.
       ) {
         throw new Error("Completed task status badge has excess line height");
       }
+      if (
+        Number.parseFloat(completedBadgeStyle.paddingTop) <=
+        Number.parseFloat(completedBadgeStyle.paddingBottom)
+      ) {
+        throw new Error("Completed task status badge lacks optical top-padding compensation");
+      }
       if (taskCard.scrollWidth > taskCard.clientWidth) {
         throw new Error(
           `Task report card overflows horizontally (${taskCard.scrollWidth}px > ${taskCard.clientWidth}px)`

--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -251,6 +251,25 @@ The same compact report typography applies to incremental agent findings.
       if (Number.parseFloat(getComputedStyle(heading).fontSize) > 14) {
         throw new Error("Task report heading is too large for compact tool chrome");
       }
+      const completedBadge = taskCard.querySelector<HTMLElement>(
+        '[data-component="TaskStatusBadge"]'
+      );
+      if (!completedBadge || completedBadge.textContent?.trim() !== "completed") {
+        throw new Error("Completed task status badge not rendered");
+      }
+      const completedBadgeStyle = getComputedStyle(completedBadge);
+      if (completedBadgeStyle.whiteSpace !== "nowrap") {
+        throw new Error("Completed task status badge allows line wrapping");
+      }
+      if (completedBadge.scrollHeight > completedBadge.clientHeight) {
+        throw new Error("Completed task status badge overflows vertically");
+      }
+      if (
+        Number.parseFloat(completedBadgeStyle.lineHeight) >
+        Number.parseFloat(completedBadgeStyle.fontSize)
+      ) {
+        throw new Error("Completed task status badge has excess line height");
+      }
       if (taskCard.scrollWidth > taskCard.clientWidth) {
         throw new Error(
           `Task report card overflows horizontally (${taskCard.scrollWidth}px > ${taskCard.clientWidth}px)`

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -135,8 +135,11 @@ const TaskStatusBadge: React.FC<{
 
   return (
     <span
+      data-component="TaskStatusBadge"
       className={cn(
-        "inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium whitespace-nowrap",
+        // Keep status pills single-line and vertically tight even when surrounding tool rows
+        // inherit a more generous line height.
+        "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-medium whitespace-nowrap",
         getStatusStyle(),
         className
       )}

--- a/src/browser/features/Tools/TaskToolCall.tsx
+++ b/src/browser/features/Tools/TaskToolCall.tsx
@@ -137,9 +137,9 @@ const TaskStatusBadge: React.FC<{
     <span
       data-component="TaskStatusBadge"
       className={cn(
-        // Keep status pills single-line and vertically tight even when surrounding tool rows
-        // inherit a more generous line height.
-        "inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] leading-none font-medium whitespace-nowrap",
+        // Lowercase status labels sit high within the font box, so preserve the compact total
+        // height while shifting one pixel of padding from below the text to above it.
+        "inline-flex shrink-0 items-center rounded px-1.5 pt-[3px] pb-px text-[10px] leading-none font-medium whitespace-nowrap",
         getStatusStyle(),
         className
       )}


### PR DESCRIPTION
## Summary

Keeps task status badges on one compact line, removes excess descender space, and optically centers the completed label within its pill.

## Background

The completed badge in expanded task results could inherit a generous line height from surrounding tool chrome. At constrained widths this made the pill appear to wrap or grow taller than its text. Equal CSS padding also left the lowercase glyphs visually high in the badge, with more apparent space below than above.

## Implementation

- Render task status badges as non-wrapping inline-flex pills with an explicit tight line height.
- Preserve the compact 14px total height while shifting one pixel of vertical padding from below the label to above it for optical alignment.
- Add a stable component selector and responsive Storybook assertions for wrapping, vertical overflow, line-height geometry, and optical padding.

## Validation

- `bun test ./src/browser/features/Tools/TaskToolCall.test.tsx`
- `make storybook-build`
- `make static-check`
- Measured the completed badge at 390px and 1200px viewports: 3px top padding, 1px bottom padding, 10px font/line height, 14px total height, and no overflow.
- Reviewed isolated 2x-density badge crops at phone and laptop viewport widths.

## Risks

Low. The styling change is limited to the shared task status badge and keeps its existing colors, font size, total height, and status labels.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$293.46`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=293.46 -->
