### PR TITLE
🤖 feat: make Grok 4.6 the default Grok model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@ai-sdk/moonshotai": "^3.0.15",
         "@ai-sdk/openai": "^4.0.11",
         "@ai-sdk/openai-compatible": "^3.0.7",
-        "@ai-sdk/xai": "^4.0.28",
+        "@ai-sdk/xai": "^4.0.37",
         "@aws-sdk/credential-providers": "^3.940.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -210,7 +210,7 @@
     "unrs-resolver",
   ],
   "patchedDependencies": {
-    "@ai-sdk/xai@4.0.28": "patches/@ai-sdk%2Fxai@4.0.28.patch",
+    "@ai-sdk/xai@4.0.37": "patches/@ai-sdk%2Fxai@4.0.37.patch",
   },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
@@ -241,7 +241,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg=="],
 
-    "@ai-sdk/xai": ["@ai-sdk/xai@4.0.28", "", { "dependencies": { "@ai-sdk/openai-compatible": "3.0.23", "@ai-sdk/provider": "4.0.5", "@ai-sdk/provider-utils": "5.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-JRXKwOqNqnEonwY0ldWIjKyyUO9PVgGUdaCOC3Qq+rWE4RqLFHsHjpYl5qGSh4tjP6ELFA9LhTFI2oj3ECgSAA=="],
+    "@ai-sdk/xai": ["@ai-sdk/xai@4.0.37", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-oecSCViDbMiySImn45gD0bVujStu4S7m1CjiPxhCq2tM8Ewi3d6FH/sx4lXJmmdofIdI2KbZMZtbFG+sZi2how=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -3799,11 +3799,9 @@
 
     "@ai-sdk/moonshotai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ=="],
 
-    "@ai-sdk/xai/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@3.0.23", "", { "dependencies": { "@ai-sdk/provider": "4.0.5", "@ai-sdk/provider-utils": "5.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rrEABAjpaFPqRV+2JLkgb70r81+yLHdi7ir99lPir8G9tSXWkHjcuTWaKDhkimG/9W1hqsHtkomgPOqK4mC2hQ=="],
+    "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
-    "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-9WAerTaPU2jcVi8dh8x27tySEuLur1Kfg7Go74GuCmsC/2MDSvrTkrK8ZrXWjryEevKfcPPmO1enveE7eqlzoA=="],
-
-    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.21", "", { "dependencies": { "@ai-sdk/provider": "4.0.5", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Q4z27c5vqKuXZN65QuF7FVm+uvm3qxEioiQ+8c3s5xXlhbE1Y/SLGBB4BuF+UWia4KaDu2HmNpdR1RGW02/eGg=="],
+    "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 

--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -30,7 +30,7 @@ Mux ships with curated models kept up to date with the frontier. Use any custom 
 | Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |
 | Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |
 | Gemini 3.6 Flash       | google:gemini-3.6-flash       | `gemini-flash`                                               |         |
-| Grok 4.5               | xai:grok-4.5                  | `grok`, `grok-4.5`                                           |         |
+| Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |
 | DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |
 | DeepSeek V4 Flash      | deepseek:deepseek-v4-flash    | `deepseek-flash`, `deepseek-v4-flash`                        |         |
 | Kimi K3                | moonshotai:kimi-k3            | `kimi`, `k3`, `kimi-k3`                                      |         |

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-p6bMI6xyPbWaNmsfG3EZK/uAxCxXVIMO192U5P24fzI="; # mux-offline-cache-hash
+            outputHash = "sha256-rVo9s20dUxtwH6Q6jXJ8B3eS83Nfm1GWQt9p9DQiSx0="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@ai-sdk/moonshotai": "^3.0.15",
     "@ai-sdk/openai": "^4.0.11",
     "@ai-sdk/openai-compatible": "^3.0.7",
-    "@ai-sdk/xai": "^4.0.28",
+    "@ai-sdk/xai": "^4.0.37",
     "@aws-sdk/credential-providers": "^3.940.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -333,6 +333,6 @@
     "unrs-resolver"
   ],
   "patchedDependencies": {
-    "@ai-sdk/xai@4.0.28": "patches/@ai-sdk%2Fxai@4.0.28.patch"
+    "@ai-sdk/xai@4.0.37": "patches/@ai-sdk%2Fxai@4.0.37.patch"
   }
 }

--- a/patches/@ai-sdk%2Fxai@4.0.37.patch
+++ b/patches/@ai-sdk%2Fxai@4.0.37.patch
@@ -1,18 +1,18 @@
 diff --git a/dist/index.js b/dist/index.js
