### PR TITLE
🤖 feat: mark settings backup as experimental in the settings UI

### DIFF
--- a/src/browser/features/Settings/Sections/BackupSection.tsx
+++ b/src/browser/features/Settings/Sections/BackupSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { ArchiveRestore, CheckCircle2, CloudUpload, RefreshCw } from "lucide-react";
+import { ArchiveRestore, CheckCircle2, CloudUpload, RefreshCw, TriangleAlert } from "lucide-react";
 import { Button } from "@/browser/components/Button/Button";
 import { Checkbox } from "@/browser/components/Checkbox/Checkbox";
 import { ConfirmationModal } from "@/browser/components/ConfirmationModal/ConfirmationModal";
@@ -518,6 +518,14 @@ export function BackupSection() {
 
   return (
     <div className="space-y-6">
+      <div className="bg-warning/10 border-warning/30 text-warning flex items-start gap-2 rounded-md border px-3 py-2 text-xs">
+        <TriangleAlert aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <p>
+          Settings backup is experimental. It may change or be removed in a future release; use it
+          carefully.
+        </p>
+      </div>
+
       <div>
         <h3 className="text-foreground text-sm font-medium">Settings backup</h3>
         <p className="text-muted mt-1 text-xs">

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -141,6 +141,7 @@ export function getSettingsSections(
     label: "Backup",
     icon: <ArchiveRestore className="h-4 w-4" />,
     component: BackupSection,
+    experimental: true,
   });
   if (governorEnabled) {
     sections.push({
@@ -280,6 +281,13 @@ export function SettingsPage(props: SettingsPageProps) {
               >
                 {section.icon}
                 {section.label}
+                {section.experimental && (
+                  <FlaskConical
+                    role="img"
+                    aria-label="Experimental"
+                    className="text-warning h-3 w-3 shrink-0"
+                  />
+                )}
               </Button>
             ))}
           </nav>
@@ -301,6 +309,13 @@ export function SettingsPage(props: SettingsPageProps) {
                 >
                   {section.icon}
                   {section.label}
+                  {section.experimental && (
+                    <FlaskConical
+                      role="img"
+                      aria-label="Experimental"
+                      className="text-warning h-3 w-3 shrink-0"
+                    />
+                  )}
                 </Button>
               ))}
             </nav>

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -282,11 +282,7 @@ export function SettingsPage(props: SettingsPageProps) {
                 {section.icon}
                 {section.label}
                 {section.experimental && (
-                  <FlaskConical
-                    role="img"
-                    aria-label="Experimental"
-                    className="text-warning h-3 w-3 shrink-0"
-                  />
+                  <FlaskConical aria-hidden="true" className="text-warning h-3 w-3 shrink-0" />
                 )}
               </Button>
             ))}
@@ -310,11 +306,7 @@ export function SettingsPage(props: SettingsPageProps) {
                   {section.icon}
                   {section.label}
                   {section.experimental && (
-                    <FlaskConical
-                      role="img"
-                      aria-label="Experimental"
-                      className="text-warning h-3 w-3 shrink-0"
-                    />
+                    <FlaskConical aria-hidden="true" className="text-warning h-3 w-3 shrink-0" />
                   )}
                 </Button>
               ))}

--- a/src/browser/features/Settings/types.ts
+++ b/src/browser/features/Settings/types.ts
@@ -5,4 +5,5 @@ export interface SettingsSection {
   label: string;
   icon: ReactNode;
   component: React.ComponentType;
+  experimental?: boolean;
 }


### PR DESCRIPTION
## Summary

Marks the settings backup feature as experimental in the UI: a flask icon appears next to "Backup" in the settings navigation, and a warning banner at the top of the Backup section tells users the feature may change or be removed and should be used carefully.

## Background

Settings backup (#3767) is new and its scope and format may still change. Users should not treat it as a stable, guaranteed feature yet.

## Implementation

- `SettingsSection` gains an optional `experimental` flag; the Backup section sets it.
- Both settings navs (desktop sidebar and mobile tab strip) render a decorative (`aria-hidden`) warning-colored `FlaskConical` icon after the label of experimental sections, so accessible button names stay unchanged.
- `BackupSection` renders a `TriangleAlert` warning banner styled like existing warning banners (`RosettaBanner`, `WindowsToolchainBanner`).

## Validation

- Storybook `SettingsPage/SectionsSmoke` story test run locally against a dev Storybook (it caught an accessible-name regression from an earlier `aria-label` on the icon).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
