### PR TITLE
🤖 fix: keep electron package installed in Docker builder despite download flakes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,11 @@ COPY patches/ patches/
 COPY scripts/postinstall.sh scripts/
 
 # Install dependencies and create Makefile sentinel so build targets don't reinstall.
-RUN bun install --frozen-lockfile && \
+# tsgo typechecks electron-importing sources, so the optional electron package must
+# install even though the server image never runs it. Its binary download can fail
+# transiently, and bun then silently drops the package instead of failing the install.
+# Skip the unused download, and Electron-ABI native rebuilds via MUX_HEADLESS.
+RUN MUX_HEADLESS=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 bun install --frozen-lockfile && \
     touch node_modules/.installed
 
 # Copy build orchestration files used by Make targets.


### PR DESCRIPTION
## Summary

Set `MUX_HEADLESS=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1` on the Docker builder's `bun install` so the optional `electron` package always installs, fixing the `Smoke / Docker` failures on `main`.

## Background

Both pushes to `main` since #3842 fail `Smoke / Docker` with `TS2307: Cannot find module 'electron'` during `make verify-docker-runtime-artifacts`. The causal chain:

1. `electron` is an optionalDependency whose postinstall downloads a ~115MB binary from GitHub releases.
2. That download currently flakes with `socket hang up` (4-5 of 5 attempts in container probes; plain `curl` to the same URL succeeds). The same flake class ejected #3842 from the merge queue earlier (electron-builder download).
3. When the postinstall fails, bun silently drops the optional package: install exits 0 and the summary still lists `+ electron@40.9.3`, but `node_modules/electron` does not exist.
4. tsgo then fails typechecking electron-importing sources.

It surfaced now because the `bun install` layer is cached by depot. Every recent green run shows `#16 CACHED`; #3842 changed `bun.lock` (xai SDK bump), forcing the first fresh install in weeks.

## Implementation

The server image never runs Electron; only the package's types are needed for typechecking. `ELECTRON_SKIP_BINARY_DOWNLOAD=1` removes the flaky network dependency while keeping the package installed. `MUX_HEADLESS=1` makes `scripts/postinstall.sh` skip Electron-ABI native rebuilds for node-pty/DuckDB, which are useless for the node runtime and would otherwise run now that electron is present.

## Validation

- Minimal container repro: without the fix `node_modules/electron` is missing after a cold-cache install; with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` it is present.
- Full builder stage build passes the exact failing `verify-docker-runtime-artifacts` step.
- Full image build plus the CI smoke procedure locally: `/health` returns `{"status":"ok"}` and `/version` reports `"mode":"server"`.

## Risks

Low. The change only affects the Docker builder stage install; desktop builds and CI installs are untouched. The runtime image already never shipped the electron binary (only server bundle artifacts are copied out of the builder).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
