### PR TITLE
🤖 feat: copy/download context menu and richer previews for tool result images

### DIFF
--- a/src/browser/components/ImageActionsMenu.tsx
+++ b/src/browser/components/ImageActionsMenu.tsx
@@ -1,0 +1,87 @@
+import type React from "react";
+import { Copy, Download } from "lucide-react";
+import type { UseContextMenuPositionReturn } from "@/browser/hooks/useContextMenuPosition";
+import {
+  PositionedMenu,
+  PositionedMenuItem,
+} from "@/browser/components/PositionedMenu/PositionedMenu";
+import {
+  copyImageDataUrlToClipboard,
+  downloadDataUrl,
+  handleImageActionKeyDown,
+} from "@/browser/utils/imageActions";
+import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
+
+export interface ImageActionsMenuImage {
+  dataUrl: string;
+  downloadFilename: string;
+}
+
+/** Copy an image data URL, logging (not throwing) on failure. */
+export function copyImageWithErrorLogging(dataUrl: string): void {
+  copyImageDataUrlToClipboard(dataUrl).catch((err: unknown) => {
+    console.error("Failed to copy image:", err);
+  });
+}
+
+interface ImageActionsMenuProps {
+  contextMenu: UseContextMenuPositionReturn;
+  /** The image the menu targets; null renders an empty (closed) menu */
+  image: ImageActionsMenuImage | null;
+  /** Extra leading menu items (e.g. "View full size" on thumbnails) */
+  children?: React.ReactNode;
+  /** Override the copy action (e.g. to surface copied-feedback in the lightbox) */
+  onCopy?: (dataUrl: string) => void;
+}
+
+/**
+ * Shared right-click menu for image surfaces (tool result thumbnails and the
+ * expanded lightbox) so both offer the same Copy/Download actions and
+ * keyboard shortcuts.
+ */
+export function ImageActionsMenu(props: ImageActionsMenuProps) {
+  const image = props.image;
+  const copy = props.onCopy ?? copyImageWithErrorLogging;
+
+  return (
+    <PositionedMenu
+      open={props.contextMenu.isOpen}
+      onOpenChange={props.contextMenu.onOpenChange}
+      position={props.contextMenu.position}
+      onKeyDown={(e) => {
+        if (!image) return;
+        const consumed = handleImageActionKeyDown(e, {
+          copy: () => copy(image.dataUrl),
+          download: () => downloadDataUrl(image.dataUrl, image.downloadFilename),
+        });
+        if (consumed) {
+          props.contextMenu.close();
+        }
+      }}
+    >
+      {image && (
+        <>
+          {props.children}
+          <PositionedMenuItem
+            icon={<Copy />}
+            label="Copy image"
+            shortcut={formatKeybind(KEYBINDS.IMAGE_COPY)}
+            onClick={() => {
+              copy(image.dataUrl);
+              props.contextMenu.close();
+            }}
+          />
+          <PositionedMenuItem
+            icon={<Download />}
+            label="Download image"
+            shortcut={formatKeybind(KEYBINDS.IMAGE_DOWNLOAD)}
+            onClick={() => {
+              downloadDataUrl(image.dataUrl, image.downloadFilename);
+              props.contextMenu.close();
+            }}
+          />
+        </>
+      )}
+    </PositionedMenu>
+  );
+}

--- a/src/browser/components/ImageLightbox.tsx
+++ b/src/browser/components/ImageLightbox.tsx
@@ -6,6 +6,8 @@ import {
   VisuallyHidden,
 } from "@/browser/components/Dialog/Dialog";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
