### PR TITLE
🤖 tests: validate persistent sub-agent compaction

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -149,6 +149,8 @@ export interface CompactionFollowUpRequest extends CompactionFollowUpInput, Pres
   model: string;
   /** Agent ID for the follow-up message (user's original agentId, not "compact") */
   agentId: string;
+  /** Preserve internal sub-agent/automation attribution across the mechanical compact turn. */
+  agentInitiated?: boolean;
   /** Internal goal continuation classification for synthetic follow-up accounting. */
   goalKind?: GoalSyntheticMessageKind;
   /** Internal dispatch guardrails for crash-safe follow-up recovery. */

--- a/src/node/services/agentSession.autoCompaction.test.ts
+++ b/src/node/services/agentSession.autoCompaction.test.ts
@@ -1101,10 +1101,21 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
       getThreshold: mock(() => 0.85),
     } as unknown as CompactionMonitor;
 
-    const result = await session.sendMessage("hello", {
-      model: "openai:gpt-4o",
-      agentId: "exec",
-    });
+    const workspaceTurnMetadata = {
+      type: "workspace-turn-task",
+      taskHandleId: "wst_mid_stream_compaction",
+      ownerWorkspaceId: "parent-mid-stream-compaction",
+      turnId: "turn-mid-stream-compaction",
+    } as const;
+    const result = await session.sendMessage(
+      "hello",
+      {
+        model: "openai:gpt-4o",
+        agentId: "exec",
+        muxMetadata: workspaceTurnMetadata,
+      },
+      { agentInitiated: true }
+    );
 
     expect(result.success).toBe(true);
 
@@ -1120,6 +1131,16 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
       .find((message) => message.metadata?.muxMetadata?.type === "compaction-request");
 
     expect(compactionRequestMessage).toBeDefined();
+
+    const compactionRequestMetadata = compactionRequestMessage?.metadata?.muxMetadata;
+    expect(compactionRequestMetadata?.type).toBe("compaction-request");
+    if (compactionRequestMetadata?.type !== "compaction-request") {
+      throw new Error("Expected a persisted mid-stream compaction request");
+    }
+    expect(compactionRequestMetadata.parsed.followUpContent?.muxMetadata).toEqual(
+      workspaceTurnMetadata
+    );
+    expect(compactionRequestMetadata.parsed.followUpContent?.agentInitiated).toBe(true);
 
     const compactionRequestText =
       compactionRequestMessage?.parts.find((part) => part.type === "text")?.text ?? "";

