### PR TITLE
🤖 fix: stop duplicating workflow report fields in result context messages

### DIFF
--- a/src/browser/utils/workflowRunMessages.test.ts
+++ b/src/browser/utils/workflowRunMessages.test.ts
@@ -10,6 +10,14 @@ import {
 import type { MuxMessage } from "@/common/types/message";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 
+function parseWorkflowResultPayload(message: string): Record<string, unknown> {
+  const match = /<mux_workflow_result>\n([\s\S]*)\n<\/mux_workflow_result>/.exec(message);
+  if (match?.[1] == null) {
+    throw new Error(`message does not contain a workflow result payload: ${message}`);
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 describe("buildWorkflowRunCardMessage", () => {
   test("builds a stable workflow_run card message with the current durable run", () => {
     const run: WorkflowRunRecord = {
@@ -115,6 +123,53 @@ describe("buildWorkflowRunCardMessage", () => {
     expect(message).toContain("retried successfully");
     expect(message).toContain('"status": "completed"');
     expect(message).not.toContain("Execution interrupted");
+  });
+
+  test("deduplicates hoisted report fields out of the result payload", () => {
+    const message = buildWorkflowResultContextMessage({
+      rawCommand: "workflow_run ./workflows/demo.js",
+      name: "./workflows/demo.js",
+      runId: "wfr_dedup",
+      status: "completed",
+      result: { reportMarkdown: "report body", structuredOutput: { gate: "go" } },
+      run: null,
+    });
+
+    const payload = parseWorkflowResultPayload(message);
+    expect(payload.reportMarkdown).toBe("report body");
+    expect(payload.structuredOutput).toEqual({ gate: "go" });
+    // Hoisted fields must not be repeated under `result` (doubles token cost).
+    expect(payload).not.toHaveProperty("result");
+  });
+
+  test("keeps only non-hoisted residual fields under result", () => {
+    const message = buildWorkflowResultContextMessage({
+      rawCommand: "workflow_run ./workflows/demo.js",
+      name: "./workflows/demo.js",
+      runId: "wfr_residual",
+      status: "completed",
+      result: { reportMarkdown: "report body", extra: "kept" },
+      run: null,
+    });
+
+    const payload = parseWorkflowResultPayload(message);
+    expect(payload.reportMarkdown).toBe("report body");
+    expect(payload.result).toEqual({ extra: "kept" });
+  });
+
+  test("keeps non-object results verbatim when nothing is hoisted", () => {
+    const message = buildWorkflowResultContextMessage({
+      rawCommand: "workflow_run ./workflows/demo.js",
+      name: "./workflows/demo.js",
+      runId: "wfr_scalar",
+      status: "completed",
+      result: "plain string result",
+      run: null,
+    });
+
+    const payload = parseWorkflowResultPayload(message);
+    expect(payload).not.toHaveProperty("reportMarkdown");
+    expect(payload.result).toBe("plain string result");
   });
 
   test("filters durable workflow UI-only rows while preserving workflow results", () => {

--- a/src/common/utils/workflowRunMessages.ts
+++ b/src/common/utils/workflowRunMessages.ts
@@ -113,6 +113,28 @@ function getWorkflowResultField(value: unknown, field: string): unknown {
   return undefined;
 }
 
+/**
+ * agent()-based workflows return `{ reportMarkdown, structuredOutput }` — exactly the fields
+ * hoisted to the payload top level. Repeating them verbatim under `result` doubled the token
+ * cost of every workflow-completion context message, so `result` keeps only fields that were
+ * NOT hoisted (non-standard result shapes) and is dropped when nothing else remains.
+ */
+function getResidualWorkflowResult(
+  resultValue: unknown,
+  hoistedFields: readonly string[]
+): unknown {
+  if (hoistedFields.length === 0 || !isRecordValue(resultValue)) {
+    return resultValue;
+  }
+  const residual: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(resultValue)) {
+    if (!hoistedFields.includes(key)) {
+      residual[key] = value;
+    }
+  }
+  return Object.keys(residual).length > 0 ? residual : null;
+}
+
 function stringifyWorkflowResultPayload(payload: unknown): string {
   try {
     return JSON.stringify(payload, null, 2);
@@ -139,6 +161,11 @@ export function buildWorkflowResultContextMessage(input: {
   const resultValue = getWorkflowResultValue(input.result, input.run);
   const reportMarkdown = getWorkflowResultField(resultValue, "reportMarkdown");
   const structuredOutput = getWorkflowResultField(resultValue, "structuredOutput");
+  const hoistedFields = [
+    ...(typeof reportMarkdown === "string" ? ["reportMarkdown"] : []),
+    ...(structuredOutput !== undefined ? ["structuredOutput"] : []),
+  ];
+  const residualResult = getResidualWorkflowResult(resultValue, hoistedFields);
   const workflowError = getWorkflowError({
     run: input.run,
     status: input.status,
@@ -152,7 +179,7 @@ export function buildWorkflowResultContextMessage(input: {
     },
     ...(typeof reportMarkdown === "string" ? { reportMarkdown } : {}),
     ...(structuredOutput !== undefined ? { structuredOutput } : {}),
-    ...(resultValue != null ? { result: resultValue } : {}),
+    ...(residualResult != null ? { result: residualResult } : {}),
     ...(workflowError ? { error: workflowError } : {}),
   };
 


### PR DESCRIPTION
## Summary

`buildWorkflowResultContextMessage` — the single builder behind every workflow-completion context message (terminal-attention wakes, background continuations, ORPC continuations, `/workflow` slash command) — hoisted `reportMarkdown`/`structuredOutput` to the payload top level **and** embedded the full result object again under `result`. Since `agent()`-based workflows return exactly `{ reportMarkdown, structuredOutput }`, every workflow-completion wake message carried its payload twice, roughly doubling its token cost.

## Background

Observed in a real terminal-attention wake where a multi-KB gate report appeared verbatim at both the payload top level and nested under `result` (~1.6k wasted tokens for that single message). The duplication has existed since the original dynamic-workflows change (#3431). The `task_await` workflow branch (`buildWorkflowAwaitResult`) already avoids this by hoisting the report fields once and omitting the redundant copy — this PR brings the context-message builder in line.

## Implementation

- New `getResidualWorkflowResult` helper strips the hoisted fields from the embedded `result` object and returns `null` when nothing else remains, so the `result` key is dropped entirely for the standard report shape.
- Non-standard result shapes are preserved: results with extra fields keep only the residual fields under `result`; non-object results (strings, arrays) and results where nothing was hoisted pass through unchanged.
- All four call sites (`taskService.buildWorkflowTerminalPrompt`, `aiService.onBackgroundRunTerminal`, `router.sendWorkflowRunTerminalContinuation`, `chatCommands`) share this builder, so no caller changes were needed.

## Validation

- Three new behavioral tests parse the JSON payload out of the built message and assert: standard report shape → hoisted once with no `result` key; extra fields → `result` keeps only the residual; scalar result → kept verbatim.
- Caller suites pass: `chatCommands.test.ts` (81), `router.test.ts` (22), `taskService.test.ts -t workflow` (51).

## Risks

Low. The change only affects the model-facing workflow-result context message; UI cards and durable run records are untouched. Worst case for an exotic result shape is that the model sees the report fields once instead of twice — the fields themselves are always preserved.
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$4.92`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=4.92 -->
