### PR TITLE
🤖 fix: add workspace detail popover padding

### DIFF
--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -549,7 +549,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               Workspace details ({formatKeybind(KEYBINDS.SHOW_WORKSPACE_DETAILS)})
             </TooltipContent>
           </Tooltip>
-          <PopoverContent align="start" className="flex flex-col gap-0.5 text-xs">
+          <PopoverContent align="start" className="flex flex-col gap-0.5 p-2 text-xs">
             <span className="font-mono">{projectLabel}</span>
             <span>{workspaceName}</span>
             <span className="text-muted">{namedWorkspacePath}</span>


### PR DESCRIPTION
## Summary

Add padding around the text in the workspace detail popover.

## Background

The popover text touches the border after the workspace detail icon opens it.

## Implementation

Add the `p-2` utility to the workspace detail `PopoverContent`.

## Validation

- `make static-check`
- `bunx prettier --check src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx`
- `git diff --check`

## Risks

This change affects only the workspace detail popover spacing.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `xhigh` • Cost: `$0.23`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=xhigh costs=0.23 -->