--- a/src/node/services/agentSession.continueMessageAgentId.test.ts
+++ b/src/node/services/agentSession.continueMessageAgentId.test.ts
@@ -28,7 +28,7 @@ interface SessionInternals {
   sendMessage: (
     message: string,
     options?: SendOptions,
-    internal?: { synthetic?: boolean }
+    internal?: { synthetic?: boolean; agentInitiated?: boolean }
   ) => Promise<SendMessageResult>;
   scheduleStartupRecovery: () => void;
   startupRecoveryPromise: Promise<void> | null;
@@ -149,7 +149,7 @@ describe("AgentSession continue-message agentId fallback", () => {
   test("legacy continueMessage.mode does not fall back to compact agent", async () => {
     let dispatchedMessage: string | undefined;
     let dispatchedOptions: SendOptions | undefined;
-    let dispatchedInternal: { synthetic?: boolean } | undefined;
+    let dispatchedInternal: { synthetic?: boolean; agentInitiated?: boolean } | undefined;
     const legacyFollowUp = {
       text: "follow up",
       model: "openai:gpt-4o",
@@ -161,7 +161,11 @@ describe("AgentSession continue-message agentId fallback", () => {
     ]);
 
     internals.sendMessage = mock(
-      (message: string, options?: SendOptions, internal?: { synthetic?: boolean }) => {
+      (
+        message: string,
+        options?: SendOptions,
+        internal?: { synthetic?: boolean; agentInitiated?: boolean }
+      ) => {
         dispatchedMessage = message;
         dispatchedOptions = options;
         dispatchedInternal = internal;
@@ -174,6 +178,33 @@ describe("AgentSession continue-message agentId fallback", () => {
     expect(dispatchedMessage).toBe("follow up");
     expect(dispatchedOptions?.agentId).toBe("plan");
     expect(dispatchedInternal?.synthetic).toBe(true);
+  });
+
+  test("dispatchPendingFollowUp preserves agent-initiated attribution", async () => {
+    let dispatchedInternal: { synthetic?: boolean; agentInitiated?: boolean } | undefined;
+    const { internals } = await createSession([
+      compactionSummaryMessage("summary-agent-initiated", {
+        text: "continue delegated work",
+        model: "openai:gpt-4o",
+        agentId: "exec",
+        agentInitiated: true,
+      }),
+    ]);
+    internals.sendMessage = mock(
+      (
+        _message: string,
+        _options?: SendOptions,
+        internal?: { synthetic?: boolean; agentInitiated?: boolean }
+      ) => {
+        dispatchedInternal = internal;
+        return Promise.resolve({ success: true as const });
+      }
+    );
+
+    await internals.dispatchPendingFollowUp();
+
+    expect(dispatchedInternal).toMatchObject({ synthetic: true, agentInitiated: true });
+    expect(internals.lastAutoRetryResumeRequest?.agentInitiated).toBe(true);
   });
 
   test("dispatchPendingFollowUp skips idle-only follow-ups when queued user input exists", async () => {

--- a/src/node/services/agentSession.postCompactionRefresh.test.ts
+++ b/src/node/services/agentSession.postCompactionRefresh.test.ts
@@ -116,6 +116,59 @@ describe("AgentSession post-compaction refresh trigger", () => {
     session.dispose();
   });
 
+  test("reports failed compaction continuation dispatch to lifecycle consumers", async () => {
+    const workspaceId = "ws-compaction-follow-up-failure";
+    const { session, historyService, aiEmitter, cleanup } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    historyCleanup = cleanup;
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("before-failed-follow-up", "user", "Preserve this context")
+    );
+    await historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("failed-follow-up-request", "user", "Please compact", {
+        muxMetadata: {
+          type: "compaction-request",
+          rawCommand: "/compact",
+          parsed: {
+            followUpContent: {
+              text: "Continue delegated work",
+              model: "openai:gpt-4o",
+              agentId: "exec",
+            },
+          },
+        },
+      })
+    );
+
+    const internals = session as unknown as {
+      activeCompactionRequest?: { id: string; modelString: string };
+      dispatchPendingFollowUp: () => Promise<boolean>;
+    };
+    internals.activeCompactionRequest = {
+      id: "failed-follow-up-request",
+      modelString: "openai:gpt-4o",
+    };
+    internals.dispatchPendingFollowUp = mock(() =>
+      Promise.reject(new Error("follow-up startup failed"))
+    );
+    const decision = session.waitForPendingCompactionCompletionDecision("failed-follow-up-summary");
+
+    aiEmitter.emit("stream-end", {
+      type: "stream-end",
+      workspaceId,
+      messageId: "failed-follow-up-summary",
+      metadata: { model: "openai:gpt-4o", agentId: "compact", finishReason: "stop" },
+      parts: [{ type: "text", text: "Compacted context" }],
+    } satisfies StreamEndEvent);
+
+    expect(await decision).toBe(false);
+    expect(internals.dispatchPendingFollowUp).toHaveBeenCalledTimes(1);
+    session.dispose();
+  });
+
   test("triggers callback on file_edit_* tool-call-end", async () => {
     const handlers = new Map<string, (...args: unknown[]) => void>();
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -2939,6 +2939,7 @@ export class AgentSession {
           options: optionsForStream,
           modelForStream,
           fileParts: followUpFileParts,
+          agentInitiated,
           goalKind,
           muxMetadata: typedMuxMetadata,
           workspaceTurnMetadata: inheritedWorkspaceTurnMetadata,
@@ -3579,6 +3580,7 @@ export class AgentSession {
     options: SendMessageOptions;
     modelForStream: string;
     fileParts?: FilePart[];
+    agentInitiated?: boolean;
     goalKind?: GoalSyntheticMessageKind;
     muxMetadata?: MuxMessageMetadata;
     workspaceTurnMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
@@ -3589,6 +3591,10 @@ export class AgentSession {
       agentId: params.options.agentId,
       ...pickPreservedSendOptions(params.options),
     };
+
+    if (params.agentInitiated === true) {
+      followUp.agentInitiated = true;
+    }
 
     if (params.goalKind != null) {
       followUp.goalKind = params.goalKind;
@@ -3756,6 +3762,7 @@ export class AgentSession {
         // buildCompactionMessageText can hide the internal resume marker.
         messageText: "Continue",
         options: streamContext.options,
+        agentInitiated: streamContext.agentInitiated,
         goalKind: streamContext.goalKind,
         modelForStream: streamContext.modelString,
       });
@@ -3771,7 +3778,7 @@ export class AgentSession {
           ...autoCompactionRequest.sendOptions,
           muxMetadata: autoCompactionRequest.metadata,
         },
-        { synthetic: true }
+        { synthetic: true, agentInitiated: autoCompactionRequest.agentInitiated }
       );
       if (!sendResult.success) {
         log.warn("Failed to dispatch mid-stream compaction request", {
@@ -5775,7 +5782,7 @@ export class AgentSession {
     // The compaction summary is now the source of truth for the next live resume
     // request. Pre-arm retry state from the reconstructed follow-up so failures
     // before stream startup do not fall back to the already-completed compact turn.
-    this.setAutoRetryResumeState(options, undefined, followUp.goalKind);
+    this.setAutoRetryResumeState(options, followUp.agentInitiated, followUp.goalKind);
 
     // Await sendMessage to ensure the follow-up is persisted before returning.
     // This guarantees ordering: the follow-up message is written to history
@@ -5784,6 +5791,7 @@ export class AgentSession {
     // re-enable auto-retry after a user explicitly opted out.
     const sendResult = await this.sendMessage(finalText, options, {
       synthetic: true,
+      agentInitiated: followUp.agentInitiated,
       goalKind: followUp.goalKind,
       goalContinuation: followUp.goalKind === GOAL_CONTINUATION_KIND,
     });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -590,6 +590,12 @@ export class AgentSession {
     }
   >();
 
+  /** Compaction persistence outcomes keyed by the compact assistant message. */
+  private readonly compactionCompletionDecisions = new Map<
+    string,
+    { promise: Promise<boolean>; resolve: (handled: boolean) => void; outcome?: boolean }
+  >();
+
   /** Tracks whether the current stream included post-compaction attachments. */
   private activeStreamHadPostCompactionInjection = false;
 
@@ -899,6 +905,22 @@ export class AgentSession {
       return;
     }
     this.emitChatEvent(event);
+  }
+
+  private beginCompactionCompletionDecision(messageId: string): void {
+    if (this.compactionCompletionDecisions.has(messageId)) return;
+    let resolveDecision!: (handled: boolean) => void;
+    const promise = new Promise<boolean>((resolve) => {
+      resolveDecision = resolve;
+    });
+    this.compactionCompletionDecisions.set(messageId, { promise, resolve: resolveDecision });
+  }
+
+  private resolveCompactionCompletionDecision(messageId: string, handled: boolean): void {
+    const decision = this.compactionCompletionDecisions.get(messageId);
+    if (decision == null || decision.outcome != null) return;
+    decision.outcome = handled;
+    decision.resolve(handled);
   }
 
   private beginStreamErrorRecoveryDecision(messageId: string): void {
@@ -4865,6 +4887,9 @@ export class AgentSession {
       try {
         const completedCompactionRequest = this.activeCompactionRequest;
         this.activeCompactionRequest = undefined;
+        if (completedCompactionRequest != null) {
+          this.beginCompactionCompletionDecision(streamEndPayload.messageId);
+        }
         this.updateUsageStateFromModelUsage({
           model: streamEndPayload.metadata.model,
           usage: streamEndPayload.metadata.contextUsage,
@@ -4875,7 +4900,14 @@ export class AgentSession {
         });
         this.clearLiveUsageState();
 
-        const handled = await this.compactionHandler.handleCompletion(streamEndPayload);
+        let handled = false;
+        try {
+          handled = await this.compactionHandler.handleCompletion(streamEndPayload);
+        } finally {
+          if (completedCompactionRequest != null) {
+            this.resolveCompactionCompletionDecision(streamEndPayload.messageId, handled);
+          }
+        }
 
         await this.recordGoalAccountingFromUsage({
           model: streamEndPayload.metadata.model,
@@ -5417,6 +5449,13 @@ export class AgentSession {
 
     this.sendQueuedMessages();
     return true;
+  }
+
+  async waitForPendingCompactionCompletionDecision(messageId: string): Promise<boolean> {
+    this.beginCompactionCompletionDecision(messageId);
+    const decision = this.compactionCompletionDecisions.get(messageId);
+    assert(decision, "compaction completion decision must exist");
+    return decision.outcome ?? decision.promise;
   }
 
   /**

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -609,6 +609,7 @@ export class AgentSession {
     openaiTruncationModeOverride?: "auto" | "disabled";
     providersConfig: ProvidersConfigMap | null;
     goalKind?: GoalSyntheticMessageKind;
+    workspaceTurnMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
   };
 
   private activeCompactionRequest?: {
@@ -3765,6 +3766,7 @@ export class AgentSession {
         agentInitiated: streamContext.agentInitiated,
         goalKind: streamContext.goalKind,
         modelForStream: streamContext.modelString,
+        muxMetadata: streamContext.workspaceTurnMetadata,
       });
       const autoCompactionRequest = this.buildAutoCompactionRequest({
         followUpContent,
@@ -4027,6 +4029,12 @@ export class AgentSession {
           : retryMuxMetadata?.type === "bash-monitor-wake"
             ? inheritOpenWorkspaceTurnMetadata(historyResult.data)
             : undefined;
+    // Mid-stream compaction runs after the original send options have already been resolved against
+    // history (notably bash-monitor wakes). Persist the actual correlation used by this stream so the
+    // post-compaction continuation remains the same delegated workspace turn.
+    if (this.activeStreamContext != null) {
+      this.activeStreamContext.workspaceTurnMetadata = streamMuxMetadata;
+    }
     const acpPromptId =
       normalizeAcpPromptId(options?.acpPromptId) ?? extractAcpPromptId(optionsMuxMetadata);
     const delegatedToolNames =

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5452,10 +5452,15 @@ export class AgentSession {
   }
 
   async waitForPendingCompactionCompletionDecision(messageId: string): Promise<boolean> {
-    this.beginCompactionCompletionDecision(messageId);
+    if (!this.compactionCompletionDecisions.has(messageId)) {
+      if (this.activeCompactionRequest == null) return false;
+      this.beginCompactionCompletionDecision(messageId);
+    }
     const decision = this.compactionCompletionDecisions.get(messageId);
     assert(decision, "compaction completion decision must exist");
-    return decision.outcome ?? decision.promise;
+    const handled = await (decision.outcome ?? decision.promise);
+    this.compactionCompletionDecisions.delete(messageId);
+    return handled;
   }
 
   /**

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4883,9 +4883,10 @@ export class AgentSession {
         streamEndedAtMs: number;
       } | null = null;
       let emittedStreamEnd = false;
+      const completedCompactionRequest = this.activeCompactionRequest;
+      let continuedAfterCompaction = false;
 
       try {
-        const completedCompactionRequest = this.activeCompactionRequest;
         this.activeCompactionRequest = undefined;
         if (completedCompactionRequest != null) {
           this.beginCompactionCompletionDecision(streamEndPayload.messageId);
@@ -4900,14 +4901,7 @@ export class AgentSession {
         });
         this.clearLiveUsageState();
 
-        let handled = false;
-        try {
-          handled = await this.compactionHandler.handleCompletion(streamEndPayload);
-        } finally {
-          if (completedCompactionRequest != null) {
-            this.resolveCompactionCompletionDecision(streamEndPayload.messageId, handled);
-          }
-        }
+        const handled = await this.compactionHandler.handleCompletion(streamEndPayload);
 
         await this.recordGoalAccountingFromUsage({
           model: streamEndPayload.metadata.model,
@@ -4958,8 +4952,9 @@ export class AgentSession {
         this.resetActiveStreamState();
 
         if (handled) {
-          // Dispatch follow-up AFTER reset so it can set its own stream state.
-          await this.dispatchPendingFollowUp();
+          // Dispatch follow-up AFTER reset so it can set its own stream state. Child lifecycle
+          // settlement defers only when this durable continuation was actually accepted.
+          continuedAfterCompaction = await this.dispatchPendingFollowUp();
         }
 
         // Stream end: auto-send queued messages (for user messages typed during streaming)
@@ -5019,6 +5014,13 @@ export class AgentSession {
           }
         }
       } finally {
+        if (completedCompactionRequest != null) {
+          this.resolveCompactionCompletionDecision(
+            streamEndPayload.messageId,
+            continuedAfterCompaction
+          );
+        }
+
         // Only clean up if we're still in COMPLETING — a new turn started by
         // dispatchPendingFollowUp() or sendQueuedMessages()
         // owns the stream state now.

--- a/src/node/services/agentSession.workspaceTurnInheritance.test.ts
+++ b/src/node/services/agentSession.workspaceTurnInheritance.test.ts
@@ -212,11 +212,15 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
         getThreshold: mock(() => 0.85),
       };
 
-      const result = await session.sendMessage("monitor wake", {
-        model: "anthropic:claude-sonnet-4-5",
-        agentId: "exec",
-        muxMetadata: { type: "bash-monitor-wake", records: [] },
-      });
+      const result = await session.sendMessage(
+        "monitor wake",
+        {
+          model: "anthropic:claude-sonnet-4-5",
+          agentId: "exec",
+          muxMetadata: { type: "bash-monitor-wake", records: [] },
+        },
+        { agentInitiated: true }
+      );
       expect(result.success).toBe(true);
 
       const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
@@ -229,6 +233,7 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
       if (requestMeta?.type !== "compaction-request") {
         throw new Error("expected a persisted compaction request");
       }
+      expect(requestMeta.parsed.followUpContent?.agentInitiated).toBe(true);
       expect(requestMeta.parsed.followUpContent?.workspaceTurnMetadata).toEqual(correlation);
     } finally {
       session.dispose();

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1137,7 +1137,9 @@ export class AIService extends EventEmitter {
         }
         return await this.mockAiStreamPlayer.play(messages, workspaceId, {
           model: modelString,
+          agentId,
           thinkingLevel,
+          muxMetadata,
           abortSignal: combinedAbortSignal,
         });
       }

--- a/src/node/services/mock/mockAiEventTypes.ts
+++ b/src/node/services/mock/mockAiEventTypes.ts
@@ -23,6 +23,7 @@ export interface MockStreamStartEvent extends MockAssistantEventBase {
   messageId: string;
   model: string;
   mode?: "plan" | "exec" | "compact";
+  agentId?: string;
   thinkingLevel?: StreamStartEvent["thinkingLevel"];
 }
 

--- a/src/node/services/mock/mockAiStreamAdapter.ts
+++ b/src/node/services/mock/mockAiStreamAdapter.ts
@@ -45,6 +45,7 @@ export interface BuildMockStreamEventsOptions {
   messageId: string;
   model?: string;
   mode?: "plan" | "exec" | "compact";
+  agentId?: string;
   thinkingLevel?: MockStreamStartEvent["thinkingLevel"];
 
   /** Chunk size for stream-delta events. */
@@ -77,6 +78,7 @@ export function buildMockStreamEventsFromReply(
     messageId: options.messageId,
     model,
     ...(mode && { mode }),
+    ...(options.agentId && { agentId: options.agentId }),
     ...(options.thinkingLevel && { thinkingLevel: options.thinkingLevel }),
   });
 

--- a/src/node/services/mock/mockAiStreamPlayer.test.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.test.ts
@@ -5,6 +5,7 @@ import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import { Ok } from "@/common/types/result";
 import type { HistoryService } from "@/node/services/historyService";
 import type { AIService } from "@/node/services/aiService";
+import type { StreamEndEvent, StreamStartEvent } from "@/common/types/stream";
 import { createTestHistoryService } from "../testHistoryService";
 
 function readWorkspaceId(payload: unknown): string | undefined {
@@ -692,6 +693,57 @@ describe("MockAiStreamPlayer", () => {
     const assistantMessage = historyMessages.find((message) => message.role === "assistant");
     expect(assistantMessage).toBeDefined();
     expect(extractText(assistantMessage)).toContain("Here are three programming languages");
+  });
+
+  test("preserves agent and workspace-turn metadata through mock stream completion", async () => {
+    const aiServiceStub = new EventEmitter();
+    const player = new MockAiStreamPlayer({
+      historyService,
+      aiService: aiServiceStub as unknown as AIService,
+    });
+    const workspaceId = "workspace-metadata";
+    const muxMetadata = {
+      type: "workspace-turn-task",
+      taskHandleId: "wst_mock_metadata",
+      ownerWorkspaceId: "parent-metadata",
+      turnId: "turn-metadata",
+    } as const;
+    let streamStart: StreamStartEvent | undefined;
+    let streamEnd: StreamEndEvent | undefined;
+    aiServiceStub.on("stream-start", (payload: StreamStartEvent) => {
+      if (payload.workspaceId === workspaceId) streamStart = payload;
+    });
+    aiServiceStub.on("stream-end", (payload: StreamEndEvent) => {
+      if (payload.workspaceId === workspaceId) streamEnd = payload;
+    });
+
+    const userMessage = createMuxMessage("user-metadata", "user", "Continue delegated work", {
+      timestamp: Date.now(),
+    });
+    const playResult = await player.play([userMessage], workspaceId, {
+      model: "anthropic:claude-sonnet-4-6",
+      agentId: "explore",
+      thinkingLevel: "high",
+      muxMetadata,
+    });
+    expect(playResult.success).toBe(true);
+    await waitForCondition(() => !player.isStreaming(workspaceId), 2000);
+
+    expect(streamStart).toMatchObject({ agentId: "explore", thinkingLevel: "high" });
+    expect(streamEnd?.metadata).toMatchObject({
+      agentId: "explore",
+      thinkingLevel: "high",
+      muxMetadata,
+    });
+    const historyResult = await historyService.getLastMessages(workspaceId, 10);
+    expect(historyResult.success).toBe(true);
+    if (!historyResult.success) throw new Error(historyResult.error);
+    const assistantMessage = historyResult.data.find((message) => message.role === "assistant");
+    expect(assistantMessage?.metadata).toMatchObject({
+      agentId: "explore",
+      thinkingLevel: "high",
+      muxMetadata,
+    });
   });
 
   test("stop prevents queued stream events from emitting", async () => {

--- a/src/node/services/mock/mockAiStreamPlayer.ts
+++ b/src/node/services/mock/mockAiStreamPlayer.ts
@@ -1,5 +1,5 @@
 import assert from "@/common/utils/assert";
-import type { MuxMessage } from "@/common/types/message";
+import type { MuxMessage, MuxMessageMetadata } from "@/common/types/message";
 import { createMuxMessage } from "@/common/types/message";
 import type { HistoryService } from "@/node/services/historyService";
 import type { Result } from "@/common/types/result";
@@ -126,6 +126,10 @@ interface ActiveStream {
   historySequence: number;
   startTime: number;
   model: string;
+  mode?: MockStreamStartEvent["mode"];
+  agentId?: string;
+  thinkingLevel?: MockStreamStartEvent["thinkingLevel"];
+  muxMetadata?: MuxMessageMetadata;
   parts: MuxMessage["parts"];
   partialWriteTimer: ReturnType<typeof setTimeout> | null;
   eventQueue: Array<() => Promise<void>>;
@@ -272,7 +276,9 @@ export class MockAiStreamPlayer {
     workspaceId: string,
     options?: {
       model?: string;
+      agentId?: string;
       thinkingLevel?: StreamStartEvent["thinkingLevel"];
+      muxMetadata?: MuxMessageMetadata;
       abortSignal?: AbortSignal;
     }
   ): Promise<Result<void, SendMessageError>> {
@@ -312,6 +318,7 @@ export class MockAiStreamPlayer {
     const events = buildMockStreamEventsFromReply(reply, {
       messageId,
       model: options?.model,
+      agentId: options?.agentId,
       thinkingLevel: options?.thinkingLevel,
     });
 
@@ -359,6 +366,10 @@ export class MockAiStreamPlayer {
     const assistantMessage = createMuxMessage(messageId, "assistant", "", {
       timestamp: Date.now(),
       model: streamStart.model,
+      ...(streamStart.mode && { mode: streamStart.mode }),
+      ...(streamStart.agentId && { agentId: streamStart.agentId }),
+      ...(streamStart.thinkingLevel && { thinkingLevel: streamStart.thinkingLevel }),
+      ...(options?.muxMetadata && { muxMetadata: options.muxMetadata }),
     });
 
     if (abortSignal?.aborted) {
@@ -391,7 +402,7 @@ export class MockAiStreamPlayer {
       return Ok(undefined);
     }
 
-    this.scheduleEvents(workspaceId, events, messageId, historySequence);
+    this.scheduleEvents(workspaceId, events, messageId, historySequence, options?.muxMetadata);
 
     await streamStartPromise;
     if (abortSignal?.aborted) {
@@ -409,15 +420,23 @@ export class MockAiStreamPlayer {
     workspaceId: string,
     events: MockAssistantEvent[],
     messageId: string,
-    historySequence: number
+    historySequence: number,
+    muxMetadata?: MuxMessageMetadata
   ): void {
     const timers: Array<ReturnType<typeof setTimeout>> = [];
+    const streamStart = events.find(
+      (event): event is MockStreamStartEvent => event.kind === "stream-start"
+    );
     this.activeStreams.set(workspaceId, {
       timers,
       messageId,
       historySequence,
       startTime: Date.now(),
-      model: KNOWN_MODELS.OPUS.id,
+      model: streamStart?.model ?? KNOWN_MODELS.OPUS.id,
+      mode: streamStart?.mode,
+      agentId: streamStart?.agentId,
+      thinkingLevel: streamStart?.thinkingLevel,
+      muxMetadata,
       parts: [],
       partialWriteTimer: null,
       eventQueue: [],
@@ -583,6 +602,10 @@ export class MockAiStreamPlayer {
         historySequence: active.historySequence,
         timestamp: active.startTime,
         model: active.model,
+        ...(active.mode && { mode: active.mode }),
+        ...(active.agentId && { agentId: active.agentId }),
+        ...(active.thinkingLevel && { thinkingLevel: active.thinkingLevel }),
+        ...(active.muxMetadata && { muxMetadata: active.muxMetadata }),
         partial: true,
       },
       parts: structuredClone(active.parts),
@@ -661,6 +684,7 @@ export class MockAiStreamPlayer {
           historySequence,
           startTime: Date.now(),
           ...(event.mode && { mode: event.mode }),
+          ...(event.agentId && { agentId: event.agentId }),
           ...(event.thinkingLevel && { thinkingLevel: event.thinkingLevel }),
         };
         active.model = event.model;
@@ -795,6 +819,10 @@ export class MockAiStreamPlayer {
           messageId,
           metadata: {
             model: event.metadata.model,
+            ...(active.mode && { mode: active.mode }),
+            ...(active.agentId && { agentId: active.agentId }),
+            ...(active.thinkingLevel && { thinkingLevel: active.thinkingLevel }),
+            ...(active.muxMetadata && { muxMetadata: active.muxMetadata }),
             systemMessageTokens: event.metadata.systemMessageTokens,
           },
           parts: completedParts,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -102,22 +102,6 @@ function findWorkspaceInConfig(config: Config, workspaceId: string) {
     .find((workspace) => workspace.id === workspaceId);
 }
 
-function compactionSummaryMessage(id: string): MuxMessage {
-  return createMuxMessage(id, "assistant", "Compacted context", {
-    compactionBoundary: true,
-    compactionEpoch: 1,
-    compacted: "user",
-    muxMetadata: {
-      type: "compaction-summary",
-      pendingFollowUp: {
-        text: "Continue",
-        model: "anthropic:claude-sonnet-4-6",
-        agentId: "exec",
-      },
-    },
-  });
-}
-
 function createWorkspaceTurnMetadata(projectPath: string): WorkspaceMetadata {
   return {
     id: "childworkspace",
@@ -3987,11 +3971,7 @@ describe("TaskService", () => {
     // On-send compaction can consume a monitor-wake continuation mid-turn; the
     // compact turn's own stream-end is uncorrelated and must not supersede the
     // still-running delegated turn.
-    const { parentId, taskService, created, historyService } = await startWorkspaceTurnForTest();
-    await historyService.appendToHistory(
-      created.workspaceId,
-      compactionSummaryMessage("workspace-turn-compaction-summary")
-    );
+    const { parentId, taskService, created } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
     };
@@ -4041,12 +4021,7 @@ describe("TaskService", () => {
     const { workspaceService, sendMessage } = createWorkspaceServiceMocks({
       waitForPendingCompactionCompletionDecision,
     });
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
-    await historyService.appendToHistory(
-      childTaskId,
-      compactionSummaryMessage("persistent-child-compaction-summary")
-    );
-
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
     await handleTaskServiceStreamEndForTest(taskService, {
       type: "stream-end",
       workspaceId: childTaskId,
@@ -12159,7 +12134,7 @@ describe("TaskService", () => {
       return Ok(undefined);
     });
     const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
 
     const reactivated = await taskService.sendMessageToDescendantAgentTask(
       parentWorkspaceId,
@@ -12177,10 +12152,6 @@ describe("TaskService", () => {
     const activeRecord = await taskHandleStore.getWorkspaceTurn(parentWorkspaceId, handleId);
     assert(activeRecord, "reactivated workspace-turn record is required");
 
-    await historyService.appendToHistory(
-      childTaskId,
-      compactionSummaryMessage("reactivated-compaction-boundary")
-    );
     await handleTaskServiceStreamEndForTest(taskService, {
       type: "stream-end",
       workspaceId: childTaskId,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -62,7 +62,7 @@ import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { SendMessageError } from "@/common/types/errors";
 import type { ErrorEvent, StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
-import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
 import { isDynamicToolPart, type DynamicToolPart } from "@/common/types/toolParts";
 import {
   buildWorkflowRunCardMessage,
@@ -102,20 +102,20 @@ function findWorkspaceInConfig(config: Config, workspaceId: string) {
     .find((workspace) => workspace.id === workspaceId);
 }
 
-function compactionRequestMetadata(withFollowUp = true): MuxMessageMetadata {
-  return {
-    type: "compaction-request",
-    rawCommand: "/compact",
-    parsed: withFollowUp
-      ? {
-          followUpContent: {
-            text: "Continue",
-            model: "anthropic:claude-sonnet-4-6",
-            agentId: "exec",
-          },
-        }
-      : {},
-  };
+function compactionSummaryMessage(id: string): MuxMessage {
+  return createMuxMessage(id, "assistant", "Compacted context", {
+    compactionBoundary: true,
+    compactionEpoch: 1,
+    compacted: "user",
+    muxMetadata: {
+      type: "compaction-summary",
+      pendingFollowUp: {
+        text: "Continue",
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "exec",
+      },
+    },
+  });
 }
 
 function createWorkspaceTurnMetadata(projectPath: string): WorkspaceMetadata {
@@ -3987,7 +3987,11 @@ describe("TaskService", () => {
     // On-send compaction can consume a monitor-wake continuation mid-turn; the
     // compact turn's own stream-end is uncorrelated and must not supersede the
     // still-running delegated turn.
-    const { parentId, taskService, created } = await startWorkspaceTurnForTest();
+    const { parentId, taskService, created, historyService } = await startWorkspaceTurnForTest();
+    await historyService.appendToHistory(
+      created.workspaceId,
+      compactionSummaryMessage("workspace-turn-compaction-summary")
+    );
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
     };
@@ -4000,7 +4004,6 @@ describe("TaskService", () => {
         model: "anthropic:claude-opus-4-6",
         agentId: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted context" }],
     });
@@ -4031,12 +4034,18 @@ describe("TaskService", () => {
     );
     const waitForPendingCompactionCompletionDecision = mock(
       (_workspaceId: string, messageId: string): Promise<boolean> =>
-        Promise.resolve(messageId !== "failed-child-compaction")
+        Promise.resolve(
+          messageId === "child-compaction-agent-id" || messageId === "child-compaction-mode"
+        )
     );
     const { workspaceService, sendMessage } = createWorkspaceServiceMocks({
       waitForPendingCompactionCompletionDecision,
     });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      childTaskId,
+      compactionSummaryMessage("persistent-child-compaction-summary")
+    );
 
     await handleTaskServiceStreamEndForTest(taskService, {
       type: "stream-end",
@@ -4046,7 +4055,6 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         agentId: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted child context" }],
     });
@@ -4058,7 +4066,6 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         mode: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted child context" }],
     });
@@ -4084,7 +4091,6 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         agentId: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(false),
       },
       parts: [{ type: "text", text: "Standalone compacted child context" }],
     });
@@ -4111,7 +4117,6 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         agentId: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Rejected compacted child context" }],
     });
@@ -12154,7 +12159,7 @@ describe("TaskService", () => {
       return Ok(undefined);
     });
     const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
-    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
 
     const reactivated = await taskService.sendMessageToDescendantAgentTask(
       parentWorkspaceId,
@@ -12172,6 +12177,10 @@ describe("TaskService", () => {
     const activeRecord = await taskHandleStore.getWorkspaceTurn(parentWorkspaceId, handleId);
     assert(activeRecord, "reactivated workspace-turn record is required");
 
+    await historyService.appendToHistory(
+      childTaskId,
+      compactionSummaryMessage("reactivated-compaction-boundary")
+    );
     await handleTaskServiceStreamEndForTest(taskService, {
       type: "stream-end",
       workspaceId: childTaskId,
@@ -12181,7 +12190,6 @@ describe("TaskService", () => {
         agentId: "compact",
         mode: "compact",
         finishReason: "stop",
-        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted specialist context" }],
     });

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4451,6 +4451,57 @@ describe("TaskService", () => {
     expect(snapshot?.error).toBeUndefined();
   });
 
+  test("compaction stream-end does not advance a running persistent child toward recovery", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentWorkspaceId = "parent-child-compaction";
+    const childTaskId = "child-compaction";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentWorkspaceId),
+        projectWorkspace(projectPath, "child", childTaskId, {
+          parentWorkspaceId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+        }),
+      ],
+      testTaskSettings()
+    );
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "child-compaction-agent-id",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "compact",
+        finishReason: "stop",
+      },
+      parts: [{ type: "text", text: "Compacted child context" }],
+    });
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "child-compaction-mode",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        mode: "compact",
+        finishReason: "stop",
+      },
+      parts: [{ type: "text", text: "Compacted child context" }],
+    });
+
+    const child = findWorkspaceInConfig(config, childTaskId);
+    expect(child?.taskStatus).toBe("running");
+    expect(child?.taskRecoveryAttempts).toBeUndefined();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   test("workspace-turn tool-calls stream-end without continuation settles error", async () => {
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {
@@ -12454,6 +12505,105 @@ describe("TaskService", () => {
     expect(generationAttention?.id).not.toBe(pendingAttention.id);
     expect(await terminalAttentionStore.get(parentWorkspaceId, pendingAttention.id)).toMatchObject({
       status: "delivered",
+    });
+  });
+
+  test("reawakened child stays active through compaction and settles from its correlated follow-up", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["compactionhandle", "compactionturn"]);
+    const projectPath = path.join(rootDir, "repo");
+    const parentWorkspaceId = "parent-reactivated-compaction";
+    const childTaskId = "child-reactivated-compaction";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentWorkspaceId),
+        projectWorkspace(projectPath, "child", childTaskId, {
+          parentWorkspaceId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "reported",
+          reportedAt: "2026-08-10T00:00:00.000Z",
+          title: "Compaction specialist",
+        }),
+      ],
+      testTaskSettings()
+    );
+    const sendMessage = mock(async (...args: unknown[]): Promise<Result<void>> => {
+      const internal = args[3] as { onAccepted?: () => Promise<void> | void } | undefined;
+      await internal?.onAccepted?.();
+      return Ok(undefined);
+    });
+    const { workspaceService } = createWorkspaceServiceMocks({ sendMessage });
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const reactivated = await taskService.sendMessageToDescendantAgentTask(
+      parentWorkspaceId,
+      childTaskId,
+      "Continue after compacting the prior context.",
+      "tool-end"
+    );
+    expect(reactivated).toMatchObject({
+      success: true,
+      data: { delivery: "reactivated", executionTaskId: "wst_compactionhandle" },
+    });
+    const handleId = "wst_compactionhandle";
+    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+      .taskHandleStore;
+    const activeRecord = await taskHandleStore.getWorkspaceTurn(parentWorkspaceId, handleId);
+    assert(activeRecord, "reactivated workspace-turn record is required");
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "reactivated-compaction-summary",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "compact",
+        mode: "compact",
+        finishReason: "stop",
+      },
+      parts: [{ type: "text", text: "Compacted specialist context" }],
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentWorkspaceId, handleId)).toMatchObject({
+      status: "running",
+      workspaceId: childTaskId,
+    });
+    expect(findWorkspaceInConfig(config, childTaskId)).toMatchObject({
+      taskStatus: "reported",
+      taskExecutionId: handleId,
+      taskExecutionStatus: "running",
+    });
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "reactivated-post-compaction-result",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        finishReason: "stop",
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: handleId,
+          ownerWorkspaceId: parentWorkspaceId,
+          turnId: activeRecord.turnId,
+        },
+      },
+      parts: [{ type: "text", text: "Post-compaction result" }],
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentWorkspaceId, handleId)).toMatchObject({
+      status: "completed",
+      workspaceId: childTaskId,
+      messageId: "reactivated-post-compaction-result",
+      reportMarkdown: "Post-compaction result",
+    });
+    expect(findWorkspaceInConfig(config, childTaskId)).toMatchObject({
+      taskStatus: "reported",
+      taskExecutionId: handleId,
+      taskExecutionStatus: "completed",
     });
   });
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -404,6 +404,7 @@ function createWorkspaceServiceMocks(
     hasPendingAutoRetry: ReturnType<typeof mock>;
     waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
     waitForIdle: ReturnType<typeof mock>;
+    waitForPendingCompactionCompletionDecision: ReturnType<typeof mock>;
     waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
     archive: ReturnType<typeof mock>;
     unarchive: ReturnType<typeof mock>;
@@ -433,6 +434,7 @@ function createWorkspaceServiceMocks(
   waitForIdle: ReturnType<typeof mock>;
   hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
   hasPendingAutoRetry: ReturnType<typeof mock>;
+  waitForPendingCompactionCompletionDecision: ReturnType<typeof mock>;
   waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
   archive: ReturnType<typeof mock>;
   unarchive: ReturnType<typeof mock>;
@@ -468,6 +470,9 @@ function createWorkspaceServiceMocks(
   const waitForIdleAndNoQueuedMessages =
     overrides?.waitForIdleAndNoQueuedMessages ?? mock((): Promise<void> => Promise.resolve());
   const waitForIdle = overrides?.waitForIdle ?? mock((): Promise<void> => Promise.resolve());
+  const waitForPendingCompactionCompletionDecision =
+    overrides?.waitForPendingCompactionCompletionDecision ??
+    mock((): Promise<boolean> => Promise.resolve(true));
   const waitForPendingStreamErrorRecoveryDecision =
     overrides?.waitForPendingStreamErrorRecoveryDecision ??
     mock((): Promise<void> => Promise.resolve());
@@ -518,6 +523,7 @@ function createWorkspaceServiceMocks(
       hasPendingAutoRetry,
       waitForIdleAndNoQueuedMessages,
       waitForIdle,
+      waitForPendingCompactionCompletionDecision,
       waitForPendingStreamErrorRecoveryDecision,
       archive,
       unarchive,
@@ -546,6 +552,7 @@ function createWorkspaceServiceMocks(
     hasPendingAutoRetry,
     waitForIdleAndNoQueuedMessages,
     waitForIdle,
+    waitForPendingCompactionCompletionDecision,
     waitForPendingStreamErrorRecoveryDecision,
     archive,
     unarchive,
@@ -4022,7 +4029,13 @@ describe("TaskService", () => {
       ],
       testTaskSettings()
     );
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const waitForPendingCompactionCompletionDecision = mock(
+      (_workspaceId: string, messageId: string): Promise<boolean> =>
+        Promise.resolve(messageId !== "failed-child-compaction")
+    );
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks({
+      waitForPendingCompactionCompletionDecision,
+    });
     const { taskService } = createTaskServiceHarness(config, { workspaceService });
 
     await handleTaskServiceStreamEndForTest(taskService, {
@@ -4080,6 +4093,30 @@ describe("TaskService", () => {
       taskStatus: "awaiting_report",
       taskRecoveryAttempts: 1,
     });
+
+    await config.editConfig((cfg) => {
+      const child = cfg.projects
+        .get(projectPath)
+        ?.workspaces.find((workspace) => workspace.id === childTaskId);
+      assert(child, "child workspace must exist");
+      delete child.taskRecoveryAttempts;
+      return cfg;
+    });
+    sendMessage.mockClear();
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "failed-child-compaction",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "compact",
+        finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(),
+      },
+      parts: [{ type: "text", text: "Rejected compacted child context" }],
+    });
+
+    expect(findWorkspaceInConfig(config, childTaskId)?.taskRecoveryAttempts).toBe(1);
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -762,471 +762,6 @@ describe("TaskService", () => {
     };
   }
 
-  async function createWorkspaceLifecycleHarness(
-    options: { archived?: boolean; archive?: ReturnType<typeof mock> } = {}
-  ) {
-    const config = await createTestConfig(rootDir);
-    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
-    await config.editConfig((cfg) => {
-      const project = cfg.projects.get(projectPath);
-      assert(project, "test project must exist");
-      project.workspaces.push({
-        path: path.join(projectPath, "child"),
-        id: "childworkspace",
-        name: "child",
-        title: "Child workspace",
-        createdAt: new Date().toISOString(),
-        runtimeConfig: { type: "local" },
-        ...(options.archived ? { archivedAt: new Date().toISOString() } : {}),
-      });
-      project.workspaces.push({
-        path: path.join(projectPath, "unowned"),
-        id: "unownedworkspace",
-        name: "unowned",
-        createdAt: new Date().toISOString(),
-        runtimeConfig: { type: "local" },
-      });
-      return cfg;
-    });
-
-    const workspaceMocks = createWorkspaceServiceMocks({ archive: options.archive });
-    const { taskService } = createTaskServiceHarness(config, {
-      workspaceService: workspaceMocks.workspaceService,
-    });
-    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
-      .taskHandleStore;
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_created",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-created",
-      status: "completed",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: true,
-      disposableWorkspace: false,
-      title: "Created child",
-    });
-    return { config, parentId, projectPath, taskService, taskHandleStore, ...workspaceMocks };
-  }
-
-  test("workspace lifecycle archives only parent-owned created workspace turns", async () => {
-    const { parentId, taskService, archive } = await createWorkspaceLifecycleHarness();
-
-    const archived = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      {}
-    );
-
-    expect(archived).toEqual(
-      Ok({
-        status: "archived",
-        action: "archive",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(archive).toHaveBeenCalledWith("childworkspace", undefined);
-
-    const unowned = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "unownedworkspace" },
-      {}
-    );
-
-    expect(unowned).toEqual(
-      Ok({ status: "invalid_scope", action: "archive", workspaceId: "unownedworkspace" })
-    );
-  });
-
-  test("workspace lifecycle treats existing follow-up handles as owned when the workspace was created by the parent", async () => {
-    const { parentId, taskService, taskHandleStore, archive } =
-      await createWorkspaceLifecycleHarness();
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_existing",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-existing",
-      status: "completed",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-      title: "Existing child",
-    });
-
-    const result = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { taskId: "wst_existing" },
-      {}
-    );
-
-    expect(result).toEqual(
-      Ok({
-        status: "archived",
-        action: "archive",
-        taskId: "wst_existing",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(archive).toHaveBeenCalledWith("childworkspace", undefined);
-  });
-
-  test("workspace lifecycle serializes concurrent handles that resolve to the same workspace", async () => {
-    let archiveCallCount = 0;
-    const harnessRefs: { config?: Config; projectPath?: string } = {};
-    const archive = mock(async (): Promise<Result<{ kind: "archived" }>> => {
-      archiveCallCount += 1;
-      await Promise.resolve();
-      const config = harnessRefs.config;
-      const projectPath = harnessRefs.projectPath;
-      assert(config, "harness config must be assigned before archive runs");
-      assert(projectPath, "harness project path must be assigned before archive runs");
-      await config.editConfig((cfg) => {
-        const child = cfg.projects
-          .get(projectPath)
-          ?.workspaces.find((workspace) => workspace.id === "childworkspace");
-        assert(child, "child workspace must exist");
-        child.archivedAt = new Date().toISOString();
-        return cfg;
-      });
-      return Ok({ kind: "archived" });
-    });
-    const harness = await createWorkspaceLifecycleHarness({ archive });
-    harnessRefs.config = harness.config;
-    harnessRefs.projectPath = harness.projectPath;
-    await harness.taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_existing",
-      ownerWorkspaceId: harness.parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-existing",
-      status: "completed",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-      title: "Existing child",
-    });
-
-    const results = await Promise.all([
-      harness.taskService.archiveOwnedWorkspaceTurnWorkspace(
-        harness.parentId,
-        { taskId: "wst_created" },
-        {}
-      ),
-      harness.taskService.archiveOwnedWorkspaceTurnWorkspace(
-        harness.parentId,
-        { taskId: "wst_existing" },
-        {}
-      ),
-    ]);
-
-    expect(results.map((result) => (result.success ? result.data.status : "error")).sort()).toEqual(
-      ["already_archived", "archived"]
-    );
-    expect(archiveCallCount).toBe(1);
-  });
-
-  test("workspace lifecycle rejects existing follow-up handles for workspaces this parent did not create", async () => {
-    const { parentId, taskService, taskHandleStore, archive } =
-      await createWorkspaceLifecycleHarness();
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_foreignexisting",
-      ownerWorkspaceId: parentId,
-      workspaceId: "unownedworkspace",
-      turnId: "turn-foreign-existing",
-      status: "completed",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-      title: "Unowned existing child",
-    });
-
-    const result = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { taskId: "wst_foreignexisting" },
-      {}
-    );
-
-    expect(result).toEqual(
-      Ok({
-        status: "invalid_scope",
-        action: "archive",
-        taskId: "wst_foreignexisting",
-        workspaceId: "unownedworkspace",
-      })
-    );
-    expect(archive).not.toHaveBeenCalled();
-  });
-
-  test("workspace lifecycle gates destructive actions on archived state before active turns", async () => {
-    const { parentId, taskService, taskHandleStore, deleteWorktree, remove } =
-      await createWorkspaceLifecycleHarness();
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_running",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-running",
-      status: "running",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-    });
-
-    const deleteResult = await taskService.deleteOwnedWorkspaceTurnWorktree(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { interruptActive: true }
-    );
-    const removeResult = await taskService.removeOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { interruptActive: true, force: true }
-    );
-
-    expect(deleteResult).toEqual(
-      Ok({
-        status: "requires_archive",
-        action: "delete_worktree",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(removeResult).toEqual(
-      Ok({
-        status: "requires_archive",
-        action: "remove",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(deleteWorktree).not.toHaveBeenCalled();
-    expect(remove).not.toHaveBeenCalled();
-  });
-
-  test("workspace lifecycle returns archive confirmation and treats already archived as idempotent", async () => {
-    const confirmationArchive = mock(
-      (): Promise<Result<{ kind: "confirm-lossy-untracked-files"; paths: string[] }>> =>
-        Promise.resolve(Ok({ kind: "confirm-lossy-untracked-files", paths: ["scratch.txt"] }))
-    );
-    const config = await createTestConfig(rootDir);
-    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
-    await config.editConfig((cfg) => {
-      const project = cfg.projects.get(projectPath);
-      assert(project, "test project must exist");
-      project.workspaces.push({
-        path: path.join(projectPath, "child"),
-        id: "childworkspace",
-        name: "child",
-        createdAt: new Date().toISOString(),
-        runtimeConfig: { type: "local" },
-      });
-      return cfg;
-    });
-    const workspaceMocks = createWorkspaceServiceMocks({ archive: confirmationArchive });
-    const { taskService } = createTaskServiceHarness(config, {
-      workspaceService: workspaceMocks.workspaceService,
-    });
-    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
-      .taskHandleStore;
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_created",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-created",
-      status: "completed",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: true,
-      disposableWorkspace: false,
-    });
-
-    const confirmation = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { acknowledgedUntrackedPaths: ["scratch.txt"] }
-    );
-
-    expect(confirmation).toEqual(
-      Ok({
-        status: "requires_confirmation",
-        action: "archive",
-        workspaceId: "childworkspace",
-        displayName: "child",
-        paths: ["scratch.txt"],
-      })
-    );
-    expect(confirmationArchive).toHaveBeenCalledWith("childworkspace", ["scratch.txt"]);
-
-    const confirmationByTaskId = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { taskId: "wst_created" },
-      { acknowledgedUntrackedPathsByWorkspaceId: { childworkspace: ["task-scratch.txt"] } }
-    );
-
-    expect(confirmationByTaskId).toEqual(
-      Ok({
-        status: "requires_confirmation",
-        action: "archive",
-        taskId: "wst_created",
-        workspaceId: "childworkspace",
-        displayName: "child",
-        paths: ["scratch.txt"],
-      })
-    );
-    expect(confirmationArchive).toHaveBeenCalledWith("childworkspace", ["task-scratch.txt"]);
-
-    await config.editConfig((cfg) => {
-      const child = cfg.projects
-        .get(projectPath)
-        ?.workspaces.find((workspace) => workspace.id === "childworkspace");
-      assert(child, "child workspace must exist");
-      child.archivedAt = new Date().toISOString();
-      return cfg;
-    });
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_running",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-running",
-      status: "running",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-    });
-
-    const alreadyArchived = await taskService.archiveOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { interruptActive: true }
-    );
-
-    expect(alreadyArchived).toEqual(
-      Ok({
-        status: "already_archived",
-        action: "archive",
-        workspaceId: "childworkspace",
-        displayName: "child",
-      })
-    );
-    expect(confirmationArchive).toHaveBeenCalledTimes(2);
-  });
-
-  test("workspace lifecycle requires explicit interruption for active archived workspace turns", async () => {
-    const { parentId, taskService, taskHandleStore, archive, deleteWorktree } =
-      await createWorkspaceLifecycleHarness({ archived: true });
-    await taskHandleStore.upsertWorkspaceTurn({
-      kind: "workspace_turn",
-      handleId: "wst_running",
-      ownerWorkspaceId: parentId,
-      workspaceId: "childworkspace",
-      turnId: "turn-running",
-      status: "running",
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      createdWorkspace: false,
-      disposableWorkspace: false,
-    });
-    (
-      taskService as unknown as {
-        activeWorkspaceTurnHandleByWorkspaceId: Map<
-          string,
-          { handleId: string; ownerWorkspaceId: string }
-        >;
-      }
-    ).activeWorkspaceTurnHandleByWorkspaceId.set("childworkspace", {
-      handleId: "wst_running",
-      ownerWorkspaceId: parentId,
-    });
-
-    const active = await taskService.deleteOwnedWorkspaceTurnWorktree(
-      parentId,
-      { workspaceId: "childworkspace" },
-      {}
-    );
-
-    expect(active).toEqual(
-      Ok({
-        status: "active",
-        action: "delete_worktree",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-        activeTaskIds: ["wst_running"],
-      })
-    );
-    expect(deleteWorktree).not.toHaveBeenCalled();
-
-    const interrupted = await taskService.deleteOwnedWorkspaceTurnWorktree(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { interruptActive: true }
-    );
-
-    expect(interrupted).toEqual(
-      Ok({
-        status: "deleted_worktree",
-        action: "delete_worktree",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(deleteWorktree).toHaveBeenCalledWith("childworkspace");
-    expect(archive).not.toHaveBeenCalled();
-  });
-
-  test("workspace lifecycle removes archived owned workspaces and treats missing metadata as already removed", async () => {
-    const { config, parentId, taskService, remove } = await createWorkspaceLifecycleHarness({
-      archived: true,
-    });
-
-    const removed = await taskService.removeOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { force: true }
-    );
-
-    expect(removed).toEqual(
-      Ok({
-        status: "removed",
-        action: "remove",
-        workspaceId: "childworkspace",
-        displayName: "Child workspace",
-      })
-    );
-    expect(remove).toHaveBeenCalledWith("childworkspace", true);
-
-    await config.editConfig((cfg) => {
-      for (const project of cfg.projects.values()) {
-        project.workspaces = project.workspaces.filter(
-          (workspace) => workspace.id !== "childworkspace"
-        );
-      }
-      return cfg;
-    });
-
-    const alreadyRemoved = await taskService.removeOwnedWorkspaceTurnWorkspace(
-      parentId,
-      { workspaceId: "childworkspace" },
-      { force: true }
-    );
-
-    expect(alreadyRemoved).toEqual(
-      Ok({ status: "already_removed", action: "remove", workspaceId: "childworkspace" })
-    );
-  });
-
   test("createWorkspaceTurn creates a normal workspace and starts a correlated turn", async () => {
     const config = await createTestConfig(rootDir);
     stubStableIds(config, ["childworkspace", "turnhandle"]);
@@ -13056,11 +12591,12 @@ describe("TaskService", () => {
     expect(findWorkspaceInConfig(config, childTaskId)?.taskStatus).toBe("interrupted");
   });
 
-  test("removeInactiveDescendantAgentTask removes inactive children without archive", async () => {
+  test("removeInactiveDescendantAgentTask enforces scope, leaf order, and idempotency", async () => {
     const config = await createTestConfig(rootDir);
     const projectPath = path.join(rootDir, "repo");
     const parentWorkspaceId = "parent-remove-child";
     const childTaskId = "child-remove-child";
+    const grandchildTaskId = "grandchild-remove-child";
     await saveWorkspaces(
       config,
       projectPath,
@@ -13070,6 +12606,10 @@ describe("TaskService", () => {
           parentWorkspaceId,
           taskStatus: "reported",
           title: "React lifecycle expert",
+        }),
+        projectWorkspace(projectPath, "grandchild", grandchildTaskId, {
+          parentWorkspaceId: childTaskId,
+          taskStatus: "reported",
         }),
       ],
       testTaskSettings()
@@ -13081,17 +12621,26 @@ describe("TaskService", () => {
     const { workspaceService } = createWorkspaceServiceMocks({ remove });
     const { taskService } = createTaskServiceHarness(config, { workspaceService });
 
-    const result = await taskService.removeInactiveDescendantAgentTask(
-      parentWorkspaceId,
-      childTaskId
-    );
-    expect(result).toMatchObject({ success: true, data: { status: "removed" } });
+    expect(
+      await taskService.removeInactiveDescendantAgentTask(parentWorkspaceId, "foreign-child")
+    ).toMatchObject({ success: true, data: { status: "invalid_scope" } });
+    expect(
+      await taskService.removeInactiveDescendantAgentTask(parentWorkspaceId, childTaskId)
+    ).toMatchObject({
+      success: true,
+      data: { status: "error", descendantTaskIds: [grandchildTaskId] },
+    });
+    expect(
+      await taskService.removeInactiveDescendantAgentTask(parentWorkspaceId, grandchildTaskId)
+    ).toMatchObject({ success: true, data: { status: "removed" } });
+    expect(
+      await taskService.removeInactiveDescendantAgentTask(parentWorkspaceId, childTaskId)
+    ).toMatchObject({ success: true, data: { status: "removed" } });
     expect(await taskService.isDescendantAgentTask(parentWorkspaceId, childTaskId)).toBe(true);
     expect(
       await taskService.removeInactiveDescendantAgentTask(parentWorkspaceId, childTaskId)
     ).toMatchObject({ success: true, data: { status: "already_removed" } });
-    expect(remove).toHaveBeenCalledWith(childTaskId, true);
-    expect(findWorkspaceInConfig(config, childTaskId)).toBeUndefined();
+    expect(remove.mock.calls.map((call) => call[0])).toEqual([grandchildTaskId, childTaskId]);
     expect(
       await taskService.sendMessageToDescendantAgentTask(
         parentWorkspaceId,
@@ -23266,191 +22815,19 @@ describe("TaskService", () => {
         return Ok(undefined);
       });
       const { aiService } = createAIServiceMocks(config, { isStreaming });
-      const archive = mock(
-        (_workspaceId: string): Promise<Result<{ kind: "archived" }>> =>
-          Promise.resolve(Ok({ kind: "archived" }))
-      );
-      const unarchive = mock(
-        (_workspaceId: string): Promise<Result<void>> => Promise.resolve(Ok(undefined))
-      );
-      const { workspaceService } = createWorkspaceServiceMocks({ archive, unarchive, remove });
+      const { workspaceService } = createWorkspaceServiceMocks({ remove });
       const { taskService } = createTaskServiceHarness(config, { aiService, workspaceService });
       const internal = taskService as unknown as TaskServiceCleanupInternals;
 
       return {
         config,
         taskService,
-        archive,
-        unarchive,
         remove,
         rootWorkspaceId,
         taskChain,
         internal,
       };
     }
-
-    test("parent lifecycle archives a completed descendant agent workspace", async () => {
-      const { archive, rootWorkspaceId, taskService, taskChain } = await setupReportedTaskChain();
-      const childTaskId = taskChain[1]?.id;
-      expect(childTaskId).toBe("child-333");
-      if (!childTaskId) return;
-
-      const result = await taskService.archiveOwnedTaskWorkspace(rootWorkspaceId, {
-        taskId: childTaskId,
-      });
-
-      expect(result).toEqual(
-        Ok({
-          status: "archived",
-          action: "archive",
-          taskId: childTaskId,
-          workspaceId: childTaskId,
-          displayName: "agent_explore_child",
-        })
-      );
-      expect(archive).toHaveBeenCalledWith(childTaskId, undefined);
-    });
-
-    test("parent lifecycle unarchives a completed descendant agent workspace", async () => {
-      const { config, unarchive, rootWorkspaceId, taskService, taskChain } =
-        await setupReportedTaskChain();
-      const childTaskId = taskChain[1]?.id;
-      expect(childTaskId).toBe("child-333");
-      if (!childTaskId) return;
-      await archiveWorkspaceInTestConfig(config, childTaskId);
-
-      const result = await taskService.unarchiveOwnedTaskWorkspace(rootWorkspaceId, {
-        taskId: childTaskId,
-      });
-
-      expect(result).toEqual(
-        Ok({
-          status: "unarchived",
-          action: "unarchive",
-          taskId: childTaskId,
-          workspaceId: childTaskId,
-          displayName: "agent_explore_child",
-        })
-      );
-      expect(unarchive).toHaveBeenCalledWith(childTaskId);
-    });
-
-    test("parent lifecycle accepts descendant workspace IDs and rejects unrelated tasks", async () => {
-      const { archive, rootWorkspaceId, taskService, taskChain } = await setupReportedTaskChain();
-      const childTaskId = taskChain[1]?.id;
-      expect(childTaskId).toBe("child-333");
-      if (!childTaskId) return;
-
-      const byWorkspaceId = await taskService.archiveOwnedTaskWorkspace(rootWorkspaceId, {
-        workspaceId: childTaskId,
-      });
-      const unrelated = await taskService.archiveOwnedTaskWorkspace(rootWorkspaceId, {
-        taskId: "unrelated-task",
-      });
-
-      expect(byWorkspaceId).toEqual(
-        Ok({
-          status: "archived",
-          action: "archive",
-          workspaceId: childTaskId,
-          displayName: "agent_explore_child",
-        })
-      );
-      expect(unrelated).toEqual(
-        Ok({ status: "invalid_scope", action: "archive", taskId: "unrelated-task" })
-      );
-      expect(archive).toHaveBeenCalledTimes(1);
-    });
-
-    test("parent lifecycle refuses to archive an active descendant agent workspace", async () => {
-      const activeTaskId = "active-222";
-      const { archive, rootWorkspaceId, taskService } = await setupReportedTaskChain({
-        taskChain: [
-          {
-            id: activeTaskId,
-            directoryName: "active-task",
-            name: "agent_exec_active",
-            agentType: "exec",
-            taskStatus: "running",
-          },
-        ],
-      });
-
-      const result = await taskService.archiveOwnedTaskWorkspace(
-        rootWorkspaceId,
-        { taskId: activeTaskId },
-        { interruptActive: true }
-      );
-
-      expect(result.success).toBe(true);
-      if (!result.success) return;
-      expect(result.data).toMatchObject({
-        status: "active",
-        action: "archive",
-        taskId: activeTaskId,
-        workspaceId: activeTaskId,
-        activeTaskIds: [activeTaskId],
-      });
-      expect(result.data.note).toContain("Stop the sub-agent");
-      expect(archive).not.toHaveBeenCalled();
-    });
-
-    test("parent lifecycle removes nested agent workspaces deepest-first", async () => {
-      const { config, remove, rootWorkspaceId, taskService, taskChain } =
-        await setupReportedTaskChain();
-      const parentTaskId = taskChain[0]?.id;
-      const childTaskId = taskChain[1]?.id;
-      expect(parentTaskId).toBe("parent-222");
-      expect(childTaskId).toBe("child-333");
-      if (!parentTaskId || !childTaskId) return;
-
-      await archiveWorkspaceInTestConfig(config, parentTaskId);
-      const blocked = await taskService.removeOwnedTaskWorkspace(rootWorkspaceId, {
-        taskId: parentTaskId,
-      });
-
-      expect(blocked).toEqual(
-        Ok({
-          status: "error",
-          action: "remove",
-          taskId: parentTaskId,
-          workspaceId: parentTaskId,
-          displayName: "agent_exec_parent",
-          descendantTaskIds: [childTaskId],
-          error:
-            "Cannot remove a workspace while descendant sub-agent workspaces remain. Remove descendants deepest-first.",
-        })
-      );
-      expect(remove).not.toHaveBeenCalled();
-
-      await archiveWorkspaceInTestConfig(config, childTaskId);
-      expect(
-        await taskService.removeOwnedTaskWorkspace(rootWorkspaceId, { taskId: childTaskId })
-      ).toEqual(
-        Ok({
-          status: "removed",
-          action: "remove",
-          taskId: childTaskId,
-          workspaceId: childTaskId,
-          displayName: "agent_explore_child",
-        })
-      );
-      expect(
-        await taskService.removeOwnedTaskWorkspace(rootWorkspaceId, { taskId: parentTaskId })
-      ).toEqual(
-        Ok({
-          status: "removed",
-          action: "remove",
-          taskId: parentTaskId,
-          workspaceId: parentTaskId,
-          displayName: "agent_exec_parent",
-        })
-      );
-      expect(remove.mock.calls).toEqual([
-        [childTaskId, false],
-        [parentTaskId, false],
-      ]);
-    });
 
     test("cleanup is blocked when toggle is on and no ancestor is archived", async () => {
       const { config, remove, taskChain, internal } = await setupReportedTaskChain();

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -62,7 +62,7 @@ import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { SendMessageError } from "@/common/types/errors";
 import type { ErrorEvent, StreamAbortEvent, StreamEndEvent } from "@/common/types/stream";
-import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
 import { isDynamicToolPart, type DynamicToolPart } from "@/common/types/toolParts";
 import {
   buildWorkflowRunCardMessage,
@@ -100,6 +100,22 @@ function findWorkspaceInConfig(config: Config, workspaceId: string) {
   return Array.from(config.loadConfigOrDefault().projects.values())
     .flatMap((project) => project.workspaces)
     .find((workspace) => workspace.id === workspaceId);
+}
+
+function compactionRequestMetadata(withFollowUp = true): MuxMessageMetadata {
+  return {
+    type: "compaction-request",
+    rawCommand: "/compact",
+    parsed: withFollowUp
+      ? {
+          followUpContent: {
+            text: "Continue",
+            model: "anthropic:claude-sonnet-4-6",
+            agentId: "exec",
+          },
+        }
+      : {},
+  };
 }
 
 function createWorkspaceTurnMetadata(projectPath: string): WorkspaceMetadata {
@@ -3977,6 +3993,7 @@ describe("TaskService", () => {
         model: "anthropic:claude-opus-4-6",
         agentId: "compact",
         finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted context" }],
     });
@@ -4016,6 +4033,7 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         agentId: "compact",
         finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted child context" }],
     });
@@ -4027,6 +4045,7 @@ describe("TaskService", () => {
         model: "anthropic:claude-sonnet-4-6",
         mode: "compact",
         finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted child context" }],
     });
@@ -4035,6 +4054,33 @@ describe("TaskService", () => {
     expect(child?.taskStatus).toBe("running");
     expect(child?.taskRecoveryAttempts).toBeUndefined();
     expect(sendMessage).not.toHaveBeenCalled();
+
+    await config.editConfig((cfg) => {
+      const child = cfg.projects
+        .get(projectPath)
+        ?.workspaces.find((workspace) => workspace.id === childTaskId);
+      assert(child, "child workspace must exist");
+      child.taskStatus = "awaiting_report";
+      return cfg;
+    });
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: childTaskId,
+      messageId: "standalone-child-compaction",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "compact",
+        finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(false),
+      },
+      parts: [{ type: "text", text: "Standalone compacted child context" }],
+    });
+
+    expect(findWorkspaceInConfig(config, childTaskId)).toMatchObject({
+      taskStatus: "awaiting_report",
+      taskRecoveryAttempts: 1,
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
   test("workspace-turn tool-calls stream-end without continuation settles error", async () => {
@@ -12098,6 +12144,7 @@ describe("TaskService", () => {
         agentId: "compact",
         mode: "compact",
         finishReason: "stop",
+        muxMetadata: compactionRequestMetadata(),
       },
       parts: [{ type: "text", text: "Compacted specialist context" }],
     });

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -64,7 +64,12 @@ import {
   type BackgroundWorkAttentionPolicy,
 } from "@/common/types/backgroundWorkAttention";
 
-import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
+import {
+  createMuxMessage,
+  getCompactionFollowUpContent,
+  type MuxMessage,
+  type MuxMessageMetadata,
+} from "@/common/types/message";
 import {
   createCompactionSummaryMessageId,
   createTaskFailureMessageId,
@@ -10283,10 +10288,15 @@ export class TaskService {
   }
 
   private async handleStreamEnd(event: StreamEndEvent): Promise<void> {
-    // Compaction is a mechanical history rewrite, not a child execution boundary. Ignoring it here
-    // keeps active and reawakened sub-agents in their existing lifecycle state until the correlated
-    // post-compaction follow-up produces the delegated turn's real outcome.
-    if (event.metadata.agentId === "compact" || event.metadata.mode === "compact") {
+    const isCompaction = event.metadata.agentId === "compact" || event.metadata.mode === "compact";
+    const compactionMetadata = event.metadata.muxMetadata;
+    // A compact turn only defers child settlement when it durably staged the next turn. Bare
+    // /compact has no follow-up, so normal stream-end recovery must still run for idle children.
+    if (
+      isCompaction &&
+      compactionMetadata?.type === "compaction-request" &&
+      getCompactionFollowUpContent(compactionMetadata) != null
+    ) {
       return;
     }
 
@@ -10560,7 +10570,7 @@ export class TaskService {
     // collection may time out. Only explicit `stop` can promote the final assistant response to the
     // terminal report; otherwise recovery asks the child to finish instead of finalizing an update.
     const finalAgentReportArgs =
-      event.metadata.finishReason === "stop"
+      !isCompaction && event.metadata.finishReason === "stop"
         ? await this.resolveFinalAgentReportArgs(workspaceId, event.parts, {
             acceptSchemaShapedWorkflowReport: acceptsSchemaShapedWorkflowReport,
           })

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -64,12 +64,7 @@ import {
   type BackgroundWorkAttentionPolicy,
 } from "@/common/types/backgroundWorkAttention";
 
-import {
-  createMuxMessage,
-  getCompactionFollowUpContent,
-  type MuxMessage,
-  type MuxMessageMetadata,
-} from "@/common/types/message";
+import { createMuxMessage, type MuxMessage, type MuxMessageMetadata } from "@/common/types/message";
 import {
   createCompactionSummaryMessageId,
   createTaskFailureMessageId,
@@ -10289,19 +10284,26 @@ export class TaskService {
 
   private async handleStreamEnd(event: StreamEndEvent): Promise<void> {
     const isCompaction = event.metadata.agentId === "compact" || event.metadata.mode === "compact";
-    const compactionMetadata = event.metadata.muxMetadata;
-    // A compact turn only defers child settlement when it durably staged the next turn. Bare
-    // /compact has no follow-up, so normal stream-end recovery must still run for idle children.
     if (
       isCompaction &&
-      compactionMetadata?.type === "compaction-request" &&
-      getCompactionFollowUpContent(compactionMetadata) != null &&
       (await this.workspaceService.waitForPendingCompactionCompletionDecision(
         event.workspaceId,
         event.messageId
       )) === true
     ) {
-      return;
+      const history = await this.historyService.getHistoryFromLatestBoundary(event.workspaceId);
+      const summary = history.success
+        ? history.data.findLast((message) => message.metadata?.compactionBoundary === true)
+        : undefined;
+      const summaryMetadata = summary?.metadata?.muxMetadata;
+      // Defer only when successful compaction durably staged the next child turn. Bare /compact and
+      // rejected compactions must continue through normal completion recovery.
+      if (
+        summaryMetadata?.type === "compaction-summary" &&
+        summaryMetadata.pendingFollowUp != null
+      ) {
+        return;
+      }
     }
 
     const workspaceId = event.workspaceId;

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -197,27 +197,7 @@ export interface AgentTaskTimestamps {
   reportedAt?: string;
 }
 
-type WorkspaceLifecycleAction = "archive" | "unarchive" | "delete_worktree" | "remove";
-interface WorkspaceLifecycleTarget {
-  taskId?: string;
-  workspaceId?: string;
-}
 type WorkspaceLifecycleResult = z.infer<typeof TaskWorkspaceLifecycleToolTargetResultSchema>;
-interface WorkspaceLifecycleOptions {
-  interruptActive?: boolean;
-  acknowledgedUntrackedPaths?: string[];
-  acknowledgedUntrackedPathsByWorkspaceId?: Record<string, string[]>;
-  force?: boolean;
-}
-
-interface ResolvedWorkspaceLifecycleTarget {
-  action: WorkspaceLifecycleAction;
-  targetKind: "agent_task" | "workspace_turn";
-  taskId?: string;
-  taskTitle?: string;
-  workspaceId: string;
-  metadata: WorkspaceMetadata | null;
-}
 
 export interface TaskCreateArgs {
   parentWorkspaceId: string;
@@ -1219,11 +1199,8 @@ export class TaskService {
   // concurrently from multiple child stream-end handlers for the same parent, and it must remain
   // safe even when the parent stream-end already holds workspaceEventLocks for the parent itself.
   private readonly deferredBestOfLocks = new MutexMap<string>();
-  // Serialize lifecycle actions per resolved child workspace: a batch may include both the
-  // created handle and later existing-mode handles for the same workspace.
-  private readonly workspaceLifecycleLocks = new MutexMap<string>();
-  // Serialize lifecycle transitions across a whole parent/descendant tree. Reawakening/removal of a
-  // child and archiving an ancestor must never cross and leave active work hidden behind the archive.
+  // Serialize lifecycle transitions across a whole parent/descendant tree so reawakening and
+  // removal cannot cross and delete a child while its next execution starts.
   private readonly workspaceTreeLifecycleLocks = new MutexMap<string>();
   // Serialize terminal writes per workspace-turn handle so late completions/interruptions cannot
   // overwrite an already-settled handle.
@@ -8320,382 +8297,72 @@ export class TaskService {
     return Ok(didUnarchive);
   }
 
-  /** Parent-scoped lifecycle entry point shared by persistent sub-agents and workspace turns. */
-  async archiveOwnedTaskWorkspace(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    return await this.archiveOwnedWorkspaceTurnWorkspace(ownerWorkspaceId, target, options);
-  }
-
-  /** Parent-scoped visibility restore for persistent sub-agents and workspace turns. */
-  async unarchiveOwnedTaskWorkspace(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    assert(ownerWorkspaceId.trim().length > 0, "unarchive lifecycle requires ownerWorkspaceId");
-    const resolved = await this.resolveOwnedWorkspaceLifecycleTarget(
-      ownerWorkspaceId,
-      "unarchive",
-      target
-    );
-    if ("status" in resolved) return Ok(resolved);
-
-    return await this.withWorkspaceLifecycleLock(ownerWorkspaceId, resolved, async (resolved) => {
-      if (resolved.metadata == null) {
-        return Ok({
-          status: "not_found",
-          action: "unarchive",
-          ...this.lifecycleTargetFields(resolved),
-          note: "Owned workspace metadata is absent and cannot be restored.",
-        });
-      }
-      if (resolved.targetKind === "agent_task") {
-        const result = await this.unarchiveAgentTaskAncestry(
-          ownerWorkspaceId,
-          resolved.workspaceId
-        );
-        if (!result.success) {
-          return Ok({
-            status: "error",
-            action: "unarchive",
-            ...this.lifecycleTargetFields(resolved),
-            error: result.error,
-          });
-        }
-        return Ok({
-          status: result.data ? "unarchived" : "already_unarchived",
-          action: "unarchive",
-          ...this.lifecycleTargetFields(resolved),
-        });
-      }
-
-      if (!isWorkspaceArchived(resolved.metadata.archivedAt, resolved.metadata.unarchivedAt)) {
-        return Ok({
-          status: "already_unarchived",
-          action: "unarchive",
-          ...this.lifecycleTargetFields(resolved),
-        });
-      }
-      const result = await this.workspaceService.unarchive(resolved.workspaceId);
-      if (!result.success) {
-        return Ok({
-          status: "error",
-          action: "unarchive",
-          ...this.lifecycleTargetFields(resolved),
-          error: result.error,
-        });
-      }
-      return Ok({
-        status: "unarchived",
-        action: "unarchive",
-        ...this.lifecycleTargetFields(resolved),
-      });
-    });
-  }
-
-  /** Parent-scoped lifecycle entry point shared by persistent sub-agents and workspace turns. */
-  async deleteOwnedTaskWorktree(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    return await this.deleteOwnedWorkspaceTurnWorktree(ownerWorkspaceId, target, options);
-  }
-
   async removeInactiveDescendantAgentTask(
     ownerWorkspaceId: string,
     taskId: string
   ): Promise<Result<WorkspaceLifecycleResult, string>> {
     assert(ownerWorkspaceId.length > 0, "removeInactiveDescendantAgentTask requires owner");
     assert(taskId.length > 0, "removeInactiveDescendantAgentTask requires taskId");
-    const resolved = await this.resolveOwnedWorkspaceLifecycleTarget(ownerWorkspaceId, "remove", {
-      taskId,
-    });
-    if ("status" in resolved) return Ok(resolved);
-    if (resolved.targetKind !== "agent_task") {
-      return Ok({ status: "invalid_scope", action: "remove", taskId });
-    }
 
-    return await this.withTaskTreeLifecycleLock(resolved.workspaceId, async () =>
-      this.withWorkspaceLifecycleLock(ownerWorkspaceId, resolved, async (locked) => {
-        const descendantTaskIds = this.listDescendantAgentTasks(locked.workspaceId).map(
-          (task) => task.taskId
+    return await this.withTaskTreeLifecycleLock(taskId, async () => {
+      const config = this.config.loadConfigOrDefault();
+      const entry = findWorkspaceEntry(config, taskId);
+      if (entry == null) {
+        const wasOwned =
+          (await this.hasRemovedAgentTaskTombstone(ownerWorkspaceId, taskId)) ||
+          (await this.filterDescendantAgentTaskIds(ownerWorkspaceId, [taskId])).includes(taskId);
+        return Ok(
+          wasOwned
+            ? { status: "already_removed", action: "remove", taskId, workspaceId: taskId }
+            : { status: "invalid_scope", action: "remove", taskId }
         );
-        if (descendantTaskIds.length > 0) {
-          return Ok({
-            status: "error",
-            action: "remove",
-            ...this.lifecycleTargetFields(locked),
-            descendantTaskIds,
-            error: "Cannot remove a sub-agent while descendant sub-agents remain.",
-          });
-        }
-        if (locked.metadata == null) {
-          return Ok({
-            status: "already_removed",
-            action: "remove",
-            ...this.lifecycleTargetFields(locked),
-          });
-        }
-        const active = await this.handleActiveWorkspaceLifecycleTurns(
-          ownerWorkspaceId,
-          locked,
-          false
-        );
-        if (active != null) return Ok(active);
-        const tombstoneResult = await this.persistRemovedAgentTaskTombstones(locked.workspaceId);
-        if (!tombstoneResult.success) {
-          return Ok({
-            status: "error",
-            action: "remove",
-            ...this.lifecycleTargetFields(locked),
-            error: tombstoneResult.error,
-          });
-        }
-        const result = await this.workspaceService.removeWhileTaskTreeLocked(
-          locked.workspaceId,
-          true
-        );
-        if (!result.success) {
-          return Ok({
-            status: "error",
-            action: "remove",
-            ...this.lifecycleTargetFields(locked),
-            error: result.error,
-          });
-        }
-        return Ok({ status: "removed", action: "remove", ...this.lifecycleTargetFields(locked) });
-      })
-    );
-  }
-
-  /** Parent-scoped lifecycle entry point shared by persistent sub-agents and workspace turns. */
-  async removeOwnedTaskWorkspace(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    return await this.removeOwnedWorkspaceTurnWorkspace(ownerWorkspaceId, target, options);
-  }
-
-  async archiveOwnedWorkspaceTurnWorkspace(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    assert(ownerWorkspaceId.trim().length > 0, "archive lifecycle requires ownerWorkspaceId");
-    const resolved = await this.resolveOwnedWorkspaceLifecycleTarget(
-      ownerWorkspaceId,
-      "archive",
-      target
-    );
-    if ("status" in resolved) return Ok(resolved);
-
-    return await this.withWorkspaceLifecycleLock(ownerWorkspaceId, resolved, async (resolved) => {
-      if (resolved.metadata == null) {
-        return Ok({
-          status: "not_found",
-          action: "archive",
-          ...this.lifecycleTargetFields(resolved),
-          note: "Owned workspace metadata is already absent.",
-        });
-      }
-      if (isWorkspaceArchived(resolved.metadata.archivedAt, resolved.metadata.unarchivedAt)) {
-        return Ok({
-          status: "already_archived",
-          action: "archive",
-          ...this.lifecycleTargetFields(resolved),
-        });
       }
 
-      const active = await this.handleActiveWorkspaceLifecycleTurns(
-        ownerWorkspaceId,
-        resolved,
-        options.interruptActive === true
-      );
-      if (active != null) return Ok(active);
-
-      const acknowledgedUntrackedPaths =
-        options.acknowledgedUntrackedPaths ??
-        options.acknowledgedUntrackedPathsByWorkspaceId?.[resolved.workspaceId];
-      const result = await this.workspaceService.archive(
-        resolved.workspaceId,
-        acknowledgedUntrackedPaths
-      );
-      if (!result.success) {
-        return Ok({
-          status: "error",
-          action: "archive",
-          ...this.lifecycleTargetFields(resolved),
-          error: result.error,
-        });
-      }
-      if (result.data.kind === "confirm-lossy-untracked-files") {
-        return Ok({
-          status: "requires_confirmation",
-          action: "archive",
-          ...this.lifecycleTargetFields(resolved),
-          paths: result.data.paths,
-        });
-      }
-      return Ok({ status: "archived", action: "archive", ...this.lifecycleTargetFields(resolved) });
-    });
-  }
-
-  async deleteOwnedWorkspaceTurnWorktree(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    assert(
-      ownerWorkspaceId.trim().length > 0,
-      "delete worktree lifecycle requires ownerWorkspaceId"
-    );
-    const resolved = await this.resolveOwnedWorkspaceLifecycleTarget(
-      ownerWorkspaceId,
-      "delete_worktree",
-      target
-    );
-    if ("status" in resolved) return Ok(resolved);
-
-    return await this.withWorkspaceLifecycleLock(ownerWorkspaceId, resolved, async (resolved) => {
-      if (resolved.metadata == null) {
-        return Ok({
-          status: "not_found",
-          action: "delete_worktree",
-          ...this.lifecycleTargetFields(resolved),
-          note: "Owned workspace metadata is already absent.",
-        });
-      }
-      if (!isWorkspaceArchived(resolved.metadata.archivedAt, resolved.metadata.unarchivedAt)) {
-        return Ok({
-          status: "requires_archive",
-          action: "delete_worktree",
-          ...this.lifecycleTargetFields(resolved),
-        });
-      }
-      if (this.isTranscriptOnlyWorkspaceMetadata(resolved.metadata)) {
-        return Ok({
-          status: "already_transcript_only",
-          action: "delete_worktree",
-          ...this.lifecycleTargetFields(resolved),
-        });
+      const index = this.buildAgentTaskIndex(config);
+      if (!this.isDescendantAgentTaskUsingParentById(index.parentById, ownerWorkspaceId, taskId)) {
+        return Ok({ status: "invalid_scope", action: "remove", taskId });
       }
 
-      const active = await this.handleActiveWorkspaceLifecycleTurns(
-        ownerWorkspaceId,
-        resolved,
-        options.interruptActive === true
-      );
-      if (active != null) return Ok(active);
-
-      const result = await this.workspaceService.deleteWorktree(resolved.workspaceId);
-      if (!result.success) {
-        return Ok({
-          status: "error",
-          action: "delete_worktree",
-          ...this.lifecycleTargetFields(resolved),
-          error: result.error,
-        });
-      }
-      return Ok({
-        status: "deleted_worktree",
-        action: "delete_worktree",
-        ...this.lifecycleTargetFields(resolved),
-      });
-    });
-  }
-
-  async removeOwnedWorkspaceTurnWorkspace(
-    ownerWorkspaceId: string,
-    target: WorkspaceLifecycleTarget,
-    options: WorkspaceLifecycleOptions = {}
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    assert(ownerWorkspaceId.trim().length > 0, "remove lifecycle requires ownerWorkspaceId");
-    const resolved = await this.resolveOwnedWorkspaceLifecycleTarget(
-      ownerWorkspaceId,
-      "remove",
-      target
-    );
-    if ("status" in resolved) return Ok(resolved);
-
-    return await this.withWorkspaceLifecycleLock(ownerWorkspaceId, resolved, async (resolved) => {
-      const descendantTaskIds = this.listDescendantAgentTasks(resolved.workspaceId).map(
-        (task) => task.taskId
-      );
+      const displayName = coerceNonEmptyString(entry.workspace.title) ?? entry.workspace.name;
+      const target = {
+        taskId,
+        workspaceId: taskId,
+        ...(displayName != null ? { displayName } : {}),
+      };
+      const descendantTaskIds = this.listDescendantAgentTasks(taskId).map((task) => task.taskId);
       if (descendantTaskIds.length > 0) {
         return Ok({
           status: "error",
           action: "remove",
-          ...this.lifecycleTargetFields(resolved),
+          ...target,
           descendantTaskIds,
-          error:
-            "Cannot remove a workspace while descendant sub-agent workspaces remain. Remove descendants deepest-first.",
+          error: "Cannot remove a sub-agent while descendant sub-agents remain.",
         });
       }
 
-      if (resolved.metadata == null) {
+      if (
+        this.isActiveAgentTaskEntry({ ...entry.workspace, projectPath: entry.projectPath }) ||
+        this.aiService.isStreaming(taskId)
+      ) {
         return Ok({
-          status: "already_removed",
+          status: "active",
           action: "remove",
-          ...this.lifecycleTargetFields(resolved),
-        });
-      }
-      if (!isWorkspaceArchived(resolved.metadata.archivedAt, resolved.metadata.unarchivedAt)) {
-        return Ok({
-          status: "requires_archive",
-          action: "remove",
-          ...this.lifecycleTargetFields(resolved),
+          ...target,
+          activeTaskIds: [taskId],
+          note: "Stop the sub-agent before removing it.",
         });
       }
 
-      const active = await this.handleActiveWorkspaceLifecycleTurns(
-        ownerWorkspaceId,
-        resolved,
-        options.interruptActive === true
-      );
-      if (active != null) return Ok(active);
-
-      const result = await this.workspaceService.remove(
-        resolved.workspaceId,
-        options.force === true
-      );
-      if (!result.success) {
-        return Ok({
-          status: "error",
-          action: "remove",
-          ...this.lifecycleTargetFields(resolved),
-          error: result.error,
-        });
+      const tombstoneResult = await this.persistRemovedAgentTaskTombstones(taskId);
+      if (!tombstoneResult.success) {
+        return Ok({ status: "error", action: "remove", ...target, error: tombstoneResult.error });
       }
-      return Ok({ status: "removed", action: "remove", ...this.lifecycleTargetFields(resolved) });
-    });
-  }
-
-  private async withWorkspaceLifecycleLock(
-    ownerWorkspaceId: string,
-    resolved: ResolvedWorkspaceLifecycleTarget,
-    operation: (
-      lockedResolved: ResolvedWorkspaceLifecycleTarget
-    ) => Promise<Result<WorkspaceLifecycleResult, string>>
-  ): Promise<Result<WorkspaceLifecycleResult, string>> {
-    return await this.workspaceLifecycleLocks.withLock(resolved.workspaceId, async () => {
-      // Ownership can change while an archive/remove waits for the per-workspace lock. Re-resolve
-      // inside the lock so a reparented or otherwise out-of-scope child cannot be mutated by a
-      // stale authorization decision.
-      const lockedResolved = await this.resolveOwnedWorkspaceLifecycleTarget(
-        ownerWorkspaceId,
-        resolved.action,
-        resolved.taskId != null
-          ? { taskId: resolved.taskId }
-          : { workspaceId: resolved.workspaceId }
+      const result = await this.workspaceService.removeWhileTaskTreeLocked(taskId, true);
+      return Ok(
+        result.success
+          ? { status: "removed", action: "remove", ...target }
+          : { status: "error", action: "remove", ...target, error: result.error }
       );
-      if ("status" in lockedResolved) {
-        return Ok(lockedResolved);
-      }
-      return await operation(lockedResolved);
     });
   }
 
@@ -8770,203 +8437,6 @@ export class TaskService {
     } catch (error: unknown) {
       return Err(`Failed to persist removed sub-agent tombstone: ${getErrorMessage(error)}`);
     }
-  }
-
-  private async isAgentTaskLifecycleTargetInScope(
-    ownerWorkspaceId: string,
-    taskId: string
-  ): Promise<boolean> {
-    const config = this.config.loadConfigOrDefault();
-    const entry = findWorkspaceEntry(config, taskId);
-    if (entry != null) {
-      const index = this.buildAgentTaskIndex(config);
-      return this.isDescendantAgentTaskUsingParentById(index.parentById, ownerWorkspaceId, taskId);
-    }
-
-    if (await this.hasRemovedAgentTaskTombstone(ownerWorkspaceId, taskId)) {
-      return true;
-    }
-
-    // Removed tasks can still be addressed idempotently through their persisted report ancestry.
-    const scopedTaskIds = await this.filterDescendantAgentTaskIds(ownerWorkspaceId, [taskId]);
-    return scopedTaskIds.includes(taskId);
-  }
-
-  private async resolveOwnedWorkspaceLifecycleTarget(
-    ownerWorkspaceId: string,
-    action: WorkspaceLifecycleAction,
-    target: WorkspaceLifecycleTarget
-  ): Promise<ResolvedWorkspaceLifecycleTarget | WorkspaceLifecycleResult> {
-    assert(
-      ownerWorkspaceId.trim().length > 0,
-      "workspace lifecycle target resolution requires owner"
-    );
-    const hasTaskId = target.taskId != null && target.taskId.trim().length > 0;
-    const hasWorkspaceId = target.workspaceId != null && target.workspaceId.trim().length > 0;
-    assert(hasTaskId !== hasWorkspaceId, "workspace lifecycle target must have exactly one ID");
-
-    let targetKind: ResolvedWorkspaceLifecycleTarget["targetKind"];
-    let taskId: string | undefined;
-    let taskTitle: string | undefined;
-    let workspaceId: string;
-    if (hasTaskId) {
-      taskId = target.taskId;
-      assert(taskId != null, "workspace lifecycle taskId must be resolved");
-      if (isWorkspaceTurnTaskId(taskId)) {
-        const record = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, taskId);
-        if (record == null) {
-          return { status: "invalid_scope", action, taskId };
-        }
-        if (
-          !(await this.taskHandleStore.isWorkspaceOwnedBy(ownerWorkspaceId, record.workspaceId))
-        ) {
-          return { status: "invalid_scope", action, taskId, workspaceId: record.workspaceId };
-        }
-        targetKind = "workspace_turn";
-        taskTitle = record.title;
-        workspaceId = record.workspaceId;
-      } else {
-        // Agent task IDs are their workspace IDs. Current config lineage is authoritative while the
-        // workspace exists; persisted report ancestry keeps already-removed tasks idempotent.
-        if (!(await this.isAgentTaskLifecycleTargetInScope(ownerWorkspaceId, taskId))) {
-          return { status: "invalid_scope", action, taskId };
-        }
-        targetKind = "agent_task";
-        workspaceId = taskId;
-      }
-    } else {
-      assert(target.workspaceId != null, "workspace lifecycle workspaceId must be resolved");
-      workspaceId = target.workspaceId;
-      if (await this.taskHandleStore.isWorkspaceOwnedBy(ownerWorkspaceId, workspaceId)) {
-        targetKind = "workspace_turn";
-      } else {
-        if (!(await this.isAgentTaskLifecycleTargetInScope(ownerWorkspaceId, workspaceId))) {
-          return {
-            status: "invalid_scope",
-            action,
-            workspaceId,
-          };
-        }
-        targetKind = "agent_task";
-      }
-    }
-
-    const metadata = await this.findWorkspaceLifecycleMetadata(workspaceId);
-    return {
-      action,
-      targetKind,
-      ...(taskId != null ? { taskId } : {}),
-      ...(taskTitle != null ? { taskTitle } : {}),
-      workspaceId,
-      metadata,
-    };
-  }
-
-  private lifecycleTargetFields(resolved: ResolvedWorkspaceLifecycleTarget): {
-    taskId?: string;
-    workspaceId: string;
-    displayName?: string;
-  } {
-    // Match the sidebar label so completed lifecycle tool rows remain understandable after
-    // archive/remove hides the child workspace from the active list.
-    const displayName =
-      coerceNonEmptyString(resolved.metadata?.title) ??
-      coerceNonEmptyString(resolved.metadata?.name) ??
-      coerceNonEmptyString(resolved.taskTitle);
-    return {
-      ...(resolved.taskId != null ? { taskId: resolved.taskId } : {}),
-      workspaceId: resolved.workspaceId,
-      ...(displayName != null ? { displayName } : {}),
-    };
-  }
-
-  private async findWorkspaceLifecycleMetadata(
-    workspaceId: string
-  ): Promise<WorkspaceMetadata | null> {
-    assert(
-      workspaceId.trim().length > 0,
-      "workspace lifecycle metadata lookup requires workspaceId"
-    );
-    try {
-      const allMetadata = await this.config.getAllWorkspaceMetadata();
-      return allMetadata.find((metadata) => metadata.id === workspaceId) ?? null;
-    } catch (error: unknown) {
-      log.debug("Failed to load workspace metadata for workspace lifecycle", {
-        workspaceId,
-        error: getErrorMessage(error),
-      });
-      return null;
-    }
-  }
-
-  private isTranscriptOnlyWorkspaceMetadata(metadata: WorkspaceMetadata): boolean {
-    return "transcriptOnly" in metadata && metadata.transcriptOnly === true;
-  }
-
-  private async handleActiveWorkspaceLifecycleTurns(
-    ownerWorkspaceId: string,
-    resolved: ResolvedWorkspaceLifecycleTarget,
-    interruptActive: boolean
-  ): Promise<WorkspaceLifecycleResult | null> {
-    const activeRecords = (
-      await this.listWorkspaceTurnTasks(ownerWorkspaceId, {
-        statuses: ["queued", "starting", "running"],
-      })
-    ).filter((record) => record.workspaceId === resolved.workspaceId);
-    const activeWorkspaceTurnTaskIds = activeRecords.map((record) => record.handleId);
-
-    if (resolved.targetKind === "agent_task") {
-      const activeTaskIds = this.listActiveDescendantAgentTaskIds(resolved.workspaceId);
-      const taskStatus = resolved.metadata?.taskStatus;
-      if (
-        (taskStatus != null && ACTIVE_AGENT_TASK_STATUSES.has(taskStatus)) ||
-        this.aiService.isStreaming(resolved.workspaceId) ||
-        isActiveWorkspaceTurnTaskStatus(resolved.metadata?.taskExecutionStatus)
-      ) {
-        activeTaskIds.unshift(resolved.workspaceId);
-      }
-
-      const uniqueActiveTaskIds = Array.from(
-        new Set([...activeTaskIds, ...activeWorkspaceTurnTaskIds])
-      );
-      if (uniqueActiveTaskIds.length === 0) {
-        return null;
-      }
-
-      return {
-        status: "active",
-        action: resolved.action,
-        ...this.lifecycleTargetFields(resolved),
-        activeTaskIds: uniqueActiveTaskIds,
-        note: "Stop the sub-agent before removing it.",
-      };
-    }
-
-    if (activeWorkspaceTurnTaskIds.length === 0) {
-      return null;
-    }
-    if (!interruptActive) {
-      return {
-        status: "active",
-        action: resolved.action,
-        ...this.lifecycleTargetFields(resolved),
-        activeTaskIds: activeWorkspaceTurnTaskIds,
-      };
-    }
-
-    for (const activeTaskId of activeWorkspaceTurnTaskIds) {
-      const interruptResult = await this.interruptWorkspaceTurn(ownerWorkspaceId, activeTaskId);
-      if (!interruptResult.success) {
-        return {
-          status: "error",
-          action: resolved.action,
-          ...this.lifecycleTargetFields(resolved),
-          activeTaskIds: activeWorkspaceTurnTaskIds,
-          error: interruptResult.error,
-        };
-      }
-    }
-    return null;
   }
 
   listDescendantAgentTasks(

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10284,6 +10284,8 @@ export class TaskService {
 
   private async handleStreamEnd(event: StreamEndEvent): Promise<void> {
     const isCompaction = event.metadata.agentId === "compact" || event.metadata.mode === "compact";
+    // AgentSession resolves true only after a durable compaction follow-up is accepted. Bare,
+    // rejected, and failed-to-dispatch compactions remain on the normal child recovery path.
     if (
       isCompaction &&
       (await this.workspaceService.waitForPendingCompactionCompletionDecision(
@@ -10291,19 +10293,7 @@ export class TaskService {
         event.messageId
       )) === true
     ) {
-      const history = await this.historyService.getHistoryFromLatestBoundary(event.workspaceId);
-      const summary = history.success
-        ? history.data.findLast((message) => message.metadata?.compactionBoundary === true)
-        : undefined;
-      const summaryMetadata = summary?.metadata?.muxMetadata;
-      // Defer only when successful compaction durably staged the next child turn. Bare /compact and
-      // rejected compactions must continue through normal completion recovery.
-      if (
-        summaryMetadata?.type === "compaction-summary" &&
-        summaryMetadata.pendingFollowUp != null
-      ) {
-        return;
-      }
+      return;
     }
 
     const workspaceId = event.workspaceId;

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10813,6 +10813,13 @@ export class TaskService {
   }
 
   private async handleStreamEnd(event: StreamEndEvent): Promise<void> {
+    // Compaction is a mechanical history rewrite, not a child execution boundary. Ignoring it here
+    // keeps active and reawakened sub-agents in their existing lifecycle state until the correlated
+    // post-compaction follow-up produces the delegated turn's real outcome.
+    if (event.metadata.agentId === "compact" || event.metadata.mode === "compact") {
+      return;
+    }
+
     const workspaceId = event.workspaceId;
 
     // Ensure any in-flight notify_on_terminal persistence (from a just-detached foreground wait)

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10295,7 +10295,11 @@ export class TaskService {
     if (
       isCompaction &&
       compactionMetadata?.type === "compaction-request" &&
-      getCompactionFollowUpContent(compactionMetadata) != null
+      getCompactionFollowUpContent(compactionMetadata) != null &&
+      (await this.workspaceService.waitForPendingCompactionCompletionDecision(
+        event.workspaceId,
+        event.messageId
+      )) === true
     ) {
       return;
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9414,6 +9414,14 @@ export class WorkspaceService extends EventEmitter {
     return this.sessions.get(workspaceId.trim())?.hasQueuedMessages(dispatchMode) ?? false;
   }
 
+  async waitForPendingCompactionCompletionDecision(
+    workspaceId: string,
+    messageId: string
+  ): Promise<boolean | undefined> {
+    const session = this.sessions.get(workspaceId.trim());
+    return session?.waitForPendingCompactionCompletionDecision(messageId);
+  }
+
   async waitForPendingStreamErrorRecoveryDecision(
     workspaceId: string,
     messageId: string

--- a/tests/ipc/tasks/persistentSubagentCompaction.test.ts
+++ b/tests/ipc/tasks/persistentSubagentCompaction.test.ts
@@ -1,0 +1,211 @@
+import { cleanupTestEnvironment, createTestEnvironment, type TestEnvironment } from "../setup";
+import {
+  cleanupTempGitRepo,
+  createTempGitRepo,
+  createWorkspace,
+  generateBranchName,
+  HAIKU_MODEL,
+  sendMessageWithModel,
+  waitFor,
+} from "../helpers";
+
+import type { Workspace as WorkspaceConfigEntry } from "@/node/config";
+import { HistoryService } from "@/node/services/historyService";
+import type { MuxMessage } from "@/common/types/message";
+
+function extractText(message: MuxMessage): string {
+  return message.parts
+    .filter(
+      (part): part is Extract<MuxMessage["parts"][number], { type: "text" }> => part.type === "text"
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
+function findWorkspace(
+  env: TestEnvironment,
+  workspaceId: string
+): WorkspaceConfigEntry | undefined {
+  return Array.from(env.config.loadConfigOrDefault().projects.values())
+    .flatMap((project) => project.workspaces)
+    .find((workspace) => workspace.id === workspaceId);
+}
+
+describe("Persistent sub-agent compaction", () => {
+  let env: TestEnvironment | undefined;
+  let repoPath: string | undefined;
+  const workspaceIds: string[] = [];
+
+  beforeEach(async () => {
+    env = await createTestEnvironment();
+    env.services.aiService.enableMockMode();
+    repoPath = await createTempGitRepo();
+  });
+
+  afterEach(async () => {
+    if (env) {
+      for (const workspaceId of workspaceIds.splice(0).reverse()) {
+        try {
+          await env.orpc.workspace.remove({ workspaceId, options: { force: true } });
+        } catch {
+          // Best-effort cleanup.
+        }
+      }
+      await cleanupTestEnvironment(env);
+      env = undefined;
+    }
+    if (repoPath) {
+      await cleanupTempGitRepo(repoPath);
+      repoPath = undefined;
+    }
+  });
+
+  test("reawakens a compacted child in place and settles its continuation without a live LLM", async () => {
+    if (!env || !repoPath) throw new Error("Test environment not initialized");
+
+    const parentResult = await createWorkspace(
+      env,
+      repoPath,
+      generateBranchName("persistent-compaction-parent")
+    );
+    if (!parentResult.success) throw new Error(parentResult.error);
+    workspaceIds.push(parentResult.metadata.id);
+
+    const childResult = await createWorkspace(
+      env,
+      repoPath,
+      generateBranchName("persistent-compaction-child")
+    );
+    if (!childResult.success) throw new Error(childResult.error);
+    workspaceIds.push(childResult.metadata.id);
+
+    const parentWorkspaceId = parentResult.metadata.id;
+    const childWorkspaceId = childResult.metadata.id;
+    const historyService = new HistoryService(env.config);
+    const seedText = "Original specialist context that should stay behind the boundary";
+
+    const seedResult = await sendMessageWithModel(env, childWorkspaceId, seedText, HAIKU_MODEL, {
+      agentId: "explore",
+    });
+    expect(seedResult.success).toBe(true);
+    const seedCompleted = await waitFor(async () => {
+      const history = await historyService.getLastMessages(childWorkspaceId, 20);
+      return (
+        history.success &&
+        history.data.some(
+          (message) => message.role === "assistant" && extractText(message).includes(seedText)
+        )
+      );
+    }, 10_000);
+    if (!seedCompleted) {
+      const history = await historyService.getLastMessages(childWorkspaceId, 20);
+      throw new Error(`Seed turn did not complete: ${JSON.stringify(history)}`);
+    }
+
+    const compactResult = await sendMessageWithModel(
+      env,
+      childWorkspaceId,
+      "Summarize the conversation into a compact form.",
+      HAIKU_MODEL,
+      {
+        agentId: "compact",
+        muxMetadata: {
+          type: "compaction-request",
+          rawCommand: "/compact -t 500",
+          parsed: { maxOutputTokens: 500 },
+        },
+      }
+    );
+    expect(compactResult.success).toBe(true);
+    const compactionCompleted = await waitFor(async () => {
+      const history = await historyService.getHistoryFromLatestBoundary(childWorkspaceId);
+      return history.success && history.data[0]?.metadata?.compactionBoundary === true;
+    }, 10_000);
+    if (!compactionCompleted) {
+      const history = await historyService.getLastMessages(childWorkspaceId, 20);
+      throw new Error(`Compaction did not complete: ${JSON.stringify(history)}`);
+    }
+
+    const reportedAt = "2026-08-10T12:00:00.000Z";
+    await env.config.addWorkspace(repoPath, {
+      ...childResult.metadata,
+      parentWorkspaceId,
+      agentId: "explore",
+      agentType: "explore",
+      taskStatus: "reported",
+      reportedAt,
+      taskModelString: HAIKU_MODEL,
+      title: "Compaction specialist",
+    });
+
+    const reactivated = await env.services.taskService.sendMessageToDescendantAgentTask(
+      parentWorkspaceId,
+      childWorkspaceId,
+      "Inspect the regression using the compacted context.",
+      "tool-end"
+    );
+    expect(reactivated.success).toBe(true);
+    if (!reactivated.success || reactivated.data.delivery !== "reactivated") {
+      throw new Error("Expected the persistent child to reactivate");
+    }
+    const executionTaskId = reactivated.data.executionTaskId;
+    if (!executionTaskId) throw new Error("Expected a reactivated execution task ID");
+
+    const continuation = await env.services.taskService.waitForWorkspaceTurn(executionTaskId, {
+      requestingWorkspaceId: parentWorkspaceId,
+      ownerWorkspaceId: parentWorkspaceId,
+      backgroundOnMessageQueued: false,
+      timeoutMs: 10_000,
+    });
+    expect(continuation).toMatchObject({
+      taskId: executionTaskId,
+      workspaceId: childWorkspaceId,
+      reportMarkdown: expect.stringContaining(
+        "Inspect the regression using the compacted context."
+      ),
+    });
+
+    const child = findWorkspace(env, childWorkspaceId);
+    expect(child).toMatchObject({
+      parentWorkspaceId,
+      taskStatus: "reported",
+      reportedAt,
+      taskExecutionId: executionTaskId,
+      taskExecutionStatus: "completed",
+    });
+
+    const activeHistory = await historyService.getHistoryFromLatestBoundary(childWorkspaceId);
+    expect(activeHistory.success).toBe(true);
+    if (!activeHistory.success) throw new Error(activeHistory.error);
+    expect(activeHistory.data[0]?.metadata?.compactionBoundary).toBe(true);
+    expect(activeHistory.data.some((message) => extractText(message).includes(seedText))).toBe(
+      false
+    );
+    expect(
+      activeHistory.data.some((message) =>
+        extractText(message).includes("Inspect the regression using the compacted context.")
+      )
+    ).toBe(true);
+
+    const fullHistory: MuxMessage[] = [];
+    const fullHistoryResult = await historyService.iterateFullHistory(
+      childWorkspaceId,
+      "forward",
+      (messages) => {
+        fullHistory.push(...messages);
+      }
+    );
+    expect(fullHistoryResult.success).toBe(true);
+    expect(fullHistory.some((message) => extractText(message).includes(seedText))).toBe(true);
+
+    const lastPromptResult = env.services.aiService.debugGetLastMockPrompt(childWorkspaceId);
+    expect(lastPromptResult.success).toBe(true);
+    if (!lastPromptResult.success || lastPromptResult.data == null) {
+      throw new Error("Expected a captured mock prompt");
+    }
+    expect(lastPromptResult.data[0]?.metadata?.compactionBoundary).toBe(true);
+    expect(lastPromptResult.data.some((message) => extractText(message).includes(seedText))).toBe(
+      false
+    );
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Adds deterministic, no-live-LLM validation that persistent sub-agents remain seamless across chat compaction. Mechanical compact turns no longer advance child lifecycle state, reawakened continuation correlation and agent-initiated attribution survive compaction, and the mock AI runtime now mirrors real stream metadata closely enough for a true backend integration test.

The PR is also a net maintainability reduction: it removes the unused generic archive/unarchive/delete-worktree TaskService backend left behind after persistent sub-agents adopted the public active → inactive → removed lifecycle. The supported `task_remove` path now uses one direct, parent-scoped persistent-child removal implementation.

## Background

The persistent sub-agent foundation from #3825 is merged into `main`. A child compaction stream was visible directly to `TaskService` and could be mistaken for the end of delegated work, moving an active child toward completion recovery. Mock streams also dropped workspace-turn correlation, preventing high-confidence end-to-end coverage for a reawakened persistent child.

The old generic lifecycle methods had no production callers; only TaskService tests exercised them. Historical `task_workspace_lifecycle` schemas and transcript rendering remain intact for old chats.

## Implementation

- Ignore compact-agent/mode stream ends in `TaskService`; only the post-compaction delegated follow-up may settle the child or continuation handle.
- Preserve `agentInitiated` and resolved workspace-turn correlation on persisted compaction follow-ups and their crash-safe dispatch/retry path.
- Carry agent identity, thinking level, and mux correlation through mock stream start, partial/final history, and stream-end events.
- Replace the unused generic workspace lifecycle resolver/lock/archive/worktree operations with direct persistent-child removal that verifies scope, rejects active/non-leaf children, persists idempotency tombstones, and removes under the task-tree lock.
- Delete lifecycle-only tests while retaining focused coverage for scope, deepest-first removal, active-state rejection, reawakening races, and idempotent retries.
- Add layered compaction regression coverage from focused unit tests through a ServiceContainer/IPC integration test.

## Validation

- `make static-check`
- `bun test src/node/services/taskService.test.ts`
- `bun test src/node/services/agentSession.autoCompaction.test.ts src/node/services/agentSession.workspaceTurnInheritance.test.ts src/node/services/agentSession.continueMessageAgentId.test.ts src/node/services/mock/mockAiStreamPlayer.test.ts`
- `bun test src/node/services/tools/task_remove.test.ts`
- `TEST_INTEGRATION=1 bun x jest tests/ipc/tasks/persistentSubagentCompaction.test.ts --runInBand`
- `git diff --numstat origin/main...HEAD`: **790 additions, 1,239 deletions, net −449 LoC**

No test invokes a live LLM API.

## Risks

Low-to-moderate product risk. Compaction changes are narrowly scoped and covered end-to-end. Lifecycle deletion removes backend methods with no production callers; the supported `task_remove` path retains scope, activity, descendant, race, and idempotency protections. Historical transcript rendering remains compatible.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$88.81`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=88.81 -->




