### PR TITLE
🤖 fix: stop painting running sidebar task groups with the selected background

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -62,6 +62,7 @@ function installProviderIconSvgMocks() {
     "@/browser/assets/icons/moonshotai.svg?react",
     "@/browser/assets/icons/aws.svg?react",
     "@/browser/assets/icons/github.svg?react",
+    "@/browser/assets/icons/coder.svg?react",
   ] as const;
 
   for (const svgPath of providerIconSvgPaths) {

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.test.tsx
@@ -58,6 +58,19 @@ describe("TaskGroupListItem", () => {
     expect(groupRow.textContent).toContain("2 running");
   });
 
+  test("does not paint running groups with the selected background", () => {
+    const running = renderTaskGroup({ runningCount: 1, isRunActive: true });
+    expect(
+      running.getByTestId("task-group-best-of-demo").classList.contains("bg-surface-secondary")
+    ).toBe(false);
+    cleanup();
+
+    const selected = renderTaskGroup({ isSelected: true });
+    expect(
+      selected.getByTestId("task-group-best-of-demo").classList.contains("bg-surface-secondary")
+    ).toBe(true);
+  });
+
   test("keeps queued-only groups pending instead of active", () => {
     const view = renderTaskGroup({ queuedCount: 1 });
 

--- a/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
+++ b/src/browser/components/ProjectSidebar/TaskGroupListItem.tsx
@@ -84,7 +84,9 @@ export function TaskGroupListItem(props: TaskGroupListItemProps) {
       className={cn(
         "bg-surface-primary relative flex items-start rounded-l-sm py-2 pr-2 select-none transition-all duration-150 hover:bg-surface-secondary",
         props.sectionId != null ? "ml-2" : "ml-0",
-        hasRunningWork && "bg-surface-secondary",
+        // Running state must not reuse the selected background: it made active
+        // workflow groups look permanently selected. Activity is conveyed by the
+        // status dot, green icon, and status text instead (matches AgentListItem).
         props.isSelected && "bg-surface-secondary"
       )}
       style={{ paddingLeft }}


### PR DESCRIPTION
## Summary

Sidebar workflow task-group headers (e.g. "Workflow · workflow") always rendered with the selected-row background while their run was active, so they looked permanently selected even when a different workspace was selected.

## Background

`TaskGroupListItem` applied `hasRunningWork && "bg-surface-secondary"`, the exact class used for `isSelected`. Regular workspace rows (`AgentListItem`) reserve that background for selection and hover; running state is conveyed by the status dot, the green kind icon, brighter title text, and the "Workflow running" / "N running" status line. The stray highlight was introduced in #3459.

## Implementation

- Remove the running-state background from the group header row; selection and hover backgrounds are unchanged, as are `data-running`, the status dot aggregate state, and the green icon/text treatment.
- Add a regression test asserting a running, non-selected group header does not carry the selected background while a selected one does.
- Fix a pre-existing `ProjectSidebar.test.tsx` suite-wide failure: #3835 added a `coder.svg?react` import to `ProviderIcon`, which the test's SVG mock list did not cover.

## Validation

Verified live in Storybook (`WorkflowRunGroups` story): running group headers no longer carry `bg-surface-secondary`, selecting a member workspace still highlights its group header, and header expand/collapse still works.

## Risks

Low: one class removed from one row component. Pixel snapshots of stories with running task groups will change background as intended.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
