### PR TITLE
🤖 feat: add analytics timezone mode

### DIFF
--- a/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
@@ -949,6 +949,51 @@ function AnalyticsDashboardStory() {
   );
 }
 
+export const StatsDashboardPhone: Story = {
+  render: () => <AnalyticsDashboardStory />,
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: {
+      matrix: { themes: ["dark", "light"], viewports: ["phone"] },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        data-testid="analytics-phone-container"
+        style={{ width: 390, height: 844, overflow: "hidden" }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const container = canvasElement.querySelector('[data-testid="analytics-phone-container"]');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error("Analytics phone story container not found");
+    }
+
+    await canvas.findByText("Total Spend");
+    await canvas.findByRole("button", { name: "Local" });
+    await canvas.findByRole("button", { name: "UTC" });
+    await canvas.findByRole("button", { name: "7D" });
+    await canvas.findByRole("button", { name: "All" });
+
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `Analytics header overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
+  },
+};
+
 export const StatsDashboard: Story = {
   render: () => <AnalyticsDashboardStory />,
   play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {

--- a/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.stories.tsx
@@ -19,7 +19,7 @@ import { NOW, createWorkspace, groupWorkspacesByProject } from "@/browser/storie
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import assert from "@/common/utils/assert";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { waitFor, within } from "@storybook/test";
+import { userEvent, waitFor, within } from "@storybook/test";
 import React from "react";
 import { AnalyticsDashboard } from "./AnalyticsDashboard.js";
 
@@ -55,6 +55,7 @@ interface StoryAnalyticsNamespace {
     granularity: "hour" | "day" | "week";
     from?: Date | null;
     to?: Date | null;
+    timeZone?: string | null;
   }) => Promise<SpendOverTimeItem[]>;
   getSpendByProject: (_input: Record<string, never>) => Promise<SpendByProjectItem[]>;
   getSpendByModel: (input: { projectPath?: string | null }) => Promise<SpendByModelItem[]>;
@@ -955,6 +956,24 @@ export const StatsDashboard: Story = {
 
     await canvas.findByText("Total Spend");
     await canvas.findByText("$184.73");
+
+    const localTimeButton = await canvas.findByRole("button", { name: "Local" });
+    const utcButton = await canvas.findByRole("button", { name: "UTC" });
+    if (localTimeButton.getAttribute("aria-pressed") !== "true") {
+      await userEvent.click(localTimeButton);
+      await waitFor(() => {
+        if (localTimeButton.getAttribute("aria-pressed") !== "true") {
+          throw new Error("Expected local timezone mode to become selected");
+        }
+      });
+    }
+
+    await userEvent.click(utcButton);
+    await waitFor(() => {
+      if (utcButton.getAttribute("aria-pressed") !== "true") {
+        throw new Error("Expected UTC timezone mode to become selected");
+      }
+    });
 
     await canvas.findByRole("heading", { name: /spend over time/i });
     await canvas.findByRole("heading", { name: /spend by project/i });

--- a/src/browser/features/Analytics/AnalyticsDashboard.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { DESKTOP_TITLEBAR_HEIGHT_CLASS, isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { isEditableElement, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import { ToggleGroup } from "@/browser/components/ToggleGroup/ToggleGroup";
 import { Button } from "@/browser/components/Button/Button";
 import { cn } from "@/common/lib/utils";
 import { AgentCostChart } from "./AgentCostChart";
@@ -39,12 +40,15 @@ interface AnalyticsDashboardProps {
 
 type TimeRange = "7d" | "30d" | "90d" | "all";
 type TimingMetric = "ttft" | "duration" | "tps";
+type TimeZoneMode = "local" | "utc";
 
 const VALID_TIME_RANGES = new Set<string>(["7d", "30d", "90d", "all"]);
 const VALID_TIMING_METRICS = new Set<string>(["ttft", "duration", "tps"]);
 
+const VALID_TIME_ZONE_MODES = new Set<string>(["local", "utc"]);
 const ANALYTICS_TIME_RANGE_STORAGE_KEY = "analytics:timeRange";
 const ANALYTICS_TIMING_METRIC_STORAGE_KEY = "analytics:timingMetric";
+const ANALYTICS_TIME_ZONE_MODE_STORAGE_KEY = "analytics:timeZoneMode";
 
 /** Coerce a persisted value to a known TimeRange, falling back to "30d" if stale/corrupted. */
 function normalizeTimeRange(value: unknown): TimeRange {
@@ -58,32 +62,69 @@ function normalizeTimingMetric(value: unknown): TimingMetric {
     : "duration";
 }
 
-/** Build a UTC-aligned date boundary N days before today. Using UTC avoids
- *  the backend's `toISOString().slice(0,10)` conversion silently shifting the
- *  day in positive-offset timezones. */
-function utcDaysAgo(days: number): Date {
-  const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - days));
+/** Build a calendar-date boundary for the selected timezone. */
+function getDateKeyInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const values = new Map(parts.map((part) => [part.type, part.value]));
+  const year = values.get("year");
+  const month = values.get("month");
+  const day = values.get("day");
+  if (year == null || month == null || day == null) {
+    throw new Error(`Unable to format date for timezone ${timeZone}`);
+  }
+
+  return `${year}-${month}-${day}`;
 }
 
-function computeDateRange(timeRange: TimeRange): {
+function dateFromDateKey(dateKey: string): Date {
+  const [year, month, day] = dateKey.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function daysAgoInTimeZone(days: number, timeZone: string): Date {
+  const dateKey = getDateKeyInTimeZone(new Date(), timeZone);
+  const date = dateFromDateKey(dateKey);
+  date.setUTCDate(date.getUTCDate() - days);
+  return date;
+}
+
+function computeDateRange(
+  timeRange: TimeRange,
+  timeZone: string
+): {
   from: Date | null;
   to: Date | null;
   granularity: "hour" | "day" | "week";
 } {
   switch (timeRange) {
     case "7d":
-      return { from: utcDaysAgo(6), to: null, granularity: "day" };
+      return { from: daysAgoInTimeZone(6, timeZone), to: null, granularity: "day" };
     case "30d":
-      return { from: utcDaysAgo(29), to: null, granularity: "day" };
+      return { from: daysAgoInTimeZone(29, timeZone), to: null, granularity: "day" };
     case "90d":
-      return { from: utcDaysAgo(89), to: null, granularity: "week" };
+      return { from: daysAgoInTimeZone(89, timeZone), to: null, granularity: "week" };
     case "all":
       return { from: null, to: null, granularity: "week" };
     default:
       // Self-heal: unknown persisted value → safe default.
-      return { from: utcDaysAgo(29), to: null, granularity: "day" };
+      return { from: daysAgoInTimeZone(29, timeZone), to: null, granularity: "day" };
   }
+}
+
+/** Coerce a persisted value to a supported timezone mode. */
+function normalizeTimeZoneMode(value: unknown): TimeZoneMode {
+  return typeof value === "string" && VALID_TIME_ZONE_MODES.has(value)
+    ? (value as TimeZoneMode)
+    : "local";
+}
+
+function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
 export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
@@ -99,13 +140,20 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
     ANALYTICS_TIMING_METRIC_STORAGE_KEY,
     "duration"
   );
+  const [rawTimeZoneMode, setTimeZoneMode] = usePersistedState<TimeZoneMode>(
+    ANALYTICS_TIME_ZONE_MODE_STORAGE_KEY,
+    "local"
+  );
 
   // Coerce persisted values to known enums — stale/corrupted localStorage
   // entries self-heal to defaults instead of crashing the dashboard.
   const timeRange = normalizeTimeRange(rawTimeRange);
   const timingMetric = normalizeTimingMetric(rawTimingMetric);
+  const timeZoneMode = normalizeTimeZoneMode(rawTimeZoneMode);
+  const timeZone = timeZoneMode === "utc" ? "UTC" : getBrowserTimeZone();
 
-  const dateRange = computeDateRange(timeRange);
+  const dateRange = computeDateRange(timeRange, "UTC");
+  const spendDateRange = computeDateRange(timeRange, timeZone);
   // SQL predicate substituted for the time-filter placeholder in saved panels
   // and the SQL explorer, so user-authored queries can opt into the header's
   // date-range selection.
@@ -117,9 +165,10 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
   });
   const spendOverTime = useAnalyticsSpendOverTime({
     projectPath,
-    granularity: dateRange.granularity,
-    from: dateRange.from,
-    to: dateRange.to,
+    granularity: spendDateRange.granularity,
+    from: spendDateRange.from,
+    to: spendDateRange.to,
+    timeZone,
   });
   const spendByProject = useAnalyticsSpendByProject({
     from: dateRange.from,
@@ -262,6 +311,18 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
             ))}
           </select>
 
+          <div className="flex shrink-0 items-center gap-1">
+            <span className="text-muted text-xs">Timezone</span>
+            <ToggleGroup
+              options={[
+                { value: "local", label: "Local" },
+                { value: "utc", label: "UTC" },
+              ]}
+              value={timeZoneMode}
+              onChange={setTimeZoneMode}
+            />
+          </div>
+
           <div className="border-border-medium bg-background ml-auto flex shrink-0 items-center gap-1 rounded-md border p-1">
             {(
               [
@@ -292,7 +353,8 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
             data={spendOverTime.data}
             loading={spendOverTime.loading}
             error={spendOverTime.error}
-            granularity={dateRange.granularity}
+            granularity={spendDateRange.granularity}
+            timeZoneMode={timeZoneMode}
           />
           <ModelBreakdown spendByProject={spendByProject} spendByModel={spendByModel} />
           <TokensByModelChart

--- a/src/browser/features/Analytics/SpendChart.tsx
+++ b/src/browser/features/Analytics/SpendChart.tsx
@@ -25,6 +25,7 @@ interface SpendChartProps {
   loading: boolean;
   error: string | null;
   granularity: "hour" | "day" | "week";
+  timeZoneMode: "local" | "utc";
 }
 
 interface SpendChartRow {
@@ -75,7 +76,8 @@ export function SpendChart(props: SpendChartProps) {
           ? "Model-attributed weekly spend."
           : props.granularity === "hour"
             ? "Model-attributed hourly spend."
-            : "Model-attributed daily spend."}
+            : "Model-attributed daily spend."}{" "}
+        ({props.timeZoneMode === "utc" ? "UTC" : "local time"})
       </p>
 
       {props.loading ? (

--- a/src/browser/features/Analytics/analyticsUtils.test.ts
+++ b/src/browser/features/Analytics/analyticsUtils.test.ts
@@ -12,6 +12,11 @@ describe("formatBucketLabel", () => {
     expect(result).toContain("23");
   });
 
+  test("keeps the hour in a localized hourly bucket", () => {
+    const result = formatBucketLabel("2026-02-23 14:00:00");
+    expect(result).toMatch(/Feb 23, 2:00 PM/);
+  });
+
   test("returns raw string for unparseable input", () => {
     expect(formatBucketLabel("not-a-date")).toBe("not-a-date");
   });

--- a/src/browser/features/Analytics/analyticsUtils.ts
+++ b/src/browser/features/Analytics/analyticsUtils.ts
@@ -53,25 +53,47 @@ const BUCKET_TIME_COMPONENT_PATTERN = /(?:^|[ T])\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)
 const BUCKET_DATE_TIME_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?/;
 
-function parseBucketWallTimeAsUtc(bucket: string): Date | null {
+function parseBucketWallTime(bucket: string): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+} | null {
   const match = BUCKET_DATE_TIME_PATTERN.exec(bucket);
   if (!match) {
     return null;
   }
 
-  const [, year, month, day, hour, minute, second = "0"] = match;
-  const parsedDate = new Date(
-    Date.UTC(
-      Number(year),
-      Number(month) - 1,
-      Number(day),
-      Number(hour),
-      Number(minute),
-      Number(second)
-    )
-  );
+  const [, year, month, day, hour, minute] = match;
+  return {
+    year: Number(year),
+    month: Number(month),
+    day: Number(day),
+    hour: Number(hour),
+    minute: Number(minute),
+  };
+}
 
-  return Number.isFinite(parsedDate.getTime()) ? parsedDate : null;
+function formatBucketWallTime(bucket: string): string | null {
+  const parts = parseBucketWallTime(bucket);
+  if (!parts) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  if (!Number.isFinite(date.getTime())) {
+    return null;
+  }
+
+  return (
+    date.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    }) +
+    `, ${parts.hour % 12 || 12}:${String(parts.minute).padStart(2, "0")} ${parts.hour >= 12 ? "PM" : "AM"}`
+  );
 }
 
 export function formatUsd(amount: number): string {
@@ -105,17 +127,13 @@ export function formatProjectDisplayName(projectPath: string): string {
 
 export function formatBucketLabel(bucket: string): string {
   const includesTime = BUCKET_TIME_COMPONENT_PATTERN.test(bucket);
-  const parsedDate = includesTime ? parseBucketWallTimeAsUtc(bucket) : new Date(bucket);
-  if (!parsedDate || !Number.isFinite(parsedDate.getTime())) {
-    return bucket;
+  if (includesTime) {
+    return formatBucketWallTime(bucket) ?? bucket;
   }
 
-  if (includesTime) {
-    return parsedDate.toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-    });
+  const parsedDate = new Date(bucket);
+  if (!Number.isFinite(parsedDate.getTime())) {
+    return bucket;
   }
 
   // Date-only buckets (YYYY-MM-DD) are UTC midnight. Render with
@@ -137,7 +155,7 @@ export function formatBucketTooltipLabel(
 ): string {
   if (granularity !== "week") return formatBucketLabel(bucket);
 
-  const start = parseBucketWallTimeAsUtc(bucket) ?? new Date(bucket);
+  const start = new Date(bucket);
   if (!Number.isFinite(start.getTime())) return bucket;
 
   const end = new Date(start);

--- a/src/browser/features/Analytics/analyticsUtils.ts
+++ b/src/browser/features/Analytics/analyticsUtils.ts
@@ -50,6 +50,29 @@ const compactNumberFormatter = new Intl.NumberFormat("en-US", {
 });
 
 const BUCKET_TIME_COMPONENT_PATTERN = /(?:^|[ T])\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?/;
+const BUCKET_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?/;
+
+function parseBucketWallTimeAsUtc(bucket: string): Date | null {
+  const match = BUCKET_DATE_TIME_PATTERN.exec(bucket);
+  if (!match) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute, second = "0"] = match;
+  const parsedDate = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second)
+    )
+  );
+
+  return Number.isFinite(parsedDate.getTime()) ? parsedDate : null;
+}
 
 export function formatUsd(amount: number): string {
   if (!Number.isFinite(amount)) {
@@ -81,12 +104,12 @@ export function formatProjectDisplayName(projectPath: string): string {
 }
 
 export function formatBucketLabel(bucket: string): string {
-  const parsedDate = new Date(bucket);
-  if (!Number.isFinite(parsedDate.getTime())) {
+  const includesTime = BUCKET_TIME_COMPONENT_PATTERN.test(bucket);
+  const parsedDate = includesTime ? parseBucketWallTimeAsUtc(bucket) : new Date(bucket);
+  if (!parsedDate || !Number.isFinite(parsedDate.getTime())) {
     return bucket;
   }
 
-  const includesTime = BUCKET_TIME_COMPONENT_PATTERN.test(bucket);
   if (includesTime) {
     return parsedDate.toLocaleString(undefined, {
       month: "short",
@@ -114,7 +137,7 @@ export function formatBucketTooltipLabel(
 ): string {
   if (granularity !== "week") return formatBucketLabel(bucket);
 
-  const start = new Date(bucket);
+  const start = parseBucketWallTimeAsUtc(bucket) ?? new Date(bucket);
   if (!Number.isFinite(start.getTime())) return bucket;
 
   const end = new Date(start);

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -23,6 +23,7 @@ let APIProvider!: typeof APIModule.APIProvider;
 let useAnalyticsProviderCacheHitRatio!: typeof UseAnalyticsModule.useAnalyticsProviderCacheHitRatio;
 let useAnalyticsRawQuery!: typeof UseAnalyticsModule.useAnalyticsRawQuery;
 let useAnalyticsSpendByModel!: typeof UseAnalyticsModule.useAnalyticsSpendByModel;
+let useAnalyticsSpendOverTime!: typeof UseAnalyticsModule.useAnalyticsSpendOverTime;
 let useAnalyticsSummary!: typeof UseAnalyticsModule.useAnalyticsSummary;
 let useSavedQueries!: typeof UseAnalyticsModule.useSavedQueries;
 let isolatedModulePaths: string[] = [];
@@ -56,12 +57,14 @@ async function importIsolatedAnalyticsModules() {
     useAnalyticsProviderCacheHitRatio,
     useAnalyticsRawQuery,
     useAnalyticsSpendByModel,
+    useAnalyticsSpendOverTime,
     useAnalyticsSummary,
     useSavedQueries,
   } = requireTestModule<{
     useAnalyticsProviderCacheHitRatio: typeof UseAnalyticsModule.useAnalyticsProviderCacheHitRatio;
     useAnalyticsRawQuery: typeof UseAnalyticsModule.useAnalyticsRawQuery;
     useAnalyticsSpendByModel: typeof UseAnalyticsModule.useAnalyticsSpendByModel;
+    useAnalyticsSpendOverTime: typeof UseAnalyticsModule.useAnalyticsSpendOverTime;
     useAnalyticsSummary: typeof UseAnalyticsModule.useAnalyticsSummary;
     useSavedQueries: typeof UseAnalyticsModule.useSavedQueries;
   }>(isolatedHookPath));
@@ -125,6 +128,13 @@ interface AnalyticsServiceCalls {
     projectPath: string | null;
     from: Date | null | undefined;
     to: Date | null | undefined;
+  }>;
+  spendOverTime: Array<{
+    projectPath: string | null;
+    granularity: "hour" | "day" | "week";
+    from: Date | null | undefined;
+    to: Date | null | undefined;
+    timeZone: string | null | undefined;
   }>;
 }
 
@@ -229,6 +239,7 @@ function createAnalyticsServiceStub(summary: Summary): {
     summary: [],
     spendByModel: [],
     cacheHitRatioByProvider: [],
+    spendOverTime: [],
   };
 
   return {
@@ -238,7 +249,16 @@ function createAnalyticsServiceStub(summary: Summary): {
         calls.summary.push({ projectPath, from, to });
         return Promise.resolve(summary);
       },
-      getSpendOverTime: () => Promise.resolve([]),
+      getSpendOverTime: (input) => {
+        calls.spendOverTime.push({
+          projectPath: input.projectPath ?? null,
+          granularity: input.granularity,
+          from: input.from,
+          to: input.to,
+          timeZone: input.timeZone,
+        });
+        return Promise.resolve([]);
+      },
       getSpendByProject: () => Promise.resolve([]),
       getSpendByModel: (projectPath, from, to) => {
         calls.spendByModel.push({ projectPath, from, to });
@@ -355,6 +375,35 @@ describe("useAnalytics hooks", () => {
     expect(latest.projectPath).toBe("/tmp/project");
     expect(latest.from.toISOString()).toBe(from.toISOString());
     expect(latest.to.toISOString()).toBe(to.toISOString());
+  });
+
+  test("forwards the selected timezone to spend-over-time endpoint", async () => {
+    const from = new Date("2026-01-07T00:00:00.000Z");
+    const to = new Date("2026-01-27T00:00:00.000Z");
+
+    const { result } = renderAnalyticsHook(() =>
+      useAnalyticsSpendOverTime({
+        projectPath: "/tmp/project",
+        granularity: "day",
+        from,
+        to,
+        timeZone: "America/New_York",
+      })
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const calls = requireAnalyticsServiceCalls().spendOverTime;
+    expect(calls.length).toBeGreaterThan(0);
+
+    const latest = calls.at(-1);
+    expect(latest).toEqual({
+      projectPath: "/tmp/project",
+      granularity: "day",
+      from,
+      to,
+      timeZone: "America/New_York",
+    });
   });
 
   test("forwards from/to filters to spend-by-model endpoint", async () => {

--- a/src/browser/hooks/useAnalytics.ts
+++ b/src/browser/hooks/useAnalytics.ts
@@ -180,6 +180,7 @@ export function useAnalyticsSpendOverTime(params: {
   granularity: "hour" | "day" | "week";
   from?: Date | null;
   to?: Date | null;
+  timeZone?: string | null;
 }): AsyncState<SpendOverTimeItem[]> {
   assert(
     params.granularity === "hour" || params.granularity === "day" || params.granularity === "week",
@@ -205,9 +206,10 @@ export function useAnalyticsSpendOverTime(params: {
         granularity: params.granularity,
         from: fromDate,
         to: toDate,
+        timeZone: params.timeZone ?? null,
       })
     );
-  }, [api, params.projectPath, params.granularity, fromMs, toMs]);
+  }, [api, params.projectPath, params.granularity, params.timeZone, fromMs, toMs]);
 
   return state;
 }

--- a/src/common/orpc/schemas/analytics.ts
+++ b/src/common/orpc/schemas/analytics.ts
@@ -189,6 +189,7 @@ export const analytics = {
       granularity: z.enum(["hour", "day", "week"]),
       from: z.coerce.date().nullish(),
       to: z.coerce.date().nullish(),
+      timeZone: z.string().nullish(),
     }),
     output: z.array(
       z.object({

--- a/src/node/services/analytics/analyticsService.ts
+++ b/src/node/services/analytics/analyticsService.ts
@@ -634,12 +634,14 @@ export class AnalyticsService {
     projectPath?: string | null;
     from?: Date | null;
     to?: Date | null;
+    timeZone?: string | null;
   }): Promise<Array<{ bucket: string; model: string; costUsd: number }>> {
     const rows = await this.executeQuery<SpendOverTimeRow[]>("getSpendOverTime", {
       granularity: params.granularity,
       projectPath: params.projectPath ?? null,
       from: toDateFilterString(params.from),
       to: toDateFilterString(params.to),
+      timeZone: params.timeZone ?? "UTC",
     });
 
     return rows.map((row) => ({

--- a/src/node/services/analytics/queries.test.ts
+++ b/src/node/services/analytics/queries.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import {
   HistogramBucketSchema,
   SpendByModelRowSchema,
+  SpendOverTimeRowSchema,
   SummaryRowSchema,
   TimingPercentilesRowSchema,
   TokensByModelRowSchema,
@@ -17,7 +18,7 @@ const duckDbHandlesToClose: Array<{ instance: DuckDBInstance; conn: DuckDBConnec
 interface EventSeed {
   workspaceId: string;
   date: string;
-  timestamp: number;
+  timestamp: number | bigint;
   model: string;
   toolName?: string | null;
   inputTokens: number;
@@ -211,5 +212,78 @@ describe("analytics queries", () => {
     }, 0);
     assert(Number.isInteger(histogramCount), "histogramCount should remain integral");
     expect(histogramCount).toBe(2);
+  });
+});
+
+describe("spend over time timezone buckets", () => {
+  test("uses the selected timezone for daily buckets and date filters", async () => {
+    const conn = await createTestConn();
+    const workspaceId = "ws-timezone-boundary";
+
+    await insertEvent(conn, {
+      workspaceId,
+      date: "2026-08-12",
+      timestamp: BigInt(Date.parse("2026-08-12T03:30:00.000Z")),
+      model: "openai:gpt-4",
+      inputTokens: 1,
+      outputTokens: 1,
+      totalCostUsd: 100,
+    });
+    await insertEvent(conn, {
+      workspaceId,
+      date: "2026-08-12",
+      timestamp: BigInt(Date.parse("2026-08-12T05:30:00.000Z")),
+      model: "openai:gpt-4",
+      inputTokens: 1,
+      outputTokens: 1,
+      totalCostUsd: 200,
+    });
+
+    const rows = z.array(SpendOverTimeRowSchema).parse(
+      await executeNamedQuery(conn, "getSpendOverTime", {
+        granularity: "day",
+        from: "2026-08-11",
+        to: "2026-08-11",
+        timeZone: "America/New_York",
+      })
+    );
+
+    expect(rows).toEqual([
+      {
+        bucket: "2026-08-11",
+        model: "openai:gpt-4",
+        cost_usd: 100,
+      },
+    ]);
+  });
+
+  test("uses UTC when the timezone is omitted", async () => {
+    const conn = await createTestConn();
+    const workspaceId = "ws-timezone-default";
+
+    await insertEvent(conn, {
+      workspaceId,
+      date: "2026-08-12",
+      timestamp: BigInt(Date.parse("2026-08-12T03:30:00.000Z")),
+      model: "openai:gpt-4",
+      inputTokens: 1,
+      outputTokens: 1,
+      totalCostUsd: 100,
+    });
+
+    const rows = z.array(SpendOverTimeRowSchema).parse(
+      await executeNamedQuery(conn, "getSpendOverTime", {
+        granularity: "day",
+        timeZone: "UTC",
+      })
+    );
+
+    expect(rows).toEqual([
+      {
+        bucket: "2026-08-12",
+        model: "openai:gpt-4",
+        cost_usd: 100,
+      },
+    ]);
   });
 });

--- a/src/node/services/analytics/queries.ts
+++ b/src/node/services/analytics/queries.ts
@@ -136,6 +136,24 @@ function parseGranularity(value: unknown): Granularity {
   return value;
 }
 
+function parseTimeZone(value: unknown): string {
+  if (value == null) {
+    return "UTC";
+  }
+
+  assert(typeof value === "string", "Analytics timeZone must be a string");
+  const timeZone = value.trim();
+  assert(timeZone.length > 0, "Analytics timeZone must not be empty");
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format();
+  } catch {
+    throw new Error(`Invalid analytics timeZone: ${timeZone}`);
+  }
+
+  return timeZone;
+}
+
 function parseTimingMetric(value: unknown): TimingMetric {
   assert(
     value === "ttft" || value === "duration" || value === "tps",
@@ -205,35 +223,60 @@ async function querySpendOverTime(
     projectPath: string | null;
     from: string | null;
     to: string | null;
+    timeZone: string;
   }
 ): Promise<SpendOverTimeRow[]> {
   const bucketExpression: Record<Granularity, string> = {
-    hour: "DATE_TRUNC('hour', to_timestamp(timestamp / 1000.0))",
-    day: "DATE_TRUNC('day', date)",
-    week: "DATE_TRUNC('week', date)",
+    hour: "DATE_TRUNC('hour', localized_timestamp)",
+    day: "CAST(calendar_date AS DATE)",
+    week: "CAST(DATE_TRUNC('week', calendar_date) AS DATE)",
   };
 
   const bucketExpr = bucketExpression[params.granularity];
   const bucketNullFilter =
-    params.granularity === "hour" ? "AND timestamp IS NOT NULL" : "AND date IS NOT NULL";
+    params.granularity === "hour"
+      ? "AND localized_timestamp IS NOT NULL"
+      : "AND calendar_date IS NOT NULL";
 
   return typedQuery(
     conn,
     `
+    WITH event_times AS (
+      SELECT
+        events.*,
+        CASE
+          WHEN timestamp IS NOT NULL THEN timezone(?, to_timestamp(timestamp / 1000.0))
+          ELSE NULL
+        END AS localized_timestamp
+      FROM events
+    ), localized_events AS (
+      SELECT
+        event_times.*,
+        COALESCE(CAST(localized_timestamp AS DATE), date) AS calendar_date
+      FROM event_times
+    )
     SELECT
       CAST(${bucketExpr} AS VARCHAR) AS bucket,
       COALESCE(model, 'unknown') AS model,
       COALESCE(SUM(total_cost_usd), 0) AS cost_usd
-    FROM events
+    FROM localized_events
     WHERE
       (? IS NULL OR project_path = ?)
-      AND (? IS NULL OR date >= CAST(? AS DATE))
-      AND (? IS NULL OR date <= CAST(? AS DATE))
+      AND (? IS NULL OR calendar_date >= CAST(? AS DATE))
+      AND (? IS NULL OR calendar_date <= CAST(? AS DATE))
       ${bucketNullFilter}
     GROUP BY 1, 2
     ORDER BY 1 ASC, 2 ASC
     `,
-    [params.projectPath, params.projectPath, params.from, params.from, params.to, params.to],
+    [
+      params.timeZone,
+      params.projectPath,
+      params.projectPath,
+      params.from,
+      params.from,
+      params.to,
+      params.to,
+    ],
     SpendOverTimeRowSchema
   );
 }
@@ -588,6 +631,7 @@ export async function executeNamedQuery(
         projectPath: parseOptionalString(params.projectPath),
         from: parseDateFilter(params.from),
         to: parseDateFilter(params.to),
+        timeZone: parseTimeZone(params.timeZone),
       });
     }
 


### PR DESCRIPTION
## Summary

Add a Local or UTC timezone mode to the Spend over time graph.

## Background

The graph grouped daily spend by UTC dates. This caused late-evening local spend to appear on the next local day.

## Implementation

- Add a persisted Local or UTC toggle.
- Detect the browser IANA timezone in Local mode.
- Pass the selected timezone through the analytics API.
- Apply the timezone to hourly, daily, and weekly buckets.
- Apply the timezone to graph date filters.
- Keep UTC as the default backend fallback.
- Show the active timezone mode below the graph.

## Validation

- Add timezone boundary tests for New York and UTC.
- Add analytics hook forwarding tests.
- Add Storybook interaction coverage for the toggle.
- Run `make static-check`.
- Run focused analytics tests.

## Risks

The change affects only the Spend over time graph query and its date range. Other analytics cards keep their current UTC date behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `xhigh` • Cost: `$2.97`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=xhigh costs=2.97 -->
