### PR TITLE
🤖 fix: use swap icon for lines and commits toggle

### DIFF
--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { ChevronDown, Github, MessageCircle } from "lucide-react";
+import { ArrowLeftRight, Github, MessageCircle } from "lucide-react";
 import { cn } from "@/common/lib/utils";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { GIT_STATUS_INDICATOR_MODE_KEY } from "@/common/constants/storage";
@@ -107,7 +107,7 @@ function DriftModeToggle() {
           onKeyDown={stopKeyboardPropagation}
         >
           {isLineDelta ? "Lines" : "Commits"}
-          <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
+          <ArrowLeftRight className="h-3 w-3 shrink-0" aria-hidden="true" />
         </button>
       </TooltipTrigger>
       <TooltipContent side="top">


### PR DESCRIPTION
## Summary

Replace the caret in the footer lines/commits toggle with the `ArrowLeftRight` icon.

## Background

The caret suggests a menu or expansion action.
The control switches between two display modes.
The swap icon communicates this action more clearly.

## Implementation

- Replace `ChevronDown` with `ArrowLeftRight`.
- Keep the existing click and keyboard toggle behavior.
- Keep the existing tooltip text.

## Validation

- `bun test src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx`
- `make static-check`
- `git diff --check`

## Risks

The change affects only the icon in the single-repository footer toggle.
The toggle behavior remains unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `xhigh` • Cost: `$0.33`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=xhigh costs=0.33 -->
