### PR TITLE
🤖 fix: resume parents directly from sub-agent reports

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -532,6 +532,8 @@ export interface ModelFallbackRecord {
 
 // Our custom metadata type
 export interface MuxMetadata {
+  /** Highest persisted history sequence included in the provider request that produced this assistant. */
+  requestHistorySequence?: number;
   historySequence?: number; // Assigned by backend for global message ordering (required when writing to history)
   duration?: number;
   ttftMs?: number; // Time-to-first-token measured from stream start; omitted when unavailable

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -2228,7 +2228,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
         compactionEpoch: 2,
         model: "openai:gpt-5.2",
       }),
-      createMuxMessage("latest-user", "user", "continue"),
+      createMuxMessage("latest-user", "user", "continue", { historySequence: 42 }),
     ];
 
     const result = await harness.service.streamMessage({
@@ -2251,6 +2251,7 @@ describe("AIService.streamMessage compaction boundary slicing", () => {
 
     const startStreamMessageIds = messageIdsFromUnknownArray(startStreamCall[1]);
     expect(startStreamMessageIds).toEqual(["boundary-2", "latest-user"]);
+    expect(initialMetadataFromStartStreamCall(startStreamCall).requestHistorySequence).toBe(42);
 
     const openaiOptions = openAIOptionsFromStartStreamCall(startStreamCall);
     expect(openaiOptions.previousResponseId).toBeUndefined();

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2386,7 +2386,12 @@ export class AIService extends EventEmitter {
         return Ok(undefined);
       }
 
+      const requestHistorySequence = providerRequestMessages.reduce(
+        (latest, message) => Math.max(latest, message.metadata?.historySequence ?? -1),
+        -1
+      );
       const assistantMessage = createMuxMessage(assistantMessageId, "assistant", "", {
+        ...(requestHistorySequence >= 0 ? { requestHistorySequence } : {}),
         timestamp: Date.now(),
         model: canonicalModelString,
         routedThroughGateway,
@@ -3009,6 +3014,7 @@ export class AIService extends EventEmitter {
         combinedAbortSignal,
         toolsForStream,
         {
+          ...(requestHistorySequence >= 0 ? { requestHistorySequence } : {}),
           systemMessageTokens,
           timestamp: Date.now(),
           agentId: effectiveAgentId,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -49,10 +49,7 @@ import * as forkOrchestrator from "@/node/services/utils/forkOrchestrator";
 import { Ok, Err, type Result } from "@/common/types/result";
 import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
-import {
-  formatSubagentReportEnvelope,
-  parseSubagentReportEnvelope,
-} from "@/common/utils/subagentReportEnvelope";
+import { formatSubagentReportEnvelope } from "@/common/utils/subagentReportEnvelope";
 import { defaultModel } from "@/common/utils/ai/models";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
@@ -2544,609 +2541,6 @@ describe("TaskService", () => {
     expect(drained).toBeDefined();
   });
 
-  test("coalesced workspace-turn errors do not turn completed sub-agent handoff into failure", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "workspace_turn",
-      sourceId: "wst_error",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "error",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const prompt = String(sendMessage.mock.calls[0]?.[1]);
-    expect(prompt).toContain("Background sub-agent task(s) have completed");
-    expect(prompt).not.toContain("failed terminally");
-    expect(prompt).toContain("wst_error");
-    expect(prompt).toContain("task_await");
-  });
-
-  test("completed subagent wake is suppressed after the parent responded to its latest progress update", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const childId = "task-progress-responded";
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: childId,
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "progress-update",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "in_progress",
-          title: "Progress",
-          reportMarkdown: "Found the relevant code path.",
-        }),
-        { timestamp: Date.now(), synthetic: true }
-      )
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage("progress-response", "assistant", "Thanks, I have integrated that update.", {
-        timestamp: Date.now(),
-      })
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "terminal-report",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "completed",
-          title: "Final report",
-          reportMarkdown: "Investigation complete.",
-        }),
-        { timestamp: Date.now(), synthetic: true, uiVisible: true }
-      )
-    );
-
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(await terminalAttentionStore.listPending(parentId)).toEqual([]);
-  });
-
-  test("completed subagent wake remains when its visible terminal report card is missing", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const childId = "task-progress-missing-terminal-card";
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: childId,
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "progress-without-card",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "in_progress",
-          title: "Progress",
-          reportMarkdown: "Progress was answered but terminal persistence failed.",
-        }),
-        { timestamp: Date.now(), synthetic: true }
-      )
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage("progress-without-card-response", "assistant", "Progress handled.", {
-        timestamp: Date.now(),
-      })
-    );
-
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain(
-      "Background sub-agent task(s) have completed"
-    );
-  });
-
-  test("completed subagent wake remains when the latest progress update has no assistant response", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const childId = "task-progress-unanswered";
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: childId,
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "old-progress",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "in_progress",
-          title: "Earlier progress",
-          reportMarkdown: "An earlier update was processed.",
-        }),
-        { timestamp: Date.now(), synthetic: true }
-      )
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage("old-response", "assistant", "Earlier response", { timestamp: Date.now() })
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "latest-progress",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "in_progress",
-          title: "Latest progress",
-          reportMarkdown: "A newer update has not been processed yet.",
-        }),
-        { timestamp: Date.now(), synthetic: true }
-      )
-    );
-
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain(
-      "Background sub-agent task(s) have completed"
-    );
-  });
-
-  test("terminal wake-up waits for queued owner turn to clear", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    let ownerPending = true;
-    const hasPendingQueuedOrPreparingTurn = mock(() => ownerPending);
-    const hasQueuedMessages = mock(() => ownerPending);
-    let releaseIdle!: () => void;
-    const waitForIdleAndNoQueuedMessages = mock(
-      (): Promise<void> =>
-        new Promise((resolve) => {
-          releaseIdle = resolve;
-        })
-    );
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({
-      sendMessage,
-      hasPendingQueuedOrPreparingTurn,
-      hasQueuedMessages,
-      waitForIdleAndNoQueuedMessages,
-    });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-    await Promise.resolve();
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-
-    ownerPending = false;
-    releaseIdle();
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("terminal wake-up waits for pending auto-retry to clear", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    let ownerPendingAutoRetry = true;
-    const hasPendingQueuedOrPreparingTurn = mock(() => ownerPendingAutoRetry);
-    let releaseRetryCleared!: () => void;
-    const waitForIdleAndNoQueuedMessages = mock(
-      (): Promise<void> =>
-        new Promise((resolve) => {
-          releaseRetryCleared = resolve;
-        })
-    );
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({
-      sendMessage,
-      hasPendingQueuedOrPreparingTurn,
-      waitForIdleAndNoQueuedMessages,
-    });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-    await Promise.resolve();
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(waitForIdleAndNoQueuedMessages).toHaveBeenCalledWith(parentId);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-
-    ownerPendingAutoRetry = false;
-    releaseRetryCleared();
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("terminal wake-up retries without idle-only flag after completion-phase busy", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    let acceptQueuedFallback: (() => Promise<void> | void) | undefined;
-    const sendMessage = mock(
-      (
-        _workspaceId: string,
-        _message: string,
-        _options: unknown,
-        internal?: { requireIdle?: boolean; onAccepted?: () => Promise<void> | void }
-      ): Promise<Result<void, { type: string; raw: string }>> => {
-        if (internal?.requireIdle === true) {
-          return Promise.resolve(
-            Err({ type: "unknown", raw: "Workspace is busy; idle-only send was skipped." })
-          );
-        }
-        acceptQueuedFallback = internal?.onAccepted;
-        return Promise.resolve(Ok(undefined));
-      }
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).toHaveBeenCalledTimes(2);
-    expect(sendMessage.mock.calls[0]?.[3]).toMatchObject({ requireIdle: true });
-    expect(sendMessage.mock.calls[1]?.[3]).not.toMatchObject({ requireIdle: true });
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-    expect(acceptQueuedFallback).toBeDefined();
-    await acceptQueuedFallback?.();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("terminal wake-up reschedules when queued fallback is canceled", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    let idleFailuresRemaining = 1;
-    let cancelQueuedFallback: ((reason: string) => Promise<void> | void) | undefined;
-    const sendMessage = mock(
-      (
-        _workspaceId: string,
-        _message: string,
-        _options: unknown,
-        internal?: {
-          requireIdle?: boolean;
-          onCanceled?: (reason: string) => Promise<void> | void;
-        }
-      ): Promise<Result<void, { type: string; raw: string }>> => {
-        if (internal?.requireIdle === true && idleFailuresRemaining > 0) {
-          idleFailuresRemaining -= 1;
-          return Promise.resolve(
-            Err({ type: "unknown", raw: "Workspace is busy; idle-only send was skipped." })
-          );
-        }
-        if (internal?.requireIdle !== true) {
-          cancelQueuedFallback = internal?.onCanceled;
-        }
-        return Promise.resolve(Ok(undefined));
-      }
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-    expect(cancelQueuedFallback).toBeDefined();
-
-    await cancelQueuedFallback?.("cleared");
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(3);
-    expect(sendMessage.mock.calls[2]?.[3]).toMatchObject({ requireIdle: true });
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("terminal wake-up re-pends when queued fallback fails before stream", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    let idleFailuresRemaining = 1;
-    let acceptQueuedFallback: (() => Promise<void> | void) | undefined;
-    let failQueuedFallback: ((error: SendMessageError) => Promise<void> | void) | undefined;
-    const sendMessage = mock(
-      (
-        _workspaceId: string,
-        _message: string,
-        _options: unknown,
-        internal?: {
-          requireIdle?: boolean;
-          onAccepted?: () => Promise<void> | void;
-          onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void;
-        }
-      ): Promise<Result<void, { type: string; raw: string }>> => {
-        if (internal?.requireIdle === true && idleFailuresRemaining > 0) {
-          idleFailuresRemaining -= 1;
-          return Promise.resolve(
-            Err({ type: "unknown", raw: "Workspace is busy; idle-only send was skipped." })
-          );
-        }
-        if (internal?.requireIdle !== true) {
-          acceptQueuedFallback = internal?.onAccepted;
-          failQueuedFallback = internal?.onAcceptedPreStreamFailure;
-        }
-        return Promise.resolve(Ok(undefined));
-      }
-    );
-    let releaseIdle!: () => void;
-    const waitForIdleAndNoQueuedMessages = mock(
-      (): Promise<void> =>
-        new Promise((resolve) => {
-          releaseIdle = resolve;
-        })
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({
-      sendMessage,
-      waitForIdleAndNoQueuedMessages,
-    });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-    await acceptQueuedFallback?.();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-
-    await failQueuedFallback?.({ type: "unknown", raw: "pre-stream failure" });
-    await Promise.resolve();
-
-    expect(sendMessage).toHaveBeenCalledTimes(2);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-
-    releaseIdle();
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(3);
-    expect(sendMessage.mock.calls[2]?.[3]).toMatchObject({ requireIdle: true });
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("terminal wake-up drains are serialized per owner", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    let releaseSend!: () => void;
-    const sendReleased = new Promise<void>((resolve) => {
-      releaseSend = resolve;
-    });
-    let sawFirstSend!: () => void;
-    const firstSendSeen = new Promise<void>((resolve) => {
-      sawFirstSend = resolve;
-    });
-    const sendMessage = mock(async (..._args: unknown[]): Promise<Result<void>> => {
-      sawFirstSend();
-      await sendReleased;
-      return Ok(undefined);
-    });
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      enqueueTerminalAttention: (params: {
-        ownerWorkspaceId: string;
-        sourceKind: "agent_task";
-        sourceId: string;
-        outputDelivery: "already_injected";
-        terminalOutcome: "completed";
-      }) => Promise<void>;
-    };
-
-    await Promise.all([
-      internal.enqueueTerminalAttention({
-        ownerWorkspaceId: parentId,
-        sourceKind: "agent_task",
-        sourceId: "task-a",
-        outputDelivery: "already_injected",
-        terminalOutcome: "completed",
-      }),
-      internal.enqueueTerminalAttention({
-        ownerWorkspaceId: parentId,
-        sourceKind: "agent_task",
-        sourceId: "task-b",
-        outputDelivery: "already_injected",
-        terminalOutcome: "completed",
-      }),
-    ]);
-    await firstSendSeen;
-    await Promise.resolve();
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    releaseSend();
-    await flushTerminalAttentionDrains(taskService);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-  });
-
-  test("terminal wake-up drain ignores nested workflow runs", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(parentId) });
-    await runStore.createRun({
-      id: "wfr_top_notify",
-      workspaceId: parentId,
-      workflow: {
-        name: "top",
-        description: "Top workflow",
-        scope: "built-in",
-        executable: true,
-      },
-      source: "export default function workflow() { return { reportMarkdown: 'top' }; }\n",
-      args: {},
-      attentionPolicy: "notify_on_terminal",
-      now: "2026-06-19T00:00:00.000Z",
-    });
-    await runStore.appendStatus("wfr_top_notify", "running", "2026-06-19T00:00:01.000Z");
-    await runStore.createRun({
-      id: "wfr_nested_internal",
-      workspaceId: parentId,
-      workflow: {
-        name: "nested",
-        description: "Nested workflow",
-        scope: "built-in",
-        executable: true,
-      },
-      source: "export default function workflow() { return { reportMarkdown: 'nested' }; }\n",
-      args: {},
-      parentWorkflow: { runId: "wfr_top_notify", stepId: "nested", inputHash: "hash", depth: 0 },
-      now: "2026-06-19T00:00:02.000Z",
-    });
-    await runStore.appendStatus("wfr_nested_internal", "running", "2026-06-19T00:00:03.000Z");
-
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "agent_task",
-      sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain(
-      "Background sub-agent task(s) have completed"
-    );
-  });
-
   test("terminal workflow wake-up reconstructs durable result context", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);
@@ -3272,8 +2666,6 @@ describe("TaskService", () => {
         ownerWorkspaceId: string;
         sourceKind: "workspace_turn";
         sourceId: string;
-        outputDelivery: "requires_task_await";
-        terminalOutcome: "completed" | "error" | "interrupted";
       }) => Promise<void>;
       drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
     };
@@ -3287,8 +2679,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_consumed_then_enqueued",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
     await flushTerminalAttentionDrains(taskService);
 
@@ -3299,8 +2689,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_pending_then_consumed",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
     await taskService.markWorkspaceTurnTerminalAttentionConsumed({
       ownerWorkspaceId: parentId,
@@ -3321,8 +2709,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_running_not_consumed",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
 
     expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
@@ -3496,8 +2882,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_restart_pending",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
 
     const sendMessage = mock(
@@ -3564,8 +2948,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "agent_task",
       sourceId: "task_done",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
     });
 
     await new TaskHandleStore(config).upsertWorkspaceTurn({
@@ -4358,8 +3740,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_handle",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "error",
     });
     await terminalAttentionStore.markDelivered(parentId, "workspace_turn:wst_handle");
     const muxMetadata = {
@@ -4385,8 +3765,6 @@ describe("TaskService", () => {
       parts: [{ type: "text", text: "Recovered after retry" }],
     });
 
-    const notification = await terminalAttentionStore.get(parentId, "workspace_turn:wst_handle");
-    expect(notification).toMatchObject({ terminalOutcome: "completed" });
     expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
       status: "completed",
       reportMarkdown: "Recovered after retry",
@@ -4662,8 +4040,6 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       sourceKind: "workspace_turn",
       sourceId: "wst_handle",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "interrupted",
     });
     await terminalAttentionStore.markDelivered(parentId, "workspace_turn:wst_handle");
     const internal = taskService as unknown as {
@@ -10266,7 +9642,7 @@ describe("TaskService", () => {
     );
   });
 
-  test("tasks-completed auto-resume preserves parent agentId from history", async () => {
+  test("terminal report resumes the parent from history without a handoff prompt", async () => {
     const config = await createTestConfig(rootDir);
 
     const projectPath = path.join(rootDir, "repo");
@@ -10295,7 +9671,7 @@ describe("TaskService", () => {
     );
 
     const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks();
     const { historyService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -10340,25 +9716,17 @@ describe("TaskService", () => {
       ],
     });
 
-    // The completed-subagent wake-up is delivered by the async terminal-attention drain.
+    // The terminal report resumes the parent through the async attention drain.
     await Promise.all([
       ...(taskService as unknown as { pendingTerminalAttentionDrains: Set<Promise<void>> })
         .pendingTerminalAttentionDrains,
     ]);
 
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const handoffPrompt = (sendMessage as unknown as { mock: { calls: Array<[string, string]> } })
-      .mock.calls[0]?.[1];
-    assert(typeof handoffPrompt === "string", "tasks-completed handoff prompt is required");
-    expect(handoffPrompt).toContain("structured outputs");
-    expect(handoffPrompt).not.toContain("task_await");
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(
       parentWorkspaceId,
-      expect.stringContaining("Background sub-agent task(s) have completed"),
-      expect.objectContaining({
-        agentId: "plan",
-      }),
-      expect.objectContaining({ skipAutoResumeReset: true, synthetic: true })
+      expect.objectContaining({ agentId: "plan" }),
+      { agentInitiated: true }
     );
 
     const parentHistory = await collectFullHistory(historyService, parentWorkspaceId);
@@ -10366,6 +9734,7 @@ describe("TaskService", () => {
     expect(serializedParentHistory).toContain("<mux_subagent_report>");
     expect(serializedParentHistory).toContain("structuredOutput");
     expect(serializedParentHistory).toContain("claims");
+    expect(serializedParentHistory).not.toContain("Background sub-agent task(s) have completed");
   });
 
   test("waitForAgentReport surfaces the child's report-time AI settings", async () => {
@@ -10430,7 +9799,7 @@ describe("TaskService", () => {
     expect(report.thinkingLevel).toBe("high");
   });
 
-  test("workflow-owned child reports do not trigger generic parent handoff", async () => {
+  test("workflow-owned child reports do not resume the parent directly", async () => {
     const config = await createTestConfig(rootDir);
 
     const projectPath = path.join(rootDir, "repo");
@@ -10487,234 +9856,6 @@ describe("TaskService", () => {
     expect(sendMessage).not.toHaveBeenCalled();
     const parentHistory = await collectFullHistory(historyService, parentWorkspaceId);
     expect(JSON.stringify(parentHistory)).not.toContain("<mux_subagent_report>");
-  });
-
-  test("pending injected report wake-up drains after foreground-awaited sibling completes", async () => {
-    const config = await createTestConfig(rootDir);
-
-    const projectPath = path.join(rootDir, "repo");
-    const parentWorkspaceId = "parent-pending-sibling-report";
-    const backgroundChildId = "task-background-report";
-    const foregroundChildId = "task-foreground-report";
-
-    await saveWorkspaces(
-      config,
-      projectPath,
-      [
-        projectWorkspace(projectPath, "parent", parentWorkspaceId, {
-          aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" },
-        }),
-        projectWorkspace(projectPath, "background-child", backgroundChildId, {
-          parentWorkspaceId,
-          agentType: "explore",
-          taskStatus: "running",
-          taskAttentionPolicy: "notify_on_terminal",
-          taskModelString: "openai:gpt-5.2",
-          taskThinkingLevel: "medium",
-        }),
-        projectWorkspace(projectPath, "foreground-child", foregroundChildId, {
-          parentWorkspaceId,
-          agentType: "explore",
-          taskStatus: "running",
-          taskModelString: "openai:gpt-5.2",
-          taskThinkingLevel: "medium",
-        }),
-      ],
-      testTaskSettings()
-    );
-
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
-    const { taskService } = createTaskServiceHarness(config, {
-      aiService,
-      workspaceService,
-    });
-
-    const foregroundWaiter = taskService.waitForAgentReport(foregroundChildId, {
-      timeoutMs: 10_000,
-      requestingWorkspaceId: parentWorkspaceId,
-    });
-
-    await handleTaskServiceStreamEndForTest(taskService, {
-      type: "stream-end",
-      workspaceId: backgroundChildId,
-      messageId: "assistant-background-output",
-      metadata: { model: "openai:gpt-5.2", finishReason: "stop" },
-      parts: [
-        {
-          type: "dynamic-tool",
-          toolCallId: "agent-report-call-background",
-          toolName: "agent_report",
-          input: { reportMarkdown: "Background result", title: "Background" },
-          state: "output-available",
-          output: { success: true },
-        },
-        { type: "text", text: "Background result" },
-      ],
-    });
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(await terminalAttentionStore.listPending(parentWorkspaceId)).toHaveLength(1);
-    expect(sendMessage).not.toHaveBeenCalled();
-
-    await handleTaskServiceStreamEndForTest(taskService, {
-      type: "stream-end",
-      workspaceId: foregroundChildId,
-      messageId: "assistant-foreground-output",
-      metadata: { model: "openai:gpt-5.2", finishReason: "stop" },
-      parts: [
-        {
-          type: "dynamic-tool",
-          toolCallId: "agent-report-call-foreground",
-          toolName: "agent_report",
-          input: { reportMarkdown: "Foreground result", title: "Foreground" },
-          state: "output-available",
-          output: { success: true },
-        },
-        { type: "text", text: "Foreground result" },
-      ],
-    });
-
-    const foregroundReport = await foregroundWaiter;
-    expect(foregroundReport.reportMarkdown).toBe("Foreground result");
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledWith(
-      parentWorkspaceId,
-      expect.stringContaining("Background sub-agent task(s) have completed"),
-      expect.anything(),
-      expect.objectContaining({ skipAutoResumeReset: true, synthetic: true })
-    );
-    expect(await terminalAttentionStore.listPending(parentWorkspaceId)).toHaveLength(0);
-  });
-
-  test("foreground waiter suppresses tasks-completed auto-resume notification", async () => {
-    const config = await createTestConfig(rootDir);
-
-    const projectPath = path.join(rootDir, "repo");
-    const parentWorkspaceId = "parent-111";
-    const childTaskId = "task-222";
-
-    await saveWorkspaces(
-      config,
-      projectPath,
-      [
-        projectWorkspace(projectPath, "parent", parentWorkspaceId, {
-          aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" },
-        }),
-        {
-          path: path.join(projectPath, "child-task"),
-          id: childTaskId,
-          name: "agent_explore_child",
-          parentWorkspaceId,
-          agentType: "explore",
-          taskStatus: "running",
-          taskModelString: "openai:gpt-5.2",
-          taskThinkingLevel: "medium",
-        },
-      ],
-      testTaskSettings()
-    );
-
-    const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
-    const { taskService } = createTaskServiceHarness(config, {
-      aiService,
-      workspaceService,
-    });
-
-    const waiter = taskService.waitForAgentReport(childTaskId, {
-      timeoutMs: 10_000,
-      requestingWorkspaceId: parentWorkspaceId,
-    });
-
-    await handleTaskServiceStreamEndForTest(taskService, {
-      type: "stream-end",
-      workspaceId: childTaskId,
-      messageId: "assistant-child-output",
-      metadata: { model: "openai:gpt-5.2", finishReason: "stop" },
-      parts: [
-        {
-          type: "dynamic-tool",
-          toolCallId: "agent-report-call-1",
-          toolName: "agent_report",
-          input: { reportMarkdown: "Hello from child", title: "Result" },
-          state: "output-available",
-          output: { success: true },
-        },
-        { type: "text", text: "Hello from child" },
-      ],
-    });
-
-    const report = await waiter;
-    expect(report.reportMarkdown).toBe("Hello from child");
-    expect(report.title).toBe("Result");
-
-    expect(sendMessage).not.toHaveBeenCalledWith(
-      parentWorkspaceId,
-      expect.stringContaining("task(s) have completed"),
-      expect.anything(),
-      expect.anything()
-    );
-  });
-
-  test("hard-interrupted parent skips tasks-completed auto-resume after child report", async () => {
-    const config = await createTestConfig(rootDir);
-
-    const projectPath = path.join(rootDir, "repo");
-    const parentWorkspaceId = "parent-111";
-    const childTaskId = "task-222";
-
-    await saveWorkspaces(
-      config,
-      projectPath,
-      [
-        projectWorkspace(projectPath, "parent", parentWorkspaceId, {
-          aiSettings: { model: "openai:gpt-5.2", thinkingLevel: "medium" },
-        }),
-        {
-          path: path.join(projectPath, "child-task"),
-          id: childTaskId,
-          name: "agent_explore_child",
-          parentWorkspaceId,
-          agentType: "explore",
-          taskStatus: "running",
-          taskModelString: "openai:gpt-5.2",
-          taskThinkingLevel: "medium",
-        },
-      ],
-      testTaskSettings()
-    );
-
-    const { aiService } = createAIServiceMocks(config);
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
-    const { taskService } = createTaskServiceHarness(config, {
-      aiService,
-      workspaceService,
-    });
-
-    taskService.markParentWorkspaceInterrupted(parentWorkspaceId);
-
-    await handleTaskServiceStreamEndForTest(taskService, {
-      type: "stream-end",
-      workspaceId: childTaskId,
-      messageId: "assistant-child-output",
-      metadata: { model: "openai:gpt-5.2", finishReason: "stop" },
-      parts: [
-        {
-          type: "dynamic-tool",
-          toolCallId: "agent-report-call-1",
-          toolName: "agent_report",
-          input: { reportMarkdown: "Hello from child", title: "Result" },
-          state: "output-available",
-          output: { success: true },
-        },
-        { type: "text", text: "Hello from child" },
-      ],
-    });
-
-    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   test("sendMessageToDescendantAgentTask sends updated guidance with the child's settings", async () => {
@@ -14552,7 +13693,9 @@ describe("TaskService", () => {
       await removeWorkspaceFromTestConfig(config, workspaceId);
       return Ok(undefined);
     });
-    const { workspaceService, sendMessage, emit } = createWorkspaceServiceMocks({ remove });
+    const { workspaceService, sendMessage, resumeStream, emit } = createWorkspaceServiceMocks({
+      remove,
+    });
     const { historyService, partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -14680,17 +13823,10 @@ describe("TaskService", () => {
 
     expect(remove).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledWith(childId, true);
-    const childReportHandoffPrompt = (
-      sendMessage as unknown as { mock: { calls: Array<[string, string]> } }
-    ).mock.calls[0]?.[1];
-    assert(typeof childReportHandoffPrompt === "string", "child report handoff prompt is required");
-    expect(childReportHandoffPrompt).not.toContain("task_await");
-    expect(sendMessage).toHaveBeenCalledWith(
-      parentId,
-      expect.stringContaining("sub-agent task(s) have completed"),
-      expect.any(Object),
-      expect.objectContaining({ skipAutoResumeReset: true, synthetic: true })
-    );
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
     expect(emit).toHaveBeenCalled();
   });
 
@@ -15158,7 +14294,7 @@ describe("TaskService", () => {
     { timeout: 15_000 }
   );
 
-  test("agent_report avoids duplicate synthetic parent reports after grouped partial finalization", async () => {
+  test("grouped partial finalization exposes each terminal report exactly once", async () => {
     const parentId = "parent-best-of-no-duplicate";
     const childOneId = "child-best-of-no-duplicate-1";
     const childTwoId = "child-best-of-no-duplicate-2";
@@ -15229,10 +14365,14 @@ describe("TaskService", () => {
       reportMarkdown: "Report from child two",
       title: "Option two",
     });
+    await flushTerminalAttentionDrains(taskService);
 
-    const parentHistoryAfterSecond = await collectFullHistory(historyService, parentId);
-    expect(JSON.stringify(parentHistoryAfterSecond)).not.toContain("<mux_subagent_report>");
-    expect(JSON.stringify(parentHistoryAfterSecond)).not.toContain("Report from child two");
+    const serializedParentHistory = JSON.stringify(
+      await collectFullHistory(historyService, parentId)
+    );
+    expect(serializedParentHistory.match(/<mux_subagent_report>/g)).toHaveLength(2);
+    expect(serializedParentHistory).toContain("Report from child one");
+    expect(serializedParentHistory).toContain("Report from child two");
   });
 
   test("agent_report falls back to synthetic parent reports when grouped recovery cannot finish", async () => {
@@ -16055,9 +15195,11 @@ describe("TaskService", () => {
       await removeWorkspaceFromTestConfig(config, workspaceId);
       return Ok(undefined);
     });
-    const { workspaceService, sendMessage: sendMessageMock } = createWorkspaceServiceMocks({
-      remove,
-    });
+    const {
+      workspaceService,
+      sendMessage: sendMessageMock,
+      resumeStream,
+    } = createWorkspaceServiceMocks({ remove });
     const { historyService, partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -16145,17 +15287,10 @@ describe("TaskService", () => {
 
     expect(remove).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledWith(childId, true);
-    const fallbackHandoffPrompt = (
-      sendMessageMock as unknown as { mock: { calls: Array<[string, string]> } }
-    ).mock.calls[0]?.[1];
-    assert(typeof fallbackHandoffPrompt === "string", "fallback handoff prompt is required");
-    expect(fallbackHandoffPrompt).not.toContain("task_await");
-    expect(sendMessageMock).toHaveBeenCalledWith(
-      parentId,
-      expect.stringContaining("sub-agent task(s) have completed"),
-      expect.any(Object),
-      expect.objectContaining({ skipAutoResumeReset: true, synthetic: true })
-    );
+    expect(sendMessageMock).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
   });
 
   test("stream-end with agent_report parts finalizes report and triggers cleanup", async () => {
@@ -16186,7 +15321,7 @@ describe("TaskService", () => {
       await removeWorkspaceFromTestConfig(config, workspaceId);
       return Ok(undefined);
     });
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks({ remove });
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks({ remove });
     const { partialService, taskService } = createTaskServiceHarness(config, {
       aiService,
       workspaceService,
@@ -16228,8 +15363,9 @@ describe("TaskService", () => {
       ],
     });
 
-    // No "agent_report reminder" sendMessage should fire (the report was in stream-end parts).
-    // The only sendMessage call should be the parent auto-resume after the child reports.
+    await flushTerminalAttentionDrains(taskService);
+
+    // No agent_report reminder or handoff message should fire; the parent resumes from history.
     const sendCalls = (sendMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls;
     for (const call of sendCalls) {
       const msg = call[1] as string;
@@ -16268,8 +15404,10 @@ describe("TaskService", () => {
 
     expect(remove).toHaveBeenCalledTimes(1);
     expect(remove).toHaveBeenCalledWith(childId, true);
-    // Parent auto-resume fires after the child report is finalized at stream-end.
-    expect(sendMessage).toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
   });
 
   test("agent_report attributes child usage to parent goal and emits one child-budget toast", async () => {
@@ -16408,7 +15546,6 @@ describe("TaskService", () => {
       turnsUsed: 2,
       attributedChildren: [childUnderId, childOverId],
     });
-    expect(emitChatEvent).toHaveBeenCalledTimes(1);
     expect(emitChatEvent).toHaveBeenCalledWith(
       parentId,
       expect.objectContaining({
@@ -16945,106 +16082,6 @@ describe("TaskService", () => {
     expect(sendMessage.mock.calls[1]?.[1]).toContain("Found a second issue.");
     expect(findWorkspaceInConfig(config, childId)?.taskStatus).toBe("running");
     expect(await readSubagentReportArtifact(config.getSessionDir(parentId), childId)).toBeNull();
-  });
-
-  test("terminal report becomes a visible card without a second parent response after progress was answered", async () => {
-    const config = await createTestConfig(rootDir);
-    const projectPath = path.join(rootDir, "repo");
-    const parentId = "parent-progress-terminal-card";
-    const childId = "child-progress-terminal-card";
-
-    await saveWorkspaces(
-      config,
-      projectPath,
-      [
-        projectWorkspace(projectPath, "parent", parentId),
-        projectWorkspace(projectPath, "child", childId, {
-          name: "agent_explore_child",
-          parentWorkspaceId: parentId,
-          agentType: "explore",
-          taskStatus: "running",
-          taskAttentionPolicy: "notify_on_terminal",
-        }),
-      ],
-      testTaskSettings()
-    );
-
-    const { workspaceService, sendMessage, emitChatEvent } = createWorkspaceServiceMocks();
-    const aiMocks = createAIServiceMocks(config, {
-      isStreaming: mock(() => true),
-      getStreamInfo: mock(() => ({
-        messageId: "parent-active-assistant",
-        model: "openai:gpt-5",
-        historySequence: 9,
-        startTime: 1,
-        parts: [
-          { type: "reasoning" as const, text: "reasoning " },
-          { type: "reasoning" as const, text: "before report" },
-        ],
-        toolCompletionTimestamps: new Map(),
-      })),
-    });
-    const { historyService, taskService } = createTaskServiceHarness(config, {
-      workspaceService,
-      aiService: aiMocks.aiService,
-    });
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage(
-        "accepted-progress",
-        "user",
-        formatSubagentReportEnvelope({
-          taskId: childId,
-          agentType: "explore",
-          status: "in_progress",
-          title: "Progress",
-          reportMarkdown: "Initial investigation complete.",
-        }),
-        { timestamp: Date.now(), synthetic: true }
-      )
-    );
-    await historyService.appendToHistory(
-      parentId,
-      createMuxMessage("progress-answer", "assistant", "I incorporated the progress update.", {
-        timestamp: Date.now(),
-      })
-    );
-
-    await handleTaskServiceStreamEndForTest(taskService, {
-      type: "stream-end",
-      workspaceId: childId,
-      messageId: "assistant-terminal-report",
-      metadata: { model: "openai:gpt-4o-mini", finishReason: "stop" },
-      parts: [{ type: "text", text: "Final investigation result." }],
-    });
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    const parentHistory = await collectFullHistory(historyService, parentId);
-    const completedReport = parentHistory.find((message) => {
-      const text = message.parts
-        .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
-        .map((part) => part.text)
-        .join("\n");
-      const report = parseSubagentReportEnvelope(text);
-      return report?.taskId === childId && report.status === "completed";
-    });
-    expect(completedReport?.metadata).toMatchObject({
-      synthetic: true,
-      uiVisible: true,
-      transcriptAnchor: {
-        messageId: "parent-active-assistant",
-        historySequence: 9,
-        textLength: 0,
-        reasoningLength: 23,
-        partIndex: 1,
-      },
-    });
-    expect(emitChatEvent).toHaveBeenCalledTimes(1);
-    expect(emitChatEvent.mock.calls[0]?.[1]).toMatchObject({
-      id: completedReport?.id,
-      metadata: { transcriptAnchor: completedReport?.metadata?.transcriptAnchor },
-    });
   });
 
   test("terminal reports supersede queued incremental updates for the same child", async () => {
@@ -20175,7 +19212,7 @@ describe("TaskService", () => {
       testTaskSettings(1, 3)
     );
 
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks();
     const { taskService, historyService } = createTaskServiceHarness(config, { workspaceService });
 
     const internal = taskService as unknown as {
@@ -20199,10 +19236,9 @@ describe("TaskService", () => {
       errorType: "authentication",
     });
 
-    // One recovery prompt to the child (stream-end), then — after the terminal
-    // settlement — one failure handoff waking the idle parent (no waiter).
+    // The child gets one recovery prompt; terminal failure resumes the parent directly from history.
     await flushTerminalAttentionDrains(taskService);
-    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenNthCalledWith(
       1,
       childId,
@@ -20210,7 +19246,9 @@ describe("TaskService", () => {
       expect.any(Object),
       expect.objectContaining({ synthetic: true, agentInitiated: true })
     );
-    expect(sendMessage.mock.calls[1]?.[0]).toBe(parentId);
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
     // The failure details travel via the durable synthetic history message,
     // not the generic wake-up prompt.
     const serializedParentHistory = JSON.stringify(
@@ -20320,7 +19358,7 @@ describe("TaskService", () => {
       testTaskSettings(1, 3)
     );
 
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks();
     const { taskService } = createTaskServiceHarness(config, { workspaceService });
 
     const internal = taskService as unknown as {
@@ -20338,12 +19376,12 @@ describe("TaskService", () => {
       errorType: "model_refusal",
     });
 
-    // No agent_report recovery prompt goes to the child. The only send is the
-    // failure handoff waking the idle parent (no foreground waiter existed).
+    // No recovery prompt goes to the child; the parent resumes from the durable failure row.
     await flushTerminalAttentionDrains(taskService);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[0]).toBe(parentId);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("failed terminally");
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
 
     const postCfg = config.loadConfigOrDefault();
     const childWorkspace = Array.from(postCfg.projects.values())
@@ -20528,7 +19566,7 @@ describe("TaskService", () => {
       testTaskSettings(2, 3)
     );
 
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks();
     const { taskService, historyService } = createTaskServiceHarness(config, { workspaceService });
 
     const internal = taskService as unknown as {
@@ -20558,15 +19596,15 @@ describe("TaskService", () => {
       errorType: "model_refusal",
     });
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).not.toHaveBeenCalled();
     const messagesAfterFirstFailure = await readParentFailureMessages();
     expect(messagesAfterFirstFailure).toHaveLength(1);
     expect(messagesAfterFirstFailure[0]).toContain(childAId);
     expect(messagesAfterFirstFailure[0]).toContain("model_refusal");
     expect(messagesAfterFirstFailure[0]).toContain(refusalMessage);
 
-    // Last background child refuses with no foreground waiter: its failure is
-    // appended too, and the idle parent gets exactly one synthetic wake-up so
-    // it does not sit at taskStatus "running" until a timeout or manual await.
+    // Last background child refuses with no foreground waiter: its failure is appended too,
+    // and the idle parent resumes once from the durable failure rows.
     await internal.handleTaskStreamError({
       type: "error",
       workspaceId: childBId,
@@ -20580,13 +19618,10 @@ describe("TaskService", () => {
     expect(messagesAfterSecondFailure[1]).toContain(childBId);
 
     await flushTerminalAttentionDrains(taskService);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[0]).toBe(parentId);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("failed terminally");
-    expect(sendMessage.mock.calls[0]?.[3]).toMatchObject({
-      synthetic: true,
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledTimes(1);
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
       agentInitiated: true,
-      skipAutoResumeReset: true,
     });
   });
 
@@ -20671,7 +19706,7 @@ describe("TaskService", () => {
       testTaskSettings(1, 3)
     );
 
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { workspaceService, sendMessage, resumeStream } = createWorkspaceServiceMocks();
     const { taskService } = createTaskServiceHarness(config, { workspaceService });
 
     const internal = taskService as unknown as {
@@ -20687,11 +19722,12 @@ describe("TaskService", () => {
       errorType: "empty_output",
     });
 
-    // Breaker tripped: no further recovery prompt to the child; the task
-    // settles terminally and the only send wakes the idle parent.
+    // Breaker tripped: no further recovery prompt; the parent resumes from the failure row.
     await flushTerminalAttentionDrains(taskService);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[0]).toBe(parentId);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(resumeStream).toHaveBeenCalledWith(parentId, expect.any(Object), {
+      agentInitiated: true,
+    });
 
     const postCfg = config.loadConfigOrDefault();
     const childWorkspace = Array.from(postCfg.projects.values())

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2630,6 +2630,53 @@ describe("TaskService", () => {
     ).toMatchObject({ status: "superseded" });
   });
 
+  test("persistent prompt-free resume failures stay pending without an idle retry loop", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const taskId = "task-persistent-resume-error";
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: taskId,
+    });
+
+    const resumeStream = mock(
+      (): Promise<Result<{ started: boolean }, SendMessageError>> =>
+        Promise.resolve(Err({ type: "unknown", raw: "Budget gate rejected the model" }))
+    );
+    const waitForIdleAndNoQueuedMessages = mock((): Promise<void> => Promise.resolve());
+    const { workspaceService } = createWorkspaceServiceMocks({
+      resumeStream,
+      waitForIdleAndNoQueuedMessages,
+    });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage(
+        "terminal-report",
+        "user",
+        formatSubagentReportEnvelope({
+          taskId,
+          agentType: "explore",
+          status: "completed",
+          title: "Result",
+          reportMarkdown: "Ready for synthesis.",
+        }),
+        { timestamp: Date.now(), synthetic: true, uiVisible: true }
+      )
+    );
+
+    const internal = taskService as unknown as {
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.drainTerminalAttention(parentId);
+
+    expect(resumeStream).toHaveBeenCalledTimes(1);
+    expect(waitForIdleAndNoQueuedMessages).not.toHaveBeenCalled();
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
+  });
+
   test("terminal workflow wake-up reconstructs durable result context", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);
@@ -2790,38 +2837,6 @@ describe("TaskService", () => {
       expect.objectContaining({ synthetic: true, agentInitiated: true })
     );
     expect(findWorkspaceInConfig(config, childTaskId)?.taskPendingGuidance).toBeUndefined();
-  });
-
-  test("initialize drains persisted terminal wake-ups from before restart", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "workspace_turn",
-      sourceId: "wst_restart_pending",
-    });
-
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-
-    await taskService.initialize();
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage.mock.calls[0]?.[0]).toBe(parentId);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("wst_restart_pending");
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("timeout_secs: 0");
-    expect(sendMessage.mock.calls[0]?.[3]).toMatchObject({
-      synthetic: true,
-      agentInitiated: true,
-      requireIdle: true,
-    });
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
   });
 
   test("initialize recovers terminal notify workspace turns without pending notification", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2541,6 +2541,95 @@ describe("TaskService", () => {
     expect(drained).toBeDefined();
   });
 
+  test("does not consume a terminal report from a request that never included it", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const taskId = "task-raced-request-snapshot";
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: taskId,
+    });
+
+    const { historyService, taskService } = createTaskServiceHarness(config);
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("original-user", "user", "Start work", { timestamp: Date.now() })
+    );
+    const reportMessage = createMuxMessage(
+      "terminal-report",
+      "user",
+      formatSubagentReportEnvelope({
+        taskId,
+        agentType: "explore",
+        status: "completed",
+        title: "Result",
+        reportMarkdown: "Finished after the request snapshot.",
+      }),
+      { timestamp: Date.now(), synthetic: true, uiVisible: true }
+    );
+    await historyService.appendToHistory(parentId, reportMessage);
+    const reportSequence = reportMessage.metadata?.historySequence;
+    assert(typeof reportSequence === "number", "report history sequence is required");
+
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("stale-assistant", "assistant", "Response to the earlier request", {
+        timestamp: Date.now(),
+        requestHistorySequence: reportSequence - 1,
+      })
+    );
+    const internal = taskService as unknown as {
+      consumeRespondedAgentTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.consumeRespondedAgentTerminalAttention(parentId);
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
+
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("informed-assistant", "assistant", "Response including the report", {
+        timestamp: Date.now(),
+        requestHistorySequence: reportSequence,
+      })
+    );
+    await internal.consumeRespondedAgentTerminalAttention(parentId);
+    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
+  });
+
+  test("orphaned agent attention does not block unrelated terminal work", async () => {
+    const config = await createTestConfig(rootDir);
+    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "agent_task",
+      sourceId: "orphaned-agent-task",
+    });
+    await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: parentId,
+      sourceKind: "workspace_turn",
+      sourceId: "wst_valid",
+    });
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const internal = taskService as unknown as {
+      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
+    };
+    await internal.drainTerminalAttention(parentId);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      parentId,
+      expect.stringContaining("wst_valid"),
+      expect.any(Object),
+      expect.any(Object)
+    );
+    expect(
+      await terminalAttentionStore.get(parentId, "agent_task:orphaned-agent-task")
+    ).toMatchObject({ status: "superseded" });
+  });
+
   test("terminal workflow wake-up reconstructs durable result context", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId } = await saveLocalParentWorkspace(config, rootDir);
@@ -2587,176 +2676,6 @@ describe("TaskService", () => {
     expect(prompt).toContain("mux_workflow_result");
     expect(prompt).toContain("Workflow finished");
     expect(prompt).toContain(runId);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("workflow task_await consumption tombstones later terminal wake-ups", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const runId = "wfr_consumed_terminal_notify";
-    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(parentId) });
-    await runStore.createRun({
-      id: runId,
-      workspaceId: parentId,
-      workflow: {
-        name: "consumed",
-        description: "Consumed workflow",
-        scope: "built-in",
-        executable: true,
-      },
-      source: "export default function workflow() { return { reportMarkdown: 'consumed' }; }\n",
-      args: {},
-      attentionPolicy: "notify_on_terminal",
-      now: "2026-06-19T00:00:00.000Z",
-    });
-    await runStore.appendStatus(runId, "running", "2026-06-19T00:00:01.000Z");
-    await runStore.appendNextEvent(runId, {
-      type: "result",
-      at: "2026-06-19T00:00:02.000Z",
-      result: { reportMarkdown: "Already consumed" },
-    });
-    await runStore.appendStatus(runId, "completed", "2026-06-19T00:00:03.000Z");
-
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-
-    await taskService.markWorkflowRunTerminalAttentionConsumed({
-      ownerWorkspaceId: parentId,
-      runId,
-      status: "completed",
-    });
-    await taskService.enqueueWorkflowRunTerminalAttention({
-      ownerWorkspaceId: parentId,
-      runId,
-      status: "completed",
-    });
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-
-    await taskService.resetWorkflowRunTerminalAttention({ ownerWorkspaceId: parentId, runId });
-    await taskService.enqueueWorkflowRunTerminalAttention({
-      ownerWorkspaceId: parentId,
-      runId,
-      status: "completed",
-    });
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("Already consumed");
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-  });
-
-  test("workspace turn task_await consumption tombstones later terminal wake-ups", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      enqueueTerminalAttention: (params: {
-        ownerWorkspaceId: string;
-        sourceKind: "workspace_turn";
-        sourceId: string;
-      }) => Promise<void>;
-      drainTerminalAttention: (ownerWorkspaceId: string) => Promise<void>;
-    };
-
-    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
-      ownerWorkspaceId: parentId,
-      handleId: "wst_consumed_then_enqueued",
-      status: "completed",
-    });
-    await internal.enqueueTerminalAttention({
-      ownerWorkspaceId: parentId,
-      sourceKind: "workspace_turn",
-      sourceId: "wst_consumed_then_enqueued",
-    });
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "workspace_turn",
-      sourceId: "wst_pending_then_consumed",
-    });
-    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
-      ownerWorkspaceId: parentId,
-      handleId: "wst_pending_then_consumed",
-      status: "completed",
-    });
-    await internal.drainTerminalAttention(parentId);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
-
-    await taskService.markWorkspaceTurnTerminalAttentionConsumed({
-      ownerWorkspaceId: parentId,
-      handleId: "wst_running_not_consumed",
-      status: "running",
-    });
-    await terminalAttentionStore.enqueueIfAbsent({
-      ownerWorkspaceId: parentId,
-      sourceKind: "workspace_turn",
-      sourceId: "wst_running_not_consumed",
-    });
-
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-  });
-
-  test("startup recovery persists terminal workflow wake-ups", async () => {
-    const config = await createTestConfig(rootDir);
-    const { parentId } = await saveLocalParentWorkspace(config, rootDir);
-    const runId = "wfr_recovered_terminal_notify";
-    const runStore = new WorkflowRunStore({ sessionDir: config.getSessionDir(parentId) });
-    await runStore.createRun({
-      id: runId,
-      workspaceId: parentId,
-      workflow: {
-        name: "recovered",
-        description: "Recovered workflow",
-        scope: "built-in",
-        executable: true,
-      },
-      source: "export default function workflow() { return { reportMarkdown: 'recovered' }; }\n",
-      args: {},
-      attentionPolicy: "notify_on_terminal",
-      now: "2026-06-19T00:00:00.000Z",
-    });
-    await runStore.appendStatus(runId, "running", "2026-06-19T00:00:01.000Z");
-    await runStore.appendNextEvent(runId, {
-      type: "result",
-      at: "2026-06-19T00:00:02.000Z",
-      result: { reportMarkdown: "Recovered workflow result" },
-    });
-    await runStore.appendStatus(runId, "completed", "2026-06-19T00:00:03.000Z");
-
-    const terminalAttentionStore = new TerminalAttentionStore(config);
-    const sendMessage = mock(
-      (..._args: unknown[]): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-    );
-    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
-    const internal = taskService as unknown as {
-      recoverTerminalWorkflowRunAttentionNotifications: () => Promise<number>;
-    };
-
-    expect(await internal.recoverTerminalWorkflowRunAttentionNotifications()).toBe(1);
-    expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(1);
-    await flushTerminalAttentionDrains(taskService);
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(String(sendMessage.mock.calls[0]?.[1])).toContain("Recovered workflow result");
     expect(await terminalAttentionStore.listPending(parentId)).toHaveLength(0);
   });
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -99,7 +99,6 @@ import {
   type ParsedThinkingInput,
   type ThinkingLevel,
 } from "@/common/types/thinking";
-import { snapshotTranscriptAnchor } from "@/node/services/transcriptAnchor";
 import type { ErrorEvent, StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
 import {
   isActiveWorkflowRunStatus,
@@ -155,7 +154,6 @@ import {
 import {
   TerminalAttentionStore,
   type TerminalAttentionNotification,
-  type TerminalAttentionOutcome,
 } from "@/node/services/terminalAttentionStore";
 import { readAgentWorkflowRunReferences } from "@/node/services/agentWorkflowRunReferences";
 import { isWorkflowRunTaskId } from "@/node/services/tools/taskId";
@@ -315,6 +313,13 @@ function formatSubagentReportUserMessage(params: {
   });
 }
 
+function parseTerminalSubagentTaskId(content: string): string | null {
+  const report = parseSubagentReportEnvelope(content);
+  if (report?.status === "completed") return report.taskId;
+  if (!content.startsWith(SUBAGENT_FAILURE_ENVELOPE_TAG)) return null;
+  return /<task_id>([^\n<]+)<\/task_id>/.exec(content)?.[1] ?? null;
+}
+
 // Failure twin of formatSubagentReportUserMessage: terminal child failures are
 // delivered into the parent context as an explicit failure block (never as a
 // report) so a later wake-up — by ANY sibling's settlement — cannot present the
@@ -342,27 +347,9 @@ function formatSubagentFailureUserMessage(params: {
   ].join("\n");
 }
 
-// Completed background reports are already persisted into the parent context; asking the parent
-// to call task_await burns an extra model/tool turn before it can synthesize the final answer.
-const COMPLETED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT =
-  `${BACKGROUND_WORK_WAKE_OPENINGS.subagentsCompleted} Their accepted reports and any structured outputs ` +
-  "are already injected into this workspace context as task tool results or synthetic user report " +
-  "messages. Write the final response now, integrating those results. If a required report appears " +
-  "missing, explain the missing context instead of waiting for another handoff.";
-
-// Failure twin of COMPLETED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT: the failure details
-// were already appended to the parent context as synthetic mux_subagent_failure
-// messages, so the wake-up prompt itself stays generic.
-const FAILED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT =
-  `${BACKGROUND_WORK_WAKE_OPENINGS.subagentsFailed} The failure ` +
-  "details are already injected into this workspace context as synthetic user messages. Do not " +
-  "re-await those tasks. Integrate the failures into your work now: adjust your approach (e.g. a " +
-  "different model, agent, or task design) or surface the failures in your response.";
-
 /**
- * Workspace-turn terminal output is NOT injected into parent history (unlike sub-agent reports);
- * it lives in the task handle store. So the wake-up must tell the agent to retrieve it with a
- * one-shot task_await (terminal already, timeout_secs: 0), not to keep waiting.
+ * Workspace-turn terminal output is not injected into parent history; it lives in the task handle
+ * store. The wake-up must tell the agent to retrieve it with a one-shot task_await.
  */
 function buildCompletedWorkspaceTurnPrompt(handleIds: string[]): string {
   assert(handleIds.length > 0, "buildCompletedWorkspaceTurnPrompt requires at least one handle id");
@@ -373,33 +360,6 @@ function buildCompletedWorkspaceTurnPrompt(handleIds: string[]): string {
     "retrieve their terminal output, then integrate it into your work. These handles are already " +
     "terminal — do not repeatedly wait if task_await returns a terminal status."
   );
-}
-
-function workflowRunTerminalOutcome(status: WorkflowRunStatus): TerminalAttentionOutcome {
-  switch (status) {
-    case "completed":
-      return "completed";
-    case "failed":
-      return "failed";
-    case "interrupted":
-      return "interrupted";
-    default:
-      return "error";
-  }
-}
-
-function workspaceTurnTerminalOutcome(status: WorkspaceTurnTaskStatus): TerminalAttentionOutcome {
-  switch (status) {
-    case "completed":
-      return "completed";
-    case "interrupted":
-      return "interrupted";
-    case "error":
-      return "error";
-    default:
-      // Non-terminal status should never reach the terminal notifier.
-      return "error";
-  }
 }
 
 function getTaskCompletionInstruction(params: {
@@ -5004,13 +4964,9 @@ export class TaskService {
   ): Promise<void> {
     if (isWorkspaceTurnTaskId(taskId)) {
       if (ownerWorkspaceId == null) return;
-      const pendingNotify = await this.workspaceTurnSettlementLocks.withLock(
+      const pendingHandleId = await this.workspaceTurnSettlementLocks.withLock(
         taskId,
-        async (): Promise<{
-          handleId: string;
-          outcome: TerminalAttentionOutcome;
-          title?: string;
-        } | null> => {
+        async (): Promise<string | null> => {
           const current = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, taskId);
           if (current == null) return null;
 
@@ -5030,23 +4986,16 @@ export class TaskService {
             this.isTerminalWorkspaceTurnStatus(updatedRecord.status) &&
             updatedRecord.terminalAttentionNotifiedAt == null
           ) {
-            return {
-              handleId: updatedRecord.handleId,
-              outcome: workspaceTurnTerminalOutcome(updatedRecord.status),
-              ...(updatedRecord.title != null ? { title: updatedRecord.title } : {}),
-            };
+            return updatedRecord.handleId;
           }
           return null;
         }
       );
-      if (pendingNotify != null) {
+      if (pendingHandleId != null) {
         await this.enqueueTerminalAttention({
           ownerWorkspaceId,
           sourceKind: "workspace_turn",
-          sourceId: pendingNotify.handleId,
-          outputDelivery: "requires_task_await",
-          terminalOutcome: pendingNotify.outcome,
-          ...(pendingNotify.title != null ? { title: pendingNotify.title } : {}),
+          sourceId: pendingHandleId,
         });
         await this.workspaceTurnSettlementLocks.withLock(taskId, async () => {
           const terminal = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, taskId);
@@ -5106,8 +5055,6 @@ export class TaskService {
             ownerWorkspaceId: workspace.id,
             sourceKind: "workflow_run",
             sourceId: run.id,
-            outputDelivery: "workflow_result_context",
-            terminalOutcome: workflowRunTerminalOutcome(run.status),
           });
           if (created != null) {
             this.scheduleTerminalAttentionDrain(workspace.id);
@@ -5135,9 +5082,6 @@ export class TaskService {
         ownerWorkspaceId: record.ownerWorkspaceId,
         sourceKind: "workspace_turn",
         sourceId: record.handleId,
-        outputDelivery: "requires_task_await",
-        terminalOutcome: workspaceTurnTerminalOutcome(record.status),
-        ...(record.title != null ? { title: record.title } : {}),
       });
       await this.workspaceTurnSettlementLocks.withLock(record.handleId, async () => {
         const current = await this.taskHandleStore.getWorkspaceTurn(
@@ -5189,8 +5133,6 @@ export class TaskService {
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workflow_run",
       sourceId: params.runId,
-      outputDelivery: "workflow_result_context",
-      terminalOutcome: workflowRunTerminalOutcome(params.status),
     });
   }
 
@@ -5226,8 +5168,6 @@ export class TaskService {
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workflow_run",
       sourceId: params.runId,
-      outputDelivery: "workflow_result_context",
-      terminalOutcome: workflowRunTerminalOutcome(params.status),
     });
     await this.terminalAttentionStore.markDelivered(
       params.ownerWorkspaceId,
@@ -5255,8 +5195,6 @@ export class TaskService {
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workspace_turn",
       sourceId: params.handleId,
-      outputDelivery: "requires_task_await",
-      terminalOutcome: workspaceTurnTerminalOutcome(params.status),
     });
     await this.terminalAttentionStore.markDelivered(
       params.ownerWorkspaceId,
@@ -5268,9 +5206,6 @@ export class TaskService {
     ownerWorkspaceId: string;
     sourceKind: TerminalAttentionNotification["sourceKind"];
     sourceId: string;
-    outputDelivery: TerminalAttentionNotification["outputDelivery"];
-    terminalOutcome: TerminalAttentionOutcome;
-    title?: string;
   }): Promise<void> {
     const created = await this.terminalAttentionStore.enqueueIfAbsent(params);
     if (created == null) {
@@ -5354,80 +5289,120 @@ export class TaskService {
     });
   }
 
-  private async findProgressRespondedTaskIds(
+  private async ensureAgentTerminalMessages(
     ownerWorkspaceId: string,
-    candidateTaskIds: ReadonlySet<string>
-  ): Promise<Set<string>> {
-    if (candidateTaskIds.size === 0) return new Set<string>();
+    notifications: readonly TerminalAttentionNotification[]
+  ): Promise<boolean> {
+    if (notifications.length === 0) return true;
 
-    const visibleCompletedReports = new Set<string>();
+    const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
+    if (!historyResult.success) return false;
+    const existingTaskIds = new Set<string>();
+    for (const message of historyResult.data) {
+      if (message.role !== "user" || message.metadata?.synthetic !== true) continue;
+      const taskId = parseTerminalSubagentTaskId(
+        message.parts
+          .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
+          .map((part) => part.text)
+          .join("\n")
+      );
+      if (taskId != null) existingTaskIds.add(taskId);
+    }
+
+    const sessionDir = this.config.getSessionDir(ownerWorkspaceId);
+    for (const notification of notifications) {
+      if (existingTaskIds.has(notification.sourceId)) continue;
+
+      const report = await readSubagentReportArtifact(sessionDir, notification.sourceId);
+      const failure =
+        report == null
+          ? await readSubagentFailureArtifact(sessionDir, notification.sourceId)
+          : null;
+      const content = report
+        ? formatSubagentReportUserMessage({
+            childWorkspaceId: notification.sourceId,
+            agentType: "agent",
+            title: report.title ?? "Subagent report",
+            reportMarkdown: report.reportMarkdown,
+            status: "completed",
+            ...(report.model != null ? { model: report.model } : {}),
+            ...(report.thinkingLevel != null ? { thinkingLevel: report.thinkingLevel } : {}),
+            ...(report.structuredOutput !== undefined
+              ? { structuredOutput: report.structuredOutput }
+              : {}),
+          })
+        : failure
+          ? formatSubagentFailureUserMessage({
+              childWorkspaceId: notification.sourceId,
+              agentType: "agent",
+              errorType: failure.errorType,
+              errorMessage: failure.errorMessage,
+            })
+          : null;
+      if (content == null) {
+        log.warn("Terminal sub-agent attention has no durable result", {
+          ownerWorkspaceId,
+          taskId: notification.sourceId,
+        });
+        return false;
+      }
+
+      const message = createMuxMessage(
+        report != null ? createTaskReportMessageId() : createTaskFailureMessageId(),
+        "user",
+        content,
+        { timestamp: Date.now(), synthetic: true, uiVisible: true }
+      );
+      const appendResult = await this.historyService.appendToHistory(ownerWorkspaceId, message);
+      if (!appendResult.success) return false;
+      this.workspaceService.emitChatEvent(ownerWorkspaceId, { ...message, type: "message" });
+    }
+    return true;
+  }
+
+  private async consumeRespondedAgentTerminalAttention(ownerWorkspaceId: string): Promise<void> {
+    const pending = (await this.terminalAttentionStore.listPending(ownerWorkspaceId)).filter(
+      (notification) => notification.sourceKind === "agent_task"
+    );
+    if (pending.length === 0) return;
+
+    const pendingIds = new Set(pending.map((notification) => notification.sourceId));
     const awaitingResponse = new Set<string>();
     const responded = new Set<string>();
-    // The duplicate-ending decision only depends on the active context epoch. If compaction already
-    // summarized an older progress turn, retain the terminal wake rather than scanning lifetime history.
     const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
     if (!historyResult.success) {
-      log.warn("Failed to inspect progress wake responses", {
+      log.warn("Failed to inspect terminal sub-agent responses", {
         ownerWorkspaceId,
         error: historyResult.error,
       });
-      return new Set<string>();
+      return;
     }
+
     for (const message of historyResult.data) {
       if (message.role === "user" && message.metadata?.synthetic === true) {
         const text = message.parts
           .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
           .map((part) => part.text)
           .join("\n");
-        const report = parseSubagentReportEnvelope(text);
-        if (
-          report?.status === "completed" &&
-          message.metadata?.uiVisible === true &&
-          candidateTaskIds.has(report.taskId)
-        ) {
-          visibleCompletedReports.add(report.taskId);
-        }
-        if (report?.status === "in_progress" && candidateTaskIds.has(report.taskId)) {
-          // A newer update requires a newer assistant response before terminal handoff can be
-          // suppressed. This avoids hiding a final result behind an unprocessed progress update.
-          awaitingResponse.add(report.taskId);
-          responded.delete(report.taskId);
+        const taskId = parseTerminalSubagentTaskId(text);
+        if (taskId != null && pendingIds.has(taskId)) {
+          awaitingResponse.add(taskId);
+          responded.delete(taskId);
         }
         continue;
       }
 
       if (message.role === "assistant" && message.metadata?.partial !== true) {
-        for (const taskId of awaitingResponse) {
-          responded.add(taskId);
-        }
+        for (const taskId of awaitingResponse) responded.add(taskId);
         awaitingResponse.clear();
       }
     }
-    return new Set([...responded].filter((taskId) => visibleCompletedReports.has(taskId)));
-  }
 
-  private async hasAcceptedSubagentProgressReport(
-    ownerWorkspaceId: string,
-    taskId: string
-  ): Promise<boolean> {
-    const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
-    if (!historyResult.success) {
-      log.warn("Failed to inspect accepted subagent progress reports", {
-        ownerWorkspaceId,
-        taskId,
-        error: historyResult.error,
-      });
-      return false;
+    for (const notification of pending) {
+      if (responded.has(notification.sourceId)) {
+        await this.terminalAttentionStore.markDelivered(ownerWorkspaceId, notification.id);
+      }
     }
-    return historyResult.data.some((message) => {
-      if (message.role !== "user" || message.metadata?.synthetic !== true) return false;
-      const text = message.parts
-        .filter((part): part is Extract<typeof part, { type: "text" }> => part.type === "text")
-        .map((part) => part.text)
-        .join("\n");
-      const report = parseSubagentReportEnvelope(text);
-      return report?.taskId === taskId && report.status === "in_progress";
-    });
   }
 
   /**
@@ -5474,66 +5449,21 @@ export class TaskService {
       return;
     }
 
-    const suppressibleTaskIds = new Set(
-      pending
-        .filter(
-          (notification) =>
-            notification.sourceKind === "agent_task" &&
-            notification.outputDelivery === "already_injected" &&
-            notification.terminalOutcome === "completed"
-        )
-        .map((notification) => notification.sourceId)
+    const agentNotifications = pending.filter(
+      (notification) => notification.sourceKind === "agent_task"
     );
-    const respondedProgressTaskIds = await this.findProgressRespondedTaskIds(
-      ownerWorkspaceId,
-      suppressibleTaskIds
-    );
-    const effectivePending: TerminalAttentionNotification[] = [];
-    for (const notification of pending) {
-      if (
-        notification.sourceKind === "agent_task" &&
-        respondedProgressTaskIds.has(notification.sourceId)
-      ) {
-        // The parent already produced a response to this child's latest progress wake. The terminal
-        // report is persisted as a visible card, so another generic model turn would create a second
-        // ending without adding context. Keep failures and first/only completions unchanged.
-        try {
-          await this.terminalAttentionStore.markDelivered(ownerWorkspaceId, notification.id);
-        } catch (error) {
-          log.error("Failed to consume redundant subagent completion wake", {
-            ownerWorkspaceId,
-            taskId: notification.sourceId,
-            error,
-          });
-        }
-        continue;
-      }
-      effectivePending.push(notification);
+    if (!(await this.ensureAgentTerminalMessages(ownerWorkspaceId, agentNotifications))) {
+      return;
     }
-    if (effectivePending.length === 0) return;
-
-    const injectedNotifications = effectivePending.filter(
-      (n) => n.outputDelivery === "already_injected"
+    const awaitHandleIds = pending
+      .filter((notification) => notification.sourceKind === "workspace_turn")
+      .map((notification) => notification.sourceId);
+    const workflowNotifications = pending.filter(
+      (notification) => notification.sourceKind === "workflow_run"
     );
-    const injectedTaskIds = injectedNotifications.map((n) => n.sourceId);
-    const awaitHandleIds = effectivePending
-      .filter((n) => n.outputDelivery === "requires_task_await")
-      .map((n) => n.sourceId);
-    const workflowNotifications = effectivePending.filter(
-      (n) => n.outputDelivery === "workflow_result_context"
-    );
-    const anyInjectedFailure = injectedNotifications.some(
-      (n) => n.terminalOutcome === "failed" || n.terminalOutcome === "error"
-    );
+    const deliverableWorkflowNotificationIds = new Set<string>();
 
     const promptSections: string[] = [];
-    if (injectedTaskIds.length > 0) {
-      promptSections.push(
-        anyInjectedFailure
-          ? FAILED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT
-          : COMPLETED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT
-      );
-    }
     if (awaitHandleIds.length > 0) {
       promptSections.push(buildCompletedWorkspaceTurnPrompt(awaitHandleIds));
     }
@@ -5546,12 +5476,19 @@ export class TaskService {
         await this.terminalAttentionStore.markSuperseded(ownerWorkspaceId, notification.id);
         continue;
       }
+      deliverableWorkflowNotificationIds.add(notification.id);
       promptSections.push(workflowPrompt);
     }
-    if (promptSections.length === 0) {
-      return;
-    }
+
+    // Sub-agent reports and failures are already durable user-context messages. Resume from history
+    // directly instead of injecting a second user turn that merely tells the model they exist.
     const prompt = promptSections.join("\n\n");
+    const effectivePending = pending.filter(
+      (notification) =>
+        notification.sourceKind !== "workflow_run" ||
+        deliverableWorkflowNotificationIds.has(notification.id)
+    );
+    if (effectivePending.length === 0) return;
 
     const markPendingDelivered = async () => {
       for (const notification of effectivePending) {
@@ -5577,6 +5514,23 @@ export class TaskService {
       thinkingLevel: resumeOptions.thinkingLevel,
       reasoningMode: resumeOptions.reasoningMode,
     };
+    if (prompt.length === 0) {
+      assert(agentNotifications.length > 0, "prompt-free terminal drain requires sub-agent work");
+      const resumeResult = await this.workspaceService.resumeStream(ownerWorkspaceId, sendOptions, {
+        agentInitiated: true,
+      });
+      if (!resumeResult.success || !resumeResult.data.started) {
+        log.debug("Prompt-free sub-agent resume was not started; leaving attention pending", {
+          ownerWorkspaceId,
+          error: resumeResult.success ? undefined : resumeResult.error,
+        });
+        this.scheduleTerminalAttentionDrainAfterIdle(ownerWorkspaceId);
+        return;
+      }
+      await markPendingDelivered();
+      return;
+    }
+
     let sendResult = await this.workspaceService.sendMessage(
       ownerWorkspaceId,
       prompt,
@@ -5748,9 +5702,7 @@ export class TaskService {
     const pendingNotify = await this.workspaceTurnSettlementLocks.withLock(
       params.record.handleId,
       async (): Promise<
-        | { kind: "notify"; outcome: TerminalAttentionOutcome; title?: string; resettled: boolean }
-        | { kind: "drain_pending" }
-        | null
+        { kind: "notify"; resettled: boolean } | { kind: "drain_pending" } | null
       > => {
         const current = await this.taskHandleStore.getWorkspaceTurn(
           params.record.ownerWorkspaceId,
@@ -5843,12 +5795,7 @@ export class TaskService {
         if (!shouldNotify) {
           return null;
         }
-        return {
-          kind: "notify",
-          outcome: workspaceTurnTerminalOutcome(nextRecord.status),
-          resettled: resettleStaleTerminal,
-          ...(nextRecord.title != null ? { title: nextRecord.title } : {}),
-        };
+        return { kind: "notify", resettled: resettleStaleTerminal };
       }
     );
 
@@ -5875,9 +5822,6 @@ export class TaskService {
       ownerWorkspaceId: params.record.ownerWorkspaceId,
       sourceKind: "workspace_turn",
       sourceId: params.record.handleId,
-      outputDelivery: "requires_task_await",
-      terminalOutcome: pendingNotify.outcome,
-      ...(pendingNotify.title != null ? { title: pendingNotify.title } : {}),
     });
     const terminal = await this.taskHandleStore.getWorkspaceTurn(
       params.record.ownerWorkspaceId,
@@ -9408,6 +9352,11 @@ export class TaskService {
       await Promise.all([...this.pendingNotifyOnTerminalPersists]);
     }
 
+    // A parent response after a terminal report consumes that report's outbox entry. This also
+    // closes the crash-recovery path where startup auto-retry finishes a response before the
+    // terminal-attention drain gets a chance to resume it.
+    await this.consumeRespondedAgentTerminalAttention(workspaceId);
+
     // The owner's own stream ending is the signal to retry any terminal wake-ups that were deferred
     // while it was busy. Drain checks idle internally and leaves notifications pending otherwise.
     this.scheduleTerminalAttentionDrain(workspaceId);
@@ -10088,8 +10037,7 @@ export class TaskService {
    * parents (deliverReportToParent + post-report auto-resume), so terminal
    * failures must too — otherwise an idle parent stays at taskStatus "running"
    * until a timeout or manual task_await, or worse: a later sibling's report
-   * wakes it with COMPLETED_BACKGROUND_SUBAGENT_HANDOFF_PROMPT and the fanout
-   * looks fully successful. Two mirrored halves:
+   * wakes it and the fanout looks fully successful. Two mirrored halves:
    *
    * 1. Always append a synthetic mux_subagent_failure message to the parent
    *    history (the durable context delivery — survives any wake-up ordering).
@@ -10137,12 +10085,18 @@ export class TaskService {
         errorType: failure.errorType,
         errorMessage: failure.errorMessage,
       }),
-      { timestamp: Date.now(), synthetic: true }
+      { timestamp: Date.now(), synthetic: true, uiVisible: true }
     );
     const appendResult = await this.historyService.appendToHistory(
       parentWorkspaceId,
       failureMessage
     );
+    if (appendResult.success) {
+      this.workspaceService.emitChatEvent(parentWorkspaceId, {
+        ...failureMessage,
+        type: "message",
+      });
+    }
     if (!appendResult.success) {
       log.error("Failed to append synthetic subagent failure to parent history", {
         parentWorkspaceId,
@@ -10169,8 +10123,6 @@ export class TaskService {
       ownerWorkspaceId: parentWorkspaceId,
       sourceKind: "agent_task",
       sourceId: childWorkspaceId,
-      outputDelivery: "already_injected",
-      terminalOutcome: "failed",
     });
   }
 
@@ -11098,16 +11050,11 @@ export class TaskService {
       });
     }
 
-    const hadAcceptedProgressReport = await this.hasAcceptedSubagentProgressReport(
-      parentWorkspaceId,
-      childWorkspaceId
-    );
     await this.deliverReportToParent(
       parentWorkspaceId,
       childWorkspaceId,
       latestChildEntry,
-      reportArgs,
-      { uiVisible: hadAcceptedProgressReport }
+      reportArgs
     );
 
     // Resolve foreground waiters.
@@ -11151,7 +11098,7 @@ export class TaskService {
 
     if (isWorkflowOwnedChildReport) {
       // Workflow-owned tasks report through WorkflowRunner's journal/final-result path. Do not
-      // also nudge the parent model with a generic background-subagent handoff.
+      // also resume the parent directly from the child report.
       log.debug("Skipping post-report parent auto-resume for workflow-owned child", {
         parentWorkspaceId,
         childWorkspaceId,
@@ -11167,8 +11114,6 @@ export class TaskService {
       ownerWorkspaceId: parentWorkspaceId,
       sourceKind: "agent_task",
       sourceId: childWorkspaceId,
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
     });
 
     return { finalized: true };
@@ -11653,8 +11598,7 @@ export class TaskService {
       title?: string;
       structuredOutput?: unknown;
       planFilePath?: string;
-    },
-    options?: { uiVisible?: boolean }
+    }
   ): Promise<void> {
     assert(
       childWorkspaceId.length > 0,
@@ -11669,8 +11613,7 @@ export class TaskService {
           parentWorkspaceId,
           childWorkspaceId,
           childEntry,
-          report,
-          options
+          report
         );
       });
     } else {
@@ -11678,8 +11621,7 @@ export class TaskService {
         parentWorkspaceId,
         childWorkspaceId,
         childEntry,
-        report,
-        options
+        report
       );
     }
 
@@ -11697,8 +11639,7 @@ export class TaskService {
       title?: string;
       structuredOutput?: unknown;
       planFilePath?: string;
-    },
-    options?: { uiVisible?: boolean }
+    }
   ): Promise<readonly string[]> {
     const agentType = coerceNonEmptyString(childEntry?.workspace.agentType) ?? "agent";
     const childModelString = childEntry?.workspace.taskModelString;
@@ -11794,22 +11735,17 @@ export class TaskService {
     });
 
     const messageId = createTaskReportMessageId();
-    const transcriptAnchor =
-      options?.uiVisible === true
-        ? snapshotTranscriptAnchor(this.aiService.getStreamInfo(parentWorkspaceId))
-        : undefined;
     const reportMessage = createMuxMessage(messageId, "user", reportContent, {
       timestamp: Date.now(),
       synthetic: true,
-      ...(options?.uiVisible === true ? { uiVisible: true } : {}),
-      ...(transcriptAnchor ? { transcriptAnchor } : {}),
+      uiVisible: true,
     });
 
     const appendResult = await this.historyService.appendToHistory(
       parentWorkspaceId,
       reportMessage
     );
-    if (appendResult.success && options?.uiVisible === true) {
+    if (appendResult.success) {
       this.workspaceService.emitChatEvent(parentWorkspaceId, {
         ...reportMessage,
         type: "message",

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5570,11 +5570,16 @@ export class TaskService {
       const resumeResult = await this.workspaceService.resumeStream(ownerWorkspaceId, sendOptions, {
         agentInitiated: true,
       });
-      if (!resumeResult.success || !resumeResult.data.started) {
-        log.debug("Prompt-free sub-agent resume was not started; leaving attention pending", {
+      if (!resumeResult.success) {
+        // Persistent failures (for example a budget/model gate) are not made retryable by waiting for
+        // idle—the owner is already idle here. Keep the outbox entry pending for a later real signal.
+        log.warn("Prompt-free sub-agent resume failed; leaving attention pending", {
           ownerWorkspaceId,
-          error: resumeResult.success ? undefined : resumeResult.error,
+          error: resumeResult.error,
         });
+        return;
+      }
+      if (!resumeResult.data.started) {
         this.scheduleTerminalAttentionDrainAfterIdle(ownerWorkspaceId);
         return;
       }

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -154,6 +154,7 @@ import {
 import {
   TerminalAttentionStore,
   type TerminalAttentionNotification,
+  type TerminalAttentionOutcome,
 } from "@/node/services/terminalAttentionStore";
 import { readAgentWorkflowRunReferences } from "@/node/services/agentWorkflowRunReferences";
 import { isWorkflowRunTaskId } from "@/node/services/tools/taskId";
@@ -360,6 +361,21 @@ function buildCompletedWorkspaceTurnPrompt(handleIds: string[]): string {
     "retrieve their terminal output, then integrate it into your work. These handles are already " +
     "terminal — do not repeatedly wait if task_await returns a terminal status."
   );
+}
+
+function terminalAttentionOutcome(
+  status: WorkflowRunStatus | WorkspaceTurnTaskStatus
+): TerminalAttentionOutcome {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "interrupted":
+      return "interrupted";
+    default:
+      return "error";
+  }
 }
 
 function getTaskCompletionInstruction(params: {
@@ -4964,9 +4980,12 @@ export class TaskService {
   ): Promise<void> {
     if (isWorkspaceTurnTaskId(taskId)) {
       if (ownerWorkspaceId == null) return;
-      const pendingHandleId = await this.workspaceTurnSettlementLocks.withLock(
+      const pendingNotification = await this.workspaceTurnSettlementLocks.withLock(
         taskId,
-        async (): Promise<string | null> => {
+        async (): Promise<{
+          handleId: string;
+          terminalOutcome: TerminalAttentionOutcome;
+        } | null> => {
           const current = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, taskId);
           if (current == null) return null;
 
@@ -4986,16 +5005,20 @@ export class TaskService {
             this.isTerminalWorkspaceTurnStatus(updatedRecord.status) &&
             updatedRecord.terminalAttentionNotifiedAt == null
           ) {
-            return updatedRecord.handleId;
+            return {
+              handleId: updatedRecord.handleId,
+              terminalOutcome: terminalAttentionOutcome(updatedRecord.status),
+            };
           }
           return null;
         }
       );
-      if (pendingHandleId != null) {
+      if (pendingNotification != null) {
         await this.enqueueTerminalAttention({
           ownerWorkspaceId,
           sourceKind: "workspace_turn",
-          sourceId: pendingHandleId,
+          sourceId: pendingNotification.handleId,
+          terminalOutcome: pendingNotification.terminalOutcome,
         });
         await this.workspaceTurnSettlementLocks.withLock(taskId, async () => {
           const terminal = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, taskId);
@@ -5055,6 +5078,7 @@ export class TaskService {
             ownerWorkspaceId: workspace.id,
             sourceKind: "workflow_run",
             sourceId: run.id,
+            terminalOutcome: terminalAttentionOutcome(run.status),
           });
           if (created != null) {
             this.scheduleTerminalAttentionDrain(workspace.id);
@@ -5081,6 +5105,7 @@ export class TaskService {
       await this.enqueueTerminalAttention({
         ownerWorkspaceId: record.ownerWorkspaceId,
         sourceKind: "workspace_turn",
+        terminalOutcome: terminalAttentionOutcome(record.status),
         sourceId: record.handleId,
       });
       await this.workspaceTurnSettlementLocks.withLock(record.handleId, async () => {
@@ -5132,6 +5157,7 @@ export class TaskService {
     await this.enqueueTerminalAttention({
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workflow_run",
+      terminalOutcome: terminalAttentionOutcome(params.status),
       sourceId: params.runId,
     });
   }
@@ -5167,6 +5193,7 @@ export class TaskService {
     await this.terminalAttentionStore.enqueueIfAbsent({
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workflow_run",
+      terminalOutcome: terminalAttentionOutcome(params.status),
       sourceId: params.runId,
     });
     await this.terminalAttentionStore.markDelivered(
@@ -5194,6 +5221,7 @@ export class TaskService {
     await this.terminalAttentionStore.enqueueIfAbsent({
       ownerWorkspaceId: params.ownerWorkspaceId,
       sourceKind: "workspace_turn",
+      terminalOutcome: terminalAttentionOutcome(params.status),
       sourceId: params.handleId,
     });
     await this.terminalAttentionStore.markDelivered(
@@ -5205,6 +5233,7 @@ export class TaskService {
   private async enqueueTerminalAttention(params: {
     ownerWorkspaceId: string;
     sourceKind: TerminalAttentionNotification["sourceKind"];
+    terminalOutcome: TerminalAttentionOutcome;
     sourceId: string;
   }): Promise<void> {
     const created = await this.terminalAttentionStore.enqueueIfAbsent(params);
@@ -5292,11 +5321,12 @@ export class TaskService {
   private async ensureAgentTerminalMessages(
     ownerWorkspaceId: string,
     notifications: readonly TerminalAttentionNotification[]
-  ): Promise<boolean> {
-    if (notifications.length === 0) return true;
+  ): Promise<Set<string>> {
+    const deliverableIds = new Set<string>();
+    if (notifications.length === 0) return deliverableIds;
 
     const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
-    if (!historyResult.success) return false;
+    if (!historyResult.success) return deliverableIds;
     const existingTaskIds = new Set<string>();
     for (const message of historyResult.data) {
       if (message.role !== "user" || message.metadata?.synthetic !== true) continue;
@@ -5311,7 +5341,10 @@ export class TaskService {
 
     const sessionDir = this.config.getSessionDir(ownerWorkspaceId);
     for (const notification of notifications) {
-      if (existingTaskIds.has(notification.sourceId)) continue;
+      if (existingTaskIds.has(notification.sourceId)) {
+        deliverableIds.add(notification.id);
+        continue;
+      }
 
       const report = await readSubagentReportArtifact(sessionDir, notification.sourceId);
       const failure =
@@ -5340,11 +5373,12 @@ export class TaskService {
             })
           : null;
       if (content == null) {
-        log.warn("Terminal sub-agent attention has no durable result", {
+        log.warn("Superseding terminal sub-agent attention with no durable result", {
           ownerWorkspaceId,
           taskId: notification.sourceId,
         });
-        return false;
+        await this.terminalAttentionStore.markSuperseded(ownerWorkspaceId, notification.id);
+        continue;
       }
 
       const message = createMuxMessage(
@@ -5354,10 +5388,18 @@ export class TaskService {
         { timestamp: Date.now(), synthetic: true, uiVisible: true }
       );
       const appendResult = await this.historyService.appendToHistory(ownerWorkspaceId, message);
-      if (!appendResult.success) return false;
+      if (!appendResult.success) {
+        log.warn("Failed to repair terminal sub-agent message", {
+          ownerWorkspaceId,
+          taskId: notification.sourceId,
+          error: appendResult.error,
+        });
+        continue;
+      }
       this.workspaceService.emitChatEvent(ownerWorkspaceId, { ...message, type: "message" });
+      deliverableIds.add(notification.id);
     }
-    return true;
+    return deliverableIds;
   }
 
   private async consumeRespondedAgentTerminalAttention(ownerWorkspaceId: string): Promise<void> {
@@ -5367,7 +5409,7 @@ export class TaskService {
     if (pending.length === 0) return;
 
     const pendingIds = new Set(pending.map((notification) => notification.sourceId));
-    const awaitingResponse = new Set<string>();
+    const terminalSequenceByTaskId = new Map<string, number>();
     const responded = new Set<string>();
     const historyResult = await this.historyService.getHistoryFromLatestBoundary(ownerWorkspaceId);
     if (!historyResult.success) {
@@ -5385,16 +5427,20 @@ export class TaskService {
           .map((part) => part.text)
           .join("\n");
         const taskId = parseTerminalSubagentTaskId(text);
-        if (taskId != null && pendingIds.has(taskId)) {
-          awaitingResponse.add(taskId);
+        const historySequence = message.metadata?.historySequence;
+        if (taskId != null && pendingIds.has(taskId) && typeof historySequence === "number") {
+          terminalSequenceByTaskId.set(taskId, historySequence);
           responded.delete(taskId);
         }
         continue;
       }
 
       if (message.role === "assistant" && message.metadata?.partial !== true) {
-        for (const taskId of awaitingResponse) responded.add(taskId);
-        awaitingResponse.clear();
+        const requestHistorySequence = message.metadata?.requestHistorySequence;
+        if (typeof requestHistorySequence !== "number") continue;
+        for (const [taskId, terminalSequence] of terminalSequenceByTaskId) {
+          if (requestHistorySequence >= terminalSequence) responded.add(taskId);
+        }
       }
     }
 
@@ -5452,9 +5498,10 @@ export class TaskService {
     const agentNotifications = pending.filter(
       (notification) => notification.sourceKind === "agent_task"
     );
-    if (!(await this.ensureAgentTerminalMessages(ownerWorkspaceId, agentNotifications))) {
-      return;
-    }
+    const deliverableAgentNotificationIds = await this.ensureAgentTerminalMessages(
+      ownerWorkspaceId,
+      agentNotifications
+    );
     const awaitHandleIds = pending
       .filter((notification) => notification.sourceKind === "workspace_turn")
       .map((notification) => notification.sourceId);
@@ -5483,11 +5530,15 @@ export class TaskService {
     // Sub-agent reports and failures are already durable user-context messages. Resume from history
     // directly instead of injecting a second user turn that merely tells the model they exist.
     const prompt = promptSections.join("\n\n");
-    const effectivePending = pending.filter(
-      (notification) =>
-        notification.sourceKind !== "workflow_run" ||
-        deliverableWorkflowNotificationIds.has(notification.id)
-    );
+    const effectivePending = pending.filter((notification) => {
+      if (notification.sourceKind === "agent_task") {
+        return deliverableAgentNotificationIds.has(notification.id);
+      }
+      if (notification.sourceKind === "workflow_run") {
+        return deliverableWorkflowNotificationIds.has(notification.id);
+      }
+      return true;
+    });
     if (effectivePending.length === 0) return;
 
     const markPendingDelivered = async () => {
@@ -5821,6 +5872,7 @@ export class TaskService {
     await this.enqueueTerminalAttention({
       ownerWorkspaceId: params.record.ownerWorkspaceId,
       sourceKind: "workspace_turn",
+      terminalOutcome: terminalAttentionOutcome(params.next.status),
       sourceId: params.record.handleId,
     });
     const terminal = await this.taskHandleStore.getWorkspaceTurn(
@@ -10061,7 +10113,7 @@ export class TaskService {
       return;
     }
     // Workflow-owned children propagate failures through the WorkflowRunner
-    // step result; do not also deliver a generic failure handoff.
+    // step result; do not also resume the parent from a child-level failure row.
     if (childEntry.workspace.workflowTask != null) {
       return;
     }
@@ -10074,8 +10126,7 @@ export class TaskService {
 
     // Durable context delivery, mirroring deliverReportToParent's synthetic
     // append: the failure must be visible to the parent's next turn regardless
-    // of whether THIS settlement wakes it or a later sibling report/failure
-    // (whose handoff prompt won't restate this child's details) does.
+    // of whether this settlement resumes it or a later sibling report/failure does.
     const failureMessage = createMuxMessage(
       createTaskFailureMessageId(),
       "user",
@@ -10122,6 +10173,7 @@ export class TaskService {
     await this.enqueueTerminalAttention({
       ownerWorkspaceId: parentWorkspaceId,
       sourceKind: "agent_task",
+      terminalOutcome: "failed",
       sourceId: childWorkspaceId,
     });
   }
@@ -11113,6 +11165,7 @@ export class TaskService {
     await this.enqueueTerminalAttention({
       ownerWorkspaceId: parentWorkspaceId,
       sourceKind: "agent_task",
+      terminalOutcome: "completed",
       sourceId: childWorkspaceId,
     });
 

--- a/src/node/services/terminalAttentionStore.test.ts
+++ b/src/node/services/terminalAttentionStore.test.ts
@@ -38,6 +38,21 @@ describe("TerminalAttentionStore", () => {
     expect(created).not.toBeNull();
     expect(created?.status).toBe("pending");
 
+    const persisted = JSON.parse(
+      await fsPromises.readFile(
+        path.join(
+          makeConfig(rootDir).getSessionDir("owner-1"),
+          TERMINAL_ATTENTION_DIR,
+          `${encodeURIComponent("workspace_turn:wst_abc")}.json`
+        ),
+        "utf-8"
+      )
+    ) as unknown;
+    expect(persisted).toMatchObject({
+      outputDelivery: "requires_task_await",
+      terminalOutcome: "completed",
+    });
+
     const pending = await store.listPending("owner-1");
     expect(pending.map((n) => n.sourceId)).toEqual(["wst_abc"]);
   });

--- a/src/node/services/terminalAttentionStore.test.ts
+++ b/src/node/services/terminalAttentionStore.test.ts
@@ -4,7 +4,10 @@ import * as path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { TerminalAttentionStore } from "@/node/services/terminalAttentionStore";
+import {
+  TERMINAL_ATTENTION_DIR,
+  TerminalAttentionStore,
+} from "@/node/services/terminalAttentionStore";
 
 function makeConfig(rootDir: string): {
   sessionsDir: string;
@@ -31,8 +34,6 @@ describe("TerminalAttentionStore", () => {
       ownerWorkspaceId: "owner-1",
       sourceKind: "workspace_turn",
       sourceId: "wst_abc",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
     expect(created).not.toBeNull();
     expect(created?.status).toBe("pending");
@@ -41,14 +42,36 @@ describe("TerminalAttentionStore", () => {
     expect(pending.map((n) => n.sourceId)).toEqual(["wst_abc"]);
   });
 
+  test("loads pending notifications written with legacy derived fields", async () => {
+    const config = makeConfig(rootDir);
+    const dir = path.join(config.getSessionDir("owner-1"), TERMINAL_ATTENTION_DIR);
+    await fsPromises.mkdir(dir, { recursive: true });
+    await fsPromises.writeFile(
+      path.join(dir, `${encodeURIComponent("agent_task:task-1")}.json`),
+      JSON.stringify({
+        id: "agent_task:task-1",
+        ownerWorkspaceId: "owner-1",
+        sourceKind: "agent_task",
+        sourceId: "task-1",
+        outputDelivery: "already_injected",
+        terminalOutcome: "completed",
+        status: "pending",
+        createdAt: "2026-08-01T00:00:00.000Z",
+      })
+    );
+
+    expect((await new TerminalAttentionStore(config).listPending("owner-1"))[0]).toMatchObject({
+      sourceId: "task-1",
+      status: "pending",
+    });
+  });
+
   test("enqueueIfAbsent is idempotent by source kind + id", async () => {
     const store = new TerminalAttentionStore(makeConfig(rootDir));
     const base = {
       ownerWorkspaceId: "owner-1",
       sourceKind: "agent_task" as const,
       sourceId: "task-1",
-      outputDelivery: "already_injected" as const,
-      terminalOutcome: "completed" as const,
     };
     const first = await store.enqueueIfAbsent(base);
     const second = await store.enqueueIfAbsent(base);
@@ -64,8 +87,6 @@ describe("TerminalAttentionStore", () => {
       ownerWorkspaceId: "owner-1",
       sourceKind: "workspace_turn",
       sourceId: "wst_done",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
     await store.markDelivered("owner-1", created!.id);
 
@@ -78,8 +99,6 @@ describe("TerminalAttentionStore", () => {
         ownerWorkspaceId: "owner-1",
         sourceKind: "workspace_turn",
         sourceId: "wst_done",
-        outputDelivery: "requires_task_await",
-        terminalOutcome: "completed",
       })
     ).toBeNull();
   });
@@ -90,16 +109,12 @@ describe("TerminalAttentionStore", () => {
       ownerWorkspaceId: "owner-1",
       sourceKind: "agent_task",
       sourceId: "task-a",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
       createdAt: "2026-01-01T00:00:00.000Z",
     });
     await store.enqueueIfAbsent({
       ownerWorkspaceId: "owner-1",
       sourceKind: "workspace_turn",
       sourceId: "wst-b",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
       createdAt: "2026-01-01T00:00:01.000Z",
     });
     const pending = await store.listPending("owner-1");
@@ -112,15 +127,11 @@ describe("TerminalAttentionStore", () => {
       ownerWorkspaceId: "owner-b",
       sourceKind: "workspace_turn",
       sourceId: "wst-b",
-      outputDelivery: "requires_task_await",
-      terminalOutcome: "completed",
     });
     const delivered = await store.enqueueIfAbsent({
       ownerWorkspaceId: "owner-a",
       sourceKind: "agent_task",
       sourceId: "task-a",
-      outputDelivery: "already_injected",
-      terminalOutcome: "completed",
     });
     expect(delivered).not.toBeNull();
     await store.markDelivered("owner-a", delivered!.id);

--- a/src/node/services/terminalAttentionStore.ts
+++ b/src/node/services/terminalAttentionStore.ts
@@ -50,9 +50,7 @@ export interface TerminalAttentionNotification {
   ownerWorkspaceId: string;
   sourceKind: TerminalAttentionSourceKind;
   sourceId: string;
-  /** Retained on disk for downgrade compatibility; current delivery derives behavior from sourceKind. */
   outputDelivery: TerminalAttentionOutputDelivery;
-  /** Retained on disk for downgrade compatibility; current delivery reads authoritative result stores. */
   terminalOutcome: TerminalAttentionOutcome;
   status: TerminalAttentionStatus;
   createdAt: string;

--- a/src/node/services/terminalAttentionStore.ts
+++ b/src/node/services/terminalAttentionStore.ts
@@ -10,36 +10,14 @@ import { log } from "@/node/services/log";
 import { isErrnoWithCode } from "@/node/utils/fs";
 
 /**
- * Persisted, idempotent record of a pending terminal wake-up the owner workspace still owes an
- * agent. The notifier (see {@link TerminalAttentionNotifier}) drains these when the owner is idle
- * and marks them delivered only after an accepted send, so a crash/restart cannot lose or duplicate
- * a wake-up.
- *
- * Output delivery:
- * - `already_injected`: a sub-agent report/failure synthetic message is already in parent history,
- *   so the wake-up tells the agent to integrate it WITHOUT calling task_await.
- * - `requires_task_await`: a workspace-turn handle's terminal output lives in the handle store, so
- *   the wake-up tells the agent to call task_await with the terminal IDs and timeout_secs: 0.
- * - `workflow_result_context`: a workflow run's terminal result lives in its durable journal, so the
- *   wake-up injects the reconstructed workflow-result context directly.
+ * Persisted, idempotent record that an owner workspace still needs to resume after terminal
+ * background work. Source-specific output stays in its authoritative store; this outbox only owns
+ * accepted-delivery dedupe and crash recovery.
  */
 export const TERMINAL_ATTENTION_DIR = "terminal-attention";
 
-// Single-source each notification enum so the exported TS type and the runtime
-// Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
-// the sibling backgroundWorkAttention policy enum.
-const TERMINAL_ATTENTION_OUTPUT_DELIVERIES = [
-  "already_injected",
-  "requires_task_await",
-  "workflow_result_context",
-] as const;
-export type TerminalAttentionOutputDelivery = (typeof TERMINAL_ATTENTION_OUTPUT_DELIVERIES)[number];
-
 const TERMINAL_ATTENTION_SOURCE_KINDS = ["agent_task", "workspace_turn", "workflow_run"] as const;
 export type TerminalAttentionSourceKind = (typeof TERMINAL_ATTENTION_SOURCE_KINDS)[number];
-
-const TERMINAL_ATTENTION_OUTCOMES = ["completed", "failed", "interrupted", "error"] as const;
-export type TerminalAttentionOutcome = (typeof TERMINAL_ATTENTION_OUTCOMES)[number];
 
 const TERMINAL_ATTENTION_STATUSES = ["pending", "delivered", "superseded"] as const;
 export type TerminalAttentionStatus = (typeof TERMINAL_ATTENTION_STATUSES)[number];
@@ -49,28 +27,20 @@ export interface TerminalAttentionNotification {
   ownerWorkspaceId: string;
   sourceKind: TerminalAttentionSourceKind;
   sourceId: string;
-  outputDelivery: TerminalAttentionOutputDelivery;
-  terminalOutcome: TerminalAttentionOutcome;
   status: TerminalAttentionStatus;
-  title?: string;
   createdAt: string;
   deliveredAt?: string;
 }
 
-const TerminalAttentionNotificationSchema = z
-  .object({
-    id: z.string().min(1),
-    ownerWorkspaceId: z.string().min(1),
-    sourceKind: z.enum(TERMINAL_ATTENTION_SOURCE_KINDS),
-    sourceId: z.string().min(1),
-    outputDelivery: z.enum(TERMINAL_ATTENTION_OUTPUT_DELIVERIES),
-    terminalOutcome: z.enum(TERMINAL_ATTENTION_OUTCOMES),
-    status: z.enum(TERMINAL_ATTENTION_STATUSES),
-    title: z.string().optional(),
-    createdAt: z.string().min(1),
-    deliveredAt: z.string().optional(),
-  })
-  .strict();
+const TerminalAttentionNotificationSchema = z.object({
+  id: z.string().min(1),
+  ownerWorkspaceId: z.string().min(1),
+  sourceKind: z.enum(TERMINAL_ATTENTION_SOURCE_KINDS),
+  sourceId: z.string().min(1),
+  status: z.enum(TERMINAL_ATTENTION_STATUSES),
+  createdAt: z.string().min(1),
+  deliveredAt: z.string().optional(),
+});
 
 /**
  * Disk-backed store for terminal attention notifications, one JSON file per notification under the
@@ -117,10 +87,7 @@ export class TerminalAttentionStore {
       ownerWorkspaceId: notification.ownerWorkspaceId,
       sourceKind: notification.sourceKind,
       sourceId: notification.sourceId,
-      outputDelivery: notification.outputDelivery,
-      terminalOutcome: notification.terminalOutcome,
       status: "pending",
-      ...(notification.title != null ? { title: notification.title } : {}),
       createdAt: notification.createdAt ?? new Date().toISOString(),
     };
     await this.write(record);

--- a/src/node/services/terminalAttentionStore.ts
+++ b/src/node/services/terminalAttentionStore.ts
@@ -16,17 +16,44 @@ import { isErrnoWithCode } from "@/node/utils/fs";
  */
 export const TERMINAL_ATTENTION_DIR = "terminal-attention";
 
+const TERMINAL_ATTENTION_OUTPUT_DELIVERIES = [
+  "already_injected",
+  "requires_task_await",
+  "workflow_result_context",
+] as const;
+export type TerminalAttentionOutputDelivery = (typeof TERMINAL_ATTENTION_OUTPUT_DELIVERIES)[number];
+
+const TERMINAL_ATTENTION_OUTCOMES = ["completed", "failed", "interrupted", "error"] as const;
+export type TerminalAttentionOutcome = (typeof TERMINAL_ATTENTION_OUTCOMES)[number];
+
 const TERMINAL_ATTENTION_SOURCE_KINDS = ["agent_task", "workspace_turn", "workflow_run"] as const;
 export type TerminalAttentionSourceKind = (typeof TERMINAL_ATTENTION_SOURCE_KINDS)[number];
 
 const TERMINAL_ATTENTION_STATUSES = ["pending", "delivered", "superseded"] as const;
 export type TerminalAttentionStatus = (typeof TERMINAL_ATTENTION_STATUSES)[number];
 
+function outputDeliveryForSource(
+  sourceKind: TerminalAttentionSourceKind
+): TerminalAttentionOutputDelivery {
+  switch (sourceKind) {
+    case "agent_task":
+      return "already_injected";
+    case "workspace_turn":
+      return "requires_task_await";
+    case "workflow_run":
+      return "workflow_result_context";
+  }
+}
+
 export interface TerminalAttentionNotification {
   id: string;
   ownerWorkspaceId: string;
   sourceKind: TerminalAttentionSourceKind;
   sourceId: string;
+  /** Retained on disk for downgrade compatibility; current delivery derives behavior from sourceKind. */
+  outputDelivery: TerminalAttentionOutputDelivery;
+  /** Retained on disk for downgrade compatibility; current delivery reads authoritative result stores. */
+  terminalOutcome: TerminalAttentionOutcome;
   status: TerminalAttentionStatus;
   createdAt: string;
   deliveredAt?: string;
@@ -37,6 +64,8 @@ const TerminalAttentionNotificationSchema = z.object({
   ownerWorkspaceId: z.string().min(1),
   sourceKind: z.enum(TERMINAL_ATTENTION_SOURCE_KINDS),
   sourceId: z.string().min(1),
+  outputDelivery: z.enum(TERMINAL_ATTENTION_OUTPUT_DELIVERIES),
+  terminalOutcome: z.enum(TERMINAL_ATTENTION_OUTCOMES),
   status: z.enum(TERMINAL_ATTENTION_STATUSES),
   createdAt: z.string().min(1),
   deliveredAt: z.string().optional(),
@@ -70,8 +99,12 @@ export class TerminalAttentionStore {
    * wake-up or duplicate a pending one.
    */
   async enqueueIfAbsent(
-    notification: Omit<TerminalAttentionNotification, "id" | "status" | "createdAt"> & {
+    notification: Omit<
+      TerminalAttentionNotification,
+      "id" | "status" | "createdAt" | "outputDelivery" | "terminalOutcome"
+    > & {
       createdAt?: string;
+      terminalOutcome?: TerminalAttentionOutcome;
     }
   ): Promise<TerminalAttentionNotification | null> {
     const id = TerminalAttentionStore.notificationId(
@@ -87,6 +120,8 @@ export class TerminalAttentionStore {
       ownerWorkspaceId: notification.ownerWorkspaceId,
       sourceKind: notification.sourceKind,
       sourceId: notification.sourceId,
+      outputDelivery: outputDeliveryForSource(notification.sourceKind),
+      terminalOutcome: notification.terminalOutcome ?? "completed",
       status: "pending",
       createdAt: notification.createdAt ?? new Date().toISOString(),
     };


### PR DESCRIPTION
## Summary

Removes the redundant synthetic “Background sub-agent task(s) have completed…” handoff turn. Completed sub-agent reports and failures now resume the parent directly from the durable report rows already in conversation history.

The refactor also removes 1,001 net lines by collapsing terminal-attention branching and deleting tests coupled to the old prompt/output state machine.

## Background

Sub-agent completion previously used a two-message handoff:

1. persist the real report/failure into parent history
2. start another visible synthetic user turn that only told the model the report was already present

That second turn surfaced as an `AUTO` chat bubble and forced a generic instruction into the transcript. Recent suppression logic only handled the narrow case where the parent had answered an incremental progress update, so normal background completions still showed the prompt.

## Implementation

- resume parent streams directly from existing terminal sub-agent report/failure rows instead of sending a second handoff message
- make terminal report and failure rows visible, ordered append-only messages
- reconstruct a missing terminal row from durable success/failure artifacts before resuming, preserving self-healing after failed history appends
- correlate assistant responses with the highest history sequence included in their provider request, so a concurrently appended report is not incorrectly treated as consumed
- supersede orphaned agent notifications without blocking valid workspace-turn or workflow notifications for the same owner
- reduce active terminal-attention behavior to source identity plus delivery state while retaining the legacy output/outcome fields on disk for downgrade compatibility
- retain explicit prompts only for sources whose output is not already in history (workspace-turn handles and workflow results)

## Validation

- `bun test src/node/services/taskService.test.ts src/node/services/terminalAttentionStore.test.ts --timeout 30000` — 337 passing
- `bun test src/node/services/agentSession.startupAutoRetry.test.ts` — 30 passing
- `bun test src/node/services/aiService.test.ts -t 'uses the latest durable boundary slice'`
- `make typecheck`
- `make static-check`
- verified production no longer contains or sends the completed/failed sub-agent handoff prompt; legacy prompt openings remain only for persisted timeline classification compatibility
- diff: 665 insertions, 1,666 deletions (1,001 net lines removed)

## Risks

Moderate, scoped to terminal background-work delivery. Workspace-turn and workflow wake prompts retain their existing behavior. Sub-agent completion now depends on `resumeStream` over durable history, with provider-request correlation, artifact-backed repair, orphan isolation, and upgrade/downgrade-compatible outbox records covering concurrency and restart cases.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$91.81`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=91.81 -->


