### PR TITLE
🤖 fix: copy dependency patches into Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends git python3 mak
 # Copy package files first for better layer caching
 COPY package.json bun.lock bunfig.toml ./
 
+# Copy dependency patches referenced by package.json patchedDependencies
+# (bun install fails without them).
+COPY patches/ patches/
+
 # Copy postinstall script (needed by bun install)
 COPY scripts/postinstall.sh scripts/
 


### PR DESCRIPTION
## Summary

Fixes the `Smoke / Docker` merge-group failure that currently blocks every merge-queue entry: the Docker builder stage never copies `patches/`, so `bun install --frozen-lockfile` fails on the `patchedDependencies` entry added in #3798.

## Background

#3798 added `package.json` → `patchedDependencies` → `patches/@ai-sdk%2Fxai@4.0.28.patch`. `smoke-docker` only runs on `merge_group` events (not per-PR), so the missing `COPY` was never exercised before landing. Since then, merge-group runs fail deterministically:

```
error: could not find patch file patches/@ai-sdk%2Fxai@4.0.28.patch
failed to solve: process "/bin/sh -c bun install --frozen-lockfile && touch node_modules/.installed" did not complete successfully: exit code: 1
```

Observed on two consecutive merge-group runs for #3797 (31077517436, 31080586729), each with `Smoke / Docker` as the only failing job.

## Implementation

One `COPY patches/ patches/` before `bun install` in the builder stage, alongside the other install inputs (`package.json`, `bun.lock`, `bunfig.toml`, `scripts/postinstall.sh`).

## Validation

- Reproduced the failure locally with `docker build --target builder` on unpatched `origin/main` — fails with the exact CI error.
- Same build with this fix completes the builder stage successfully.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$69.35`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=69.35 -->
