### PR TITLE
feat: add a timeline_event transcript card

### DIFF
--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -29,6 +29,8 @@ import type {
 
 import {
   TIMELINE_CATEGORIES,
+  formatTimelineTime,
+  getTimelineDayLabel,
   getTimelineEventCategories,
   getTimelineEventKind,
   getTimelineEventTitle,
@@ -89,17 +91,6 @@ const FILTERS: Array<{ value: TimelineFilter; label: string }> = [
   })),
 ];
 
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: "numeric",
-  minute: "2-digit",
-});
-
-const dayFormatter = new Intl.DateTimeFormat(undefined, {
-  month: "short",
-  day: "numeric",
-  year: "numeric",
-});
-
 function isTimelineFilter(value: string): value is TimelineFilter {
   return value === "all" || TIMELINE_CATEGORIES.some((category) => category === value);
 }
@@ -107,18 +98,6 @@ function isTimelineFilter(value: string): value is TimelineFilter {
 function getDayKey(timestamp: number): string {
   const date = new Date(timestamp);
   return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-}
-
-function getDayLabel(timestamp: number): string {
-  const date = new Date(timestamp);
-  const today = new Date();
-  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
-  const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-  const dayOffset = Math.round((startOfToday - startOfDate) / 86_400_000);
-
-  if (dayOffset === 0) return "Today";
-  if (dayOffset === 1) return "Yesterday";
-  return dayFormatter.format(date);
 }
 
 function groupEventsByDay(events: TimelineEvent[]): DayGroup[] {
@@ -129,7 +108,7 @@ function groupEventsByDay(events: TimelineEvent[]): DayGroup[] {
     if (existing) {
       existing.events.push(event);
     } else {
-      groups.set(key, { key, label: getDayLabel(event.ts), events: [event] });
+      groups.set(key, { key, label: getTimelineDayLabel(event.ts), events: [event] });
     }
   }
   return Array.from(groups.values());
@@ -218,7 +197,7 @@ function TimelineRuleRow(props: {
         dateTime={new Date(props.event.ts).toISOString()}
         className="text-muted counter-nums shrink-0 text-[10px]"
       >
-        {timeFormatter.format(props.event.ts)}
+        {formatTimelineTime(props.event.ts)}
       </time>
     </>
   ) : (
@@ -314,7 +293,7 @@ function TimelineEventRow(props: {
         dateTime={new Date(props.event.ts).toISOString()}
         className="text-muted counter-nums shrink-0 pt-0.5 text-[10px]"
       >
-        {timeFormatter.format(props.event.ts)}
+        {formatTimelineTime(props.event.ts)}
       </time>
     </button>
   );
@@ -580,7 +559,7 @@ function TimelinePreviewCard(props: {
             dateTime={new Date(props.event.ts).toISOString()}
             className="text-muted counter-nums shrink-0 text-[10px]"
           >
-            {timeFormatter.format(props.event.ts)}
+            {formatTimelineTime(props.event.ts)}
           </time>
         </div>
         {eventText ? (

--- a/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
+++ b/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
@@ -99,6 +99,35 @@ const TIMELINE_PRESENTATION: Record<TimelineEventKind, TimelinePresentation> = {
 
 const knownKinds = new Set<string>(TIMELINE_EVENT_KINDS);
 
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const dayFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+/** Row timestamp as the Timeline tab renders it (also used by the transcript card's preview). */
+export function formatTimelineTime(timestamp: number): string {
+  return timeFormatter.format(timestamp);
+}
+
+/** Day-group header label as the Timeline tab renders it. */
+export function getTimelineDayLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const today = new Date();
+  const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+  const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  const dayOffset = Math.round((startOfToday - startOfDate) / 86_400_000);
+
+  if (dayOffset === 0) return "Today";
+  if (dayOffset === 1) return "Yesterday";
+  return dayFormatter.format(date);
+}
+
 export function getTimelinePresentation(kind: string): TimelinePresentation {
   if (knownKinds.has(kind)) {
     return TIMELINE_PRESENTATION[kind as TimelineEventKind];

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -288,6 +288,9 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   // Activity (ECG line) rather than HeartPulse: it matches the scanning pulse-trace
   // motif inside the HeartbeatToolCall card. The config menu uses HeartPulse.
   heartbeat: Activity,
+  // Sparkles matches the icon the Timeline tab feed renders on agent.event rows, which is
+  // exactly where a timeline_event call lands.
+  timeline_event: Sparkles,
 };
 
 export const ToolIcon: React.FC<ToolIconProps> = ({ toolName, emoji, emojiSpin, className }) => {

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -49,6 +49,7 @@ import { WorkspaceLifecycleToolCall } from "../WorkspaceLifecycleToolCall";
 import { SetGoalToolCall } from "../SetGoalToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
 import { HeartbeatToolCall } from "../HeartbeatToolCall";
+import { TimelineEventToolCall } from "../TimelineEventToolCall";
 import { WorkflowResumeToolCall, WorkflowRunToolCall } from "../WorkflowRunToolCall";
 import { CompleteGoalToolCall } from "../CompleteGoalToolCall";
 
@@ -227,6 +228,10 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     schema: TOOL_DEFINITIONS.complete_goal.schema,
   },
   heartbeat: { component: HeartbeatToolCall, schema: TOOL_DEFINITIONS.heartbeat.schema },
+  timeline_event: {
+    component: TimelineEventToolCall,
+    schema: TOOL_DEFINITIONS.timeline_event.schema,
+  },
   review_pane_update: {
     component: ReviewPaneUpdateToolCall,
     schema: TOOL_DEFINITIONS.review_pane_update.schema,

--- a/src/browser/features/Tools/TimelineEventToolCall.stories.tsx
+++ b/src/browser/features/Tools/TimelineEventToolCall.stories.tsx
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TimelineEventToolCall } from "@/browser/features/Tools/TimelineEventToolCall";
+import { PIXEL_DISABLED, lightweightMeta, StoryUiShell } from "@/browser/stories/meta.js";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/TimelineEvent",
+  component: TimelineEventToolCall,
+  parameters: {
+    ...lightweightMeta.parameters,
+    // Excluded because the repo-wide Pixel snapshot budget is at its ceiling.
+    pixel: PIXEL_DISABLED,
+  },
+  decorators: [
+    (Story) => (
+      <StoryUiShell>
+        <div className="bg-background p-6">
+          <div className="w-full max-w-2xl">
+            <Story />
+          </div>
+        </div>
+      </StoryUiShell>
+    ),
+  ],
+} satisfies Meta<typeof TimelineEventToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Fixed instant so the preview's day header and time cell are deterministic.
+const RECORDED_AT = new Date("2026-07-28T09:42:00").getTime();
+
+/** milestone · work landed, PR opened (expanded to show the feed-row preview). */
+export const MilestoneExpanded: Story = {
+  args: {
+    args: {
+      description: "Landed the session-token refactor on main and opened PR #412 for review.",
+      category: "milestone",
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** picked_up · external input pulled in — collapsed, the note itself is the summary. */
+export const PickedUpCollapsed: Story = {
+  args: {
+    args: {
+      description:
+        "Picked up a review comment on PR #412 asking to gate the new token path behind a flag.",
+      category: "picked_up",
+    },
+    status: "completed",
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** decision · approach changed, with the why. */
+export const DecisionExpanded: Story = {
+  args: {
+    args: {
+      description:
+        "Switched workspace status updates from polling to SSE — polling starved the renderer past ~200 workspaces.",
+      category: "decision",
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** blocker · progress stopped. */
+export const Blocker: Story = {
+  args: {
+    args: {
+      description:
+        "Blocked on staging migrations — the deploy role lacks ALTER TABLE and needs an infra approval.",
+      category: "blocker",
+    },
+    status: "completed",
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** handoff · work passed on. */
+export const Handoff: Story = {
+  args: {
+    args: {
+      description:
+        "Handed flaky-test triage to the infra workspace with a repro script and the failing seeds.",
+      category: "handoff",
+    },
+    status: "completed",
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** No category · the chip and row badge fall back to the feed's generic "Agent". */
+export const NoCategory: Story = {
+  args: {
+    args: {
+      description: "Rebased the feature branch onto main after the v0.27.0 release tag.",
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/**
+ * Throttled · the tool succeeded but TimelineService dropped the note (duplicate or too
+ * many in the window): amber "Not recorded" chip, and no feed-row preview.
+ */
+export const Throttled: Story = {
+  args: {
+    args: {
+      description: "Landed the session-token refactor on main and opened PR #412 for review.",
+      category: "milestone",
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, recorded: false },
+    toolCallTimestamp: RECORDED_AT,
+  },
+};
+
+/** Mid-flight, before the result arrives. */
+export const Executing: Story = {
+  args: {
+    args: {
+      description: "Landed the session-token refactor on main and opened PR #412 for review.",
+      category: "milestone",
+    },
+    status: "executing",
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * Error · the tool rejected the call (whitespace-only description passes the schema's min
+ * length but fails the backend's trim check), so the header shows the explicit
+ * empty-description placeholder instead of blank text.
+ */
+export const ErrorEmptyDescription: Story = {
+  args: {
+    args: { description: "   ", category: "milestone" },
+    status: "failed",
+    defaultExpanded: true,
+    result: { success: false, error: "timeline_event requires a non-empty description" },
+  },
+};
+
+/**
+ * Narrow container · long unbroken token in the description. Pinned to a fixed ~375px
+ * wrapper (the Storybook test-runner renders at desktop width and ignores viewport / Pixel
+ * matrix variants, so the narrow case must be forced) with a play that fails if the header
+ * or the feed-row preview overflows instead of truncating/clamping.
+ */
+export const NarrowContainer: Story = {
+  args: {
+    args: {
+      description:
+        "Deployed preview build https://ci.example.com/runs/0123456789abcdef0123456789abcdef/artifacts/mux-nightly-darwin-arm64.dmg for QA.",
+      category: "milestone",
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, recorded: true },
+    toolCallTimestamp: RECORDED_AT,
+  },
+  decorators: [
+    (Story) => (
+      <div data-testid="timeline-event-card-container" className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    if (!canvasElement.querySelector('[data-testid="timeline-row-preview"]')) {
+      throw new Error("Timeline row preview did not render");
+    }
+    const container = canvasElement.querySelector('[data-testid="timeline-event-card-container"]');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error("Timeline event story container not found");
+    }
+    // Let layout settle before measuring.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `Timeline event tool card overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
+  },
+};

--- a/src/browser/features/Tools/TimelineEventToolCall.tsx
+++ b/src/browser/features/Tools/TimelineEventToolCall.tsx
@@ -1,0 +1,240 @@
+import React from "react";
+import { Flag, Forward, Inbox, OctagonAlert, Split, type LucideIcon } from "lucide-react";
+import {
+  formatTimelineTime,
+  getTimelineDayLabel,
+  getTimelinePresentation,
+} from "@/browser/features/RightSidebar/Timeline/timelinePresentation";
+import type { TimelineEventToolArgs, TimelineEventToolResult } from "@/common/types/tools";
+import { TimelineEventToolResultSchema } from "@/common/utils/tools/toolDefinitions";
+import {
+  ErrorBox,
+  ExpandIcon,
+  StatusIndicator,
+  ToolContainer,
+  ToolDetails,
+  ToolHeader,
+  ToolIcon,
+} from "./Shared/ToolPrimitives";
+import {
+  getStatusDisplay,
+  isToolErrorResult,
+  unwrapResult,
+  useToolExpansion,
+  type ToolStatus,
+} from "./Shared/toolUtils";
+
+/**
+ * Transcript card for the `timeline_event` tool — the agent's one-sentence note on the
+ * durable workspace timeline. Collapsed, the note itself is the summary, tagged with its
+ * category. Expanded, it previews the row as it lands in the Timeline tab (ask-mode ink,
+ * category badge) under the feed's day header.
+ *
+ * Mirrors the timeline backend (TimelineEventToolResultSchema / timelineService.ts): a
+ * successful result carries `recorded`, which is false when the note was throttled
+ * (duplicate description or too many agent events in a short window) and nothing was
+ * added to the timeline — the card must not claim otherwise.
+ */
+
+type TimelineEventCategory = NonNullable<TimelineEventToolArgs["category"]>;
+type TimelineEventSuccess = Extract<TimelineEventToolResult, { success: true }>;
+
+// The feed itself renders every agent.event row with the kind icon (Sparkles) and a
+// plain-text category badge; these per-category glyphs are the card header's own
+// vocabulary for telling categories apart at a glance.
+const CATEGORY_PRESENTATION: Record<TimelineEventCategory, { icon: LucideIcon; blurb: string }> = {
+  picked_up: {
+    icon: Inbox,
+    blurb: "External input pulled into the work — a review comment, CI failure, or issue.",
+  },
+  milestone: {
+    icon: Flag,
+    blurb: "A notable step landed — implemented, committed, pushed, or opened as a PR.",
+  },
+  decision: { icon: Split, blurb: "The approach changed, including why." },
+  blocker: { icon: OctagonAlert, blurb: "Progress is blocked, or a blocker was cleared." },
+  handoff: { icon: Forward, blurb: "Work was handed off." },
+};
+
+const AGENT_EVENT_PRESENTATION = getTimelinePresentation("agent.event");
+
+const FALLBACK_BLURB = "A general agent event on the workspace timeline.";
+
+/** Badge text exactly as TimelineEventRow derives it: underscores → spaces, or "Agent". */
+function categoryBadgeLabel(category: TimelineEventCategory | null | undefined): string {
+  return category?.replace(/_/g, " ") ?? "Agent";
+}
+
+const CategoryChip: React.FC<{ category: TimelineEventCategory | null | undefined }> = (props) => {
+  const Icon =
+    props.category != null
+      ? CATEGORY_PRESENTATION[props.category].icon
+      : AGENT_EVENT_PRESENTATION.icon;
+  return (
+    <span className="border-ask-mode/30 text-ask-mode inline-flex shrink-0 items-center gap-1 rounded border px-1 py-0.5 text-[9px] leading-none font-medium uppercase">
+      <Icon aria-hidden="true" className="h-2.5 w-2.5 shrink-0" />
+      {categoryBadgeLabel(props.category)}
+    </span>
+  );
+};
+
+// Static replica of the Timeline tab's agent-authored TimelineEventRow (TimelinePanel.tsx):
+// icon ring, two-line title, category badge, timestamp. Non-interactive because it previews
+// the feed from inside the transcript rather than living in it.
+const TimelineRowPreview: React.FC<{
+  description: string;
+  category: TimelineEventCategory | null | undefined;
+  timestamp: number | undefined;
+}> = (props) => {
+  const Icon = AGENT_EVENT_PRESENTATION.icon;
+  return (
+    <div
+      data-testid="timeline-row-preview"
+      className="border-ask-mode/25 bg-ask-mode-alpha grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 rounded-md border px-2 py-2 text-left"
+    >
+      <span className="border-ask-mode/40 text-ask-mode bg-surface-secondary mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border">
+        <Icon className="h-3.5 w-3.5" />
+      </span>
+      <span className="min-w-0">
+        <span className="text-content-primary line-clamp-2 min-w-0 text-xs font-medium">
+          {props.description}
+        </span>
+        <span className="mt-0.5 flex min-w-0 items-center gap-1.5">
+          <span className="border-ask-mode/30 text-ask-mode shrink-0 rounded border px-1 py-px text-[9px] font-medium uppercase">
+            {categoryBadgeLabel(props.category)}
+          </span>
+        </span>
+      </span>
+      {props.timestamp != null && (
+        <time
+          dateTime={new Date(props.timestamp).toISOString()}
+          className="text-muted counter-nums shrink-0 pt-0.5 text-[10px]"
+        >
+          {formatTimelineTime(props.timestamp)}
+        </time>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Both persisted error shapes: top-level tools store `{ success: false, error }`, while a
+ * failure inside a nested code_execution call is reconstructed as a bare `{ error }` with
+ * no success flag.
+ */
+function extractErrorMessage(result: unknown): string | null {
+  if (isToolErrorResult(result)) {
+    return result.error;
+  }
+  if (result != null && typeof result === "object" && !("success" in result)) {
+    const error = (result as Record<string, unknown>).error;
+    if (typeof error === "string") {
+      return error;
+    }
+  }
+  return null;
+}
+
+// Results flow verbatim from persisted transcripts, so validate against the schema rather
+// than trusting the shape (self-healing: a malformed result degrades to a status note).
+function extractTimelineEventSuccess(result: unknown): TimelineEventSuccess | null {
+  const parsed = TimelineEventToolResultSchema.safeParse(result);
+  return parsed.success && parsed.data.success ? parsed.data : null;
+}
+
+// Fallback body when no result state applies (mid-flight, interrupted, or a corrupt
+// result). The header already shows the full args — description and category — so a
+// one-line status note is all that is left to say.
+const STATUS_NOTES: Record<ToolStatus, string> = {
+  pending: "Waiting to record…",
+  executing: "Recording to the workspace timeline…",
+  backgrounded: "Recording to the workspace timeline…",
+  completed: "Recorded status unavailable.",
+  failed: "The note was not recorded.",
+  interrupted: "Interrupted before the note was recorded.",
+  redacted: "Result redacted.",
+};
+
+interface TimelineEventToolCallProps {
+  args: TimelineEventToolArgs;
+  result?: unknown;
+  status?: ToolStatus;
+  /** Initial expansion fallback (until the user toggles this tool in the workspace). */
+  defaultExpanded?: boolean;
+  /**
+   * When the model emitted the call — approximates the recorded event's timestamp, which
+   * the result does not carry. The preview omits its day header and time cell without it.
+   */
+  toolCallTimestamp?: number;
+}
+
+export const TimelineEventToolCall: React.FC<TimelineEventToolCallProps> = (props) => {
+  const status = props.status ?? "pending";
+  const { expanded, toggleExpanded } = useToolExpansion(props.defaultExpanded ?? false);
+
+  // The backend trims before recording, so mirror it: a whitespace-only description (which
+  // passes the schema's min length) renders the explicit empty placeholder, not blank text.
+  const description = props.args.description.trim();
+  const category = props.args.category;
+  // Results can arrive wrapped in the SDK JSON container { type: "json", value: ... }.
+  const result = unwrapResult(props.result);
+  const errorMessage = extractErrorMessage(result);
+  const success = extractTimelineEventSuccess(result);
+  const blurb = category != null ? CATEGORY_PRESENTATION[category].blurb : FALLBACK_BLURB;
+
+  return (
+    <ToolContainer expanded={expanded}>
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="timeline_event" />
+        <span className="text-secondary font-medium whitespace-nowrap">Timeline</span>
+        <CategoryChip category={category} />
+        {description.length > 0 ? (
+          <span className="text-foreground min-w-0 truncate">{description}</span>
+        ) : (
+          <span className="text-muted min-w-0 truncate italic">(empty description)</span>
+        )}
+        {success != null && !success.recorded && (
+          <span className="bg-warning-overlay text-warning border-warning/40 inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[10px] leading-none font-medium tracking-wide uppercase">
+            Not recorded
+          </span>
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {errorMessage != null ? (
+            <ErrorBox>{errorMessage}</ErrorBox>
+          ) : success?.recorded ? (
+            <div className="space-y-2">
+              <div className="bg-code-bg rounded px-3 py-2.5">
+                {props.toolCallTimestamp != null && (
+                  <div className="text-muted mb-2 text-[10px] font-semibold tracking-wide uppercase">
+                    {getTimelineDayLabel(props.toolCallTimestamp)}
+                  </div>
+                )}
+                <TimelineRowPreview
+                  description={description}
+                  category={category}
+                  timestamp={props.toolCallTimestamp}
+                />
+              </div>
+              <div className="text-muted text-[10.5px] leading-relaxed">
+                {blurb} Recorded on the durable workspace timeline — find it in the Timeline tab
+                under <span className="text-foreground">Agent</span>.
+              </div>
+            </div>
+          ) : success != null ? (
+            <div data-testid="timeline-not-recorded" className="text-warning px-3 py-2 text-[11px]">
+              Not recorded — a duplicate or too many notes in a short window. The timeline throttles
+              agent events to stay a birds-eye record of the work.
+            </div>
+          ) : (
+            <div className="text-muted px-3 py-2 text-[11px] italic">{STATUS_NOTES[status]}</div>
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/TimelineEventToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/TimelineEventToolCall.ui.test.tsx
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import type { ReactElement } from "react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import { TimelineEventToolCall } from "./TimelineEventToolCall";
+
+const TEST_WORKSPACE_ID = "timeline-event-test";
+
+// ToolIcon renders a Radix Tooltip which requires a TooltipProvider and contexts.
+function renderWithProviders(ui: ReactElement) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName="timeline_event">
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+const ROW_PREVIEW = '[data-testid="timeline-row-preview"]';
+const NOT_RECORDED = '[data-testid="timeline-not-recorded"]';
+
+describe("TimelineEventToolCall", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("recorded result renders the feed-row preview", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: true }}
+      />
+    );
+    expect(view.container.querySelector(ROW_PREVIEW)).not.toBeNull();
+    expect(view.container.querySelector(NOT_RECORDED)).toBeNull();
+  });
+
+  test("throttled result (recorded: false) suppresses the preview and flags the drop", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: false }}
+      />
+    );
+    expect(view.container.querySelector(ROW_PREVIEW)).toBeNull();
+    expect(view.container.querySelector(NOT_RECORDED)).not.toBeNull();
+  });
+
+  test("unwraps the SDK JSON container before reading the result", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="completed"
+        defaultExpanded
+        result={{ type: "json", value: { success: true, recorded: true } }}
+      />
+    );
+    expect(view.container.querySelector(ROW_PREVIEW)).not.toBeNull();
+  });
+
+  test("category badge maps underscores to spaces; missing category falls back to Agent", () => {
+    const withCategory = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Picked up a review comment.", category: "picked_up" }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: true }}
+      />
+    );
+    // Header chip + row badge both derive from the same transform.
+    expect(withCategory.queryAllByText("picked up").length).toBe(2);
+    cleanup();
+
+    const withoutCategory = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Rebased the feature branch." }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: true }}
+      />
+    );
+    expect(withoutCategory.queryAllByText("Agent").length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("renders the top-level error shape ({ success: false, error })", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "   ", category: "milestone" }}
+        status="failed"
+        defaultExpanded
+        result={{ success: false, error: "timeline_event requires a non-empty description" }}
+      />
+    );
+    expect(view.queryByText("timeline_event requires a non-empty description")).not.toBeNull();
+    expect(view.container.querySelector(ROW_PREVIEW)).toBeNull();
+  });
+
+  test("renders the nested bare error shape ({ error }) without a success flag", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="failed"
+        defaultExpanded
+        result={{ error: "workspace timeline unavailable" }}
+      />
+    );
+    expect(view.queryByText("workspace timeline unavailable")).not.toBeNull();
+    expect(view.container.querySelector(ROW_PREVIEW)).toBeNull();
+  });
+
+  test("no result yet renders neither preview, drop note, nor error", () => {
+    const view = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="executing"
+        defaultExpanded
+      />
+    );
+    expect(view.container.querySelector(ROW_PREVIEW)).toBeNull();
+    expect(view.container.querySelector(NOT_RECORDED)).toBeNull();
+  });
+
+  test("preview time and day header render only when a call timestamp is available", () => {
+    const withTimestamp = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: true }}
+        toolCallTimestamp={new Date("2026-07-28T09:42:00").getTime()}
+      />
+    );
+    expect(withTimestamp.container.querySelector(`${ROW_PREVIEW} time`)).not.toBeNull();
+    cleanup();
+
+    const withoutTimestamp = renderWithProviders(
+      <TimelineEventToolCall
+        args={{ description: "Opened PR #412 for review.", category: "milestone" }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, recorded: true }}
+      />
+    );
+    expect(withoutTimestamp.container.querySelector(`${ROW_PREVIEW} time`)).toBeNull();
+  });
+});

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -32,6 +32,7 @@ import type {
   TaskListToolResultSchema,
   TaskTerminateToolResultSchema,
   TaskWorkspaceLifecycleToolResultSchema,
+  TimelineEventToolResultSchema,
   TOOL_DEFINITIONS,
   WebFetchToolResultSchema,
   WorkflowRunToolResultSchema,
@@ -137,6 +138,10 @@ export type FileReadToolResult = z.infer<typeof FileReadToolResultSchema>;
 // Heartbeat tool types, derived from schema (avoid drift)
 export type HeartbeatToolArgs = z.infer<typeof TOOL_DEFINITIONS.heartbeat.schema>;
 export type HeartbeatToolResult = z.infer<typeof HeartbeatToolResultSchema>;
+
+// Timeline-event tool types, derived from schema (avoid drift)
+export type TimelineEventToolArgs = z.infer<typeof TOOL_DEFINITIONS.timeline_event.schema>;
+export type TimelineEventToolResult = z.infer<typeof TimelineEventToolResultSchema>;
 
 // Memory tool types, derived from schema (avoid drift)
 export type MemoryToolArgs = z.infer<typeof TOOL_DEFINITIONS.memory.schema>;

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -3016,6 +3016,19 @@ export const HeartbeatToolResultSchema = z.union([
   }),
 ]);
 
+// `recorded: false` means TimelineService throttled the note (duplicate description or too
+// many agent events in a short window) and nothing was added to the timeline.
+export const TimelineEventToolResultSchema = z.union([
+  z.object({
+    success: z.literal(true),
+    recorded: z.boolean(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string(),
+  }),
+]);
+
 export const MemoryToolResultSchema = z.union([
   z.object({
     success: z.literal(true),


### PR DESCRIPTION
## Summary

Adds a dedicated transcript card for the `timeline_event` tool, which currently falls back to the generic renderer. Collapsed, the agent's one-sentence note is the summary, tagged with an ask-mode category chip. Expanded, the card previews the row exactly as it lands in the Timeline tab (ask-mode ink, Sparkles ring, category badge) under its day header, and explains where to find it.

## Background

The durable workspace timeline landed in #3755/#3756 with the `timeline_event` tool, but calls render as generic JSON dumps in the transcript. The card design comes from the Mux Design System mockup (`Timeline Event Tool Call.html`), bound here to the real backend shapes rather than the mockup's idealized ones.

## Implementation

- `TimelineEventToolResultSchema` (+ derived `TimelineEventToolArgs`/`TimelineEventToolResult` types) — the real result is `{ success: true, recorded: boolean }`, where `recorded: false` means TimelineService throttled the note (duplicate or rate-limited) and nothing was written. The card surfaces that as an amber "Not recorded" chip plus an explanation instead of a preview that would overstate what happened.
- The feed-row preview is a static replica of `TimelineEventRow`'s agent-authored variant. To keep it provably in sync with the tab, the row icon comes from the shared `getTimelinePresentation("agent.event")`, and the day/time formatters (`getTimelineDayLabel`, `formatTimelineTime`) are extracted from `TimelinePanel.tsx` into `timelinePresentation.ts` and used by both. The preview's day header and time cell derive from `toolCallTimestamp` and are omitted when unavailable — nothing is fabricated.
- Result handling follows the current card conventions: `unwrapResult` for the SDK JSON container, `safeParse` for self-healing on malformed persisted results, and both persisted error shapes (`{ success: false, error }` and the nested bare `{ error }`).
- Registered in `getToolComponent.ts`; header icon (Sparkles, matching the feed's `agent.event` rows) in `TOOL_NAME_TO_ICON`.

## Validation

- New happy-dom suite covers the behavioral branches: recorded/throttled gating, badge derivation (`picked_up` → "picked up", missing category → "Agent"), both error shapes, JSON-container unwrap, and timestamp gating.
- Stories mirror the design gallery (all five categories, fallback, throttled, executing, error) plus a 375px pinned-width play test asserting no horizontal overflow. Snapshots are `pixel: PIXEL_DISABLED` since the repo-wide budget is at its ceiling.
- Full `bun test src` matches the clean-main baseline exactly (the same 30 pre-existing env-dependent failures, none in touched areas); TimelinePanel's 16 jest tests and a static Storybook build pass.

## Risks

Low. The card and registry entry are new code paths gated to `timeline_event`. The only shared-code change is moving the day/time formatters out of `TimelinePanel.tsx` (behavior-preserving, covered by the existing timeline jest suite).
