### PR TITLE
🤖 fix: collapse subagent reports by default

### DIFF
--- a/src/browser/features/Messages/MessageRenderer.test.tsx
+++ b/src/browser/features/Messages/MessageRenderer.test.tsx
@@ -250,7 +250,7 @@ describe("MessageRenderer subagent report rows", () => {
     };
   }
 
-  test("presents incremental synthetic reports without exposing the protocol envelope", () => {
+  test("presents incremental synthetic reports collapsed without exposing the protocol envelope", () => {
     const message = createReportMessage(`<mux_subagent_report>
 <task_id>task-123</task_id>
 <agent_type>explore</agent_type>
@@ -261,7 +261,7 @@ Found the **message renderer** and its responsive story coverage.
 </report_markdown>
 </mux_subagent_report>`);
 
-    const { getByText, queryByText } = render(
+    const { getByRole, getByText, queryByText } = render(
       <TooltipProvider>
         <MessageRenderer message={message} />
       </TooltipProvider>
@@ -270,9 +270,16 @@ Found the **message renderer** and its responsive story coverage.
     expect(getByText("subagent update")).toBeDefined();
     expect(getByText("Rendering path traced")).toBeDefined();
     expect(getByText("In progress")).toBeDefined();
-    expect(getByText(/message renderer/)).toBeDefined();
+    const toggle = getByRole("button", { name: "Show subagent report details" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByText(/message renderer/)).toBeNull();
     expect(queryByText("auto")).toBeNull();
     expect(queryByText(/mux_subagent_report/)).toBeNull();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(getByText(/message renderer/)).toBeDefined();
   });
 
   test("preserves arbitrary protocol examples and semantic whitespace", () => {
@@ -326,13 +333,15 @@ All rendering paths were verified.
 </report_markdown>
 </mux_subagent_report>`);
 
-    const { getByText, queryByText } = render(
+    const { getByRole, getByText, queryByText } = render(
       <TooltipProvider>
         <MessageRenderer message={message} />
       </TooltipProvider>
     );
 
     expect(getByText("Presentation trace completed cleanly")).toBeDefined();
+    expect(queryByText("All rendering paths were verified.")).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Show subagent report details" }));
     expect(getByText("All rendering paths were verified.")).toBeDefined();
     expect(queryByText(/mux_subagent_report/)).toBeNull();
   });
@@ -360,13 +369,17 @@ The responsive presentation is ready.
 
     expect(getByText("subagent report")).toBeDefined();
     expect(getByText("Completed")).toBeDefined();
-    const toggle = getByRole("button", { name: "Structured output" });
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(queryByText("The responsive presentation is ready.")).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Show subagent report details" }));
+    expect(getByText("The responsive presentation is ready.")).toBeDefined();
+
+    const structuredOutputToggle = getByRole("button", { name: "Structured output" });
+    expect(structuredOutputToggle.getAttribute("aria-expanded")).toBe("false");
     expect(queryByText(/mobileVerified/)).toBeNull();
 
-    fireEvent.click(toggle);
+    fireEvent.click(structuredOutputToggle);
 
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(structuredOutputToggle.getAttribute("aria-expanded")).toBe("true");
     expect(getByText(/"mobileVerified": true/)).toBeDefined();
   });
 

--- a/src/browser/features/Messages/SubagentReportMessageContent.tsx
+++ b/src/browser/features/Messages/SubagentReportMessageContent.tsx
@@ -26,6 +26,8 @@ interface SubagentReportMessageContentProps {
 export function SubagentReportMessageContent(
   props: SubagentReportMessageContentProps
 ): ReactElement {
+  // Reports can be lengthy and numerous, so keep the transcript scannable until the user opts in.
+  const [reportExpanded, setReportExpanded] = useState(false);
   const [structuredOutputExpanded, setStructuredOutputExpanded] = useState(false);
   const structuredOutputJson = formatSubagentStructuredOutput(props.report);
   const isInProgress = props.report.status === "in_progress";
@@ -34,7 +36,13 @@ export function SubagentReportMessageContent(
 
   return (
     <div className="min-w-0">
-      <div className="flex min-w-0 items-start gap-2.5">
+      <button
+        type="button"
+        aria-expanded={reportExpanded}
+        aria-label={`${reportExpanded ? "Hide" : "Show"} subagent report details`}
+        onClick={() => setReportExpanded((previous) => !previous)}
+        className="hover:bg-muted/10 focus-visible:ring-ring focus-visible:ring-offset-background flex w-full min-w-0 cursor-pointer items-start gap-2.5 rounded-md text-left focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+      >
         <Bot aria-hidden="true" className="text-muted mt-0.5 size-4 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm leading-snug font-medium text-[var(--color-user-text)]">
@@ -70,37 +78,48 @@ export function SubagentReportMessageContent(
             </span>
           </div>
         </div>
-      </div>
-
-      <MarkdownRenderer
-        content={props.report.reportMarkdown}
-        className="mt-2 text-sm leading-relaxed text-[var(--color-user-text)]"
-      />
-
-      {structuredOutputJson && (
-        <div className="mt-2 border-t border-[var(--color-user-border)] pt-2">
-          <button
-            type="button"
-            aria-expanded={structuredOutputExpanded}
-            onClick={() => setStructuredOutputExpanded((previous) => !previous)}
-            className="text-muted hover:text-foreground flex cursor-pointer items-center gap-1.5 text-xs"
-          >
-            <ChevronRight
-              aria-hidden="true"
-              className={cn(
-                "size-3 transition-transform duration-200",
-                structuredOutputExpanded && "rotate-90"
-              )}
-            />
-            <Braces aria-hidden="true" className="size-3" />
-            Structured output
-          </button>
-          {structuredOutputExpanded && (
-            <pre className="bg-code-bg mt-2 max-h-[40vh] max-w-full overflow-auto rounded-sm p-2 font-mono text-xs leading-relaxed whitespace-pre text-[var(--color-user-text)]">
-              {structuredOutputJson}
-            </pre>
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "text-muted mt-0.5 size-4 shrink-0 transition-transform duration-200",
+            reportExpanded && "rotate-90"
           )}
-        </div>
+        />
+      </button>
+
+      {reportExpanded && (
+        <>
+          <MarkdownRenderer
+            content={props.report.reportMarkdown}
+            className="mt-2 text-sm leading-relaxed text-[var(--color-user-text)]"
+          />
+
+          {structuredOutputJson && (
+            <div className="mt-2 border-t border-[var(--color-user-border)] pt-2">
+              <button
+                type="button"
+                aria-expanded={structuredOutputExpanded}
+                onClick={() => setStructuredOutputExpanded((previous) => !previous)}
+                className="text-muted hover:text-foreground flex cursor-pointer items-center gap-1.5 text-xs"
+              >
+                <ChevronRight
+                  aria-hidden="true"
+                  className={cn(
+                    "size-3 transition-transform duration-200",
+                    structuredOutputExpanded && "rotate-90"
+                  )}
+                />
+                <Braces aria-hidden="true" className="size-3" />
+                Structured output
+              </button>
+              {structuredOutputExpanded && (
+                <pre className="bg-code-bg mt-2 max-h-[40vh] max-w-full overflow-auto rounded-sm p-2 font-mono text-xs leading-relaxed whitespace-pre text-[var(--color-user-text)]">
+                  {structuredOutputJson}
+                </pre>
+              )}
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Collapse subagent report details by default so transcript timelines remain scannable, while keeping the report body and structured output available through accessible disclosure controls.

## Implementation

- turn the report header into an accessible expand/collapse control
- hide report markdown until the user expands the report
- preserve the existing nested structured-output disclosure
- cover collapsed, expanded, legacy, and structured-output behavior in message renderer tests

## Validation

- `bun test src/browser/features/Messages/MessageRenderer.test.tsx`
- pinned 390×844 Storybook verification: both reports defaulted to `aria-expanded=false` with no horizontal overflow
- `make static-check`

## Risks

Low and limited to subagent report presentation in the transcript. Copy behavior and report envelope parsing are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `high` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=high costs=0.00 -->
