### PR TITLE
🤖 fix: keep creation page project selector visible below fixed mobile header

### DIFF
--- a/src/browser/components/ProjectPage/ProjectPage.tsx
+++ b/src/browser/components/ProjectPage/ProjectPage.tsx
@@ -281,8 +281,9 @@ export const ProjectPage: React.FC<ProjectPageProps> = ({
               </Button>
             )}
           </div>
-          {/* Scrollable content area */}
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          {/* Scrollable content area. mobile-header-spacer keeps content below
+              the fixed mobile header on touch devices. */}
+          <div className="mobile-header-spacer min-h-0 flex-1 overflow-y-auto">
             {/* Main content - vertically centered with reduced gaps */}
             <div className="flex min-h-[50vh] flex-col items-center justify-center px-4 py-6">
               <div className={cn("flex w-full flex-col gap-4", CREATION_COLUMN_MAX_WIDTH_CLASS)}>

--- a/src/browser/components/ScratchPage/ScratchPage.tsx
+++ b/src/browser/components/ScratchPage/ScratchPage.tsx
@@ -87,7 +87,8 @@ export function ScratchPage(props: ScratchPageProps) {
               </Button>
             )}
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto">
+          {/* mobile-header-spacer keeps content below the fixed mobile header on touch devices. */}
+          <div className="mobile-header-spacer min-h-0 flex-1 overflow-y-auto">
             <div className="flex min-h-[50vh] flex-col items-center justify-center px-4 py-6">
               <div className={cn("flex w-full flex-col gap-4", CREATION_COLUMN_MAX_WIDTH_CLASS)}>
                 {!providersLoading && !hasProviders ? (


### PR DESCRIPTION
## Summary

Fixes the project creation and scratch pages on iOS, where the project selector row (`cmux ˅ / workspace-name`, and the `Scratch ˅` picker) rendered underneath the fixed mobile header and could never be scrolled into view.

## Background

On touch devices (`max-width: 768px` + `pointer: coarse`), `.mobile-sticky-header` becomes `position: fixed` and leaves the layout flow. Content below is expected to carry `.mobile-header-spacer` for clearance, which `ChatPane` does, but `ProjectPage` and `ScratchPage` never did. The same coarse-pointer block forces 44px minimum touch targets, inflating the header to ~60px, taller than the selector row's extent, so the row sat above `scrollTop 0` and was fully occluded on iOS. Desktop and plain narrow-viewport emulation were unaffected because `pointer: coarse` never matches there, which is why this went unnoticed after #3817.

## Implementation

Adds the existing `mobile-header-spacer` class to the scroll content container of both pages, matching ChatPane's precedent. No CSS changes.

## Validation

- Reproduced pre-fix in a dev-server sandbox with the coarse-pointer rules applied: header bottom 61px vs selector row top 24px (fully hidden).
- Post-fix: row top 112px, clear of the header; verified both the project page and scratch page renders, and confirmed on a physical iPhone.

## Risks

Low. On touch devices the pages gain the same 88px top padding ChatPane already uses; non-touch layouts are unchanged because the rule only applies under `pointer: coarse`.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
