### PR TITLE
🤖 feat: stack-aware PR indicator with gh-stack dropdown

### DIFF
--- a/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
+++ b/src/browser/components/ChatPane/WorkspaceFooterBar.tsx
@@ -410,6 +410,7 @@ export const WorkspaceFooterBar: React.FC<WorkspaceFooterBarProps> = (props) => 
         <WorkspaceLinks
           workspaceId={props.workspaceId}
           className="[@media(max-width:768px)]:hidden"
+          menuDirection="up"
         />
         {hasRepository && (
           <>

--- a/src/browser/components/PRStackBadge/PRStackBadge.stories.tsx
+++ b/src/browser/components/PRStackBadge/PRStackBadge.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "@storybook/test";
+
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import type { WorkspaceStackInfo } from "@/common/types/links";
+import { PRStackBadge } from "./PRStackBadge";
+
+const STACK: WorkspaceStackInfo = {
+  trunk: "main",
+  branches: [
+    {
+      branch: "mike/stack-foundation",
+      isCurrent: false,
+      needsRebase: false,
+      pr: {
+        number: 28051,
+        url: "https://github.com/coder/mux/pull/28051",
+        state: "MERGED",
+        title: "feat: add the stack foundation",
+      },
+    },
+    {
+      branch: "mike/stack-store",
+      isCurrent: false,
+      needsRebase: false,
+      pr: {
+        number: 28052,
+        url: "https://github.com/coder/mux/pull/28052",
+        state: "OPEN",
+        title: "feat: cache stack metadata for visible workspaces",
+      },
+    },
+    {
+      branch: "mike/stack-menu",
+      isCurrent: true,
+      needsRebase: false,
+      pr: {
+        number: 28053,
+        url: "https://github.com/coder/mux/pull/28053",
+        state: "OPEN",
+        title: "feat: add a pull request stack dropdown with long titles",
+        isDraft: true,
+      },
+    },
+    {
+      branch: "mike/stack-responsive",
+      isCurrent: false,
+      needsRebase: true,
+      pr: {
+        number: 28054,
+        url: "https://github.com/coder/mux/pull/28054",
+        state: "OPEN",
+        title: "fix: keep the stack menu inside narrow viewports",
+      },
+    },
+    {
+      branch: "mike/stack-submit",
+      isCurrent: false,
+      needsRebase: false,
+    },
+    {
+      branch: "mike/stack-queue",
+      isCurrent: false,
+      needsRebase: false,
+      pr: {
+        number: 28056,
+        url: "https://github.com/coder/mux/pull/28056",
+        state: "QUEUED",
+        title: "feat: finish stack awareness",
+      },
+    },
+  ],
+};
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Header/PRStackBadge",
+  component: PRStackBadge,
+} satisfies Meta<typeof PRStackBadge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+async function openStackMenu(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(canvas.getByRole("button", { name: "View stack with 6 branches" }));
+}
+
+export const SixLayerStack: Story = {
+  args: {
+    stack: STACK,
+    menuDirection: "down",
+  },
+  render: (args) => (
+    <div className="bg-background min-h-96 p-6">
+      <div className="flex justify-end">
+        <PRStackBadge {...args} />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => openStackMenu(canvasElement),
+};
+
+export const PhoneWidth: Story = {
+  args: {
+    stack: STACK,
+    menuDirection: "down",
+  },
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: {
+      matrix: { viewports: ["phone"] },
+    },
+  },
+  render: (args) => (
+    <div className="bg-background min-h-96 w-full p-2">
+      <div className="flex justify-end">
+        <PRStackBadge {...args} />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => openStackMenu(canvasElement),
+};

--- a/src/browser/components/PRStackBadge/PRStackBadge.test.tsx
+++ b/src/browser/components/PRStackBadge/PRStackBadge.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { installDom } from "../../../../tests/ui/dom";
+import type { WorkspaceStackInfo } from "@/common/types/links";
+import { PRStackBadge } from "./PRStackBadge";
+
+const STACK: WorkspaceStackInfo = {
+  trunk: "main",
+  branches: [
+    {
+      branch: "mike/feat-a",
+      isCurrent: false,
+      needsRebase: false,
+      pr: {
+        number: 101,
+        url: "https://github.com/coder/mux/pull/101",
+        state: "MERGED",
+        title: "First layer",
+      },
+    },
+    {
+      branch: "mike/feat-b",
+      isCurrent: true,
+      needsRebase: false,
+    },
+    {
+      branch: "mike/feat-c",
+      isCurrent: false,
+      needsRebase: true,
+      pr: {
+        number: 103,
+        url: "https://github.com/coder/mux/pull/103",
+        state: "OPEN",
+        title: "Top layer",
+      },
+    },
+  ],
+};
+
+let cleanupDom: (() => void) | null = null;
+
+describe("PRStackBadge", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  it("opens a top-first stack menu with links and trunk last", () => {
+    const view = render(<PRStackBadge stack={STACK} />);
+    const trigger = view.getByRole("button", { name: "View stack with 3 branches" });
+
+    expect(trigger.textContent).toContain("3");
+    fireEvent.click(trigger);
+
+    const rows = view.getAllByTestId("stack-branch-row");
+    expect(rows.map((row) => row.getAttribute("data-branch"))).toEqual([
+      "mike/feat-c",
+      "mike/feat-b",
+      "mike/feat-a",
+    ]);
+    expect(rows[0].getAttribute("href")).toBe("https://github.com/coder/mux/pull/103");
+    expect(rows[1].tagName).toBe("DIV");
+    expect(rows[1].getAttribute("aria-current")).toBe("true");
+    expect(rows[2].getAttribute("href")).toBe("https://github.com/coder/mux/pull/101");
+
+    const menuItems = view.getAllByRole("menuitem");
+    expect(menuItems[menuItems.length - 1]).toBe(view.getByTestId("stack-trunk-row"));
+    expect(view.getByTestId("stack-trunk-row").textContent).toContain("main");
+  });
+
+  it("positions the menu from the trigger without leaving a narrow viewport", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 375 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 800 });
+
+    const downView = render(<PRStackBadge stack={STACK} menuDirection="down" />);
+    const downTrigger = downView.getByRole("button", { name: "View stack with 3 branches" });
+    if (!downTrigger.parentElement) {
+      throw new Error("Stack trigger container not found");
+    }
+    const downRect: DOMRect = {
+      x: 340,
+      y: 20,
+      left: 340,
+      right: 370,
+      top: 20,
+      bottom: 44,
+      width: 30,
+      height: 24,
+      toJSON: () => ({}),
+    };
+    downTrigger.parentElement.getBoundingClientRect = () => downRect;
+
+    fireEvent.click(downTrigger);
+    const downMenu = downView.getByRole("menu");
+    expect(downMenu.style.left).toBe("79px");
+    expect(downMenu.style.width).toBe("288px");
+    expect(downMenu.style.top).toBe("48px");
+    downView.unmount();
+
+    const upView = render(<PRStackBadge stack={STACK} menuDirection="up" />);
+    const upTrigger = upView.getByRole("button", { name: "View stack with 3 branches" });
+    if (!upTrigger.parentElement) {
+      throw new Error("Stack trigger container not found");
+    }
+    const upRect: DOMRect = {
+      x: 20,
+      y: 740,
+      left: 20,
+      right: 100,
+      top: 740,
+      bottom: 764,
+      width: 80,
+      height: 24,
+      toJSON: () => ({}),
+    };
+    upTrigger.parentElement.getBoundingClientRect = () => upRect;
+
+    fireEvent.click(upTrigger);
+    const upMenu = upView.getByRole("menu");
+    expect(upMenu.style.left).toBe("8px");
+    expect(upMenu.style.bottom).toBe("64px");
+  });
+
+  it("closes on Escape and outside click", () => {
+    const view = render(<PRStackBadge stack={STACK} />);
+    const trigger = view.getByRole("button", { name: "View stack with 3 branches" });
+
+    fireEvent.click(trigger);
+    fireEvent.keyDown(trigger, { key: "Escape" });
+    expect(view.queryByRole("menu")).toBeNull();
+
+    fireEvent.click(trigger);
+    expect(view.queryByRole("menu")).not.toBeNull();
+    fireEvent.mouseDown(document.body);
+    expect(view.queryByRole("menu")).toBeNull();
+  });
+});

