### PR TITLE
🤖 feat: migrate MCP client to official TS SDK v2 with 2026-07-28 spec support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mux",
@@ -11,7 +10,6 @@
         "@ai-sdk/anthropic": "^4.0.11",
         "@ai-sdk/deepseek": "^3.0.7",
         "@ai-sdk/google": "^4.0.11",
-        "@ai-sdk/mcp": "^2.0.10",
         "@ai-sdk/moonshotai": "^3.0.15",
         "@ai-sdk/openai": "^4.0.11",
         "@ai-sdk/openai-compatible": "^3.0.7",
@@ -24,6 +22,7 @@
         "@homebridge/ciao": "^1.3.4",
         "@jitl/quickjs-wasmfile-release-asyncify": "^0.31.0",
         "@lydell/node-pty": "1.1.0",
+        "@modelcontextprotocol/client": "2.0.0",
         "@mozilla/readability": "^0.6.0",
         "@novnc/novnc": "^1.6.0",
         "@openrouter/ai-sdk-provider": "^3.0.0",
@@ -104,7 +103,7 @@
         "ws": "^8.18.3",
         "xxhash-wasm": "^1.1.0",
         "yaml": "^2.8.2",
-        "zod": "^4.1.11",
+        "zod": "^4.2.0",
         "zod-to-json-schema": "^3.24.6",
       },
       "devDependencies": {
@@ -236,8 +235,6 @@
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.15", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-JHvgCU4SR6OdjOI+8rxIF3zhIboFAkQ1vEa+QOIdkK5VyME1ONx8SbgM2YtnSY1DOsCtUyhd+EG876pYpRjopg=="],
 
     "@ai-sdk/google": ["@ai-sdk/google@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1PvB3JC1D9eA43NCyHYhlz07YNfnAt9/8pvr8R7eaHp6J7LABM3lTHMvDMk1nRNGfBlV8H7U1jtgNEgB4u7MMw=="],
