### PR TITLE
🤖 fix: refine reasoning selector feedback

### DIFF
--- a/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
+++ b/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
@@ -174,7 +174,7 @@ export const ThinkingSelector: React.FC<ThinkingSelectorProps> = (props) => {
               <span
                 data-thinking-pro-status
                 className={cn(
-                  "border-border-medium text-muted rounded-[3px] border bg-transparent px-1 text-[9px] leading-[14px] font-semibold tracking-wide",
+                  "border-border-medium text-muted ml-0.5 rounded-[3px] border bg-transparent px-1 text-[9px] leading-[14px] font-semibold tracking-wide",
                   COMPOSER_PRO_HIDE_CLASS
                 )}
               >
@@ -270,7 +270,7 @@ export const ThinkingSelector: React.FC<ThinkingSelectorProps> = (props) => {
                   data-component="FastModeToggle"
                   aria-pressed={fastModeActive}
                   disabled={fastModeSaving}
-                  className="hover:bg-hover disabled:text-muted flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left transition-colors disabled:cursor-wait"
+                  className="hover:bg-hover disabled:text-muted flex w-full items-center gap-2.5 px-2.5 py-1.5 text-left transition-colors disabled:cursor-default"
                   onClick={() => {
                     handleFastModeToggle().catch(() => undefined);
                   }}


### PR DESCRIPTION
## Summary

Improves the composer reasoning selector by giving the PRO badge more breathing room and keeping the Fast mode toggle from showing a busy pointer while its provider setting is saved.

## Stack context

This is a single-layer change based directly on `main`.

## Why

The reasoning effort and PRO labels appeared crowded. Rapid interaction with the dropdown could also show a wait cursor, which suggested a foreground load even though the menu remained responsive.

## Implementation

- Adds localized spacing before the PRO badge without changing the Fast icon or chevron spacing.
- Retains Fast mode's duplicate-click guard while using the normal disabled cursor.

## Validation

- `make static-check`
- `bun x eslint src/browser/components/ThinkingSelector/ThinkingSelector.tsx`
- Storybook verification at full and narrow composer widths, including no horizontal overflow
- Rapid effort switching verification with the dropdown remaining open

## Risk

Low. The change is limited to two Tailwind utility classes in the reasoning selector.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh -->