--- a/src/browser/components/PRStackBadge/PRStackBadge.tsx
+++ b/src/browser/components/PRStackBadge/PRStackBadge.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  AlertCircle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  GitBranch,
+  GitPullRequest,
+  Layers,
+  Rocket,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Button } from "@/browser/components/Button/Button";
+import { stopKeyboardPropagation } from "@/browser/utils/events";
+import { cn } from "@/common/lib/utils";
+import type { WorkspaceStackBranch, WorkspaceStackInfo } from "@/common/types/links";
+
+export interface PRStackBadgeProps {
+  stack: WorkspaceStackInfo;
+  menuDirection?: "up" | "down";
+  className?: string;
+}
+
+interface BranchStatusDisplay {
+  Icon: LucideIcon;
+  colorClass: string;
+  label: string;
+}
+
+function getBranchStatusDisplay(branch: WorkspaceStackBranch): BranchStatusDisplay {
+  if (!branch.pr) {
+    return { Icon: GitBranch, colorClass: "text-muted", label: "No pull request" };
+  }
+  if (branch.pr.state === "MERGED") {
+    return { Icon: Check, colorClass: "text-purple-500", label: "Merged" };
+  }
+  if (branch.pr.state === "CLOSED") {
+    return { Icon: X, colorClass: "text-danger-soft", label: "Closed" };
+  }
+  if (branch.pr.isDraft) {
+    return { Icon: GitPullRequest, colorClass: "text-muted", label: "Draft" };
+  }
+  if (branch.pr.state === "QUEUED") {
+    return { Icon: Rocket, colorClass: "text-warning", label: "Queued" };
+  }
+  if (branch.needsRebase) {
+    return { Icon: AlertCircle, colorClass: "text-warning", label: "Needs rebase" };
+  }
+  return { Icon: GitPullRequest, colorClass: "text-success", label: "Open" };
+}
+
+function StackBranchRow(props: { branch: WorkspaceStackBranch; onNavigate: () => void }) {
+  const display = getBranchStatusDisplay(props.branch);
+  const content = (
+    <>
+      <span className={cn("mt-0.5 shrink-0", display.colorClass)} aria-label={display.label}>
+        <display.Icon className="h-3.5 w-3.5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-xs font-medium">
+          {props.branch.pr?.title ?? props.branch.branch}
+        </span>
+        <span className="text-muted block truncate text-[10px]">
+          {props.branch.pr ? `#${props.branch.pr.number} · ` : ""}
+          {props.branch.branch}
+        </span>
+      </span>
+    </>
+  );
+  const className = cn(
+    "flex min-w-0 items-start gap-2 px-3 py-2 text-left",
+    props.branch.isCurrent && "bg-hover",
+    props.branch.pr?.url && "hover:bg-hover focus-visible:bg-hover focus-visible:outline-none"
+  );
+
+  if (props.branch.pr?.url) {
+    return (
+      <a
+        href={props.branch.pr.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        role="menuitem"
+        data-testid="stack-branch-row"
+        data-branch={props.branch.branch}
+        aria-current={props.branch.isCurrent ? "true" : undefined}
+        className={className}
+        onClick={props.onNavigate}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div
+      role="menuitem"
+      aria-disabled="true"
+      data-testid="stack-branch-row"
+      data-branch={props.branch.branch}
+      aria-current={props.branch.isCurrent ? "true" : undefined}
+      className={cn(className, "text-muted")}
+    >
+      {content}
+    </div>
+  );
+}
+
+export function PRStackBadge(props: PRStackBadgeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<CSSProperties>();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const menuDirection = props.menuDirection ?? "down";
+
+  const toggleMenu = () => {
+    if (isOpen) {
+      setIsOpen(false);
+      return;
+    }
+
+    const trigger = containerRef.current?.getBoundingClientRect();
+    if (!trigger) {
+      return;
+    }
+
+    const viewportMargin = 8;
+    const menuWidth = Math.min(288, window.innerWidth - viewportMargin * 2);
+    const left = Math.min(
+      Math.max(trigger.right - menuWidth, viewportMargin),
+      window.innerWidth - menuWidth - viewportMargin
+    );
+    setMenuStyle({
+      left,
+      width: menuWidth,
+      ...(menuDirection === "up"
+        ? { bottom: window.innerHeight - trigger.top + 4 }
+        : { top: trigger.bottom + 4 }),
+    });
+    setIsOpen(true);
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("relative shrink-0", props.className)}
+      onKeyDown={(event) => {
+        if (event.key === "Escape" && isOpen) {
+          event.preventDefault();
+          stopKeyboardPropagation(event);
+          setIsOpen(false);
+        }
+      }}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="text-muted h-6 shrink-0 gap-1 px-2 text-xs font-medium"
+        aria-label={`View stack with ${props.stack.branches.length} branches`}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        onClick={toggleMenu}
+      >
+        <Layers className="h-3 w-3" />
+        <span className="counter-nums">{props.stack.branches.length}</span>
+        {isOpen ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+      </Button>
+
+      {isOpen && (
+        <div
+          role="menu"
+          aria-label="Pull request stack"
+          className="bg-surface-primary border-border-light fixed z-[1020] max-w-[calc(100vw-1rem)] overflow-hidden rounded-md border shadow-lg"
+          style={menuStyle}
+        >
+          <div className="max-h-80 overflow-y-auto py-1">
+            {[...props.stack.branches].reverse().map((branch) => (
+              <StackBranchRow
+                key={branch.branch}
+                branch={branch}
+                onNavigate={() => setIsOpen(false)}
+              />
+            ))}
+            <div
+              role="menuitem"
+              aria-disabled="true"
+              data-testid="stack-trunk-row"
+              className="text-muted border-border-light flex items-center gap-2 border-t px-3 py-2 text-xs"
+            >
+              <GitBranch className="h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0 truncate">{props.stack.trunk}</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
+++ b/src/browser/components/WorkspaceLinks/WorkspaceLinks.tsx
@@ -1,20 +1,32 @@
-/** The PR is detected from the workspace's current branch via `gh pr view`. */
-
-import { useWorkspacePR } from "@/browser/stores/PRStatusStore";
+import { useWorkspacePR, useWorkspaceStack } from "@/browser/stores/PRStatusStore";
 import { PRLinkBadge } from "../PRLinkBadge/PRLinkBadge";
+import { PRStackBadge } from "../PRStackBadge/PRStackBadge";
 
 interface WorkspaceLinksProps {
   workspaceId: string;
-  /** Applied to the badge itself so callers can hide it without leaving an empty flex item. */
+  /** Applied to each badge so callers can hide them without leaving empty flex items. */
   className?: string;
+  menuDirection?: "up" | "down";
 }
 
-export function WorkspaceLinks({ workspaceId, className }: WorkspaceLinksProps) {
-  const workspacePR = useWorkspacePR(workspaceId);
+export function WorkspaceLinks(props: WorkspaceLinksProps) {
+  const workspacePR = useWorkspacePR(props.workspaceId);
+  const workspaceStack = useWorkspaceStack(props.workspaceId);
 
-  if (!workspacePR) {
+  if (!workspacePR && !workspaceStack) {
     return null;
   }
 
-  return <PRLinkBadge prLink={workspacePR} className={className} />;
+  return (
+    <>
+      {workspacePR && <PRLinkBadge prLink={workspacePR} className={props.className} />}
+      {workspaceStack && (
+        <PRStackBadge
+          stack={workspaceStack}
+          className={props.className}
+          menuDirection={props.menuDirection}
+        />
+      )}
+    </>
+  );
 }

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -557,10 +557,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
         </Popover>
       </div>
       <div className={cn("flex items-center gap-2", isDesktop && "titlebar-no-drag")}>
-        {/* The footer info bar hides its PR badge at this width, so the header carries it there. */}
+        {/* The footer hides these links at this width, so the header carries them. */}
         <WorkspaceLinks
           workspaceId={workspaceId}
           className="hidden [@media(max-width:768px)]:inline-flex"
+          menuDirection="down"
         />
         <Popover open={notificationPopoverOpen} onOpenChange={setNotificationPopoverOpen}>
           <Tooltip {...(notificationPopoverOpen ? { open: false } : {})}>

--- a/src/browser/stores/PRStatusStore.stack.test.ts
+++ b/src/browser/stores/PRStatusStore.stack.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+
+import type { WorkspaceStackInfo } from "@/common/types/links";
+import { mergeStackPullRequestMetadata, parseStackViewOutput } from "./PRStatusStore";
+
+const STACK_VIEW_FIXTURE = JSON.stringify({
+  trunk: "main",
+  currentBranch: "mike/feat-b",
+  branches: [
+    {
+      name: "mike/feat-a",
+      head: "aaa",
+      base: "main",
+      isCurrent: false,
+      isMerged: false,
+      isQueued: false,
+      needsRebase: false,
+      pr: {
+        number: 101,
+        url: "https://github.com/coder/mux/pull/101",
+        state: "OPEN",
+      },
+    },
+    {
+      name: "mike/feat-b",
+      head: "bbb",
+      base: "mike/feat-a",
+      isCurrent: true,
+      isMerged: false,
+      isQueued: true,
+      needsRebase: true,
+      pr: {
+        number: 102,
+        url: "https://github.com/coder/mux/pull/102",
+        state: "OPEN",
+      },
+    },
+  ],
+});
+
+function makeBranch(name: string) {
+  return {
+    name,
+    base: "main",
+    isCurrent: false,
+    isMerged: false,
+    isQueued: false,
+    needsRebase: false,
+  };
+}
+
+describe("parseStackViewOutput", () => {
+  it("parses gh-stack output into UI-oriented branch data", () => {
+    const stack = parseStackViewOutput(STACK_VIEW_FIXTURE);
+
+    expect(stack).toEqual({
+      trunk: "main",
+      branches: [
+        {
+          branch: "mike/feat-a",
+          isCurrent: false,
+          needsRebase: false,
+          pr: {
+            number: 101,
+            url: "https://github.com/coder/mux/pull/101",
+            state: "OPEN",
+          },
+        },
+        {
+          branch: "mike/feat-b",
+          isCurrent: true,
+          needsRebase: true,
+          pr: {
+            number: 102,
+            url: "https://github.com/coder/mux/pull/102",
+            state: "QUEUED",
+          },
+        },
+      ],
+    });
+  });
+
+  it("returns null for no-stack and malformed output", () => {
+    expect(parseStackViewOutput('{"no_stack":true}')).toBeNull();
+    expect(parseStackViewOutput("not json")).toBeNull();
+  });
+
+  it("keeps branches without pull requests", () => {
+    const stack = parseStackViewOutput(
+      JSON.stringify({
+        trunk: "main",
+        branches: [makeBranch("mike/feat-a"), makeBranch("mike/feat-b")],
+      })
+    );
+
+    expect(stack?.branches.map((branch) => branch.pr)).toEqual([undefined, undefined]);
+  });
+
+  it("hides a one-branch stack", () => {
+    expect(
+      parseStackViewOutput(JSON.stringify({ trunk: "main", branches: [makeBranch("mike/feat-a")] }))
+    ).toBeNull();
+  });
+});
+
+describe("mergeStackPullRequestMetadata", () => {
+  it("merges available metadata while preserving queued and missing entries", () => {
+    const stack: WorkspaceStackInfo = {
+      trunk: "main",
+      branches: [
+        {
+          branch: "mike/feat-a",
+          isCurrent: false,
+          needsRebase: false,
+          pr: { number: 101, state: "OPEN" },
+        },
+        {
+          branch: "mike/feat-b",
+          isCurrent: true,
+          needsRebase: false,
+          pr: { number: 102, state: "QUEUED" },
+        },
+        {
+          branch: "mike/feat-c",
+          isCurrent: false,
+          needsRebase: false,
+          pr: { number: 103, state: "OPEN" },
+        },
+      ],
+    };
+
+    const merged = mergeStackPullRequestMetadata(stack, {
+      data: {
+        repository: {
+          p101: { number: 101, title: "Closed change", state: "CLOSED", isDraft: false },
+          p102: { number: 102, title: "Queued change", state: "OPEN", isDraft: true },
+        },
+      },
+    });
+
+    expect(merged.branches[0].pr).toEqual({
+      number: 101,
+      state: "CLOSED",
+      title: "Closed change",
+      isDraft: false,
+    });
+    expect(merged.branches[1].pr).toEqual({
+      number: 102,
+      state: "QUEUED",
+      title: "Queued change",
+      isDraft: true,
+    });
+    expect(merged.branches[2]).toBe(stack.branches[2]);
+  });
+});

--- a/src/browser/stores/PRStatusStore.test.ts
+++ b/src/browser/stores/PRStatusStore.test.ts
@@ -74,7 +74,7 @@ async function runPassiveRefreshScenario(
   shouldRun: boolean
 ): Promise<number> {
   const executeBash = mock(() => {
-    // These tests only care whether passive refresh attempted both gh commands.
+    // Return failures because these tests only assert whether runtime gating invokes both commands.
     return Promise.resolve({ success: false as const, error: "gh unavailable" });
   });
 

--- a/src/browser/stores/PRStatusStore.test.ts
+++ b/src/browser/stores/PRStatusStore.test.ts
@@ -29,7 +29,7 @@ async function waitUntil(condition: () => boolean, timeoutMs = 1000): Promise<vo
   const deadline = Date.now() + timeoutMs;
   while (!condition()) {
     if (Date.now() >= deadline) {
-      throw new Error("Timed out waiting for passive PR refresh");
+      throw new Error("Timed out waiting for passive GitHub refresh");
     }
     await sleep(10);
   }
@@ -74,8 +74,7 @@ async function runPassiveRefreshScenario(
   shouldRun: boolean
 ): Promise<number> {
   const executeBash = mock(() => {
-    // Return a top-level failure so detectWorkspacePR exits before JSON parsing.
-    // These tests only care whether passive refresh attempted the gh command.
+    // These tests only care whether passive refresh attempted both gh commands.
     return Promise.resolve({ success: false as const, error: "gh unavailable" });
   });
 
@@ -95,7 +94,7 @@ async function runPassiveRefreshScenario(
     store.subscribeWorkspace(metadata.id, () => undefined);
 
     if (shouldRun) {
-      await waitUntil(() => executeBash.mock.calls.length > 0);
+      await waitUntil(() => executeBash.mock.calls.length === 2);
     } else {
       await sleep(100);
     }
@@ -134,7 +133,7 @@ describe("passive refresh runtime gating", () => {
       true
     );
 
-    expect(callCount).toBe(1);
+    expect(callCount).toBe(2);
   });
 
   it("retries PR refresh when devcontainer runtime transitions from null to running", async () => {
@@ -162,8 +161,8 @@ describe("passive refresh runtime gating", () => {
       runtimeStatusStore.setStatus("running");
       runtimeStatusStore.emit(metadata.id);
 
-      await waitUntil(() => executeBash.mock.calls.length > 0);
-      expect(executeBash.mock.calls.length).toBe(1);
+      await waitUntil(() => executeBash.mock.calls.length === 2);
+      expect(executeBash.mock.calls.length).toBe(2);
     } finally {
       store.dispose();
     }
@@ -208,7 +207,7 @@ describe("passive refresh runtime gating", () => {
       true
     );
 
-    expect(callCount).toBe(1);
+    expect(callCount).toBe(2);
   });
 });
 

--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -380,6 +380,7 @@ export class PRStatusStore {
     this.refreshController.requestImmediate();
   }
 
+  /** Subscriptions drive refresh, so consumers do not monitor workspaces separately. */
   subscribeWorkspace = (workspaceId: string, listener: () => void) => {
     const unsubscribe = this.workspacePRSubscriptions.subscribeKey(workspaceId, listener);
 
@@ -917,6 +918,7 @@ export class PRStatusStore {
             () => {
               firedSynchronously = true;
               this.runtimeRetryUnsubscribers.delete(workspaceId);
+              // Clear due entries so cache TTLs cannot suppress the deferred refresh.
               if (shouldFetchPR) {
                 this.workspacePRCache.delete(workspaceId);
               }

--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -19,6 +19,8 @@ import type {
   GitHubPRStatus,
   GitHubPRLinkWithStatus,
   MergeQueueEntry,
+  WorkspaceStackBranch,
+  WorkspaceStackInfo,
 } from "@/common/types/links";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { createLRUCache } from "@/browser/utils/lruCache";
@@ -50,21 +52,18 @@ const STATUS_CACHE_TTL_MS = 5 * 1000;
 
 // How long to wait before retrying after an error
 const ERROR_RETRY_DELAY_MS = 5 * 1000;
+const STACK_CACHE_TTL_MS = 60_000;
 
 // GraphQL query for merge queue data (not available in `gh pr view --json`).
 const MERGE_QUEUE_QUERY =
   "query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){mergeQueueEntry{state position}}}}";
 
-/**
- * Persisted PR status for localStorage LRU cache.
- * Stores only the essential data needed to display the badge on app restart.
- */
 interface PersistedPRStatus {
-  prLink: GitHubPRLink;
+  prLink: GitHubPRLink | null;
   status?: GitHubPRStatus;
+  stack?: WorkspaceStackInfo;
 }
 
-// LRU cache for persisting PR status across app restarts
 const prStatusLRU = createLRUCache<PersistedPRStatus>({
   entryPrefix: "prStatus:",
   indexKey: "prStatusIndex",
@@ -139,6 +138,142 @@ export function parseMergeQueueEntry(raw: unknown): MergeQueueEntry | null {
   return { state, position };
 }
 
+function isStackPRState(value: unknown): value is NonNullable<WorkspaceStackBranch["pr"]>["state"] {
+  return value === "OPEN" || value === "MERGED" || value === "QUEUED" || value === "CLOSED";
+}
+
+export function parseStackViewOutput(output: string): WorkspaceStackInfo | null {
+  try {
+    const parsed = JSON.parse(output) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+
+    const record = parsed as Record<string, unknown>;
+    if (record.no_stack === true || typeof record.trunk !== "string") {
+      return null;
+    }
+    if (!Array.isArray(record.branches) || record.branches.length < 2) {
+      return null;
+    }
+
+    const branches: WorkspaceStackBranch[] = [];
+    for (const rawBranch of record.branches) {
+      if (typeof rawBranch !== "object" || rawBranch === null) {
+        return null;
+      }
+
+      const branchRecord = rawBranch as Record<string, unknown>;
+      if (
+        typeof branchRecord.name !== "string" ||
+        typeof branchRecord.isCurrent !== "boolean" ||
+        typeof branchRecord.isMerged !== "boolean" ||
+        typeof branchRecord.isQueued !== "boolean" ||
+        typeof branchRecord.needsRebase !== "boolean"
+      ) {
+        return null;
+      }
+
+      let pr: WorkspaceStackBranch["pr"];
+      if (branchRecord.pr != null) {
+        if (typeof branchRecord.pr !== "object") {
+          return null;
+        }
+
+        const prRecord = branchRecord.pr as Record<string, unknown>;
+        if (
+          typeof prRecord.number !== "number" ||
+          !Number.isInteger(prRecord.number) ||
+          prRecord.number <= 0 ||
+          !isStackPRState(prRecord.state) ||
+          (prRecord.url != null && typeof prRecord.url !== "string")
+        ) {
+          return null;
+        }
+
+        const state = branchRecord.isMerged
+          ? "MERGED"
+          : branchRecord.isQueued
+            ? "QUEUED"
+            : prRecord.state;
+        pr = {
+          number: prRecord.number,
+          state,
+          ...(typeof prRecord.url === "string" ? { url: prRecord.url } : {}),
+        };
+      }
+
+      branches.push({
+        branch: branchRecord.name,
+        isCurrent: branchRecord.isCurrent,
+        needsRebase: branchRecord.needsRebase,
+        ...(pr ? { pr } : {}),
+      });
+    }
+
+    return { trunk: record.trunk, branches };
+  } catch {
+    return null;
+  }
+}
+
+export function mergeStackPullRequestMetadata(
+  stack: WorkspaceStackInfo,
+  raw: unknown
+): WorkspaceStackInfo {
+  if (typeof raw !== "object" || raw === null) {
+    return stack;
+  }
+
+  const data = (raw as Record<string, unknown>).data;
+  if (typeof data !== "object" || data === null) {
+    return stack;
+  }
+
+  const repository = (data as Record<string, unknown>).repository;
+  if (typeof repository !== "object" || repository === null) {
+    return stack;
+  }
+
+  const pullRequests = repository as Record<string, unknown>;
+  return {
+    ...stack,
+    branches: stack.branches.map((branch) => {
+      if (!branch.pr) {
+        return branch;
+      }
+
+      const rawPullRequest = pullRequests[`p${branch.pr.number}`];
+      if (typeof rawPullRequest !== "object" || rawPullRequest === null) {
+        return branch;
+      }
+
+      const pullRequest = rawPullRequest as Record<string, unknown>;
+      if (pullRequest.number !== branch.pr.number) {
+        return branch;
+      }
+
+      const graphqlState = pullRequest.state;
+      const state =
+        branch.pr.state === "QUEUED" && graphqlState === "OPEN"
+          ? "QUEUED"
+          : isStackPRState(graphqlState)
+            ? graphqlState
+            : branch.pr.state;
+
+      return {
+        ...branch,
+        pr: {
+          ...branch.pr,
+          state,
+          ...(typeof pullRequest.title === "string" ? { title: pullRequest.title } : {}),
+          ...(typeof pullRequest.isDraft === "boolean" ? { isDraft: pullRequest.isDraft } : {}),
+        },
+      };
+    }),
+  };
+}
+
 /**
  * Workspace PR detection result (from branch, not chat).
  */
@@ -148,6 +283,12 @@ interface WorkspacePRCacheEntry {
   /** PR status if available */
   status?: GitHubPRStatus;
   error?: string;
+  fetchedAt: number;
+  loading: boolean;
+}
+
+interface WorkspaceStackCacheEntry {
+  stack: WorkspaceStackInfo | null;
   fetchedAt: number;
   loading: boolean;
 }
@@ -166,9 +307,9 @@ export class PRStatusStore {
   private readonly refreshController: RefreshController;
   private isActive = true;
 
-  // Workspace-based PR detection (keyed by workspaceId)
   private workspacePRSubscriptions = new MapStore<string, WorkspacePRCacheEntry>();
   private workspacePRCache = new Map<string, WorkspacePRCacheEntry>();
+  private workspaceStackCache = new Map<string, WorkspaceStackCacheEntry>();
   private runtimeRetryUnsubscribers = new Map<string, () => void>();
 
   // Track active subscriptions per workspace so we only refresh workspaces that are actually visible.
@@ -239,16 +380,6 @@ export class PRStatusStore {
     this.refreshController.requestImmediate();
   }
 
-  // ─────────────────────────────────────────────────────────────────────────────
-  // Workspace-based PR detection (primary mode)
-  // ─────────────────────────────────────────────────────────────────────────────
-
-  /**
-   * Subscribe to workspace PR changes (branch-based detection).
-   *
-   * Like GitStatusStore: subscriptions drive refresh. Components should not need to
-   * manually "monitor" workspaces.
-   */
   subscribeWorkspace = (workspaceId: string, listener: () => void) => {
     const unsubscribe = this.workspacePRSubscriptions.subscribeKey(workspaceId, listener);
 
@@ -307,6 +438,159 @@ export class PRStatusStore {
     }
 
     return undefined;
+  }
+
+  getWorkspaceStack(workspaceId: string): WorkspaceStackCacheEntry | undefined {
+    const memCached = this.workspaceStackCache.get(workspaceId);
+    if (memCached) return memCached;
+
+    const persisted = prStatusLRU.get(workspaceId);
+    if (!persisted?.stack) {
+      return undefined;
+    }
+
+    const entry: WorkspaceStackCacheEntry = {
+      stack: persisted.stack,
+      loading: true,
+      fetchedAt: 0,
+    };
+    this.workspaceStackCache.set(workspaceId, entry);
+    return entry;
+  }
+
+  private persistWorkspacePR(
+    workspaceId: string,
+    prLink: GitHubPRLink,
+    status: GitHubPRStatus
+  ): void {
+    const stackEntry = this.workspaceStackCache.get(workspaceId);
+    const persistedStack = stackEntry
+      ? (stackEntry.stack ?? undefined)
+      : prStatusLRU.get(workspaceId)?.stack;
+    prStatusLRU.set(workspaceId, {
+      prLink,
+      status,
+      ...(persistedStack ? { stack: persistedStack } : {}),
+    });
+  }
+
+  private persistWorkspaceStack(workspaceId: string, stack: WorkspaceStackInfo | null): void {
+    const persisted = prStatusLRU.get(workspaceId);
+    if (!stack) {
+      if (persisted?.stack) {
+        prStatusLRU.set(workspaceId, {
+          prLink: persisted.prLink,
+          status: persisted.status,
+        });
+      }
+      return;
+    }
+
+    const prEntry = this.workspacePRCache.get(workspaceId);
+    prStatusLRU.set(workspaceId, {
+      prLink: prEntry ? prEntry.prLink : (persisted?.prLink ?? null),
+      status: prEntry ? prEntry.status : persisted?.status,
+      stack,
+    });
+  }
+
+  private writeWorkspaceStack(workspaceId: string, stack: WorkspaceStackInfo | null): void {
+    this.workspaceStackCache.set(workspaceId, {
+      stack,
+      loading: false,
+      fetchedAt: Date.now(),
+    });
+    this.persistWorkspaceStack(workspaceId, stack);
+    this.workspacePRSubscriptions.bump(workspaceId);
+  }
+
+  private async detectWorkspaceStack(workspaceId: string): Promise<void> {
+    if (!this.client || !this.isActive) return;
+
+    const existing = this.workspaceStackCache.get(workspaceId);
+    this.workspaceStackCache.set(workspaceId, {
+      stack: existing?.stack ?? null,
+      loading: true,
+      fetchedAt: Date.now(),
+    });
+    this.workspacePRSubscriptions.bump(workspaceId);
+
+    try {
+      const result = await this.client.workspace.executeBash({
+        workspaceId,
+        script: `gh stack view --json 2>/dev/null || echo '{"no_stack":true}'`,
+        options: repoRootBashOptions(20),
+      });
+
+      if (!this.isActive) return;
+      if (!result.success || !result.data.success || !result.data.output) {
+        this.writeWorkspaceStack(workspaceId, null);
+        return;
+      }
+
+      const stack = parseStackViewOutput(result.data.output);
+      if (!stack) {
+        this.writeWorkspaceStack(workspaceId, null);
+        return;
+      }
+
+      const enrichedStack = await this.enrichWorkspaceStack(workspaceId, stack);
+      if (this.isActive) {
+        this.writeWorkspaceStack(workspaceId, enrichedStack);
+      }
+    } catch {
+      if (this.isActive) {
+        this.writeWorkspaceStack(workspaceId, null);
+      }
+    }
+  }
+
+  private async enrichWorkspaceStack(
+    workspaceId: string,
+    stack: WorkspaceStackInfo
+  ): Promise<WorkspaceStackInfo> {
+    if (!this.client || !this.isActive) {
+      return stack;
+    }
+
+    const repository = stack.branches
+      .map((branch) => branch.pr?.url)
+      .filter((url): url is string => url != null)
+      .map(parseGitHubPRUrl)
+      .find((parsed) => parsed != null);
+    const numbers = Array.from(
+      new Set(stack.branches.flatMap((branch) => (branch.pr ? [branch.pr.number] : [])))
+    );
+    if (!repository || numbers.length === 0) {
+      return stack;
+    }
+
+    const fields = numbers
+      .map((number) => `p${number}:pullRequest(number:${number}){number title state isDraft}`)
+      .join(" ");
+    const query = `query($owner:String!,$name:String!){repository(owner:$owner,name:$name){${fields}}}`;
+
+    try {
+      const result = await this.client.workspace.executeBash({
+        workspaceId,
+        script: [
+          "gh api graphql",
+          `-f query='${query}'`,
+          `-f owner='${repository.owner}'`,
+          `-f name='${repository.repo}'`,
+          "2>/dev/null",
+        ].join(" "),
+        options: repoRootBashOptions(20),
+      });
+
+      if (!this.isActive || !result.success || !result.data.success || !result.data.output) {
+        return stack;
+      }
+
+      return mergeStackPullRequestMetadata(stack, JSON.parse(result.data.output));
+    } catch {
+      return stack;
+    }
   }
 
   /**
@@ -408,7 +692,7 @@ export class PRStatusStore {
             });
 
             // Persist to localStorage for instant display on app restart
-            prStatusLRU.set(workspaceId, { prLink, status });
+            this.persistWorkspacePR(workspaceId, prLink, status);
 
             this.scheduleMergeQueueRefresh(workspaceId, prLinkBase, prUrl, status.fetchedAt);
           }
@@ -492,10 +776,7 @@ export class PRStatusStore {
           ...currentEntry,
           status: updatedStatus,
         });
-        prStatusLRU.set(workspaceId, {
-          prLink: currentEntry.prLink,
-          status: updatedStatus,
-        });
+        this.persistWorkspacePR(workspaceId, currentEntry.prLink, updatedStatus);
         this.workspacePRSubscriptions.bump(workspaceId);
       })
       .catch(() => {
@@ -590,10 +871,12 @@ export class PRStatusStore {
     return now - entry.fetchedAt > STATUS_CACHE_TTL_MS;
   }
 
-  /**
-   * Refresh PR status for all subscribed workspaces.
-   * Called via RefreshController (focus + debounced refresh).
-   */
+  private shouldFetchStack(entry: WorkspaceStackCacheEntry | undefined, now: number): boolean {
+    if (!entry) return true;
+    if (entry.loading && entry.fetchedAt !== 0) return false;
+    return now - entry.fetchedAt > STACK_CACHE_TTL_MS;
+  }
+
   private async refreshAll(): Promise<void> {
     if (!this.client || !this.isActive) return;
 
@@ -606,42 +889,55 @@ export class PRStatusStore {
     const refreshes: Array<Promise<void>> = [];
 
     for (const workspaceId of workspaceIds) {
-      const cached = this.workspacePRCache.get(workspaceId);
-      if (this.shouldFetchWorkspace(cached, now)) {
-        // Skip passive PR refresh for devcontainer workspaces whose runtime is
-        // not already running, to avoid waking stopped containers.
-        const metadata = this.workspaceMetadata.get(workspaceId);
-        if (
-          metadata &&
-          !canRunPassiveRuntimeCommand(
-            metadata.runtimeConfig,
-            this.runtimeStatusStore.getStatus(workspaceId)
-          )
-        ) {
-          // Arm a one-shot retry so the workspace gets a PR refresh once the
-          // runtime becomes passively runnable again.
-          if (!this.runtimeRetryUnsubscribers.has(workspaceId)) {
-            let firedSynchronously = false;
-            const unsubscribe = onPassiveRuntimeEligible(
-              workspaceId,
-              metadata.runtimeConfig,
-              this.runtimeStatusStore,
-              () => {
-                firedSynchronously = true;
-                this.runtimeRetryUnsubscribers.delete(workspaceId);
-                // Clear PR cache so TTL doesn't suppress the deferred retry.
-                this.workspacePRCache.delete(workspaceId);
-                this.refreshController.requestImmediate();
-              }
-            );
-            if (!firedSynchronously) {
-              this.runtimeRetryUnsubscribers.set(workspaceId, unsubscribe);
-            }
-          }
-          continue;
-        }
+      const shouldFetchPR = this.shouldFetchWorkspace(this.workspacePRCache.get(workspaceId), now);
+      const shouldFetchStack = this.shouldFetchStack(
+        this.workspaceStackCache.get(workspaceId),
+        now
+      );
+      if (!shouldFetchPR && !shouldFetchStack) {
+        continue;
+      }
 
+      // Skip passive GitHub refreshes for devcontainer workspaces whose runtime is
+      // not already running, to avoid waking stopped containers.
+      const metadata = this.workspaceMetadata.get(workspaceId);
+      if (
+        metadata &&
+        !canRunPassiveRuntimeCommand(
+          metadata.runtimeConfig,
+          this.runtimeStatusStore.getStatus(workspaceId)
+        )
+      ) {
+        if (!this.runtimeRetryUnsubscribers.has(workspaceId)) {
+          let firedSynchronously = false;
+          const unsubscribe = onPassiveRuntimeEligible(
+            workspaceId,
+            metadata.runtimeConfig,
+            this.runtimeStatusStore,
+            () => {
+              firedSynchronously = true;
+              this.runtimeRetryUnsubscribers.delete(workspaceId);
+              if (shouldFetchPR) {
+                this.workspacePRCache.delete(workspaceId);
+              }
+              if (shouldFetchStack) {
+                this.workspaceStackCache.delete(workspaceId);
+              }
+              this.refreshController.requestImmediate();
+            }
+          );
+          if (!firedSynchronously) {
+            this.runtimeRetryUnsubscribers.set(workspaceId, unsubscribe);
+          }
+        }
+        continue;
+      }
+
+      if (shouldFetchPR) {
         refreshes.push(this.detectWorkspacePR(workspaceId));
+      }
+      if (shouldFetchStack) {
+        refreshes.push(this.detectWorkspaceStack(workspaceId));
       }
     }
 
@@ -724,6 +1020,26 @@ export function useWorkspacePR(workspaceId: string): GitHubPRLinkWithStatus | nu
       };
       workspacePRHookCache.set(workspaceId, newResult);
       return newResult;
+    }
+  );
+}
+
+const workspaceStackHookCache = new Map<string, WorkspaceStackInfo | null>();
+
+export function useWorkspaceStack(workspaceId: string): WorkspaceStackInfo | null {
+  const store = getPRStatusStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => store.subscribeWorkspace(workspaceId, listener),
+    () => {
+      const stack = store.getWorkspaceStack(workspaceId)?.stack ?? null;
+      const existing = workspaceStackHookCache.get(workspaceId);
+      if (existing === stack) {
+        return existing;
+      }
+
+      workspaceStackHookCache.set(workspaceId, stack);
+      return stack;
     }
   );
 }

--- a/src/common/types/links.ts
+++ b/src/common/types/links.ts
@@ -80,6 +80,25 @@ export interface GitHubPRStatus {
   fetchedAt: number;
 }
 
+export interface WorkspaceStackBranch {
+  branch: string;
+  isCurrent: boolean;
+  needsRebase: boolean;
+  pr?: {
+    number: number;
+    url?: string;
+    state: "OPEN" | "MERGED" | "QUEUED" | "CLOSED";
+    title?: string;
+    isDraft?: boolean;
+  };
+}
+
+export interface WorkspaceStackInfo {
+  trunk: string;
+  /** Branches are ordered from stack bottom to top. */
+  branches: WorkspaceStackBranch[];
+}
+
 /**
  * Extended PR link with status information.
  */


### PR DESCRIPTION
## Summary

The workspace PR indicator now detects when the current branch belongs to a stack managed by GitHub's official `gh-stack` extension and shows a stack badge (layers icon, branch count, chevron) next to the PR badge. Clicking it opens a dropdown listing every PR in the stack, top of stack first, with truncated titles, PR numbers, branches, state icons, and the trunk row last, mirroring GitHub's own stack popover. The current branch is highlighted, and rows with PRs link to GitHub.

## Background

The PR indicator only ran `gh pr view` for the current branch, so the rest of a stack was invisible in Mux. GitHub's stack UI shows a count badge with a popover listing the whole stack; this brings the same affordance into the workspace footer and header.

## Implementation

- `PRStatusStore` gains a stack cache fed by `gh stack view --json` (verified against gh-stack v0.1.0 source: `trunk`, `currentBranch`, `branches[{name,base,isCurrent,isMerged,isQueued,needsRebase,pr{number,url,state}}]`, bottom-first order; any nonzero exit means "no stack"). The probe runs on its own 60s TTL, not the 5s PR cadence, because the command syncs PR state over the network (~2s on a 6-PR stack). It shares the devcontainer passive-runtime gate with the PR probe.
- gh-stack JSON has no PR titles, so a single aliased `gh api graphql` call enriches all stack PRs with `title`, `state` (adds CLOSED), and `isDraft`. Enrichment is best-effort; on failure rows fall back to branch names.
- New `PRStackBadge` renders the trigger and a conditionally rendered in-tree menu (no Radix portal, per happy-dom testability convention), with trigger-relative fixed positioning so the footer's overflow clipping cannot cut it off. Opens upward from the footer, downward from the header, clamped to the viewport.
- Stack info persists in the existing localStorage LRU so the badge appears instantly on restart before the first refresh.

## Validation

- Live UAT in a dev-server sandbox with a handcrafted `.git/gh-stack` state file referencing real coder/mux PRs (gh-stack synced real states, GraphQL resolved real titles): stacked, PR-less-current-branch, combined PR+stack, non-stack regression, corrupted-state-file degradation, 375px header placement, and footer upward opening all verified with screenshots.
- Unit tests for `parseStackViewOutput` and `mergeStackPullRequestMetadata`; happy-dom component tests for open/close, ordering, current marker, links, and viewport clamping; Storybook stories with a 6-PR fixture.

## Risks

Low. Stack detection is additive and fails closed: any gh-stack absence, error, or malformed output yields "no stack" and never surfaces as a PR badge error. The PR badge path is unchanged apart from a shared persistence helper and the refresh loop gaining an independent stack TTL check.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
