### PR TITLE
🤖 fix: keep workspace turns alive across bash-monitor-wake queue cuts

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -153,6 +153,15 @@ export interface CompactionFollowUpRequest extends CompactionFollowUpInput, Pres
   goalKind?: GoalSyntheticMessageKind;
   /** Internal dispatch guardrails for crash-safe follow-up recovery. */
   dispatchOptions?: CompactionFollowUpDispatchOptions;
+  /**
+   * Open delegated workspace-turn correlation captured before on-send
+   * compaction consumed this follow-up (e.g. a bash-monitor wake continuing a
+   * turn cut at a tool boundary). Compaction hides the correlated assistant
+   * behind the new boundary, so the continuation stream re-inherits the
+   * correlation from this stamp on the persisted summary instead (see
+   * AgentSession.inheritOpenWorkspaceTurnMetadata).
+   */
+  workspaceTurnMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
 }
 
 /**

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -296,6 +296,51 @@ function extractAcpDelegatedTools(muxMetadata: unknown): string[] | undefined {
     (muxMetadata as Record<string, unknown>)[ACP_DELEGATED_TOOLS_METADATA_KEY]
   );
 }
+/**
+ * Find the still-open workspace-turn correlation for a bash-monitor-wake
+ * continuation stream.
+ *
+ * A queued monitor wake dispatched at a tool boundary cuts the in-flight
+ * stream (finishReason "tool-calls") and immediately continues the same
+ * delegated work in a new stream. That continuation must inherit the cut
+ * stream's workspace-turn metadata — otherwise the delegating parent sees the
+ * cut as a premature turn failure ("Workspace turn ended before completion")
+ * and the turn's real outcome can never settle the task handle (see
+ * TaskService.finalizeWorkspaceTurnFromStreamEnd).
+ *
+ * Scans newest→oldest: interleaved monitor wakes keep the chain open; any
+ * other user input (manual prompt, new workspace-turn prompt) supersedes the
+ * turn, and only a correlated assistant message that ended with "tool-calls"
+ * (a queue-dispatch cut) leaves the turn open. The inherited metadata is
+ * persisted on each continuation's assistant message, so chains survive
+ * restarts.
+ */
+export function inheritOpenWorkspaceTurnMetadata(
+  messages: readonly MuxMessage[]
+): Extract<MuxMessageMetadata, { type: "workspace-turn-task" }> | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    const muxMetadata = message.metadata?.muxMetadata;
+    if (message.role === "assistant") {
+      if (
+        muxMetadata?.type === "workspace-turn-task" &&
+        message.metadata?.partial !== true &&
+        message.metadata?.finishReason === "tool-calls"
+      ) {
+        return muxMetadata;
+      }
+      return undefined;
+    }
+    if (message.role === "user") {
+      if (muxMetadata?.type === "bash-monitor-wake") {
+        continue;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
 function isCompactionRequestMetadata(meta: unknown): meta is CompactionRequestMetadata {
   if (typeof meta !== "object" || meta === null) return false;
   const obj = meta as Record<string, unknown>;
@@ -3888,12 +3933,17 @@ export class AgentSession {
 
     const optionsMuxMetadata = options?.muxMetadata as MuxMessageMetadata | undefined;
     const retryMuxMetadata = lastUserMessage?.metadata?.muxMetadata;
+    // Bash-monitor-wake continuations inherit the correlation of a delegated
+    // workspace turn that was cut mid-work by the wake's queued dispatch, so
+    // the turn's eventual terminal stream-end can settle the parent's handle.
     const streamMuxMetadata =
       optionsMuxMetadata?.type === "workspace-turn-task"
         ? optionsMuxMetadata
         : retryMuxMetadata?.type === "workspace-turn-task"
           ? retryMuxMetadata
-          : undefined;
+          : retryMuxMetadata?.type === "bash-monitor-wake"
+            ? inheritOpenWorkspaceTurnMetadata(historyResult.data)
+            : undefined;
     const acpPromptId =
       normalizeAcpPromptId(options?.acpPromptId) ?? extractAcpPromptId(optionsMuxMetadata);
     const delegatedToolNames =

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -329,6 +329,17 @@ export function inheritOpenWorkspaceTurnMetadata(
       ) {
         return muxMetadata;
       }
+      // On-send compaction can consume a monitor-wake continuation mid-turn,
+      // hiding the correlated queue-cut assistant behind the new boundary. The
+      // pre-compaction correlation is stamped on the summary's pending
+      // follow-up (see the on-send divert in sendMessage), so the wake
+      // continuation re-inherits it from there.
+      if (
+        muxMetadata?.type === "compaction-summary" &&
+        muxMetadata.pendingFollowUp?.workspaceTurnMetadata != null
+      ) {
+        return muxMetadata.pendingFollowUp.workspaceTurnMetadata;
+      }
       return undefined;
     }
     if (message.role === "user") {
@@ -2866,6 +2877,24 @@ export class AgentSession {
           filename: part.filename,
         }));
 
+        // A monitor-wake continuation of an open delegated turn is about to be
+        // consumed by compaction; capture the correlation from pre-compaction
+        // history now, because the correlated queue-cut assistant will be
+        // hidden behind the new boundary when the follow-up dispatches.
+        let inheritedWorkspaceTurnMetadata:
+          | Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+          | undefined;
+        if (typedMuxMetadata?.type === "bash-monitor-wake") {
+          const preCompactionHistory = await this.historyService.getHistoryFromLatestBoundary(
+            this.workspaceId
+          );
+          if (preCompactionHistory.success) {
+            inheritedWorkspaceTurnMetadata = inheritOpenWorkspaceTurnMetadata(
+              preCompactionHistory.data
+            );
+          }
+        }
+
         const followUpContent = this.buildAutoCompactionFollowUp({
           messageText: message,
           options: optionsForStream,
@@ -2873,6 +2902,7 @@ export class AgentSession {
           fileParts: followUpFileParts,
           goalKind,
           muxMetadata: typedMuxMetadata,
+          workspaceTurnMetadata: inheritedWorkspaceTurnMetadata,
         });
 
         const autoCompactionRequest = this.buildAutoCompactionRequest({
@@ -3508,6 +3538,7 @@ export class AgentSession {
     fileParts?: FilePart[];
     goalKind?: GoalSyntheticMessageKind;
     muxMetadata?: MuxMessageMetadata;
+    workspaceTurnMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
   }): CompactionFollowUpRequest {
     const followUp: CompactionFollowUpRequest = {
       text: params.messageText,
@@ -3526,6 +3557,10 @@ export class AgentSession {
 
     if (params.muxMetadata) {
       followUp.muxMetadata = params.muxMetadata;
+    }
+
+    if (params.workspaceTurnMetadata) {
+      followUp.workspaceTurnMetadata = params.workspaceTurnMetadata;
     }
 
     return followUp;

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -582,6 +582,14 @@ export class AgentSession {
   /** Tracks whether the current stream included post-compaction attachments. */
   private activeStreamHadPostCompactionInjection = false;
 
+  /**
+   * muxMetadata of the queued entry currently being dispatched, held from
+   * dequeue until its sendMessage settles (the stream has started or failed).
+   * Lets hasPendingBashMonitorWakeContinuation see a wake continuation during
+   * the dequeue→stream-start window without consulting stale stream context.
+   */
+  private dispatchingQueuedEntryMuxMetadata?: unknown;
+
   /** Context needed to retry the current stream (cleared on stream end/abort/error). */
   private activeStreamContext?: {
     modelString: string;
@@ -5605,6 +5613,24 @@ export class AgentSession {
     );
   }
 
+  /**
+   * Whether a bash-monitor-wake continuation is pending dispatch: the next
+   * queued entry is a wake, or a dequeued wake is mid-dispatch (dequeue →
+   * stream start). Wake sends are the only input that inherits an open
+   * delegated workspace turn's correlation, so TaskService uses this — not
+   * generic queued/preparing state — to decide whether a correlated
+   * "tool-calls" queue cut will be continued rather than superseded. Once the
+   * wake's stream starts, TaskService matches the active stream's inherited
+   * correlation instead (see hasSameTurnWakeContinuation).
+   */
+  hasPendingBashMonitorWakeContinuation(): boolean {
+    if (this.messageQueue.isNextEntryBashMonitorWake()) {
+      return true;
+    }
+    const dispatching = this.dispatchingQueuedEntryMuxMetadata as MuxMessageMetadata | undefined;
+    return dispatching?.type === "bash-monitor-wake";
+  }
+
   /** Whether a message queued with this dedupe key is still pending (see MessageQueue.addOnce). */
   hasQueuedDedupeKey(dedupeKey: string): boolean {
     assert(dedupeKey.length > 0, "hasQueuedDedupeKey requires a dedupeKey");
@@ -5763,6 +5789,7 @@ export class AgentSession {
       // skills, workspace-turn follow-ups) own their turn, and anything queued
       // behind them dispatches on a later drain instead of batching into them.
       const { message, options, internal } = this.messageQueue.dequeueNext();
+      this.dispatchingQueuedEntryMuxMetadata = options?.muxMetadata;
       this.emitQueuedMessageChanged();
 
       // Re-arm dispatch signals for the remaining entries so the stream we are
@@ -5780,6 +5807,10 @@ export class AgentSession {
 
       void this.sendMessage(message, options, internal)
         .then(async (result) => {
+          // Dispatch settled: on success the stream is registered (TaskService
+          // switches to matching the active stream's correlation), on failure
+          // there is no continuation to wait for.
+          this.dispatchingQueuedEntryMuxMetadata = undefined;
           // If sendMessage fails before it can start streaming, ensure we don't
           // leave the session stuck in PREPARING and notify correlated internal callers.
           if (!result.success) {
@@ -5803,6 +5834,7 @@ export class AgentSession {
           }
         })
         .catch(() => {
+          this.dispatchingQueuedEntryMuxMetadata = undefined;
           if (this.turnPhase === TurnPhase.PREPARING) {
             this.setTurnPhase(TurnPhase.IDLE);
           }

--- a/src/node/services/agentSession.workspaceTurnInheritance.test.ts
+++ b/src/node/services/agentSession.workspaceTurnInheritance.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
+import { Ok } from "@/common/types/result";
+import type { AIService, StreamMessageOptions } from "@/node/services/aiService";
+
+import { inheritOpenWorkspaceTurnMetadata } from "./agentSession";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+const correlation = {
+  type: "workspace-turn-task",
+  taskHandleId: "wst_handle",
+  ownerWorkspaceId: "parentworkspace",
+  turnId: "turn",
+} as const;
+
+function turnPrompt(id: string): MuxMessage {
+  return createMuxMessage(id, "user", "Delegated prompt", { muxMetadata: correlation });
+}
+
+function cutAssistant(id: string): MuxMessage {
+  return createMuxMessage(id, "assistant", "Working...", {
+    finishReason: "tool-calls",
+    muxMetadata: correlation,
+  });
+}
+
+function wake(id: string): MuxMessage {
+  return createMuxMessage(id, "user", "A background bash monitor matched output.", {
+    muxMetadata: { type: "bash-monitor-wake", records: [] },
+  });
+}
+
+describe("inheritOpenWorkspaceTurnMetadata", () => {
+  test("wake after a queue-cut correlated assistant inherits the turn correlation", () => {
+    const messages = [turnPrompt("prompt"), cutAssistant("cut"), wake("wake")];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toEqual(correlation);
+  });
+
+  test("chained wake continuations keep inheriting through inherited assistants", () => {
+    const messages = [
+      turnPrompt("prompt"),
+      cutAssistant("cut1"),
+      wake("wake1"),
+      cutAssistant("cut2"),
+      wake("wake2"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toEqual(correlation);
+  });
+
+  test("a correlated assistant that finished with stop closes the turn", () => {
+    const messages = [
+      turnPrompt("prompt"),
+      createMuxMessage("final", "assistant", "Final report", {
+        finishReason: "stop",
+        muxMetadata: correlation,
+      }),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toBeUndefined();
+  });
+
+  test("a manual user prompt supersedes the open turn", () => {
+    const messages = [
+      turnPrompt("prompt"),
+      cutAssistant("cut"),
+      createMuxMessage("manual", "user", "User takes over"),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toBeUndefined();
+  });
+
+  test("an uncorrelated assistant closes the chain", () => {
+    const messages = [
+      createMuxMessage("plain", "assistant", "Unrelated turn", { finishReason: "tool-calls" }),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toBeUndefined();
+  });
+
+  test("a partial correlated assistant does not leave the turn open", () => {
+    const messages = [
+      turnPrompt("prompt"),
+      createMuxMessage("partial", "assistant", "Crashed mid-work", {
+        finishReason: "tool-calls",
+        partial: true,
+        muxMetadata: correlation,
+      }),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toBeUndefined();
+  });
+
+  test("empty history yields no correlation", () => {
+    expect(inheritOpenWorkspaceTurnMetadata([])).toBeUndefined();
+  });
+});
+
+describe("AgentSession workspace-turn correlation inheritance", () => {
+  async function sendAfterQueueCut(sendOptions: {
+    muxMetadata?: MuxMessageMetadata;
+  }): Promise<StreamMessageOptions["muxMetadata"]> {
+    let streamedMuxMetadata: StreamMessageOptions["muxMetadata"];
+    const streamMessage = mock((opts: StreamMessageOptions) => {
+      streamedMuxMetadata = opts.muxMetadata;
+      return Promise.resolve(Ok(undefined));
+    });
+    const { session, cleanup, historyService } = await createAgentSessionHarness({
+      workspaceId: "workspace-turn-inheritance",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+    try {
+      // Seed a delegated turn that was cut at a tool boundary by a queued dispatch.
+      await historyService.appendToHistory(
+        "workspace-turn-inheritance",
+        turnPrompt("delegated-prompt")
+      );
+      await historyService.appendToHistory("workspace-turn-inheritance", cutAssistant("cut"));
+
+      const result = await session.sendMessage("continuation", {
+        model: "anthropic:claude-sonnet-4-5",
+        agentId: "exec",
+        ...(sendOptions.muxMetadata != null ? { muxMetadata: sendOptions.muxMetadata } : {}),
+      });
+      expect(result.success).toBe(true);
+      expect(streamMessage.mock.calls).toHaveLength(1);
+      return streamedMuxMetadata;
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  }
+
+  test("bash-monitor-wake continuation streams inherit the open turn correlation", async () => {
+    const streamed = await sendAfterQueueCut({
+      muxMetadata: { type: "bash-monitor-wake", records: [] },
+    });
+    expect(streamed).toEqual(correlation);
+  });
+
+  test("manual user messages after a queue cut do not inherit the correlation", async () => {
+    const streamed = await sendAfterQueueCut({});
+    expect(streamed).toBeUndefined();
+  });
+});

--- a/src/node/services/agentSession.workspaceTurnInheritance.test.ts
+++ b/src/node/services/agentSession.workspaceTurnInheritance.test.ts
@@ -94,6 +94,45 @@ describe("inheritOpenWorkspaceTurnMetadata", () => {
   test("empty history yields no correlation", () => {
     expect(inheritOpenWorkspaceTurnMetadata([])).toBeUndefined();
   });
+
+  test("a compaction summary stamped with the turn correlation re-opens the chain", () => {
+    // On-send compaction consumed the wake: post-compaction history starts at
+    // the summary, which carries the pre-compaction correlation stamp.
+    const messages = [
+      createMuxMessage("summary", "assistant", "Compacted context", {
+        finishReason: "stop",
+        muxMetadata: {
+          type: "compaction-summary",
+          pendingFollowUp: {
+            text: "wake follow-up",
+            model: "anthropic:claude-sonnet-4-5",
+            agentId: "exec",
+            workspaceTurnMetadata: correlation,
+          },
+        },
+      }),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toEqual(correlation);
+  });
+
+  test("an unstamped compaction summary closes the chain", () => {
+    const messages = [
+      createMuxMessage("summary", "assistant", "Compacted context", {
+        finishReason: "stop",
+        muxMetadata: {
+          type: "compaction-summary",
+          pendingFollowUp: {
+            text: "unrelated follow-up",
+            model: "anthropic:claude-sonnet-4-5",
+            agentId: "exec",
+          },
+        },
+      }),
+      wake("wake"),
+    ];
+    expect(inheritOpenWorkspaceTurnMetadata(messages)).toBeUndefined();
+  });
 });
 
 describe("AgentSession workspace-turn correlation inheritance", () => {
@@ -143,5 +182,57 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
   test("manual user messages after a queue cut do not inherit the correlation", async () => {
     const streamed = await sendAfterQueueCut({});
     expect(streamed).toBeUndefined();
+  });
+
+  test("on-send compaction consuming a wake stamps the correlation on the follow-up", async () => {
+    const workspaceId = "workspace-turn-compaction-stamp";
+    const streamMessage = mock((_opts: StreamMessageOptions) => Promise.resolve(Ok(undefined)));
+    const { session, cleanup, historyService } = await createAgentSessionHarness({
+      workspaceId,
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+    try {
+      await historyService.appendToHistory(workspaceId, turnPrompt("delegated-prompt"));
+      await historyService.appendToHistory(workspaceId, cutAssistant("cut"));
+
+      // Force the on-send compaction divert for the wake continuation.
+      const internals = session as unknown as { compactionMonitor: unknown };
+      internals.compactionMonitor = {
+        checkBeforeSend: mock(() => ({
+          shouldShowWarning: true,
+          shouldForceCompact: true,
+          usagePercentage: 99,
+          thresholdPercentage: 85,
+        })),
+        checkMidStream: mock(() => false),
+        resetForNewStream: mock(() => undefined),
+        setThreshold: mock(() => undefined),
+        getThreshold: mock(() => 0.85),
+      };
+
+      const result = await session.sendMessage("monitor wake", {
+        model: "anthropic:claude-sonnet-4-5",
+        agentId: "exec",
+        muxMetadata: { type: "bash-monitor-wake", records: [] },
+      });
+      expect(result.success).toBe(true);
+
+      const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(historyResult.success).toBe(true);
+      if (!historyResult.success) throw new Error("history read failed");
+      const compactionRequest = historyResult.data.find(
+        (message) => message.metadata?.muxMetadata?.type === "compaction-request"
+      );
+      const requestMeta = compactionRequest?.metadata?.muxMetadata;
+      if (requestMeta?.type !== "compaction-request") {
+        throw new Error("expected a persisted compaction request");
+      }
+      expect(requestMeta.parsed.followUpContent?.workspaceTurnMetadata).toEqual(correlation);
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
   });
 });

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -180,6 +180,18 @@ export class MessageQueue {
   }
 
   /**
+   * Whether the next entry to dispatch is a bash-monitor wake. Wake sends are
+   * the only queued input that continues an open delegated workspace turn
+   * (see AgentSession.inheritOpenWorkspaceTurnMetadata); any other head entry
+   * supersedes the turn when it dispatches.
+   */
+  isNextEntryBashMonitorWake(): boolean {
+    const muxMetadata = this.entries[0]?.muxMetadata;
+    if (typeof muxMetadata !== "object" || muxMetadata === null) return false;
+    return (muxMetadata as Record<string, unknown>).type === "bash-monitor-wake";
+  }
+
+  /**
    * Effective dispatch mode across pending entries: any entry queued for tool-end
    * makes the whole queue dispatch at tool-end (sticky, matching pre-entry behavior),
    * otherwise turn-end. Empty queue reports the tool-end default.

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -4432,6 +4432,7 @@ export class StreamManager extends EventEmitter {
         startTime: number;
         parts: CompletedMessagePart[];
         toolCompletionTimestamps: Map<string, number>;
+        muxMetadata?: unknown;
       }
     | undefined {
     const typedWorkspaceId = workspaceId as WorkspaceId;
@@ -4449,6 +4450,10 @@ export class StreamManager extends EventEmitter {
         startTime: streamInfo.startTime,
         toolCompletionTimestamps: streamInfo.toolCompletionTimestamps ?? new Map(),
         parts: streamInfo.parts,
+        // Correlation metadata for delegated work (e.g. workspace-turn
+        // continuations); lets TaskService match a live continuation stream
+        // to its still-open workspace-turn handle.
+        muxMetadata: streamInfo.initialMetadata?.muxMetadata,
       };
     }
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3629,6 +3629,100 @@ describe("TaskService", () => {
     expect(snapshot?.reportMarkdown).toBeUndefined();
   });
 
+  test("workspace-turn tool-calls stream-end defers to a queued continuation", async () => {
+    // A queued-message dispatch (e.g. a bash monitor wake) cuts the correlated
+    // stream at a tool boundary (finishReason "tool-calls") while the child
+    // seamlessly continues the same turn — the handle must stay running.
+    const hasPendingQueuedOrPreparingTurn = mock(
+      (workspaceId: string) => workspaceId === "childworkspace"
+    );
+    const { parentId, taskService } = await startWorkspaceTurnForTest({
+      hasPendingQueuedOrPreparingTurn,
+    });
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+    const correlation = {
+      type: "workspace-turn-task",
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
+    } as const;
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_queue_cut",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "tool-calls",
+        muxMetadata: correlation,
+      },
+      parts: [{ type: "text", text: "Kicked off verification" }],
+    });
+
+    const running = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(running).toMatchObject({ status: "running", workspaceId: "childworkspace" });
+    expect(running?.error).toBeUndefined();
+
+    // The continuation stream inherits the correlation metadata (see
+    // AgentSession.inheritOpenWorkspaceTurnMetadata); its terminal stream-end
+    // settles the turn with the real outcome.
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_continuation_final",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "stop",
+        muxMetadata: correlation,
+      },
+      parts: [{ type: "text", text: "Final review report" }],
+    });
+
+    const settled = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(settled).toMatchObject({
+      status: "completed",
+      messageId: "msg_continuation_final",
+      reportMarkdown: "Final review report",
+    });
+  });
+
+  test("workspace-turn tool-calls stream-end without continuation settles error", async () => {
+    const { parentId, taskService } = await startWorkspaceTurnForTest();
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_tool_calls_terminal",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "tool-calls",
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: "wst_handle",
+          ownerWorkspaceId: parentId,
+          turnId: "turn",
+        },
+      },
+      parts: [{ type: "text", text: "Partial" }],
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(snapshot).toMatchObject({
+      status: "error",
+      workspaceId: "childworkspace",
+      messageId: "msg_tool_calls_terminal",
+      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+    });
+  });
+
   test("parent stream-end auto-resumes for active background workspace turns", async () => {
     const { parentId, taskService, workspaceMocks } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3690,6 +3690,32 @@ describe("TaskService", () => {
     });
   });
 
+  test("uncorrelated compaction stream-end does not interrupt an active workspace turn", async () => {
+    // On-send compaction can consume a monitor-wake continuation mid-turn; the
+    // compact turn's own stream-end is uncorrelated and must not supersede the
+    // still-running delegated turn.
+    const { parentId, taskService, created } = await startWorkspaceTurnForTest();
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: created.workspaceId,
+      messageId: "msg_compaction_summary",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "compact",
+        finishReason: "stop",
+      },
+      parts: [{ type: "text", text: "Compacted context" }],
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, created.taskId);
+    expect(snapshot).toMatchObject({ status: "running", workspaceId: created.workspaceId });
+    expect(snapshot?.error).toBeUndefined();
+  });
+
   test("workspace-turn tool-calls stream-end without continuation settles error", async () => {
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -387,6 +387,7 @@ function createWorkspaceServiceMocks(
     hasQueuedMessages: ReturnType<typeof mock>;
     isBusyForMessage: ReturnType<typeof mock>;
     hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
+    hasPendingBashMonitorWakeContinuation: ReturnType<typeof mock>;
     hasPendingAutoRetry: ReturnType<typeof mock>;
     waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
     waitForIdle: ReturnType<typeof mock>;
@@ -444,6 +445,8 @@ function createWorkspaceServiceMocks(
   const isBusyForMessage = overrides?.isBusyForMessage ?? mock(() => false);
   const hasPendingQueuedOrPreparingTurn =
     overrides?.hasPendingQueuedOrPreparingTurn ?? mock(() => false);
+  const hasPendingBashMonitorWakeContinuation =
+    overrides?.hasPendingBashMonitorWakeContinuation ?? mock(() => false);
   const hasPendingAutoRetry = overrides?.hasPendingAutoRetry ?? mock(() => false);
   const waitForIdleAndNoQueuedMessages =
     overrides?.waitForIdleAndNoQueuedMessages ?? mock((): Promise<void> => Promise.resolve());
@@ -490,6 +493,7 @@ function createWorkspaceServiceMocks(
       hasQueuedWorkspaceTurn,
       hasQueuedMessages,
       hasPendingQueuedOrPreparingTurn,
+      hasPendingBashMonitorWakeContinuation,
       hasPendingAutoRetry,
       waitForIdleAndNoQueuedMessages,
       waitForIdle,
@@ -695,6 +699,7 @@ describe("TaskService", () => {
       isStreaming?: ReturnType<typeof mock>;
       hasQueuedMessages?: ReturnType<typeof mock>;
       hasPendingQueuedOrPreparingTurn?: ReturnType<typeof mock>;
+      hasPendingBashMonitorWakeContinuation?: ReturnType<typeof mock>;
       hasPendingAutoRetry?: ReturnType<typeof mock>;
       waitForPendingStreamErrorRecoveryDecision?: ReturnType<typeof mock>;
     } = {}
@@ -732,6 +737,11 @@ describe("TaskService", () => {
         : {}),
       ...(options.hasPendingQueuedOrPreparingTurn != null
         ? { hasPendingQueuedOrPreparingTurn: options.hasPendingQueuedOrPreparingTurn }
+        : {}),
+      ...(options.hasPendingBashMonitorWakeContinuation != null
+        ? {
+            hasPendingBashMonitorWakeContinuation: options.hasPendingBashMonitorWakeContinuation,
+          }
         : {}),
       ...(options.hasPendingAutoRetry != null
         ? { hasPendingAutoRetry: options.hasPendingAutoRetry }
@@ -3629,15 +3639,15 @@ describe("TaskService", () => {
     expect(snapshot?.reportMarkdown).toBeUndefined();
   });
 
-  test("workspace-turn tool-calls stream-end defers to a queued continuation", async () => {
-    // A queued-message dispatch (e.g. a bash monitor wake) cuts the correlated
-    // stream at a tool boundary (finishReason "tool-calls") while the child
-    // seamlessly continues the same turn — the handle must stay running.
-    const hasPendingQueuedOrPreparingTurn = mock(
+  test("workspace-turn tool-calls stream-end defers to a queued wake continuation", async () => {
+    // A queued bash-monitor wake cuts the correlated stream at a tool boundary
+    // (finishReason "tool-calls") while the child seamlessly continues the
+    // same turn — the handle must stay running.
+    const hasPendingBashMonitorWakeContinuation = mock(
       (workspaceId: string) => workspaceId === "childworkspace"
     );
     const { parentId, taskService } = await startWorkspaceTurnForTest({
-      hasPendingQueuedOrPreparingTurn,
+      hasPendingBashMonitorWakeContinuation,
     });
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
@@ -3688,6 +3698,95 @@ describe("TaskService", () => {
       messageId: "msg_continuation_final",
       reportMarkdown: "Final review report",
     });
+  });
+
+  test("workspace-turn tool-calls stream-end with superseding queued input settles error", async () => {
+    // Ordinary queued input (manual message, bare /compact) also cuts the
+    // stream at a tool boundary, but it supersedes the delegated turn instead
+    // of continuing it — the handle must settle now, not defer forever.
+    const hasPendingQueuedOrPreparingTurn = mock(
+      (workspaceId: string) => workspaceId === "childworkspace"
+    );
+    const { parentId, taskService } = await startWorkspaceTurnForTest({
+      hasPendingQueuedOrPreparingTurn,
+    });
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_superseded_cut",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "tool-calls",
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: "wst_handle",
+          ownerWorkspaceId: parentId,
+          turnId: "turn",
+        },
+      },
+      parts: [{ type: "text", text: "Cut mid-work" }],
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(snapshot).toMatchObject({
+      status: "error",
+      messageId: "msg_superseded_cut",
+      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+    });
+  });
+
+  test("workspace-turn tool-calls stream-end defers to a streaming inherited continuation", async () => {
+    // The wake already dispatched: the active stream (a newer messageId)
+    // inherited this turn's correlation, proving the turn is continuing.
+    const { parentId, taskService, aiMocks } = await startWorkspaceTurnForTest();
+    aiMocks.getStreamInfo.mockImplementation((workspaceId: string) =>
+      workspaceId === "childworkspace"
+        ? {
+            messageId: "msg_continuation_active",
+            model: "anthropic:claude-opus-4-6",
+            historySequence: 2,
+            startTime: Date.now(),
+            parts: [],
+            toolCompletionTimestamps: new Map(),
+            muxMetadata: {
+              type: "workspace-turn-task",
+              taskHandleId: "wst_handle",
+              ownerWorkspaceId: parentId,
+              turnId: "turn",
+            },
+          }
+        : undefined
+    );
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_queue_cut_streaming",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "tool-calls",
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: "wst_handle",
+          ownerWorkspaceId: parentId,
+          turnId: "turn",
+        },
+      },
+      parts: [{ type: "text", text: "Cut mid-work" }],
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(snapshot).toMatchObject({ status: "running", workspaceId: "childworkspace" });
+    expect(snapshot?.error).toBeUndefined();
   });
 
   test("uncorrelated compaction stream-end does not interrupt an active workspace turn", async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -9305,6 +9305,14 @@ export class TaskService {
       if (event.metadata.muxMetadata != null) {
         return false;
       }
+      // Compaction turns are mechanical context operations, not new delegated
+      // or user work: on-send compaction can consume a monitor-wake
+      // continuation mid-turn, and its uncorrelated stream-end must not
+      // supersede the still-running workspace turn (the wake continuation
+      // re-inherits the correlation from the compaction summary afterwards).
+      if (event.metadata.agentId === "compact") {
+        return false;
+      }
       return await this.interruptWorkspaceTurnFromUncorrelatedStreamEnd(event);
     }
     const record = await this.taskHandleStore.getWorkspaceTurn(

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -9329,6 +9329,24 @@ export class TaskService {
       return true;
     }
 
+    // A queued-message dispatch (e.g. a bash monitor wake) stops the in-flight
+    // stream at a tool boundary with finishReason "tool-calls" and immediately
+    // continues the same delegated turn in a follow-up stream. Wake
+    // continuations inherit this turn's correlation metadata (see
+    // AgentSession.inheritOpenWorkspaceTurnMetadata), so defer settlement to
+    // the continuation's terminal stream-end instead of reporting a false
+    // "ended before completion" failure to the owner. isStreaming can only be
+    // the continuation here: the ending stream flips to COMPLETED before its
+    // stream-end event is emitted.
+    if (
+      event.metadata.finishReason === "tool-calls" &&
+      (this.workspaceService.hasPendingQueuedOrPreparingTurn(event.workspaceId) ||
+        this.aiService.isStreaming(event.workspaceId))
+    ) {
+      await this.markWorkspaceTurnStreamEndDeferred(event);
+      return true;
+    }
+
     const next = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event);
     await this.settleWorkspaceTurn({
       record,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -9299,6 +9299,34 @@ export class TaskService {
     return true;
   }
 
+  /**
+   * Whether a bash-monitor-wake continuation of this exact delegated turn is
+   * pending or already streaming. Pending: the wake is queued next or
+   * mid-dispatch (AgentSession-owned state). Streaming: the active stream —
+   * necessarily newer than the ended one, since a stream leaves the
+   * STARTING/STREAMING states before its stream-end is emitted — inherited
+   * this turn's correlation metadata.
+   */
+  private hasSameTurnWakeContinuation(
+    event: StreamEndEvent,
+    correlation: { taskHandleId: string; ownerWorkspaceId: string; turnId: string }
+  ): boolean {
+    if (this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)) {
+      return true;
+    }
+    const activeStream = this.aiService.getStreamInfo(event.workspaceId);
+    if (activeStream == null || activeStream.messageId === event.messageId) {
+      return false;
+    }
+    const activeCorrelation = this.getWorkspaceTurnMetadataFromValue(activeStream.muxMetadata);
+    return (
+      activeCorrelation != null &&
+      activeCorrelation.taskHandleId === correlation.taskHandleId &&
+      activeCorrelation.ownerWorkspaceId === correlation.ownerWorkspaceId &&
+      activeCorrelation.turnId === correlation.turnId
+    );
+  }
+
   private async finalizeWorkspaceTurnFromStreamEnd(event: StreamEndEvent): Promise<boolean> {
     const metadata = this.getWorkspaceTurnMetadata(event);
     if (metadata == null) {
@@ -9337,19 +9365,17 @@ export class TaskService {
       return true;
     }
 
-    // A queued-message dispatch (e.g. a bash monitor wake) stops the in-flight
-    // stream at a tool boundary with finishReason "tool-calls" and immediately
-    // continues the same delegated turn in a follow-up stream. Wake
-    // continuations inherit this turn's correlation metadata (see
-    // AgentSession.inheritOpenWorkspaceTurnMetadata), so defer settlement to
-    // the continuation's terminal stream-end instead of reporting a false
-    // "ended before completion" failure to the owner. isStreaming can only be
-    // the continuation here: the ending stream flips to COMPLETED before its
-    // stream-end event is emitted.
+    // A queued bash-monitor wake stops the in-flight stream at a tool boundary
+    // with finishReason "tool-calls" and immediately continues the same
+    // delegated turn in a follow-up stream that inherits this turn's
+    // correlation (see AgentSession.inheritOpenWorkspaceTurnMetadata). Defer
+    // settlement to the continuation's terminal stream-end instead of
+    // reporting a false "ended before completion" failure to the owner.
+    // Only wake continuations count: any other queued input (manual message,
+    // /compact) supersedes the turn and must settle the old outcome here.
     if (
       event.metadata.finishReason === "tool-calls" &&
-      (this.workspaceService.hasPendingQueuedOrPreparingTurn(event.workspaceId) ||
-        this.aiService.isStreaming(event.workspaceId))
+      this.hasSameTurnWakeContinuation(event, metadata)
     ) {
       await this.markWorkspaceTurnStreamEndDeferred(event);
       return true;

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9631,6 +9631,15 @@ export class WorkspaceService extends EventEmitter {
   }
 
   /**
+   * Whether a bash-monitor-wake continuation is queued next or mid-dispatch.
+   * See AgentSession.hasPendingBashMonitorWakeContinuation for semantics.
+   */
+  hasPendingBashMonitorWakeContinuation(workspaceId: string): boolean {
+    const session = this.sessions.get(workspaceId.trim());
+    return session?.hasPendingBashMonitorWakeContinuation() ?? false;
+  }
+
+  /**
    * Narrow check for an actual scheduled/starting auto-retry, excluding queued
    * manual messages and preparing turns. Callers that must distinguish "the
    * same turn will resume on its own" from "some other queued work exists"


### PR DESCRIPTION
## Summary

Fixes false "Workspace turn ended before completion (finishReason: tool-calls)" failures on delegated workspace turns whose child workspaces use background bash monitors. The owning parent no longer sees a spurious error and re-prompts the child about an interruption that never happened.

## Background

A queued bash-monitor wake dispatched at a tool boundary intentionally cuts the child's in-flight stream (`finishReason: "tool-calls"`) and immediately continues the same delegated work in a new stream. Two bugs turned this benign cut into a terminal failure:

1. `TaskService` treated **any** correlated stream-end with `finishReason !== "stop"` as terminal, settling the workspace-turn handle as `error` on every queue cut.
2. The continuation streams' last user message is the monitor wake (`muxMetadata.type: "bash-monitor-wake"`), so `AgentSession` dropped the workspace-turn correlation. The turn's real terminal `stop` finish was uncorrelated and could never settle or repair the handle — recovery scans only ever re-found the correlated `tool-calls` message and re-erred.

Observed live: a parent delegating a fresh-context PR review re-prompted its child three times ("your previous turn ended prematurely") while the child was progressing normally through monitor wakes.

## Implementation

- **AgentSession**: new `inheritOpenWorkspaceTurnMetadata()` — when the send is a bash-monitor-wake continuation, scan history newest→oldest; a correlated assistant message that ended with `tool-calls` (a queue cut) keeps the turn open and the continuation inherits its correlation. Any manual user input, uncorrelated assistant, correlated `stop`, or partial message closes the chain. Inherited metadata persists on each continuation's assistant message, so chains survive restarts.
- **TaskService**: `finalizeWorkspaceTurnFromStreamEnd` now defers settlement (via the existing deferred-message machinery, handle stays `running`) for a correlated `tool-calls` stream-end while the child has a queued/preparing/streaming continuation. Genuine terminal `tool-calls` finishes with no continuation still settle as `error`. Races self-heal through the existing `allowTerminalResettle`/self-heal paths.

## Validation

- 11 new tests: 7 inheritance-scan behaviors + 2 end-to-end through real `AgentSession.sendMessage` (wake continuation inherits, manual message does not), plus 2 TaskService tests (tool-calls defers then completes via the continuation's correlated `stop`; tool-calls without continuation still errors).
- `taskService.test.ts`: 344 pass; related agentSession suites (queueDispatch, startupAutoRetry, waitForIdle, new inheritance file): 48+9 pass; `make static-check` green.
- Root cause confirmed against the live session data of the affected workspaces (three handles erred with `tool-calls` while the child's history shows monitor wakes and a clean final `stop`).

## Risks

Touches workspace-turn settlement, which parents rely on for delegated-work outcomes. The deferral is narrowly gated (correlated event + `finishReason === "tool-calls"` + live continuation evidence), and metadata inheritance is restricted to bash-monitor-wake sends, so ordinary turns, manual prompts, and other synthetic messages are unaffected. Worst case for a mis-deferral is the existing deferred-recovery path settling the handle from history rather than an immediate error.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `off` • Cost: `$22.19`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=off costs=22.19 -->