-
-    "@ai-sdk/mcp": ["@ai-sdk/mcp@2.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7", "pkce-challenge": "^5.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LP47CEk3e6BwCqXamvv4nKbgOWQ5z5T/qS/J2fola5h98KTy7JT7I1yw5LKtB89MZBLviYmEh98Ep4ovHOz/vA=="],
 
     "@ai-sdk/moonshotai": ["@ai-sdk/moonshotai@3.0.15", "", { "dependencies": { "@ai-sdk/openai-compatible": "3.0.12", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-R4+UEk1f1+lare2dQ1xK1vOJLXFmKo2wZ/d1wXTCZGOsls2I4KXEgl6oq1rB2PRT6NkvA5DK52fMA9DaeQZoYQ=="],
 
@@ -863,6 +860,10 @@
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
@@ -1459,7 +1460,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -2201,6 +2202,8 @@
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -2650,6 +2653,8 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "joi": ["joi@17.13.3", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA=="],
+
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -3623,7 +3628,7 @@
 
     "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unicode-canonical-property-names-ecmascript": ["unicode-canonical-property-names-ecmascript@2.0.1", "", {}, "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg=="],
 
@@ -3787,7 +3792,7 @@
 
     "zip-stream": ["zip-stream@4.1.1", "", { "dependencies": { "archiver-utils": "^3.0.4", "compress-commons": "^4.1.2", "readable-stream": "^3.6.0" } }, "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ=="],
 
-    "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.0", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ=="],
 
@@ -3867,13 +3872,25 @@
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
+    "@jest/console/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "@jest/console/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@jest/core/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/core/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "@jest/core/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/core/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
+
+    "@jest/environment/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/fake-timers/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/pattern/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@jest/reporters/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/reporters/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3890,6 +3907,8 @@
     "@jest/transform/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@jest/transform/write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
+
+    "@jest/types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -3995,17 +4014,17 @@
 
     "@types/body-parser/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
-    "@types/cacheable-request/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
-
     "@types/connect/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/cors/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/express-serve-static-core/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
-    "@types/keyv/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+    "@types/fs-extra/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@types/jsdom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/plist/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
-
-    "@types/responselike/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@types/send/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -4016,6 +4035,10 @@
     "@types/sshpk/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
     "@types/wait-on/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
+
+    "@types/write-file-atomic/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
+    "@types/ws/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "@types/yauzl/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
@@ -4052,6 +4075,8 @@
     "builder-util/http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
 
     "builder-util/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
+    "bun-types/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "caching-transform/write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
@@ -4090,8 +4115,6 @@
     "dom-serializer/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
-
-    "electron/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4141,6 +4164,8 @@
 
     "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "happy-dom/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "hasha/type-fest": ["type-fest@0.8.1", "", {}, "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
@@ -4181,6 +4206,8 @@
 
     "jest-environment-node/@types/node": ["@types/node@22.19.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ=="],
 
+    "jest-haste-map/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-junit/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
@@ -4190,6 +4217,8 @@
     "jest-matcher-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-message-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-mock/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-process-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4203,6 +4232,8 @@
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
+    "jest-runtime/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "jest-runtime/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-runtime/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -4210,6 +4241,8 @@
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
 
     "jest-snapshot/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "jest-util/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4219,11 +4252,15 @@
 
     "jest-watch-typeahead/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
+    "jest-watcher/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
+
     "jest-watcher/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
     "jest-watcher/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-watcher/string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
+
+    "jest-worker/@types/node": ["@types/node@20.19.25", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
@@ -4391,15 +4428,27 @@
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
+    "@jest/console/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "@jest/console/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/console/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@jest/core/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@jest/core/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "@jest/core/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/core/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@jest/environment/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@jest/fake-timers/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@jest/pattern/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@jest/reporters/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@jest/reporters/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4422,6 +4471,8 @@
     "@jest/transform/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@jest/transform/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "@jest/types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4473,13 +4524,37 @@
 
     "@testing-library/jest-dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "@types/cacheable-request/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "@types/asn1/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "@types/keyv/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "@types/body-parser/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "@types/responselike/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "@types/connect/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/cors/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/fs-extra/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/jsdom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/plist/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/send/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/serve-static/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "@types/sshpk/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/wait-on/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/write-file-atomic/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@types/yauzl/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -4514,6 +4589,8 @@
     "builder-util/http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "builder-util/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "caching-transform/write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -4553,8 +4630,6 @@
 
     "electron-publish/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "electron/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -4575,9 +4650,13 @@
 
     "global-prefix/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "happy-dom/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "htmlparser2/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "jest-circus/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "jest-circus/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4607,6 +4686,10 @@
 
     "jest-each/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-environment-node/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "jest-haste-map/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "jest-junit/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "jest-matcher-utils/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -4617,6 +4700,8 @@
 
     "jest-message-util/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-mock/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "jest-process-manager/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-process-manager/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4625,9 +4710,13 @@
 
     "jest-resolve/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-runner/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "jest-runner/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-runner/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "jest-runtime/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "jest-runtime/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -4645,6 +4734,8 @@
 
     "jest-snapshot/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-util/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "jest-util/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "jest-util/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4653,6 +4744,8 @@
 
     "jest-validate/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jest-watcher/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "jest-watcher/ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "jest-watcher/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -4660,6 +4753,8 @@
     "jest-watcher/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "jest-watcher/string-length/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "jest-worker/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-ufRtgBViq/5RAGzL/f79pIYK/+3BCQNNAD1nCz/edRg="; # mux-offline-cache-hash
+            outputHash = "sha256-iF5fJ7QM64MbN0/A1WOzQbon2/6zGB9tOjaePoZFesY="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@ai-sdk/anthropic": "^4.0.11",
     "@ai-sdk/deepseek": "^3.0.7",
     "@ai-sdk/google": "^4.0.11",
-    "@ai-sdk/mcp": "^2.0.10",
     "@ai-sdk/moonshotai": "^3.0.15",
     "@ai-sdk/openai": "^4.0.11",
     "@ai-sdk/openai-compatible": "^3.0.7",
@@ -66,6 +65,7 @@
     "@homebridge/ciao": "^1.3.4",
     "@jitl/quickjs-wasmfile-release-asyncify": "^0.31.0",
     "@lydell/node-pty": "1.1.0",
+    "@modelcontextprotocol/client": "2.0.0",
     "@mozilla/readability": "^0.6.0",
     "@novnc/novnc": "^1.6.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
@@ -146,7 +146,7 @@
     "ws": "^8.18.3",
     "xxhash-wasm": "^1.1.0",
     "yaml": "^2.8.2",
-    "zod": "^4.1.11",
+    "zod": "^4.2.0",
     "zod-to-json-schema": "^3.24.6"
   },
   "devDependencies": {

--- a/src/common/orpc/schemas/mcp.ts
+++ b/src/common/orpc/schemas/mcp.ts
@@ -223,7 +223,11 @@ export const BearerChallengeSchema = z.object({
 });
 
 export const MCPTestResultSchema = z.discriminatedUnion("success", [
-  z.object({ success: z.literal(true), tools: z.array(z.string()) }),
+  z.object({
+    success: z.literal(true),
+    tools: z.array(z.string()),
+    protocolVersion: z.string().optional(),
+  }),
   z.object({
     success: z.literal(false),
     error: z.string(),

--- a/src/common/types/mcp.ts
+++ b/src/common/types/mcp.ts
@@ -84,7 +84,12 @@ export interface BearerChallenge {
 
 /** Result of testing an MCP server connection */
 export type MCPTestResult =
-  | { success: true; tools: string[] }
+  | {
+      success: true;
+      tools: string[];
+      /** MCP protocol revision negotiated during the test connection. */
+      protocolVersion?: string;
+    }
   | { success: false; error: string; oauthChallenge?: BearerChallenge };
 
 /** Cached test result with timestamp for age display */

--- a/src/common/types/mcpOauth.ts
+++ b/src/common/types/mcpOauth.ts
@@ -27,9 +27,9 @@ export interface MCPOAuthPendingServerConfig {
 /**
  * OAuth 2.1 token response.
  *
- * Matches the shape used by @ai-sdk/mcp (OAuthTokensSchema), including the
- * authorization-server binding fields the SDK appends via
- * addAuthorizationServerInformationToTokens() before saveTokens().
+ * Matches the stored-token shape used by the official MCP SDK
+ * (StoredOAuthTokens), plus the legacy @ai-sdk/mcp authorization-server
+ * binding fields, which are preserved for downgrade compatibility.
  */
 export interface MCPOAuthTokens {
   access_token: string;
@@ -39,23 +39,34 @@ export interface MCPOAuthTokens {
   scope?: string;
   refresh_token?: string;
   /**
-   * Authorization server URL these tokens were issued by.
+   * Authorization server URL these tokens were issued by (legacy @ai-sdk/mcp
+   * binding field).
    *
-   * @ai-sdk/mcp auth() requires this (or the same field on clientInformation)
-   * to be present before it will use refresh_token; when missing it
-   * invalidates the stored tokens and demands interactive re-auth. Dropping
-   * it from the persisted store breaks token refresh across app restarts.
+   * The legacy @ai-sdk/mcp auth() required this (or the same field on
+   * clientInformation) before it would use refresh_token; when missing it
+   * invalidated the stored tokens and demanded interactive re-auth. The
+   * official SDK v2 ignores it, but the persisted store keeps round-tripping
+   * it so downgrading Mux does not break token refresh across app restarts.
    */
   authorization_server?: string;
   /** Token endpoint bound to authorization_server; required alongside it. */
   token_endpoint?: string;
+  /**
+   * Authorization-server issuer identifier stamped by the official SDK v2
+   * before saveTokens() (SEP-2352 credential/issuer binding). Must survive
+   * the store round-trip so stored credentials stay bound to the issuer that
+   * minted them; the SDK back-stamps unstamped (pre-upgrade) credentials on
+   * first use.
+   */
+  issuer?: string;
 }
 
 /**
  * OAuth dynamic client registration information.
  *
- * Matches the shape used by @ai-sdk/mcp (OAuthClientInformationSchema),
- * including the same authorization-server binding fields as MCPOAuthTokens.
+ * Matches the stored-client shape used by the official MCP SDK
+ * (StoredOAuthClientInformation), including the same legacy binding and
+ * issuer-stamp fields as MCPOAuthTokens.
  */
 export interface MCPOAuthClientInformation {
   client_id: string;
@@ -66,6 +77,8 @@ export interface MCPOAuthClientInformation {
   authorization_server?: string;
   /** See MCPOAuthTokens.token_endpoint. */
   token_endpoint?: string;
+  /** See MCPOAuthTokens.issuer. */
+  issuer?: string;
 }
 
 /**

--- a/src/common/utils/tools/schemaSanitizer.test.ts
+++ b/src/common/utils/tools/schemaSanitizer.test.ts
@@ -192,7 +192,7 @@ describe("schemaSanitizer", () => {
         type: "dynamic",
         description: "MCP test tool",
         inputSchema: {
-          // Simulate the jsonSchema getter that @ai-sdk/mcp creates
+          // Simulate the jsonSchema getter that the MCP tool adapter creates
           get jsonSchema() {
             return jsonSchema;
           },

--- a/src/common/utils/tools/schemaSanitizer.ts
+++ b/src/common/utils/tools/schemaSanitizer.ts
@@ -322,7 +322,7 @@ function sanitizeWorkflowAgentReportSchemaNode(schema: unknown): void {
  *
  * Tools can have schemas in two places:
  * - `parameters`: Used by tools created with ai SDK's `tool()` function
- * - `inputSchema`: Used by MCP tools created with `dynamicTool()` from @ai-sdk/mcp
+ * - `inputSchema`: Used by MCP tools created with `dynamicTool()` (see mcpClient.ts)
  *
  * @param tool - The original tool to sanitize
  * @returns A new tool with sanitized parameter schema

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -158,8 +158,17 @@ function mcpToModelOutput({
   output: unknown;
 }): ReturnType<NonNullable<Tool["toModelOutput"]>> {
   const result = output as {
+    type?: string;
+    value?: unknown;
     content?: Array<Record<string, unknown> & { type?: string }>;
   };
+  // mcpServerManager's wrapMCPTools runs transformMCPResult over execute
+  // results first (it owns the image size guard); image results arrive here
+  // already in AI SDK model-output shape. Pass them through instead of
+  // re-converting (which would demote them to JSON and lose multimodal input).
+  if (result && typeof result === "object" && result.type === "content" && "value" in result) {
+    return result as ReturnType<NonNullable<Tool["toModelOutput"]>>;
+  }
   if (!result || typeof result !== "object" || !Array.isArray(result.content)) {
     return { type: "json", value: result as never };
   }
@@ -224,10 +233,14 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
           title: definition.title ?? definition.annotations?.title,
           // Server-provided JSON schemas are runtime data; the SDK types them
           // as loose JSON values, so narrow to the AI SDK's JSONSchema7 shape.
+          // Preserve a server-declared additionalProperties (map-style params
+          // like env vars or labels rely on it); default to false only when
+          // absent, matching the previous @ai-sdk/mcp behavior for strict
+          // providers. Provider-specific strictness stays in schemaSanitizer.
           inputSchema: jsonSchema({
             ...inputSchema,
             properties: inputSchema.properties ?? {},
-            additionalProperties: false,
+            additionalProperties: inputSchema.additionalProperties ?? false,
           } as JSONSchema7),
           execute: async (args: unknown, options: { abortSignal?: AbortSignal }) => {
             options.abortSignal?.throwIfAborted();

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -1,0 +1,197 @@
+import {
+  Client,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+  type OAuthClientProvider,
+  type Transport,
+} from "@modelcontextprotocol/client";
+import { dynamicTool, jsonSchema, type JSONSchema7, type Tool } from "ai";
+import assert from "@/common/utils/assert";
+
+/**
+ * MCP client adapter over the official TypeScript SDK v2
+ * (@modelcontextprotocol/client).
+ *
+ * Mux previously used @ai-sdk/mcp, which only speaks MCP protocol revisions up
+ * to 2025-11-25 (initialize handshake + Mcp-Session-Id sessions) and has no
+ * support for the stateless 2026-07-28 revision (SEP-2575/2567). The official
+ * SDK v2 client implements both revisions; its default connect sequence is the
+ * plain legacy `initialize` handshake, byte-identical to the previous wire
+ * behavior, so existing user-configured servers see no change.
+ *
+ * This module intentionally mirrors the small surface mcpServerManager
+ * consumed from @ai-sdk/mcp (createMCPClient -> { tools(), close() }) so the
+ * manager's instance-cache/lease/recycle machinery stays unchanged.
+ */
+
+/** Client identity sent to servers (initialize request / clientInfo _meta). */
+const CLIENT_INFO = { name: "mux", version: "1.0.0" };
+
+/**
+ * Maximum time a single MCP tool call may run.
+ *
+ * mcpServerManager's wrapMCPTools enforces this deadline (with recycle
+ * semantics) around every tool execution.
+ */
+export const MCP_TOOL_CALL_TIMEOUT_MS = 300_000;
+
+/**
+ * SDK-level timeout for tools/call requests.
+ *
+ * @ai-sdk/mcp had no per-request timeouts; the official SDK defaults to 60s,
+ * which would cut long-running tool calls that Mux intentionally allows (up to
+ * MCP_TOOL_CALL_TIMEOUT_MS). Keep the SDK timeout slightly above the wrapper
+ * deadline so wrapMCPTools' MCPDeadlineError (which drives client recycling)
+ * always wins the race, while the SDK still cleans up abandoned requests.
+ */
+const SDK_TOOL_CALL_TIMEOUT_MS = MCP_TOOL_CALL_TIMEOUT_MS + 5_000;
+
+export interface MCPHttpTransportConfig {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string> | undefined;
+  /** Custom fetch (e.g. WWW-Authenticate capture during server tests). */
+  fetch?: typeof fetch;
+  authProvider?: OAuthClientProvider;
+}
+
+export interface MCPClientConfig {
+  /** Either a ready transport (stdio) or an HTTP/SSE transport config. */
+  transport: Transport | MCPHttpTransportConfig;
+  /** Receives transport/protocol errors surfaced outside request call sites. */
+  onUncaughtError?: (error: unknown) => void;
+}
+
+export interface MCPClientHandle {
+  /** Fetch tools/list and build AI SDK tools whose execute calls tools/call. */
+  tools(): Promise<Record<string, Tool>>;
+  close(): Promise<void>;
+}
+
+function isHttpTransportConfig(
+  transport: Transport | MCPHttpTransportConfig
+): transport is MCPHttpTransportConfig {
+  return "type" in transport && (transport.type === "http" || transport.type === "sse");
+}
+
+function createHttpTransport(config: MCPHttpTransportConfig): Transport {
+  const url = new URL(config.url);
+  // MCP server URLs are user-configured and already trusted to execute tools,
+  // so follow HTTP redirects (http->https, trailing slash) to avoid breaking
+  // existing setups. Note undici's fetch follows redirects by default; this
+  // pins the behavior explicitly.
+  const requestInit: RequestInit = {
+    redirect: "follow",
+    ...(config.headers !== undefined ? { headers: config.headers } : {}),
+  };
+
+  const options = {
+    requestInit,
+    ...(config.fetch !== undefined ? { fetch: config.fetch } : {}),
+    ...(config.authProvider !== undefined ? { authProvider: config.authProvider } : {}),
+  };
+
+  // Custom headers in requestInit are merged into every request by both
+  // transports, including the SSE GET stream (verified against SDK v2.0.0's
+  // _commonHeaders implementation).
+  return config.type === "http"
+    ? new StreamableHTTPClientTransport(url, options)
+    : new SSEClientTransport(url, options);
+}
+
+/**
+ * MCP CallToolResult -> AI SDK tool-result output for the model.
+ *
+ * Mirrors @ai-sdk/mcp's mcpToModelOutput so model-visible tool results stay
+ * identical across the SDK swap.
+ */
+function mcpToModelOutput({
+  output,
+}: {
+  output: unknown;
+}): ReturnType<NonNullable<Tool["toModelOutput"]>> {
+  const result = output as {
+    content?: Array<Record<string, unknown> & { type?: string }>;
+  };
+  if (!result || typeof result !== "object" || !Array.isArray(result.content)) {
+    return { type: "json", value: result as never };
+  }
+  const convertedContent = result.content.map((part) => {
+    if (part.type === "text" && typeof part.text === "string") {
+      return { type: "text" as const, text: part.text };
+    }
+    if (
+      part.type === "image" &&
+      typeof part.data === "string" &&
+      typeof part.mimeType === "string"
+    ) {
+      return {
+        type: "file" as const,
+        mediaType: part.mimeType,
+        data: { type: "data" as const, data: part.data },
+      };
+    }
+    return { type: "text" as const, text: JSON.stringify(part) };
+  });
+  return { type: "content", value: convertedContent };
+}
+
+/**
+ * Connect to an MCP server and return a handle exposing AI SDK tools.
+ *
+ * Uses the SDK's default legacy connect (2025-11-25 initialize handshake), so
+ * every configured server sees the same bytes as before the SDK migration.
+ */
+export async function createMCPClient(config: MCPClientConfig): Promise<MCPClientHandle> {
+  const client = new Client(CLIENT_INFO);
+
+  if (config.onUncaughtError) {
+    const onUncaughtError = config.onUncaughtError;
+    client.onerror = (error) => onUncaughtError(error);
+  }
+
+  const transport = isHttpTransportConfig(config.transport)
+    ? createHttpTransport(config.transport)
+    : config.transport;
+
+  await client.connect(transport);
+
+  return {
+    tools: async () => {
+      const listResult = await client.listTools();
+      assert(Array.isArray(listResult.tools), "MCP tools/list result must carry a tools array");
+
+      const tools: Record<string, Tool> = {};
+      for (const definition of listResult.tools) {
+        const inputSchema = definition.inputSchema ?? { type: "object" };
+        tools[definition.name] = dynamicTool({
+          description: definition.description,
+          title: definition.title ?? definition.annotations?.title,
+          // Server-provided JSON schemas are runtime data; the SDK types them
+          // as loose JSON values, so narrow to the AI SDK's JSONSchema7 shape.
+          inputSchema: jsonSchema({
+            ...inputSchema,
+            properties: inputSchema.properties ?? {},
+            additionalProperties: false,
+          } as JSONSchema7),
+          execute: async (args: unknown, options: { abortSignal?: AbortSignal }) => {
+            options.abortSignal?.throwIfAborted();
+            return await client.callTool(
+              {
+                name: definition.name,
+                arguments: args as Record<string, unknown>,
+              },
+              {
+                timeout: SDK_TOOL_CALL_TIMEOUT_MS,
+                ...(options.abortSignal !== undefined ? { signal: options.abortSignal } : {}),
+              }
+            );
+          },
+          toModelOutput: mcpToModelOutput,
+        });
+      }
+      return tools;
+    },
+    close: () => client.close(),
+  };
+}

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -166,7 +166,7 @@ function mcpToModelOutput({
       return { type: "text" as const, text: part.text };
     }
     if (
-      part.type === "image" &&
+      (part.type === "image" || part.type === "audio") &&
       typeof part.data === "string" &&
       typeof part.mimeType === "string"
     ) {
@@ -175,6 +175,26 @@ function mcpToModelOutput({
         mediaType: part.mimeType,
         data: { type: "data" as const, data: part.data },
       };
+    }
+    // Embedded resources: surface text contents as text and binary contents
+    // as file parts instead of stringifying the base64 payload into JSON.
+    if (part.type === "resource" && part.resource && typeof part.resource === "object") {
+      const resource = part.resource as {
+        uri?: string;
+        text?: string;
+        blob?: string;
+        mimeType?: string;
+      };
+      if (typeof resource.text === "string") {
+        return { type: "text" as const, text: resource.text };
+      }
+      if (typeof resource.blob === "string") {
+        return {
+          type: "file" as const,
+          mediaType: resource.mimeType ?? "application/octet-stream",
+          data: { type: "data" as const, data: resource.blob },
+        };
+      }
     }
     return { type: "text" as const, text: JSON.stringify(part) };
   });

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -148,52 +148,54 @@ function mcpToModelOutput({
 }): ReturnType<NonNullable<Tool["toModelOutput"]>> {
   const result = output as {
     type?: string;
-    value?: unknown;
+    value?: Array<Record<string, unknown> & { type?: string }>;
     content?: Array<Record<string, unknown> & { type?: string }>;
   };
   // mcpServerManager's wrapMCPTools runs transformMCPResult over execute
-  // results first (it owns the image size guard); image results arrive here
-  // already in AI SDK model-output shape. Pass them through instead of
-  // re-converting (which would demote them to JSON and lose multimodal input).
-  if (result && typeof result === "object" && result.type === "content" && "value" in result) {
-    return result as ReturnType<NonNullable<Tool["toModelOutput"]>>;
+  // results first — the single conversion layer for MCP binary content
+  // (image/audio/blob resources, size guard included) — producing Mux's
+  // canonical { type: "content", value: [text | media] } shape. Map its
+  // media parts to model-output file parts here.
+  if (
+    result &&
+    typeof result === "object" &&
+    result.type === "content" &&
+    Array.isArray(result.value)
+  ) {
+    return {
+      type: "content",
+      value: result.value.map((part) => {
+        if (
+          part.type === "media" &&
+          typeof part.data === "string" &&
+          typeof part.mediaType === "string"
+        ) {
+          return {
+            type: "file" as const,
+            mediaType: part.mediaType,
+            data: { type: "data" as const, data: part.data },
+          };
+        }
+        if (part.type === "text" && typeof part.text === "string") {
+          return { type: "text" as const, text: part.text };
+        }
+        return { type: "text" as const, text: JSON.stringify(part) };
+      }),
+    };
   }
   if (!result || typeof result !== "object" || !Array.isArray(result.content)) {
     return { type: "json", value: result as never };
   }
+  // Untransformed MCP results (no binary payloads; see transformMCPResult):
+  // text and text-resource parts only in practice.
   const convertedContent = result.content.map((part) => {
     if (part.type === "text" && typeof part.text === "string") {
       return { type: "text" as const, text: part.text };
     }
-    if (
-      (part.type === "image" || part.type === "audio") &&
-      typeof part.data === "string" &&
-      typeof part.mimeType === "string"
-    ) {
-      return {
-        type: "file" as const,
-        mediaType: part.mimeType,
-        data: { type: "data" as const, data: part.data },
-      };
-    }
-    // Embedded resources: surface text contents as text and binary contents
-    // as file parts instead of stringifying the base64 payload into JSON.
     if (part.type === "resource" && part.resource && typeof part.resource === "object") {
-      const resource = part.resource as {
-        uri?: string;
-        text?: string;
-        blob?: string;
-        mimeType?: string;
-      };
+      const resource = part.resource as { uri?: string; text?: string };
       if (typeof resource.text === "string") {
         return { type: "text" as const, text: resource.text };
-      }
-      if (typeof resource.blob === "string") {
-        return {
-          type: "file" as const,
-          mediaType: resource.mimeType ?? "application/octet-stream",
-          data: { type: "data" as const, data: resource.blob },
-        };
       }
     }
     return { type: "text" as const, text: JSON.stringify(part) };

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -1,7 +1,5 @@
 import {
   Client,
-  SdkError,
-  SdkErrorCode,
   SSEClientTransport,
   StreamableHTTPClientTransport,
   type OAuthClientProvider,
@@ -104,15 +102,6 @@ export interface MCPClientHandle {
 /** True when the connection negotiated the stateless 2026-07-28+ era. */
 export function isModernEra(prior: PriorDiscovery): boolean {
   return prior.kind === "modern";
-}
-
-/**
- * True for the typed error the SDK throws when a cached modern era verdict
- * (`prior: { kind: "modern" }`) no longer overlaps the server's supported
- * protocol versions. Callers should drop the cached verdict and re-probe.
- */
-export function isEraNegotiationFailedError(error: unknown): boolean {
-  return error instanceof SdkError && error.code === SdkErrorCode.EraNegotiationFailed;
 }
 
 function isHttpTransportConfig(

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -1,8 +1,11 @@
 import {
   Client,
+  SdkError,
+  SdkErrorCode,
   SSEClientTransport,
   StreamableHTTPClientTransport,
   type OAuthClientProvider,
+  type PriorDiscovery,
   type Transport,
 } from "@modelcontextprotocol/client";
 import { dynamicTool, jsonSchema, type JSONSchema7, type Tool } from "ai";
@@ -55,17 +58,61 @@ export interface MCPHttpTransportConfig {
   authProvider?: OAuthClientProvider;
 }
 
+/**
+ * Timeout for the connect-time `server/discover` probe.
+ *
+ * Deliberately short: a legacy stdio server that silently ignores unknown
+ * pre-`initialize` requests only reveals itself via probe timeout, and that
+ * wait counts against mcpServerManager's 60s startup deadline. Probe verdicts
+ * are cached per server config (see MCPServerManager.eraVerdicts), so the
+ * cost is paid once per config change, not per startup.
+ */
+const NEGOTIATION_PROBE_TIMEOUT_MS = 5_000;
+
 export interface MCPClientConfig {
   /** Either a ready transport (stdio) or an HTTP/SSE transport config. */
   transport: Transport | MCPHttpTransportConfig;
   /** Receives transport/protocol errors surfaced outside request call sites. */
   onUncaughtError?: (error: unknown) => void;
+  /**
+   * Cached era verdict from a previous negotiation against the same server
+   * config. When present, connect() adopts it with zero probe round trips:
+   * a modern verdict replays the stored server/discover result (failing
+   * loudly via EraNegotiationFailed if stale), a legacy verdict runs the
+   * plain initialize handshake directly.
+   */
+  prior?: PriorDiscovery;
 }
 
 export interface MCPClientHandle {
   /** Fetch tools/list and build AI SDK tools whose execute calls tools/call. */
   tools(): Promise<Record<string, Tool>>;
+  /**
+   * The MCP protocol revision negotiated at connect ("2026-07-28" once the
+   * server/discover probe finds a modern server; "2025-11-25" or earlier on
+   * the legacy initialize fallback).
+   */
+  negotiatedProtocolVersion(): string | undefined;
+  /**
+   * Persistable era verdict for this connection, suitable for `prior` on a
+   * later connect against the same server config.
+   */
+  priorDiscovery(): PriorDiscovery;
   close(): Promise<void>;
+}
+
+/** True when the connection negotiated the stateless 2026-07-28+ era. */
+export function isModernEra(prior: PriorDiscovery): boolean {
+  return prior.kind === "modern";
+}
+
+/**
+ * True for the typed error the SDK throws when a cached modern era verdict
+ * (`prior: { kind: "modern" }`) no longer overlaps the server's supported
+ * protocol versions. Callers should drop the cached verdict and re-probe.
+ */
+export function isEraNegotiationFailedError(error: unknown): boolean {
+  return error instanceof SdkError && error.code === SdkErrorCode.EraNegotiationFailed;
 }
 
 function isHttpTransportConfig(
@@ -139,11 +186,19 @@ function mcpToModelOutput({
 /**
  * Connect to an MCP server and return a handle exposing AI SDK tools.
  *
- * Uses the SDK's default legacy connect (2025-11-25 initialize handshake), so
- * every configured server sees the same bytes as before the SDK migration.
+ * Version negotiation is per connection (and therefore per configured
+ * server): connect() probes with `server/discover` and conservatively falls
+ * back to the plain legacy 2025-11-25 initialize handshake — byte-identical
+ * to a pre-2026 client — on anything but definitive modern evidence. A
+ * `prior` verdict skips the probe entirely.
  */
 export async function createMCPClient(config: MCPClientConfig): Promise<MCPClientHandle> {
-  const client = new Client(CLIENT_INFO);
+  const client = new Client(CLIENT_INFO, {
+    versionNegotiation: {
+      mode: "auto",
+      probe: { timeoutMs: NEGOTIATION_PROBE_TIMEOUT_MS },
+    },
+  });
 
   if (config.onUncaughtError) {
     const onUncaughtError = config.onUncaughtError;
@@ -154,7 +209,7 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
     ? createHttpTransport(config.transport)
     : config.transport;
 
-  await client.connect(transport);
+  await client.connect(transport, config.prior !== undefined ? { prior: config.prior } : {});
 
   return {
     tools: async () => {
@@ -191,6 +246,11 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
         });
       }
       return tools;
+    },
+    negotiatedProtocolVersion: () => client.getNegotiatedProtocolVersion(),
+    priorDiscovery: (): PriorDiscovery => {
+      const discover = client.getDiscoverResult();
+      return discover !== undefined ? { kind: "modern", discover } : { kind: "legacy" };
     },
     close: () => client.close(),
   };

--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -11,6 +11,7 @@ import {
   probeServerForBearerChallenge,
   resolveOAuthScope,
 } from "./mcpOauthService";
+import type { MCPOAuthClientInformation, MCPOAuthTokens } from "@/common/types/mcpOauth";
 
 function getStoreFilePath(muxHome: string): string {
   return path.join(muxHome, "mcp-oauth.json");
@@ -206,11 +207,13 @@ describe("McpOauthService store", () => {
     expect(await readStoreFile()).toEqual({ version: 2, entries: {} });
   });
 
-  // Regression test: @ai-sdk/mcp auth() only uses a stored refresh_token when
-  // the persisted tokens/clientInformation retain the authorization_server +
-  // token_endpoint binding it saved. Stripping them during store parsing made
-  // auth() invalidate the tokens and demand interactive re-login after every
-  // app restart.
+  // Regression test: the legacy @ai-sdk/mcp auth() only used a stored
+  // refresh_token when the persisted tokens/clientInformation retained the
+  // authorization_server + token_endpoint binding it saved. Stripping them
+  // during store parsing made auth() invalidate the tokens and demand
+  // interactive re-login after every app restart. The official SDK v2 ignores
+  // these fields (it stamps `issuer` instead), but the store must keep
+  // round-tripping them so downgrading Mux does not break token refresh.
   test("authorization server binding survives store round-trip", async () => {
     const populatedStore = {
       version: 2,
@@ -238,12 +241,16 @@ describe("McpOauthService store", () => {
     const provider = await service.getAuthProviderForServer({ serverUrl });
     expect(provider).toBeDefined();
 
-    const tokens = await provider!.tokens();
+    // The SDK types no longer carry the legacy binding fields; read them via
+    // Mux's storage type, which is what the provider actually returns.
+    const tokens = (await provider!.tokens()) as MCPOAuthTokens | undefined;
     expect(tokens?.refresh_token).toBe("refresh-token");
     expect(tokens?.authorization_server).toBe("https://auth.example.com/");
     expect(tokens?.token_endpoint).toBe("https://auth.example.com/token");
 
-    const clientInformation = await provider!.clientInformation();
+    const clientInformation = (await provider!.clientInformation()) as
+      | MCPOAuthClientInformation
+      | undefined;
     expect(clientInformation?.authorization_server).toBe("https://auth.example.com/");
     expect(clientInformation?.token_endpoint).toBe("https://auth.example.com/token");
   });
@@ -251,7 +258,7 @@ describe("McpOauthService store", () => {
   test.each([
     // Corrupted: not a parseable URL.
     "not a url",
-    // Parseable but rejected by @ai-sdk/mcp's SafeUrlSchema; must be dropped
+    // Parseable but rejected by the MCP SDK's SafeUrlSchema; must be dropped
     // for self-healing rather than surfacing as a metadata mismatch in auth().
     "javascript:alert(1)",
     "data:text/plain,x",
@@ -281,7 +288,7 @@ describe("McpOauthService store", () => {
     const provider = await service.getAuthProviderForServer({ serverUrl });
     expect(provider).toBeDefined();
 
-    const tokens = await provider!.tokens();
+    const tokens = (await provider!.tokens()) as MCPOAuthTokens | undefined;
     expect(tokens?.refresh_token).toBe("refresh-token");
     expect(tokens?.authorization_server).toBeUndefined();
     expect(tokens?.token_endpoint).toBeUndefined();
@@ -465,7 +472,7 @@ describe("McpOauthService.startDesktopFlow", () => {
           res.end(
             JSON.stringify({
               // RFC 8414 canonical issuer: no trailing slash at the root.
-              // @ai-sdk/mcp v2 strictly validates metadata issuer identity.
+              // The MCP SDK strictly validates metadata issuer identity.
               issuer: new URL(baseUrl).origin,
               authorization_endpoint: `${baseUrl}authorize`,
               token_endpoint: `${baseUrl}token`,
@@ -532,9 +539,10 @@ describe("McpOauthService.startDesktopFlow", () => {
 
       const authorizeUrl = new URL(startResult.data.authorizeUrl);
       expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256");
-      // OAuth providers may canonicalize a root resource URL to its origin. That is
-      // equivalent to the configured root server URL, while base-path URLs are covered below.
-      expect(authorizeUrl.searchParams.get("resource")).toBe(new URL(baseUrl).origin);
+      // The SDK sends the canonicalized server URL as the RFC 8707 resource
+      // (the legacy @ai-sdk/mcp collapsed root URLs to their origin instead;
+      // both name the same resource). Base-path URLs are covered below.
+      expect(authorizeUrl.searchParams.get("resource")).toBe(new URL(baseUrl).toString());
 
       // Clean up the loopback listener (no callback will occur during this test).
       await service.cancelDesktopFlow(startResult.data.flowId);
@@ -559,7 +567,7 @@ describe("McpOauthService.startDesktopFlow", () => {
           res.end(
             JSON.stringify({
               // RFC 8414 canonical issuer: no trailing slash at the root.
-              // @ai-sdk/mcp v2 strictly validates metadata issuer identity.
+              // The MCP SDK strictly validates metadata issuer identity.
               issuer: new URL(authorizationServerBaseUrl).origin,
               authorization_endpoint: `${authorizationServerBaseUrl}authorize`,
               token_endpoint: `${authorizationServerBaseUrl}token`,

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -3,7 +3,7 @@ import * as http from "http";
 import * as path from "path";
 import * as fsPromises from "fs/promises";
 import writeFileAtomic from "write-file-atomic";
-import { auth, type OAuthClientProvider } from "@ai-sdk/mcp";
+import { auth, type OAuthClientProvider } from "@modelcontextprotocol/client";
 import type { Config } from "@/node/config";
 import type { MCPConfigService } from "@/node/services/mcpConfigService";
 import type { WindowService } from "@/node/services/windowService";
@@ -100,7 +100,7 @@ interface OAuthFlowBase {
   scope?: string;
   resourceMetadataUrl?: URL;
 
-  /** PKCE verifier for this flow (set by @ai-sdk/mcp auth()). */
+  /** PKCE verifier for this flow (set by the MCP SDK auth()). */
   codeVerifier: string | null;
 
   timeout: ReturnType<typeof setTimeout>;
@@ -290,7 +290,7 @@ export async function probeServerForBearerChallenge(options: {
  * Resolve the OAuth scope to request for an authorization flow.
  *
  * The Bearer challenge's `scope=` wins when present. Otherwise we fall back to
- * the Protected Resource Metadata's `scopes_supported` (RFC 9728). @ai-sdk/mcp
+ * the Protected Resource Metadata's `scopes_supported` (RFC 9728). The MCP SDK
  * fetches this same metadata to locate the authorization server but ignores its
  * advertised scopes, so without this a server that omits `scope=` from its 401
  * (e.g. Carta) grants only identity scopes and every resource call then fails
@@ -330,13 +330,15 @@ async function fetchProtectedResourceScopes(url: URL): Promise<string[]> {
 }
 
 /**
- * Parses the @ai-sdk/mcp authorization-server binding fields
+ * Parses the legacy @ai-sdk/mcp authorization-server binding fields
  * (authorization_server / token_endpoint) from a stored credentials object.
  *
- * These MUST survive the store round-trip: auth() refuses to use a stored
- * refresh_token without them and instead invalidates the tokens and demands
- * interactive re-login (i.e. dropping them silently breaks token refresh
- * after an app restart).
+ * These MUST survive the store round-trip: the legacy @ai-sdk/mcp auth()
+ * refused to use a stored refresh_token without them and instead invalidated
+ * the tokens and demanded interactive re-login. The official SDK v2 ignores
+ * these fields (it stamps `issuer` instead — see MCPOAuthTokens.issuer), but
+ * we keep round-tripping them so downgrading Mux does not break token
+ * refresh after an app restart.
  */
 function parseAuthorizationServerBinding(value: Record<string, unknown>): {
   authorization_server?: string;
@@ -365,6 +367,23 @@ function parseAuthorizationServerBinding(value: Record<string, unknown>): {
   }
 
   return { authorization_server: authorizationServer, token_endpoint: tokenEndpoint };
+}
+
+/**
+ * Parses the official SDK v2 issuer stamp (SEP-2352 credential/issuer binding)
+ * from a stored credentials object. Must survive the store round-trip:
+ * dropping it would reactivate the SDK's unstamped-credential warning on every
+ * request and defeat issuer binding. Same defensive http(s) validation as
+ * parseAuthorizationServerBinding; a corrupted value is dropped for
+ * self-healing (the SDK back-stamps on the next save).
+ */
+function parseIssuerStamp(value: Record<string, unknown>): { issuer?: string } {
+  const raw = value.issuer;
+  if (typeof raw !== "string" || !URL.canParse(raw)) {
+    return {};
+  }
+  const protocol = new URL(raw).protocol;
+  return protocol === "http:" || protocol === "https:" ? { issuer: raw } : {};
 }
 
 function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | null {
@@ -404,6 +423,7 @@ function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | nul
             ? clientInformationRaw.client_secret_expires_at
             : undefined,
         ...parseAuthorizationServerBinding(clientInformationRaw),
+        ...parseIssuerStamp(clientInformationRaw),
       }
     : undefined;
 
@@ -423,6 +443,7 @@ function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | nul
         refresh_token:
           typeof tokensRaw.refresh_token === "string" ? tokensRaw.refresh_token : undefined,
         ...parseAuthorizationServerBinding(tokensRaw),
+        ...parseIssuerStamp(tokensRaw),
       }
     : undefined;
 
@@ -798,7 +819,7 @@ export class McpOauthService {
     const redirectUri = `http://127.0.0.1:${address.port}/callback`;
 
     // Best-effort probe for OAuth hints (scope/resource_metadata). If it fails,
-    // @ai-sdk/mcp can still fall back to well-known discovery.
+    // the MCP SDK can still fall back to well-known discovery.
     const challenge = await probeServerForBearerChallenge({
       serverUrl: serverUrlForDiscovery,
       transport,
@@ -942,7 +963,7 @@ export class McpOauthService {
       createDeferred<Result<void, string>>();
 
     // Best-effort probe for OAuth hints (scope/resource_metadata). If it fails,
-    // @ai-sdk/mcp can still fall back to well-known discovery.
+    // the MCP SDK can still fall back to well-known discovery.
     const challenge = await probeServerForBearerChallenge({
       serverUrl: serverUrlForDiscovery,
       transport,
@@ -1140,6 +1161,11 @@ export class McpOauthService {
         return Promise.resolve(flow.codeVerifier);
       },
       invalidateCredentials: async (scope) => {
+        // "discovery" (SDK v2) refers to cached AS metadata, which Mux does
+        // not persist; nothing to invalidate.
+        if (scope === "discovery") {
+          return;
+        }
         await this.invalidateStoredCredentials({
           serverUrl: flow.serverUrlForStoreKey,
           scope,
@@ -1207,6 +1233,11 @@ export class McpOauthService {
       },
       codeVerifier: () => Promise.reject(new Error("PKCE verifier is not available")),
       invalidateCredentials: async (scope) => {
+        // "discovery" (SDK v2) refers to cached AS metadata, which Mux does
+        // not persist; nothing to invalidate.
+        if (scope === "discovery") {
+          return;
+        }
         await this.invalidateStoredCredentials({
           serverUrl: input.serverUrl,
           scope,

--- a/src/node/services/mcpResultTransform.test.ts
+++ b/src/node/services/mcpResultTransform.test.ts
@@ -109,12 +109,36 @@ describe("transformMCPResult", () => {
       expect(transformMCPResult("serena")).toBe("serena");
     });
 
-    it("should pass through error results unchanged", () => {
+    it("should pass through text-only error results unchanged", () => {
       const errorResult = {
         isError: true,
         content: [{ type: "text" as const, text: "Error!" }],
       };
       expect(transformMCPResult(errorResult)).toBe(errorResult);
+    });
+
+    it("should convert binary content in error results and mark the error", () => {
+      // Error results carrying binary payloads must not bypass the media
+      // conversion (or the size guard); the error flag is surfaced as text.
+      const bigData = "x".repeat(9 * 1024 * 1024);
+      const errorResult = {
+        isError: true,
+        content: [
+          { type: "text" as const, text: "capture failed" },
+          { type: "image" as const, data: "abc123", mimeType: "image/png" },
+          { type: "image" as const, data: bigData, mimeType: "image/png" },
+        ],
+      };
+      const result = transformMCPResult(errorResult) as {
+        type: string;
+        value: Array<{ type: string; text?: string; data?: string; mediaType?: string }>;
+      };
+      expect(result.type).toBe("content");
+      expect(result.value[0]).toEqual({ type: "text", text: "[Tool reported an error]" });
+      expect(result.value[1]).toEqual({ type: "text", text: "capture failed" });
+      expect(result.value[2]).toEqual({ type: "media", data: "abc123", mediaType: "image/png" });
+      expect(result.value[3].type).toBe("text");
+      expect(result.value[3].text).toContain("Image omitted");
     });
 
     it("should pass through toolResult unchanged", () => {

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -97,8 +97,8 @@ export function transformMCPResult(result: unknown): unknown {
 
   const typed = result as MCPCallToolResult;
 
-  // If it's an error or has toolResult, pass through as-is
-  if (typed.isError || typed.toolResult !== undefined) {
+  // If it has toolResult (non-standard result shape), pass through as-is
+  if (typed.toolResult !== undefined) {
     return result;
   }
 
@@ -107,8 +107,9 @@ export function transformMCPResult(result: unknown): unknown {
     return result;
   }
 
-  // Only rewrite results carrying binary payloads; text-only results pass
-  // through in MCP shape (converted by the tool's toModelOutput).
+  // Only rewrite results carrying binary payloads; text-only results
+  // (including text-only errors) pass through in MCP shape (converted by the
+  // tool's toModelOutput, which keeps the isError flag visible to the model).
   const hasBinaryContent = typed.content.some(
     (c) =>
       c.type === "image" ||
@@ -150,6 +151,13 @@ export function transformMCPResult(result: unknown): unknown {
     // Fallback: stringify unknown content
     return { type: "text" as const, text: JSON.stringify(item) };
   });
+
+  // The model-output "content" shape has no error flag, so error results
+  // carrying binary payloads get an explicit text marker instead of bypassing
+  // the media conversion (and its size guard).
+  if (typed.isError) {
+    transformedContent.unshift({ type: "text", text: "[Tool reported an error]" });
+  }
 
   return { type: "content", value: transformedContent };
 }

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -11,7 +11,7 @@ import { log } from "@/node/services/log";
 export const MAX_IMAGE_DATA_BYTES = 8 * 1024 * 1024; // 8MB guard per image
 
 /**
- * MCP CallToolResult content types (from @ai-sdk/mcp)
+ * MCP CallToolResult content types (MCP spec wire shapes)
  */
 interface MCPTextContent {
   type: "text";

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -24,12 +24,18 @@ interface MCPImageContent {
   mimeType: string;
 }
 
+interface MCPAudioContent {
+  type: "audio";
+  data: string; // base64
+  mimeType: string;
+}
+
 interface MCPResourceContent {
   type: "resource";
   resource: { uri: string; text?: string; blob?: string; mimeType?: string };
 }
 
-type MCPContent = MCPTextContent | MCPImageContent | MCPResourceContent;
+type MCPContent = MCPTextContent | MCPImageContent | MCPAudioContent | MCPResourceContent;
 
 export interface MCPCallToolResult {
   content?: MCPContent[];
@@ -56,10 +62,33 @@ function formatBytesSI(bytes: number): string {
   return `${Math.round(bytes / 1000)} KB`;
 }
 
+/** Binary media guard shared by image/audio content and blob resources. */
+function toGuardedMediaPart(
+  kind: string,
+  data: string | undefined,
+  mediaType: string
+): AISDKContentPart {
+  const dataLength = data?.length ?? 0;
+  if (dataLength > MAX_IMAGE_DATA_BYTES) {
+    log.warn(`[MCP] ${kind} data too large, omitting from context`, {
+      mediaType,
+      dataLength,
+      maxAllowed: MAX_IMAGE_DATA_BYTES,
+    });
+    return {
+      type: "text",
+      text: `[${kind} omitted: ${formatBytesSI(dataLength)} exceeds per-${kind.toLowerCase()} guard of ${formatBytesSI(MAX_IMAGE_DATA_BYTES)}. Reduce resolution or quality and retry.]`,
+    };
+  }
+  return { type: "media", data: data ?? "", mediaType };
+}
+
 /**
  * Transform MCP tool result to AI SDK format.
- * Converts MCP's "image" content type to AI SDK's "media" type.
- * Truncates large images to prevent context overflow.
+ * Converts MCP binary content (image, audio, embedded blob resources) to AI
+ * SDK "media" parts — the single conversion layer for MCP media (mixed
+ * text+binary results included). Truncates large payloads to prevent context
+ * overflow.
  */
 export function transformMCPResult(result: unknown): unknown {
   if (!result || typeof result !== "object") {
@@ -78,18 +107,21 @@ export function transformMCPResult(result: unknown): unknown {
     return result;
   }
 
-  // Check if any content is an image
-  const hasImage = typed.content.some((c) => c.type === "image");
-  if (!hasImage) {
+  // Only rewrite results carrying binary payloads; text-only results pass
+  // through in MCP shape (converted by the tool's toModelOutput).
+  const hasBinaryContent = typed.content.some(
+    (c) =>
+      c.type === "image" ||
+      c.type === "audio" ||
+      (c.type === "resource" && typeof c.resource?.blob === "string")
+  );
+  if (!hasBinaryContent) {
     return result;
   }
 
   // Debug: log what we received from MCP
   log.debug("[MCP] transformMCPResult input", {
     contentTypes: typed.content.map((c) => c.type),
-    imageItems: typed.content
-      .filter((c): c is MCPImageContent => c.type === "image")
-      .map((c) => ({ type: c.type, mimeType: c.mimeType, dataLen: c.data?.length })),
   });
 
   // Transform to AI SDK content format
@@ -98,29 +130,22 @@ export function transformMCPResult(result: unknown): unknown {
       return { type: "text" as const, text: item.text };
     }
     if (item.type === "image") {
-      const imageItem = item;
-      // Check if image data exceeds the limit
-      const dataLength = imageItem.data?.length ?? 0;
-      if (dataLength > MAX_IMAGE_DATA_BYTES) {
-        log.warn("[MCP] Image data too large, omitting from context", {
-          mimeType: imageItem.mimeType,
-          dataLength,
-          maxAllowed: MAX_IMAGE_DATA_BYTES,
-        });
-        return {
-          type: "text" as const,
-          text: `[Image omitted: ${formatBytesSI(dataLength)} exceeds per-image guard of ${formatBytesSI(MAX_IMAGE_DATA_BYTES)}. Reduce resolution or quality and retry.]`,
-        };
-      }
       // Ensure mediaType is present - default to image/png if missing
-      const mediaType = imageItem.mimeType || "image/png";
-      log.debug("[MCP] Transforming image content", { mimeType: imageItem.mimeType, mediaType });
-      return { type: "media" as const, data: imageItem.data, mediaType };
+      return toGuardedMediaPart("Image", item.data, item.mimeType || "image/png");
     }
-    // For resource type, convert to text representation
+    if (item.type === "audio") {
+      return toGuardedMediaPart("Audio", item.data, item.mimeType || "audio/wav");
+    }
     if (item.type === "resource") {
-      const text = item.resource.text ?? item.resource.uri;
-      return { type: "text" as const, text };
+      if (typeof item.resource.blob === "string") {
+        return toGuardedMediaPart(
+          "Resource",
+          item.resource.blob,
+          item.resource.mimeType ?? "application/octet-stream"
+        );
+      }
+      // Text resources: surface the text (or the URI as a reference).
+      return { type: "text" as const, text: item.resource.text ?? item.resource.uri };
     }
     // Fallback: stringify unknown content
     return { type: "text" as const, text: JSON.stringify(item) };

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -574,6 +574,77 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("startSingleServerImpl re-probes when a cached legacy verdict is rejected", async () => {
+    // A server cached as legacy can be upgraded in place to a 2026-only
+    // implementation that rejects the initialize handshake. The manager must
+    // drop the cached verdict and re-probe instead of failing every startup
+    // until the verdict TTL expires.
+    const controller = new AbortController();
+    const priors: unknown[] = [];
+    const tool = testTool();
+
+    const makeHandle = (era: "legacy" | "modern") =>
+      ({
+        tools: mock(() => Promise.resolve({ upgraded_tool: tool })),
+        negotiatedProtocolVersion: () => (era === "modern" ? "2026-07-28" : "2025-11-25"),
+        priorDiscovery: () =>
+          era === "modern"
+            ? { kind: "modern" as const, discover: {} }
+            : { kind: "legacy" as const },
+        close: mock(() => Promise.resolve(undefined)),
+      }) as unknown as Awaited<ReturnType<typeof mcpSdk.createMCPClient>>;
+
+    const createMCPClientSpy = spyOn(mcpSdk, "createMCPClient").mockImplementation(
+      (config: mcpSdk.MCPClientConfig) => {
+        priors.push(config.prior);
+        // Call 1: fresh probe -> legacy verdict cached.
+        if (priors.length === 1) {
+          return Promise.resolve(makeHandle("legacy"));
+        }
+        // Call 2: cached legacy verdict -> server was upgraded and now
+        // rejects the initialize handshake.
+        if (priors.length === 2) {
+          return Promise.reject(new Error("initialize rejected: unsupported protocol version"));
+        }
+        // Call 3: fresh re-probe -> modern.
+        return Promise.resolve(makeHandle("modern"));
+      }
+    );
+
+    const exec = mock(() =>
+      Promise.resolve({
+        stdin: new WritableStream<Uint8Array>({ close: () => undefined }),
+        stdout: new ReadableStream<Uint8Array>({ cancel: () => undefined }),
+        stderr: new ReadableStream<Uint8Array>({ cancel: () => undefined }),
+        exitCode: new Promise<number>(() => undefined),
+        duration: Promise.resolve(0),
+      })
+    );
+
+    try {
+      const startOnce = () =>
+        access.startSingleServerImpl(
+          "upgraded",
+          stdioConfig("node upgraded-server.js"),
+          { exec } as unknown as Runtime,
+          PROJECT_PATH,
+          WORKSPACE_PATH,
+          undefined,
+          () => undefined,
+          controller.signal
+        ) as Promise<{ name: string; tools: Record<string, Tool> } | null>;
+
+      const first = await startOnce();
+      expect(Object.keys(first?.tools ?? {})).toEqual(["upgraded_tool"]);
+
+      const second = await startOnce();
+      expect(priors).toEqual([undefined, { kind: "legacy" }, undefined]);
+      expect(Object.keys(second?.tools ?? {})).toEqual(["upgraded_tool"]);
+    } finally {
+      createMCPClientSpy.mockRestore();
+    }
+  });
+
   test("getToolsForWorkspace tracks failed server names in stats", async () => {
     const workspaceId = "ws-failed-names";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -519,6 +519,61 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("startSingleServerImpl respawns stdio server as legacy after probe crash", async () => {
+    // Fragile legacy stdio servers can exit on the server/discover probe.
+    // The manager must respawn the process once and reconnect with a legacy
+    // era verdict so the server still comes up.
+    const controller = new AbortController();
+    const priors: unknown[] = [];
+    const tool = testTool();
+
+    const createMCPClientSpy = spyOn(mcpSdk, "createMCPClient").mockImplementation(
+      (config: mcpSdk.MCPClientConfig) => {
+        priors.push(config.prior);
+        if (priors.length === 1) {
+          // First attempt: probe kills the server -> connect fails.
+          return Promise.reject(new Error("Connection closed"));
+        }
+        return Promise.resolve({
+          tools: mock(() => Promise.resolve({ crashy_tool: tool })),
+          negotiatedProtocolVersion: () => "2025-11-25",
+          priorDiscovery: () => ({ kind: "legacy" as const }),
+          close: mock(() => Promise.resolve(undefined)),
+        } as unknown as Awaited<ReturnType<typeof mcpSdk.createMCPClient>>);
+      }
+    );
+
+    const exec = mock(() =>
+      Promise.resolve({
+        stdin: new WritableStream<Uint8Array>({ close: () => undefined }),
+        stdout: new ReadableStream<Uint8Array>({ cancel: () => undefined }),
+        stderr: new ReadableStream<Uint8Array>({ cancel: () => undefined }),
+        exitCode: new Promise<number>(() => undefined),
+        duration: Promise.resolve(0),
+      })
+    );
+
+    try {
+      const result = (await access.startSingleServerImpl(
+        "crashy",
+        stdioConfig("node crash-on-probe.js"),
+        { exec } as unknown as Runtime,
+        PROJECT_PATH,
+        WORKSPACE_PATH,
+        undefined,
+        () => undefined,
+        controller.signal
+      )) as { name: string; tools: Record<string, Tool> } | null;
+
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(priors).toEqual([undefined, { kind: "legacy" }]);
+      expect(result?.name).toBe("crashy");
+      expect(Object.keys(result?.tools ?? {})).toEqual(["crashy_tool"]);
+    } finally {
+      createMCPClientSpy.mockRestore();
+    }
+  });
+
   test("getToolsForWorkspace tracks failed server names in stats", async () => {
     const workspaceId = "ws-failed-names";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "http";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import * as mcpSdk from "@ai-sdk/mcp";
+import * as mcpSdk from "@/node/services/mcpClient";
 import {
   MCPServerManager,
   isClosedClientError,

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1317,7 +1317,8 @@ export class MCPServerManager {
             projectPath,
             workspacePath,
             projectSecrets,
-            () => this.markActivity(workspaceId)
+            () => this.markActivity(workspaceId),
+            workspaceId
           );
 
           // Config changes can replace the workspace cache entry while this retry is still
@@ -1453,7 +1454,8 @@ export class MCPServerManager {
           projectPath,
           workspacePath,
           projectSecrets,
-          () => this.markActivity(workspaceId)
+          () => this.markActivity(workspaceId),
+          workspaceId
         );
         restartFailedNames = failedNames;
         restartTimedOutNames = timedOutNames;
@@ -1532,7 +1534,8 @@ export class MCPServerManager {
       projectPath,
       workspacePath,
       projectSecrets,
-      () => this.markActivity(workspaceId)
+      () => this.markActivity(workspaceId),
+      workspaceId
     );
 
     const allFailedNames = [...restartFailedNames, ...startFailedNames];
@@ -1781,7 +1784,8 @@ export class MCPServerManager {
     projectPath: string,
     workspacePath: string,
     projectSecrets: Record<string, string> | undefined,
-    onActivity: () => void
+    onActivity: () => void,
+    workspaceId?: string
   ): Promise<{
     instances: Map<string, MCPServerInstance>;
     failedServerNames: string[];
@@ -1801,7 +1805,8 @@ export class MCPServerManager {
           projectPath,
           workspacePath,
           projectSecrets,
-          onActivity
+          onActivity,
+          workspaceId
         );
         if (instance) {
           instances.set(name, instance);
@@ -1826,7 +1831,8 @@ export class MCPServerManager {
     projectPath: string,
     workspacePath: string,
     projectSecrets: Record<string, string> | undefined,
-    onActivity: () => void
+    onActivity: () => void,
+    workspaceId?: string
   ): Promise<MCPServerInstance | null> {
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const abortController = new AbortController();
@@ -1848,7 +1854,8 @@ export class MCPServerManager {
       projectSecrets,
       onActivity,
       abortController.signal,
-      registerAbortCleanup
+      registerAbortCleanup,
+      workspaceId
     ).then(
       (instance) => (didTimeout ? keepPendingAfterTimeout() : instance),
       (error) => {
@@ -1936,19 +1943,22 @@ export class MCPServerManager {
     projectSecrets: Record<string, string> | undefined,
     onActivity: () => void,
     signal: AbortSignal,
-    onAbortCleanup?: (cleanupPromise: Promise<void>) => void
+    onAbortCleanup?: (cleanupPromise: Promise<void>) => void,
+    workspaceId?: string
   ): Promise<MCPServerInstance | null> {
     if (signal.aborted) {
       return null;
     }
 
     if (info.transport === "stdio") {
-      // Include the effective execution context (cwd defaults to the
-      // workspace path): the same command can resolve different server
-      // versions from different worktrees/runtimes, so verdicts must not
-      // leak across workspaces.
+      // Scope verdicts by workspace identity (each workspace binds exactly
+      // one runtime, and workspace IDs are unique across hosts) plus the
+      // effective execution cwd: the same command can resolve different
+      // server versions from different worktrees, hosts, or runtimes, so a
+      // verdict probed in one execution context must not leak into another.
       const verdictKey = JSON.stringify([
         "stdio",
+        workspaceId ?? null,
         name,
         info.command,
         info.args ?? null,

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -571,9 +571,25 @@ async function runServerTest(
   projectPath: string,
   logContext: string
 ): Promise<MCPTestResult> {
-  const timeoutPromise = new Promise<MCPTestResult>((resolve) =>
-    setTimeout(() => resolve({ success: false, error: "Connection timed out" }), TEST_TIMEOUT_MS)
-  );
+  // Resettable deadline: the fragile-legacy stdio respawn below restarts the
+  // clock so the compatibility retry gets a full test window instead of
+  // whatever is left after the failed probe attempt.
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  let resolveTimeout: (result: MCPTestResult) => void;
+  const timeoutPromise = new Promise<MCPTestResult>((resolve) => {
+    resolveTimeout = resolve;
+  });
+  const armTestDeadline = () => {
+    timeoutHandle = setTimeout(
+      () => resolveTimeout({ success: false, error: "Connection timed out" }),
+      TEST_TIMEOUT_MS
+    );
+  };
+  const resetTestDeadline = () => {
+    clearTimeout(timeoutHandle);
+    armTestDeadline();
+  };
+  armTestDeadline();
 
   const testPromise = (async (): Promise<MCPTestResult> => {
     let stdioTransport: MCPStdioTransport | null = null;
@@ -613,6 +629,9 @@ async function runServerTest(
           } catch {
             // ignore cleanup errors
           }
+          // Give the respawned process a full test window; the failed probe
+          // attempt may have consumed most of the original deadline.
+          resetTestDeadline();
           stdioTransport = await spawnTransport();
           client = await createMCPClient({
             transport: stdioTransport,
@@ -1924,13 +1943,17 @@ export class MCPServerManager {
     }
 
     if (info.transport === "stdio") {
+      // Include the effective execution context (cwd defaults to the
+      // workspace path): the same command can resolve different server
+      // versions from different worktrees/runtimes, so verdicts must not
+      // leak across workspaces.
       const verdictKey = JSON.stringify([
         "stdio",
         name,
         info.command,
         info.args ?? null,
         info.env ?? null,
-        info.cwd ?? null,
+        info.cwd ?? workspacePath,
       ]);
       let prior = this.getCachedEraVerdict(verdictKey);
       // A cached verdict of either kind can go stale without a config change:

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -585,15 +585,40 @@ async function runServerTest(
         const runtime = createRuntime({ type: "local", srcBaseDir: projectPath });
         log.debug(`[MCP] Testing ${logContext}`, { transport: "stdio" });
 
-        const execStream = await runtime.exec(server.command, {
-          cwd: server.cwd ?? projectPath,
-          ...(server.env !== undefined ? { env: server.env } : {}),
-          timeout: TEST_TIMEOUT_MS / 1000,
-        });
+        const spawnTransport = async () => {
+          const execStream = await runtime.exec(server.command, {
+            cwd: server.cwd ?? projectPath,
+            ...(server.env !== undefined ? { env: server.env } : {}),
+            timeout: TEST_TIMEOUT_MS / 1000,
+          });
 
-        stdioTransport = new MCPStdioTransport(execStream);
-        await stdioTransport.start();
-        client = await createMCPClient({ transport: stdioTransport });
+          const transport = new MCPStdioTransport(execStream);
+          await transport.start();
+          return transport;
+        };
+
+        stdioTransport = await spawnTransport();
+        try {
+          client = await createMCPClient({ transport: stdioTransport });
+        } catch (error) {
+          // Fragile legacy stdio servers can exit on the server/discover
+          // negotiation probe. Mirror the production startup path
+          // (startSingleServerImpl): respawn once and connect with a legacy
+          // verdict so a working legacy server does not fail the test.
+          log.debug(`[MCP] ${logContext} stdio probe connect failed; retrying as legacy`, {
+            error: getErrorMessage(error),
+          });
+          try {
+            await stdioTransport.close();
+          } catch {
+            // ignore cleanup errors
+          }
+          stdioTransport = await spawnTransport();
+          client = await createMCPClient({
+            transport: stdioTransport,
+            prior: { kind: "legacy" },
+          });
+        }
       } else {
         log.debug(`[MCP] Testing ${logContext}`, { transport: server.transport });
 

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1,7 +1,8 @@
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
-import { createMCPClient, type OAuthClientProvider } from "@ai-sdk/mcp";
+import type { OAuthClientProvider } from "@modelcontextprotocol/client";
 import type { Tool } from "ai";
+import { createMCPClient, MCP_TOOL_CALL_TIMEOUT_MS } from "@/node/services/mcpClient";
 import { log } from "@/node/services/log";
 import { MCPStdioTransport } from "@/node/services/mcpStdioTransport";
 import type {
@@ -38,9 +39,11 @@ const IDLE_CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
 const MCP_STARTUP_TIMEOUT_MS = 60_000; // 60s — generous for npx package downloads
 const MCP_STARTUP_CLEANUP_WAIT_TIMEOUT_MS = 5_000; // fail-safe so timeout error cannot hang forever
 
-/** Detect errors from the @ai-sdk/mcp SDK indicating the client/transport is closed.
- *  MCPClientError is not exported from the SDK, so we match on known message patterns.
- *  Known patterns: "closed client", "Connection closed", "Connection closed unexpectedly". */
+/** Detect errors from the MCP SDK indicating the client/transport is closed.
+ *  We match on known message patterns rather than error classes so wrapped or
+ *  re-thrown errors are still recognized.
+ *  Known patterns: "Not connected", "Connection closed" (official SDK v2),
+ *  plus "closed client" kept from the previous @ai-sdk/mcp integration. */
 export function isClosedClientError(error: unknown): boolean {
   const msg = getErrorMessage(error).toLowerCase();
   return (
@@ -49,8 +52,6 @@ export function isClosedClientError(error: unknown): boolean {
     msg.includes("not connected")
   );
 }
-
-const MCP_TOOL_CALL_TIMEOUT_MS = 300_000;
 
 /**
  * Thrown by runMCPToolWithDeadline when abort or timeout wins the race.
@@ -364,7 +365,8 @@ function extractWwwAuthenticateHeader(error: unknown): string | null {
 function createWwwAuthenticateCaptureFetch() {
   let capturedHeader: string | null = null;
 
-  // @ai-sdk/mcp expects a full fetch implementation (including static helpers like
+  // The MCP SDK accepts any fetch-like function, but some call paths (and our
+  // own probes) may rely on static helpers like
   // preconnect), so wrap the call path while preserving the original function shape.
   const fetchWithCapture = Object.assign(async (...args: Parameters<typeof fetch>) => {
     const response = await fetch(...args);
@@ -574,11 +576,6 @@ async function runServerTest(
           url: server.url,
           headers: server.headers,
           fetch: challengeCapture.fetch,
-          // AI SDK 7 rejects HTTP redirects by default (SSRF hardening for
-          // untrusted URLs). MCP server URLs here are user-configured and
-          // already trusted to execute tools, so keep following redirects to
-          // avoid breaking existing setups (e.g. http→https, trailing slash).
-          redirect: "follow" as const,
           ...(server.authProvider ? { authProvider: server.authProvider } : {}),
         };
 
@@ -2019,9 +2016,6 @@ export class MCPServerManager {
     const transportBase = {
       url: info.url,
       headers,
-      // AI SDK 7 rejects HTTP redirects by default; these URLs are
-      // user-configured and trusted (see the test-connection transport above).
-      redirect: "follow" as const,
       ...(authProvider ? { authProvider } : {}),
     };
 

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1,8 +1,14 @@
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
-import type { OAuthClientProvider } from "@modelcontextprotocol/client";
+import type { OAuthClientProvider, PriorDiscovery } from "@modelcontextprotocol/client";
 import type { Tool } from "ai";
-import { createMCPClient, MCP_TOOL_CALL_TIMEOUT_MS } from "@/node/services/mcpClient";
+import {
+  createMCPClient,
+  isEraNegotiationFailedError,
+  isModernEra,
+  MCP_TOOL_CALL_TIMEOUT_MS,
+  type MCPClientHandle,
+} from "@/node/services/mcpClient";
 import { log } from "@/node/services/log";
 import { MCPStdioTransport } from "@/node/services/mcpStdioTransport";
 import type {
@@ -35,6 +41,16 @@ import { getErrorMessage } from "@/common/utils/errors";
 
 const TEST_TIMEOUT_MS = 10_000;
 const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Freshness horizon for cached *legacy* era verdicts.
+ *
+ * A stale modern verdict fails loudly at connect (EraNegotiationFailed), so
+ * modern verdicts never expire. A stale legacy verdict succeeds silently
+ * forever (an upgraded server still answers `initialize`), so legacy verdicts
+ * are re-probed after this horizon to notice server upgrades.
+ */
+const LEGACY_ERA_VERDICT_TTL_MS = 24 * 60 * 60 * 1000;
 const IDLE_CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
 const MCP_STARTUP_TIMEOUT_MS = 60_000; // 60s — generous for npx package downloads
 const MCP_STARTUP_CLEANUP_WAIT_TIMEOUT_MS = 5_000; // fail-safe so timeout error cannot hang forever
@@ -62,6 +78,19 @@ class MCPDeadlineError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "MCPDeadlineError";
+  }
+}
+
+/**
+ * Wraps errors raised while connecting a freshly-spawned stdio MCP client.
+ * Typed so the negotiation retry loop can distinguish "the connect (possibly
+ * the server/discover probe) failed against a live process" — which warrants
+ * one legacy respawn retry — from spawn/exec failures that a retry cannot fix.
+ */
+class MCPStdioConnectError extends Error {
+  constructor(readonly cause: unknown) {
+    super(`MCP stdio connect failed: ${getErrorMessage(cause)}`);
+    this.name = "MCPStdioConnectError";
   }
 }
 
@@ -617,6 +646,7 @@ async function runServerTest(
 
       const tools = await client.tools();
       const toolNames = Object.keys(tools);
+      const protocolVersion = client.negotiatedProtocolVersion();
 
       await client.close();
       client = null;
@@ -626,8 +656,15 @@ async function runServerTest(
         stdioTransport = null;
       }
 
-      log.info(`[MCP] ${logContext} test successful`, { toolCount: toolNames.length });
-      return { success: true, tools: toolNames };
+      log.info(`[MCP] ${logContext} test successful`, {
+        toolCount: toolNames.length,
+        protocolVersion,
+      });
+      return {
+        success: true,
+        tools: toolNames,
+        ...(protocolVersion !== undefined ? { protocolVersion } : {}),
+      };
     } catch (error) {
       const message = getErrorMessage(error);
       log.warn(`[MCP] ${logContext} test failed`, { error: message });
@@ -674,6 +711,15 @@ interface MCPServerInstance {
   tools: Record<string, Tool>;
   /** True once the underlying MCP client/transport has been closed. */
   isClosed: boolean;
+  /**
+   * Re-fetch tools/list through the SDK's SEP-2549 response cache and swap in
+   * the refreshed tool set. Only present on 2026-07-28+ connections, whose
+   * list results carry ttlMs/cacheScope freshness hints: a still-fresh cached
+   * list is served with zero round trips, a stale one refetches. Legacy
+   * connections keep the previous instance-lifetime tool caching (their list
+   * results carry no freshness hints).
+   */
+  refreshTools?: () => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -716,6 +762,14 @@ export interface MCPServerManagerOptions {
 export class MCPServerManager {
   private readonly workspaceServers = new Map<string, WorkspaceServers>();
   private readonly workspaceLeases = new Map<string, number>();
+  /**
+   * Cached per-server protocol era verdicts, keyed by server config
+   * (name + transport-relevant fields). Lets subsequent startups skip the
+   * connect-time server/discover probe. In-memory only: a config change
+   * yields a different key, so verdicts never outlive the config they were
+   * probed against.
+   */
+  private readonly eraVerdicts = new Map<string, { prior: PriorDiscovery; cachedAtMs: number }>();
   private readonly idleCheckInterval: ReturnType<typeof setInterval>;
   private inlineServers: Record<string, string> = {};
   private readonly policyService: PolicyService | null;
@@ -750,6 +804,48 @@ export class MCPServerManager {
 
   private getLeaseCount(workspaceId: string): number {
     return this.workspaceLeases.get(workspaceId) ?? 0;
+  }
+
+  private getCachedEraVerdict(key: string): PriorDiscovery | undefined {
+    const entry = this.eraVerdicts.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (!isModernEra(entry.prior) && Date.now() - entry.cachedAtMs > LEGACY_ERA_VERDICT_TTL_MS) {
+      // Legacy verdicts go stale silently; re-probe past the horizon.
+      this.eraVerdicts.delete(key);
+      return undefined;
+    }
+    return entry.prior;
+  }
+
+  private storeEraVerdict(key: string, prior: PriorDiscovery): void {
+    this.eraVerdicts.set(key, { prior, cachedAtMs: Date.now() });
+  }
+
+  /**
+   * Best-effort tools/list refresh for cached modern-era instances
+   * (SEP-2549): a still-fresh cached list is served by the SDK with zero
+   * round trips; a stale one refetches. Failures keep the existing tool set —
+   * tool availability must never regress because a refresh failed.
+   */
+  private async refreshModernInstanceTools(
+    instances: Map<string, MCPServerInstance>
+  ): Promise<void> {
+    await Promise.all(
+      [...instances.values()]
+        .filter((instance) => instance.refreshTools !== undefined && !instance.isClosed)
+        .map(async (instance) => {
+          try {
+            await instance.refreshTools!();
+          } catch (error) {
+            log.debug("[MCP] Tool list refresh failed; keeping cached tools", {
+              name: instance.name,
+              error: getErrorMessage(error),
+            });
+          }
+        })
+    );
   }
 
   /**
@@ -1246,6 +1342,10 @@ export class MCPServerManager {
         serverCount: enabledEntries.length,
       });
 
+      // Honor SEP-2549 freshness hints on modern-era connections instead of
+      // caching tool lists for the instance lifetime.
+      await this.refreshModernInstanceTools(existing.instances);
+
       return {
         tools: this.collectTools(existing.instances, fullServerInfo, overrides),
         stats: existing.stats,
@@ -1354,6 +1454,10 @@ export class MCPServerManager {
         failedServerNames
       );
       existing.stats = leasedStats;
+
+      // Honor SEP-2549 freshness hints on modern-era connections instead of
+      // caching tool lists for the instance lifetime.
+      await this.refreshModernInstanceTools(instancesForTools);
 
       return {
         tools: this.collectTools(instancesForTools, fullServerInfo, overrides),
@@ -1796,6 +1900,83 @@ export class MCPServerManager {
     }
 
     if (info.transport === "stdio") {
+      const verdictKey = JSON.stringify([
+        "stdio",
+        name,
+        info.command,
+        info.args ?? null,
+        info.env ?? null,
+        info.cwd ?? null,
+      ]);
+      let prior = this.getCachedEraVerdict(verdictKey);
+      // A server/discover probe can kill fragile legacy stdio servers that
+      // exit on any pre-initialize request. Allow one legacy respawn retry
+      // when no cached verdict skipped the probe.
+      let allowLegacyRetry = prior === undefined;
+
+      // Negotiation retry loop; bounded (each branch below fires at most once).
+      for (;;) {
+        try {
+          const started = await this.startStdioInstance(
+            name,
+            info,
+            runtime,
+            workspacePath,
+            onActivity,
+            signal,
+            onAbortCleanup,
+            prior
+          );
+          if (started === null) {
+            return null;
+          }
+          this.storeEraVerdict(verdictKey, started.prior);
+          return started.instance;
+        } catch (error) {
+          if (signal.aborted) {
+            return null;
+          }
+          if (prior !== undefined && isModernEra(prior) && isEraNegotiationFailedError(error)) {
+            // Stale modern verdict (server downgraded or changed identity):
+            // drop it and re-probe from scratch.
+            log.info("[MCP] Cached modern era verdict rejected; re-probing", { name });
+            this.eraVerdicts.delete(verdictKey);
+            prior = undefined;
+            allowLegacyRetry = true;
+            continue;
+          }
+          if (allowLegacyRetry && error instanceof MCPStdioConnectError) {
+            log.info("[MCP] stdio negotiation probe failed; respawning as legacy", {
+              name,
+              error: getErrorMessage(error.cause),
+            });
+            prior = { kind: "legacy" };
+            allowLegacyRetry = false;
+            continue;
+          }
+          throw error instanceof MCPStdioConnectError ? error.cause : error;
+        }
+      }
+    }
+
+    return this.startRemoteInstance(name, info, projectSecrets, onActivity, signal, onAbortCleanup);
+  }
+
+  /**
+   * Spawn and connect a stdio MCP server (one attempt; negotiation retries
+   * live in startSingleServerImpl). Returns null when aborted.
+   */
+  private async startStdioInstance(
+    name: string,
+    info: MCPStdioServerInfo,
+    runtime: Runtime,
+    workspacePath: string,
+    onActivity: () => void,
+    signal: AbortSignal,
+    onAbortCleanup: ((cleanupPromise: Promise<void>) => void) | undefined,
+    prior: PriorDiscovery | undefined
+  ): Promise<{ instance: MCPServerInstance; prior: PriorDiscovery } | null> {
+    {
       log.debug("[MCP] Spawning stdio server", { name });
       const launch = await prepareStdioLaunch(info);
       const execStream = await runtime.exec(launch.command, {
@@ -1914,7 +2095,16 @@ export class MCPServerManager {
           return null;
         }
 
-        client = await createMCPClient({ transport });
+        try {
+          client = await createMCPClient({
+            transport,
+            ...(prior !== undefined ? { prior } : {}),
+          });
+        } catch (error) {
+          // The connect failure may have been the negotiation probe killing a
+          // fragile legacy server; typed so the caller can respawn as legacy.
+          throw new MCPStdioConnectError(error);
+        }
         if (signal.aborted) {
           await cleanupStartupResources();
           return null;
@@ -1932,17 +2122,22 @@ export class MCPServerManager {
           return null;
         }
 
-        const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, {
-          onActivity,
-          onClosed: () => {
-            if (instanceRef.current) instanceRef.current.isClosed = true;
-          },
-        });
+        const wrapRawTools = (raw: Record<string, Tool>) =>
+          wrapMCPTools(raw, {
+            onActivity,
+            onClosed: () => {
+              if (instanceRef.current) instanceRef.current.isClosed = true;
+            },
+          });
+
+        const tools = wrapRawTools(rawTools as unknown as Record<string, Tool>);
+        const negotiatedPrior = readyClient.priorDiscovery();
 
         log.info("[MCP] Server ready", {
           name,
           transport: "stdio",
           toolCount: Object.keys(tools).length,
+          protocolVersion: readyClient.negotiatedProtocolVersion(),
         });
 
         const instance: MCPServerInstance = {
@@ -1951,6 +2146,14 @@ export class MCPServerManager {
           autoFallbackUsed: false,
           tools,
           isClosed: transportClosed,
+          ...(isModernEra(negotiatedPrior)
+            ? {
+                refreshTools: async () => {
+                  const raw = await readyClient.tools();
+                  instance.tools = wrapRawTools(raw);
+                },
+              }
+            : {}),
           close: async () => {
             // Mark closed first to prevent any new tool calls from being treated as
             // valid by higher-level caching logic.
@@ -1971,7 +2174,7 @@ export class MCPServerManager {
         };
 
         instanceRef.current = instance;
-        return instance;
+        return { instance, prior: negotiatedPrior };
       } catch (error) {
         await cleanupStartupResources();
         if (signal.aborted) {
@@ -1982,7 +2185,20 @@ export class MCPServerManager {
         signal.removeEventListener("abort", onAbort);
       }
     }
+  }
 
+  /**
+   * Connect an HTTP/SSE MCP server (with auto http→sse fallback and one
+   * stale-modern-verdict retry). Returns null when aborted.
+   */
+  private async startRemoteInstance(
+    name: string,
+    info: Exclude<MCPServerInfo, MCPStdioServerInfo>,
+    projectSecrets: Record<string, string> | undefined,
+    onActivity: () => void,
+    signal: AbortSignal,
+    onAbortCleanup?: (cleanupPromise: Promise<void>) => void
+  ): Promise<MCPServerInstance | null> {
     const { headers } = resolveHeaders(info.headers, projectSecrets);
 
     // Only attach authProvider when we have stored OAuth tokens for this server.
@@ -2019,6 +2235,9 @@ export class MCPServerManager {
       ...(authProvider ? { authProvider } : {}),
     };
 
+    const verdictKey = JSON.stringify(["remote", name, info.transport, info.url, headers ?? null]);
+    let prior = this.getCachedEraVerdict(verdictKey);
+
     const tryHttp = async () =>
       createMCPClient({
         transport: {
@@ -2026,6 +2245,7 @@ export class MCPServerManager {
           ...transportBase,
         },
         onUncaughtError,
+        ...(prior !== undefined ? { prior } : {}),
       });
 
     const trySse = async () =>
@@ -2035,6 +2255,7 @@ export class MCPServerManager {
           ...transportBase,
         },
         onUncaughtError,
+        ...(prior !== undefined ? { prior } : {}),
       });
 
     let client: Awaited<ReturnType<typeof createMCPClient>> | null = null;
@@ -2081,27 +2302,43 @@ export class MCPServerManager {
     };
     signal.addEventListener("abort", onAbort, { once: true });
 
-    try {
+    const establishClient = async (): Promise<MCPClientHandle> => {
       if (info.transport === "http") {
         resolvedTransport = "http";
-        client = await tryHttp();
-      } else if (info.transport === "sse") {
+        return await tryHttp();
+      }
+      if (info.transport === "sse") {
         resolvedTransport = "sse";
-        client = await trySse();
-      } else {
-        // auto
-        try {
-          resolvedTransport = "http";
-          client = await tryHttp();
-        } catch (error) {
-          if (!shouldAutoFallbackToSse(error)) {
-            throw error;
-          }
-          autoFallbackUsed = true;
-          resolvedTransport = "sse";
-          log.debug("[MCP] Auto-fallback http→sse", { name, status: extractHttpStatusCode(error) });
-          client = await trySse();
+        return await trySse();
+      }
+      // auto
+      try {
+        resolvedTransport = "http";
+        return await tryHttp();
+      } catch (error) {
+        if (!shouldAutoFallbackToSse(error)) {
+          throw error;
         }
+        autoFallbackUsed = true;
+        resolvedTransport = "sse";
+        log.debug("[MCP] Auto-fallback http→sse", { name, status: extractHttpStatusCode(error) });
+        return await trySse();
+      }
+    };
+
+    try {
+      try {
+        client = await establishClient();
+      } catch (error) {
+        if (prior === undefined || !isModernEra(prior) || !isEraNegotiationFailedError(error)) {
+          throw error;
+        }
+        // Stale modern verdict (server downgraded or changed identity):
+        // drop it and reconnect with a fresh probe.
+        log.info("[MCP] Cached modern era verdict rejected; re-probing", { name });
+        this.eraVerdicts.delete(verdictKey);
+        prior = undefined;
+        client = await establishClient();
       }
 
       if (signal.aborted) {
@@ -2122,18 +2359,24 @@ export class MCPServerManager {
 
       let clientClosed = false;
 
-      const tools = wrapMCPTools(rawTools as unknown as Record<string, Tool>, {
-        onActivity,
-        onClosed: () => {
-          if (instanceRef.current) instanceRef.current.isClosed = true;
-        },
-      });
+      const wrapRawTools = (raw: Record<string, Tool>) =>
+        wrapMCPTools(raw, {
+          onActivity,
+          onClosed: () => {
+            if (instanceRef.current) instanceRef.current.isClosed = true;
+          },
+        });
+
+      const tools = wrapRawTools(rawTools as unknown as Record<string, Tool>);
+      const negotiatedPrior = activeClient.priorDiscovery();
+      this.storeEraVerdict(verdictKey, negotiatedPrior);
 
       log.info("[MCP] Server ready", {
         name,
         transport: resolvedTransport,
         toolCount: Object.keys(tools).length,
         autoFallbackUsed,
+        protocolVersion: activeClient.negotiatedProtocolVersion(),
       });
 
       const instance: MCPServerInstance = {
@@ -2142,6 +2385,14 @@ export class MCPServerManager {
         autoFallbackUsed,
         tools,
         isClosed: transportErrored || clientClosed,
+        ...(isModernEra(negotiatedPrior)
+          ? {
+              refreshTools: async () => {
+                const raw = await activeClient.tools();
+                instance.tools = wrapRawTools(raw);
+              },
+            }
+          : {}),
         close: async () => {
           // Mark closed first to prevent any new tool calls from being treated as
           // valid by higher-level caching logic.

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1936,7 +1936,15 @@ export class MCPServerManager {
           if (signal.aborted) {
             return null;
           }
-          if (prior !== undefined && isModernEra(prior) && isEraNegotiationFailedError(error)) {
+          // Connect failures reach us wrapped in MCPStdioConnectError; unwrap
+          // before checking for the typed negotiation error, or a stale modern
+          // verdict would stay cached forever.
+          const connectCause = error instanceof MCPStdioConnectError ? error.cause : error;
+          if (
+            prior !== undefined &&
+            isModernEra(prior) &&
+            isEraNegotiationFailedError(connectCause)
+          ) {
             // Stale modern verdict (server downgraded or changed identity):
             // drop it and re-probe from scratch.
             log.info("[MCP] Cached modern era verdict rejected; re-probing", { name });

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -4,7 +4,6 @@ import type { OAuthClientProvider, PriorDiscovery } from "@modelcontextprotocol/
 import type { Tool } from "ai";
 import {
   createMCPClient,
-  isEraNegotiationFailedError,
   isModernEra,
   MCP_TOOL_CALL_TIMEOUT_MS,
   type MCPClientHandle,
@@ -1909,6 +1908,12 @@ export class MCPServerManager {
         info.cwd ?? null,
       ]);
       let prior = this.getCachedEraVerdict(verdictKey);
+      // A cached verdict of either kind can go stale without a config change:
+      // a modern verdict after a server downgrade (typed EraNegotiationFailed)
+      // and a legacy verdict after an upgrade to a 2026-only server that
+      // rejects the initialize handshake. On the first connect failure with a
+      // cached verdict, drop it and re-probe from scratch.
+      let priorFromCache = prior !== undefined;
       // A server/discover probe can kill fragile legacy stdio servers that
       // exit on any pre-initialize request. Allow one legacy respawn retry
       // when no cached verdict skipped the probe.
@@ -1936,20 +1941,15 @@ export class MCPServerManager {
           if (signal.aborted) {
             return null;
           }
-          // Connect failures reach us wrapped in MCPStdioConnectError; unwrap
-          // before checking for the typed negotiation error, or a stale modern
-          // verdict would stay cached forever.
-          const connectCause = error instanceof MCPStdioConnectError ? error.cause : error;
-          if (
-            prior !== undefined &&
-            isModernEra(prior) &&
-            isEraNegotiationFailedError(connectCause)
-          ) {
-            // Stale modern verdict (server downgraded or changed identity):
-            // drop it and re-probe from scratch.
-            log.info("[MCP] Cached modern era verdict rejected; re-probing", { name });
+          if (priorFromCache) {
+            log.info("[MCP] Cached era verdict rejected; re-probing", {
+              name,
+              cachedEra: prior !== undefined && isModernEra(prior) ? "modern" : "legacy",
+              error: getErrorMessage(error instanceof MCPStdioConnectError ? error.cause : error),
+            });
             this.eraVerdicts.delete(verdictKey);
             prior = undefined;
+            priorFromCache = false;
             allowLegacyRetry = true;
             continue;
           }
@@ -2338,14 +2338,22 @@ export class MCPServerManager {
       try {
         client = await establishClient();
       } catch (error) {
-        if (prior === undefined || !isModernEra(prior) || !isEraNegotiationFailedError(error)) {
+        if (prior === undefined) {
           throw error;
         }
-        // Stale modern verdict (server downgraded or changed identity):
-        // drop it and reconnect with a fresh probe.
-        log.info("[MCP] Cached modern era verdict rejected; re-probing", { name });
+        // A cached verdict of either kind can go stale without a config
+        // change: a modern verdict after a server downgrade (typed
+        // EraNegotiationFailed) and a legacy verdict after an upgrade to a
+        // 2026-only server that rejects the initialize handshake. Drop the
+        // verdict and reconnect with a fresh probe.
+        log.info("[MCP] Cached era verdict rejected; re-probing", {
+          name,
+          cachedEra: isModernEra(prior) ? "modern" : "legacy",
+          error: getErrorMessage(error),
+        });
         this.eraVerdicts.delete(verdictKey);
         prior = undefined;
+        autoFallbackUsed = false;
         client = await establishClient();
       }
 

--- a/src/node/services/mcpStdioTransport.ts
+++ b/src/node/services/mcpStdioTransport.ts
@@ -1,14 +1,16 @@
 import { TextDecoder, TextEncoder } from "util";
-import type { MCPTransport, JSONRPCMessage } from "@ai-sdk/mcp";
+import type { Transport, JSONRPCMessage } from "@modelcontextprotocol/client";
 import type { ExecStream } from "@/node/runtime/Runtime";
 import { log } from "@/node/services/log";
 
 /**
  * Minimal stdio transport for MCP servers using newline-delimited JSON (NDJSON).
  * Each message is a single line of JSON followed by \n.
- * This matches the protocol used by @ai-sdk/mcp's StdioMCPTransport.
+ * This matches the protocol used by the official SDK's StdioClientTransport,
+ * but reads/writes a Runtime.exec() stream so MCP servers can run on remote
+ * (SSH/devcontainer) runtimes too.
  */
-export class MCPStdioTransport implements MCPTransport {
+export class MCPStdioTransport implements Transport {
   private readonly decoder = new TextDecoder();
   private readonly encoder = new TextEncoder();
   private readonly stdoutReader: ReadableStreamDefaultReader<Uint8Array>;


### PR DESCRIPTION
## Summary

Migrates Mux's MCP client from `@ai-sdk/mcp` to the official TypeScript SDK v2 (`@modelcontextprotocol/client` 2.0.0) and brings it up to MCP spec revision [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) (stateless core), with per-server version negotiation and legacy fallback so every existing 2025-11-25 server configuration keeps working with no manual migration.

## Background

The 2026-07-28 revision removes the `initialize`/`initialized` handshake and `Mcp-Session-Id` sessions (SEP-2575/2567): every request carries its protocol version, client capabilities, and client identity in `_meta`, servers must implement `server/discover`, Streamable HTTP POSTs carry `Mcp-Method`/`Mcp-Name`, and list results carry `ttlMs`/`cacheScope` cache hints (SEP-2549). `@ai-sdk/mcp` (even latest 2.0.29) still pins `LATEST_PROTOCOL_VERSION = "2025-11-25"` with no upstream signal for the new revision — Mux could not connect to stateless-only servers at all. The official SDK v2 is the reference client for both revisions.

## Implementation

Two commits, each independently green:

**1. SDK swap in legacy mode (wire-identical)**
- New `src/node/services/mcpClient.ts` adapter exposing the same `createMCPClient → { tools(), close() }` surface `mcpServerManager` consumed from `@ai-sdk/mcp`, so the manager's instance-cache/lease/recycle machinery is untouched. `tools/list` results become AI SDK `dynamicTool` wrappers whose `execute` calls `tools/call` (mirrors `@ai-sdk/mcp`'s construction incl. `toModelOutput`, keeping model-visible results identical).
- `MCPStdioTransport` (NDJSON over `Runtime.exec()`, works on SSH runtimes) now implements the official SDK `Transport` interface — shape-compatible, near-zero change.
- `mcpOauthService` drives the official `auth()` (gains SEP-2468 `iss` validation); providers handle the new `discovery` invalidation scope; the persisted store round-trips the SDK v2 `issuer` stamp (SEP-2352) alongside the legacy `@ai-sdk/mcp` binding fields for downgrade compatibility.

**2. Per-server negotiation + cache hints**
- `createMCPClient` negotiates per connection (SDK `auto` mode): `connect()` probes with `server/discover` (5s probe timeout) and conservatively falls back to the plain legacy `initialize` handshake — byte-identical to a 2025 client — on anything but definitive modern evidence. Negotiation is inherently per configured server; never global.
- `MCPServerManager` caches era verdicts per server config (in-memory; key includes transport-relevant fields so config changes re-probe). Legacy verdicts re-probe after 24h; stale modern verdicts fail loudly (`EraNegotiationFailed`) and trigger one fresh-probe retry.
- Fragile legacy stdio servers that exit on the unknown probe request are respawned once and reconnected with a legacy verdict (typed `MCPStdioConnectError` drives the retry).
- SEP-2549: modern-era instances re-list through the SDK's `ttlMs`/`cacheScope`-aware response cache on cached `getToolsForWorkspace` paths (fresh entries are zero round trips) instead of caching tool lists for the instance lifetime; refresh failures keep the existing tool set so tool availability never regresses. Legacy connections keep the previous instance-lifetime caching (no freshness hints exist there).
- The server test flow now reports the negotiated protocol revision.

Non-goals (deliberate): MRTR input fulfilment (Mux registers no elicitation/sampling/roots handlers — pure tools consumer), `subscriptions/listen`, the tasks extension.

## Validation

- Live matrix through Mux's real adapter + stdio transport:
  - legacy stdio fixture (`tests/ipc/fixtures/mcp-screenshot-server.js`) → negotiated `2025-11-25`, tool call returns image content
  - modern 2026-07-28-only Streamable HTTP server (official SDK v2 `createMcpHandler`) → negotiated `2026-07-28`, tool round trip OK, plus zero-probe reconnect from a cached modern verdict
  - legacy Streamable HTTP (SDK v2 legacy transport) → negotiated `2025-11-25`
  - crash-on-probe stdio server (exits on any pre-`initialize` request) → probe connect fails, legacy-verdict respawn succeeds; manager retry covered by a behavioral unit test
- `make static-check` green; full `src/node/services` suite (4529 tests) green.
- The model-in-the-loop MCP integration tests (`tests/ipc/config/mcpConfig.test.ts`) could not run in this workspace (provider gateway returned 403 for the API key); the non-model MCP config integration tests pass. CI covers the rest.

## Risks

- **OAuth flows** (moderate): `auth()` implementation changed under the hood. The wire behavior is same-ancestry and all 20 OAuth unit tests pass (one test expectation updated: SDK v2 sends the canonicalized server URL as the RFC 8707 `resource` instead of collapsing root URLs to the origin — semantically the same resource). New: SDK v2 strictly validates AS metadata `iss` (RFC 8414 §3.3) and issuer-binds stored credentials; a misbehaving AS that previously slipped through could now require re-login.
- **Fragile stdio servers** (low): the `server/discover` probe can kill legacy servers that exit on unknown requests. Mitigated by the one-shot legacy respawn + verdict cache; worst case is one extra spawn on first startup per config.
- **Startup latency** (low): first startup per server config pays the probe (≤5s stdio timeout; HTTP servers answer promptly). Verdict caching removes it from subsequent startups.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `off` • Cost: `$67.89`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=off costs=67.89 -->
