### PR TITLE
🤖 fix: reveal the last prompt in the transcript

### DIFF
--- a/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
@@ -29,6 +29,8 @@ let workspaceState = {
   muxMessages: [],
   hasOlderHistory: false,
 };
+let loadOlderHistory = (): Promise<"loaded" | "exhausted" | "busy" | "unavailable" | "failed"> =>
+  Promise.resolve("exhausted");
 let cleanupDom: (() => void) | null = null;
 const workspaceId = "workspace-1";
 
@@ -63,7 +65,7 @@ function installFooterBarTestDoubles() {
     () =>
       ({
         getWorkspaceState: () => workspaceState,
-        loadOlderHistory: () => Promise.resolve("exhausted" as const),
+        loadOlderHistory: () => loadOlderHistory(),
       }) as unknown as ReturnType<typeof WorkspaceStoreModule.useWorkspaceStoreRaw>
   );
   spyOn(GitStatusStoreModule, "useGitStatus").mockImplementation(() => null);
@@ -143,6 +145,7 @@ describe("WorkspaceFooterBar repository controls", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
     workspaceState = { messages: [], muxMessages: [], hasOlderHistory: false };
+    loadOlderHistory = () => Promise.resolve("exhausted" as const);
     cleanupDom = installDom();
     installFooterBarTestDoubles();
     /* eslint-disable @typescript-eslint/no-require-imports */
@@ -272,6 +275,7 @@ describe("WorkspaceFooterBar last prompt", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
     workspaceState = { messages: [], muxMessages: [], hasOlderHistory: false };
+    loadOlderHistory = () => Promise.resolve("exhausted" as const);
     cleanupDom = installDom();
     installFooterBarTestDoubles();
     workspaceMetadata.set(workspaceId, repoMetadata);
@@ -348,6 +352,61 @@ describe("WorkspaceFooterBar last prompt", () => {
         messageId: "prompt-1",
       });
       expect(view.queryByTestId("workspace-footer-last-prompt-reveal")).toBeNull();
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
+  it("does not reveal an obsolete prompt after a newer prompt arrives", async () => {
+    let resolveLoad: ((result: "loaded") => void) | undefined;
+    loadOlderHistory = () =>
+      new Promise<"loaded">((resolve) => {
+        resolveLoad = resolve;
+      });
+    workspaceState = {
+      messages: [],
+      muxMessages: [],
+      hasOlderHistory: true,
+    };
+    let currentPrompt: { text: string; messageId: string } | null = {
+      text: "old prompt",
+      messageId: "prompt-old",
+    };
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(
+      () => currentPrompt
+    );
+    const revealed: Event[] = [];
+    const listener = (event: Event) => revealed.push(event);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const view = renderFooter();
+      fireEvent.click(view.getByTestId("workspace-footer-last-prompt"));
+      fireEvent.click(view.getByTestId("workspace-footer-last-prompt-reveal"));
+      await Promise.resolve();
+
+      currentPrompt = { text: "new prompt", messageId: "prompt-new" };
+      view.rerender(
+        <TooltipProvider delayDuration={0}>
+          <WorkspaceFooterBar
+            workspaceId={workspaceId}
+            projectName="demo"
+            projectPath="/projects/demo"
+            workspaceName="feature-branch"
+            namedWorkspacePath="/projects/demo/workspaces/feature-branch"
+            runtimeConfig={{ type: "worktree", srcBaseDir: "/tmp/src" }}
+          />
+        </TooltipProvider>
+      );
+      workspaceState.messages = [makeUserMessage("prompt-old")];
+      workspaceState.hasOlderHistory = false;
+      resolveLoad?.("loaded");
+
+      const result = await Promise.resolve().then(
+        () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+      );
+      void result;
+      expect(revealed).toHaveLength(0);
     } finally {
       window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
     }

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
@@ -357,6 +357,36 @@ describe("WorkspaceFooterBar last prompt", () => {
     }
   });
 
+  it("reveals the last prompt from the timeline shortcut while the popup is open", async () => {
+    workspaceState = {
+      messages: [makeUserMessage("prompt-shortcut")],
+      muxMessages: [],
+      hasOlderHistory: false,
+    };
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(() => ({
+      text: "ship the footer",
+      messageId: "prompt-shortcut",
+    }));
+    const revealed: Event[] = [];
+    const listener = (event: Event) => revealed.push(event);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const view = renderFooter();
+      fireEvent.click(view.getByTestId("workspace-footer-last-prompt"));
+      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true, shiftKey: true });
+
+      await waitFor(() => expect(revealed).toHaveLength(1));
+      expect((revealed[0] as CustomEvent).detail).toEqual({
+        workspaceId,
+        messageId: "prompt-shortcut",
+      });
+      expect(view.queryByTestId("workspace-footer-last-prompt-reveal")).toBeNull();
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
   it("does not reveal an obsolete prompt after a newer prompt arrives", async () => {
     let resolveLoad: ((result: "loaded") => void) | undefined;
     loadOlderHistory = () =>

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
@@ -2,7 +2,7 @@ import "../../../../tests/ui/dom";
 
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { installDom } from "../../../../tests/ui/dom";
 import * as WorkspaceContextModule from "@/browser/contexts/WorkspaceContext";
 import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
@@ -17,11 +17,18 @@ import * as MultiProjectGitStatusIndicatorModule from "../GitStatusIndicator/Mul
 import * as WorkspaceLinksModule from "../WorkspaceLinks/WorkspaceLinks";
 import { TooltipProvider } from "../Tooltip/Tooltip";
 import type { WorkspaceFooterBar as WorkspaceFooterBarComponent } from "./WorkspaceFooterBar";
+import type { DisplayedMessage } from "@/common/types/message";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { CUSTOM_EVENTS } from "@/common/constants/events";
 
 let WorkspaceFooterBar!: typeof WorkspaceFooterBarComponent;
 
 let workspaceMetadata = new Map<string, FrontendWorkspaceMetadata>();
+let workspaceState = {
+  messages: [] as DisplayedMessage[],
+  muxMessages: [],
+  hasOlderHistory: false,
+};
 let cleanupDom: (() => void) | null = null;
 const workspaceId = "workspace-1";
 
@@ -51,7 +58,14 @@ function installFooterBarTestDoubles() {
       ({ totalTokens: 0 }) as unknown as ReturnType<typeof WorkspaceStoreModule.useWorkspaceUsage>
   );
   spyOn(WorkspaceStoreModule, "useWorkspaceStreamingStats").mockImplementation(() => null);
-  spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPrompt").mockImplementation(() => null);
+  spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(() => null);
+  spyOn(WorkspaceStoreModule, "useWorkspaceStoreRaw").mockImplementation(
+    () =>
+      ({
+        getWorkspaceState: () => workspaceState,
+        loadOlderHistory: () => Promise.resolve("exhausted" as const),
+      }) as unknown as ReturnType<typeof WorkspaceStoreModule.useWorkspaceStoreRaw>
+  );
   spyOn(GitStatusStoreModule, "useGitStatus").mockImplementation(() => null);
   spyOn(PRStatusStoreModule, "useWorkspacePR").mockImplementation(() => null);
   spyOn(RuntimeStatusStoreModule, "useRuntimeStatus").mockImplementation(() => "unsupported");
@@ -115,9 +129,20 @@ function renderFooter(overrides?: Partial<ComponentProps<typeof WorkspaceFooterB
   );
 }
 
+function makeUserMessage(historyId: string): DisplayedMessage {
+  return {
+    type: "user",
+    id: historyId,
+    historyId,
+    content: "ship the footer",
+    historySequence: 1,
+  };
+}
+
 describe("WorkspaceFooterBar repository controls", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
+    workspaceState = { messages: [], muxMessages: [], hasOlderHistory: false };
     cleanupDom = installDom();
     installFooterBarTestDoubles();
     /* eslint-disable @typescript-eslint/no-require-imports */
@@ -246,6 +271,7 @@ describe("WorkspaceFooterBar repository controls", () => {
 describe("WorkspaceFooterBar last prompt", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
+    workspaceState = { messages: [], muxMessages: [], hasOlderHistory: false };
     cleanupDom = installDom();
     installFooterBarTestDoubles();
     workspaceMetadata.set(workspaceId, repoMetadata);
@@ -270,9 +296,10 @@ describe("WorkspaceFooterBar last prompt", () => {
   });
 
   it("renders the item once a user prompt exists", () => {
-    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPrompt").mockImplementation(
-      () => "ship the footer"
-    );
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(() => ({
+      text: "ship the footer",
+      messageId: "prompt-1",
+    }));
 
     const { queryByTestId } = renderFooter();
 
@@ -280,9 +307,10 @@ describe("WorkspaceFooterBar last prompt", () => {
   });
 
   it("toggles the prompt popover from the keyboard shortcut", () => {
-    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPrompt").mockImplementation(
-      () => "ship the footer"
-    );
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(() => ({
+      text: "ship the footer",
+      messageId: "prompt-1",
+    }));
 
     const { getByTestId } = renderFooter();
     const trigger = getByTestId("workspace-footer-last-prompt");
@@ -295,9 +323,42 @@ describe("WorkspaceFooterBar last prompt", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 
+  it("reveals the last prompt from the popup", async () => {
+    workspaceState = {
+      messages: [makeUserMessage("prompt-1")],
+      muxMessages: [],
+      hasOlderHistory: false,
+    };
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(() => ({
+      text: "ship the footer",
+      messageId: "prompt-1",
+    }));
+    const revealed: Event[] = [];
+    const listener = (event: Event) => revealed.push(event);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const view = renderFooter();
+      fireEvent.click(view.getByTestId("workspace-footer-last-prompt"));
+      fireEvent.click(view.getByTestId("workspace-footer-last-prompt-reveal"));
+
+      await waitFor(() => expect(revealed).toHaveLength(1));
+      expect((revealed[0] as CustomEvent).detail).toEqual({
+        workspaceId,
+        messageId: "prompt-1",
+      });
+      expect(view.queryByTestId("workspace-footer-last-prompt-reveal")).toBeNull();
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
   it("does not reopen the popover when a prompt returns after being absent", () => {
-    let currentPrompt: string | null = "ship the footer";
-    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPrompt").mockImplementation(
+    let currentPrompt: { text: string; messageId: string } | null = {
+      text: "ship the footer",
+      messageId: "prompt-1",
+    };
+    spyOn(WorkspaceStoreModule, "useWorkspaceLastUserPromptInfo").mockImplementation(
       () => currentPrompt
     );
 
@@ -322,7 +383,7 @@ describe("WorkspaceFooterBar last prompt", () => {
     );
     expect(view.queryByTestId("workspace-footer-last-prompt")).toBeNull();
 
-    currentPrompt = "a brand new prompt";
+    currentPrompt = { text: "a brand new prompt", messageId: "prompt-2" };
     view.rerender(
       <TooltipProvider delayDuration={0}>
         <WorkspaceFooterBar

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
@@ -357,7 +357,7 @@ describe("WorkspaceFooterBar last prompt", () => {
     }
   });
 
-  it("reveals the last prompt from the timeline shortcut while the popup is open", async () => {
+  it("reveals the last prompt from its shortcut while the popup is open", async () => {
     workspaceState = {
       messages: [makeUserMessage("prompt-shortcut")],
       muxMessages: [],
@@ -374,7 +374,7 @@ describe("WorkspaceFooterBar last prompt", () => {
     try {
       const view = renderFooter();
       fireEvent.click(view.getByTestId("workspace-footer-last-prompt"));
-      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true, shiftKey: true });
+      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true, altKey: true });
 
       await waitFor(() => expect(revealed).toHaveLength(1));
       expect((revealed[0] as CustomEvent).detail).toEqual({

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -225,6 +225,7 @@ function FooterLastPrompt(props: { workspaceId: string }) {
 
   useEffect(() => {
     revealOperationRef.current += 1;
+    setRevealState("idle");
     return () => {
       revealOperationRef.current += 1;
     };

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -250,6 +250,13 @@ function FooterLastPrompt(props: { workspaceId: string }) {
   }, [lastPromptMessageId]);
 
   useEffect(() => {
+    if (open) {
+      return;
+    }
+    revealOperationRef.current += 1;
+  }, [open]);
+
+  useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       if (
         !open ||

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -211,11 +211,18 @@ function FooterLastPrompt(props: { workspaceId: string }) {
   const workspaceStore = useWorkspaceStoreRaw();
   const [open, setOpen] = React.useState(false);
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
+  const revealOperationRef = React.useRef(0);
+  const lastPromptMessageId = lastPrompt?.messageId;
   const [revealState, setRevealState] = React.useState<
     "idle" | "revealing" | "not-found" | "error"
   >("idle");
 
-  const lastPromptMessageId = lastPrompt?.messageId;
+  useEffect(() => {
+    revealOperationRef.current += 1;
+    return () => {
+      revealOperationRef.current += 1;
+    };
+  }, [lastPromptMessageId]);
 
   // Reset open state when the prompt disappears so a later prompt cannot inherit it.
   useEffect(() => {
@@ -245,14 +252,16 @@ function FooterLastPrompt(props: { workspaceId: string }) {
     }
 
     setRevealState("revealing");
+    const operation = ++revealOperationRef.current;
     revealTimelineTarget({
       workspaceId: props.workspaceId,
       getTarget: () => ({ messageId: lastPrompt.messageId }),
       workspaceStore,
       pinTarget: pinTimelineRevealTarget,
+      isCancelled: () => operation !== revealOperationRef.current,
     })
       .then((result: TimelineRevealResult) => {
-        if (result === "cancelled") {
+        if (result === "cancelled" || operation !== revealOperationRef.current) {
           return;
         }
         if (result === "revealed") {
@@ -263,7 +272,9 @@ function FooterLastPrompt(props: { workspaceId: string }) {
         }
       })
       .catch(() => {
-        setRevealState("error");
+        if (operation === revealOperationRef.current) {
+          setRevealState("error");
+        }
       });
   };
 

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -252,6 +252,9 @@ function FooterLastPrompt(props: { workspaceId: string }) {
       pinTarget: pinTimelineRevealTarget,
     })
       .then((result: TimelineRevealResult) => {
+        if (result === "cancelled") {
+          return;
+        }
         if (result === "revealed") {
           setOpen(false);
           setRevealState("idle");

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -33,7 +33,12 @@ import { WorkspaceLinks } from "../WorkspaceLinks/WorkspaceLinks";
 import { Popover, PopoverTrigger, PopoverContent } from "../Popover/Popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { revealTimelineTarget, type TimelineRevealResult } from "@/browser/utils/timelineReveal";
-import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import {
+  formatKeybind,
+  isEditableElement,
+  KEYBINDS,
+  matchesKeybind,
+} from "@/browser/utils/ui/keybinds";
 
 interface WorkspaceFooterBarProps {
   workspaceId: string;
@@ -211,6 +216,7 @@ function FooterLastPrompt(props: { workspaceId: string }) {
   const workspaceStore = useWorkspaceStoreRaw();
   const [open, setOpen] = React.useState(false);
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
+  const revealButtonRef = React.useRef<HTMLButtonElement>(null);
   const revealOperationRef = React.useRef(0);
   const lastPromptMessageId = lastPrompt?.messageId;
   const [revealState, setRevealState] = React.useState<
@@ -241,6 +247,24 @@ function FooterLastPrompt(props: { workspaceId: string }) {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [lastPromptMessageId]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (
+        !open ||
+        !matchesKeybind(event, KEYBINDS.REVEAL_TIMELINE_EVENT) ||
+        isEditableElement(event.target)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      if (revealButtonRef.current && !revealButtonRef.current.disabled) {
+        revealButtonRef.current.click();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open]);
 
   if (lastPrompt === null) {
     return null;
@@ -310,6 +334,7 @@ function FooterLastPrompt(props: { workspaceId: string }) {
         <div className="whitespace-pre-wrap">{lastPrompt.text}</div>
         <button
           type="button"
+          ref={revealButtonRef}
           data-testid="workspace-footer-last-prompt-reveal"
           disabled={revealState === "revealing"}
           onClick={handleReveal}

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -254,6 +254,7 @@ function FooterLastPrompt(props: { workspaceId: string }) {
       return;
     }
     revealOperationRef.current += 1;
+    setRevealState("idle");
   }, [open]);
 
   useEffect(() => {

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -12,9 +12,11 @@ import { hasWorkspaceRepository } from "@/browser/utils/workspaceCapabilities";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import {
-  useWorkspaceLastUserPrompt,
+  pinTimelineRevealTarget,
+  useWorkspaceLastUserPromptInfo,
   useWorkspaceRoundedStreamingTps,
   useWorkspaceSidebarState,
+  useWorkspaceStoreRaw,
   useWorkspaceUsage,
 } from "@/browser/stores/WorkspaceStore";
 import { useGitStatus } from "@/browser/stores/GitStatusStore";
@@ -30,6 +32,7 @@ import { MultiProjectGitStatusIndicator } from "../GitStatusIndicator/MultiProje
 import { WorkspaceLinks } from "../WorkspaceLinks/WorkspaceLinks";
 import { Popover, PopoverTrigger, PopoverContent } from "../Popover/Popover";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
+import { revealTimelineTarget, type TimelineRevealResult } from "@/browser/utils/timelineReveal";
 import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
 
 interface WorkspaceFooterBarProps {
@@ -204,15 +207,22 @@ function FooterUsageStats(props: { workspaceId: string }) {
 }
 
 function FooterLastPrompt(props: { workspaceId: string }) {
-  const lastPrompt = useWorkspaceLastUserPrompt(props.workspaceId);
+  const lastPrompt = useWorkspaceLastUserPromptInfo(props.workspaceId);
+  const workspaceStore = useWorkspaceStoreRaw();
   const [open, setOpen] = React.useState(false);
   const [tooltipOpen, setTooltipOpen] = React.useState(false);
+  const [revealState, setRevealState] = React.useState<
+    "idle" | "revealing" | "not-found" | "error"
+  >("idle");
+
+  const lastPromptMessageId = lastPrompt?.messageId;
 
   // Reset open state when the prompt disappears so a later prompt cannot inherit it.
   useEffect(() => {
-    if (lastPrompt === null) {
+    if (lastPromptMessageId == null) {
       setOpen(false);
       setTooltipOpen(false);
+      setRevealState("idle");
       return;
     }
     const handler = (e: KeyboardEvent) => {
@@ -223,11 +233,36 @@ function FooterLastPrompt(props: { workspaceId: string }) {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [lastPrompt]);
+  }, [lastPromptMessageId]);
 
   if (lastPrompt === null) {
     return null;
   }
+
+  const handleReveal = () => {
+    if (revealState === "revealing") {
+      return;
+    }
+
+    setRevealState("revealing");
+    revealTimelineTarget({
+      workspaceId: props.workspaceId,
+      getTarget: () => ({ messageId: lastPrompt.messageId }),
+      workspaceStore,
+      pinTarget: pinTimelineRevealTarget,
+    })
+      .then((result: TimelineRevealResult) => {
+        if (result === "revealed") {
+          setOpen(false);
+          setRevealState("idle");
+        } else {
+          setRevealState(result);
+        }
+      })
+      .catch(() => {
+        setRevealState("error");
+      });
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -256,9 +291,23 @@ function FooterLastPrompt(props: { workspaceId: string }) {
         align="end"
         sideOffset={8}
         collisionPadding={12}
-        className="max-h-60 w-auto max-w-[min(25rem,var(--radix-popover-content-available-width,25rem))] overflow-y-auto p-3 text-xs leading-relaxed break-words whitespace-pre-wrap"
+        className="max-h-60 w-auto max-w-[min(25rem,var(--radix-popover-content-available-width,25rem))] overflow-y-auto p-3 text-xs leading-relaxed break-words"
       >
-        {lastPrompt}
+        <div className="whitespace-pre-wrap">{lastPrompt.text}</div>
+        <button
+          type="button"
+          data-testid="workspace-footer-last-prompt-reveal"
+          disabled={revealState === "revealing"}
+          onClick={handleReveal}
+          className="border-border bg-surface-primary text-content-primary hover:bg-hover focus-visible:ring-accent mt-3 rounded-md border px-2.5 py-1.5 text-xs font-medium focus-visible:ring-1 focus-visible:outline-none disabled:cursor-wait disabled:opacity-60"
+        >
+          {revealState === "revealing" ? "Revealing…" : "Reveal in transcript"}
+        </button>
+        {revealState === "not-found" ? (
+          <div className="text-muted mt-1.5 text-[10px]">Prompt not found in the transcript</div>
+        ) : revealState === "error" ? (
+          <div className="text-muted mt-1.5 text-[10px]">Reveal unavailable</div>
+        ) : null}
       </PopoverContent>
     </Popover>
   );

--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -253,7 +253,7 @@ function FooterLastPrompt(props: { workspaceId: string }) {
     const handler = (event: KeyboardEvent) => {
       if (
         !open ||
-        !matchesKeybind(event, KEYBINDS.REVEAL_TIMELINE_EVENT) ||
+        !matchesKeybind(event, KEYBINDS.REVEAL_LAST_PROMPT) ||
         isEditableElement(event.target)
       ) {
         return;

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -450,8 +450,9 @@ function TimelinePreviewCard(props: {
         getTarget: () => resolveRevealTarget(anchor),
         workspaceStore,
         pinTarget: pinTimelineRevealTarget,
+        isCancelled: () => operation !== revealOperationRef.current,
       });
-      if (operation !== revealOperationRef.current) {
+      if (result === "cancelled") {
         return;
       }
       setRevealState(result === "revealed" ? "idle" : result);

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -15,9 +15,9 @@ import {
   type WorkspaceState,
   type WorkspaceTimelineSnapshot,
 } from "@/browser/stores/WorkspaceStore";
+import { revealTimelineTarget } from "@/browser/utils/timelineReveal";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { KEYBINDS, isEditableElement, matchesKeybind } from "@/browser/utils/ui/keybinds";
-import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import { cn } from "@/common/lib/utils";
 import { capitalize } from "@/common/utils/capitalize";
 import { formatDuration } from "@/common/utils/formatDuration";
@@ -357,8 +357,6 @@ function CollapsedEventRun(props: {
   );
 }
 
-const MAX_REVEAL_HISTORY_PAGES = 10;
-
 type PreviewState =
   | { status: "loading" }
   | { status: "ready"; preview: TimelinePreview }
@@ -438,27 +436,6 @@ function TimelinePreviewCard(props: {
     return { messageId, toolCallId: currentAnchor.toolCallId };
   };
 
-  const isRevealTargetLoaded = (target: { messageId?: string; toolCallId?: string }) => {
-    const messages = workspaceStore.getWorkspaceState(props.workspaceId).messages;
-    if (target.toolCallId) {
-      return messages.some(
-        (message) => message.type === "tool" && message.toolCallId === target.toolCallId
-      );
-    }
-    return target.messageId
-      ? messages.some((message) => "historyId" in message && message.historyId === target.messageId)
-      : false;
-  };
-
-  const dispatchReveal = (target: { messageId?: string; toolCallId?: string }) => {
-    window.dispatchEvent(
-      createCustomEvent(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, {
-        workspaceId: props.workspaceId,
-        ...target,
-      })
-    );
-  };
-
   const handleReveal = async () => {
     if (!anchor || !hasTranscriptTarget || revealState === "revealing") {
       return;
@@ -468,55 +445,16 @@ function TimelinePreviewCard(props: {
     setRevealState("revealing");
 
     try {
-      let target = resolveRevealTarget(anchor);
-      if (isRevealTargetLoaded(target)) {
-        dispatchReveal(target);
-        setRevealState("idle");
+      const result = await revealTimelineTarget({
+        workspaceId: props.workspaceId,
+        getTarget: () => resolveRevealTarget(anchor),
+        workspaceStore,
+        pinTarget: pinTimelineRevealTarget,
+      });
+      if (operation !== revealOperationRef.current) {
         return;
       }
-
-      // Keep only a resolved reveal target outside the normal transcript window. A sequence-only
-      // anchor may need history paging before it has an ID, so do not reject it before that loop.
-      if (target.messageId != null || target.toolCallId != null) {
-        pinTimelineRevealTarget(props.workspaceId, target);
-      }
-      target = resolveRevealTarget(anchor);
-      if (isRevealTargetLoaded(target)) {
-        dispatchReveal(target);
-        setRevealState("idle");
-        return;
-      }
-
-      for (let page = 0; page < MAX_REVEAL_HISTORY_PAGES; page++) {
-        const workspaceState = workspaceStore.getWorkspaceState(props.workspaceId);
-        if (!workspaceState.hasOlderHistory) {
-          break;
-        }
-
-        const loadResult = await workspaceStore.loadOlderHistory(props.workspaceId);
-        if (operation !== revealOperationRef.current) {
-          return;
-        }
-        if (loadResult === "failed" || loadResult === "busy" || loadResult === "unavailable") {
-          setRevealState("error");
-          return;
-        }
-
-        target = resolveRevealTarget(anchor);
-        if (target.messageId != null || target.toolCallId != null) {
-          pinTimelineRevealTarget(props.workspaceId, target);
-        }
-        if (isRevealTargetLoaded(target)) {
-          dispatchReveal(target);
-          setRevealState("idle");
-          return;
-        }
-        if (loadResult === "exhausted") {
-          break;
-        }
-      }
-
-      setRevealState("not-found");
+      setRevealState(result === "revealed" ? "idle" : result);
     } catch {
       if (operation === revealOperationRef.current) {
         setRevealState("error");

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -48,6 +48,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   FOCUS_CHAT: "Focus chat input",
   CLOSE_TAB: "Close tab",
   REVEAL_TIMELINE_EVENT: "Reveal selected timeline event in transcript",
+  REVEAL_LAST_PROMPT: "Reveal last prompt in transcript",
   SIDEBAR_TAB_1: "Tab 1",
   SIDEBAR_TAB_2: "Tab 2",
   SIDEBAR_TAB_3: "Tab 3",
@@ -149,6 +150,7 @@ const KEYBIND_GROUPS: Array<{
       "RESUME_STREAM",
       "TOGGLE_VOICE_INPUT",
       "SHOW_LAST_PROMPT",
+      "REVEAL_LAST_PROMPT",
     ],
   },
   {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -132,8 +132,13 @@ export function mergeTimelineEvents(
   );
 }
 
+export interface WorkspaceLastUserPromptInfo {
+  text: string;
+  messageId: string;
+}
+
 interface WorkspaceLastUserPromptSnapshot {
-  displayed: string | null;
+  displayed: WorkspaceLastUserPromptInfo | null;
   historyEpoch: number;
   isCaughtUp: boolean;
 }
@@ -2586,7 +2591,7 @@ export class WorkspaceStore {
     return this.aggregators.get(workspaceId)?.getHistoryEpoch() ?? 0;
   }
 
-  getWorkspaceLastUserPrompt(workspaceId: string): string | null {
+  getWorkspaceLastUserPromptInfo(workspaceId: string): WorkspaceLastUserPromptInfo | null {
     const aggregator = this.aggregators.get(workspaceId);
     if (!aggregator) {
       return null;
@@ -2601,16 +2606,20 @@ export class WorkspaceStore {
       // Generated attachment markup is provider context, not part of the user's prompt.
       const trimmed = stripStagedAttachmentNotice(message.content).trim();
       if (trimmed.length > 0) {
-        return trimmed;
+        return { text: trimmed, messageId: message.historyId };
       }
     }
 
     return null;
   }
 
+  getWorkspaceLastUserPrompt(workspaceId: string): string | null {
+    return this.getWorkspaceLastUserPromptInfo(workspaceId)?.text ?? null;
+  }
+
   getWorkspaceLastUserPromptSnapshot(workspaceId: string): WorkspaceLastUserPromptSnapshot {
     return this.lastUserPromptStore.get(workspaceId, () => ({
-      displayed: this.getWorkspaceLastUserPrompt(workspaceId),
+      displayed: this.getWorkspaceLastUserPromptInfo(workspaceId),
       historyEpoch: this.getWorkspaceHistoryEpoch(workspaceId),
       isCaughtUp: this.isWorkspaceTranscriptCaughtUp(workspaceId),
     }));
@@ -2620,7 +2629,9 @@ export class WorkspaceStore {
     return this.lastUserPromptStore.subscribeKey(workspaceId, listener);
   }
 
-  async fetchLastUserPromptFromHistory(workspaceId: string): Promise<string | null> {
+  async fetchLastUserPromptFromHistory(
+    workspaceId: string
+  ): Promise<WorkspaceLastUserPromptInfo | null> {
     const client = this.client;
     if (!client) {
       return null;
@@ -4913,7 +4924,9 @@ export function useActiveGoalCount(): number {
   );
 }
 
-export function useWorkspaceLastUserPrompt(workspaceId: string): string | null {
+export function useWorkspaceLastUserPromptInfo(
+  workspaceId: string
+): WorkspaceLastUserPromptInfo | null {
   const store = getStoreInstance();
   const { displayed, historyEpoch, isCaughtUp } = useSyncExternalStore(
     (listener) => store.subscribeLastUserPrompt(workspaceId, listener),
@@ -4924,7 +4937,7 @@ export function useWorkspaceLastUserPrompt(workspaceId: string): string | null {
   const [fallback, setFallback] = useState<{
     workspaceId: string;
     historyEpoch: number;
-    prompt: string | null;
+    prompt: WorkspaceLastUserPromptInfo | null;
   } | null>(null);
 
   useEffect(() => {
@@ -4943,12 +4956,13 @@ export function useWorkspaceLastUserPrompt(workspaceId: string): string | null {
   }, [store, workspaceId, displayed, historyEpoch, isCaughtUp]);
 
   // Ignore fallback results from a superseded replay or deletion.
-  const fallbackPrompt =
-    fallback?.workspaceId === workspaceId && fallback.historyEpoch === historyEpoch
-      ? fallback.prompt
-      : null;
+  return fallback?.workspaceId === workspaceId && fallback.historyEpoch === historyEpoch
+    ? (displayed ?? fallback.prompt)
+    : displayed;
+}
 
-  return displayed ?? fallbackPrompt;
+export function useWorkspaceLastUserPrompt(workspaceId: string): string | null {
+  return useWorkspaceLastUserPromptInfo(workspaceId)?.text ?? null;
 }
 
 /**

--- a/src/browser/stores/useWorkspaceLastUserPrompt.test.tsx
+++ b/src/browser/stores/useWorkspaceLastUserPrompt.test.tsx
@@ -26,7 +26,9 @@ describe("useWorkspaceLastUserPrompt", () => {
     let snapshot = { displayed: null, historyEpoch: 1, isCaughtUp: caughtUp };
 
     spyOn(store, "getWorkspaceLastUserPromptSnapshot").mockImplementation(() => snapshot);
-    const fetchPrompt = mock(() => Promise.resolve("prompt from disk"));
+    const fetchPrompt = mock(() =>
+      Promise.resolve({ text: "prompt from disk", messageId: "prompt-from-disk" })
+    );
     spyOn(store, "fetchLastUserPromptFromHistory").mockImplementation(fetchPrompt);
 
     return {

--- a/src/browser/utils/timelineReveal.test.ts
+++ b/src/browser/utils/timelineReveal.test.ts
@@ -1,0 +1,131 @@
+import "../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { installDom } from "../../../tests/ui/dom";
+import type { DisplayedMessage } from "@/common/types/message";
+import { CUSTOM_EVENTS } from "@/common/constants/events";
+import { revealTimelineTarget, type TimelineRevealStore } from "./timelineReveal";
+
+const workspaceId = "timeline-reveal-test";
+
+function createStore(
+  options: {
+    messages?: DisplayedMessage[];
+    hasOlderHistory?: boolean;
+    loadOlderHistory?: () => Promise<"loaded" | "exhausted" | "busy" | "unavailable" | "failed">;
+  } = {}
+): TimelineRevealStore & {
+  state: { messages: DisplayedMessage[]; hasOlderHistory: boolean };
+} {
+  const state: { messages: DisplayedMessage[]; hasOlderHistory: boolean } = {
+    messages: options.messages ?? [],
+    hasOlderHistory: options.hasOlderHistory ?? false,
+  };
+  return {
+    state,
+    getWorkspaceState: () => ({
+      messages: state.messages,
+      muxMessages: [],
+      hasOlderHistory: state.hasOlderHistory,
+    }),
+    loadOlderHistory: options.loadOlderHistory ?? (() => Promise.resolve("exhausted")),
+  };
+}
+
+function makeUserMessage(historyId: string): DisplayedMessage {
+  return {
+    type: "user",
+    id: historyId,
+    historyId,
+    content: "prompt",
+    historySequence: 1,
+  };
+}
+
+describe("revealTimelineTarget", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  it("dispatches immediately for a loaded target", async () => {
+    const store = createStore({ messages: [makeUserMessage("prompt-1")] });
+    const pinTarget = mock(() => undefined);
+    const events: Event[] = [];
+    const listener = (event: Event) => events.push(event);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const result = await revealTimelineTarget({
+        workspaceId,
+        getTarget: () => ({ messageId: "prompt-1" }),
+        workspaceStore: store,
+        pinTarget,
+      });
+      expect(result).toBe("revealed");
+      expect(pinTarget).not.toHaveBeenCalled();
+      expect(events).toHaveLength(1);
+      expect((events[0] as CustomEvent).detail).toEqual({
+        workspaceId,
+        messageId: "prompt-1",
+      });
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
+  it("pins a target that becomes renderable without loading history", async () => {
+    const store = createStore();
+    const pinTarget = mock((_workspaceId: string, target: { messageId?: string }) => {
+      store.state.messages = [makeUserMessage(target.messageId ?? "")];
+    });
+    const listener = mock(() => undefined);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const result = await revealTimelineTarget({
+        workspaceId,
+        getTarget: () => ({ messageId: "prompt-2" }),
+        workspaceStore: store,
+        pinTarget,
+      });
+      expect(result).toBe("revealed");
+      expect(pinTarget).toHaveBeenCalledWith(workspaceId, { messageId: "prompt-2" });
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
+  it("loads older history before dispatching a target that is not yet loaded", async () => {
+    const store = createStore({ hasOlderHistory: true });
+    const loadOlderHistory = mock(() => {
+      store.state.messages = [makeUserMessage("prompt-3")];
+      store.state.hasOlderHistory = false;
+      return Promise.resolve("loaded" as const);
+    });
+    store.loadOlderHistory = loadOlderHistory;
+    const listener = mock(() => undefined);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const result = await revealTimelineTarget({
+        workspaceId,
+        getTarget: () => ({ messageId: "prompt-3" }),
+        workspaceStore: store,
+        pinTarget: mock(() => undefined),
+      });
+      expect(result).toBe("revealed");
+      expect(loadOlderHistory).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+});

--- a/src/browser/utils/timelineReveal.test.ts
+++ b/src/browser/utils/timelineReveal.test.ts
@@ -103,6 +103,43 @@ describe("revealTimelineTarget", () => {
     }
   });
 
+  it("does not dispatch a target after cancellation during history loading", async () => {
+    const store = createStore({ hasOlderHistory: true });
+    let resolveLoad: ((result: "loaded") => void) | undefined;
+    const loadOlderHistory = mock(
+      () =>
+        new Promise<"loaded">((resolve) => {
+          resolveLoad = resolve;
+        })
+    );
+    store.loadOlderHistory = loadOlderHistory;
+    const pinTarget = mock(() => undefined);
+    const listener = mock(() => undefined);
+    let cancelled = false;
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      const revealPromise = revealTimelineTarget({
+        workspaceId,
+        getTarget: () => ({ messageId: "prompt-cancelled" }),
+        workspaceStore: store,
+        pinTarget,
+        isCancelled: () => cancelled,
+      });
+      await Promise.resolve();
+      cancelled = true;
+      store.state.messages = [makeUserMessage("prompt-cancelled")];
+      store.state.hasOlderHistory = false;
+      resolveLoad?.("loaded");
+
+      const result = await revealPromise;
+      expect(result).toBe("cancelled");
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
   it("loads older history before dispatching a target that is not yet loaded", async () => {
     const store = createStore({ hasOlderHistory: true });
     const loadOlderHistory = mock(() => {

--- a/src/browser/utils/timelineReveal.ts
+++ b/src/browser/utils/timelineReveal.ts
@@ -10,7 +10,7 @@ export interface TimelineRevealStore {
   loadOlderHistory: (workspaceId: string) => Promise<HistoryLoadResult>;
 }
 
-export type TimelineRevealResult = "revealed" | "not-found" | "error";
+export type TimelineRevealResult = "revealed" | "not-found" | "error" | "cancelled";
 
 export interface TimelineRevealTarget {
   messageId?: string;
@@ -54,18 +54,35 @@ export async function revealTimelineTarget(options: {
   workspaceStore: TimelineRevealStore;
   pinTarget: (workspaceId: string, target: TimelineRevealTarget) => void;
   maxHistoryPages?: number;
+  isCancelled?: () => boolean;
 }): Promise<TimelineRevealResult> {
-  const { workspaceId, getTarget, workspaceStore, pinTarget } = options;
+  const { workspaceId, getTarget, workspaceStore, pinTarget, isCancelled } = options;
   const maxHistoryPages = options.maxHistoryPages ?? DEFAULT_MAX_REVEAL_HISTORY_PAGES;
+  const cancelled = () => isCancelled?.() === true;
 
   let target = getTarget();
   if (hasTimelineRevealTarget(target)) {
+    if (cancelled()) {
+      return "cancelled";
+    }
     if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+      if (cancelled()) {
+        return "cancelled";
+      }
       dispatchTimelineReveal(workspaceId, target);
       return "revealed";
     }
+    if (cancelled()) {
+      return "cancelled";
+    }
     pinTarget(workspaceId, target);
+    if (cancelled()) {
+      return "cancelled";
+    }
     if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+      if (cancelled()) {
+        return "cancelled";
+      }
       dispatchTimelineReveal(workspaceId, target);
       return "revealed";
     }
@@ -77,14 +94,26 @@ export async function revealTimelineTarget(options: {
     }
 
     const loadResult = await workspaceStore.loadOlderHistory(workspaceId);
+    if (cancelled()) {
+      return "cancelled";
+    }
     if (loadResult === "failed" || loadResult === "busy" || loadResult === "unavailable") {
       return "error";
     }
 
     target = getTarget();
     if (hasTimelineRevealTarget(target)) {
+      if (cancelled()) {
+        return "cancelled";
+      }
       pinTarget(workspaceId, target);
+      if (cancelled()) {
+        return "cancelled";
+      }
       if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+        if (cancelled()) {
+          return "cancelled";
+        }
         dispatchTimelineReveal(workspaceId, target);
         return "revealed";
       }

--- a/src/browser/utils/timelineReveal.ts
+++ b/src/browser/utils/timelineReveal.ts
@@ -1,0 +1,98 @@
+import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
+import type { HistoryLoadResult, WorkspaceState } from "@/browser/stores/WorkspaceStore";
+
+const DEFAULT_MAX_REVEAL_HISTORY_PAGES = 10;
+
+export interface TimelineRevealStore {
+  getWorkspaceState: (
+    workspaceId: string
+  ) => Pick<WorkspaceState, "messages" | "muxMessages" | "hasOlderHistory">;
+  loadOlderHistory: (workspaceId: string) => Promise<HistoryLoadResult>;
+}
+
+export type TimelineRevealResult = "revealed" | "not-found" | "error";
+
+export interface TimelineRevealTarget {
+  messageId?: string;
+  toolCallId?: string;
+}
+
+function hasTimelineRevealTarget(target: TimelineRevealTarget): boolean {
+  return target.messageId != null || target.toolCallId != null;
+}
+
+function isRevealTargetLoaded(
+  workspaceState: Pick<WorkspaceState, "messages">,
+  target: TimelineRevealTarget
+): boolean {
+  if (target.toolCallId) {
+    return workspaceState.messages.some(
+      (message) => message.type === "tool" && message.toolCallId === target.toolCallId
+    );
+  }
+
+  return target.messageId
+    ? workspaceState.messages.some(
+        (message) => "historyId" in message && message.historyId === target.messageId
+      )
+    : false;
+}
+
+function dispatchTimelineReveal(workspaceId: string, target: TimelineRevealTarget): void {
+  window.dispatchEvent(
+    createCustomEvent(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, {
+      workspaceId,
+      ...target,
+    })
+  );
+}
+
+/** Loads, pins, and reveals a timeline target in the transcript. */
+export async function revealTimelineTarget(options: {
+  workspaceId: string;
+  getTarget: () => TimelineRevealTarget;
+  workspaceStore: TimelineRevealStore;
+  pinTarget: (workspaceId: string, target: TimelineRevealTarget) => void;
+  maxHistoryPages?: number;
+}): Promise<TimelineRevealResult> {
+  const { workspaceId, getTarget, workspaceStore, pinTarget } = options;
+  const maxHistoryPages = options.maxHistoryPages ?? DEFAULT_MAX_REVEAL_HISTORY_PAGES;
+
+  let target = getTarget();
+  if (hasTimelineRevealTarget(target)) {
+    if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+      dispatchTimelineReveal(workspaceId, target);
+      return "revealed";
+    }
+    pinTarget(workspaceId, target);
+    if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+      dispatchTimelineReveal(workspaceId, target);
+      return "revealed";
+    }
+  }
+
+  for (let page = 0; page < maxHistoryPages; page++) {
+    if (!workspaceStore.getWorkspaceState(workspaceId).hasOlderHistory) {
+      break;
+    }
+
+    const loadResult = await workspaceStore.loadOlderHistory(workspaceId);
+    if (loadResult === "failed" || loadResult === "busy" || loadResult === "unavailable") {
+      return "error";
+    }
+
+    target = getTarget();
+    if (hasTimelineRevealTarget(target)) {
+      pinTarget(workspaceId, target);
+      if (isRevealTargetLoaded(workspaceStore.getWorkspaceState(workspaceId), target)) {
+        dispatchTimelineReveal(workspaceId, target);
+        return "revealed";
+      }
+    }
+    if (loadResult === "exhausted") {
+      break;
+    }
+  }
+
+  return "not-found";
+}

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -441,6 +441,9 @@ export const KEYBINDS = {
   /** Reveal the selected timeline event in the transcript */
   REVEAL_TIMELINE_EVENT: { key: "Enter", ctrl: true, shift: true },
 
+  /** Reveal the last prompt in the transcript while its popup is open */
+  REVEAL_LAST_PROMPT: { key: "Enter", ctrl: true, alt: true },
+
   /** Switch to tab by position in right sidebar (1-9) */
   // macOS: Cmd+N, Win/Linux: Ctrl+N
   // NOTE: Both Ctrl and Cmd work for switching tabs on Mac (macOS has no standard Cmd+number behavior)

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -1496,7 +1496,12 @@ export const workspace = {
     /** Searches full history, including prompts before the replay boundary. */
     lastUserPrompt: {
       input: z.object({ workspaceId: z.string() }),
-      output: z.string().nullable(),
+      output: z
+        .object({
+          text: z.string(),
+          messageId: z.string(),
+        })
+        .nullable(),
     },
   },
   /**

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -13670,7 +13670,8 @@ describe("WorkspaceService.getLastUserPrompt", () => {
     try {
       await seed(historyService, workspaceId);
       const workspaceService = createWorkspaceServiceForTest({ config, historyService });
-      return await workspaceService.getLastUserPrompt(workspaceId);
+      const result = await workspaceService.getLastUserPrompt(workspaceId);
+      return result?.text ?? null;
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -10017,13 +10017,15 @@ export class WorkspaceService extends EventEmitter {
   }
 
   /** Full history is required because compaction removes older prompts from replay. */
-  async getLastUserPrompt(workspaceId: string): Promise<string | null> {
+  async getLastUserPrompt(
+    workspaceId: string
+  ): Promise<{ text: string; messageId: string } | null> {
     assert(
       typeof workspaceId === "string" && workspaceId.trim().length > 0,
       "workspaceId is required"
     );
 
-    let found: string | null = null;
+    let found: { text: string; messageId: string } | null = null;
     const result = await this.historyService.iterateFullHistory(
       workspaceId,
       "backward",
@@ -10035,7 +10037,7 @@ export class WorkspaceService extends EventEmitter {
           }
           const text = extractUserPromptText(message);
           if (text.length > 0) {
-            found = text;
+            found = { text, messageId: message.id };
             return false;
           }
         }


### PR DESCRIPTION
## Summary

Add a button to the Last Prompt popup that reveals the prompt in the transcript.

## Background

The popup previously showed prompt text only. Users could not move from the popup to the prompt location.

## Implementation

- Return the prompt message ID with the last-prompt history result.
- Add a shared timeline reveal helper.
- Reuse the helper in the timeline and Last Prompt popup.
- Page older history when compaction hides the prompt.
- Close the popup after a successful reveal.

## Validation

- `make static-check`
- Focused Last Prompt and timeline reveal tests.
- Prompt history service tests.

## Risks

The change touches prompt history data and timeline reveal behavior. The shared helper keeps both reveal paths consistent.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `xhigh` • Cost: `$3.49`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=xhigh costs=3.49 -->