-index ea833a84c3323dcc72534e076d68473dfdb77128..41568478bea4246ff9acd7943bbd4d4ee6bd28e3 100644
+index 0c3addd1069ebb39d852b2a14653d58230fd192c..f6b8762d46c6400a48ab3734ef5fe8c0e13d8dad 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -2096,8 +2096,8 @@ import { z as z12 } from "zod/v4";
- var xSearchArgsSchema = lazySchema4(
-   () => zodSchema4(
-     z12.object({
--      allowedXHandles: z12.array(z12.string()).max(10).optional(),
--      excludedXHandles: z12.array(z12.string()).max(10).optional(),
-+      allowedXHandles: z12.array(z12.string()).max(20).optional(),
-+      excludedXHandles: z12.array(z12.string()).max(20).optional(),
-       fromDate: z12.string().optional(),
-       toDate: z12.string().optional(),
-       enableImageUnderstanding: z12.boolean().optional(),
+@@ -2150,8 +2150,8 @@ import { z as z13 } from "zod/v4";
+ var xSearchArgsSchema = lazySchema5(
+   () => zodSchema5(
+     z13.object({
+-      allowedXHandles: z13.array(z13.string()).max(10).optional(),
+-      excludedXHandles: z13.array(z13.string()).max(10).optional(),
++      allowedXHandles: z13.array(z13.string()).max(20).optional(),
++      excludedXHandles: z13.array(z13.string()).max(20).optional(),
+       fromDate: z13.string().optional(),
+       toDate: z13.string().optional(),
+       enableImageUnderstanding: z13.boolean().optional(),
 diff --git a/src/tool/x-search.ts b/src/tool/x-search.ts
 index 5566aa9c391f67cab60fe50ff2a2b55ca71b0b73..6d0dd586f07c5ea9d2bd2dcbed4be211be2e3c8a 100644
 --- a/src/tool/x-search.ts

--- a/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
+++ b/src/browser/components/ThinkingSelector/ThinkingSelector.tsx
@@ -18,6 +18,7 @@ import { getThinkingDisplayLabel, type ThinkingLevel } from "@/common/types/thin
 import { openaiProModeAvailable } from "@/common/utils/ai/proMode";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { enforceThinkingPolicy, getAvailableThinkingLevels } from "@/common/utils/thinking/policy";
+import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import { COMPOSER_PRO_HIDE_CLASS } from "@/constants/layout";
 import { COMPOSER_PICKER_PANEL_CLASS, composerPickerOptionClass } from "../composerPickerStyles";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip/Tooltip";
@@ -60,7 +61,10 @@ export const ThinkingSelector: React.FC<ThinkingSelectorProps> = (props) => {
     minimum,
     providersConfig
   );
-  const displayLabel = getThinkingDisplayLabel(effectiveThinkingLevel, props.modelString);
+  // Label from the capability model so mapped aliases (e.g. xai:team-grok ->
+  // xai:grok-4.6) show the same provider-aware xhigh/max wording as the ladder.
+  const capabilityModel = resolveModelForMetadata(props.modelString, providersConfig ?? null);
+  const displayLabel = getThinkingDisplayLabel(effectiveThinkingLevel, capabilityModel);
   const resolvedRoute = routing.resolveRoute(normalizeToCanonical(props.modelString)).route;
   const proModeAvailable =
     props.allowProMode !== false &&
@@ -132,12 +136,12 @@ export const ThinkingSelector: React.FC<ThinkingSelectorProps> = (props) => {
             className="text-foreground w-[5ch] shrink-0 text-center text-[11px] font-medium select-none"
             aria-label={`Thinking level fixed to ${fixedLevel}`}
           >
-            {getThinkingDisplayLabel(fixedLevel, props.modelString)}
+            {getThinkingDisplayLabel(fixedLevel, capabilityModel)}
           </span>
         </TooltipTrigger>
         <TooltipContent align="center">
           Model {props.modelString} locks thinking at{" "}
-          {getThinkingDisplayLabel(fixedLevel, props.modelString)} to match its capabilities.
+          {getThinkingDisplayLabel(fixedLevel, capabilityModel)} to match its capabilities.
         </TooltipContent>
       </Tooltip>
     );

--- a/src/browser/features/Settings/Sections/ProvidersSection.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.tsx
@@ -421,7 +421,7 @@ export function ProvidersSection() {
   const [xaiServiceTierSaving, setXAIServiceTierSaving] = useState(false);
   // Persist OpenAI ZDR store toggles before publishing UI state so a failed write
   // cannot leave the dropdown claiming disabled while requests still send store=true.
-  // xAI Grok 4.5 always uses store=false in the request path (no settings surface).
+  // xAI frontier Grok always uses store=false in the request path (no settings surface).
   const [openaiStoreSaving, setOpenAIStoreSaving] = useState(false);
 
   const routing = useRouting();

--- a/src/browser/utils/fastModeServiceTier.test.ts
+++ b/src/browser/utils/fastModeServiceTier.test.ts
@@ -24,8 +24,9 @@ describe("fast mode service tier", () => {
     expect(getFastModeProvider("openai:gpt-5.6-sol", { resolvedRouteProvider: "direct" })).toBe(
       "openai"
     );
+    expect(getFastModeProvider("xai:grok-4.6", { resolvedRouteProvider: "direct" })).toBe("xai");
     expect(getFastModeProvider("xai:grok-4.5", { resolvedRouteProvider: "direct" })).toBe("xai");
-    expect(getFastModeProvider("xai:grok-4.5", { resolvedRouteProvider: "openrouter" })).toBeNull();
+    expect(getFastModeProvider("xai:grok-4.6", { resolvedRouteProvider: "openrouter" })).toBeNull();
     expect(
       getFastModeProvider("xai:team-grok", {
         resolvedRouteProvider: "direct",

--- a/src/browser/utils/fastModeServiceTier.ts
+++ b/src/browser/utils/fastModeServiceTier.ts
@@ -5,7 +5,7 @@ import type {
 } from "@/common/config/schemas/providersConfig";
 import { PROVIDER_DEFINITIONS } from "@/common/constants/providers";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
-import { isGrok45Model } from "@/common/types/thinking";
+import { isGrokFrontierModel } from "@/common/types/thinking";
 import { getExplicitGatewayPrefix, normalizeToCanonical } from "@/common/utils/ai/models";
 import { openaiDirectProviderOptionsAvailable } from "@/common/utils/ai/openaiProviderOptionsAvailability";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
@@ -37,7 +37,7 @@ export function getFastModeProvider(
   const normalized = normalizeToCanonical(modelString);
   const [origin] = normalized.split(":", 2);
   const capabilityModel = resolveModelForMetadata(normalized, options?.providersConfig ?? null);
-  if (origin !== "xai" || !isGrok45Model(capabilityModel)) return null;
+  if (origin !== "xai" || !isGrokFrontierModel(capabilityModel)) return null;
 
   // xAI service_tier is also provider-native and cannot survive a gateway route.
   const explicitGateway = getExplicitGatewayPrefix(modelString);

--- a/src/common/constants/knownModels.test.ts
+++ b/src/common/constants/knownModels.test.ts
@@ -46,13 +46,14 @@ describe("Known Models Integration", () => {
     expect(MODEL_ABBREVIATIONS["gpt-5.5"]).toBeUndefined();
   });
 
-  test("grok aliases resolve only to Grok 4.5 in the curated registry", () => {
-    expect(MODEL_ABBREVIATIONS.grok).toBe("xai:grok-4.5");
-    expect(MODEL_ABBREVIATIONS["grok-4.5"]).toBe("xai:grok-4.5");
+  test("grok aliases resolve only to Grok 4.6 in the curated registry", () => {
+    expect(MODEL_ABBREVIATIONS.grok).toBe("xai:grok-4.6");
+    expect(MODEL_ABBREVIATIONS["grok-4.6"]).toBe("xai:grok-4.6");
+    expect(MODEL_ABBREVIATIONS["grok-4.5"]).toBeUndefined();
     expect(MODEL_ABBREVIATIONS["grok-4.1"]).toBeUndefined();
     expect(MODEL_ABBREVIATIONS["grok-code"]).toBeUndefined();
     expect(Object.values(KNOWN_MODELS).filter((model) => model.provider === "xai")).toEqual([
-      KNOWN_MODELS.GROK_45,
+      KNOWN_MODELS.GROK_46,
     ]);
   });
 

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -185,18 +185,18 @@ const MODEL_DEFINITIONS = {
     aliases: ["gemini-flash"],
     tokenizerOverride: "google/gemini-2.5-pro",
   },
-  // Grok 4.5 - xAI's flagship coding and agentic model, released July 2026.
-  // Legacy Grok 4.1 Fast and Grok Code remain usable as custom model strings but are
-  // intentionally omitted from the curated index after their May 15, 2026 retirement.
-  GROK_45: {
+  // Grok 4.6 - xAI's frontier coding and agentic model, released August 12, 2026.
+  // Supersedes Grok 4.5 at the same headline price; Grok 4.5 remains usable as the
+  // custom model string `xai:grok-4.5`.
+  GROK_46: {
     provider: "xai",
-    providerModelId: "grok-4.5",
-    aliases: ["grok", "grok-4.5"],
+    providerModelId: "grok-4.6",
+    aliases: ["grok", "grok-4.6"],
   },
   // DeepSeek V4 Pro is the flagship V4 tier (1.6T total / 49B active params, 1M context,
   // 384K max output). Bare `deepseek` alias points here per the convention that the
   // shortest alias tracks each provider's flagship model (mirrors `gemini` → Gemini Pro,
-  // `grok` → Grok 4.5).
+  // `grok` → Grok 4.6).
   DEEPSEEK_V4_PRO: {
     provider: "deepseek",
     providerModelId: "deepseek-v4-pro",

--- a/src/common/schemas/providerOptions.ts
+++ b/src/common/schemas/providerOptions.ts
@@ -64,11 +64,11 @@ export const MuxProviderOptionsSchema = z.object({
         description:
           'xAI processing tier: "priority" requests faster processing at 2× token pricing; "default" uses standard processing',
       }),
-      // Request-level escape hatch only. Grok 4.5 defaults to store=false in
+      // Request-level escape hatch only. Frontier Grok defaults to store=false in
       // buildProviderOptions so ZDR and non-ZDR share one path (no settings UI).
       store: z.boolean().optional().meta({
         description:
-          "Whether xAI stores Responses. Grok 4.5 defaults to false (ZDR-safe); set true only to opt back into server storage.",
+          "Whether xAI stores Responses. Frontier Grok defaults to false (ZDR-safe); set true only to opt back into server storage.",
       }),
       searchParameters: z
         .object({

--- a/src/common/types/thinking.test.ts
+++ b/src/common/types/thinking.test.ts
@@ -35,6 +35,12 @@ describe("getThinkingDisplayLabel", () => {
     expect(getThinkingDisplayLabel("max", "openai:gpt-5.5-pro")).toBe("XHIGH");
   });
 
+  test("returns XHIGH for xhigh on Grok 4.6 (native effort), MAX on Grok 4.5", () => {
+    expect(getThinkingDisplayLabel("xhigh", "xai:grok-4.6")).toBe("XHIGH");
+    expect(getThinkingDisplayLabel("xhigh", "mux-gateway:xai/grok-4.6")).toBe("XHIGH");
+    expect(getThinkingDisplayLabel("xhigh", "xai:grok-4.5")).toBe("MAX");
+  });
+
   test("returns MAX for xhigh/max when no model specified (default)", () => {
     expect(getThinkingDisplayLabel("xhigh")).toBe("MAX");
     expect(getThinkingDisplayLabel("max")).toBe("MAX");

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -309,7 +309,7 @@ export function openaiSupportsProMode(modelString: string): boolean {
 /**
  * Whether the model is a frontier Grok (4.5 or 4.6, including provider/gateway
  * prefixes and aliases). These models always reason and are served over xAI's
- * Responses API. Extend the regex when xAI ships the next frontier version.
+ * Responses API.
  */
 export function isGrokFrontierModel(modelString: string): boolean {
   const withoutPrefix = stripModelProviderPrefixes(modelString);
@@ -317,8 +317,8 @@ export function isGrokFrontierModel(modelString: string): boolean {
 }
 
 /**
- * Whether the model is Grok 4.6, the first Grok with native xhigh reasoning
- * effort (Grok 4.5 tops out at high).
+ * Whether the model is Grok 4.6, which supports native xhigh reasoning effort
+ * (Grok 4.5 tops out at high).
  */
 export function isGrok46Model(modelString: string): boolean {
   const withoutPrefix = stripModelProviderPrefixes(modelString);

--- a/src/common/types/thinking.ts
+++ b/src/common/types/thinking.ts
@@ -47,6 +47,9 @@ export function getThinkingDisplayLabel(level: ThinkingLevel, modelString?: stri
 
     // Anthropic Opus 4.7+: xhigh is a distinct effort level from max
     if (level === "xhigh" && anthropicSupportsNativeXhigh(modelString)) return "XHIGH";
+
+    // Grok 4.6: xhigh is a distinct native reasoning effort (its policy has no max).
+    if (level === "xhigh" && isGrok46Model(modelString)) return "XHIGH";
   }
   return THINKING_DISPLAY_LABELS[level];
 }
@@ -304,12 +307,22 @@ export function openaiSupportsProMode(modelString: string): boolean {
 }
 
 /**
- * Whether the model is Grok 4.5 (including provider/gateway prefixes and aliases).
- * Grok 4.5 always reasons and accepts low, medium, or high effort.
+ * Whether the model is a frontier Grok (4.5 or 4.6, including provider/gateway
+ * prefixes and aliases). These models always reason and are served over xAI's
+ * Responses API. Extend the regex when xAI ships the next frontier version.
  */
-export function isGrok45Model(modelString: string): boolean {
+export function isGrokFrontierModel(modelString: string): boolean {
   const withoutPrefix = stripModelProviderPrefixes(modelString);
-  return /^grok-4\.5(?:$|-)/.test(withoutPrefix);
+  return /^grok-4\.[56](?:$|-)/.test(withoutPrefix);
+}
+
+/**
+ * Whether the model is Grok 4.6, the first Grok with native xhigh reasoning
+ * effort (Grok 4.5 tops out at high).
+ */
+export function isGrok46Model(modelString: string): boolean {
+  const withoutPrefix = stripModelProviderPrefixes(modelString);
+  return /^grok-4\.6(?:$|-)/.test(withoutPrefix);
 }
 
 /**

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -1650,6 +1650,21 @@ describe("buildProviderOptions - xAI", () => {
     });
   });
 
+  test("passes native xhigh through for Grok 4.6 while Grok 4.5 clamps to high", () => {
+    expect(buildProviderOptions("xai:grok-4.6", "xhigh")).toEqual({
+      xai: { reasoningEffort: "xhigh", store: false },
+    });
+    expect(buildProviderOptions("xai:grok-4.6", "max")).toEqual({
+      xai: { reasoningEffort: "xhigh", store: false },
+    });
+    expect(buildProviderOptions("xai:grok-4.6", "medium")).toEqual({
+      xai: { reasoningEffort: "medium", store: false },
+    });
+    expect(buildProviderOptions("xai:grok-4.5", "xhigh")).toEqual({
+      xai: { reasoningEffort: "high", store: false },
+    });
+  });
+
   test("omits deprecated search parameters and strips service tier from Grok 4.5 SDK options", () => {
     expect(
       buildProviderOptions("xai:grok-4.5", "high", undefined, undefined, {

--- a/src/common/utils/ai/providerOptions.ts
+++ b/src/common/utils/ai/providerOptions.ts
@@ -12,7 +12,7 @@ import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import type { JSONValue } from "@ai-sdk/provider";
 import type {
   XaiProviderOptions,
-  // Chat options alias does not include store; Responses options do (Grok 4.5 / ZDR).
+  // Chat options alias does not include store; Responses options do (frontier Grok / ZDR).
   XaiResponsesProviderOptions,
 } from "@ai-sdk/xai";
 import type { ProviderName } from "@/common/constants/providers";
@@ -26,7 +26,8 @@ import {
   ANTHROPIC_THINKING_BUDGETS,
   GEMINI_THINKING_BUDGETS,
   getOpenAIReasoningEffort,
-  isGrok45Model,
+  isGrok46Model,
+  isGrokFrontierModel,
   isKimiK3Model,
   openaiSupportsProMode,
   OPENROUTER_REASONING_EFFORT,
@@ -78,7 +79,7 @@ interface MoonshotAIProviderOptions {
 }
 
 /**
- * xAI providerOptions payload. Chat models use XaiProviderOptions; Grok 4.5
+ * xAI providerOptions payload. Chat models use XaiProviderOptions; frontier Grok
  * Responses also accepts store (ZDR). Union keeps both families assignable.
  */
 type XaiBuiltProviderOptions = XaiProviderOptions & Pick<XaiResponsesProviderOptions, "store">;
@@ -558,10 +559,12 @@ export function buildProviderOptions(
       store,
       ...overrides
     } = muxProviderOptions?.xai ?? {};
-    const isGrok45 = isGrok45Model(capabilityModel);
-    const reasoningEffort: XaiProviderOptions["reasoningEffort"] = isGrok45
+    const isGrokFrontier = isGrokFrontierModel(capabilityModel);
+    // Grok 4.6 supports native xhigh effort; Grok 4.5 tops out at high.
+    const topEffort = isGrok46Model(capabilityModel) ? "xhigh" : "high";
+    const reasoningEffort: XaiProviderOptions["reasoningEffort"] = isGrokFrontier
       ? effectiveThinking === "xhigh" || effectiveThinking === "max"
-        ? "high"
+        ? topEffort
         : effectiveThinking === "off"
           ? "low"
           : effectiveThinking
@@ -572,21 +575,21 @@ export function buildProviderOptions(
       returnCitations: true,
     };
 
-    // Grok 4.5 Responses: always prefer store=false.
+    // Frontier Grok Responses: always prefer store=false.
     // Mux already resends full history explicitly and persists encrypted reasoning
     // client-side, so server storage is unnecessary. Forcing store=false means ZDR
     // and non-ZDR orgs share one code path and one quality bar (no settings surface).
     // Explicit muxProviderOptions.xai.store still wins for tests/escapes.
-    const effectiveStore = isGrok45 ? (store ?? false) : store;
+    const effectiveStore = isGrokFrontier ? (store ?? false) : store;
 
     const options = {
       xai: {
         ...overrides,
         ...(reasoningEffort != null && { reasoningEffort }),
         ...(effectiveStore != null && { store: effectiveStore }),
-        // Grok 4.5 uses xAI's modern Responses tools; getToolsForModel translates
+        // Frontier Grok uses xAI's modern Responses tools; getToolsForModel translates
         // legacy Live Search settings instead of sending deprecated search_parameters.
-        ...(!isGrok45 && {
+        ...(!isGrokFrontier && {
           searchParameters: searchParameters ?? defaultSearchParameters,
         }),
       },

--- a/src/common/utils/compaction/contextLimit.test.ts
+++ b/src/common/utils/compaction/contextLimit.test.ts
@@ -61,9 +61,10 @@ describe("getEffectiveContextLimit", () => {
     expect(toggledLimit).toBe(1_050_000);
   });
 
-  test("uses Grok 4.5's published 500K context window", () => {
-    expect(getEffectiveContextLimit(KNOWN_MODELS.GROK_45.id, false, null)).toBe(500_000);
-    expect(getEffectiveContextLimit("xai:grok-4.5-latest", false, null)).toBe(500_000);
+  test("uses frontier Grok's published 500K context window", () => {
+    expect(getEffectiveContextLimit(KNOWN_MODELS.GROK_46.id, false, null)).toBe(500_000);
+    expect(getEffectiveContextLimit("xai:grok-4.6-latest", false, null)).toBe(500_000);
+    expect(getEffectiveContextLimit("xai:grok-4.5", false, null)).toBe(500_000);
   });
 
   test("caps GPT-5.5 at the Codex OAuth context window when OAuth is the active auth route", () => {

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -906,6 +906,15 @@ describe("Grok 4.5 thinking policy", () => {
   });
 });
 
+describe("Grok 4.6 thinking policy", () => {
+  test("adds native xhigh on top of the frontier Grok ladder", () => {
+    expect(getThinkingPolicyForModel("xai:grok-4.6")).toEqual(["low", "medium", "high", "xhigh"]);
+    expect(getDefaultMinimumThinkingLevel("xai:grok-4.6")).toBe("medium");
+    expect(enforceThinkingPolicy("xai:grok-4.6", "off")).toBe("low");
+    expect(enforceThinkingPolicy("xai:grok-4.6", "max")).toBe("xhigh");
+  });
+});
+
 describe("getAvailableThinkingLevels", () => {
   test("returns the raw capability when no floor is provided", () => {
     expect(getAvailableThinkingLevels("anthropic:claude-sonnet-4-5")).toEqual([

--- a/src/common/utils/thinking/policy.ts
+++ b/src/common/utils/thinking/policy.ts
@@ -19,7 +19,8 @@ import {
   THINKING_LEVEL_OFF,
   anthropicRejectsDisabledThinking,
   anthropicSupportsNativeXhigh,
-  isGrok45Model,
+  isGrok46Model,
+  isGrokFrontierModel,
   isKimiK3Model,
   openaiSupportsNativeMaxEffort,
   stripModelProviderPrefixes,
@@ -65,6 +66,7 @@ export function isGeminiFlashThinkingLevelModelName(modelName: string): boolean 
  * - openai:gpt-5-pro → ["high"] (only supported level, legacy)
  * - Gemini Flash chat variants → ["off", "low", "medium", "high"]
  * - gemini-3 Pro variants → ["low", "high"] (thinking level only)
+ * - xai:grok-4.6 → ["low", "medium", "high", "xhigh"] (reasoning cannot be disabled)
  * - xai:grok-4.5 → ["low", "medium", "high"] (reasoning cannot be disabled)
  * - default → ["off", "low", "medium", "high"] (standard 4 levels; xhigh is opt-in per model)
  *
@@ -173,8 +175,12 @@ function getExplicitThinkingPolicy(modelString: string): ThinkingPolicy | null {
     return ["low", "high"];
   }
 
-  // Grok 4.5 always reasons and supports configurable low/medium/high effort.
-  if (isGrok45Model(withoutProviderNamespace)) {
+  // Frontier Grok models always reason. Grok 4.6 adds native xhigh effort;
+  // Grok 4.5 supports configurable low/medium/high.
+  if (isGrok46Model(withoutProviderNamespace)) {
+    return ["low", "medium", "high", "xhigh"];
+  }
+  if (isGrokFrontierModel(withoutProviderNamespace)) {
     return ["low", "medium", "high"];
   }
 

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -39,12 +39,26 @@ describe("getModelStats", () => {
     expect(expectStats("openai:gpt-5.6")).toEqual(expectStats("openai:gpt-5.6-sol"));
   });
 
-  test("resolves Grok 4.5 family aliases and case variants for usage meters", () => {
-    const grok = expectStats(KNOWN_MODELS.GROK_45.id);
+  test("resolves Grok 4.6 family aliases and case variants for usage meters", () => {
+    const grok = expectStats(KNOWN_MODELS.GROK_46.id);
     expect(grok.max_input_tokens).toBe(500000);
     expect(grok.max_output_tokens).toBeUndefined();
-    expect(expectStats("xai:grok-4.5-latest")).toEqual(grok);
-    expect(expectStats("XAI:Grok-4.5")).toEqual(grok);
+    expect(expectStats("xai:grok-4.6-latest")).toEqual(grok);
+    expect(expectStats("XAI:Grok-4.6")).toEqual(grok);
+  });
+
+  test("resolves Grok 4.6 pricing with its higher cached-input rate", () => {
+    const grok46 = expectStats("xai:grok-4.6");
+    expect(grok46.input_cost_per_token).toBe(0.000002);
+    expect(grok46.output_cost_per_token).toBe(0.000006);
+    expect(grok46.cache_read_input_token_cost).toBe(0.0000005);
+    expect(grok46.input_cost_per_token_above_200k_tokens).toBe(0.000004);
+    expect(grok46.output_cost_per_token_above_200k_tokens).toBe(0.000012);
+    expect(grok46.cache_read_input_token_cost_above_200k_tokens).toBe(0.000001);
+
+    // Grok 4.5 stays servable as a custom model string with its own (cheaper) cache rate.
+    const grok45 = expectStats("xai:grok-4.5");
+    expect(grok45.cache_read_input_token_cost).toBe(0.0000003);
   });
 
   test("keeps mixed-case LiteLLM catalog ids before lowercase fallbacks", () => {

--- a/src/common/utils/tokens/modelStats.test.ts
+++ b/src/common/utils/tokens/modelStats.test.ts
@@ -56,7 +56,7 @@ describe("getModelStats", () => {
     expect(grok46.output_cost_per_token_above_200k_tokens).toBe(0.000012);
     expect(grok46.cache_read_input_token_cost_above_200k_tokens).toBe(0.000001);
 
-    // Grok 4.5 stays servable as a custom model string with its own (cheaper) cache rate.
+    // Grok 4.5 keeps its distinct cheaper cache rate.
     const grok45 = expectStats("xai:grok-4.5");
     expect(grok45.cache_read_input_token_cost).toBe(0.0000003);
   });

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -69,7 +69,32 @@ const GPT_56_SOL_STATS: ModelData = {
 };
 
 export const modelsExtra: Record<string, ModelData> = {
-  // Grok 4.5 - Released July 2026. xAI's flagship coding and agentic model.
+  // Grok 4.6 - Released August 12, 2026. xAI's frontier coding and agentic model.
+  // Same $2/$6 headline rates as Grok 4.5 but a higher cached-input rate ($0.50 vs
+  // $0.30). Pricing doubles for prompts above 200K tokens; Priority Processing is a
+  // separate request-time 2× multiplier and is therefore not baked into these rates.
+  "xai/grok-4.6": {
+    max_input_tokens: 500000,
+    // Leave max_output_tokens unset: StreamManager forwards it as the request
+    // maxOutputTokens default, and xAI publishes no output limit for grok-4.6.
+    input_cost_per_token: 0.000002, // $2 per million input tokens
+    input_cost_per_token_above_200k_tokens: 0.000004, // $4 per million input tokens
+    output_cost_per_token: 0.000006, // $6 per million output tokens
+    output_cost_per_token_above_200k_tokens: 0.000012, // $12 per million output tokens
+    cache_read_input_token_cost: 0.0000005, // $0.50 per million cached input tokens
+    cache_read_input_token_cost_above_200k_tokens: 0.000001, // $1 per million cached input tokens
+    litellm_provider: "xai",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+    knowledge_cutoff: "2026-02-01",
+    supported_endpoints: ["/v1/chat/completions", "/v1/responses"],
+  },
+
+  // Grok 4.5 - Released July 2026. Superseded by Grok 4.6 as the curated xAI model;
+  // still servable as the custom model string `xai:grok-4.5`.
   // Pricing doubles for prompts above 200K tokens; Priority Processing applies a
   // separate 2× multiplier at request time and is therefore not baked into these rates.
   "xai/grok-4.5": {

--- a/src/common/utils/tools/toolDefinitions.test.ts
+++ b/src/common/utils/tools/toolDefinitions.test.ts
@@ -752,8 +752,13 @@ describe("TOOL_DEFINITIONS", () => {
     }
   });
 
-  it("exposes xAI native search tools only for Grok 4.5", () => {
-    for (const modelString of ["xai:grok-4.5", "xai:grok-4.5-latest"]) {
+  it("exposes xAI native search tools only for frontier Grok", () => {
+    for (const modelString of [
+      "xai:grok-4.6",
+      "xai:grok-4.6-latest",
+      "xai:grok-4.5",
+      "xai:grok-4.5-latest",
+    ]) {
       expect(getAvailableTools(modelString)).toEqual(
         expect.arrayContaining(["web_search", "x_search"])
       );

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -3313,7 +3313,9 @@ export function getAvailableTools(
       }
       return baseTools;
     case "xai":
-      return isGrokFrontierModel(modelString) ? [...baseTools, "web_search", "x_search"] : baseTools;
+      return isGrokFrontierModel(modelString)
+        ? [...baseTools, "web_search", "x_search"]
+        : baseTools;
     case "google":
       if (supportsGoogleNativeToolsWithFunctionTools(modelId)) {
         return [...baseTools, "google_search", "url_context"];

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -26,7 +26,7 @@
  * by our own backend code and always use `undefined` for absent fields.
  */
 
-import { isGrok45Model } from "@/common/types/thinking";
+import { isGrokFrontierModel } from "@/common/types/thinking";
 import { z } from "zod";
 import {
   AgentIdSchema,
@@ -3313,7 +3313,7 @@ export function getAvailableTools(
       }
       return baseTools;
     case "xai":
-      return isGrok45Model(modelString) ? [...baseTools, "web_search", "x_search"] : baseTools;
+      return isGrokFrontierModel(modelString) ? [...baseTools, "web_search", "x_search"] : baseTools;
     case "google":
       if (supportsGoogleNativeToolsWithFunctionTools(modelId)) {
         return [...baseTools, "google_search", "url_context"];

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -2,7 +2,7 @@ import { xai } from "@ai-sdk/xai";
 import { type LanguageModel, type Tool } from "ai";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import type { MuxProviderOptions } from "@/common/types/providerOptions";
-import { isGrok45Model } from "@/common/types/thinking";
+import { isGrokFrontierModel } from "@/common/types/thinking";
 import type { BackgroundWorkAttentionPolicy } from "@/common/types/backgroundWorkAttention";
 import { cloneToolPreservingDescriptors } from "@/common/utils/tools/cloneToolPreservingDescriptors";
 import { createFileReadTool } from "@/node/services/tools/file_read";
@@ -700,7 +700,7 @@ export function getForcedXaiSearchToolNames(
   modelString: string,
   searchParameters: ToolConfiguration["xaiSearchParameters"]
 ): string[] | undefined {
-  if (!isGrok45Model(modelString) || searchParameters?.mode !== "on") {
+  if (!isGrokFrontierModel(modelString) || searchParameters?.mode !== "on") {
     return undefined;
   }
 
@@ -907,7 +907,7 @@ export async function getToolsForModel(
       }
 
       case "xai": {
-        if (isGrok45Model(capabilityModelString) && config.xaiNativeToolsEnabled !== false) {
+        if (isGrokFrontierModel(capabilityModelString) && config.xaiNativeToolsEnabled !== false) {
           const nativeSearch = getXaiNativeSearchConfiguration(config.xaiSearchParameters);
           allTools = {
             ...baseTools,

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3212,7 +3212,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Codex Max 5.1          | openai:gpt-5.1-codex-max      | `codex-max`                                                  |         |",
       "| Gemini 3.1 Pro Preview | google:gemini-3.1-pro-preview | `gemini`, `gemini-pro`                                       |         |",
       "| Gemini 3.6 Flash       | google:gemini-3.6-flash       | `gemini-flash`                                               |         |",
-      "| Grok 4.5               | xai:grok-4.5                  | `grok`, `grok-4.5`                                           |         |",
+      "| Grok 4.6               | xai:grok-4.6                  | `grok`, `grok-4.6`                                           |         |",
       "| DeepSeek V4 Pro        | deepseek:deepseek-v4-pro      | `deepseek`, `deepseek-pro`, `deepseek-v4`, `deepseek-v4-pro` |         |",
       "| DeepSeek V4 Flash      | deepseek:deepseek-v4-flash    | `deepseek-flash`, `deepseek-v4-flash`                        |         |",
       "| Kimi K3                | moonshotai:kimi-k3            | `kimi`, `k3`, `kimi-k3`                                      |         |",

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -469,15 +469,17 @@ describe("ProviderModelFactory.createModel", () => {
 });
 
 describe("ProviderModelFactory xAI API selection", () => {
-  it("uses Responses for Grok 4.5 so exact billed cost metadata is available", async () => {
+  it("uses Responses for frontier Grok so exact billed cost metadata is available", async () => {
     await withTempConfig(async (config, factory) => {
       config.saveProvidersConfig({ xai: { apiKey: "xai-test-key" } });
 
-      const result = await factory.createModel("xai:grok-4.5");
+      for (const model of ["xai:grok-4.6", "xai:grok-4.5"]) {
+        const result = await factory.createModel(model);
 
-      expect(result.success).toBe(true);
-      if (!result.success) return;
-      expect((result.data as { provider?: unknown }).provider).toBe("xai.responses");
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+        expect((result.data as { provider?: unknown }).provider).toBe("xai.responses");
+      }
     });
   });
 

--- a/src/node/services/providerModelFactory.ts
+++ b/src/node/services/providerModelFactory.ts
@@ -3,7 +3,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { XaiProviderOptions } from "@ai-sdk/xai";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { wrapLanguageModel, type LanguageModel } from "ai";
-import { isGrok45Model, type ThinkingLevel } from "@/common/types/thinking";
+import { isGrokFrontierModel, type ThinkingLevel } from "@/common/types/thinking";
 import { Ok, Err } from "@/common/types/result";
 import type { Result } from "@/common/types/result";
 import type { SendMessageError } from "@/common/types/errors";
@@ -213,12 +213,12 @@ export function resolveOpenAIWebSocketResponsesUrl(baseURL: unknown): string | u
 }
 
 /**
- * Force Grok 4.5 Responses onto store=false by default (ZDR-safe).
+ * Force frontier Grok Responses onto store=false by default (ZDR-safe).
  * Applied for both direct xAI and gateway-routed Grok so callers that omit
  * providerOptions (identity generation, memory harvest, headless tools) never
  * hit the upstream store=true default. Explicit request-level store wins.
  */
-function injectGrok45StoreDefault(
+function injectGrokStoreDefault(
   model: {
     doStream: (options: never) => unknown;
     doGenerate: (options: never) => unknown;
@@ -1549,20 +1549,20 @@ export class ProviderModelFactory {
           ...restOptions,
           fetch: providerFetch,
         });
-        // Grok 4.5 uses the Responses API so @ai-sdk/xai surfaces exact billed
+        // Frontier Grok uses the Responses API so @ai-sdk/xai surfaces exact billed
         // cost metadata (including Priority Processing). Mapped provider aliases inherit
         // that capability; older custom model strings stay on Chat Completions for
         // legacy search_parameters compatibility.
         const capabilityModel = resolveModelForMetadata(`xai:${modelId}`, providersConfig);
-        const model = isGrok45Model(capabilityModel)
+        const model = isGrokFrontierModel(capabilityModel)
           ? provider.responses(modelId)
           : provider.chat(modelId);
 
-        // Grok 4.5 Responses: force store=false by default so ZDR and non-ZDR share
+        // Frontier Grok Responses: force store=false by default so ZDR and non-ZDR share
         // one path. buildProviderOptions already defaults this; inject here too so
         // callers that omit providerOptions still get ZDR-safe requests.
-        if (isGrok45Model(capabilityModel)) {
-          injectGrok45StoreDefault(model, muxProviderOptions?.xai?.store);
+        if (isGrokFrontierModel(capabilityModel)) {
+          injectGrokStoreDefault(model, muxProviderOptions?.xai?.store);
         }
 
         return Ok(model);
@@ -1822,13 +1822,13 @@ export class ProviderModelFactory {
           model.doGenerate = (options) => originalDoGenerate(injectStoreFlag(options));
         }
 
-        // Gateway-routed Grok 4.5 must get the same store=false default as direct xAI.
+        // Gateway-routed frontier Grok must get the same store=false default as direct xAI.
         // Route form is mux-gateway:xai/<model>; capability lookup uses canonical xai:id.
         if (modelId.startsWith("xai/")) {
           const gatewayGrokModel = `xai:${modelId.slice("xai/".length)}`;
           const capabilityModel = resolveModelForMetadata(gatewayGrokModel, providersConfig);
-          if (isGrok45Model(capabilityModel)) {
-            injectGrok45StoreDefault(model, muxProviderOptions?.xai?.store);
+          if (isGrokFrontierModel(capabilityModel)) {
+            injectGrokStoreDefault(model, muxProviderOptions?.xai?.store);
           }
         }
 

--- a/src/node/services/providerService.ts
+++ b/src/node/services/providerService.ts
@@ -406,7 +406,7 @@ export class ProviderService {
       }
 
       // OpenAI-specific: response storage setting (required for ZDR).
-      // xAI Grok 4.5 always uses store=false in the request path (no settings surface).
+      // xAI frontier Grok always uses store=false in the request path (no settings surface).
       if (provider === "openai" && typeof config.store === "boolean") {
         providerInfo.store = config.store;
       }

--- a/tests/ipc/providers/xaiGrok46.test.ts
+++ b/tests/ipc/providers/xaiGrok46.test.ts
@@ -42,10 +42,10 @@ async function waitForTerminal(
     collector.waitForEvent("stream-error", timeoutMs),
   ]);
   if (!terminalEvent) {
-    throw new Error("Expected terminal stream event from Grok 4.5");
+    throw new Error("Expected terminal stream event from Grok 4.6");
   }
   if (terminalEvent.type === "stream-error") {
-    throw new Error(`Grok 4.5 stream failed: ${terminalEvent.error}`);
+    throw new Error(`Grok 4.6 stream failed: ${terminalEvent.error}`);
   }
   if (!isStreamEnd(terminalEvent)) {
     throw new Error(`Expected stream-end event, received ${terminalEvent.type}`);
@@ -53,11 +53,11 @@ async function waitForTerminal(
   return terminalEvent;
 }
 
-describeIntegration("xAI Grok 4.5 integration", () => {
+describeIntegration("xAI Grok 4.6 integration", () => {
   configureTestRetries(3);
 
   test("streams a priority request and reports exact billed cost metadata", async () => {
-    const { env, workspaceId, cleanup } = await setupWorkspace("xai", "grok-4-5");
+    const { env, workspaceId, cleanup } = await setupWorkspace("xai", "grok-4-6");
     const collector = createStreamCollector(env.orpc, workspaceId);
     collector.start();
 
@@ -65,10 +65,10 @@ describeIntegration("xAI Grok 4.5 integration", () => {
       const result = await sendMessageWithModel(
         env,
         workspaceId,
-        "Reply with exactly: GROK45_OK",
-        KNOWN_MODELS.GROK_45.id,
+        "Reply with exactly: GROK46_OK",
+        KNOWN_MODELS.GROK_46.id,
         {
-          // Grok 4.5's built-in minimum thinking floor is medium.
+          // Grok 4.6's built-in minimum thinking floor is medium.
           thinkingLevel: "medium",
           providerOptions: {
             xai: {
@@ -84,7 +84,7 @@ describeIntegration("xAI Grok 4.5 integration", () => {
       const streamEnd = await waitForTerminal(collector, 60_000);
 
       assertStreamSuccess(collector);
-      expect(streamEnd.metadata.model).toBe(KNOWN_MODELS.GROK_45.id);
+      expect(streamEnd.metadata.model).toBe(KNOWN_MODELS.GROK_46.id);
       expect(streamEnd.metadata.thinkingLevel).toBe("medium");
 
       const xaiMetadata = streamEnd.metadata.providerMetadata?.xai as
@@ -100,10 +100,10 @@ describeIntegration("xAI Grok 4.5 integration", () => {
   }, 90_000);
 
   test("multi-turn with default store=false keeps encrypted reasoning and continues cleanly", async () => {
-    // Grok 4.5 Responses always use store=false in Mux (ZDR-safe default).
+    // Grok 4.6 Responses always use store=false in Mux (ZDR-safe default).
     // With store=false, xAI returns reasoning.encrypted_content which Mux must
     // persist and replay; otherwise the second turn fails or loses quality.
-    const { env, workspaceId, cleanup } = await setupWorkspace("xai", "grok-4-5-zdr");
+    const { env, workspaceId, cleanup } = await setupWorkspace("xai", "grok-4-6-zdr");
     const historyService = new HistoryService(env.config);
 
     try {
@@ -119,7 +119,7 @@ describeIntegration("xAI Grok 4.5 integration", () => {
           "Do not mention the codeword yet.",
           "Reply with exactly: READY",
         ].join(" "),
-        KNOWN_MODELS.GROK_45.id,
+        KNOWN_MODELS.GROK_46.id,
         {
           thinkingLevel: "medium",
           toolPolicy: DISABLE_TOOLS,
@@ -155,7 +155,7 @@ describeIntegration("xAI Grok 4.5 integration", () => {
         env,
         workspaceId,
         "Now reply with exactly the secret codeword and nothing else.",
-        KNOWN_MODELS.GROK_45.id,
+        KNOWN_MODELS.GROK_46.id,
         {
           thinkingLevel: "medium",
           toolPolicy: DISABLE_TOOLS,
@@ -172,7 +172,7 @@ describeIntegration("xAI Grok 4.5 integration", () => {
       assertStreamSuccess(secondCollector);
 
       expect(secondCollector.getStreamContent()).toMatch(/MUXZDR42/);
-      expect(firstEnd.metadata.model).toBe(KNOWN_MODELS.GROK_45.id);
+      expect(firstEnd.metadata.model).toBe(KNOWN_MODELS.GROK_46.id);
       secondCollector.stop();
     } finally {
       await cleanup();

--- a/tests/ui/agents/thinkingSelector.test.ts
+++ b/tests/ui/agents/thinkingSelector.test.ts
@@ -181,9 +181,9 @@ describeIntegration("Thinking selector", () => {
       await expectPressed(within(menu).getByRole("button", { name: /Fast mode/i }), true);
       fireEvent.click(container.querySelector("[data-thinking-selector-trigger]")!);
 
-      // Grok uses the same thinking selector with its native low/medium/high ladder,
-      // while Fast mode writes xAI's priority tier instead of OpenAI's.
-      await selectModel(container, harness.workspaceId, KNOWN_MODELS.GROK_45.id);
+      // Grok uses the same thinking selector with its native low/medium/high/xhigh
+      // ladder, while Fast mode writes xAI's priority tier instead of OpenAI's.
+      await selectModel(container, harness.workspaceId, KNOWN_MODELS.GROK_46.id);
       menu = await openThinkingSelector(container);
       if (menu.querySelector('[data-component="ProModeToggle"]')) {
         throw new Error("Pro toggle should not render for Grok");
@@ -193,6 +193,7 @@ describeIntegration("Thinking selector", () => {
       }
       within(menu).getByRole("option", { name: "Medium" });
       within(menu).getByRole("option", { name: "High" });
+      within(menu).getByRole("option", { name: "Extra High" });
 
       const grokFastToggle = within(menu).getByRole("button", { name: /Fast mode/i });
       await expectPressed(grokFastToggle, false);


### PR DESCRIPTION
## Summary

Makes Grok 4.6 (released today) the curated default Grok model: the `grok` alias now resolves to `xai:grok-4.6`, with official pricing, the new native `xhigh` reasoning effort, and an `@ai-sdk/xai` bump that adds first-class support for both.

## Background

xAI shipped Grok 4.6 on August 12, 2026 as the successor to Grok 4.5 ("a significant improvement over Grok 4.5 at the same price"). Verified against xAI's own docs (docs.x.ai model card + pricing table):

- $2/M input, $6/M output, $0.50/M cached input; all rates double for prompts ≥200K tokens ($4/$12/$1)
- 500K context, text+image input, no published output limit, knowledge cutoff Feb 1, 2026
- Reasoning effort: low/medium/high (default)/**xhigh** (new; 4.5 tops out at high)
- Responses API, native web/X search, priority processing: same as 4.5

## Implementation

- `@ai-sdk/xai` 4.0.28 → 4.0.37 (adds the `grok-4.6` model ID and `xhigh` to the reasoning-effort schemas). The repo's xSearch handle-limit patch (max 10 → 20) is not upstreamed in 4.0.37, so it is re-rolled onto the new version.
- `isGrok45Model` generalizes to `isGrokFrontierModel` (matches 4.5 and 4.6) at every call site: Responses API routing, store=false ZDR default, native search tools, priority-tier fast mode. A new `isGrok46Model` gates the xhigh-capable ladder.
- Thinking policy for 4.6 is `["low","medium","high","xhigh"]`; `buildProviderOptions` passes `xhigh` through natively for 4.6 (clamps `max` → `xhigh`) while 4.5 keeps clamping to `high`.
- New `xai/grok-4.6` pricing entry in models-extra; the 4.5 entry stays so `xai:grok-4.5` remains servable as a custom model string (it has a different cached-input rate: $0.30 vs $0.50).
- Docs model table + built-in skill content regenerated.

## Validation

- Live smoke tests against the real xAI API with a configured key:
  - `tests/ipc/providers/xaiGrok46.test.ts` (renamed from the 4.5 suite): priority-tier stream with exact billed `costInUsdTicks`, and multi-turn store=false with encrypted reasoning replay. Both pass against `grok-4.6`.
  - One-off `generateText` with `reasoningEffort: "xhigh"` accepted by the API (reasoning tokens billed, cached input observed).
- `make static-check` green; full `bun test src` run has 7 failures that also reproduce on the base commit (pre-existing flakes in taskService/WorkspaceFooterBar/backup, unrelated to this diff).

## Risks

Low. The predicate rename is behavior-preserving for 4.5 (regression suites for 4.5 strings kept). The main new surface is xhigh passthrough, which is gated to 4.6 only and verified against the live API. SDK bump is patch-level (4.0.28 → 4.0.37) with the local patch re-rolled.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