+import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
+import { ImageActionsMenu } from "@/browser/components/ImageActionsMenu";
 import {
   copyImageDataUrlToClipboard,
   downloadDataUrl,
@@ -40,6 +42,9 @@ export function ImageLightbox(props: ImageLightboxProps) {
   const src = props.src;
   // Reuse the shared copied-feedback hook with an image write function.
   const { copied, copyToClipboard } = useCopyToClipboard(copyImageDataUrlToClipboard);
+  // Same right-click/long-press menu as the thumbnails so the expanded view
+  // stays consistent with the tool card experience.
+  const contextMenu = useContextMenuPosition({ longPress: true });
   const downloadFilename = props.downloadFilename ?? props.filename ?? "image";
 
   return (
@@ -61,7 +66,22 @@ export function ImageLightbox(props: ImageLightboxProps) {
         </VisuallyHidden>
         {src !== null && (
           <>
-            <img src={src} alt={props.alt} className="max-h-[80vh] max-w-full object-contain" />
+            <img
+              src={src}
+              alt={props.alt}
+              className="max-h-[80vh] max-w-full object-contain"
+              onContextMenu={contextMenu.onContextMenu}
+              onTouchStart={contextMenu.touchHandlers.onTouchStart}
+              onTouchEnd={contextMenu.touchHandlers.onTouchEnd}
+              onTouchMove={contextMenu.touchHandlers.onTouchMove}
+            />
+            {/* Route menu copies through the feedback hook so the Copy button
+                flashes "Copied" regardless of how the copy was triggered. */}
+            <ImageActionsMenu
+              contextMenu={contextMenu}
+              image={{ dataUrl: src, downloadFilename }}
+              onCopy={(dataUrl) => void copyToClipboard(dataUrl)}
+            />
             <div className="flex w-full min-w-0 items-center gap-2 px-1">
               {props.filename && (
                 <span className="text-muted min-w-0 flex-1 truncate text-xs">{props.filename}</span>

--- a/src/browser/components/ImageLightbox.tsx
+++ b/src/browser/components/ImageLightbox.tsx
@@ -6,7 +6,12 @@ import {
   VisuallyHidden,
 } from "@/browser/components/Dialog/Dialog";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
-import { copyImageDataUrlToClipboard } from "@/browser/utils/imageActions";
+import {
+  copyImageDataUrlToClipboard,
+  downloadDataUrl,
+  handleImageActionKeyDown,
+} from "@/browser/utils/imageActions";
+import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 
 interface ImageLightboxProps {
   src: string | null;
@@ -22,10 +27,20 @@ interface ImageLightboxProps {
 const ACTION_BUTTON_CLASS =
   "border-border-light hover:bg-hover flex items-center gap-1 rounded border px-2 py-1 text-xs text-[var(--color-text)]";
 
+/** Keybind hint rendered inside an action button; hidden on mobile views. */
+function ShortcutHint(props: { keybind: (typeof KEYBINDS)[keyof typeof KEYBINDS] }) {
+  return (
+    <span className="text-muted hidden text-[10px] sm:inline">
+      ({formatKeybind(props.keybind)})
+    </span>
+  );
+}
+
 export function ImageLightbox(props: ImageLightboxProps) {
   const src = props.src;
   // Reuse the shared copied-feedback hook with an image write function.
   const { copied, copyToClipboard } = useCopyToClipboard(copyImageDataUrlToClipboard);
+  const downloadFilename = props.downloadFilename ?? props.filename ?? "image";
 
   return (
     <Dialog open={src !== null} onOpenChange={props.onClose}>
@@ -33,6 +48,13 @@ export function ImageLightbox(props: ImageLightboxProps) {
         maxWidth="90vw"
         maxHeight="90vh"
         className="flex w-auto flex-col items-center justify-center gap-2 bg-black/90 p-2"
+        onKeyDown={(e) => {
+          if (src === null) return;
+          handleImageActionKeyDown(e, {
+            copy: () => void copyToClipboard(src),
+            download: () => downloadDataUrl(src, downloadFilename),
+          });
+        }}
       >
         <VisuallyHidden>
           <DialogTitle>{props.title}</DialogTitle>
@@ -52,14 +74,12 @@ export function ImageLightbox(props: ImageLightboxProps) {
                 >
                   {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
                   {copied ? "Copied" : "Copy"}
+                  <ShortcutHint keybind={KEYBINDS.IMAGE_COPY} />
                 </button>
-                <a
-                  href={src}
-                  download={props.downloadFilename ?? props.filename ?? "image"}
-                  className={ACTION_BUTTON_CLASS}
-                >
+                <a href={src} download={downloadFilename} className={ACTION_BUTTON_CLASS}>
                   <Download className="h-3 w-3" />
                   Download
+                  <ShortcutHint keybind={KEYBINDS.IMAGE_DOWNLOAD} />
                 </a>
               </div>
             </div>

--- a/src/browser/components/ImageLightbox.tsx
+++ b/src/browser/components/ImageLightbox.tsx
@@ -1,30 +1,69 @@
+import { Check, Copy, Download } from "lucide-react";
 import {
   Dialog,
   DialogContent,
   DialogTitle,
   VisuallyHidden,
 } from "@/browser/components/Dialog/Dialog";
+import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
+import { copyImageDataUrlToClipboard } from "@/browser/utils/imageActions";
 
 interface ImageLightboxProps {
   src: string | null;
   title: string;
   alt: string;
+  /** Optional filename shown in the action bar */
+  filename?: string;
+  /** Filename used by the Download action (defaults to filename, then "image") */
+  downloadFilename?: string;
   onClose: () => void;
 }
 
+const ACTION_BUTTON_CLASS =
+  "border-border-light hover:bg-hover flex items-center gap-1 rounded border px-2 py-1 text-xs text-[var(--color-text)]";
+
 export function ImageLightbox(props: ImageLightboxProps) {
+  const src = props.src;
+  // Reuse the shared copied-feedback hook with an image write function.
+  const { copied, copyToClipboard } = useCopyToClipboard(copyImageDataUrlToClipboard);
+
   return (
-    <Dialog open={props.src !== null} onOpenChange={props.onClose}>
+    <Dialog open={src !== null} onOpenChange={props.onClose}>
       <DialogContent
         maxWidth="90vw"
         maxHeight="90vh"
-        className="flex w-auto items-center justify-center bg-black/90 p-2"
+        className="flex w-auto flex-col items-center justify-center gap-2 bg-black/90 p-2"
       >
         <VisuallyHidden>
           <DialogTitle>{props.title}</DialogTitle>
         </VisuallyHidden>
-        {props.src && (
-          <img src={props.src} alt={props.alt} className="max-h-[85vh] max-w-full object-contain" />
+        {src !== null && (
+          <>
+            <img src={src} alt={props.alt} className="max-h-[80vh] max-w-full object-contain" />
+            <div className="flex w-full min-w-0 items-center gap-2 px-1">
+              {props.filename && (
+                <span className="text-muted min-w-0 flex-1 truncate text-xs">{props.filename}</span>
+              )}
+              <div className="ml-auto flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => void copyToClipboard(src)}
+                  className={ACTION_BUTTON_CLASS}
+                >
+                  {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+                <a
+                  href={src}
+                  download={props.downloadFilename ?? props.filename ?? "image"}
+                  className={ACTION_BUTTON_CLASS}
+                >
+                  <Download className="h-3 w-3" />
+                  Download
+                </a>
+              </div>
+            </div>
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/src/browser/components/PositionedMenu/PositionedMenu.tsx
+++ b/src/browser/components/PositionedMenu/PositionedMenu.tsx
@@ -14,6 +14,11 @@ interface PositionedMenuProps {
   children: React.ReactNode;
   /** Tailwind width class (default: "w-[180px]") */
   className?: string;
+  /**
+   * Keyboard handler for menu-scoped shortcuts. Attached to the popover
+   * content, which receives focus when the menu opens.
+   */
+  onKeyDown?: (e: React.KeyboardEvent) => void;
 }
 
 /**
@@ -66,6 +71,7 @@ export function PositionedMenu(props: PositionedMenuProps) {
         className={cn("min-w-0! bg-surface-primary p-1", props.className ?? "w-[180px]")}
         style={{ visibility: !props.open || isPlaced ? "visible" : "hidden" }}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={props.onKeyDown}
       >
         {props.children}
       </PopoverContent>

--- a/src/browser/components/PositionedMenu/PositionedMenu.tsx
+++ b/src/browser/components/PositionedMenu/PositionedMenu.tsx
@@ -30,6 +30,24 @@ interface PositionedMenuProps {
 export function PositionedMenu(props: PositionedMenuProps) {
   const [isPlaced, setIsPlaced] = React.useState(false);
 
+  // Anchor via a Radix virtual ref measured in viewport coordinates instead of
+  // a `position: fixed` <span>. Fixed-position elements resolve against the
+  // nearest transformed ancestor, so a span rendered inside e.g. DialogContent
+  // (centered with translate(-50%,-50%)) landed offset from the cursor. A
+  // virtual rect is consumed by Floating UI directly in viewport space and is
+  // immune to the caller's ancestor transforms.
+  const positionRef = React.useRef(props.position);
+  positionRef.current = props.position;
+  const virtualAnchorRef = React.useRef({
+    getBoundingClientRect: () =>
+      DOMRect.fromRect({
+        x: positionRef.current?.x ?? 0,
+        y: positionRef.current?.y ?? 0,
+        width: 0,
+        height: 0,
+      }),
+  });
+
   // Keep content invisible for one animation frame after opening/repositioning.
   // This gives Radix/Floating UI time to compute final placement and avoids a
   // first-frame flash at fallback coordinates.
@@ -51,19 +69,7 @@ export function PositionedMenu(props: PositionedMenuProps) {
 
   return (
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
-      {props.position && (
-        <PopoverAnchor asChild>
-          <span
-            style={{
-              position: "fixed",
-              left: props.position.x,
-              top: props.position.y,
-              width: 0,
-              height: 0,
-            }}
-          />
-        </PopoverAnchor>
-      )}
+      {props.position && <PopoverAnchor virtualRef={virtualAnchorRef} />}
       <PopoverContent
         align="start"
         side="right"

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -92,6 +92,11 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   REVIEW_COMMENT: "Add comment (immersive)",
   REVIEW_FOCUS_NOTES: "Focus notes sidebar (immersive)",
   TOGGLE_PLAN_ANNOTATE: "Toggle plan annotate mode",
+  // Image-viewer-scoped keybinds (lightbox / image context menu); intentionally
+  // omitted from KEYBIND_GROUPS because they only apply while an image surface
+  // is focused.
+  IMAGE_COPY: "Copy image (image viewer)",
+  IMAGE_DOWNLOAD: "Download image (image viewer)",
   // Easter egg keybind; intentionally omitted from KEYBIND_GROUPS.
   TOGGLE_POWER_MODE: "",
 };

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -208,6 +208,58 @@ export const ImageContextMenu: Story = {
   },
 };
 
+// Touch-only contract: a 500ms long-press on the thumbnail opens the same
+// context menu. Pixel does not emulate touch (pointer: coarse never matches),
+// so this play function exercises the touch path directly per the Storybook
+// responsive/Pixel validation rule.
+export const ImageLongPressMenu: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "screenshot.png" }}
+        result={{
+          type: "content",
+          value: [
+            { type: "text", text: "[Attachment prepared: screenshot.png]" },
+            {
+              type: "media",
+              data: samplePng,
+              mediaType: "image/png",
+              filename: "screenshot.png",
+            },
+          ],
+        }}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const image = await canvas.findByRole("img", { name: "screenshot.png" });
+
+    // Start a touch and hold: the long-press timer opens the menu after 500ms.
+    // Fixed coordinates keep the menu position deterministic for snapshots.
+    await fireEvent.touchStart(image, { touches: [{ clientX: 120, clientY: 160 }] });
+
+    // The menu renders in a portal attached to document.body. waitFor polls
+    // past the 500ms long-press threshold.
+    const body = within(document.body);
+    await waitFor(() => body.getByText("Copy image"), { timeout: 3000 });
+
+    await fireEvent.touchEnd(image);
+
+    // The click that follows a long-press must be suppressed: the lightbox
+    // dialog should not open on top of the context menu.
+    await fireEvent.click(image);
+    await waitFor(() => {
+      if (document.body.querySelector("[role='dialog']")) {
+        throw new Error("Lightbox should not open after a long-press");
+      }
+    });
+  },
+};
+
 export const FailedAttachment: Story = {
   render: () => (
     <ToolStoryShell>

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -227,14 +227,14 @@ export const ImageLongPressMenu: Story = {
     // Chromium's TouchEvent constructor requires real Touch instances (plain
     // objects throw). Fixed coordinates keep the menu position deterministic.
     const touch = new Touch({ identifier: 1, target: image, clientX: 120, clientY: 160 });
-    await fireEvent.touchStart(image, { touches: [touch] });
+    await fireEvent.touchStart(image, { touches: [touch], changedTouches: [touch] });
 
     // The menu renders in a portal attached to document.body. waitFor polls
     // past the 500ms long-press threshold.
     const body = within(document.body);
     await waitFor(() => body.getByText("Copy image"), { timeout: 3000 });
 
-    await fireEvent.touchEnd(image);
+    await fireEvent.touchEnd(image, { changedTouches: [touch] });
 
     // The click that follows a long-press must be suppressed: the lightbox
     // must not open on top of the context menu. The Radix popover menu itself
@@ -248,9 +248,14 @@ export const ImageLongPressMenu: Story = {
   },
 };
 
-// The expanded lightbox offers the same right-click menu as the thumbnails.
-// The play function also asserts layering: Escape closes only the menu (the
-// topmost Radix layer) while the lightbox dialog stays open.
+// The expanded lightbox offers the same context menu as the thumbnails, on
+// both input paths. The play function asserts:
+// 1. right-click opens the menu at the cursor (regression contract: the
+//    dialog's centering transform used to offset the fixed-position anchor),
+// 2. Escape closes only the menu (topmost Radix layer) while the lightbox
+//    dialog stays open,
+// 3. the touch-only 500ms long-press path opens the menu too (Pixel does not
+//    emulate touch, so this must be a play contract).
 export const LightboxContextMenu: Story = {
   render: renderImageAttachment,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
@@ -270,8 +275,27 @@ export const LightboxContextMenu: Story = {
 
     // Fixed coordinates keep the menu position deterministic for snapshots.
     await fireEvent.contextMenu(fullSizeImage, { clientX: 240, clientY: 200 });
-    await waitFor(() => body.getByText("Copy image"));
+    const menuItem = await waitFor(() => body.getByText("Copy image"));
     await waitFor(() => body.getByText("Download image"));
+
+    // The menu must open at the cursor. Before the virtual-anchor fix, the
+    // dialog's translate(-50%,-50%) made the fixed-position anchor resolve
+    // against the dialog box, offsetting the menu by hundreds of pixels.
+    // 100px tolerance allows for collision flipping while still catching that.
+    // Retry inside waitFor: Floating UI positions the content a frame after it
+    // mounts (PositionedMenu keeps it hidden until placement settles).
+    const menuContent = menuItem.closest("[role='dialog']");
+    if (!menuContent) {
+      throw new Error("Menu popover content not found");
+    }
+    await waitFor(() => {
+      const menuRect = menuContent.getBoundingClientRect();
+      if (Math.abs(menuRect.left - 240) > 100 || Math.abs(menuRect.top - 200) > 100) {
+        throw new Error(
+          `Context menu misaligned with cursor (240,200): got (${menuRect.left},${menuRect.top})`
+        );
+      }
+    });
 
     // Escape must close only the menu; the lightbox stays open underneath.
     // Radix attaches its escape listener asynchronously after the menu
@@ -286,9 +310,16 @@ export const LightboxContextMenu: Story = {
     });
     await waitFor(() => body.getByText("Image Preview"));
 
-    // Reopen and leave open so the Pixel snapshot captures lightbox + menu.
-    await fireEvent.contextMenu(fullSizeImage, { clientX: 240, clientY: 200 });
-    await waitFor(() => body.getByText("Copy image"));
+    // Reopen via the touch long-press path (lightbox-specific contract; the
+    // thumbnail long-press story never exercises the lightbox wiring) and
+    // leave open so the Pixel snapshot captures lightbox + menu.
+    // changedTouches must be populated: the Radix dialog mounts
+    // react-remove-scroll, whose document-level touch listeners read
+    // event.changedTouches[0] and crash on events that omit it.
+    const touch = new Touch({ identifier: 1, target: fullSizeImage, clientX: 240, clientY: 200 });
+    await fireEvent.touchStart(fullSizeImage, { touches: [touch], changedTouches: [touch] });
+    await waitFor(() => body.getByText("Copy image"), { timeout: 3000 });
+    await fireEvent.touchEnd(fullSizeImage, { changedTouches: [touch] });
   },
 };
 

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fireEvent, waitFor, within } from "@storybook/test";
 import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
 import { AttachFileToolCall } from "@/browser/features/Tools/AttachFileToolCall";
 import { lightweightMeta } from "@/browser/stories/meta.js";
@@ -129,6 +130,25 @@ export const Gallery: Story = {
             status="completed"
           />
         </GallerySection>
+        <GallerySection label="PDF attachment (download card)">
+          <AttachFileToolCall
+            toolName="attach_file"
+            args={{ path: "quarterly-report.pdf" }}
+            result={{
+              type: "content",
+              value: [
+                { type: "text", text: "[Attachment prepared: quarterly-report.pdf]" },
+                {
+                  type: "media",
+                  data: sampleBytes,
+                  mediaType: "application/pdf",
+                  filename: "quarterly-report.pdf",
+                },
+              ],
+            }}
+            status="completed"
+          />
+        </GallerySection>
         <GallerySection label="Display-only generic file">
           <AttachFileToolCall
             toolName="attach_file"
@@ -147,6 +167,45 @@ export const Gallery: Story = {
       </div>
     </ToolStoryShell>
   ),
+};
+
+// Right-click on an image thumbnail opens a context menu with view/copy/download
+// actions. The play function opens the menu so the Pixel snapshot captures it.
+export const ImageContextMenu: Story = {
+  render: () => (
+    <ToolStoryShell>
+      <AttachFileToolCall
+        toolName="attach_file"
+        args={{ path: "screenshot.png" }}
+        result={{
+          type: "content",
+          value: [
+            { type: "text", text: "[Attachment prepared: screenshot.png]" },
+            {
+              type: "media",
+              data: samplePng,
+              mediaType: "image/png",
+              filename: "screenshot.png",
+            },
+          ],
+        }}
+        status="completed"
+      />
+    </ToolStoryShell>
+  ),
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const image = await canvas.findByRole("img", { name: "screenshot.png" });
+
+    // Fixed coordinates keep the menu position deterministic for snapshots.
+    await fireEvent.contextMenu(image, { clientX: 120, clientY: 160 });
+
+    // The menu renders in a portal attached to document.body.
+    const body = within(document.body);
+    await waitFor(() => body.getByText("Copy image"));
+    await waitFor(() => body.getByText("Download image"));
+    await waitFor(() => body.getByText("View full size"));
+  },
 };
 
 export const FailedAttachment: Story = {

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -169,10 +169,9 @@ export const Gallery: Story = {
   ),
 };
 
-// Right-click on an image thumbnail opens a context menu with view/copy/download
-// actions. The play function opens the menu so the Pixel snapshot captures it.
-export const ImageContextMenu: Story = {
-  render: () => (
+// Shared render for the interactive image-menu stories below.
+function renderImageAttachment() {
+  return (
     <ToolStoryShell>
       <AttachFileToolCall
         toolName="attach_file"
@@ -192,7 +191,13 @@ export const ImageContextMenu: Story = {
         status="completed"
       />
     </ToolStoryShell>
-  ),
+  );
+}
+
+// Right-click on an image thumbnail opens a context menu with view/copy/download
+// actions. The play function opens the menu so the Pixel snapshot captures it.
+export const ImageContextMenu: Story = {
+  render: renderImageAttachment,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
     const image = await canvas.findByRole("img", { name: "screenshot.png" });
@@ -213,27 +218,7 @@ export const ImageContextMenu: Story = {
 // so this play function exercises the touch path directly per the Storybook
 // responsive/Pixel validation rule.
 export const ImageLongPressMenu: Story = {
-  render: () => (
-    <ToolStoryShell>
-      <AttachFileToolCall
-        toolName="attach_file"
-        args={{ path: "screenshot.png" }}
-        result={{
-          type: "content",
-          value: [
-            { type: "text", text: "[Attachment prepared: screenshot.png]" },
-            {
-              type: "media",
-              data: samplePng,
-              mediaType: "image/png",
-              filename: "screenshot.png",
-            },
-          ],
-        }}
-        status="completed"
-      />
-    </ToolStoryShell>
-  ),
+  render: renderImageAttachment,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
     const canvas = within(canvasElement);
     const image = await canvas.findByRole("img", { name: "screenshot.png" });
@@ -260,6 +245,50 @@ export const ImageLongPressMenu: Story = {
         throw new Error("Lightbox should not open after a long-press");
       }
     });
+  },
+};
+
+// The expanded lightbox offers the same right-click menu as the thumbnails.
+// The play function also asserts layering: Escape closes only the menu (the
+// topmost Radix layer) while the lightbox dialog stays open.
+export const LightboxContextMenu: Story = {
+  render: renderImageAttachment,
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const thumbnail = await canvas.findByRole("img", { name: "screenshot.png" });
+    await fireEvent.click(thumbnail);
+
+    // The lightbox renders in a portal; locate the full-size image inside it
+    // via the dialog's (visually hidden) title.
+    const body = within(document.body);
+    await waitFor(() => body.getByText("Image Preview"));
+    const dialog = document.body.querySelector("[role='dialog']");
+    if (!(dialog instanceof HTMLElement)) {
+      throw new Error("Lightbox dialog not found");
+    }
+    const fullSizeImage = within(dialog).getByRole("img");
+
+    // Fixed coordinates keep the menu position deterministic for snapshots.
+    await fireEvent.contextMenu(fullSizeImage, { clientX: 240, clientY: 200 });
+    await waitFor(() => body.getByText("Copy image"));
+    await waitFor(() => body.getByText("Download image"));
+
+    // Escape must close only the menu; the lightbox stays open underneath.
+    // Radix attaches its escape listener asynchronously after the menu
+    // contents render, so dispatch inside the retry loop — guarded so we never
+    // send Escape once the menu is gone (a stray extra Escape would close the
+    // lightbox and break the layering assertion below).
+    await waitFor(async () => {
+      if (body.queryByText("Copy image")) {
+        await fireEvent.keyDown(document, { key: "Escape" });
+        throw new Error("Context menu should close on Escape");
+      }
+    });
+    await waitFor(() => body.getByText("Image Preview"));
+
+    // Reopen and leave open so the Pixel snapshot captures lightbox + menu.
+    await fireEvent.contextMenu(fullSizeImage, { clientX: 240, clientY: 200 });
+    await waitFor(() => body.getByText("Copy image"));
   },
 };
 

--- a/src/browser/features/Tools/AttachFileToolCall.stories.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.stories.tsx
@@ -239,8 +239,10 @@ export const ImageLongPressMenu: Story = {
     const image = await canvas.findByRole("img", { name: "screenshot.png" });
 
     // Start a touch and hold: the long-press timer opens the menu after 500ms.
-    // Fixed coordinates keep the menu position deterministic for snapshots.
-    await fireEvent.touchStart(image, { touches: [{ clientX: 120, clientY: 160 }] });
+    // Chromium's TouchEvent constructor requires real Touch instances (plain
+    // objects throw). Fixed coordinates keep the menu position deterministic.
+    const touch = new Touch({ identifier: 1, target: image, clientX: 120, clientY: 160 });
+    await fireEvent.touchStart(image, { touches: [touch] });
 
     // The menu renders in a portal attached to document.body. waitFor polls
     // past the 500ms long-press threshold.
@@ -250,10 +252,11 @@ export const ImageLongPressMenu: Story = {
     await fireEvent.touchEnd(image);
 
     // The click that follows a long-press must be suppressed: the lightbox
-    // dialog should not open on top of the context menu.
+    // must not open on top of the context menu. The Radix popover menu itself
+    // has role="dialog", so detect the lightbox by its (visually hidden) title.
     await fireEvent.click(image);
     await waitFor(() => {
-      if (document.body.querySelector("[role='dialog']")) {
+      if (body.queryByText("Image Preview")) {
         throw new Error("Lightbox should not open after a long-press");
       }
     });

--- a/src/browser/features/Tools/AttachFileToolCall.test.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.test.tsx
@@ -57,4 +57,59 @@ describe("AttachFileToolCall", () => {
     expect(download.getAttribute("download")).toBe("release-notes.md");
     expect(download.getAttribute("href")).toBe(`data:text/markdown;base64,${data}`);
   });
+
+  test("renders image attachments with a filename caption", () => {
+    const data = Buffer.from("fake-png-bytes").toString("base64");
+
+    const view = render(
+      <TooltipProvider>
+        <AttachFileToolCall
+          toolName="attach_file"
+          args={{ path: "screenshot.png" }}
+          result={{
+            type: "content",
+            value: [
+              { type: "text", text: "[Attachment prepared: screenshot.png]" },
+              { type: "media", data, mediaType: "image/png", filename: "screenshot.png" },
+            ],
+          }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+
+    const image = view.getByRole("img", { name: "screenshot.png" });
+    expect(image.getAttribute("src")).toBe(`data:image/png;base64,${data}`);
+    // Caption is rendered alongside the thumbnail so users can identify the file.
+    expect(view.getByText("screenshot.png")).toBeTruthy();
+  });
+
+  test("renders a download card for media attachments without an inline preview (PDF)", () => {
+    const data = Buffer.from("fake-pdf-bytes").toString("base64");
+
+    const view = render(
+      <TooltipProvider>
+        <AttachFileToolCall
+          toolName="attach_file"
+          args={{ path: "report.pdf" }}
+          result={{
+            type: "content",
+            value: [
+              { type: "text", text: "[Attachment prepared: report.pdf]" },
+              { type: "media", data, mediaType: "application/pdf", filename: "report.pdf" },
+            ],
+          }}
+          status="completed"
+        />
+      </TooltipProvider>
+    );
+
+    // No inline preview for PDFs (not in the raster allowlist)...
+    expect(view.queryByRole("img")).toBeNull();
+    // ...but the attachment is surfaced as a download card instead of being invisible.
+    expect(view.getByText("report.pdf")).toBeTruthy();
+    const download = view.getByRole("link", { name: /Download/ });
+    expect(download.getAttribute("download")).toBe("report.pdf");
+    expect(download.getAttribute("href")).toBe(`data:application/pdf;base64,${data}`);
+  });
 });

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -29,7 +29,12 @@ import {
 import { useToolExpansion, getStatusDisplay, type ToolStatus } from "./Shared/toolUtils";
 import { JsonHighlight } from "./Shared/HighlightedCode";
 import { redactToolResultAttachmentsForDisplay } from "./Shared/toolResultDisplay";
-import { ToolResultImages, extractImagesFromToolResult } from "./Shared/ToolResultImages";
+import {
+  ToolResultImages,
+  extractImagesFromToolResult,
+  sanitizeImageData,
+  type MediaContent,
+} from "./Shared/ToolResultImages";
 
 const MARKDOWN_PREVIEW_CHAR_LIMIT = 50_000;
 const MARKDOWN_PREVIEW_MEDIA_TYPES = new Set([MARKDOWN_MEDIA_TYPE, "text/x-markdown"]);
@@ -145,6 +150,44 @@ const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
   );
 };
 
+/**
+ * Card for media attachments that were sent to the model but cannot be
+ * previewed inline (PDF, SVG). SVG is intentionally never rendered in the
+ * renderer because it can contain scripts (see sanitizeImageData); both
+ * formats are offered as downloads instead so the attachment isn't invisible.
+ */
+const MediaAttachmentDownloadCard: React.FC<{ media: MediaContent }> = (props) => {
+  const baseMediaType = normalizeAttachmentMediaType(props.media.mediaType);
+  const dataUrl = isValidBase64AttachmentData(props.media.data)
+    ? `data:${baseMediaType};base64,${props.media.data}`
+    : null;
+  const label = props.media.filename ?? `Attachment (${baseMediaType})`;
+
+  return (
+    <div className="border-border-light bg-dark mt-2 max-w-xl rounded border p-3">
+      <div className="mb-2 flex items-center gap-2 text-sm text-[var(--color-subtle)]">
+        <FileText className="h-4 w-4 shrink-0" />
+        <span className="truncate font-medium text-[var(--color-text)]">{label}</span>
+        <span className="counter-nums text-xs">{baseMediaType}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-[var(--color-subtle)]">
+        <span>Attached for the model; inline preview is not available for this file type.</span>
+        {dataUrl == null && <span>File data is unavailable for download.</span>}
+        {dataUrl != null && (
+          <a
+            href={dataUrl}
+            download={props.media.filename ?? "attachment"}
+            className="border-border-light hover:bg-surface flex items-center gap-1 rounded border px-2 py-1 text-[var(--color-text)]"
+          >
+            <Download className="h-3 w-3" />
+            Download
+          </a>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => {
   const { expanded, toggleExpanded } = useToolExpansion();
   const displayFiles = extractDisplayFilesFromToolResult(props.result);
@@ -152,6 +195,11 @@ export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => 
   const hasDetails = props.args !== undefined || props.result !== undefined;
   const images = extractImagesFromToolResult(props.result);
   const hasImages = images.length > 0;
+  // Media attachments the image gallery refuses to render (PDF, SVG) would
+  // otherwise be invisible in the tool card; surface them as download cards.
+  const downloadOnlyMedia = images.filter(
+    (image) => sanitizeImageData(image.mediaType, image.data) === null
+  );
   const shouldShowDetails = expanded || hasImages || hasDisplayFiles;
 
   return (
@@ -166,6 +214,16 @@ export const AttachFileToolCall: React.FC<AttachFileToolCallProps> = (props) => 
       </ToolHeader>
 
       {hasImages && <ToolResultImages result={props.result} />}
+      {downloadOnlyMedia.length > 0 && (
+        <div className="space-y-2">
+          {downloadOnlyMedia.map((media, index) => (
+            <MediaAttachmentDownloadCard
+              key={`${media.filename ?? media.mediaType}-${index}`}
+              media={media}
+            />
+          ))}
+        </div>
+      )}
       {hasDisplayFiles && (
         <div className="space-y-2">
           {displayFiles.map((file, index) => (

--- a/src/browser/features/Tools/Shared/ToolResultImages.test.ts
+++ b/src/browser/features/Tools/Shared/ToolResultImages.test.ts
@@ -79,6 +79,36 @@ describe("extractImagesFromToolResult", () => {
     expect(extractImagesFromToolResult({ type: "error", value: [] })).toEqual([]);
     expect(extractImagesFromToolResult({ type: "content", value: "not-array" })).toEqual([]);
   });
+
+  it("should retain string filenames from media parts", () => {
+    const result = {
+      type: "content",
+      value: [
+        { type: "media", data: "imagedata", mediaType: "image/png", filename: "screenshot.png" },
+      ],
+    };
+
+    const images = extractImagesFromToolResult(result);
+
+    expect(images).toHaveLength(1);
+    expect(images[0].filename).toBe("screenshot.png");
+  });
+
+  it("should normalize missing or malformed filenames to undefined without dropping the image", () => {
+    const result = {
+      type: "content",
+      value: [
+        { type: "media", data: "a", mediaType: "image/png" },
+        { type: "media", data: "b", mediaType: "image/png", filename: 42 },
+        { type: "media", data: "c", mediaType: "image/png", filename: "" },
+      ],
+    };
+
+    const images = extractImagesFromToolResult(result);
+
+    expect(images).toHaveLength(3);
+    expect(images.every((image) => image.filename === undefined)).toBe(true);
+  });
 });
 
 describe("sanitizeImageData", () => {

--- a/src/browser/features/Tools/Shared/ToolResultImages.tsx
+++ b/src/browser/features/Tools/Shared/ToolResultImages.tsx
@@ -13,7 +13,9 @@ import {
   copyImageDataUrlToClipboard,
   downloadDataUrl,
   getImageDownloadFilename,
+  handleImageActionKeyDown,
 } from "@/browser/utils/imageActions";
+import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 
 /**
  * Image content from tool results (attach_file, desktop screenshots, MCP tools).
@@ -136,6 +138,10 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
     }
   };
 
+  const handleDownloadImage = (image: SafeToolResultImage) => {
+    downloadDataUrl(image.dataUrl, getImageDownloadFilename(image.filename, image.mediaType));
+  };
+
   return (
     <>
       <div className="mt-2 flex flex-wrap gap-2">
@@ -184,9 +190,21 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
         open={contextMenu.isOpen}
         onOpenChange={contextMenu.onOpenChange}
         position={contextMenu.position}
+        onKeyDown={(e) => {
+          if (!menuImage) return;
+          const consumed = handleImageActionKeyDown(e, {
+            copy: () => void handleCopyImage(menuImage),
+            download: () => handleDownloadImage(menuImage),
+          });
+          if (consumed) {
+            contextMenu.close();
+          }
+        }}
       >
         {menuImage && (
           <>
+            {/* No shortcut hint: Enter/Space on the focused thumbnail button
+                already opens the lightbox (native button activation). */}
             <PositionedMenuItem
               icon={<Maximize2 />}
               label="View full size"
@@ -198,6 +216,7 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
             <PositionedMenuItem
               icon={<Copy />}
               label="Copy image"
+              shortcut={formatKeybind(KEYBINDS.IMAGE_COPY)}
               onClick={() => {
                 void handleCopyImage(menuImage);
                 contextMenu.close();
@@ -206,11 +225,9 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
             <PositionedMenuItem
               icon={<Download />}
               label="Download image"
+              shortcut={formatKeybind(KEYBINDS.IMAGE_DOWNLOAD)}
               onClick={() => {
-                downloadDataUrl(
-                  menuImage.dataUrl,
-                  getImageDownloadFilename(menuImage.filename, menuImage.mediaType)
-                );
+                handleDownloadImage(menuImage);
                 contextMenu.close();
               }}
             />

--- a/src/browser/features/Tools/Shared/ToolResultImages.tsx
+++ b/src/browser/features/Tools/Shared/ToolResultImages.tsx
@@ -1,16 +1,30 @@
 import React, { useState } from "react";
+import { Copy, Download, Maximize2 } from "lucide-react";
 import { isValidBase64AttachmentData } from "@/common/utils/attachments/base64";
 import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { ImageLightbox } from "@/browser/components/ImageLightbox";
+import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
+import {
+  PositionedMenu,
+  PositionedMenuItem,
+} from "@/browser/components/PositionedMenu/PositionedMenu";
+import {
+  copyImageDataUrlToClipboard,
+  downloadDataUrl,
+  getImageDownloadFilename,
+} from "@/browser/utils/imageActions";
 
 /**
- * Image content from MCP tool results (transformed from MCP's image type to AI SDK's media type)
+ * Image content from tool results (attach_file, desktop screenshots, MCP tools).
+ * MCP's image type is transformed to the AI SDK's media type upstream.
  */
-interface MediaContent {
+export interface MediaContent {
   type: "media";
   data: string; // base64
   mediaType: string;
+  /** Original filename when known (e.g. attach_file results) */
+  filename?: string;
 }
 
 function isMediaContent(value: unknown): value is MediaContent {
@@ -66,7 +80,23 @@ export function sanitizeImageData(mediaType: string, data: string): string | nul
 export function extractImagesFromToolResult(result: unknown): MediaContent[] {
   if (!isToolContentResult(result)) return [];
 
-  return result.value.filter(isMediaContent);
+  return result.value.filter(isMediaContent).map((media) => {
+    // Normalize to a known shape: media parts may carry extra fields, and
+    // filename may be absent or malformed (e.g. from arbitrary MCP servers).
+    const filename = (media as { filename?: unknown }).filename;
+    return {
+      type: "media" as const,
+      data: media.data,
+      mediaType: media.mediaType,
+      filename: typeof filename === "string" && filename.length > 0 ? filename : undefined,
+    };
+  });
+}
+
+interface SafeToolResultImage {
+  dataUrl: string;
+  mediaType: string;
+  filename?: string;
 }
 
 interface ToolResultImagesProps {
@@ -74,42 +104,130 @@ interface ToolResultImagesProps {
 }
 
 /**
- * Display images extracted from MCP tool results (e.g., Chrome DevTools screenshots)
+ * Display images extracted from tool results (attach_file, desktop screenshots,
+ * MCP tools). Click opens a lightbox; right-click (or long-press on touch)
+ * opens a menu with copy/download actions.
  */
 export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) => {
   const images = extractImagesFromToolResult(result);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState<SafeToolResultImage | null>(null);
+  // The image the context menu currently targets (set on right-click/long-press).
+  const [menuImage, setMenuImage] = useState<SafeToolResultImage | null>(null);
+  const contextMenu = useContextMenuPosition({ longPress: true });
 
   // Sanitize all images upfront, filtering out any that fail validation
   const safeImages = images
-    .map((image) => sanitizeImageData(image.mediaType, image.data))
-    .filter((url): url is string => url !== null);
+    .map((image): SafeToolResultImage | null => {
+      const dataUrl = sanitizeImageData(image.mediaType, image.data);
+      if (dataUrl === null) {
+        return null;
+      }
+      return { dataUrl, mediaType: image.mediaType, filename: image.filename };
+    })
+    .filter((image): image is SafeToolResultImage => image !== null);
 
   if (safeImages.length === 0) return null;
+
+  const handleCopyImage = async (image: SafeToolResultImage) => {
+    try {
+      await copyImageDataUrlToClipboard(image.dataUrl);
+    } catch (err) {
+      console.error("Failed to copy image:", err);
+    }
+  };
 
   return (
     <>
       <div className="mt-2 flex flex-wrap gap-2">
-        {safeImages.map((dataUrl, index) => (
-          <TooltipIfPresent key={index} tooltip="Click to view full size" side="top">
+        {safeImages.map((image, index) => (
+          <TooltipIfPresent
+            key={index}
+            tooltip="Click to view full size. Right-click for actions."
+            side="top"
+          >
             <button
-              onClick={() => setSelectedImage(dataUrl)}
-              className="border-border-light bg-dark block cursor-pointer overflow-hidden rounded border p-0 transition-opacity hover:opacity-80"
+              onClick={() => {
+                // A long-press already opened the context menu; don't also open the lightbox.
+                if (contextMenu.suppressClickIfLongPress()) return;
+                setSelectedImage(image);
+              }}
+              onContextMenu={(e) => {
+                setMenuImage(image);
+                contextMenu.onContextMenu(e);
+              }}
+              onTouchStart={(e) => {
+                setMenuImage(image);
+                contextMenu.touchHandlers.onTouchStart(e);
+              }}
+              onTouchEnd={contextMenu.touchHandlers.onTouchEnd}
+              onTouchMove={contextMenu.touchHandlers.onTouchMove}
+              className="border-border-light bg-dark flex max-w-full cursor-pointer flex-col overflow-hidden rounded border p-0 transition-opacity hover:opacity-80"
             >
               <img
-                src={dataUrl}
-                alt={`Tool result image ${index + 1}`}
+                src={image.dataUrl}
+                alt={image.filename ?? `Tool result image ${index + 1}`}
                 className="max-h-48 max-w-full object-contain"
               />
+              {image.filename && (
+                // w-0 min-w-full keeps the caption from widening the thumbnail
+                // beyond the image while still truncating long filenames.
+                <span className="text-muted border-border-light w-0 min-w-full truncate border-t px-1.5 py-0.5 text-left text-[10px]">
+                  {image.filename}
+                </span>
+              )}
             </button>
           </TooltipIfPresent>
         ))}
       </div>
 
+      <PositionedMenu
+        open={contextMenu.isOpen}
+        onOpenChange={contextMenu.onOpenChange}
+        position={contextMenu.position}
+      >
+        {menuImage && (
+          <>
+            <PositionedMenuItem
+              icon={<Maximize2 />}
+              label="View full size"
+              onClick={() => {
+                setSelectedImage(menuImage);
+                contextMenu.close();
+              }}
+            />
+            <PositionedMenuItem
+              icon={<Copy />}
+              label="Copy image"
+              onClick={() => {
+                void handleCopyImage(menuImage);
+                contextMenu.close();
+              }}
+            />
+            <PositionedMenuItem
+              icon={<Download />}
+              label="Download image"
+              onClick={() => {
+                downloadDataUrl(
+                  menuImage.dataUrl,
+                  getImageDownloadFilename(menuImage.filename, menuImage.mediaType)
+                );
+                contextMenu.close();
+              }}
+            />
+          </>
+        )}
+      </PositionedMenu>
+
       <ImageLightbox
-        src={selectedImage}
+        src={selectedImage?.dataUrl ?? null}
         title="Image Preview"
-        alt="Full size preview"
+        alt={selectedImage?.filename ?? "Full size preview"}
+        filename={selectedImage?.filename}
+        downloadFilename={
+          selectedImage
+            ? getImageDownloadFilename(selectedImage.filename, selectedImage.mediaType)
+            : undefined
+        }
         onClose={() => setSelectedImage(null)}
       />
     </>

--- a/src/browser/features/Tools/Shared/ToolResultImages.tsx
+++ b/src/browser/features/Tools/Shared/ToolResultImages.tsx
@@ -1,21 +1,13 @@
 import React, { useState } from "react";
-import { Copy, Download, Maximize2 } from "lucide-react";
+import { Maximize2 } from "lucide-react";
 import { isValidBase64AttachmentData } from "@/common/utils/attachments/base64";
 import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { ImageLightbox } from "@/browser/components/ImageLightbox";
 import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
-import {
-  PositionedMenu,
-  PositionedMenuItem,
-} from "@/browser/components/PositionedMenu/PositionedMenu";
-import {
-  copyImageDataUrlToClipboard,
-  downloadDataUrl,
-  getImageDownloadFilename,
-  handleImageActionKeyDown,
-} from "@/browser/utils/imageActions";
-import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
+import { PositionedMenuItem } from "@/browser/components/PositionedMenu/PositionedMenu";
+import { ImageActionsMenu } from "@/browser/components/ImageActionsMenu";
+import { getImageDownloadFilename } from "@/browser/utils/imageActions";
 
 /**
  * Image content from tool results (attach_file, desktop screenshots, MCP tools).
@@ -130,18 +122,6 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
 
   if (safeImages.length === 0) return null;
 
-  const handleCopyImage = async (image: SafeToolResultImage) => {
-    try {
-      await copyImageDataUrlToClipboard(image.dataUrl);
-    } catch (err) {
-      console.error("Failed to copy image:", err);
-    }
-  };
-
-  const handleDownloadImage = (image: SafeToolResultImage) => {
-    downloadDataUrl(image.dataUrl, getImageDownloadFilename(image.filename, image.mediaType));
-  };
-
   return (
     <>
       <div className="mt-2 flex flex-wrap gap-2">
@@ -186,54 +166,30 @@ export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ result }) =>
         ))}
       </div>
 
-      <PositionedMenu
-        open={contextMenu.isOpen}
-        onOpenChange={contextMenu.onOpenChange}
-        position={contextMenu.position}
-        onKeyDown={(e) => {
-          if (!menuImage) return;
-          const consumed = handleImageActionKeyDown(e, {
-            copy: () => void handleCopyImage(menuImage),
-            download: () => handleDownloadImage(menuImage),
-          });
-          if (consumed) {
-            contextMenu.close();
-          }
-        }}
+      <ImageActionsMenu
+        contextMenu={contextMenu}
+        image={
+          menuImage
+            ? {
+                dataUrl: menuImage.dataUrl,
+                downloadFilename: getImageDownloadFilename(menuImage.filename, menuImage.mediaType),
+              }
+            : null
+        }
       >
+        {/* No shortcut hint: Enter/Space on the focused thumbnail button
+            already opens the lightbox (native button activation). */}
         {menuImage && (
-          <>
-            {/* No shortcut hint: Enter/Space on the focused thumbnail button
-                already opens the lightbox (native button activation). */}
-            <PositionedMenuItem
-              icon={<Maximize2 />}
-              label="View full size"
-              onClick={() => {
-                setSelectedImage(menuImage);
-                contextMenu.close();
-              }}
-            />
-            <PositionedMenuItem
-              icon={<Copy />}
-              label="Copy image"
-              shortcut={formatKeybind(KEYBINDS.IMAGE_COPY)}
-              onClick={() => {
-                void handleCopyImage(menuImage);
-                contextMenu.close();
-              }}
-            />
-            <PositionedMenuItem
-              icon={<Download />}
-              label="Download image"
-              shortcut={formatKeybind(KEYBINDS.IMAGE_DOWNLOAD)}
-              onClick={() => {
-                handleDownloadImage(menuImage);
-                contextMenu.close();
-              }}
-            />
-          </>
+          <PositionedMenuItem
+            icon={<Maximize2 />}
+            label="View full size"
+            onClick={() => {
+              setSelectedImage(menuImage);
+              contextMenu.close();
+            }}
+          />
         )}
-      </PositionedMenu>
+      </ImageActionsMenu>
 
       <ImageLightbox
         src={selectedImage?.dataUrl ?? null}

--- a/src/browser/utils/imageActions.test.ts
+++ b/src/browser/utils/imageActions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { dataUrlToBlob, getImageDownloadFilename } from "./imageActions";
+
+describe("dataUrlToBlob", () => {
+  it("decodes a valid base64 data URL into a typed blob", async () => {
+    const blob = dataUrlToBlob("data:image/png;base64,SGVsbG8=");
+
+    expect(blob).not.toBeNull();
+    expect(blob?.type).toBe("image/png");
+    expect(await blob?.text()).toBe("Hello");
+  });
+
+  it("strips media type parameters", () => {
+    const blob = dataUrlToBlob("data:IMAGE/PNG;base64,SGVsbG8=");
+    expect(blob?.type).toBe("image/png");
+  });
+
+  it("returns null for non-data URLs and non-base64 payloads", () => {
+    expect(dataUrlToBlob("https://example.com/image.png")).toBeNull();
+    expect(dataUrlToBlob("data:image/png,rawpayload")).toBeNull();
+    expect(dataUrlToBlob("data:image/png;base64,not valid base64!!")).toBeNull();
+  });
+});
+
+describe("getImageDownloadFilename", () => {
+  it("prefers the attachment's own filename", () => {
+    expect(getImageDownloadFilename("screenshot.png", "image/png")).toBe("screenshot.png");
+  });
+
+  it("derives an extension from the media type when no filename exists", () => {
+    expect(getImageDownloadFilename(undefined, "image/png")).toBe("image.png");
+    expect(getImageDownloadFilename(undefined, "image/webp")).toBe("image.webp");
+  });
+
+  it("maps subtypes whose extension differs from the MIME subtype", () => {
+    expect(getImageDownloadFilename(undefined, "image/jpeg")).toBe("image.jpg");
+    expect(getImageDownloadFilename(undefined, "image/svg+xml")).toBe("image.svg");
+  });
+
+  it("normalizes media type casing and parameters", () => {
+    expect(getImageDownloadFilename(undefined, "IMAGE/PNG; charset=binary")).toBe("image.png");
+  });
+
+  it("falls back to a bare name when no extension can be derived", () => {
+    expect(getImageDownloadFilename(undefined, "image")).toBe("image");
+    expect(getImageDownloadFilename("", "image/png")).toBe("image.png");
+  });
+});

--- a/src/browser/utils/imageActions.test.ts
+++ b/src/browser/utils/imageActions.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
-import { dataUrlToBlob, getImageDownloadFilename } from "./imageActions";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type React from "react";
+import { GlobalWindow } from "happy-dom";
+import { dataUrlToBlob, getImageDownloadFilename, handleImageActionKeyDown } from "./imageActions";
 
 describe("dataUrlToBlob", () => {
   it("decodes a valid base64 data URL into a typed blob", async () => {
@@ -44,5 +46,91 @@ describe("getImageDownloadFilename", () => {
   it("falls back to a bare name when no extension can be derived", () => {
     expect(getImageDownloadFilename(undefined, "image")).toBe("image");
     expect(getImageDownloadFilename("", "image/png")).toBe("image.png");
+  });
+});
+
+describe("handleImageActionKeyDown", () => {
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+  });
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+  });
+
+  function createKeyEvent(init: { key: string; ctrlKey?: boolean; metaKey?: boolean }) {
+    const preventDefault = mock(() => undefined);
+    const event = {
+      key: init.key,
+      code: undefined,
+      ctrlKey: init.ctrlKey ?? false,
+      metaKey: init.metaKey ?? false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault,
+      stopPropagation: mock(() => undefined),
+    } as unknown as React.KeyboardEvent;
+    return { event, preventDefault };
+  }
+
+  it("consumes mod+C as copy and prevents default", () => {
+    const copy = mock(() => undefined);
+    const download = mock(() => undefined);
+    const { event, preventDefault } = createKeyEvent({ key: "c", ctrlKey: true });
+
+    expect(handleImageActionKeyDown(event, { copy, download })).toBe(true);
+    expect(copy).toHaveBeenCalledTimes(1);
+    expect(download).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("consumes mod+S as download and prevents the browser save dialog", () => {
+    const copy = mock(() => undefined);
+    const download = mock(() => undefined);
+    const { event, preventDefault } = createKeyEvent({ key: "s", ctrlKey: true });
+
+    expect(handleImageActionKeyDown(event, { copy, download })).toBe(true);
+    expect(download).toHaveBeenCalledTimes(1);
+    expect(copy).not.toHaveBeenCalled();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("ignores unrelated keys and unmodified letters", () => {
+    const copy = mock(() => undefined);
+    const download = mock(() => undefined);
+
+    expect(handleImageActionKeyDown(createKeyEvent({ key: "c" }).event, { copy, download })).toBe(
+      false
+    );
+    expect(
+      handleImageActionKeyDown(createKeyEvent({ key: "x", ctrlKey: true }).event, {
+        copy,
+        download,
+      })
+    ).toBe(false);
+    expect(copy).not.toHaveBeenCalled();
+    expect(download).not.toHaveBeenCalled();
+  });
+
+  it("defers mod+C to native copy when text is selected", () => {
+    // Simulate an active text selection in the document.
+    const doc = globalThis.window.document;
+    doc.body.textContent = "selectable text";
+    const range = doc.createRange();
+    range.selectNodeContents(doc.body);
+    const selection = globalThis.window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const copy = mock(() => undefined);
+    const download = mock(() => undefined);
+    const { event, preventDefault } = createKeyEvent({ key: "c", ctrlKey: true });
+
+    expect(handleImageActionKeyDown(event, { copy, download })).toBe(false);
+    expect(copy).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -1,0 +1,105 @@
+import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+
+/**
+ * Actions for images rendered from base64 data URLs (tool result images,
+ * attach_file previews): copy to the system clipboard and download.
+ */
+
+// Subtypes whose conventional file extension differs from the MIME subtype.
+const IMAGE_EXTENSION_BY_SUBTYPE = new Map<string, string>([
+  ["jpeg", "jpg"],
+  ["svg+xml", "svg"],
+]);
+
+/**
+ * Decode a base64 data URL into a Blob. Returns null when the input is not a
+ * well-formed base64 data URL.
+ */
+export function dataUrlToBlob(dataUrl: string): Blob | null {
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(dataUrl);
+  if (!match) {
+    return null;
+  }
+
+  const [, mediaType, base64Data] = match;
+  try {
+    const binary = globalThis.atob(base64Data);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return new Blob([bytes], { type: normalizeAttachmentMediaType(mediaType) });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the filename used when downloading an image attachment: prefer the
+ * attachment's own filename, otherwise derive an extension from its media type.
+ */
+export function getImageDownloadFilename(filename: string | undefined, mediaType: string): string {
+  if (filename) {
+    return filename;
+  }
+
+  const subtype = normalizeAttachmentMediaType(mediaType).split("/")[1] ?? "";
+  const extension = IMAGE_EXTENSION_BY_SUBTYPE.get(subtype) ?? subtype;
+  return extension.length > 0 ? `image.${extension}` : "image";
+}
+
+/** Re-encode an arbitrary raster image blob to PNG through an offscreen canvas. */
+async function reencodeImageBlobToPng(blob: Blob): Promise<Blob> {
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Failed to acquire 2d canvas context for image re-encode");
+    }
+    context.drawImage(bitmap, 0, 0);
+
+    const pngBlob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, "image/png");
+    });
+    if (!pngBlob) {
+      throw new Error("Failed to encode image as PNG");
+    }
+    return pngBlob;
+  } finally {
+    bitmap.close();
+  }
+}
+
+/**
+ * Copy an image (given as a base64 data URL) to the system clipboard.
+ *
+ * Chromium's async Clipboard API only accepts "image/png" image payloads, so
+ * non-PNG sources are re-encoded through a canvas first. Animated formats
+ * (GIF) copy their first frame, matching native browser behavior.
+ */
+export async function copyImageDataUrlToClipboard(dataUrl: string): Promise<void> {
+  const blob = dataUrlToBlob(dataUrl);
+  if (!blob) {
+    throw new Error("Invalid image data URL");
+  }
+
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+    throw new Error("Clipboard image writes are not supported in this environment");
+  }
+
+  const pngBlob = blob.type === "image/png" ? blob : await reencodeImageBlobToPng(blob);
+  await navigator.clipboard.write([new ClipboardItem({ "image/png": pngBlob })]);
+}
+
+/** Trigger a browser download of a data URL via a temporary anchor element. */
+export function downloadDataUrl(dataUrl: string, filename: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = dataUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -1,4 +1,7 @@
+import type React from "react";
 import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import { KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import { stopKeyboardPropagation } from "@/browser/utils/events";
 
 /**
  * Actions for images rendered from base64 data URLs (tool result images,
@@ -92,6 +95,37 @@ export async function copyImageDataUrlToClipboard(dataUrl: string): Promise<void
 
   const pngBlob = blob.type === "image/png" ? blob : await reencodeImageBlobToPng(blob);
   await navigator.clipboard.write([new ClipboardItem({ "image/png": pngBlob })]);
+}
+
+/**
+ * Shared keyboard handler for image surfaces (lightbox, image context menu):
+ * mod+C copies the image, mod+S downloads it. Returns true when the event was
+ * consumed. When text is selected, mod+C is left to the native copy behavior.
+ */
+export function handleImageActionKeyDown(
+  e: React.KeyboardEvent,
+  actions: { copy: () => void; download: () => void }
+): boolean {
+  if (matchesKeybind(e, KEYBINDS.IMAGE_COPY)) {
+    if (window.getSelection()?.toString()) {
+      return false;
+    }
+    e.preventDefault();
+    // Block global handlers (e.g. Ctrl+C stream interrupt in vim mode).
+    stopKeyboardPropagation(e);
+    actions.copy();
+    return true;
+  }
+
+  if (matchesKeybind(e, KEYBINDS.IMAGE_DOWNLOAD)) {
+    // preventDefault suppresses the browser's save-page dialog.
+    e.preventDefault();
+    stopKeyboardPropagation(e);
+    actions.download();
+    return true;
+  }
+
+  return false;
 }
 
 /** Trigger a browser download of a data URL via a temporary anchor element. */

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -575,6 +575,12 @@ export const KEYBINDS = {
   /** Toggle plan annotation mode in propose_plan */
   TOGGLE_PLAN_ANNOTATE: { key: "a", shift: true },
 
+  /** Copy image to clipboard (scoped to image lightbox / image context menu) */
+  IMAGE_COPY: { key: "c", ctrl: true },
+
+  /** Download image (scoped to image lightbox / image context menu) */
+  IMAGE_DOWNLOAD: { key: "s", ctrl: true },
+
   TOGGLE_POWER_MODE: { key: "F12", shift: true },
 } as const;
 


### PR DESCRIPTION
## Summary

Renews the image experience for `attach_file` (and all other tool results that render images: `desktop_screenshot`, MCP tools) — adds a right-click context menu with **Copy image**, **Download image**, and **View full size** (plus keyboard shortcuts), filename captions on thumbnails, a copy/download action bar **and the same context menu** in the expanded lightbox, and download cards for PDF/SVG attachments that previously rendered no visual at all.

## Background

Tool result images were view-only: a thumbnail that opened a bare lightbox. There was no way to copy an image to the clipboard, no way to save it, no way to tell which file a thumbnail came from, and PDF/SVG attachments (which are real model attachments but excluded from the raster-image allowlist) were completely invisible in the tool card.

## Implementation

- **`src/browser/utils/imageActions.ts`** (new): shared image actions for base64 data URLs.
  - `copyImageDataUrlToClipboard` — Chromium's async Clipboard API only accepts `image/png` payloads, so non-PNG sources (JPEG/WebP/GIF/…) are re-encoded through an offscreen canvas first.
  - `downloadDataUrl` + `getImageDownloadFilename` — download with a sensible filename (attachment filename, else extension derived from media type, with `jpeg→jpg`, `svg+xml→svg` mapping).
  - `handleImageActionKeyDown` — shared handler for the new centralized keybinds `KEYBINDS.IMAGE_COPY` (mod+C) and `KEYBINDS.IMAGE_DOWNLOAD` (mod+S); defers mod+C to native copy when text is selected, suppresses the browser save dialog on mod+S, and stops propagation so global handlers (vim-mode Ctrl+C stream interrupt) don't fire.
- **`src/browser/components/ImageActionsMenu.tsx`** (new): shared right-click menu (Copy image / Download image + shortcut handling) used by both the thumbnail grid and the expanded lightbox, so the two surfaces stay consistent by construction.
- **`ToolResultImages`** (shared by attach_file / desktop_screenshot / MCP / generic tool cards):
  - Right-click (or 500ms long-press on touch) opens the shared menu with a thumbnail-only "View full size" item prepended, reusing the existing `useContextMenuPosition` infrastructure. Menu items show shortcut hints (hidden on mobile); the shortcuts work while the menu is open via a new `PositionedMenu.onKeyDown` prop.
  - Thumbnails now show a truncating filename caption when the media part carries one.
  - `extractImagesFromToolResult` normalizes `filename` (non-string/empty → `undefined`) without dropping the image.
- **`ImageLightbox`**: adds a footer bar with the filename plus Copy (with copied-feedback via the existing `useCopyToClipboard` hook) and Download actions. The full-size image offers the same right-click/long-press context menu as the thumbnails (menu copies route through the feedback hook so the Copy button flashes "Copied"); the same keyboard shortcuts work while the lightbox is open. Escape layering is preserved: Escape closes the menu first, then the lightbox.
- **`AttachFileToolCall`**: PDF and SVG media attachments — which are deliberately never rendered inline (SVG can contain scripts; see `sanitizeImageData`) — now surface as a download card instead of being invisible.

Security note: the existing raster-only allowlist and base64 validation in `sanitizeImageData` are unchanged; SVG remains never rendered in the DOM and is only offered as a download.

## Validation

- `make static-check` passes; 374 tests across `src/browser/features/Tools/` + new `imageActions` tests pass; full Storybook test-runner passes locally (343 tests).
- New unit tests: data-URL → Blob decoding, download filename derivation, filename normalization in `extractImagesFromToolResult`, image caption rendering, the PDF download-card branch, and keyboard-shortcut behavior (copy/download dispatch, selection deferral, unrelated-key passthrough).
- New Storybook coverage: Gallery gains a PDF download-card section; `ImageContextMenu` opens the right-click menu via a play function so Pixel snapshots capture it; `ImageLongPressMenu` exercises the touch-only 500ms long-press path and asserts the follow-up click is suppressed; `LightboxContextMenu` opens the menu on the expanded image and asserts Escape closes only the menu while the lightbox stays open.

## Risks

Low. The context menu wraps the existing thumbnail button without changing click-to-lightbox behavior, and the transcript-wide right-click menu is unaffected (buttons are already excluded via its interactive-target selector). Clipboard copy requires `ClipboardItem` support (available in Electron/Chromium); it fails gracefully with a console error elsewhere. New keybinds are scoped to focused image surfaces only (menu content / lightbox dialog), so they cannot shadow global shortcuts elsewhere.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=0.00 -->
