### PR TITLE
🤖 fix: never resume the parent as the compact agent after compaction

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3967,6 +3967,79 @@ describe("TaskService", () => {
     expect(snapshot?.error).toBeUndefined();
   });
 
+  test("bare compaction stream-end resumes the pre-compaction parent identity", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = "parent-bare-compaction";
+    const childId = "child-bare-compaction";
+    const execModel = "openai:gpt-5.6-sol";
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId, {
+          aiSettingsByAgent: {
+            exec: { model: execModel, thinkingLevel: "high" },
+          },
+        }),
+        projectWorkspace(projectPath, "child", childId, {
+          parentWorkspaceId: parentId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    const waitForPendingCompactionCompletionDecision = mock(
+      (): Promise<boolean> => Promise.resolve(false)
+    );
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks({
+      waitForPendingCompactionCompletionDecision,
+    });
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("pre-compact-exec", "assistant", "Waiting for delegated work", {
+        timestamp: Date.now(),
+        agentId: "exec",
+      })
+    );
+    await historyService.appendToHistory(
+      parentId,
+      createMuxMessage("bare-compact-output", "assistant", "Compaction summary", {
+        timestamp: Date.now(),
+        agentId: "compact",
+      })
+    );
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: parentId,
+      messageId: "bare-compact-output",
+      metadata: {
+        model: "anthropic:claude-sonnet-4-6",
+        agentId: "compact",
+        finishReason: "stop",
+      },
+      parts: [{ type: "text", text: "Compaction summary" }],
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      parentId,
+      expect.any(String),
+      expect.objectContaining({
+        agentId: "exec",
+        model: execModel,
+        thinkingLevel: "high",
+      }),
+      expect.any(Object)
+    );
+  });
+
   test("uncorrelated compaction stream-end does not interrupt an active workspace turn", async () => {
     // On-send compaction can consume a monitor-wake continuation mid-turn; the
     // compact turn's own stream-end is uncorrelated and must not supersede the
@@ -18466,6 +18539,77 @@ describe("TaskService", () => {
     expect(sendMessage.mock.calls[1]?.[1]).toContain("Found a second issue.");
     expect(findWorkspaceInConfig(config, childId)?.taskStatus).toBe("running");
     expect(await readSubagentReportArtifact(config.getSessionDir(parentId), childId)).toBeNull();
+  });
+
+  test.each([
+    [
+      "agent_report resumes the parent with pre-compaction agent settings",
+      "after-compaction",
+      "openai:gpt-5.6-sol",
+      "xhigh",
+      ["exec", "compact"],
+    ],
+    [
+      "agent_report falls back to exec settings when history only has compaction output",
+      "after-truncation",
+      "anthropic:claude-sonnet-4-6",
+      "medium",
+      ["compact"],
+    ],
+  ] as const)("%s", async (_name, idSuffix, execModel, thinkingLevel, historyAgentIds) => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = `parent-progress-${idSuffix}`;
+    const childId = `child-progress-${idSuffix}`;
+
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId, {
+          aiSettingsByAgent: {
+            exec: { model: execModel, thinkingLevel },
+          },
+        }),
+        projectWorkspace(projectPath, "child", childId, {
+          parentWorkspaceId: parentId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "running",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
+    for (const [index, agentId] of historyAgentIds.entries()) {
+      await historyService.appendToHistory(
+        parentId,
+        createMuxMessage(
+          `${idSuffix}-assistant-${index}`,
+          "assistant",
+          agentId === "compact" ? "Compaction summary" : "Delegating now",
+          { timestamp: Date.now(), agentId }
+        )
+      );
+    }
+
+    await taskService.reportAgentProgress(childId, `progress-${idSuffix}`, {
+      reportMarkdown: "Found the root cause.",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      parentId,
+      expect.any(String),
+      expect.objectContaining({
+        agentId: "exec",
+        model: execModel,
+        thinkingLevel,
+      }),
+      expect.any(Object)
+    );
   });
 
   test("terminal reports supersede queued incremental updates for the same child", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -18541,76 +18541,82 @@ describe("TaskService", () => {
     expect(await readSubagentReportArtifact(config.getSessionDir(parentId), childId)).toBeNull();
   });
 
+  // The scan case uses "plan" so it cannot pass via the exec recovery fallback.
   test.each([
     [
       "agent_report resumes the parent with pre-compaction agent settings",
       "after-compaction",
+      "plan",
       "openai:gpt-5.6-sol",
       "xhigh",
-      ["exec", "compact"],
+      ["plan", "compact"],
     ],
     [
       "agent_report falls back to exec settings when history only has compaction output",
       "after-truncation",
+      "exec",
       "anthropic:claude-sonnet-4-6",
       "medium",
       ["compact"],
     ],
-  ] as const)("%s", async (_name, idSuffix, execModel, thinkingLevel, historyAgentIds) => {
-    const config = await createTestConfig(rootDir);
-    const projectPath = path.join(rootDir, "repo");
-    const parentId = `parent-progress-${idSuffix}`;
-    const childId = `child-progress-${idSuffix}`;
+  ] as const)(
+    "%s",
+    async (_name, idSuffix, expectedAgentId, model, thinkingLevel, historyAgentIds) => {
+      const config = await createTestConfig(rootDir);
+      const projectPath = path.join(rootDir, "repo");
+      const parentId = `parent-progress-${idSuffix}`;
+      const childId = `child-progress-${idSuffix}`;
 
-    await saveWorkspaces(
-      config,
-      projectPath,
-      [
-        projectWorkspace(projectPath, "parent", parentId, {
-          aiSettingsByAgent: {
-            exec: { model: execModel, thinkingLevel },
-          },
-        }),
-        projectWorkspace(projectPath, "child", childId, {
-          parentWorkspaceId: parentId,
-          agentId: "explore",
-          agentType: "explore",
-          taskStatus: "running",
-        }),
-      ],
-      testTaskSettings()
-    );
+      await saveWorkspaces(
+        config,
+        projectPath,
+        [
+          projectWorkspace(projectPath, "parent", parentId, {
+            aiSettingsByAgent: {
+              [expectedAgentId]: { model, thinkingLevel },
+            },
+          }),
+          projectWorkspace(projectPath, "child", childId, {
+            parentWorkspaceId: parentId,
+            agentId: "explore",
+            agentType: "explore",
+            taskStatus: "running",
+          }),
+        ],
+        testTaskSettings()
+      );
 
-    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
-    const { historyService, taskService } = createTaskServiceHarness(config, { workspaceService });
-    for (const [index, agentId] of historyAgentIds.entries()) {
-      await historyService.appendToHistory(
+      const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+      const { historyService, taskService } = createTaskServiceHarness(config, {
+        workspaceService,
+      });
+      for (const [index, agentId] of historyAgentIds.entries()) {
+        await historyService.appendToHistory(
+          parentId,
+          createMuxMessage(`${idSuffix}-assistant-${index}`, "assistant", "Parent turn output", {
+            timestamp: Date.now(),
+            agentId,
+          })
+        );
+      }
+
+      await taskService.reportAgentProgress(childId, `progress-${idSuffix}`, {
+        reportMarkdown: "Found the root cause.",
+      });
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(sendMessage).toHaveBeenCalledWith(
         parentId,
-        createMuxMessage(
-          `${idSuffix}-assistant-${index}`,
-          "assistant",
-          agentId === "compact" ? "Compaction summary" : "Delegating now",
-          { timestamp: Date.now(), agentId }
-        )
+        expect.any(String),
+        expect.objectContaining({
+          agentId: expectedAgentId,
+          model,
+          thinkingLevel,
+        }),
+        expect.any(Object)
       );
     }
-
-    await taskService.reportAgentProgress(childId, `progress-${idSuffix}`, {
-      reportMarkdown: "Found the root cause.",
-    });
-
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith(
-      parentId,
-      expect.any(String),
-      expect.objectContaining({
-        agentId: "exec",
-        model: execModel,
-        thinkingLevel,
-      }),
-      expect.any(Object)
-    );
-  });
+  );
 
   test("terminal reports supersede queued incremental updates for the same child", async () => {
     const config = await createTestConfig(rootDir);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1857,7 +1857,7 @@ export class TaskService {
    * Derives auto-resume send options (agentId, model, thinkingLevel) from durable
    * conversation metadata, so synthetic resumes preserve the parent's active agent.
    *
-   * Precedence: stream-end event metadata → last assistant message in history → workspace AI settings → defaults.
+   * Precedence: stream-end event metadata → last non-compaction assistant message in history → workspace AI settings → defaults.
    */
   private async resolveParentAutoResumeOptions(
     parentWorkspaceId: string,
@@ -1876,16 +1876,21 @@ export class TaskService {
     reasoningMode?: OpenAIReasoningMode;
   }> {
     // 1) Try stream-end hint metadata (available in handleStreamEnd path)
-    let agentId = hint?.agentId;
+    // Compaction is an internal mechanical turn, never a valid identity for resuming user work.
+    let agentId = hint?.agentId === "compact" ? undefined : hint?.agentId;
 
-    // 2) Fall back to latest assistant message metadata in history (restart-safe)
+    // 2) Fall back to latest non-compaction assistant message metadata in history (restart-safe)
     if (!agentId) {
       try {
         const historyResult = await this.historyService.getLastMessages(parentWorkspaceId, 20);
         if (historyResult.success) {
           for (let i = historyResult.data.length - 1; i >= 0; i--) {
             const msg = historyResult.data[i];
-            if (msg?.role === "assistant" && msg.metadata?.agentId) {
+            if (
+              msg?.role === "assistant" &&
+              msg.metadata?.agentId &&
+              msg.metadata.agentId !== "compact"
+            ) {
               agentId = msg.metadata.agentId;
               break;
             }

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -1876,10 +1876,10 @@ export class TaskService {
     reasoningMode?: OpenAIReasoningMode;
   }> {
     // 1) Try stream-end hint metadata (available in handleStreamEnd path)
-    // Compaction is an internal mechanical turn, never a valid identity for resuming user work.
+    // Compaction is internal bookkeeping, not an identity for resuming user work.
     let agentId = hint?.agentId === "compact" ? undefined : hint?.agentId;
 
-    // 2) Fall back to latest non-compaction assistant message metadata in history (restart-safe)
+    // Durable history preserves the parent identity across process restarts.
     if (!agentId) {
       try {
         const historyResult = await this.historyService.getLastMessages(parentWorkspaceId, 20);


### PR DESCRIPTION
## Summary

Parent auto-resume no longer adopts the compact agent's identity. `TaskService.resolveParentAutoResumeOptions` now treats `compact` as ineligible in both the stream-end hint and the history scan, so wake turns triggered around compaction resume with the real pre-compaction agent, its configured model, and its tools.

## Background

When a sub-agent report arrived while auto-compaction was streaming, the parent's wake turn dispatched with agentId `compact`: the resume-identity scan picked the compact summary assistant (the latest assistant in history), and the stream-end hint path could carry `compact` the same way for bare compactions. Since workspaces have no per-agent AI settings for `compact`, the model fell back to the hardcoded `DEFAULT_MODEL` (Opus) with thinking off, and the compact agent's deny-all baseline stripped every tool. The result was one maximally expensive, fully uncached provider call that then stalled because the turn had no tools.

## Implementation

`resolveParentAutoResumeOptions` is the single chokepoint for sub-agent report wakes, terminal-attention drains, and stream-end auto-resume. The fix ignores a `compact` hint and skips `compact` assistants during the bounded history scan, so the true pre-compaction agent wins; the existing exec recovery fallback is unchanged. Compaction summary turns themselves still run on the compact agent, and the compaction summary's own pending follow-up path is untouched (it always stages an explicit model and agent).

## Validation

- Three regression tests: report wake after compaction, bare compaction stream-end hint, and compact-only history fallback.
- Red-green verified with two independent toggles: reverting the production fix fails the tests, and disabling only the history scan (leaving the hint skip and fallback intact) also fails the strengthened scan test, which pins a `plan` identity so it cannot pass via the exec fallback.
- Full `taskService.test.ts` has 3 pre-existing failures that reproduce identically on the base commit; they are unrelated to this change.

## Risks

Low. The change narrows which history messages qualify as a resume identity source; the worst case for an exotic history (only compact assistants in the last 20 messages) is the existing deterministic exec fallback, which was already the behavior for empty histories.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
