### PR TITLE
🤖 feat: surface MCP prompts in the chat composer

### DIFF
--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -332,9 +332,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const asyncCommandTokenRef = useRef(0);
   const workspaceId = variant === "workspace" ? props.workspaceId : null;
   // Send-time command/ref resolution can await cold MCP discovery. Every
-  // in-flight send in the current scope shares this controller; aborting it on
-  // scope change or unmount discards stale continuations so they cannot send
-  // to the captured workspace or clear the newly selected workspace's draft.
+  // in-flight send in the current scope shares this controller; when the
+  // composer is reused for a different scope, aborting it discards stale
+  // continuations so they cannot clear the new scope's draft or send against
+  // it. Unmount intentionally does not abort: a send submitted just before
+  // navigating away (e.g. to Settings) must still deliver to its captured
+  // workspace (see unreadIndicator.test.ts).
   const sendResolutionAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -653,8 +656,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       isMountedRef.current = false;
       mcpPromptsAbortRef.current?.abort();
       mcpPromptsAbortRef.current = null;
-      sendResolutionAbortRef.current?.abort();
-      sendResolutionAbortRef.current = null;
     };
   }, []);
   const inputRef = useRef<HTMLTextAreaElement>(null);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2632,7 +2632,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
     const inlineReferenceCandidates = extractInlineSkillReferenceCandidates(messageText);
-    const [combinedSkillRefs, combinedMcpPromptRefs] = await Promise.all([
+    const [combinedSkillRefs, mcpPromptRefsResult] = await Promise.all([
       resolveInlineSkillRefsForSend({
         messageText,
         slashInvocation: skillInvocation,
@@ -2650,6 +2650,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         candidates: inlineReferenceCandidates,
       }),
     ]);
+    if (mcpPromptRefsResult.error) {
+      pushToast({ type: "error", message: mcpPromptRefsResult.error });
+      return;
+    }
+    const combinedMcpPromptRefs = mcpPromptRefsResult.refs;
 
     // Route to creation handler for creation variant
     if (variant === "creation") {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -331,13 +331,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   });
   const asyncCommandTokenRef = useRef(0);
   const workspaceId = variant === "workspace" ? props.workspaceId : null;
-  // Send-time command/ref resolution can await cold MCP discovery. Every
-  // in-flight send in the current scope shares this controller; when the
-  // composer is reused for a different scope, aborting it discards stale
-  // continuations so they cannot clear the new scope's draft or send against
-  // it. Unmount intentionally does not abort: a send submitted just before
-  // navigating away (e.g. to Settings) must still deliver to its captured
-  // workspace (see unreadIndicator.test.ts).
+  // One controller covers all sends in a composer scope. Scope changes abort
+  // stale continuations; unmount does not, so submitted sends can still reach
+  // their captured workspace after navigation.
   const sendResolutionAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -85,7 +85,10 @@ import { Button } from "@/browser/components/Button/Button";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
-import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
+import {
+  extractInlineSkillReferenceCandidates,
+  findInlineSkillReferenceAtCursor,
+} from "@/browser/utils/agentSkills/inlineSkillReferences";
 import {
   convertSymbolCommandAtCursor,
   convertTerminatedSymbolCommand,
@@ -439,6 +442,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const projectedWorkflowRunCardKeysRef = useRef(new Set<string>());
   const workflowsRequestIdRef = useRef(0);
   const agentSkillsRequestIdRef = useRef(0);
+  const mcpPromptsRequestIdRef = useRef(0);
   const mcpPromptsRequestRef = useRef<Promise<void> | null>(null);
   const mcpPromptsLoadedAtRef = useRef(0);
   const mcpPromptsWorkspaceRef = useRef<string | null>(null);
@@ -1577,6 +1581,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       if (mcpPromptsWorkspaceRef.current !== null) {
         mcpPromptsWorkspaceRef.current = null;
         mcpPromptsLoadedAtRef.current = 0;
+        mcpPromptsRequestIdRef.current++;
         mcpPromptsRequestRef.current = null;
         setMcpPromptDescriptors([]);
       }
@@ -1586,6 +1591,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (mcpPromptsWorkspaceRef.current !== workspaceId) {
       mcpPromptsWorkspaceRef.current = workspaceId;
       mcpPromptsLoadedAtRef.current = 0;
+      mcpPromptsRequestIdRef.current++;
       mcpPromptsRequestRef.current = null;
       setMcpPromptDescriptors([]);
     }
@@ -1596,15 +1602,24 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (!opensPromptSurface || Date.now() - mcpPromptsLoadedAtRef.current < 30_000) return;
     if (mcpPromptsRequestRef.current) return;
 
+    const requestId = ++mcpPromptsRequestIdRef.current;
     const request = api.workspace.mcp.prompts
       .list({ workspaceId })
       .then((prompts) => {
-        if (mcpPromptsWorkspaceRef.current !== workspaceId) return;
+        if (
+          mcpPromptsWorkspaceRef.current !== workspaceId ||
+          mcpPromptsRequestIdRef.current !== requestId
+        ) {
+          return;
+        }
         setMcpPromptDescriptors(prompts);
         mcpPromptsLoadedAtRef.current = Date.now();
       })
       .catch(() => {
-        if (mcpPromptsWorkspaceRef.current === workspaceId) {
+        if (
+          mcpPromptsWorkspaceRef.current === workspaceId &&
+          mcpPromptsRequestIdRef.current === requestId
+        ) {
           mcpPromptsLoadedAtRef.current = Date.now();
         }
       })
@@ -1638,8 +1653,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
 
-    // Avoid recomputing on caret movement within the same partial, but refresh when
-    // skill or MCP prompt discovery finishes for already-typed `$partial` input.
     if (
       !shouldRefreshInlineSkillSuggestions({
         inputChanged,
@@ -2616,20 +2629,25 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       pushToast({ type: "error", message: invocationError });
       return;
     }
-    const combinedSkillRefs = await resolveInlineSkillRefsForSend({
-      messageText,
-      slashInvocation: skillInvocation,
-      agentSkillDescriptors,
-      api,
-      discovery: skillDiscovery,
-    });
-    const combinedMcpPromptRefs = await resolveMcpPromptRefsForSend({
-      messageText,
-      slashInvocation: mcpPromptInvocation,
-      descriptors: mcpPromptDescriptors,
-      api,
-      discovery: skillDiscovery,
-    });
+    const inlineReferenceCandidates = extractInlineSkillReferenceCandidates(messageText);
+    const [combinedSkillRefs, combinedMcpPromptRefs] = await Promise.all([
+      resolveInlineSkillRefsForSend({
+        messageText,
+        slashInvocation: skillInvocation,
+        agentSkillDescriptors,
+        api,
+        discovery: skillDiscovery,
+        candidates: inlineReferenceCandidates,
+      }),
+      resolveMcpPromptRefsForSend({
+        messageText,
+        slashInvocation: mcpPromptInvocation,
+        descriptors: mcpPromptDescriptors,
+        api,
+        discovery: skillDiscovery,
+        candidates: inlineReferenceCandidates,
+      }),
+    ]);
 
     // Route to creation handler for creation variant
     if (variant === "creation") {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -173,6 +173,7 @@ import {
 } from "@/common/types/runtime";
 import { resolveThinkingInput } from "@/common/utils/thinking/policy";
 import {
+  type AgentSkillReference,
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   prepareUserMessageForSend,
@@ -228,6 +229,8 @@ import {
   resolveMcpPromptRefsForSend,
   validateCreationRuntime,
   filePartsToChatAttachments,
+  type MCPPromptInvocation,
+  type SkillInvocation,
   type SkillResolutionTarget,
 } from "./utils";
 import { normalizeAgentId } from "@/common/utils/agentIds";
@@ -446,6 +449,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const mcpPromptsRequestRef = useRef<Promise<void> | null>(null);
   const mcpPromptsLoadedAtRef = useRef(0);
   const mcpPromptsWorkspaceRef = useRef<string | null>(null);
+  // Abandoned cold discovery would otherwise keep starting servers and
+  // waiting out prompts/list deadlines for a workspace we already left.
+  const mcpPromptsAbortRef = useRef<AbortController | null>(null);
   const atMentionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const atMentionRequestIdRef = useRef(0);
   const lastAtMentionScopeIdRef = useRef<string | null>(null);
@@ -638,6 +644,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
+      mcpPromptsAbortRef.current?.abort();
+      mcpPromptsAbortRef.current = null;
     };
   }, []);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1038,7 +1046,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
   );
 
-  const isSendInFlight = variant === "creation" ? creationState.isSending : isSending;
+  // Creation sends also pass through the async resolution phase guarded by
+  // sendingCount, so include it alongside the creation-specific flag.
+  const isSendInFlight = variant === "creation" ? creationState.isSending || isSending : isSending;
   const sendInFlightBlocksInput =
     variant === "workspace" ? isSendInFlight && !isStreamStarting : isSendInFlight;
 
@@ -1583,6 +1593,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         mcpPromptsLoadedAtRef.current = 0;
         mcpPromptsRequestIdRef.current++;
         mcpPromptsRequestRef.current = null;
+        mcpPromptsAbortRef.current?.abort();
+        mcpPromptsAbortRef.current = null;
         setMcpPromptDescriptors([]);
       }
       return;
@@ -1593,6 +1605,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       mcpPromptsLoadedAtRef.current = 0;
       mcpPromptsRequestIdRef.current++;
       mcpPromptsRequestRef.current = null;
+      mcpPromptsAbortRef.current?.abort();
+      mcpPromptsAbortRef.current = null;
       setMcpPromptDescriptors([]);
     }
 
@@ -1603,8 +1617,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     if (mcpPromptsRequestRef.current) return;
 
     const requestId = ++mcpPromptsRequestIdRef.current;
+    const abortController = new AbortController();
+    mcpPromptsAbortRef.current = abortController;
     const request = api.workspace.mcp.prompts
-      .list({ workspaceId })
+      .list({ workspaceId }, { signal: abortController.signal })
       .then((prompts) => {
         if (
           mcpPromptsWorkspaceRef.current !== workspaceId ||
@@ -1626,6 +1642,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       .finally(() => {
         if (mcpPromptsRequestRef.current === request) {
           mcpPromptsRequestRef.current = null;
+        }
+        if (mcpPromptsAbortRef.current === abortController) {
+          mcpPromptsAbortRef.current = null;
         }
       });
     mcpPromptsRequestRef.current = request;
@@ -2614,44 +2633,55 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                 transferredDraftProjectDiscovery,
             }
           : null;
-    const {
-      parsed,
-      skillInvocation,
-      mcpPromptInvocation,
-      error: invocationError,
-    } = await parseCommandWithSkillInvocation({
-      messageText,
-      agentSkillDescriptors,
-      mcpPromptDescriptors,
-      api,
-      discovery: skillDiscovery,
-    });
-    if (invocationError) {
-      pushToast({ type: "error", message: invocationError });
-      return;
-    }
-    const inlineReferenceCandidates = extractInlineSkillReferenceCandidates(messageText);
-    const [combinedSkillRefs, mcpPromptRefsResult] = await Promise.all([
-      resolveInlineSkillRefsForSend({
+    // Resolving commands/references can include cold MCP server startup and
+    // prompt discovery; mark the send in flight so a second Enter cannot start
+    // a duplicate send against the same captured draft.
+    setSendingCount((c) => c + 1);
+    let parsed: ParsedCommand;
+    let skillInvocation: SkillInvocation | null;
+    let mcpPromptInvocation: MCPPromptInvocation | null;
+    let combinedSkillRefs: AgentSkillReference[];
+    let mcpPromptRefsResult: Awaited<ReturnType<typeof resolveMcpPromptRefsForSend>>;
+    try {
+      const resolution = await parseCommandWithSkillInvocation({
         messageText,
-        slashInvocation: skillInvocation,
         agentSkillDescriptors,
+        mcpPromptDescriptors,
         api,
         discovery: skillDiscovery,
-        candidates: inlineReferenceCandidates,
-      }),
-      resolveMcpPromptRefsForSend({
-        messageText,
-        slashInvocation: mcpPromptInvocation,
-        descriptors: mcpPromptDescriptors,
-        api,
-        discovery: skillDiscovery,
-        candidates: inlineReferenceCandidates,
-      }),
-    ]);
-    if (mcpPromptRefsResult.error) {
-      pushToast({ type: "error", message: mcpPromptRefsResult.error });
-      return;
+      });
+      parsed = resolution.parsed;
+      skillInvocation = resolution.skillInvocation;
+      mcpPromptInvocation = resolution.mcpPromptInvocation;
+      if (resolution.error) {
+        pushToast({ type: "error", message: resolution.error });
+        return;
+      }
+      const inlineReferenceCandidates = extractInlineSkillReferenceCandidates(messageText);
+      [combinedSkillRefs, mcpPromptRefsResult] = await Promise.all([
+        resolveInlineSkillRefsForSend({
+          messageText,
+          slashInvocation: skillInvocation,
+          agentSkillDescriptors,
+          api,
+          discovery: skillDiscovery,
+          candidates: inlineReferenceCandidates,
+        }),
+        resolveMcpPromptRefsForSend({
+          messageText,
+          slashInvocation: mcpPromptInvocation,
+          descriptors: mcpPromptDescriptors,
+          api,
+          discovery: skillDiscovery,
+          candidates: inlineReferenceCandidates,
+        }),
+      ]);
+      if (mcpPromptRefsResult.error) {
+        pushToast({ type: "error", message: mcpPromptRefsResult.error });
+        return;
+      }
+    } finally {
+      setSendingCount((c) => c - 1);
     }
     const combinedMcpPromptRefs = mcpPromptRefsResult.refs;
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2837,7 +2837,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const promptMuxMetadata: MuxMessageMetadata | undefined = mcpPromptInvocation
         ? {
             type: "normal",
-            rawCommand: messageText,
+            // Include the staged-attachment notice so edit restoration and
+            // compact-and-retry (which prefer rawCommand) keep the attached files.
+            rawCommand: appendStagedAttachmentNotice(messageText, sendAttachments),
             commandPrefix: `/${mcpPromptInvocation.descriptor.commandKey}`,
           }
         : undefined;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1629,7 +1629,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
       });
     mcpPromptsRequestRef.current = request;
-  }, [api, input, variant, workspaceId]);
+    // atMentionCursorNonce: caret movement into an existing `$` token must also
+    // trigger discovery (e.g. a restored draft with the caret placed later).
+  }, [api, input, variant, workspaceId, atMentionCursorNonce]);
 
   useEffect(() => {
     if (showAtMentionSuggestions) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -156,6 +156,7 @@ import {
 } from "@/browser/utils/chatEditing";
 
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import {
   coerceThinkingLevel,
@@ -173,6 +174,7 @@ import {
   type ReviewNoteDataForDisplay,
   prepareUserMessageForSend,
   withAgentSkillRefs,
+  withMcpPromptRefs,
 } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
 import {
@@ -220,6 +222,7 @@ import {
   hasProjectScopedSkillRef,
   parseCommandWithSkillInvocation,
   resolveInlineSkillRefsForSend,
+  resolveMcpPromptRefsForSend,
   validateCreationRuntime,
   filePartsToChatAttachments,
   type SkillResolutionTarget,
@@ -436,6 +439,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const projectedWorkflowRunCardKeysRef = useRef(new Set<string>());
   const workflowsRequestIdRef = useRef(0);
   const agentSkillsRequestIdRef = useRef(0);
+  const mcpPromptsRequestRef = useRef<Promise<void> | null>(null);
+  const mcpPromptsLoadedAtRef = useRef(0);
+  const mcpPromptsWorkspaceRef = useRef<string | null>(null);
   const atMentionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const atMentionRequestIdRef = useRef(0);
   const lastAtMentionScopeIdRef = useRef<string | null>(null);
@@ -444,6 +450,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const lastSkillInputRef = useRef<string | null>(null);
   const lastSkillQueryRef = useRef<string | null>(null);
   const lastSkillDescriptorsRef = useRef<AgentSkillDescriptor[] | null>(null);
+  const lastMcpPromptDescriptorsRef = useRef<MCPPromptDescriptor[] | null>(null);
   const [showCommandSuggestions, setShowCommandSuggestions] = useState(false);
 
   const [commandSuggestions, setCommandSuggestions] = useState<SlashSuggestion[]>([]);
@@ -452,6 +459,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [symbolSuggestions, setSymbolSuggestions] = useState<SlashSuggestion[]>([]);
   const lastSymbolQueryRef = useRef<string>("");
   const [agentSkillDescriptors, setAgentSkillDescriptors] = useState<AgentSkillDescriptor[]>([]);
+  const [mcpPromptDescriptors, setMcpPromptDescriptors] = useState<MCPPromptDescriptor[]>([]);
   const [toast, setToast] = useState<Toast | null>(null);
   // State for destructive command confirmation modal (currently only /clear).
   const [pendingDestructiveCommand, setPendingDestructiveCommand] = useState(false);
@@ -1564,7 +1572,50 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     atMentionCursorNonce,
   ]);
 
-  // Watch input/cursor for inline $skill references
+  useEffect(() => {
+    if (!api || variant !== "workspace" || !workspaceId) {
+      if (mcpPromptsWorkspaceRef.current !== null) {
+        mcpPromptsWorkspaceRef.current = null;
+        mcpPromptsLoadedAtRef.current = 0;
+        mcpPromptsRequestRef.current = null;
+        setMcpPromptDescriptors([]);
+      }
+      return;
+    }
+
+    if (mcpPromptsWorkspaceRef.current !== workspaceId) {
+      mcpPromptsWorkspaceRef.current = workspaceId;
+      mcpPromptsLoadedAtRef.current = 0;
+      mcpPromptsRequestRef.current = null;
+      setMcpPromptDescriptors([]);
+    }
+
+    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
+    const opensPromptSurface =
+      input.trimStart().startsWith("/") || findInlineSkillReferenceAtCursor(input, cursor) !== null;
+    if (!opensPromptSurface || Date.now() - mcpPromptsLoadedAtRef.current < 30_000) return;
+    if (mcpPromptsRequestRef.current) return;
+
+    const request = api.workspace.mcp.prompts
+      .list({ workspaceId })
+      .then((prompts) => {
+        if (mcpPromptsWorkspaceRef.current !== workspaceId) return;
+        setMcpPromptDescriptors(prompts);
+        mcpPromptsLoadedAtRef.current = Date.now();
+      })
+      .catch(() => {
+        if (mcpPromptsWorkspaceRef.current === workspaceId) {
+          mcpPromptsLoadedAtRef.current = Date.now();
+        }
+      })
+      .finally(() => {
+        if (mcpPromptsRequestRef.current === request) {
+          mcpPromptsRequestRef.current = null;
+        }
+      });
+    mcpPromptsRequestRef.current = request;
+  }, [api, input, variant, workspaceId]);
+
   useEffect(() => {
     if (showAtMentionSuggestions) {
       // File mentions win precedence if an edge-case token could match both menus.
@@ -1587,8 +1638,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
 
-    // Avoid recomputing on caret movement within the same partial, but still refresh when
-    // skill discovery finishes asynchronously for already-typed `$partial` input.
+    // Avoid recomputing on caret movement within the same partial, but refresh when
+    // skill or MCP prompt discovery finishes for already-typed `$partial` input.
     if (
       !shouldRefreshInlineSkillSuggestions({
         inputChanged,
@@ -1596,6 +1647,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         partial: match.partial,
         previousDescriptors: lastSkillDescriptorsRef.current,
         descriptors: agentSkillDescriptors,
+        previousMcpPrompts: lastMcpPromptDescriptorsRef.current,
+        mcpPrompts: mcpPromptDescriptors,
       })
     ) {
       return;
@@ -1606,16 +1659,25 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     const nextSuggestions = getInlineSkillSuggestions({
       partial: match.partial,
       descriptors: agentSkillDescriptors,
+      mcpPrompts: mcpPromptDescriptors,
     });
     lastSkillDescriptorsRef.current = agentSkillDescriptors;
+    lastMcpPromptDescriptorsRef.current = mcpPromptDescriptors;
     setSkillSuggestions(nextSuggestions);
     setShowSkillSuggestions(nextSuggestions.length > 0);
-  }, [input, showAtMentionSuggestions, agentSkillDescriptors, atMentionCursorNonce]);
+  }, [
+    input,
+    showAtMentionSuggestions,
+    agentSkillDescriptors,
+    mcpPromptDescriptors,
+    atMentionCursorNonce,
+  ]);
 
   // Keep slash suggestions current before Enter can accept a stale item.
   useLayoutEffect(() => {
     const suggestions = getSlashCommandSuggestions(input, {
       agentSkills: agentSkillDescriptors,
+      mcpPrompts: mcpPromptDescriptors,
       variant,
       isExperimentEnabled: (experimentId) =>
         resolveSlashCommandExperimentValue(experimentId, {
@@ -1630,6 +1692,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   }, [
     input,
     agentSkillDescriptors,
+    mcpPromptDescriptors,
     variant,
     workspaceHeartbeatsExperimentEnabled,
     dynamicWorkflowsExperimentEnabled,
@@ -2537,16 +2600,33 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                 transferredDraftProjectDiscovery,
             }
           : null;
-    const { parsed, skillInvocation } = await parseCommandWithSkillInvocation({
+    const {
+      parsed,
+      skillInvocation,
+      mcpPromptInvocation,
+      error: invocationError,
+    } = await parseCommandWithSkillInvocation({
       messageText,
       agentSkillDescriptors,
+      mcpPromptDescriptors,
       api,
       discovery: skillDiscovery,
     });
+    if (invocationError) {
+      pushToast({ type: "error", message: invocationError });
+      return;
+    }
     const combinedSkillRefs = await resolveInlineSkillRefsForSend({
       messageText,
       slashInvocation: skillInvocation,
       agentSkillDescriptors,
+      api,
+      discovery: skillDiscovery,
+    });
+    const combinedMcpPromptRefs = await resolveMcpPromptRefsForSend({
+      messageText,
+      slashInvocation: mcpPromptInvocation,
+      descriptors: mcpPromptDescriptors,
       api,
       discovery: skillDiscovery,
     });
@@ -2687,7 +2767,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const modelOverride = modelOneShot?.modelString;
 
       // Regular message (or /<model-alias> one-shot override) - send directly via API
-      const messageTextForSend = modelOneShot?.message ?? skillInvocation?.userText ?? messageText;
+      const messageTextForSend =
+        modelOneShot?.message ??
+        skillInvocation?.userText ??
+        mcpPromptInvocation?.userText ??
+        messageText;
 
       if (!api) {
         pushToast({ type: "error", message: "Not connected to server" });
@@ -2725,6 +2809,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             skillInvocation.descriptor,
             skillInvocation.argumentText
           )
+        : undefined;
+      const promptMuxMetadata: MuxMessageMetadata | undefined = mcpPromptInvocation
+        ? {
+            type: "normal",
+            rawCommand: messageText,
+            commandPrefix: `/${mcpPromptInvocation.descriptor.commandKey}`,
+          }
         : undefined;
 
       const policyModel = modelOverride ?? baseModel;
@@ -2794,9 +2885,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
         // When editing a /compact command, regenerate the actual summarization request
         let actualMessageText = messageTextForSend;
-        let muxMetadata: MuxMessageMetadata | undefined = skillMuxMetadata;
+        let muxMetadata: MuxMessageMetadata | undefined = skillMuxMetadata ?? promptMuxMetadata;
         if (combinedSkillRefs.length > 0) {
           muxMetadata = withAgentSkillRefs(muxMetadata, combinedSkillRefs);
+        }
+        if (combinedMcpPromptRefs.length > 0) {
+          muxMetadata = withMcpPromptRefs(muxMetadata, combinedMcpPromptRefs);
         }
         let compactionOptions: Partial<SendMessageOptions> = {};
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1629,8 +1629,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
       });
     mcpPromptsRequestRef.current = request;
-    // atMentionCursorNonce: caret movement into an existing `$` token must also
-    // trigger discovery (e.g. a restored draft with the caret placed later).
+    // Caret movement must retrigger discovery when the input text is unchanged.
   }, [api, input, variant, workspaceId, atMentionCursorNonce]);
 
   useEffect(() => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -331,9 +331,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   });
   const asyncCommandTokenRef = useRef(0);
   const workspaceId = variant === "workspace" ? props.workspaceId : null;
+  // Send-time command/ref resolution can await cold MCP discovery. Every
+  // in-flight send in the current scope shares this controller; aborting it on
+  // scope change or unmount discards stale continuations so they cannot send
+  // to the captured workspace or clear the newly selected workspace's draft.
+  const sendResolutionAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     asyncCommandScopeRef.current = { variant, workspaceId };
+    sendResolutionAbortRef.current?.abort();
+    sendResolutionAbortRef.current = null;
   }, [variant, workspaceId]);
 
   const store = useWorkspaceStoreRaw();
@@ -646,6 +653,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       isMountedRef.current = false;
       mcpPromptsAbortRef.current?.abort();
       mcpPromptsAbortRef.current = null;
+      sendResolutionAbortRef.current?.abort();
+      sendResolutionAbortRef.current = null;
     };
   }, []);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -2637,6 +2646,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     // prompt discovery; mark the send in flight so a second Enter cannot start
     // a duplicate send against the same captured draft.
     setSendingCount((c) => c + 1);
+    sendResolutionAbortRef.current ??= new AbortController();
+    const resolutionSignal = sendResolutionAbortRef.current.signal;
+    const isSendScopeCurrent = () =>
+      !resolutionSignal.aborted &&
+      asyncCommandScopeRef.current.variant === variant &&
+      asyncCommandScopeRef.current.workspaceId === workspaceId;
     let parsed: ParsedCommand;
     let skillInvocation: SkillInvocation | null;
     let mcpPromptInvocation: MCPPromptInvocation | null;
@@ -2649,7 +2664,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         mcpPromptDescriptors,
         api,
         discovery: skillDiscovery,
+        signal: resolutionSignal,
       });
+      if (!isSendScopeCurrent()) return;
       parsed = resolution.parsed;
       skillInvocation = resolution.skillInvocation;
       mcpPromptInvocation = resolution.mcpPromptInvocation;
@@ -2674,8 +2691,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           api,
           discovery: skillDiscovery,
           candidates: inlineReferenceCandidates,
+          signal: resolutionSignal,
         }),
       ]);
+      if (!isSendScopeCurrent()) return;
       if (mcpPromptRefsResult.error) {
         pushToast({ type: "error", message: mcpPromptRefsResult.error });
         return;

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -18,6 +18,7 @@ function descriptor(
 function promptDescriptor() {
   return {
     commandKey: "mcp__coder__review",
+    stableKey: "mcp__coder__review_11111111",
     serverName: "coder",
     promptName: "review",
     description: "Review code",
@@ -92,6 +93,19 @@ describe("parseCommandWithSkillInvocation", () => {
     expect(result.mcpPromptInvocation?.userText).toBe(
       'Using MCP prompt coder/review: "src app" security and tests'
     );
+  });
+
+  test("resolves a stale collision-suffixed key via the descriptor stableKey", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review_11111111 src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [promptDescriptor()],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation?.descriptor.commandKey).toBe("mcp__coder__review");
+    expect(result.mcpPromptInvocation?.arguments).toEqual({ path: "src" });
   });
 
   test("reports a missing required MCP prompt argument before send", async () => {
@@ -229,7 +243,12 @@ describe("resolveMcpPromptRefsForSend", () => {
       slashInvocation: null,
       descriptors: [
         noArgs,
-        { ...promptDescriptor(), commandKey: "mcp__coder__required", promptName: "required" },
+        {
+          ...promptDescriptor(),
+          commandKey: "mcp__coder__required",
+          stableKey: "mcp__coder__required_22222222",
+          promptName: "required",
+        },
       ],
       api: null,
       discovery: null,

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -134,6 +134,40 @@ describe("parseCommandWithSkillInvocation", () => {
     );
   });
 
+  test("blocks a reserved mcp__ command that matches no available prompt", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__deleted src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [promptDescriptor()],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation).toBeNull();
+    expect(result.error).toBe("'/mcp__coder__deleted' does not match any available MCP prompt.");
+  });
+
+  test("blocks a reserved mcp__ command when prompt discovery fails", async () => {
+    const api = {
+      workspace: {
+        mcp: { prompts: { list: () => Promise.reject(new Error("server down")) } },
+      },
+    } as unknown as Parameters<typeof parseCommandWithSkillInvocation>[0]["api"];
+
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [],
+      api,
+      discovery: { kind: "workspace", workspaceId: "ws-1" },
+    });
+
+    expect(result.mcpPromptInvocation).toBeNull();
+    expect(result.error).toBe(
+      "Could not load MCP prompts to resolve '/mcp__coder__review'; check the MCP server connection and try again."
+    );
+  });
+
   test("reports a missing required MCP prompt argument before send", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/mcp__coder__review",

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -168,6 +168,50 @@ describe("parseCommandWithSkillInvocation", () => {
     );
   });
 
+  test("maps a lone token to a later required argument past an earlier optional one", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [
+        {
+          ...promptDescriptor(),
+          arguments: [
+            { name: "focus", required: false },
+            { name: "path", required: true },
+          ],
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.mcpPromptInvocation?.arguments).toEqual({ path: "src" });
+  });
+
+  test("fills an earlier optional argument when enough tokens remain for required ones", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review security src deep",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [
+        {
+          ...promptDescriptor(),
+          arguments: [
+            { name: "focus", required: false },
+            { name: "path", required: true },
+          ],
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation?.arguments).toEqual({
+      focus: "security",
+      path: "src deep",
+    });
+  });
+
   test("reports a missing required MCP prompt argument before send", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/mcp__coder__review",

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -264,7 +264,7 @@ describe("resolveInlineSkillRefsForSend", () => {
 describe("resolveMcpPromptRefsForSend", () => {
   test("resolves inline no-required-argument prompts and drops required prompts", async () => {
     const noArgs = { ...promptDescriptor(), arguments: [] };
-    const refs = await resolveMcpPromptRefsForSend({
+    const result = await resolveMcpPromptRefsForSend({
       messageText: "Use $mcp__coder__review and $mcp__coder__required",
       slashInvocation: null,
       descriptors: [
@@ -280,7 +280,8 @@ describe("resolveMcpPromptRefsForSend", () => {
       discovery: null,
     });
 
-    expect(refs).toEqual([
+    expect(result.error).toBeUndefined();
+    expect(result.refs).toEqual([
       {
         serverName: "coder",
         promptName: "review",
@@ -288,6 +289,51 @@ describe("resolveMcpPromptRefsForSend", () => {
         source: "inline",
       },
     ]);
+  });
+
+  test("blocks an inline unsuffixed key orphaned by a new collision", async () => {
+    const result = await resolveMcpPromptRefsForSend({
+      messageText: "Use $mcp__coder__review please",
+      slashInvocation: null,
+      descriptors: [
+        { ...promptDescriptor(), arguments: [], commandKey: "mcp__coder__review_11111111" },
+        {
+          ...promptDescriptor(),
+          arguments: [],
+          commandKey: "mcp__coder__review_22222222",
+          stableKey: "mcp__coder__review_22222222",
+          serverName: "Coder",
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.refs).toEqual([]);
+    expect(result.error).toBe(
+      "'$mcp__coder__review' no longer matches an MCP prompt key; did you mean $mcp__coder__review_11111111 or $mcp__coder__review_22222222?"
+    );
+  });
+
+  test("still drops orphaned inline keys whose base matches only required-argument prompts", async () => {
+    const result = await resolveMcpPromptRefsForSend({
+      messageText: "Use $mcp__coder__review please",
+      slashInvocation: null,
+      descriptors: [
+        { ...promptDescriptor(), commandKey: "mcp__coder__review_11111111" },
+        {
+          ...promptDescriptor(),
+          commandKey: "mcp__coder__review_22222222",
+          stableKey: "mcp__coder__review_22222222",
+          serverName: "Coder",
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.refs).toEqual([]);
   });
 });
 

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -4,6 +4,7 @@ import {
   hasProjectScopedSkillRef,
   parseCommandWithSkillInvocation,
   resolveInlineSkillRefsForSend,
+  resolveMcpPromptRefsForSend,
   type SkillInvocation,
 } from "./utils";
 
@@ -12,6 +13,19 @@ function descriptor(
   scope: AgentSkillDescriptor["scope"] = "global"
 ): AgentSkillDescriptor {
   return { name, description: `${name} description`, scope };
+}
+
+function promptDescriptor() {
+  return {
+    commandKey: "mcp__coder__review",
+    serverName: "coder",
+    promptName: "review",
+    description: "Review code",
+    arguments: [
+      { name: "path", required: true },
+      { name: "focus", required: false },
+    ],
+  };
 }
 
 function slashInvocation(skill: AgentSkillDescriptor): SkillInvocation {
@@ -60,6 +74,37 @@ describe("parseCommandWithSkillInvocation", () => {
     });
 
     expect(result.skillInvocation?.descriptor.name).toBe("tdd");
+  });
+
+  test("maps quoted MCP prompt arguments positionally and lets the last consume the remainder", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: '/mcp__coder__review "src app" security and tests',
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [promptDescriptor()],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation?.arguments).toEqual({
+      path: "src app",
+      focus: "security and tests",
+    });
+    expect(result.mcpPromptInvocation?.userText).toBe(
+      'Using MCP prompt coder/review: "src app" security and tests'
+    );
+  });
+
+  test("reports a missing required MCP prompt argument before send", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [promptDescriptor()],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation).toBeNull();
+    expect(result.error).toBe("Missing required MCP prompt argument: path");
   });
 });
 
@@ -173,6 +218,31 @@ describe("resolveInlineSkillRefsForSend", () => {
         discovery: null,
       })
     ).toEqual([]);
+  });
+});
+
+describe("resolveMcpPromptRefsForSend", () => {
+  test("resolves inline no-required-argument prompts and drops required prompts", async () => {
+    const noArgs = { ...promptDescriptor(), arguments: [] };
+    const refs = await resolveMcpPromptRefsForSend({
+      messageText: "Use $mcp__coder__review and $mcp__coder__required",
+      slashInvocation: null,
+      descriptors: [
+        noArgs,
+        { ...promptDescriptor(), commandKey: "mcp__coder__required", promptName: "required" },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(refs).toEqual([
+      {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+        source: "inline",
+      },
+    ]);
   });
 });
 

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -108,6 +108,26 @@ describe("parseCommandWithSkillInvocation", () => {
     expect(result.mcpPromptInvocation?.arguments).toEqual({ path: "src" });
   });
 
+  test("prefers an exact commandKey match over another prompt's stableKey alias", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review_11111111 src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [
+        promptDescriptor(),
+        {
+          ...promptDescriptor(),
+          commandKey: "mcp__coder__review_11111111",
+          stableKey: "mcp__coder__review_11111111_22222222",
+          promptName: "review_11111111",
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation?.descriptor.promptName).toBe("review_11111111");
+  });
+
   test("blocks an unsuffixed key orphaned by a new collision with the current keys", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/mcp__coder__review src",

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -108,6 +108,32 @@ describe("parseCommandWithSkillInvocation", () => {
     expect(result.mcpPromptInvocation?.arguments).toEqual({ path: "src" });
   });
 
+  test("blocks an unsuffixed key orphaned by a new collision with the current keys", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [
+        {
+          ...promptDescriptor(),
+          commandKey: "mcp__coder__review_11111111",
+        },
+        {
+          ...promptDescriptor(),
+          commandKey: "mcp__coder__review_22222222",
+          stableKey: "mcp__coder__review_22222222",
+          serverName: "Coder",
+        },
+      ],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.mcpPromptInvocation).toBeNull();
+    expect(result.error).toBe(
+      "'/mcp__coder__review' no longer matches an MCP prompt key; did you mean /mcp__coder__review_11111111 or /mcp__coder__review_22222222?"
+    );
+  });
+
   test("reports a missing required MCP prompt argument before send", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/mcp__coder__review",

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -459,8 +459,8 @@ describe("resolveMcpPromptRefsForSend", () => {
   });
 
   test("forwards the send abort signal to prompt discovery on both surfaces", async () => {
-    // A send abandoned by a workspace switch must be able to cancel the cold
-    // discovery request instead of holding it open until the startup deadline.
+    // Workspace switches must cancel cold discovery instead of waiting for its
+    // startup deadline.
     const listCalls: Array<{ signal?: AbortSignal } | undefined> = [];
     const api = {
       workspace: {

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -457,6 +457,46 @@ describe("resolveMcpPromptRefsForSend", () => {
     expect(result.error).toBeUndefined();
     expect(result.refs).toEqual([]);
   });
+
+  test("forwards the send abort signal to prompt discovery on both surfaces", async () => {
+    // A send abandoned by a workspace switch must be able to cancel the cold
+    // discovery request instead of holding it open until the startup deadline.
+    const listCalls: Array<{ signal?: AbortSignal } | undefined> = [];
+    const api = {
+      workspace: {
+        mcp: {
+          prompts: {
+            list: (_input: unknown, callOptions?: { signal?: AbortSignal }) => {
+              listCalls.push(callOptions);
+              return Promise.resolve([{ ...promptDescriptor(), arguments: [] }]);
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof parseCommandWithSkillInvocation>[0]["api"];
+    const controller = new AbortController();
+
+    await parseCommandWithSkillInvocation({
+      messageText: "/mcp__coder__review src",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [],
+      api,
+      discovery: { kind: "workspace", workspaceId: "ws-1" },
+      signal: controller.signal,
+    });
+    await resolveMcpPromptRefsForSend({
+      messageText: "Use $mcp__coder__review please",
+      slashInvocation: null,
+      descriptors: [],
+      api,
+      discovery: { kind: "workspace", workspaceId: "ws-1" },
+      signal: controller.signal,
+    });
+
+    expect(listCalls).toHaveLength(2);
+    expect(listCalls[0]?.signal).toBe(controller.signal);
+    expect(listCalls[1]?.signal).toBe(controller.signal);
+  });
 });
 
 describe("hasProjectScopedSkillRef", () => {

--- a/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
+++ b/src/browser/features/ChatInput/utils.inlineSkillRefs.test.ts
@@ -95,6 +95,30 @@ describe("parseCommandWithSkillInvocation", () => {
     );
   });
 
+  test("expands an MCP prompt when the message has leading whitespace", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "  /mcp__coder__review src security",
+      agentSkillDescriptors: [],
+      mcpPromptDescriptors: [promptDescriptor()],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.mcpPromptInvocation?.arguments).toEqual({ path: "src", focus: "security" });
+  });
+
+  test("resolves a skill when the message has leading whitespace", async () => {
+    const result = await parseCommandWithSkillInvocation({
+      messageText: "  /tdd do something",
+      agentSkillDescriptors: [descriptor("tdd")],
+      api: null,
+      discovery: null,
+    });
+
+    expect(result.skillInvocation?.descriptor.name).toBe("tdd");
+  });
+
   test("resolves a stale collision-suffixed key via the descriptor stableKey", async () => {
     const result = await parseCommandWithSkillInvocation({
       messageText: "/mcp__coder__review_11111111 src",

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -96,8 +96,7 @@ function formatSkillInvocationText(skillName: string, userMessage: string): stri
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
 }
 
-// stableKey keeps previously inserted collision-suffixed keys (drafts, history
-// recall) resolving after catalog changes strip the survivor's suffix.
+// Match stableKey so drafts and recalled history survive collision-driven key changes.
 function matchesPromptCommandKey(descriptor: MCPPromptDescriptor, command: string): boolean {
   return descriptor.commandKey === command || descriptor.stableKey === command;
 }
@@ -148,9 +147,8 @@ async function resolveMcpPromptInvocation(options: {
   });
   const descriptor = descriptors?.find((candidate) => matchesPromptCommandKey(candidate, command));
   if (!descriptor) {
-    // A prompt that once owned this unsuffixed key gains a hash suffix when a
-    // colliding sibling appears, so an old draft's key stops matching. Block
-    // the send with the current keys instead of silently sending plain text.
+    // A new collision can orphan an unsuffixed key from an old draft. Block the
+    // send and offer current keys rather than treating it as plain text.
     const baseMatches = (descriptors ?? []).filter(
       (candidate) => buildMcpPromptBaseKey(candidate.serverName, candidate.promptName) === command
     );

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -108,6 +108,13 @@ function formatSkillInvocationText(skillName: string, userMessage: string): stri
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
 }
 
+// parseCommand() trims before matching, so pasted or draft-restored text with
+// leading whitespace must be sliced from the same trimmed view or the command
+// falls through as literal text.
+function textAfterCommandPrefix(messageText: string, command: string): string {
+  return messageText.trimStart().slice(`/${command}`.length);
+}
+
 // Exact commandKey wins across the whole catalog; stableKey only recovers
 // drafts whose collision-suffixed key changed, so an alias must never shadow
 // another prompt's current commandKey.
@@ -156,8 +163,7 @@ async function resolveMcpPromptInvocation(options: {
   }
 
   const command = options.parsed.command;
-  const prefix = `/${command}`;
-  const afterPrefix = options.messageText.slice(prefix.length);
+  const afterPrefix = textAfterCommandPrefix(options.messageText, command);
   if (afterPrefix.length > 0 && !/^\s/.test(afterPrefix)) return { invocation: null };
 
   const descriptors = await loadMcpPromptDescriptors({
@@ -220,8 +226,7 @@ async function resolveSkillInvocation(options: {
   }
 
   const command = options.parsed.command;
-  const prefix = `/${command}`;
-  const afterPrefix = options.messageText.slice(prefix.length);
+  const afterPrefix = textAfterCommandPrefix(options.messageText, command);
   const hasSeparator = afterPrefix.length === 0 || /^\s/.test(afterPrefix);
 
   if (!hasSeparator) {

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -9,7 +9,10 @@ import {
 import { resolveSkillUserInvocable } from "@/common/orpc/schemas/agentSkill";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
-import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpPromptCommandKey";
+import {
+  buildMcpPromptBaseKey,
+  isMcpPromptCommandKey,
+} from "@/common/utils/tools/mcpPromptCommandKey";
 import type { ParsedRuntime } from "@/common/types/runtime";
 import {
   buildAgentSkillMetadata,
@@ -144,7 +147,22 @@ async function resolveMcpPromptInvocation(options: {
     commandKeys: [command],
   });
   const descriptor = descriptors?.find((candidate) => matchesPromptCommandKey(candidate, command));
-  if (!descriptor) return { invocation: null };
+  if (!descriptor) {
+    // A prompt that once owned this unsuffixed key gains a hash suffix when a
+    // colliding sibling appears, so an old draft's key stops matching. Block
+    // the send with the current keys instead of silently sending plain text.
+    const baseMatches = (descriptors ?? []).filter(
+      (candidate) => buildMcpPromptBaseKey(candidate.serverName, candidate.promptName) === command
+    );
+    if (baseMatches.length > 0) {
+      const candidates = baseMatches.map((candidate) => `/${candidate.commandKey}`).join(" or ");
+      return {
+        invocation: null,
+        error: `'/${command}' no longer matches an MCP prompt key; did you mean ${candidates}?`,
+      };
+    }
+    return { invocation: null };
+  }
 
   const mapped = mapPromptArguments(descriptor, afterPrefix.trim());
   if (mapped.missingRequired) {

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -1,13 +1,15 @@
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
-import { parseCommand } from "@/browser/utils/slashCommands/parser";
+import { parseCommand, tokenizeSlashCommandArguments } from "@/browser/utils/slashCommands/parser";
 import type { APIClient } from "@/browser/contexts/API";
 import {
   extractInlineSkillReferenceCandidates,
   resolveInlineSkillReferences,
+  type InlineSkillCandidate,
 } from "@/browser/utils/agentSkills/inlineSkillReferences";
 import { resolveSkillUserInvocable } from "@/common/orpc/schemas/agentSkill";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
+import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpToolName";
 import type { ParsedRuntime } from "@/common/types/runtime";
 import {
   buildAgentSkillMetadata,
@@ -40,22 +42,14 @@ export interface MCPPromptInvocation {
   arguments: Record<string, string>;
 }
 
-function tokenizePromptArguments(input: string): string[] {
-  return (input.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []).map((token) =>
-    token.replace(/^"(.*)"$/, "$1")
-  );
-}
-
 function mapPromptArguments(
   descriptor: MCPPromptDescriptor,
   input: string
 ): { arguments: Record<string, string>; missingRequired?: string } {
   const definitions = descriptor.arguments ?? [];
-  const tokens = tokenizePromptArguments(input);
+  const tokens = tokenizeSlashCommandArguments(input);
   const values: Record<string, string> = {};
-  for (let index = 0; index < definitions.length; index++) {
-    const definition = definitions[index];
-    if (!definition) continue;
+  for (const [index, definition] of definitions.entries()) {
     const value =
       index === definitions.length - 1 ? tokens.slice(index).join(" ") : (tokens[index] ?? "");
     if (!value) {
@@ -99,6 +93,28 @@ function formatSkillInvocationText(skillName: string, userMessage: string): stri
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
 }
 
+async function loadMcpPromptDescriptors(options: {
+  descriptors: MCPPromptDescriptor[];
+  api: APIClient | null;
+  discovery: SkillResolutionTarget | null;
+  commandKeys: string[];
+}): Promise<MCPPromptDescriptor[] | null> {
+  const hasAllDescriptors = options.commandKeys.every((commandKey) =>
+    options.descriptors.some((descriptor) => descriptor.commandKey === commandKey)
+  );
+  if (hasAllDescriptors || !options.api || options.discovery?.kind !== "workspace") {
+    return options.descriptors;
+  }
+
+  try {
+    return await options.api.workspace.mcp.prompts.list({
+      workspaceId: options.discovery.workspaceId,
+    });
+  } catch {
+    return null;
+  }
+}
+
 async function resolveMcpPromptInvocation(options: {
   messageText: string;
   parsed: ParsedCommand;
@@ -106,7 +122,7 @@ async function resolveMcpPromptInvocation(options: {
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
 }): Promise<{ invocation: MCPPromptInvocation | null; error?: string }> {
-  if (!isUnknownSlashCommand(options.parsed) || !options.parsed.command.startsWith("mcp__")) {
+  if (!isUnknownSlashCommand(options.parsed) || !isMcpPromptCommandKey(options.parsed.command)) {
     return { invocation: null };
   }
 
@@ -115,18 +131,13 @@ async function resolveMcpPromptInvocation(options: {
   const afterPrefix = options.messageText.slice(prefix.length);
   if (afterPrefix.length > 0 && !/^\s/.test(afterPrefix)) return { invocation: null };
 
-  let descriptors = options.descriptors;
-  let descriptor = descriptors.find((candidate) => candidate.commandKey === command);
-  if (!descriptor && options.api && options.discovery?.kind === "workspace") {
-    try {
-      descriptors = await options.api.workspace.mcp.prompts.list({
-        workspaceId: options.discovery.workspaceId,
-      });
-      descriptor = descriptors.find((candidate) => candidate.commandKey === command);
-    } catch {
-      return { invocation: null };
-    }
-  }
+  const descriptors = await loadMcpPromptDescriptors({
+    descriptors: options.descriptors,
+    api: options.api,
+    discovery: options.discovery,
+    commandKeys: [command],
+  });
+  const descriptor = descriptors?.find((candidate) => candidate.commandKey === command);
   if (!descriptor) return { invocation: null };
 
   const mapped = mapPromptArguments(descriptor, afterPrefix.trim());
@@ -272,6 +283,7 @@ export async function resolveInlineSkillRefsForSend(options: {
   agentSkillDescriptors: AgentSkillDescriptor[];
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
+  candidates?: InlineSkillCandidate[];
 }): Promise<AgentSkillReference[]> {
   const refs: AgentSkillReference[] = [];
 
@@ -280,9 +292,9 @@ export async function resolveInlineSkillRefsForSend(options: {
     refs.push({ skillName: descriptor.name, scope: descriptor.scope, source: "slash" });
   }
 
-  const candidates = extractInlineSkillReferenceCandidates(options.messageText).filter(
-    (candidate) => !candidate.skillName.startsWith("mcp__")
-  );
+  const candidates = (
+    options.candidates ?? extractInlineSkillReferenceCandidates(options.messageText)
+  ).filter((candidate) => !isMcpPromptCommandKey(candidate.skillName));
   if (candidates.length > 0) {
     const inlineRefs = await resolveInlineSkillReferences({
       candidates,
@@ -302,6 +314,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   descriptors: MCPPromptDescriptor[];
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
+  candidates?: InlineSkillCandidate[];
 }): Promise<MCPPromptReference[]> {
   const refs: MCPPromptReference[] = [];
   if (options.slashInvocation) {
@@ -315,26 +328,18 @@ export async function resolveMcpPromptRefsForSend(options: {
     });
   }
 
-  const candidates = extractInlineSkillReferenceCandidates(options.messageText).filter(
-    (candidate) => candidate.skillName.startsWith("mcp__")
-  );
+  const candidates = (
+    options.candidates ?? extractInlineSkillReferenceCandidates(options.messageText)
+  ).filter((candidate) => isMcpPromptCommandKey(candidate.skillName));
   if (candidates.length === 0) return refs;
 
-  let descriptors = options.descriptors;
-  if (options.api && options.discovery?.kind === "workspace") {
-    const unresolved = candidates.some(
-      (candidate) => !descriptors.some((prompt) => prompt.commandKey === candidate.skillName)
-    );
-    if (unresolved) {
-      try {
-        descriptors = await options.api.workspace.mcp.prompts.list({
-          workspaceId: options.discovery.workspaceId,
-        });
-      } catch {
-        return refs;
-      }
-    }
-  }
+  const descriptors = await loadMcpPromptDescriptors({
+    descriptors: options.descriptors,
+    api: options.api,
+    discovery: options.discovery,
+    commandKeys: candidates.map((candidate) => candidate.skillName),
+  });
+  if (!descriptors) return refs;
 
   for (const candidate of candidates) {
     const prompt = descriptors.find(

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -339,7 +339,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
   candidates?: InlineSkillCandidate[];
-}): Promise<MCPPromptReference[]> {
+}): Promise<{ refs: MCPPromptReference[]; error?: string }> {
   const refs: MCPPromptReference[] = [];
   if (options.slashInvocation) {
     const invocation = options.slashInvocation;
@@ -355,7 +355,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   const candidates = (
     options.candidates ?? extractInlineSkillReferenceCandidates(options.messageText)
   ).filter((candidate) => isMcpPromptCommandKey(candidate.skillName));
-  if (candidates.length === 0) return refs;
+  if (candidates.length === 0) return { refs };
 
   const descriptors = await loadMcpPromptDescriptors({
     descriptors: options.descriptors,
@@ -363,15 +363,34 @@ export async function resolveMcpPromptRefsForSend(options: {
     discovery: options.discovery,
     commandKeys: candidates.map((candidate) => candidate.skillName),
   });
-  if (!descriptors) return refs;
+  if (!descriptors) return { refs };
 
+  const isInlineInvocable = (descriptor: MCPPromptDescriptor) =>
+    !(descriptor.arguments ?? []).some((argument) => argument.required);
   for (const candidate of candidates) {
     const prompt = descriptors.find(
       (descriptor) =>
-        matchesPromptCommandKey(descriptor, candidate.skillName) &&
-        !(descriptor.arguments ?? []).some((argument) => argument.required)
+        matchesPromptCommandKey(descriptor, candidate.skillName) && isInlineInvocable(descriptor)
     );
-    if (!prompt) continue;
+    if (!prompt) {
+      // Same orphaned-key ambiguity as the slash path: a new collision
+      // suffixed the keys, so block the send instead of dropping the ref.
+      const baseMatches = descriptors.filter(
+        (descriptor) =>
+          buildMcpPromptBaseKey(descriptor.serverName, descriptor.promptName) ===
+            candidate.skillName && isInlineInvocable(descriptor)
+      );
+      if (baseMatches.length > 0) {
+        const suggestions = baseMatches
+          .map((descriptor) => `$${descriptor.commandKey}`)
+          .join(" or ");
+        return {
+          refs: [],
+          error: `'$${candidate.skillName}' no longer matches an MCP prompt key; did you mean ${suggestions}?`,
+        };
+      }
+      continue;
+    }
     refs.push({
       serverName: prompt.serverName,
       promptName: prompt.promptName,
@@ -379,7 +398,7 @@ export async function resolveMcpPromptRefsForSend(options: {
       source: "inline",
     });
   }
-  return dedupeMcpPromptRefs(refs);
+  return { refs: dedupeMcpPromptRefs(refs) };
 }
 
 /** Returns true when any ref's scope is "project" (used by creation flow to force disableWorkspaceAgents). */

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -7,11 +7,14 @@ import {
 } from "@/browser/utils/agentSkills/inlineSkillReferences";
 import { resolveSkillUserInvocable } from "@/common/orpc/schemas/agentSkill";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import type { ParsedRuntime } from "@/common/types/runtime";
 import {
   buildAgentSkillMetadata,
   dedupeAgentSkillRefs,
+  dedupeMcpPromptRefs,
   type AgentSkillReference,
+  type MCPPromptReference,
   type MuxMessageMetadata,
 } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/types";
@@ -31,11 +34,43 @@ export interface SkillInvocation {
   argumentText: string;
 }
 
+export interface MCPPromptInvocation {
+  descriptor: MCPPromptDescriptor;
+  userText: string;
+  arguments: Record<string, string>;
+}
+
+function tokenizePromptArguments(input: string): string[] {
+  return (input.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []).map((token) =>
+    token.replace(/^"(.*)"$/, "$1")
+  );
+}
+
+function mapPromptArguments(
+  descriptor: MCPPromptDescriptor,
+  input: string
+): { arguments: Record<string, string>; missingRequired?: string } {
+  const definitions = descriptor.arguments ?? [];
+  const tokens = tokenizePromptArguments(input);
+  const values: Record<string, string> = {};
+  for (let index = 0; index < definitions.length; index++) {
+    const definition = definitions[index];
+    if (!definition) continue;
+    const value =
+      index === definitions.length - 1 ? tokens.slice(index).join(" ") : (tokens[index] ?? "");
+    if (!value) {
+      if (definition.required) return { arguments: values, missingRequired: definition.name };
+      continue;
+    }
+    values[definition.name] = value;
+  }
+  return { arguments: values };
+}
+
 export type SkillResolutionTarget =
   | { kind: "project"; projectPath: string }
   | { kind: "workspace"; workspaceId: string; disableWorkspaceAgents?: boolean };
 
-// Unknown slash commands are used for agent-skill invocations (/{skillName} ...).
 type UnknownSlashCommand = Extract<ParsedCommand, { type: "unknown-command" }>;
 
 function isUnknownSlashCommand(value: ParsedCommand): value is UnknownSlashCommand {
@@ -62,6 +97,55 @@ export function buildSkillInvocationMetadata(
  */
 function formatSkillInvocationText(skillName: string, userMessage: string): string {
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
+}
+
+async function resolveMcpPromptInvocation(options: {
+  messageText: string;
+  parsed: ParsedCommand;
+  descriptors: MCPPromptDescriptor[];
+  api: APIClient | null;
+  discovery: SkillResolutionTarget | null;
+}): Promise<{ invocation: MCPPromptInvocation | null; error?: string }> {
+  if (!isUnknownSlashCommand(options.parsed) || !options.parsed.command.startsWith("mcp__")) {
+    return { invocation: null };
+  }
+
+  const command = options.parsed.command;
+  const prefix = `/${command}`;
+  const afterPrefix = options.messageText.slice(prefix.length);
+  if (afterPrefix.length > 0 && !/^\s/.test(afterPrefix)) return { invocation: null };
+
+  let descriptors = options.descriptors;
+  let descriptor = descriptors.find((candidate) => candidate.commandKey === command);
+  if (!descriptor && options.api && options.discovery?.kind === "workspace") {
+    try {
+      descriptors = await options.api.workspace.mcp.prompts.list({
+        workspaceId: options.discovery.workspaceId,
+      });
+      descriptor = descriptors.find((candidate) => candidate.commandKey === command);
+    } catch {
+      return { invocation: null };
+    }
+  }
+  if (!descriptor) return { invocation: null };
+
+  const mapped = mapPromptArguments(descriptor, afterPrefix.trim());
+  if (mapped.missingRequired) {
+    return {
+      invocation: null,
+      error: `Missing required MCP prompt argument: ${mapped.missingRequired}`,
+    };
+  }
+  const argumentText = afterPrefix.trimStart();
+  return {
+    invocation: {
+      descriptor,
+      userText: argumentText
+        ? `Using MCP prompt ${descriptor.serverName}/${descriptor.promptName}: ${argumentText}`
+        : `Using MCP prompt ${descriptor.serverName}/${descriptor.promptName}`,
+      arguments: mapped.arguments,
+    },
+  };
 }
 
 async function resolveSkillInvocation(options: {
@@ -131,10 +215,32 @@ async function resolveSkillInvocation(options: {
 export async function parseCommandWithSkillInvocation(options: {
   messageText: string;
   agentSkillDescriptors: AgentSkillDescriptor[];
+  mcpPromptDescriptors?: MCPPromptDescriptor[];
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
-}): Promise<{ parsed: ParsedCommand; skillInvocation: SkillInvocation | null }> {
+}): Promise<{
+  parsed: ParsedCommand;
+  skillInvocation: SkillInvocation | null;
+  mcpPromptInvocation: MCPPromptInvocation | null;
+  error?: string;
+}> {
   const parsed = parseCommand(options.messageText);
+  const promptResolution = await resolveMcpPromptInvocation({
+    messageText: options.messageText,
+    parsed,
+    descriptors: options.mcpPromptDescriptors ?? [],
+    api: options.api,
+    discovery: options.discovery,
+  });
+  if (promptResolution.invocation || promptResolution.error) {
+    return {
+      parsed: promptResolution.invocation ? null : parsed,
+      skillInvocation: null,
+      mcpPromptInvocation: promptResolution.invocation,
+      ...(promptResolution.error ? { error: promptResolution.error } : {}),
+    };
+  }
+
   const skillInvocation = await resolveSkillInvocation({
     messageText: options.messageText,
     parsed,
@@ -146,6 +252,7 @@ export async function parseCommandWithSkillInvocation(options: {
   return {
     parsed: skillInvocation == null ? parsed : null,
     skillInvocation,
+    mcpPromptInvocation: null,
   };
 }
 
@@ -173,7 +280,9 @@ export async function resolveInlineSkillRefsForSend(options: {
     refs.push({ skillName: descriptor.name, scope: descriptor.scope, source: "slash" });
   }
 
-  const candidates = extractInlineSkillReferenceCandidates(options.messageText);
+  const candidates = extractInlineSkillReferenceCandidates(options.messageText).filter(
+    (candidate) => !candidate.skillName.startsWith("mcp__")
+  );
   if (candidates.length > 0) {
     const inlineRefs = await resolveInlineSkillReferences({
       candidates,
@@ -185,6 +294,63 @@ export async function resolveInlineSkillRefsForSend(options: {
   }
 
   return dedupeAgentSkillRefs(refs);
+}
+
+export async function resolveMcpPromptRefsForSend(options: {
+  messageText: string;
+  slashInvocation: MCPPromptInvocation | null;
+  descriptors: MCPPromptDescriptor[];
+  api: APIClient | null;
+  discovery: SkillResolutionTarget | null;
+}): Promise<MCPPromptReference[]> {
+  const refs: MCPPromptReference[] = [];
+  if (options.slashInvocation) {
+    const invocation = options.slashInvocation;
+    refs.push({
+      serverName: invocation.descriptor.serverName,
+      promptName: invocation.descriptor.promptName,
+      commandKey: invocation.descriptor.commandKey,
+      source: "slash",
+      arguments: invocation.arguments,
+    });
+  }
+
+  const candidates = extractInlineSkillReferenceCandidates(options.messageText).filter(
+    (candidate) => candidate.skillName.startsWith("mcp__")
+  );
+  if (candidates.length === 0) return refs;
+
+  let descriptors = options.descriptors;
+  if (options.api && options.discovery?.kind === "workspace") {
+    const unresolved = candidates.some(
+      (candidate) => !descriptors.some((prompt) => prompt.commandKey === candidate.skillName)
+    );
+    if (unresolved) {
+      try {
+        descriptors = await options.api.workspace.mcp.prompts.list({
+          workspaceId: options.discovery.workspaceId,
+        });
+      } catch {
+        return refs;
+      }
+    }
+  }
+
+  for (const candidate of candidates) {
+    const prompt = descriptors.find(
+      (descriptor) =>
+        descriptor.commandKey === candidate.skillName &&
+        !(descriptor.arguments ?? []).some((argument) => argument.required)
+    );
+    if (!prompt) continue;
+    refs.push({
+      serverName: prompt.serverName,
+      promptName: prompt.promptName,
+      commandKey: prompt.commandKey,
+      source: "inline",
+    });
+  }
+  return dedupeMcpPromptRefs(refs);
 }
 
 /** Returns true when any ref's scope is "project" (used by creation flow to force disableWorkspaceAgents). */

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -134,6 +134,7 @@ async function loadMcpPromptDescriptors(options: {
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
   commandKeys: string[];
+  signal?: AbortSignal;
 }): Promise<MCPPromptDescriptor[] | null> {
   const hasAllDescriptors = options.commandKeys.every(
     (commandKey) => findPromptDescriptor(options.descriptors, commandKey) !== undefined
@@ -143,9 +144,10 @@ async function loadMcpPromptDescriptors(options: {
   }
 
   try {
-    return await options.api.workspace.mcp.prompts.list({
-      workspaceId: options.discovery.workspaceId,
-    });
+    return await options.api.workspace.mcp.prompts.list(
+      { workspaceId: options.discovery.workspaceId },
+      options.signal !== undefined ? { signal: options.signal } : undefined
+    );
   } catch {
     return null;
   }
@@ -157,6 +159,7 @@ async function resolveMcpPromptInvocation(options: {
   descriptors: MCPPromptDescriptor[];
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
+  signal?: AbortSignal;
 }): Promise<{ invocation: MCPPromptInvocation | null; error?: string }> {
   if (!isUnknownSlashCommand(options.parsed) || !isMcpPromptCommandKey(options.parsed.command)) {
     return { invocation: null };
@@ -171,6 +174,7 @@ async function resolveMcpPromptInvocation(options: {
     api: options.api,
     discovery: options.discovery,
     commandKeys: [command],
+    ...(options.signal !== undefined ? { signal: options.signal } : {}),
   });
   const descriptor = descriptors ? findPromptDescriptor(descriptors, command) : undefined;
   if (!descriptor) {
@@ -283,6 +287,7 @@ export async function parseCommandWithSkillInvocation(options: {
   mcpPromptDescriptors?: MCPPromptDescriptor[];
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
+  signal?: AbortSignal;
 }): Promise<{
   parsed: ParsedCommand;
   skillInvocation: SkillInvocation | null;
@@ -296,6 +301,7 @@ export async function parseCommandWithSkillInvocation(options: {
     descriptors: options.mcpPromptDescriptors ?? [],
     api: options.api,
     discovery: options.discovery,
+    ...(options.signal !== undefined ? { signal: options.signal } : {}),
   });
   if (promptResolution.invocation || promptResolution.error) {
     return {
@@ -369,6 +375,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   api: APIClient | null;
   discovery: SkillResolutionTarget | null;
   candidates?: InlineSkillCandidate[];
+  signal?: AbortSignal;
 }): Promise<{ refs: MCPPromptReference[]; error?: string }> {
   const refs: MCPPromptReference[] = [];
   if (options.slashInvocation) {
@@ -392,6 +399,7 @@ export async function resolveMcpPromptRefsForSend(options: {
     api: options.api,
     discovery: options.discovery,
     commandKeys: candidates.map((candidate) => candidate.skillName),
+    ...(options.signal !== undefined ? { signal: options.signal } : {}),
   });
   if (!descriptors) return { refs };
 

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -9,7 +9,7 @@ import {
 import { resolveSkillUserInvocable } from "@/common/orpc/schemas/agentSkill";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
-import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpToolName";
+import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpPromptCommandKey";
 import type { ParsedRuntime } from "@/common/types/runtime";
 import {
   buildAgentSkillMetadata,

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -160,7 +160,15 @@ async function resolveMcpPromptInvocation(options: {
         error: `'/${command}' no longer matches an MCP prompt key; did you mean ${candidates}?`,
       };
     }
-    return { invocation: null };
+    // The mcp__ prefix is reserved, so an unresolvable command must block the
+    // send instead of falling through as literal text.
+    return {
+      invocation: null,
+      error:
+        descriptors === null
+          ? `Could not load MCP prompts to resolve '/${command}'; check the MCP server connection and try again.`
+          : `'/${command}' does not match any available MCP prompt.`,
+    };
   }
 
   const mapped = mapPromptArguments(descriptor, afterPrefix.trim());

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -17,6 +17,7 @@ import type { ParsedRuntime } from "@/common/types/runtime";
 import {
   buildAgentSkillMetadata,
   dedupeAgentSkillRefs,
+  buildMcpPromptUserText,
   dedupeMcpPromptRefs,
   type AgentSkillReference,
   type MCPPromptReference,
@@ -173,9 +174,7 @@ async function resolveMcpPromptInvocation(options: {
   return {
     invocation: {
       descriptor,
-      userText: argumentText
-        ? `Using MCP prompt ${descriptor.serverName}/${descriptor.promptName}: ${argumentText}`
-        : `Using MCP prompt ${descriptor.serverName}/${descriptor.promptName}`,
+      userText: buildMcpPromptUserText(descriptor.serverName, descriptor.promptName, argumentText),
       arguments: mapped.arguments,
     },
   };

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -108,9 +108,18 @@ function formatSkillInvocationText(skillName: string, userMessage: string): stri
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
 }
 
-// Match stableKey so drafts and recalled history survive collision-driven key changes.
-function matchesPromptCommandKey(descriptor: MCPPromptDescriptor, command: string): boolean {
-  return descriptor.commandKey === command || descriptor.stableKey === command;
+// Exact commandKey wins across the whole catalog; stableKey only recovers
+// drafts whose collision-suffixed key changed, so an alias must never shadow
+// another prompt's current commandKey.
+function findPromptDescriptor(
+  descriptors: MCPPromptDescriptor[],
+  command: string,
+  isEligible: (descriptor: MCPPromptDescriptor) => boolean = () => true
+): MCPPromptDescriptor | undefined {
+  return (
+    descriptors.find((descriptor) => descriptor.commandKey === command && isEligible(descriptor)) ??
+    descriptors.find((descriptor) => descriptor.stableKey === command && isEligible(descriptor))
+  );
 }
 
 async function loadMcpPromptDescriptors(options: {
@@ -119,8 +128,8 @@ async function loadMcpPromptDescriptors(options: {
   discovery: SkillResolutionTarget | null;
   commandKeys: string[];
 }): Promise<MCPPromptDescriptor[] | null> {
-  const hasAllDescriptors = options.commandKeys.every((commandKey) =>
-    options.descriptors.some((descriptor) => matchesPromptCommandKey(descriptor, commandKey))
+  const hasAllDescriptors = options.commandKeys.every(
+    (commandKey) => findPromptDescriptor(options.descriptors, commandKey) !== undefined
   );
   if (hasAllDescriptors || !options.api || options.discovery?.kind !== "workspace") {
     return options.descriptors;
@@ -157,7 +166,7 @@ async function resolveMcpPromptInvocation(options: {
     discovery: options.discovery,
     commandKeys: [command],
   });
-  const descriptor = descriptors?.find((candidate) => matchesPromptCommandKey(candidate, command));
+  const descriptor = descriptors ? findPromptDescriptor(descriptors, command) : undefined;
   if (!descriptor) {
     // A new collision can orphan an unsuffixed key from an old draft. Block the
     // send and offer current keys rather than treating it as plain text.
@@ -384,10 +393,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   const isInlineInvocable = (descriptor: MCPPromptDescriptor) =>
     !(descriptor.arguments ?? []).some((argument) => argument.required);
   for (const candidate of candidates) {
-    const prompt = descriptors.find(
-      (descriptor) =>
-        matchesPromptCommandKey(descriptor, candidate.skillName) && isInlineInvocable(descriptor)
-    );
+    const prompt = findPromptDescriptor(descriptors, candidate.skillName, isInlineInvocable);
     if (!prompt) {
       // Same orphaned-key ambiguity as the slash path: a new collision
       // suffixed the keys, so block the send instead of dropping the ref.

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -53,14 +53,25 @@ function mapPromptArguments(
   const definitions = descriptor.arguments ?? [];
   const tokens = tokenizeSlashCommandArguments(input);
   const values: Record<string, string> = {};
+  let tokenIndex = 0;
   for (const [index, definition] of definitions.entries()) {
+    // Skip an optional slot when the remaining tokens are needed by later
+    // required arguments, so `[optional, required]` maps one token to the
+    // required argument instead of reporting it missing.
+    const requiredAfter = definitions.slice(index + 1).filter((d) => d.required).length;
+    if (!definition.required && tokens.length - tokenIndex <= requiredAfter) {
+      continue;
+    }
     const value =
-      index === definitions.length - 1 ? tokens.slice(index).join(" ") : (tokens[index] ?? "");
+      index === definitions.length - 1
+        ? tokens.slice(tokenIndex).join(" ")
+        : (tokens[tokenIndex] ?? "");
     if (!value) {
       if (definition.required) return { arguments: values, missingRequired: definition.name };
       continue;
     }
     values[definition.name] = value;
+    tokenIndex++;
   }
   return { arguments: values };
 }

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -93,6 +93,12 @@ function formatSkillInvocationText(skillName: string, userMessage: string): stri
   return userMessage ? `Using skill ${skillName}: ${userMessage}` : `Use skill ${skillName}`;
 }
 
+// stableKey keeps previously inserted collision-suffixed keys (drafts, history
+// recall) resolving after catalog changes strip the survivor's suffix.
+function matchesPromptCommandKey(descriptor: MCPPromptDescriptor, command: string): boolean {
+  return descriptor.commandKey === command || descriptor.stableKey === command;
+}
+
 async function loadMcpPromptDescriptors(options: {
   descriptors: MCPPromptDescriptor[];
   api: APIClient | null;
@@ -100,7 +106,7 @@ async function loadMcpPromptDescriptors(options: {
   commandKeys: string[];
 }): Promise<MCPPromptDescriptor[] | null> {
   const hasAllDescriptors = options.commandKeys.every((commandKey) =>
-    options.descriptors.some((descriptor) => descriptor.commandKey === commandKey)
+    options.descriptors.some((descriptor) => matchesPromptCommandKey(descriptor, commandKey))
   );
   if (hasAllDescriptors || !options.api || options.discovery?.kind !== "workspace") {
     return options.descriptors;
@@ -137,7 +143,7 @@ async function resolveMcpPromptInvocation(options: {
     discovery: options.discovery,
     commandKeys: [command],
   });
-  const descriptor = descriptors?.find((candidate) => candidate.commandKey === command);
+  const descriptor = descriptors?.find((candidate) => matchesPromptCommandKey(candidate, command));
   if (!descriptor) return { invocation: null };
 
   const mapped = mapPromptArguments(descriptor, afterPrefix.trim());
@@ -344,7 +350,7 @@ export async function resolveMcpPromptRefsForSend(options: {
   for (const candidate of candidates) {
     const prompt = descriptors.find(
       (descriptor) =>
-        descriptor.commandKey === candidate.skillName &&
+        matchesPromptCommandKey(descriptor, candidate.skillName) &&
         !(descriptor.arguments ?? []).some((argument) => argument.required)
     );
     if (!prompt) continue;

--- a/src/browser/hooks/useCompactAndRetry.followUp.test.ts
+++ b/src/browser/hooks/useCompactAndRetry.followUp.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { buildFollowUpFromSource } from "./useCompactAndRetry";
+import type { DisplayedUserMessage } from "@/common/types/message";
+
+function userMessage(overrides: Partial<DisplayedUserMessage>): DisplayedUserMessage {
+  return {
+    type: "user",
+    id: "user-1",
+    historyId: "user-1",
+    content: "Fix the bug",
+    historySequence: 1,
+    ...overrides,
+  };
+}
+
+describe("buildFollowUpFromSource", () => {
+  test("rebuilds the transformed invocation text for a slash MCP prompt turn", () => {
+    const followUp = buildFollowUpFromSource(
+      userMessage({
+        content: "/mcp__coder__review src security",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+            arguments: { path: "src", focus: "security" },
+          },
+        ],
+      })
+    );
+
+    expect(followUp.text).toBe("Using MCP prompt coder/review: src security");
+    expect(followUp.muxMetadata?.mcpPromptRefs).toHaveLength(1);
+  });
+
+  test("keeps plain user content unchanged", () => {
+    const followUp = buildFollowUpFromSource(userMessage({ content: "Fix the bug" }));
+    expect(followUp.text).toBe("Fix the bug");
+    expect(followUp.muxMetadata).toBeUndefined();
+  });
+
+  test("keeps inline-only MCP prompt turns unchanged", () => {
+    const followUp = buildFollowUpFromSource(
+      userMessage({
+        content: "Check $mcp__coder__review please",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "inline",
+          },
+        ],
+      })
+    );
+    expect(followUp.text).toBe("Check $mcp__coder__review please");
+    expect(followUp.muxMetadata?.mcpPromptRefs).toHaveLength(1);
+  });
+});

--- a/src/browser/hooks/useCompactAndRetry.followUp.test.ts
+++ b/src/browser/hooks/useCompactAndRetry.followUp.test.ts
@@ -32,8 +32,7 @@ describe("buildFollowUpFromSource", () => {
 
     expect(followUp.text).toBe("Using MCP prompt coder/review: src security");
     expect(followUp.muxMetadata?.mcpPromptRefs).toHaveLength(1);
-    // The follow-up row must keep displaying and edit-restoring as the
-    // original slash invocation, not the transformed provider text.
+    // Metadata keeps the follow-up row editable as the original slash invocation.
     const metadata = followUp.muxMetadata;
     if (metadata?.type !== "normal") throw new Error("expected normal metadata");
     expect(metadata.rawCommand).toBe("/mcp__coder__review src security");
@@ -59,7 +58,6 @@ describe("buildFollowUpFromSource", () => {
     expect(followUp.text).toBe("Using MCP prompt coder/review: src security");
     const metadata = followUp.muxMetadata;
     if (metadata?.type !== "normal") throw new Error("expected normal metadata");
-    // rawCommand preserves the displayed content verbatim.
     expect(metadata.rawCommand).toBe("  /mcp__coder__review src security");
   });
 

--- a/src/browser/hooks/useCompactAndRetry.followUp.test.ts
+++ b/src/browser/hooks/useCompactAndRetry.followUp.test.ts
@@ -40,6 +40,44 @@ describe("buildFollowUpFromSource", () => {
     expect(followUp.muxMetadata).toBeUndefined();
   });
 
+  test("preserves inline skill refs alongside slash MCP prompt refs", () => {
+    const followUp = buildFollowUpFromSource(
+      userMessage({
+        content: "/mcp__coder__review src",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+          },
+        ],
+        agentSkillRefs: [{ skillName: "tdd", scope: "global", source: "inline" }],
+        agentSkill: { skillName: "mcp__coder__review", scope: "built-in" },
+      })
+    );
+
+    expect(followUp.muxMetadata?.mcpPromptRefs).toHaveLength(1);
+    expect(followUp.muxMetadata?.agentSkillRefs).toEqual([
+      { skillName: "tdd", scope: "global", source: "inline" },
+    ]);
+  });
+
+  test("does not duplicate the slash skill ref when preserving displayed refs", () => {
+    const followUp = buildFollowUpFromSource(
+      userMessage({
+        content: "/tdd strict",
+        agentSkill: { skillName: "tdd", scope: "global", arguments: "strict" },
+        agentSkillRefs: [{ skillName: "tdd", scope: "global", source: "slash" }],
+      })
+    );
+
+    expect(followUp.muxMetadata?.type).toBe("agent-skill");
+    expect(followUp.muxMetadata?.agentSkillRefs).toEqual([
+      { skillName: "tdd", scope: "global", source: "slash" },
+    ]);
+  });
+
   test("keeps inline-only MCP prompt turns unchanged", () => {
     const followUp = buildFollowUpFromSource(
       userMessage({

--- a/src/browser/hooks/useCompactAndRetry.followUp.test.ts
+++ b/src/browser/hooks/useCompactAndRetry.followUp.test.ts
@@ -40,6 +40,29 @@ describe("buildFollowUpFromSource", () => {
     expect(metadata.commandPrefix).toBe("/mcp__coder__review");
   });
 
+  test("rebuilds a slash MCP prompt turn whose content has leading whitespace", () => {
+    const followUp = buildFollowUpFromSource(
+      userMessage({
+        content: "  /mcp__coder__review src security",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+            arguments: { path: "src", focus: "security" },
+          },
+        ],
+      })
+    );
+
+    expect(followUp.text).toBe("Using MCP prompt coder/review: src security");
+    const metadata = followUp.muxMetadata;
+    if (metadata?.type !== "normal") throw new Error("expected normal metadata");
+    // rawCommand preserves the displayed content verbatim.
+    expect(metadata.rawCommand).toBe("  /mcp__coder__review src security");
+  });
+
   test("keeps plain user content unchanged", () => {
     const followUp = buildFollowUpFromSource(userMessage({ content: "Fix the bug" }));
     expect(followUp.text).toBe("Fix the bug");

--- a/src/browser/hooks/useCompactAndRetry.followUp.test.ts
+++ b/src/browser/hooks/useCompactAndRetry.followUp.test.ts
@@ -32,6 +32,12 @@ describe("buildFollowUpFromSource", () => {
 
     expect(followUp.text).toBe("Using MCP prompt coder/review: src security");
     expect(followUp.muxMetadata?.mcpPromptRefs).toHaveLength(1);
+    // The follow-up row must keep displaying and edit-restoring as the
+    // original slash invocation, not the transformed provider text.
+    const metadata = followUp.muxMetadata;
+    if (metadata?.type !== "normal") throw new Error("expected normal metadata");
+    expect(metadata.rawCommand).toBe("/mcp__coder__review src security");
+    expect(metadata.commandPrefix).toBe("/mcp__coder__review");
   });
 
   test("keeps plain user content unchanged", () => {

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -75,8 +75,12 @@ export function buildFollowUpFromSource(
   // displays and edit-restores as the original slash invocation.
   let text = source.content;
   let promptMetadata: MuxMessageMetadata | undefined;
-  if (slashMcpPromptRef && text.startsWith("/")) {
-    const argumentText = text.replace(/^\/\S+/, "").trimStart();
+  // Trim only for command detection/extraction (the parser accepted the
+  // original send from a trimmed view); rawCommand keeps source.content
+  // verbatim so the retried row displays exactly like the original.
+  const trimmedContent = source.content.trimStart();
+  if (slashMcpPromptRef && trimmedContent.startsWith("/")) {
+    const argumentText = trimmedContent.replace(/^\/\S+/, "").trimStart();
     text = buildMcpPromptUserText(
       slashMcpPromptRef.serverName,
       slashMcpPromptRef.promptName,

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -67,9 +67,8 @@ export function buildFollowUpFromSource(
         })
       : undefined;
 
-  // source.content is the displayed raw slash command for MCP prompt turns,
-  // but the provider-visible row was the transformed invocation text, so
-  // rebuild it or the retry would send the literal /mcp__ command.
+  // MCP slash messages display the raw command but send transformed text, so
+  // retries must rebuild the provider-visible form.
   let text = source.content;
   if (slashMcpPromptRef && text.startsWith("/")) {
     const argumentText = text.replace(/^\/\S+/, "").trimStart();

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -22,6 +22,7 @@ import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import {
   buildAgentSkillMetadata,
   buildMcpPromptUserText,
+  withAgentSkillRefs,
   withMcpPromptRefs,
   type CompactionFollowUpInput,
   type DisplayedMessage,
@@ -83,7 +84,12 @@ export function buildFollowUpFromSource(
     text,
     fileParts: source.fileParts,
     reviews: source.reviews,
-    muxMetadata: withMcpPromptRefs(skillMetadata, source.mcpPromptRefs ?? []),
+    // Inline skill refs must survive alongside prompt refs; withAgentSkillRefs
+    // dedupes against the slash ref that buildAgentSkillMetadata already added.
+    muxMetadata: withAgentSkillRefs(
+      withMcpPromptRefs(skillMetadata, source.mcpPromptRefs ?? []),
+      source.agentSkillRefs ?? []
+    ),
   };
 }
 

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -21,6 +21,7 @@ import type { FilePart, ProvidersConfigMap } from "@/common/orpc/types";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import {
   buildAgentSkillMetadata,
+  buildMcpPromptUserText,
   withMcpPromptRefs,
   type CompactionFollowUpInput,
   type DisplayedMessage,
@@ -52,7 +53,7 @@ function findTriggerUserMessage(
  * Build follow-up content from a user message source.
  * Preserves skill metadata if the original message was a skill invocation.
  */
-function buildFollowUpFromSource(
+export function buildFollowUpFromSource(
   source: Extract<DisplayedMessage, { type: "user" }>
 ): CompactionFollowUpInput {
   const slashMcpPromptRef = source.mcpPromptRefs?.find((ref) => ref.source === "slash");
@@ -66,8 +67,21 @@ function buildFollowUpFromSource(
         })
       : undefined;
 
+  // source.content is the displayed raw slash command for MCP prompt turns,
+  // but the provider-visible row was the transformed invocation text, so
+  // rebuild it or the retry would send the literal /mcp__ command.
+  let text = source.content;
+  if (slashMcpPromptRef && text.startsWith("/")) {
+    const argumentText = text.replace(/^\/\S+/, "").trimStart();
+    text = buildMcpPromptUserText(
+      slashMcpPromptRef.serverName,
+      slashMcpPromptRef.promptName,
+      argumentText
+    );
+  }
+
   return {
-    text: source.content,
+    text,
     fileParts: source.fileParts,
     reviews: source.reviews,
     muxMetadata: withMcpPromptRefs(skillMetadata, source.mcpPromptRefs ?? []),

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -26,6 +26,7 @@ import {
   withMcpPromptRefs,
   type CompactionFollowUpInput,
   type DisplayedMessage,
+  type MuxMessageMetadata,
 } from "@/common/types/message";
 
 interface CompactAndRetryState {
@@ -69,8 +70,11 @@ export function buildFollowUpFromSource(
       : undefined;
 
   // MCP slash messages display the raw command but send transformed text, so
-  // retries must rebuild the provider-visible form.
+  // retries must rebuild the provider-visible form and preserve the slash
+  // metadata (mirroring the ChatInput send site) so the follow-up row still
+  // displays and edit-restores as the original slash invocation.
   let text = source.content;
+  let promptMetadata: MuxMessageMetadata | undefined;
   if (slashMcpPromptRef && text.startsWith("/")) {
     const argumentText = text.replace(/^\/\S+/, "").trimStart();
     text = buildMcpPromptUserText(
@@ -78,6 +82,11 @@ export function buildFollowUpFromSource(
       slashMcpPromptRef.promptName,
       argumentText
     );
+    promptMetadata = {
+      type: "normal",
+      rawCommand: source.content,
+      commandPrefix: `/${slashMcpPromptRef.commandKey}`,
+    };
   }
 
   return {
@@ -87,7 +96,7 @@ export function buildFollowUpFromSource(
     // Inline skill refs must survive alongside prompt refs; withAgentSkillRefs
     // dedupes against the slash ref that buildAgentSkillMetadata already added.
     muxMetadata: withAgentSkillRefs(
-      withMcpPromptRefs(skillMetadata, source.mcpPromptRefs ?? []),
+      withMcpPromptRefs(skillMetadata ?? promptMetadata, source.mcpPromptRefs ?? []),
       source.agentSkillRefs ?? []
     ),
   };

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -21,6 +21,7 @@ import type { FilePart, ProvidersConfigMap } from "@/common/orpc/types";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import {
   buildAgentSkillMetadata,
+  withMcpPromptRefs,
   type CompactionFollowUpInput,
   type DisplayedMessage,
 } from "@/common/types/message";
@@ -54,18 +55,22 @@ function findTriggerUserMessage(
 function buildFollowUpFromSource(
   source: Extract<DisplayedMessage, { type: "user" }>
 ): CompactionFollowUpInput {
-  return {
-    text: source.content,
-    fileParts: source.fileParts,
-    reviews: source.reviews,
-    muxMetadata: source.agentSkill
+  const slashMcpPromptRef = source.mcpPromptRefs?.find((ref) => ref.source === "slash");
+  const skillMetadata =
+    source.agentSkill && source.agentSkill.skillName !== slashMcpPromptRef?.commandKey
       ? buildAgentSkillMetadata({
           rawCommand: source.content,
           skillName: source.agentSkill.skillName,
           scope: source.agentSkill.scope,
           arguments: source.agentSkill.arguments,
         })
-      : undefined,
+      : undefined;
+
+  return {
+    text: source.content,
+    fileParts: source.fileParts,
+    reviews: source.reviews,
+    muxMetadata: withMcpPromptRefs(skillMetadata, source.mcpPromptRefs ?? []),
   };
 }
 

--- a/src/browser/hooks/useCompactAndRetry.ts
+++ b/src/browser/hooks/useCompactAndRetry.ts
@@ -69,10 +69,9 @@ export function buildFollowUpFromSource(
         })
       : undefined;
 
-  // MCP slash messages display the raw command but send transformed text, so
-  // retries must rebuild the provider-visible form and preserve the slash
-  // metadata (mirroring the ChatInput send site) so the follow-up row still
-  // displays and edit-restores as the original slash invocation.
+  // MCP slash messages display raw commands but send transformed text. Rebuild
+  // provider content and preserve slash metadata so retried rows remain editable
+  // as their original invocation.
   let text = source.content;
   let promptMetadata: MuxMessageMetadata | undefined;
   // Trim only for command detection/extraction (the parser accepted the

--- a/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.test.ts
@@ -56,6 +56,12 @@ describe("extractInlineSkillReferenceCandidates", () => {
     ]);
   });
 
+  test("extracts normalized MCP prompt references with underscores", () => {
+    expect(extractInlineSkillReferenceCandidates("Use $mcp__coder__review")).toEqual([
+      { skillName: "mcp__coder__review", startIndex: 4, endIndex: 23 },
+    ]);
+  });
+
   test("keeps duplicate parser candidates", () => {
     expect(extractInlineSkillReferenceCandidates("$tdd $tdd")).toEqual([
       { skillName: "tdd", startIndex: 0, endIndex: 4 },

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -4,6 +4,7 @@ import { SkillNameSchema, resolveSkillUserInvocable } from "@/common/orpc/schema
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { AgentSkillReference } from "@/common/types/message";
 import { dedupeAgentSkillRefs } from "@/common/types/message";
+import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpToolName";
 import {
   collectCodeRanges,
   isCursorInsideCodeRange,
@@ -103,7 +104,7 @@ export function extractInlineSkillReferenceCandidates(text: string): InlineSkill
       tokenEnd--;
     }
 
-    if (SkillNameSchema.safeParse(skillName).success || /^mcp__[a-z0-9_]+$/.test(skillName)) {
+    if (SkillNameSchema.safeParse(skillName).success || isMcpPromptCommandKey(skillName)) {
       candidates.push({ skillName, startIndex: index, endIndex: tokenEnd });
     }
 

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -4,7 +4,7 @@ import { SkillNameSchema, resolveSkillUserInvocable } from "@/common/orpc/schema
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { AgentSkillReference } from "@/common/types/message";
 import { dedupeAgentSkillRefs } from "@/common/types/message";
-import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpToolName";
+import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpPromptCommandKey";
 import {
   collectCodeRanges,
   isCursorInsideCodeRange,

--- a/src/browser/utils/agentSkills/inlineSkillReferences.ts
+++ b/src/browser/utils/agentSkills/inlineSkillReferences.ts
@@ -32,7 +32,9 @@ function isSkillStartChar(ch: string | undefined): boolean {
 }
 
 function isSkillContinuationChar(ch: string | undefined): boolean {
-  return Boolean(ch && ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9") || ch === "-"));
+  return Boolean(
+    ch && ((ch >= "a" && ch <= "z") || (ch >= "0" && ch <= "9") || ch === "-" || ch === "_")
+  );
 }
 
 function hasSaneLeftBoundary(text: string, dollarIndex: number): boolean {
@@ -101,7 +103,7 @@ export function extractInlineSkillReferenceCandidates(text: string): InlineSkill
       tokenEnd--;
     }
 
-    if (SkillNameSchema.safeParse(skillName).success) {
+    if (SkillNameSchema.safeParse(skillName).success || /^mcp__[a-z0-9_]+$/.test(skillName)) {
       candidates.push({ skillName, startIndex: index, endIndex: tokenEnd });
     }
 

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
@@ -37,6 +37,29 @@ describe("getInlineSkillSuggestions", () => {
     ]);
   });
 
+  test("suggests only MCP prompts without required arguments", () => {
+    expect(
+      getInlineSkillSuggestions({
+        partial: "mcp__coder",
+        descriptors: [],
+        mcpPrompts: [
+          {
+            commandKey: "mcp__coder__review",
+            serverName: "coder",
+            promptName: "review",
+            arguments: [],
+          },
+          {
+            commandKey: "mcp__coder__required",
+            serverName: "coder",
+            promptName: "required",
+            arguments: [{ name: "path", required: true }],
+          },
+        ],
+      }).map((suggestion) => suggestion.display)
+    ).toEqual(["$mcp__coder__review"]);
+  });
+
   test("hides user-invocable: false skills from suggestions", () => {
     expect(
       getInlineSkillSuggestions({

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.test.ts
@@ -45,12 +45,14 @@ describe("getInlineSkillSuggestions", () => {
         mcpPrompts: [
           {
             commandKey: "mcp__coder__review",
+            stableKey: "mcp__coder__review_11111111",
             serverName: "coder",
             promptName: "review",
             arguments: [],
           },
           {
             commandKey: "mcp__coder__required",
+            stableKey: "mcp__coder__required_22222222",
             serverName: "coder",
             promptName: "required",
             arguments: [{ name: "path", required: true }],

--- a/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
+++ b/src/browser/utils/agentSkills/inlineSkillSuggestions.ts
@@ -1,12 +1,14 @@
 import { matchesNameBySegmentPrefix } from "@/browser/utils/suggestionMatching";
 import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 
 interface InlineSkillSuggestionContext {
   /** The token typed after `$`. Empty string is allowed (just typed `$`). */
   partial: string;
   /** Already-loaded descriptors for current discovery target. */
   descriptors: AgentSkillDescriptor[];
+  mcpPrompts?: MCPPromptDescriptor[];
 }
 
 interface InlineSkillSuggestionRefreshContext {
@@ -15,6 +17,8 @@ interface InlineSkillSuggestionRefreshContext {
   partial: string;
   previousDescriptors: AgentSkillDescriptor[] | null;
   descriptors: AgentSkillDescriptor[];
+  previousMcpPrompts?: MCPPromptDescriptor[] | null;
+  mcpPrompts?: MCPPromptDescriptor[];
 }
 
 const INLINE_SKILL_INSERT_EXISTING_SEPARATOR_RE = /[\s.,;:!?)\]}>"'`]/;
@@ -25,7 +29,8 @@ export function shouldRefreshInlineSkillSuggestions(
   return (
     context.inputChanged ||
     context.previousPartial !== context.partial ||
-    context.previousDescriptors !== context.descriptors
+    context.previousDescriptors !== context.descriptors ||
+    context.previousMcpPrompts !== context.mcpPrompts
   );
 }
 
@@ -37,21 +42,11 @@ export function getInlineSkillInsertionTrailingText(after: string): "" | " " {
   return " ";
 }
 
-/**
- * Returns suggestions for `$skill` autocomplete.
- *
- * - Filter rule: full-name prefix or hyphen-segment prefix, matching slash skill commands.
- * - Empty `partial` returns the full descriptor list (so typing just `$` opens the menu).
- * - Result order: descriptors order from caller (no re-sort). Caller already lists in
- *   scope-priority order.
- * - We do NOT filter out skills whose name collides with a slash command (e.g. `clear`):
- *   `$clear` should reference a skill named `clear` even though `/clear` is a built-in.
- * - user-invocable: false skills are hidden (inline `$skill` is a user-facing surface).
- */
+/** MCP prompts with required arguments are omitted because inline references cannot supply them. */
 export function getInlineSkillSuggestions(
   context: InlineSkillSuggestionContext
 ): SlashSuggestion[] {
-  return context.descriptors
+  const skills = context.descriptors
     .filter((descriptor) => descriptor.userInvocable !== false)
     .filter((descriptor) => matchesNameBySegmentPrefix(descriptor.name, context.partial))
     .map((descriptor) => ({
@@ -60,4 +55,14 @@ export function getInlineSkillSuggestions(
       description: descriptor.description ?? "",
       replacement: `$${descriptor.name}`,
     }));
+  const prompts = (context.mcpPrompts ?? [])
+    .filter((prompt) => !(prompt.arguments ?? []).some((argument) => argument.required))
+    .filter((prompt) => matchesNameBySegmentPrefix(prompt.commandKey, context.partial))
+    .map((prompt) => ({
+      id: `inline-mcp-prompt:${prompt.commandKey}`,
+      display: `$${prompt.commandKey}`,
+      description: prompt.description ?? `MCP prompt from ${prompt.serverName}`,
+      replacement: `$${prompt.commandKey}`,
+    }));
+  return [...skills, ...prompts];
 }

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -522,6 +522,65 @@ describe("Agent skill snapshot association", () => {
     });
   });
 
+  it("attaches MCP prompt snapshots to slash and inline invocation surfaces", () => {
+    const aggregator = createAggregator();
+    const snapshot = createMuxMessage("prompt-snapshot", "user", "Expanded prompt body", {
+      historySequence: 1,
+      timestamp: 0,
+      synthetic: true,
+      mcpPromptSnapshot: {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+      },
+    });
+    const slash = createMuxMessage("prompt-slash", "user", "Using MCP prompt coder/review", {
+      historySequence: 2,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        rawCommand: "/mcp__coder__review",
+        commandPrefix: "/mcp__coder__review",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+          },
+        ],
+      },
+    });
+    const inline = createMuxMessage("prompt-inline", "user", "Use $mcp__coder__review", {
+      historySequence: 3,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "inline",
+          },
+        ],
+      },
+    });
+
+    aggregator.loadHistoricalMessages([snapshot, slash, inline]);
+    const displayed = aggregator.getDisplayedMessages();
+    expect(displayed).toHaveLength(2);
+    const slashMessage = displayed[0];
+    const inlineMessage = displayed[1];
+    if (slashMessage?.type !== "user" || inlineMessage?.type !== "user") {
+      throw new Error("Expected displayed user messages");
+    }
+    expect(slashMessage.agentSkill?.snapshot?.body).toBe("Expanded prompt body");
+    expect(inlineMessage.inlineSkillSnapshots?.mcp__coder__review?.snapshot.body).toBe(
+      "Expanded prompt body"
+    );
+  });
+
   it("uses the latest snapshot available at each invocation turn", () => {
     const aggregator = createAggregator();
     const firstFrontmatter = "name: pull-requests\ndescription: First";

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -533,6 +533,7 @@ describe("Agent skill snapshot association", () => {
         serverName: "coder",
         promptName: "review",
         commandKey: "mcp__coder__review",
+        invokingMessageId: "prompt-slash",
       },
     });
     const slash = createMuxMessage("prompt-slash", "user", "Using MCP prompt coder/review", {
@@ -561,6 +562,7 @@ describe("Agent skill snapshot association", () => {
         serverName: "coder",
         promptName: "review",
         commandKey: "mcp__coder__review",
+        invokingMessageId: "prompt-inline",
       },
     });
     const inline = createMuxMessage("prompt-inline", "user", "Use $mcp__coder__review", {
@@ -659,6 +661,7 @@ describe("Agent skill snapshot association", () => {
         serverName: "coder",
         promptName: "review",
         commandKey: "mcp__coder__review",
+        invokingMessageId: "prompt-first",
       },
     });
     const first = createMuxMessage("prompt-first", "user", "Using MCP prompt coder/review", {
@@ -691,6 +694,43 @@ describe("Agent skill snapshot association", () => {
     }
     expect(firstMessage.agentSkill?.snapshot?.body).toBe("Expanded prompt body");
     expect(secondMessage.agentSkill?.snapshot).toBeUndefined();
+  });
+
+  it("does not attach a crash-orphaned snapshot to a later same-prompt turn", () => {
+    const aggregator = createAggregator();
+    const orphan = createMuxMessage("orphan-snapshot", "user", "Stale expansion", {
+      historySequence: 1,
+      timestamp: 0,
+      synthetic: true,
+      mcpPromptSnapshot: {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+        invokingMessageId: "user-crashed",
+      },
+    });
+    const later = createMuxMessage("prompt-later", "user", "Use $mcp__coder__review", {
+      historySequence: 2,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "inline" as const,
+          },
+        ],
+      },
+    });
+
+    aggregator.loadHistoricalMessages([orphan, later]);
+    const displayed = aggregator.getDisplayedMessages();
+    const laterMessage = displayed[0];
+    if (laterMessage?.type !== "user") throw new Error("Expected displayed user message");
+    expect(laterMessage.inlineSkillSnapshots).toBeUndefined();
+    expect(laterMessage.agentSkill).toBeUndefined();
   });
 
   it("uses the latest snapshot available at each invocation turn", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -551,7 +551,6 @@ describe("Agent skill snapshot association", () => {
         ],
       },
     });
-    // Each send persists its own snapshot row directly before its user row.
     const inlineSnapshot = createMuxMessage("prompt-snapshot-2", "user", "Expanded prompt body", {
       historySequence: 3,
       timestamp: 0,
@@ -622,7 +621,6 @@ describe("Agent skill snapshot association", () => {
         mcpPromptRefs: [promptRef],
       },
     });
-    // Second invocation whose materialization failed: no snapshot row precedes it.
     const second = createMuxMessage("prompt-second", "user", "Using MCP prompt coder/review", {
       historySequence: 3,
       timestamp: 0,

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -550,6 +550,7 @@ describe("Agent skill snapshot association", () => {
             source: "slash",
           },
         ],
+        agentSkillRefs: [{ skillName: "tdd", scope: "global", source: "inline" }],
       },
     });
     const inlineSnapshot = createMuxMessage("prompt-snapshot-2", "user", "Expanded prompt body", {
@@ -588,6 +589,9 @@ describe("Agent skill snapshot association", () => {
     }
     expect(slashMessage.agentSkill?.snapshot?.body).toBe("Expanded prompt body");
     expect(slashMessage.mcpPromptRefs).toEqual(slash.metadata?.muxMetadata?.mcpPromptRefs);
+    expect(slashMessage.agentSkillRefs).toEqual([
+      { skillName: "tdd", scope: "global", source: "inline" },
+    ]);
     expect(inlineMessage.mcpPromptRefs).toEqual(inline.metadata?.muxMetadata?.mcpPromptRefs);
     expect(inlineMessage.inlineSkillSnapshots?.mcp__coder__review?.snapshot.body).toBe(
       "Expanded prompt body"

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -576,6 +576,8 @@ describe("Agent skill snapshot association", () => {
       throw new Error("Expected displayed user messages");
     }
     expect(slashMessage.agentSkill?.snapshot?.body).toBe("Expanded prompt body");
+    expect(slashMessage.mcpPromptRefs).toEqual(slash.metadata?.muxMetadata?.mcpPromptRefs);
+    expect(inlineMessage.mcpPromptRefs).toEqual(inline.metadata?.muxMetadata?.mcpPromptRefs);
     expect(inlineMessage.inlineSkillSnapshots?.mcp__coder__review?.snapshot.body).toBe(
       "Expanded prompt body"
     );

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -4,6 +4,7 @@ import {
   createMuxMessage,
   type AgentSkillReference,
   type DisplayedUserMessage,
+  type MCPPromptReference,
 } from "@/common/types/message";
 import { StreamingMessageAggregator } from "./StreamingMessageAggregator";
 
@@ -591,6 +592,51 @@ describe("Agent skill snapshot association", () => {
     expect(inlineMessage.inlineSkillSnapshots?.mcp__coder__review?.snapshot.body).toBe(
       "Expanded prompt body"
     );
+  });
+
+  it("filters malformed persisted refs instead of crashing aggregation", () => {
+    const aggregator = createAggregator();
+    // Simulates corrupted chat.jsonl rows; muxMetadata persists untyped.
+    const corruptMcpRefs: unknown = [null, {}, { serverName: "coder" }, 42];
+    const corruptSkillRefs: unknown = [null, { skillName: "tdd" }];
+    const corrupted = createMuxMessage("prompt-corrupted", "user", "Corrupted refs", {
+      historySequence: 1,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        mcpPromptRefs: corruptMcpRefs as MCPPromptReference[],
+        agentSkillRefs: corruptSkillRefs as AgentSkillReference[],
+      },
+    });
+    const mixedRefs: unknown = [
+      null,
+      {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+        source: "slash",
+      },
+    ];
+    const valid = createMuxMessage("prompt-valid", "user", "Using MCP prompt coder/review", {
+      historySequence: 2,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        mcpPromptRefs: mixedRefs as MCPPromptReference[],
+      },
+    });
+
+    aggregator.loadHistoricalMessages([corrupted, valid]);
+    const displayed = aggregator.getDisplayedMessages();
+    expect(displayed).toHaveLength(2);
+
+    const corruptedMessage = displayed[0];
+    const validMessage = displayed[1];
+    if (corruptedMessage?.type !== "user" || validMessage?.type !== "user") {
+      throw new Error("Expected displayed user messages");
+    }
+    expect(corruptedMessage.mcpPromptRefs).toBeUndefined();
+    expect(validMessage.mcpPromptRefs).toHaveLength(1);
   });
 
   it("does not attach an older turn's prompt snapshot when materialization failed", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.skills.test.ts
@@ -551,8 +551,19 @@ describe("Agent skill snapshot association", () => {
         ],
       },
     });
-    const inline = createMuxMessage("prompt-inline", "user", "Use $mcp__coder__review", {
+    // Each send persists its own snapshot row directly before its user row.
+    const inlineSnapshot = createMuxMessage("prompt-snapshot-2", "user", "Expanded prompt body", {
       historySequence: 3,
+      timestamp: 0,
+      synthetic: true,
+      mcpPromptSnapshot: {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+      },
+    });
+    const inline = createMuxMessage("prompt-inline", "user", "Use $mcp__coder__review", {
+      historySequence: 4,
       timestamp: 0,
       muxMetadata: {
         type: "normal",
@@ -567,7 +578,7 @@ describe("Agent skill snapshot association", () => {
       },
     });
 
-    aggregator.loadHistoricalMessages([snapshot, slash, inline]);
+    aggregator.loadHistoricalMessages([snapshot, slash, inlineSnapshot, inline]);
     const displayed = aggregator.getDisplayedMessages();
     expect(displayed).toHaveLength(2);
     const slashMessage = displayed[0];
@@ -581,6 +592,57 @@ describe("Agent skill snapshot association", () => {
     expect(inlineMessage.inlineSkillSnapshots?.mcp__coder__review?.snapshot.body).toBe(
       "Expanded prompt body"
     );
+  });
+
+  it("does not attach an older turn's prompt snapshot when materialization failed", () => {
+    const aggregator = createAggregator();
+    const promptRef = {
+      serverName: "coder",
+      promptName: "review",
+      commandKey: "mcp__coder__review",
+      source: "slash" as const,
+    };
+    const snapshot = createMuxMessage("prompt-snapshot", "user", "Expanded prompt body", {
+      historySequence: 1,
+      timestamp: 0,
+      synthetic: true,
+      mcpPromptSnapshot: {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+      },
+    });
+    const first = createMuxMessage("prompt-first", "user", "Using MCP prompt coder/review", {
+      historySequence: 2,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        rawCommand: "/mcp__coder__review",
+        commandPrefix: "/mcp__coder__review",
+        mcpPromptRefs: [promptRef],
+      },
+    });
+    // Second invocation whose materialization failed: no snapshot row precedes it.
+    const second = createMuxMessage("prompt-second", "user", "Using MCP prompt coder/review", {
+      historySequence: 3,
+      timestamp: 0,
+      muxMetadata: {
+        type: "normal",
+        rawCommand: "/mcp__coder__review",
+        commandPrefix: "/mcp__coder__review",
+        mcpPromptRefs: [promptRef],
+      },
+    });
+
+    aggregator.loadHistoricalMessages([snapshot, first, second]);
+    const displayed = aggregator.getDisplayedMessages();
+    const firstMessage = displayed[0];
+    const secondMessage = displayed[1];
+    if (firstMessage?.type !== "user" || secondMessage?.type !== "user") {
+      throw new Error("Expected displayed user messages");
+    }
+    expect(firstMessage.agentSkill?.snapshot?.body).toBe("Expanded prompt body");
+    expect(secondMessage.agentSkill?.snapshot).toBeUndefined();
   });
 
   it("uses the latest snapshot available at each invocation turn", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -4,13 +4,13 @@ import type {
   DisplayedMessage,
   CompactionRequestData,
   InlineSkillSnapshotMap,
-  AgentSkillReference,
-  MCPPromptReference,
 } from "@/common/types/message";
 import {
   createMuxMessage,
   getMcpPromptReferenceKey,
   isCompactionSummaryMetadata,
+  sanitizeAgentSkillRefs,
+  sanitizeMcpPromptRefs,
 } from "@/common/types/message";
 
 import {
@@ -410,59 +410,43 @@ function maybeCollectAgentSkillSnapshot(
   });
 }
 
-function isAgentSkillReferenceArray(
-  refs: readonly AgentSkillReference[] | undefined
-): refs is readonly AgentSkillReference[] {
-  return Array.isArray(refs);
-}
-
-function isMcpPromptReferenceArray(
-  refs: readonly MCPPromptReference[] | undefined
-): refs is readonly MCPPromptReference[] {
-  return Array.isArray(refs);
-}
-
 function deriveInlineSkillSnapshotDisplayState(
-  refs: readonly AgentSkillReference[] | undefined,
+  rawRefs: unknown,
   latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>,
-  mcpRefs: readonly MCPPromptReference[] | undefined,
+  rawMcpRefs: unknown,
   latestMcpPromptSnapshotByKey: ReadonlyMap<string, MCPPromptSnapshotContent>
 ): InlineSkillSnapshotDisplayState {
   const snapshotsBySkillName: InlineSkillSnapshotMap = {};
   const cacheEntryBySkillName = new Map<string, string>();
 
-  if (isAgentSkillReferenceArray(refs)) {
-    for (const ref of refs) {
-      if (ref.source !== "inline") continue;
-      const snapshot = latestAgentSkillSnapshotByKey.get(
-        getAgentSkillSnapshotKey(ref.scope, ref.skillName)
-      );
-      if (!snapshot || (snapshot.frontmatterYaml === undefined && snapshot.body === undefined)) {
-        continue;
-      }
-      snapshotsBySkillName[ref.skillName] = {
-        skillName: ref.skillName,
-        scope: ref.scope,
-        snapshot: { frontmatterYaml: snapshot.frontmatterYaml, body: snapshot.body },
-      };
-      cacheEntryBySkillName.set(ref.skillName, getAgentSkillSnapshotDisplayCacheKey(snapshot));
+  for (const ref of sanitizeAgentSkillRefs(rawRefs)) {
+    if (ref.source !== "inline") continue;
+    const snapshot = latestAgentSkillSnapshotByKey.get(
+      getAgentSkillSnapshotKey(ref.scope, ref.skillName)
+    );
+    if (!snapshot || (snapshot.frontmatterYaml === undefined && snapshot.body === undefined)) {
+      continue;
     }
+    snapshotsBySkillName[ref.skillName] = {
+      skillName: ref.skillName,
+      scope: ref.scope,
+      snapshot: { frontmatterYaml: snapshot.frontmatterYaml, body: snapshot.body },
+    };
+    cacheEntryBySkillName.set(ref.skillName, getAgentSkillSnapshotDisplayCacheKey(snapshot));
   }
 
-  if (isMcpPromptReferenceArray(mcpRefs)) {
-    for (const ref of mcpRefs) {
-      if (ref.source !== "inline") continue;
-      const snapshot = latestMcpPromptSnapshotByKey.get(
-        getMcpPromptReferenceKey(ref.serverName, ref.promptName)
-      );
-      if (!snapshot) continue;
-      snapshotsBySkillName[ref.commandKey] = {
-        skillName: ref.commandKey,
-        scope: "built-in",
-        snapshot: { body: snapshot.body },
-      };
-      cacheEntryBySkillName.set(ref.commandKey, snapshot.body);
-    }
+  for (const ref of sanitizeMcpPromptRefs(rawMcpRefs)) {
+    if (ref.source !== "inline") continue;
+    const snapshot = latestMcpPromptSnapshotByKey.get(
+      getMcpPromptReferenceKey(ref.serverName, ref.promptName)
+    );
+    if (!snapshot) continue;
+    snapshotsBySkillName[ref.commandKey] = {
+      skillName: ref.commandKey,
+      scope: "built-in",
+      snapshot: { body: snapshot.body },
+    };
+    cacheEntryBySkillName.set(ref.commandKey, snapshot.body);
   }
 
   if (cacheEntryBySkillName.size === 0) return {};
@@ -3586,8 +3570,8 @@ export class StreamingMessageAggregator {
           ? latestAgentSkillSnapshotByKey.get(agentSkillSnapshotKey)
           : undefined;
         const slashMcpPromptRef =
-          message.role === "user" && Array.isArray(muxMeta?.mcpPromptRefs)
-            ? muxMeta.mcpPromptRefs.find((ref) => ref.source === "slash")
+          message.role === "user"
+            ? sanitizeMcpPromptRefs(muxMeta?.mcpPromptRefs).find((ref) => ref.source === "slash")
             : undefined;
         const mcpPromptSnapshot = slashMcpPromptRef
           ? blockMcpPromptSnapshotByKey.get(

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -5,6 +5,7 @@ import type {
   CompactionRequestData,
   InlineSkillSnapshotMap,
   AgentSkillReference,
+  MCPPromptReference,
 } from "@/common/types/message";
 import { createMuxMessage, isCompactionSummaryMetadata } from "@/common/types/message";
 
@@ -339,6 +340,30 @@ interface AgentSkillSnapshotContent {
   body?: string;
 }
 
+interface MCPPromptSnapshotContent {
+  serverName: string;
+  promptName: string;
+  commandKey: string;
+  description?: string;
+  body: string;
+}
+
+function getMcpPromptSnapshotKey(serverName: string, promptName: string): string {
+  return `${serverName}\u0000${promptName}`;
+}
+
+function maybeCollectMcpPromptSnapshot(
+  message: MuxMessage,
+  snapshots: Map<string, MCPPromptSnapshotContent>
+): void {
+  const metadata = message.metadata?.mcpPromptSnapshot;
+  if (!metadata) return;
+  snapshots.set(getMcpPromptSnapshotKey(metadata.serverName, metadata.promptName), {
+    ...metadata,
+    body: getTextPartContent(message.parts),
+  });
+}
+
 interface InlineSkillSnapshotDisplayState {
   snapshots?: InlineSkillSnapshotMap;
   cacheKey?: string;
@@ -391,55 +416,60 @@ function isAgentSkillReferenceArray(
   return Array.isArray(refs);
 }
 
+function isMcpPromptReferenceArray(
+  refs: readonly MCPPromptReference[] | undefined
+): refs is readonly MCPPromptReference[] {
+  return Array.isArray(refs);
+}
+
 function deriveInlineSkillSnapshotDisplayState(
   refs: readonly AgentSkillReference[] | undefined,
-  latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>
+  latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>,
+  mcpRefs: readonly MCPPromptReference[] | undefined,
+  latestMcpPromptSnapshotByKey: ReadonlyMap<string, MCPPromptSnapshotContent>
 ): InlineSkillSnapshotDisplayState {
-  if (!isAgentSkillReferenceArray(refs) || refs.length === 0) {
-    return {};
-  }
-
   const snapshotsBySkillName: InlineSkillSnapshotMap = {};
   const cacheEntryBySkillName = new Map<string, string>();
 
-  for (const ref of refs) {
-    if (ref.source !== "inline") {
-      continue;
-    }
-
-    const snapshot = latestAgentSkillSnapshotByKey.get(
-      getAgentSkillSnapshotKey(ref.scope, ref.skillName)
-    );
-    if (!snapshot || (snapshot.frontmatterYaml === undefined && snapshot.body === undefined)) {
-      continue;
-    }
-
-    snapshotsBySkillName[ref.skillName] = {
-      skillName: ref.skillName,
-      scope: ref.scope,
-      snapshot: {
-        frontmatterYaml: snapshot.frontmatterYaml,
-        body: snapshot.body,
-      },
-    };
-    cacheEntryBySkillName.set(
-      ref.skillName,
-      JSON.stringify({
-        scope: ref.scope,
+  if (isAgentSkillReferenceArray(refs)) {
+    for (const ref of refs) {
+      if (ref.source !== "inline") continue;
+      const snapshot = latestAgentSkillSnapshotByKey.get(
+        getAgentSkillSnapshotKey(ref.scope, ref.skillName)
+      );
+      if (!snapshot || (snapshot.frontmatterYaml === undefined && snapshot.body === undefined)) {
+        continue;
+      }
+      snapshotsBySkillName[ref.skillName] = {
         skillName: ref.skillName,
-        snapshot: getAgentSkillSnapshotDisplayCacheKey(snapshot),
-      })
-    );
+        scope: ref.scope,
+        snapshot: { frontmatterYaml: snapshot.frontmatterYaml, body: snapshot.body },
+      };
+      cacheEntryBySkillName.set(ref.skillName, getAgentSkillSnapshotDisplayCacheKey(snapshot));
+    }
   }
 
-  if (cacheEntryBySkillName.size === 0) {
-    return {};
+  if (isMcpPromptReferenceArray(mcpRefs)) {
+    for (const ref of mcpRefs) {
+      if (ref.source !== "inline") continue;
+      const snapshot = latestMcpPromptSnapshotByKey.get(
+        getMcpPromptSnapshotKey(ref.serverName, ref.promptName)
+      );
+      if (!snapshot) continue;
+      snapshotsBySkillName[ref.commandKey] = {
+        skillName: ref.commandKey,
+        scope: "built-in",
+        snapshot: { body: snapshot.body },
+      };
+      cacheEntryBySkillName.set(ref.commandKey, snapshot.body);
+    }
   }
 
+  if (cacheEntryBySkillName.size === 0) return {};
   return {
     snapshots: snapshotsBySkillName,
     cacheKey: Array.from(cacheEntryBySkillName.entries())
-      .sort(([leftSkillName], [rightSkillName]) => leftSkillName.localeCompare(rightSkillName))
+      .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
       .map(([, cacheEntry]) => cacheEntry)
       .join("\n"),
   };
@@ -3514,11 +3544,10 @@ export class StreamingMessageAggregator {
         ((message.metadata?.synthetic === true && message.metadata?.uiVisible !== true) ||
           isWorkflowResultMessage(message));
 
-      // Synthetic agent-skill snapshot messages are hidden from the transcript unless
-      // debugLlmRequest is enabled. We still want to surface their content in the UI by
-      // attaching the resolved snapshot (frontmatterYaml + body) to subsequent user
-      // messages that reference skills via /{skillName} or inline $skillName tokens.
+      // Synthetic skill and MCP prompt snapshots stay hidden unless debugLlmRequest is enabled.
+      // Their resolved content is attached to the user messages that reference them.
       const latestAgentSkillSnapshotByKey = new Map<string, AgentSkillSnapshotContent>();
+      const latestMcpPromptSnapshotByKey = new Map<string, MCPPromptSnapshotContent>();
 
       // Pair completed subagent cards with the assistant response to their prior progress turn.
       // Persisted anchors improve within-response precision, but historical correctness must not
@@ -3530,6 +3559,7 @@ export class StreamingMessageAggregator {
 
       for (const message of allMessages) {
         maybeCollectAgentSkillSnapshot(message, latestAgentSkillSnapshotByKey);
+        maybeCollectMcpPromptSnapshot(message, latestMcpPromptSnapshotByKey);
         // Synthetic messages are typically for model context only.
         // Show them only in debug mode, or when explicitly marked as UI-visible.
         if (shouldHideMessageFromTranscript(message)) {
@@ -3545,20 +3575,33 @@ export class StreamingMessageAggregator {
         const agentSkillSnapshot = agentSkillSnapshotKey
           ? latestAgentSkillSnapshotByKey.get(agentSkillSnapshotKey)
           : undefined;
+        const slashMcpPromptRef =
+          message.role === "user" && Array.isArray(muxMeta?.mcpPromptRefs)
+            ? muxMeta.mcpPromptRefs.find((ref) => ref.source === "slash")
+            : undefined;
+        const mcpPromptSnapshot = slashMcpPromptRef
+          ? latestMcpPromptSnapshotByKey.get(
+              getMcpPromptSnapshotKey(slashMcpPromptRef.serverName, slashMcpPromptRef.promptName)
+            )
+          : undefined;
 
         const agentSkillSnapshotForDisplay = agentSkillSnapshot
           ? { frontmatterYaml: agentSkillSnapshot.frontmatterYaml, body: agentSkillSnapshot.body }
-          : undefined;
+          : mcpPromptSnapshot
+            ? { body: mcpPromptSnapshot.body }
+            : undefined;
 
         const agentSkillSnapshotCacheKey = agentSkillSnapshot
           ? getAgentSkillSnapshotDisplayCacheKey(agentSkillSnapshot)
-          : undefined;
+          : mcpPromptSnapshot?.body;
 
         const inlineSkillSnapshotState =
           message.role === "user"
             ? deriveInlineSkillSnapshotDisplayState(
                 muxMeta?.agentSkillRefs,
-                latestAgentSkillSnapshotByKey
+                latestAgentSkillSnapshotByKey,
+                muxMeta?.mcpPromptRefs,
+                latestMcpPromptSnapshotByKey
               )
             : undefined;
         const inlineSkillSnapshotsCacheKey = inlineSkillSnapshotState?.cacheKey;

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -7,7 +7,11 @@ import type {
   AgentSkillReference,
   MCPPromptReference,
 } from "@/common/types/message";
-import { createMuxMessage, isCompactionSummaryMetadata } from "@/common/types/message";
+import {
+  createMuxMessage,
+  getMcpPromptReferenceKey,
+  isCompactionSummaryMetadata,
+} from "@/common/types/message";
 
 import {
   copyStreamLifecycleSnapshot,
@@ -348,17 +352,13 @@ interface MCPPromptSnapshotContent {
   body: string;
 }
 
-function getMcpPromptSnapshotKey(serverName: string, promptName: string): string {
-  return `${serverName}\u0000${promptName}`;
-}
-
 function maybeCollectMcpPromptSnapshot(
   message: MuxMessage,
   snapshots: Map<string, MCPPromptSnapshotContent>
 ): void {
   const metadata = message.metadata?.mcpPromptSnapshot;
   if (!metadata) return;
-  snapshots.set(getMcpPromptSnapshotKey(metadata.serverName, metadata.promptName), {
+  snapshots.set(getMcpPromptReferenceKey(metadata.serverName, metadata.promptName), {
     ...metadata,
     body: getTextPartContent(message.parts),
   });
@@ -453,7 +453,7 @@ function deriveInlineSkillSnapshotDisplayState(
     for (const ref of mcpRefs) {
       if (ref.source !== "inline") continue;
       const snapshot = latestMcpPromptSnapshotByKey.get(
-        getMcpPromptSnapshotKey(ref.serverName, ref.promptName)
+        getMcpPromptReferenceKey(ref.serverName, ref.promptName)
       );
       if (!snapshot) continue;
       snapshotsBySkillName[ref.commandKey] = {
@@ -3544,8 +3544,7 @@ export class StreamingMessageAggregator {
         ((message.metadata?.synthetic === true && message.metadata?.uiVisible !== true) ||
           isWorkflowResultMessage(message));
 
-      // Synthetic skill and MCP prompt snapshots stay hidden unless debugLlmRequest is enabled.
-      // Their resolved content is attached to the user messages that reference them.
+      // Retain hidden snapshots so referenced user messages can display their resolved content.
       const latestAgentSkillSnapshotByKey = new Map<string, AgentSkillSnapshotContent>();
       const latestMcpPromptSnapshotByKey = new Map<string, MCPPromptSnapshotContent>();
 
@@ -3581,7 +3580,7 @@ export class StreamingMessageAggregator {
             : undefined;
         const mcpPromptSnapshot = slashMcpPromptRef
           ? latestMcpPromptSnapshotByKey.get(
-              getMcpPromptSnapshotKey(slashMcpPromptRef.serverName, slashMcpPromptRef.promptName)
+              getMcpPromptReferenceKey(slashMcpPromptRef.serverName, slashMcpPromptRef.promptName)
             )
           : undefined;
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -3546,7 +3546,16 @@ export class StreamingMessageAggregator {
 
       // Retain hidden snapshots so referenced user messages can display their resolved content.
       const latestAgentSkillSnapshotByKey = new Map<string, AgentSkillSnapshotContent>();
-      const latestMcpPromptSnapshotByKey = new Map<string, MCPPromptSnapshotContent>();
+      // MCP prompt snapshots are re-materialized per turn and may fail, so a user
+      // row only sees the contiguous snapshot block directly before it; a
+      // history-wide map would falsely attach an older turn's expansion.
+      const blockMcpPromptSnapshotByKey = new Map<string, MCPPromptSnapshotContent>();
+      const isSyntheticSnapshotRow = (message: MuxMessage): boolean =>
+        message.metadata?.synthetic === true &&
+        (message.metadata.mcpPromptSnapshot !== undefined ||
+          message.metadata.agentSkillSnapshot !== undefined ||
+          message.metadata.fileAtMentionSnapshot !== undefined);
+      let previousWasSnapshotRow = true;
 
       // Pair completed subagent cards with the assistant response to their prior progress turn.
       // Persisted anchors improve within-response precision, but historical correctness must not
@@ -3557,8 +3566,10 @@ export class StreamingMessageAggregator {
       );
 
       for (const message of allMessages) {
+        if (!previousWasSnapshotRow) blockMcpPromptSnapshotByKey.clear();
+        previousWasSnapshotRow = isSyntheticSnapshotRow(message);
         maybeCollectAgentSkillSnapshot(message, latestAgentSkillSnapshotByKey);
-        maybeCollectMcpPromptSnapshot(message, latestMcpPromptSnapshotByKey);
+        maybeCollectMcpPromptSnapshot(message, blockMcpPromptSnapshotByKey);
         // Synthetic messages are typically for model context only.
         // Show them only in debug mode, or when explicitly marked as UI-visible.
         if (shouldHideMessageFromTranscript(message)) {
@@ -3579,7 +3590,7 @@ export class StreamingMessageAggregator {
             ? muxMeta.mcpPromptRefs.find((ref) => ref.source === "slash")
             : undefined;
         const mcpPromptSnapshot = slashMcpPromptRef
-          ? latestMcpPromptSnapshotByKey.get(
+          ? blockMcpPromptSnapshotByKey.get(
               getMcpPromptReferenceKey(slashMcpPromptRef.serverName, slashMcpPromptRef.promptName)
             )
           : undefined;
@@ -3600,7 +3611,7 @@ export class StreamingMessageAggregator {
                 muxMeta?.agentSkillRefs,
                 latestAgentSkillSnapshotByKey,
                 muxMeta?.mcpPromptRefs,
-                latestMcpPromptSnapshotByKey
+                blockMcpPromptSnapshotByKey
               )
             : undefined;
         const inlineSkillSnapshotsCacheKey = inlineSkillSnapshotState?.cacheKey;

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -348,6 +348,7 @@ interface MCPPromptSnapshotContent {
   serverName: string;
   promptName: string;
   commandKey: string;
+  invokingMessageId?: string;
   description?: string;
   body: string;
 }
@@ -411,6 +412,7 @@ function maybeCollectAgentSkillSnapshot(
 }
 
 function deriveInlineSkillSnapshotDisplayState(
+  messageId: string,
   rawRefs: unknown,
   latestAgentSkillSnapshotByKey: ReadonlyMap<string, AgentSkillSnapshotContent>,
   rawMcpRefs: unknown,
@@ -440,7 +442,8 @@ function deriveInlineSkillSnapshotDisplayState(
     const snapshot = latestMcpPromptSnapshotByKey.get(
       getMcpPromptReferenceKey(ref.serverName, ref.promptName)
     );
-    if (!snapshot) continue;
+    // Same exact-correlation rule as the slash surface (crash orphans).
+    if (snapshot?.invokingMessageId !== messageId) continue;
     snapshotsBySkillName[ref.commandKey] = {
       skillName: ref.commandKey,
       scope: "built-in",
@@ -3573,11 +3576,17 @@ export class StreamingMessageAggregator {
           message.role === "user"
             ? sanitizeMcpPromptRefs(muxMeta?.mcpPromptRefs).find((ref) => ref.source === "slash")
             : undefined;
-        const mcpPromptSnapshot = slashMcpPromptRef
+        const mcpPromptSnapshotCandidate = slashMcpPromptRef
           ? blockMcpPromptSnapshotByKey.get(
               getMcpPromptReferenceKey(slashMcpPromptRef.serverName, slashMcpPromptRef.promptName)
             )
           : undefined;
+        // Prompt identity alone can attach a crash-orphaned expansion to a
+        // later same-prompt turn; require the exact invoking row.
+        const mcpPromptSnapshot =
+          mcpPromptSnapshotCandidate?.invokingMessageId === message.id
+            ? mcpPromptSnapshotCandidate
+            : undefined;
 
         const agentSkillSnapshotForDisplay = agentSkillSnapshot
           ? { frontmatterYaml: agentSkillSnapshot.frontmatterYaml, body: agentSkillSnapshot.body }
@@ -3592,6 +3601,7 @@ export class StreamingMessageAggregator {
         const inlineSkillSnapshotState =
           message.role === "user"
             ? deriveInlineSkillSnapshotDisplayState(
+                message.id,
                 muxMeta?.agentSkillRefs,
                 latestAgentSkillSnapshotByKey,
                 muxMeta?.mcpPromptRefs,

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -7,7 +7,7 @@ import type {
   MuxMessage,
   MuxMessageMetadata,
 } from "@/common/types/message";
-import { getCompactionFollowUpContent } from "@/common/types/message";
+import { getCompactionFollowUpContent, sanitizeMcpPromptRefs } from "@/common/types/message";
 import type { StreamErrorType } from "@/common/types/errors";
 import { GOAL_BUDGET_LIMIT_KIND, GOAL_CONTINUATION_KIND } from "@/constants/goals";
 import { getFollowUpContentText } from "@/browser/utils/compaction/format";
@@ -259,7 +259,8 @@ function buildUserDisplayedMessages(options: {
     }));
 
   let rawCommand = getRawCommand(muxMeta);
-  const mcpPromptRefs = Array.isArray(muxMeta?.mcpPromptRefs) ? muxMeta.mcpPromptRefs : undefined;
+  const sanitizedMcpPromptRefs = sanitizeMcpPromptRefs(muxMeta?.mcpPromptRefs);
+  const mcpPromptRefs = sanitizedMcpPromptRefs.length > 0 ? sanitizedMcpPromptRefs : undefined;
   const slashMcpPromptRef = mcpPromptRefs?.find((ref) => ref.source === "slash");
   const agentSkill =
     muxMeta?.type === "agent-skill"

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -259,6 +259,9 @@ function buildUserDisplayedMessages(options: {
     }));
 
   let rawCommand = getRawCommand(muxMeta);
+  const slashMcpPromptRef = Array.isArray(muxMeta?.mcpPromptRefs)
+    ? muxMeta.mcpPromptRefs.find((ref) => ref.source === "slash")
+    : undefined;
   const agentSkill =
     muxMeta?.type === "agent-skill"
       ? {
@@ -267,7 +270,13 @@ function buildUserDisplayedMessages(options: {
           arguments: muxMeta.arguments,
           snapshot: agentSkillSnapshot,
         }
-      : undefined;
+      : slashMcpPromptRef
+        ? {
+            skillName: slashMcpPromptRef.commandKey,
+            scope: "built-in" as const,
+            snapshot: agentSkillSnapshot,
+          }
+        : undefined;
 
   const bashMonitorWakeRecords = getValidBashMonitorWakeRecords(muxMeta);
 

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -259,9 +259,8 @@ function buildUserDisplayedMessages(options: {
     }));
 
   let rawCommand = getRawCommand(muxMeta);
-  const slashMcpPromptRef = Array.isArray(muxMeta?.mcpPromptRefs)
-    ? muxMeta.mcpPromptRefs.find((ref) => ref.source === "slash")
-    : undefined;
+  const mcpPromptRefs = Array.isArray(muxMeta?.mcpPromptRefs) ? muxMeta.mcpPromptRefs : undefined;
+  const slashMcpPromptRef = mcpPromptRefs?.find((ref) => ref.source === "slash");
   const agentSkill =
     muxMeta?.type === "agent-skill"
       ? {
@@ -315,6 +314,7 @@ function buildUserDisplayedMessages(options: {
       isBudgetLimitWrapup: message.metadata?.kind === GOAL_BUDGET_LIMIT_KIND ? true : undefined,
       timestamp: baseTimestamp,
       agentSkill,
+      mcpPromptRefs,
       inlineSkillSnapshots,
       compactionRequest,
       reviews: muxMeta?.reviews,

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -7,7 +7,11 @@ import type {
   MuxMessage,
   MuxMessageMetadata,
 } from "@/common/types/message";
-import { getCompactionFollowUpContent, sanitizeMcpPromptRefs } from "@/common/types/message";
+import {
+  getCompactionFollowUpContent,
+  sanitizeAgentSkillRefs,
+  sanitizeMcpPromptRefs,
+} from "@/common/types/message";
 import type { StreamErrorType } from "@/common/types/errors";
 import { GOAL_BUDGET_LIMIT_KIND, GOAL_CONTINUATION_KIND } from "@/constants/goals";
 import { getFollowUpContentText } from "@/browser/utils/compaction/format";
@@ -261,6 +265,8 @@ function buildUserDisplayedMessages(options: {
   let rawCommand = getRawCommand(muxMeta);
   const sanitizedMcpPromptRefs = sanitizeMcpPromptRefs(muxMeta?.mcpPromptRefs);
   const mcpPromptRefs = sanitizedMcpPromptRefs.length > 0 ? sanitizedMcpPromptRefs : undefined;
+  const sanitizedAgentSkillRefs = sanitizeAgentSkillRefs(muxMeta?.agentSkillRefs);
+  const agentSkillRefs = sanitizedAgentSkillRefs.length > 0 ? sanitizedAgentSkillRefs : undefined;
   const slashMcpPromptRef = mcpPromptRefs?.find((ref) => ref.source === "slash");
   const agentSkill =
     muxMeta?.type === "agent-skill"
@@ -316,6 +322,7 @@ function buildUserDisplayedMessages(options: {
       timestamp: baseTimestamp,
       agentSkill,
       mcpPromptRefs,
+      agentSkillRefs,
       inlineSkillSnapshots,
       compactionRequest,
       reviews: muxMeta?.reviews,

--- a/src/browser/utils/slashCommands/parser.ts
+++ b/src/browser/utils/slashCommands/parser.ts
@@ -8,6 +8,18 @@ import { MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 import { normalizeModelInput } from "@/common/utils/ai/normalizeModelInput";
 import { parseThinkingInput, type ParsedThinkingInput } from "@/common/types/thinking";
 
+function tokenizeSlashCommandTokens(input: string): string[] {
+  return input.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [];
+}
+
+function unquoteSlashCommandToken(token: string): string {
+  return token.replace(/^"(.*)"$/, "$1");
+}
+
+export function tokenizeSlashCommandArguments(input: string): string[] {
+  return tokenizeSlashCommandTokens(input).map(unquoteSlashCommandToken);
+}
+
 /**
  * Parse a raw command string into a structured command
  * @param input The raw command string (e.g., "/model sonnet" or "/compact -t 5000")
@@ -21,7 +33,7 @@ export function parseCommand(input: string): ParsedCommand {
 
   // Remove leading slash and split by spaces (respecting quotes)
   // Parse tokens from the full input so newlines can act as whitespace between args.
-  const parts = (trimmed.substring(1).match(/(?:[^\s"]+|"[^"]*")+/g) ?? []) as string[];
+  const parts = tokenizeSlashCommandTokens(trimmed.substring(1));
   if (parts.length === 0) {
     return null;
   }
@@ -88,7 +100,7 @@ export function parseCommand(input: string): ParsedCommand {
     };
   }
 
-  const cleanRemainingTokens = remainingTokens.map((token) => token.replace(/^"(.*)"$/, "$1"));
+  const cleanRemainingTokens = remainingTokens.map(unquoteSlashCommandToken);
 
   // Calculate rawInput: everything after the command key, preserving newlines
   // For "/compact -t 5000\nContinue here", rawInput should be "-t 5000\nContinue here"

--- a/src/browser/utils/slashCommands/suggestions.test.ts
+++ b/src/browser/utils/slashCommands/suggestions.test.ts
@@ -94,6 +94,30 @@ describe("getSlashCommandSuggestions", () => {
     expect(skillSuggestion?.description).toContain("(project)");
   });
 
+  it("includes MCP prompts with positional argument hints", () => {
+    const suggestions = getSlashCommandSuggestions("/mcp__coder", {
+      mcpPrompts: [
+        {
+          commandKey: "mcp__coder__review",
+          serverName: "coder",
+          promptName: "review",
+          description: "Review code",
+          arguments: [
+            { name: "path", required: true },
+            { name: "focus", required: false },
+          ],
+        },
+      ],
+    });
+
+    expect(suggestions).toContainEqual({
+      id: "mcp-prompt:mcp__coder__review",
+      display: "/mcp__coder__review [path] [focus?]",
+      description: "Review code (coder)",
+      replacement: "/mcp__coder__review ",
+    });
+  });
+
   it("hides user-invocable: false skills from slash suggestions", () => {
     const suggestions = getSlashCommandSuggestions("/", {
       agentSkills: [

--- a/src/browser/utils/slashCommands/suggestions.test.ts
+++ b/src/browser/utils/slashCommands/suggestions.test.ts
@@ -99,6 +99,7 @@ describe("getSlashCommandSuggestions", () => {
       mcpPrompts: [
         {
           commandKey: "mcp__coder__review",
+          stableKey: "mcp__coder__review_11111111",
           serverName: "coder",
           promptName: "review",
           description: "Review code",

--- a/src/browser/utils/slashCommands/suggestions.ts
+++ b/src/browser/utils/slashCommands/suggestions.ts
@@ -92,6 +92,20 @@ function buildTopLevelSuggestions(
     };
   });
 
+  const promptSuggestions = (context.mcpPrompts ?? [])
+    .filter((prompt) => matchesNameBySegmentPrefix(prompt.commandKey, partial))
+    .map((prompt) => {
+      const argumentHint = (prompt.arguments ?? [])
+        .map((argument) => `[${argument.name}${argument.required ? "" : "?"}]`)
+        .join(" ");
+      return {
+        id: `mcp-prompt:${prompt.commandKey}`,
+        display: `/${prompt.commandKey}${argumentHint ? ` ${argumentHint}` : ""}`,
+        description: `${prompt.description ?? "MCP prompt"} (${prompt.serverName})`,
+        replacement: `/${prompt.commandKey} `,
+      };
+    });
+
   // Model alias one-shot suggestions (e.g., /haiku, /sonnet, /opus+high).
   // The build callback below hardcodes the trailing space, so `appendSpace`
   // is intentionally omitted here.
@@ -113,7 +127,12 @@ function buildTopLevelSuggestions(
     })
   );
 
-  return [...commandSuggestions, ...skillSuggestions, ...modelAliasSuggestions];
+  return [
+    ...commandSuggestions,
+    ...skillSuggestions,
+    ...promptSuggestions,
+    ...modelAliasSuggestions,
+  ];
 }
 
 function buildSubcommandSuggestions(

--- a/src/browser/utils/slashCommands/types.ts
+++ b/src/browser/utils/slashCommands/types.ts
@@ -11,6 +11,7 @@
 
 import type { ExperimentId } from "@/common/constants/experiments";
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import type { ParsedThinkingInput } from "@/common/types/thinking";
 
 export type ParsedCommand =
@@ -101,6 +102,7 @@ export interface SlashSuggestion {
 
 export interface SlashSuggestionContext extends SlashCommandVisibilityContext {
   agentSkills?: AgentSkillDescriptor[];
+  mcpPrompts?: MCPPromptDescriptor[];
 }
 
 export interface SuggestionDefinition {

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -105,6 +105,7 @@ import {
   MCPAddGlobalParamsSchema,
   MCPAddParamsSchema,
   MCPListParamsSchema,
+  MCPPromptDescriptorSchema,
   MCPRemoveGlobalParamsSchema,
   MCPRemoveParamsSchema,
   MCPServerMapSchema,
@@ -1829,6 +1830,12 @@ export const workspace = {
     get: {
       input: z.object({ workspaceId: z.string() }),
       output: WorkspaceMCPOverridesSchema,
+    },
+    prompts: {
+      list: {
+        input: z.object({ workspaceId: z.string() }),
+        output: z.array(MCPPromptDescriptorSchema),
+      },
     },
     set: {
       input: z.object({

--- a/src/common/orpc/schemas/mcp.ts
+++ b/src/common/orpc/schemas/mcp.ts
@@ -75,6 +75,24 @@ export const MCPServerInfoSchema = z.discriminatedUnion("transport", [
   }),
 ]);
 
+export const MCPPromptDescriptorSchema = z.object({
+  commandKey: z.string(),
+  serverName: z.string(),
+  promptName: z.string(),
+  description: z.string().optional(),
+  arguments: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string().optional(),
+        required: z.boolean().optional(),
+      })
+    )
+    .optional(),
+});
+
+export type MCPPromptDescriptor = z.infer<typeof MCPPromptDescriptorSchema>;
+
 export const MCPServerMapSchema = z.record(z.string(), MCPServerInfoSchema);
 
 export const MCPListParamsSchema = z.object({

--- a/src/common/orpc/schemas/mcp.ts
+++ b/src/common/orpc/schemas/mcp.ts
@@ -77,6 +77,8 @@ export const MCPServerInfoSchema = z.discriminatedUnion("transport", [
 
 export const MCPPromptDescriptorSchema = z.object({
   commandKey: z.string(),
+  /** Identity-derived alias (always hash-suffixed); stable across catalog changes. */
+  stableKey: z.string(),
   serverName: z.string(),
   promptName: z.string(),
   description: z.string().optional(),

--- a/src/common/orpc/schemas/message.test.ts
+++ b/src/common/orpc/schemas/message.test.ts
@@ -9,6 +9,26 @@ function createMessage() {
   };
 }
 
+describe("MuxMessageSchema mcpPromptSnapshot parsing", () => {
+  test("preserves invokingMessageId across boundary parsing", () => {
+    const parsed = MuxMessageSchema.parse({
+      ...createMessage(),
+      role: "user" as const,
+      metadata: {
+        synthetic: true,
+        mcpPromptSnapshot: {
+          serverName: "coder",
+          promptName: "review",
+          commandKey: "mcp__coder__review",
+          invokingMessageId: "user-1",
+        },
+      },
+    });
+
+    expect(parsed.metadata?.mcpPromptSnapshot?.invokingMessageId).toBe("user-1");
+  });
+});
+
 describe("MuxMessageSchema compactionEpoch parsing", () => {
   test("preserves valid positive integer compactionEpoch", () => {
     const parsed = MuxMessageSchema.parse({

--- a/src/common/orpc/schemas/message.test.ts
+++ b/src/common/orpc/schemas/message.test.ts
@@ -10,6 +10,25 @@ function createMessage() {
 }
 
 describe("MuxMessageSchema mcpPromptSnapshot parsing", () => {
+  test("strips malformed snapshot metadata instead of failing the history parse", () => {
+    const malformedSnapshotValues: unknown[] = [null, {}, { serverName: 42 }, "snapshot", []];
+
+    for (const malformed of malformedSnapshotValues) {
+      const parsed = MuxMessageSchema.parse({
+        ...createMessage(),
+        role: "user" as const,
+        metadata: {
+          synthetic: true,
+          mcpPromptSnapshot: malformed,
+          agentSkillSnapshot: malformed,
+        },
+      });
+
+      expect(parsed.metadata?.mcpPromptSnapshot).toBeUndefined();
+      expect(parsed.metadata?.agentSkillSnapshot).toBeUndefined();
+    }
+  });
+
   test("preserves invokingMessageId across boundary parsing", () => {
     const parsed = MuxMessageSchema.parse({
       ...createMessage(),

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -192,6 +192,14 @@ export const MuxMessageSchema = z.object({
           frontmatterYaml: z.string().optional(),
         })
         .optional(),
+      mcpPromptSnapshot: z
+        .object({
+          serverName: z.string(),
+          promptName: z.string(),
+          commandKey: z.string(),
+          description: z.string().optional(),
+        })
+        .optional(),
       // Marks the hidden @file snapshot turn, which the timeline skips as context plumbing.
       fileAtMentionSnapshot: z.array(z.string()).optional(),
       error: z.string().optional(),

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -184,8 +184,7 @@ export const MuxMessageSchema = z.object({
       uiVisible: z.boolean().optional(),
       transcriptAnchor: TranscriptAnchorSchema.optional().catch(undefined),
 
-      // Self-healing: one malformed persisted snapshot row must degrade to a
-      // plain synthetic message, not fail the whole history parse.
+      // Ignore malformed snapshot metadata so one row cannot fail the whole history parse.
       agentSkillSnapshot: z
         .object({
           skillName: SkillNameSchema,

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -184,6 +184,8 @@ export const MuxMessageSchema = z.object({
       uiVisible: z.boolean().optional(),
       transcriptAnchor: TranscriptAnchorSchema.optional().catch(undefined),
 
+      // Self-healing: one malformed persisted snapshot row must degrade to a
+      // plain synthetic message, not fail the whole history parse.
       agentSkillSnapshot: z
         .object({
           skillName: SkillNameSchema,
@@ -191,7 +193,8 @@ export const MuxMessageSchema = z.object({
           sha256: z.string(),
           frontmatterYaml: z.string().optional(),
         })
-        .optional(),
+        .optional()
+        .catch(undefined),
       mcpPromptSnapshot: z
         .object({
           serverName: z.string(),
@@ -200,7 +203,8 @@ export const MuxMessageSchema = z.object({
           invokingMessageId: z.string().optional(),
           description: z.string().optional(),
         })
-        .optional(),
+        .optional()
+        .catch(undefined),
       // Marks the hidden @file snapshot turn, which the timeline skips as context plumbing.
       fileAtMentionSnapshot: z.array(z.string()).optional(),
       error: z.string().optional(),

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -197,6 +197,7 @@ export const MuxMessageSchema = z.object({
           serverName: z.string(),
           promptName: z.string(),
           commandKey: z.string(),
+          invokingMessageId: z.string().optional(),
           description: z.string().optional(),
         })
         .optional(),

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { createMuxMessage, filterOrphanedMcpPromptSnapshots } from "./message";
+import type { MuxMessage } from "./message";
+
+function snapshot(id: string, promptName = "review"): MuxMessage {
+  return createMuxMessage(id, "user", `Expanded ${promptName}`, {
+    historySequence: 0,
+    synthetic: true,
+    mcpPromptSnapshot: {
+      serverName: "coder",
+      promptName,
+      commandKey: `mcp__coder__${promptName}`,
+    },
+  });
+}
+
+function invokingUser(id: string, promptNames: string[]): MuxMessage {
+  return createMuxMessage(id, "user", "Using MCP prompt", {
+    historySequence: 0,
+    muxMetadata: {
+      type: "normal",
+      mcpPromptRefs: promptNames.map((promptName) => ({
+        serverName: "coder",
+        promptName,
+        commandKey: `mcp__coder__${promptName}`,
+        source: "slash" as const,
+      })),
+    },
+  });
+}
+
+describe("filterOrphanedMcpPromptSnapshots", () => {
+  test("keeps snapshots claimed by the next user message", () => {
+    const messages = [snapshot("snap-1"), invokingUser("user-1", ["review"])];
+    expect(filterOrphanedMcpPromptSnapshots(messages)).toEqual(messages);
+  });
+
+  test("drops a snapshot left at the tail by a crash", () => {
+    const assistant = createMuxMessage("assistant-1", "assistant", "done", {
+      historySequence: 0,
+    });
+    const messages = [invokingUser("user-1", []), assistant, snapshot("snap-1")];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual([
+      "user-1",
+      "assistant-1",
+    ]);
+  });
+
+  test("drops a snapshot whose following user message does not reference it", () => {
+    const messages = [snapshot("snap-1", "review"), invokingUser("user-1", ["status"])];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
+  });
+
+  test("keeps only the newest snapshot per prompt when a crashed attempt is retried", () => {
+    const messages = [
+      snapshot("snap-stale", "review"),
+      snapshot("snap-fresh", "review"),
+      invokingUser("user-1", ["review"]),
+    ];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual([
+      "snap-fresh",
+      "user-1",
+    ]);
+  });
+
+  test("skill snapshots inside the block do not break the claim", () => {
+    const skillSnapshot = createMuxMessage("skill-snap", "user", "skill body", {
+      historySequence: 0,
+      synthetic: true,
+      agentSkillSnapshot: { skillName: "tdd", scope: "global", sha256: "abc" },
+    });
+    const messages = [snapshot("snap-1"), skillSnapshot, invokingUser("user-1", ["review"])];
+    expect(filterOrphanedMcpPromptSnapshots(messages)).toEqual(messages);
+  });
+});

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createMuxMessage, filterOrphanedMcpPromptSnapshots } from "./message";
 import type { MuxMessage } from "./message";
 
-function snapshot(id: string, promptName = "review"): MuxMessage {
+function snapshot(id: string, invokingMessageId?: string, promptName = "review"): MuxMessage {
   return createMuxMessage(id, "user", `Expanded ${promptName}`, {
     historySequence: 0,
     synthetic: true,
@@ -10,6 +10,7 @@ function snapshot(id: string, promptName = "review"): MuxMessage {
       serverName: "coder",
       promptName,
       commandKey: `mcp__coder__${promptName}`,
+      ...(invokingMessageId !== undefined ? { invokingMessageId } : {}),
     },
   });
 }
@@ -30,46 +31,43 @@ function invokingUser(id: string, promptNames: string[]): MuxMessage {
 }
 
 describe("filterOrphanedMcpPromptSnapshots", () => {
-  test("keeps snapshots claimed by the next user message", () => {
-    const messages = [snapshot("snap-1"), invokingUser("user-1", ["review"])];
+  test("keeps snapshots whose invoking user row is present", () => {
+    const messages = [snapshot("snap-1", "user-1"), invokingUser("user-1", ["review"])];
     expect(filterOrphanedMcpPromptSnapshots(messages)).toEqual(messages);
   });
 
-  test("drops a snapshot left at the tail by a crash", () => {
+  test("drops a snapshot whose invoking user row was never persisted", () => {
     const assistant = createMuxMessage("assistant-1", "assistant", "done", {
       historySequence: 0,
     });
-    const messages = [invokingUser("user-1", []), assistant, snapshot("snap-1")];
+    const messages = [invokingUser("user-1", []), assistant, snapshot("snap-1", "user-never")];
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual([
       "user-1",
       "assistant-1",
     ]);
   });
 
-  test("drops a snapshot whose following user message does not reference it", () => {
-    const messages = [snapshot("snap-1", "review"), invokingUser("user-1", ["status"])];
+  test("drops a crash orphan even when a later turn references the same prompt", () => {
+    // The later inline invocation failed to materialize (no new snapshot) but
+    // its user row still carries the ref; identity must not claim the orphan.
+    const messages = [
+      snapshot("orphan-snap", "user-crashed"),
+      invokingUser("user-later", ["review"]),
+    ];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-later"]);
+  });
+
+  test("drops legacy snapshots without an invoking id", () => {
+    const messages = [snapshot("snap-legacy"), invokingUser("user-1", ["review"])];
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
   });
 
-  test("keeps only the newest snapshot per prompt when a crashed attempt is retried", () => {
+  test("keeps multiple snapshots correlated to the same turn", () => {
     const messages = [
-      snapshot("snap-stale", "review"),
-      snapshot("snap-fresh", "review"),
-      invokingUser("user-1", ["review"]),
+      snapshot("snap-1", "user-1", "review"),
+      snapshot("snap-2", "user-1", "status"),
+      invokingUser("user-1", ["review", "status"]),
     ];
-    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual([
-      "snap-fresh",
-      "user-1",
-    ]);
-  });
-
-  test("skill snapshots inside the block do not break the claim", () => {
-    const skillSnapshot = createMuxMessage("skill-snap", "user", "skill body", {
-      historySequence: 0,
-      synthetic: true,
-      agentSkillSnapshot: { skillName: "tdd", scope: "global", sha256: "abc" },
-    });
-    const messages = [snapshot("snap-1"), skillSnapshot, invokingUser("user-1", ["review"])];
     expect(filterOrphanedMcpPromptSnapshots(messages)).toEqual(messages);
   });
 });

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -101,6 +101,25 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
     expect(filterOrphanedMcpPromptSnapshots([corrupted])).toEqual([]);
   });
 
+  test("drops a prefixed expansion row whose snapshot field is entirely absent", () => {
+    const corrupted = createMuxMessage("mcp-prompt-snapshot-456-def", "user", "Expanded", {
+      historySequence: 0,
+      synthetic: true,
+    });
+
+    expect(
+      filterOrphanedMcpPromptSnapshots([corrupted, invokingUser("user-1", ["review"])]).map(
+        (m) => m.id
+      )
+    ).toEqual(["user-1"]);
+  });
+
+  test("drops a prefixed expansion row with no metadata at all", () => {
+    const bare = createMuxMessage("mcp-prompt-snapshot-789-ghi", "user", "Expanded");
+
+    expect(filterOrphanedMcpPromptSnapshots([bare])).toEqual([]);
+  });
+
   test("keeps ordinary rows with a corrupted snapshot field, stripped", () => {
     const authored = createMuxMessage("user-authored", "user", "Real user text", {
       historySequence: 0,

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createMuxMessage, filterOrphanedMcpPromptSnapshots } from "./message";
+import {
+  createMuxMessage,
+  filterOrphanedMcpPromptSnapshots,
+  sanitizeMcpPromptRefs,
+} from "./message";
 import type { MuxMessage } from "./message";
 
 function snapshot(id: string, invokingMessageId?: string, promptName = "review"): MuxMessage {
@@ -82,5 +86,28 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
       invokingUser("user-1", ["review", "status"]),
     ];
     expect(filterOrphanedMcpPromptSnapshots(messages)).toEqual(messages);
+  });
+});
+
+describe("sanitizeMcpPromptRefs arguments", () => {
+  const baseRef = {
+    serverName: "coder",
+    promptName: "review",
+    commandKey: "mcp__coder__review",
+    source: "slash" as const,
+  };
+
+  test("keeps a valid string-record arguments field", () => {
+    const refs = sanitizeMcpPromptRefs([{ ...baseRef, arguments: { path: "src" } }]);
+    expect(refs).toEqual([{ ...baseRef, arguments: { path: "src" } }]);
+  });
+
+  test("drops malformed arguments but keeps the reference identity", () => {
+    const malformedArgumentsValues: unknown[] = ["path", { path: 1 }, [1], 42, null];
+
+    for (const malformed of malformedArgumentsValues) {
+      const refs = sanitizeMcpPromptRefs([{ ...baseRef, arguments: malformed }]);
+      expect(refs).toEqual([baseRef]);
+    }
   });
 });

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -52,8 +52,6 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
   });
 
   test("drops a crash orphan even when a later turn references the same prompt", () => {
-    // The later inline invocation failed to materialize (no new snapshot) but
-    // its user row still carries the ref; identity must not claim the orphan.
     const messages = [
       snapshot("orphan-snap", "user-crashed"),
       invokingUser("user-later", ["review"]),

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -77,6 +77,29 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
   });
 
+  test("drops raw rows whose snapshot field is present but malformed", () => {
+    // Raw chat.jsonl rows bypass the oRPC sanitizer, so the request-side
+    // filter must treat a present-but-invalid field as corruption.
+    const corruptRow = (id: string, snapshotValue: unknown): MuxMessage => {
+      const message = createMuxMessage(id, "user", "Expanded review", {
+        historySequence: 0,
+        synthetic: true,
+      });
+      (message.metadata as Record<string, unknown>).mcpPromptSnapshot = snapshotValue;
+      return message;
+    };
+    const messages = [
+      corruptRow("snap-null", null),
+      corruptRow("snap-wrong-shape", { serverName: 42, promptName: "review" }),
+      snapshot("snap-valid", "user-1"),
+      invokingUser("user-1", ["review"]),
+    ];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual([
+      "snap-valid",
+      "user-1",
+    ]);
+  });
+
   test("keeps multiple snapshots correlated to the same turn", () => {
     const messages = [
       snapshot("snap-1", "user-1", "review"),

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -77,6 +77,34 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
   });
 
+  test("keeps other synthetic rows with a corrupted snapshot field, stripped", () => {
+    // A file-mention snapshot row corrupted with a malformed mcpPromptSnapshot
+    // must survive as a sanitized row, not be dropped as an MCP orphan.
+    const fileSnapshotRow = createMuxMessage("file-snap-1", "user", "File contents", {
+      historySequence: 0,
+      synthetic: true,
+      fileAtMentionSnapshot: ["@src/foo.ts"],
+    });
+    (fileSnapshotRow.metadata as Record<string, unknown>).mcpPromptSnapshot = null;
+
+    const result = filterOrphanedMcpPromptSnapshots([fileSnapshotRow]);
+    expect(result.map((m) => m.id)).toEqual(["file-snap-1"]);
+    expect(result[0].metadata?.fileAtMentionSnapshot).toEqual(["@src/foo.ts"]);
+    expect("mcpPromptSnapshot" in (result[0].metadata ?? {})).toBe(false);
+  });
+
+  test("drops a corrupted expansion row identified by its snapshot message id", () => {
+    // The dedicated ID prefix marks genuine expansion rows even when the
+    // snapshot payload itself is corrupted beyond shape recognition.
+    const corrupted = createMuxMessage("mcp-prompt-snapshot-123-abc", "user", "Expanded", {
+      historySequence: 0,
+      synthetic: true,
+    });
+    (corrupted.metadata as Record<string, unknown>).mcpPromptSnapshot = null;
+
+    expect(filterOrphanedMcpPromptSnapshots([corrupted])).toEqual([]);
+  });
+
   test("keeps ordinary rows with a corrupted snapshot field, stripped", () => {
     const authored = createMuxMessage("user-authored", "user", "Real user text", {
       historySequence: 0,
@@ -104,8 +132,8 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
       return message;
     };
     const messages = [
-      corruptRow("snap-null", null),
-      corruptRow("snap-wrong-shape", { serverName: 42, promptName: "review" }),
+      corruptRow("mcp-prompt-snapshot-1-null", null),
+      corruptRow("mcp-prompt-snapshot-2-shape", { serverName: 42, promptName: "review" }),
       snapshot("snap-valid", "user-1"),
       invokingUser("user-1", ["review"]),
     ];
@@ -145,5 +173,18 @@ describe("sanitizeMcpPromptRefs arguments", () => {
       const refs = sanitizeMcpPromptRefs([{ ...baseRef, arguments: malformed }]);
       expect(refs).toEqual([baseRef]);
     }
+  });
+
+  test("drops references with empty or invalid identity strings", () => {
+    // Retaining an empty identity would make snapshot materialization fail on
+    // every compact-and-retry instead of self-healing the corrupted history.
+    const invalidIdentities: unknown[] = [
+      { serverName: "", promptName: "", commandKey: "", source: "slash" },
+      { ...baseRef, serverName: "" },
+      { ...baseRef, promptName: "" },
+      { ...baseRef, commandKey: "not-an-mcp-key" },
+    ];
+    expect(sanitizeMcpPromptRefs(invalidIdentities)).toEqual([]);
+    expect(sanitizeMcpPromptRefs([baseRef])).toEqual([baseRef]);
   });
 });

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -77,6 +77,21 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
   });
 
+  test("keeps ordinary rows with a corrupted snapshot field, stripped", () => {
+    const authored = createMuxMessage("user-authored", "user", "Real user text", {
+      historySequence: 0,
+    });
+    (authored.metadata as Record<string, unknown>).mcpPromptSnapshot = null;
+    const assistant = createMuxMessage("assistant-1", "assistant", "Model reply", {
+      historySequence: 0,
+    });
+    (assistant.metadata as Record<string, unknown>).mcpPromptSnapshot = { bogus: true };
+
+    const result = filterOrphanedMcpPromptSnapshots([authored, assistant]);
+    expect(result.map((m) => m.id)).toEqual(["user-authored", "assistant-1"]);
+    expect(result.every((m) => !("mcpPromptSnapshot" in (m.metadata ?? {})))).toBe(true);
+  });
+
   test("drops raw rows whose snapshot field is present but malformed", () => {
     // Raw chat.jsonl rows bypass the oRPC sanitizer, so the request-side
     // filter must treat a present-but-invalid field as corruption.

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -57,6 +57,19 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-later"]);
   });
 
+  test("drops a snapshot whose invoking id points at a row without a matching ref", () => {
+    const unrelated = createMuxMessage("user-unrelated", "user", "Plain message", {
+      historySequence: 0,
+    });
+    const messages = [snapshot("snap-1", "user-unrelated"), unrelated];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-unrelated"]);
+  });
+
+  test("drops a snapshot whose invoking id points at a different prompt's turn", () => {
+    const messages = [snapshot("snap-1", "user-1", "review"), invokingUser("user-1", ["status"])];
+    expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);
+  });
+
   test("drops legacy snapshots without an invoking id", () => {
     const messages = [snapshot("snap-legacy"), invokingUser("user-1", ["review"])];
     expect(filterOrphanedMcpPromptSnapshots(messages).map((m) => m.id)).toEqual(["user-1"]);

--- a/src/common/types/message.mcpPromptSnapshots.test.ts
+++ b/src/common/types/message.mcpPromptSnapshots.test.ts
@@ -78,8 +78,6 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
   });
 
   test("keeps other synthetic rows with a corrupted snapshot field, stripped", () => {
-    // A file-mention snapshot row corrupted with a malformed mcpPromptSnapshot
-    // must survive as a sanitized row, not be dropped as an MCP orphan.
     const fileSnapshotRow = createMuxMessage("file-snap-1", "user", "File contents", {
       historySequence: 0,
       synthetic: true,
@@ -94,8 +92,6 @@ describe("filterOrphanedMcpPromptSnapshots", () => {
   });
 
   test("drops a corrupted expansion row identified by its snapshot message id", () => {
-    // The dedicated ID prefix marks genuine expansion rows even when the
-    // snapshot payload itself is corrupted beyond shape recognition.
     const corrupted = createMuxMessage("mcp-prompt-snapshot-123-abc", "user", "Expanded", {
       historySequence: 0,
       synthetic: true,
@@ -176,8 +172,6 @@ describe("sanitizeMcpPromptRefs arguments", () => {
   });
 
   test("drops references with empty or invalid identity strings", () => {
-    // Retaining an empty identity would make snapshot materialization fail on
-    // every compact-and-retry instead of self-healing the corrupted history.
     const invalidIdentities: unknown[] = [
       { serverName: "", promptName: "", commandKey: "", source: "slash" },
       { ...baseRef, serverName: "" },

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -330,8 +330,7 @@ export function sanitizeMcpPromptRefs(value: unknown): MCPPromptReference[] {
   if (!Array.isArray(value)) return [];
   return value.filter(isMcpPromptReference).map((ref) => {
     if (ref.arguments === undefined || isStringRecord(ref.arguments)) return ref;
-    // Malformed persisted arguments would make every prompts/get retry fail,
-    // so drop just that field and keep the reference identity.
+    // Drop malformed persisted arguments so prompt expansion can retry without them.
     const { arguments: _malformed, ...rest } = ref;
     return rest;
   });
@@ -352,10 +351,9 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
 }
 
 /**
- * A crash between snapshot persistence and the user-row append can orphan MCP
- * prompt snapshots, so provider requests keep one only when the user row it
- * was materialized for is present and still references that server/prompt
- * (self-healing rule; guards corrupted ids pointing at unrelated rows).
+ * Drops MCP prompt snapshots orphaned by a crash between snapshot persistence
+ * and the user-row append: a snapshot survives only when its invoking user row
+ * exists and still references the same prompt.
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
   const promptRefKeysByMessageId = new Map<string, Set<string>>();
@@ -763,12 +761,7 @@ export interface MuxMetadata {
     serverName: string;
     promptName: string;
     commandKey: string;
-    /**
-     * Id of the user row this snapshot expands. Exact correlation, because
-     * adjacency plus prompt identity lets a later same-prompt turn claim a
-     * crash-orphaned snapshot. Optional only for rows persisted before the
-     * field existed; those are treated as orphans.
-     */
+    /** Missing legacy values are treated as crash orphans. */
     invokingMessageId?: string;
     description?: string;
   };

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -320,9 +320,21 @@ export function isMcpPromptReference(value: unknown): value is MCPPromptReferenc
   );
 }
 
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
 /** muxMetadata persists as z.any(), so corrupted references require read-time filtering. */
 export function sanitizeMcpPromptRefs(value: unknown): MCPPromptReference[] {
-  return Array.isArray(value) ? value.filter(isMcpPromptReference) : [];
+  if (!Array.isArray(value)) return [];
+  return value.filter(isMcpPromptReference).map((ref) => {
+    if (ref.arguments === undefined || isStringRecord(ref.arguments)) return ref;
+    // Malformed persisted arguments would make every prompts/get retry fail,
+    // so drop just that field and keep the reference identity.
+    const { arguments: _malformed, ...rest } = ref;
+    return rest;
+  });
 }
 
 export function isAgentSkillReference(value: unknown): value is AgentSkillReference {

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -296,10 +296,14 @@ export interface MCPPromptReference {
   arguments?: Record<string, string>;
 }
 
+export function getMcpPromptReferenceKey(serverName: string, promptName: string): string {
+  return `${serverName}\u0000${promptName}`;
+}
+
 export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
   const deduped = new Map<string, MCPPromptReference>();
   for (const ref of refs) {
-    const key = `${ref.serverName}\u0000${ref.promptName}`;
+    const key = getMcpPromptReferenceKey(ref.serverName, ref.promptName);
     const existing = deduped.get(key);
     if (!existing || (existing.source === "inline" && ref.source === "slash")) {
       deduped.set(key, ref);
@@ -312,9 +316,12 @@ export function withMcpPromptRefs(
   metadata: MuxMessageMetadata | undefined,
   refs: MCPPromptReference[]
 ): MuxMessageMetadata | undefined {
-  const existing = Array.isArray(metadata?.mcpPromptRefs) ? metadata.mcpPromptRefs : [];
-  if (existing.length === 0 && refs.length === 0) return metadata;
-  const mcpPromptRefs = dedupeMcpPromptRefs([...existing, ...refs]);
+  const existingRefs = Array.isArray(metadata?.mcpPromptRefs) ? metadata.mcpPromptRefs : [];
+  if (existingRefs.length === 0 && refs.length === 0) {
+    return metadata;
+  }
+
+  const mcpPromptRefs = dedupeMcpPromptRefs([...existingRefs, ...refs]);
   return metadata ? { ...metadata, mcpPromptRefs } : { type: "normal", mcpPromptRefs };
 }
 
@@ -766,7 +773,7 @@ export type DisplayedMessage =
       isBudgetLimitWrapup?: boolean;
       /** True when this row is loaded above the latest Context Boundary and must not mutate active context. */
       isBeforeLatestContextBoundary?: boolean;
-      /** Present when this message invoked an agent skill via /{skill-name} */
+      /** Present when this message invoked an agent skill or MCP prompt via slash command. */
       agentSkill?: {
         skillName: string;
         scope: AgentSkillScope;
@@ -781,8 +788,10 @@ export type DisplayedMessage =
           body?: string;
         };
       };
+      /** Preserved so compaction retry can rematerialize MCP prompt invocations. */
+      mcpPromptRefs?: MCPPromptReference[];
       /**
-       * Inline skill snapshots are derived display state from prior synthetic snapshot messages.
+       * Inline skill and MCP prompt snapshots are derived from prior synthetic messages.
        * They are not persisted on the user message itself.
        */
       inlineSkillSnapshots?: InlineSkillSnapshotMap;

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -288,6 +288,36 @@ export function withAgentSkillRefs(
   };
 }
 
+export interface MCPPromptReference {
+  serverName: string;
+  promptName: string;
+  commandKey: string;
+  source: "slash" | "inline";
+  arguments?: Record<string, string>;
+}
+
+export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
+  const deduped = new Map<string, MCPPromptReference>();
+  for (const ref of refs) {
+    const key = `${ref.serverName}\u0000${ref.promptName}`;
+    const existing = deduped.get(key);
+    if (!existing || (existing.source === "inline" && ref.source === "slash")) {
+      deduped.set(key, ref);
+    }
+  }
+  return [...deduped.values()];
+}
+
+export function withMcpPromptRefs(
+  metadata: MuxMessageMetadata | undefined,
+  refs: MCPPromptReference[]
+): MuxMessageMetadata | undefined {
+  const existing = Array.isArray(metadata?.mcpPromptRefs) ? metadata.mcpPromptRefs : [];
+  if (existing.length === 0 && refs.length === 0) return metadata;
+  const mcpPromptRefs = dedupeMcpPromptRefs([...existing, ...refs]);
+  return metadata ? { ...metadata, mcpPromptRefs } : { type: "normal", mcpPromptRefs };
+}
+
 export interface BuildAgentSkillMetadataOptions {
   rawCommand: string;
   skillName: string;
@@ -345,6 +375,7 @@ interface MuxMessageMetadataBase {
    * muxMetadata loose by design, so this orthogonal field needs no schema change.
    */
   agentSkillRefs?: AgentSkillReference[];
+  mcpPromptRefs?: MCPPromptReference[];
   /** Display-only insertion point within an assistant message that was streaming. */
   transcriptAnchor?: TranscriptAnchor;
 }
@@ -640,6 +671,12 @@ export interface MuxMetadata {
      * Optional for backwards compatibility with older histories.
      */
     frontmatterYaml?: string;
+  };
+  mcpPromptSnapshot?: {
+    serverName: string;
+    promptName: string;
+    commandKey: string;
+    description?: string;
   };
 }
 

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -341,40 +341,21 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
 
 /**
  * A crash between snapshot persistence and the user-row append can orphan MCP
- * prompt snapshots, so provider requests keep one only when the next
- * non-snapshot row is a user message that references it (self-healing rule).
+ * prompt snapshots, so provider requests keep one only when the user row it
+ * was materialized for is present in the same history (self-healing rule).
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
-  const claimedIds = new Set<string>();
-  let pendingBlock: MuxMessage[] = [];
-  for (const message of messages) {
-    if (isSyntheticSnapshotUserMessage(message)) {
-      if (message.metadata?.mcpPromptSnapshot) pendingBlock.push(message);
-      continue;
-    }
-    if (pendingBlock.length > 0 && message.role === "user") {
-      const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
-      const refKeys = new Set(
-        refs.map((ref) => getMcpPromptReferenceKey(ref.serverName, ref.promptName))
-      );
-      // Refs are deduped per turn, so claim the newest snapshot per prompt;
-      // older duplicates come from a crashed earlier attempt.
-      const claimedKeys = new Set<string>();
-      for (let i = pendingBlock.length - 1; i >= 0; i--) {
-        const snapshot = pendingBlock[i].metadata?.mcpPromptSnapshot;
-        if (!snapshot) continue;
-        const key = getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName);
-        if (refKeys.has(key) && !claimedKeys.has(key)) {
-          claimedKeys.add(key);
-          claimedIds.add(pendingBlock[i].id);
-        }
-      }
-    }
-    pendingBlock = [];
-  }
-  return messages.filter(
-    (message) => !message.metadata?.mcpPromptSnapshot || claimedIds.has(message.id)
+  const nonSnapshotMessageIds = new Set(
+    messages.filter((message) => !message.metadata?.mcpPromptSnapshot).map((message) => message.id)
   );
+  return messages.filter((message) => {
+    const snapshot = message.metadata?.mcpPromptSnapshot;
+    if (!snapshot) return true;
+    return (
+      snapshot.invokingMessageId !== undefined &&
+      nonSnapshotMessageIds.has(snapshot.invokingMessageId)
+    );
+  });
 }
 
 export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
@@ -760,6 +741,13 @@ export interface MuxMetadata {
     serverName: string;
     promptName: string;
     commandKey: string;
+    /**
+     * Id of the user row this snapshot expands. Exact correlation, because
+     * adjacency plus prompt identity lets a later same-prompt turn claim a
+     * crash-orphaned snapshot. Optional only for rows persisted before the
+     * field existed; those are treated as orphans.
+     */
+    invokingMessageId?: string;
     description?: string;
   };
 }

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -14,6 +14,7 @@ import type { AgentMode } from "./mode";
 import type { AgentSkillScope } from "./agentSkill";
 import type { ThinkingLevel } from "./thinking";
 import { type ReviewNoteData, formatReviewForModel } from "./review";
+import { isMcpPromptCommandKey } from "@/common/utils/tools/mcpPromptCommandKey";
 
 export type { ModelMessage };
 
@@ -312,10 +313,15 @@ export function buildMcpPromptUserText(
 export function isMcpPromptReference(value: unknown): value is MCPPromptReference {
   if (value === null || typeof value !== "object") return false;
   const ref = value as Partial<MCPPromptReference>;
+  // Empty identities would make snapshot materialization fail on every
+  // compact-and-retry instead of self-healing, so reject them here.
   return (
     typeof ref.serverName === "string" &&
+    ref.serverName.length > 0 &&
     typeof ref.promptName === "string" &&
+    ref.promptName.length > 0 &&
     typeof ref.commandKey === "string" &&
+    isMcpPromptCommandKey(ref.commandKey) &&
     (ref.source === "slash" || ref.source === "inline")
   );
 }
@@ -350,16 +356,15 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
   return Array.isArray(value) ? value.filter(isAgentSkillReference) : [];
 }
 
-function isMcpPromptSnapshotWithInvokingId(
+/** Shared with the node-side ID factory so snapshot rows stay identifiable. */
+export const MCP_PROMPT_SNAPSHOT_MESSAGE_ID_PREFIX = "mcp-prompt-snapshot-";
+
+function isMcpPromptSnapshotBaseShape(
   value: unknown
-): value is { serverName: string; promptName: string; invokingMessageId: string } {
+): value is { serverName: string; promptName: string; invokingMessageId?: string } {
   if (value === null || typeof value !== "object") return false;
   const snapshot = value as Partial<NonNullable<MuxMetadata["mcpPromptSnapshot"]>>;
-  return (
-    typeof snapshot.serverName === "string" &&
-    typeof snapshot.promptName === "string" &&
-    typeof snapshot.invokingMessageId === "string"
-  );
+  return typeof snapshot.serverName === "string" && typeof snapshot.promptName === "string";
 }
 
 /**
@@ -368,16 +373,20 @@ function isMcpPromptSnapshotWithInvokingId(
  * exists and still references the same prompt.
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
-  // Only synthetic user rows are droppable snapshot rows; corruption can add
-  // the field to authored/model rows, which must survive with it stripped.
-  const isSnapshotRow = (message: MuxMessage): boolean =>
+  // Only genuine MCP expansion rows are droppable: synthetic user rows
+  // identified by the dedicated snapshot ID prefix or a valid snapshot shape.
+  // Corruption can add the field to any other row (authored, model, or other
+  // synthetic kinds), which must survive with the invalid field stripped.
+  const isMcpSnapshotRow = (message: MuxMessage): boolean =>
     message.role === "user" &&
     message.metadata?.synthetic === true &&
-    message.metadata.mcpPromptSnapshot !== undefined;
+    message.metadata.mcpPromptSnapshot !== undefined &&
+    (message.id.startsWith(MCP_PROMPT_SNAPSHOT_MESSAGE_ID_PREFIX) ||
+      isMcpPromptSnapshotBaseShape(message.metadata.mcpPromptSnapshot));
 
   const promptRefKeysByMessageId = new Map<string, Set<string>>();
   for (const message of messages) {
-    if (message.role !== "user" || isSnapshotRow(message)) continue;
+    if (message.role !== "user" || isMcpSnapshotRow(message)) continue;
     const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
     if (refs.length === 0) continue;
     promptRefKeysByMessageId.set(
@@ -388,14 +397,17 @@ export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMes
   return messages.flatMap((message): MuxMessage[] => {
     const snapshot: unknown = message.metadata?.mcpPromptSnapshot;
     if (snapshot === undefined || message.metadata === undefined) return [message];
-    if (!isSnapshotRow(message)) {
+    if (!isMcpSnapshotRow(message)) {
       const { mcpPromptSnapshot: _stripped, ...metadata } = message.metadata;
       return [{ ...message, metadata }];
     }
     // Raw chat.jsonl rows bypass the oRPC .catch(undefined) sanitizer, so a
-    // present-but-malformed snapshot field (e.g. null) marks a corrupted
-    // expansion row: exclude it from provider requests.
-    if (!isMcpPromptSnapshotWithInvokingId(snapshot)) return [];
+    // present-but-malformed snapshot on an expansion row marks it corrupted:
+    // exclude it from provider requests. Legacy rows without an invoking id
+    // are treated as crash orphans.
+    if (!isMcpPromptSnapshotBaseShape(snapshot) || snapshot.invokingMessageId === undefined) {
+      return [];
+    }
     const invokingRefKeys = promptRefKeysByMessageId.get(snapshot.invokingMessageId);
     return invokingRefKeys?.has(
       getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName)

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -300,6 +300,20 @@ export function getMcpPromptReferenceKey(serverName: string, promptName: string)
   return `${serverName}\u0000${promptName}`;
 }
 
+/**
+ * Provider-visible user text for a slash MCP prompt invocation. The composer
+ * persists this transformed text while displaying the raw slash command, so
+ * retry paths must rebuild it with the same shape.
+ */
+export function buildMcpPromptUserText(
+  serverName: string,
+  promptName: string,
+  argumentText: string
+): string {
+  const base = `Using MCP prompt ${serverName}/${promptName}`;
+  return argumentText ? `${base}: ${argumentText}` : base;
+}
+
 export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
   const deduped = new Map<string, MCPPromptReference>();
   for (const ref of refs) {

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -320,10 +320,7 @@ export function isMcpPromptReference(value: unknown): value is MCPPromptReferenc
   );
 }
 
-/**
- * muxMetadata persists as z.any(), so one corrupted history line (e.g. [null])
- * must be filtered at read time rather than crashing aggregation (self-healing rule).
- */
+/** muxMetadata persists as z.any(), so corrupted references require read-time filtering. */
 export function sanitizeMcpPromptRefs(value: unknown): MCPPromptReference[] {
   return Array.isArray(value) ? value.filter(isMcpPromptReference) : [];
 }
@@ -338,7 +335,6 @@ export function isAgentSkillReference(value: unknown): value is AgentSkillRefere
   );
 }
 
-/** Same read-time filtering as sanitizeMcpPromptRefs for the peer refs field. */
 export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
   return Array.isArray(value) ? value.filter(isAgentSkillReference) : [];
 }

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -956,6 +956,21 @@ export interface QueuedMessage {
   hasCompactionRequest?: boolean;
 }
 
+/**
+ * Synthetic snapshot rows (file @-mention, agent skill, MCP prompt) that precede
+ * a user message. Edit truncation and history scans must treat them as part of
+ * the user message they annotate, so every snapshot kind must be listed here.
+ */
+export function isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {
+  return (
+    message.role === "user" &&
+    message.metadata?.synthetic === true &&
+    (message.metadata.fileAtMentionSnapshot !== undefined ||
+      message.metadata.agentSkillSnapshot !== undefined ||
+      message.metadata.mcpPromptSnapshot !== undefined)
+  );
+}
+
 // Helper to create a simple text message
 export function createMuxMessage(
   id: string,

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -368,9 +368,16 @@ function isMcpPromptSnapshotWithInvokingId(
  * exists and still references the same prompt.
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
+  // Only synthetic user rows are droppable snapshot rows; corruption can add
+  // the field to authored/model rows, which must survive with it stripped.
+  const isSnapshotRow = (message: MuxMessage): boolean =>
+    message.role === "user" &&
+    message.metadata?.synthetic === true &&
+    message.metadata.mcpPromptSnapshot !== undefined;
+
   const promptRefKeysByMessageId = new Map<string, Set<string>>();
   for (const message of messages) {
-    if (message.role !== "user" || message.metadata?.mcpPromptSnapshot !== undefined) continue;
+    if (message.role !== "user" || isSnapshotRow(message)) continue;
     const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
     if (refs.length === 0) continue;
     promptRefKeysByMessageId.set(
@@ -378,18 +385,23 @@ export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMes
       new Set(refs.map((ref) => getMcpPromptReferenceKey(ref.serverName, ref.promptName)))
     );
   }
-  return messages.filter((message) => {
+  return messages.flatMap((message): MuxMessage[] => {
+    const snapshot: unknown = message.metadata?.mcpPromptSnapshot;
+    if (snapshot === undefined || message.metadata === undefined) return [message];
+    if (!isSnapshotRow(message)) {
+      const { mcpPromptSnapshot: _stripped, ...metadata } = message.metadata;
+      return [{ ...message, metadata }];
+    }
     // Raw chat.jsonl rows bypass the oRPC .catch(undefined) sanitizer, so a
     // present-but-malformed snapshot field (e.g. null) marks a corrupted
     // expansion row: exclude it from provider requests.
-    const snapshot: unknown = message.metadata?.mcpPromptSnapshot;
-    if (snapshot === undefined) return true;
-    if (!isMcpPromptSnapshotWithInvokingId(snapshot)) return false;
+    if (!isMcpPromptSnapshotWithInvokingId(snapshot)) return [];
     const invokingRefKeys = promptRefKeysByMessageId.get(snapshot.invokingMessageId);
-    return (
-      invokingRefKeys?.has(getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName)) ===
-      true
-    );
+    return invokingRefKeys?.has(
+      getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName)
+    ) === true
+      ? [message]
+      : [];
   });
 }
 

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -833,6 +833,8 @@ export type DisplayedMessage =
       };
       /** Preserved so compaction retry can rematerialize MCP prompt invocations. */
       mcpPromptRefs?: MCPPromptReference[];
+      /** Preserved so compaction retry can rematerialize inline skill references. */
+      agentSkillRefs?: AgentSkillReference[];
       /**
        * Inline skill and MCP prompt snapshots are derived from prior synthetic messages.
        * They are not persisted on the user message itself.

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -339,6 +339,44 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
   return Array.isArray(value) ? value.filter(isAgentSkillReference) : [];
 }
 
+/**
+ * A crash between snapshot persistence and the user-row append can orphan MCP
+ * prompt snapshots, so provider requests keep one only when the next
+ * non-snapshot row is a user message that references it (self-healing rule).
+ */
+export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
+  const claimedIds = new Set<string>();
+  let pendingBlock: MuxMessage[] = [];
+  for (const message of messages) {
+    if (isSyntheticSnapshotUserMessage(message)) {
+      if (message.metadata?.mcpPromptSnapshot) pendingBlock.push(message);
+      continue;
+    }
+    if (pendingBlock.length > 0 && message.role === "user") {
+      const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
+      const refKeys = new Set(
+        refs.map((ref) => getMcpPromptReferenceKey(ref.serverName, ref.promptName))
+      );
+      // Refs are deduped per turn, so claim the newest snapshot per prompt;
+      // older duplicates come from a crashed earlier attempt.
+      const claimedKeys = new Set<string>();
+      for (let i = pendingBlock.length - 1; i >= 0; i--) {
+        const snapshot = pendingBlock[i].metadata?.mcpPromptSnapshot;
+        if (!snapshot) continue;
+        const key = getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName);
+        if (refKeys.has(key) && !claimedKeys.has(key)) {
+          claimedKeys.add(key);
+          claimedIds.add(pendingBlock[i].id);
+        }
+      }
+    }
+    pendingBlock = [];
+  }
+  return messages.filter(
+    (message) => !message.metadata?.mcpPromptSnapshot || claimedIds.has(message.id)
+  );
+}
+
 export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
   const deduped = new Map<string, MCPPromptReference>();
   for (const ref of refs) {

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -342,18 +342,28 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
 /**
  * A crash between snapshot persistence and the user-row append can orphan MCP
  * prompt snapshots, so provider requests keep one only when the user row it
- * was materialized for is present in the same history (self-healing rule).
+ * was materialized for is present and still references that server/prompt
+ * (self-healing rule; guards corrupted ids pointing at unrelated rows).
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
-  const nonSnapshotMessageIds = new Set(
-    messages.filter((message) => !message.metadata?.mcpPromptSnapshot).map((message) => message.id)
-  );
+  const promptRefKeysByMessageId = new Map<string, Set<string>>();
+  for (const message of messages) {
+    if (message.role !== "user" || message.metadata?.mcpPromptSnapshot) continue;
+    const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
+    if (refs.length === 0) continue;
+    promptRefKeysByMessageId.set(
+      message.id,
+      new Set(refs.map((ref) => getMcpPromptReferenceKey(ref.serverName, ref.promptName)))
+    );
+  }
   return messages.filter((message) => {
     const snapshot = message.metadata?.mcpPromptSnapshot;
     if (!snapshot) return true;
+    if (snapshot.invokingMessageId === undefined) return false;
+    const invokingRefKeys = promptRefKeysByMessageId.get(snapshot.invokingMessageId);
     return (
-      snapshot.invokingMessageId !== undefined &&
-      nonSnapshotMessageIds.has(snapshot.invokingMessageId)
+      invokingRefKeys?.has(getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName)) ===
+      true
     );
   });
 }

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -350,6 +350,18 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
   return Array.isArray(value) ? value.filter(isAgentSkillReference) : [];
 }
 
+function isMcpPromptSnapshotWithInvokingId(
+  value: unknown
+): value is { serverName: string; promptName: string; invokingMessageId: string } {
+  if (value === null || typeof value !== "object") return false;
+  const snapshot = value as Partial<NonNullable<MuxMetadata["mcpPromptSnapshot"]>>;
+  return (
+    typeof snapshot.serverName === "string" &&
+    typeof snapshot.promptName === "string" &&
+    typeof snapshot.invokingMessageId === "string"
+  );
+}
+
 /**
  * Drops MCP prompt snapshots orphaned by a crash between snapshot persistence
  * and the user-row append: a snapshot survives only when its invoking user row
@@ -358,7 +370,7 @@ export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
   const promptRefKeysByMessageId = new Map<string, Set<string>>();
   for (const message of messages) {
-    if (message.role !== "user" || message.metadata?.mcpPromptSnapshot) continue;
+    if (message.role !== "user" || message.metadata?.mcpPromptSnapshot !== undefined) continue;
     const refs = sanitizeMcpPromptRefs(message.metadata?.muxMetadata?.mcpPromptRefs);
     if (refs.length === 0) continue;
     promptRefKeysByMessageId.set(
@@ -367,9 +379,12 @@ export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMes
     );
   }
   return messages.filter((message) => {
-    const snapshot = message.metadata?.mcpPromptSnapshot;
-    if (!snapshot) return true;
-    if (snapshot.invokingMessageId === undefined) return false;
+    // Raw chat.jsonl rows bypass the oRPC .catch(undefined) sanitizer, so a
+    // present-but-malformed snapshot field (e.g. null) marks a corrupted
+    // expansion row: exclude it from provider requests.
+    const snapshot: unknown = message.metadata?.mcpPromptSnapshot;
+    if (snapshot === undefined) return true;
+    if (!isMcpPromptSnapshotWithInvokingId(snapshot)) return false;
     const invokingRefKeys = promptRefKeysByMessageId.get(snapshot.invokingMessageId);
     return (
       invokingRefKeys?.has(getMcpPromptReferenceKey(snapshot.serverName, snapshot.promptName)) ===

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -373,10 +373,9 @@ function isMcpPromptSnapshotBaseShape(
  * exists and still references the same prompt.
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
-  // Only genuine MCP expansion rows are droppable: synthetic user rows
-  // identified by the dedicated snapshot ID prefix or a valid snapshot shape.
-  // Corruption can add the field to any other row (authored, model, or other
-  // synthetic kinds), which must survive with the invalid field stripped.
+  // Drop only genuine expansion rows, identified by the ID prefix or valid
+  // snapshot shape. Other rows may be corrupted with this field and must
+  // survive after it is stripped.
   const isMcpSnapshotRow = (message: MuxMessage): boolean =>
     message.role === "user" &&
     message.metadata?.synthetic === true &&
@@ -401,10 +400,8 @@ export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMes
       const { mcpPromptSnapshot: _stripped, ...metadata } = message.metadata;
       return [{ ...message, metadata }];
     }
-    // Raw chat.jsonl rows bypass the oRPC .catch(undefined) sanitizer, so a
-    // present-but-malformed snapshot on an expansion row marks it corrupted:
-    // exclude it from provider requests. Legacy rows without an invoking id
-    // are treated as crash orphans.
+    // Raw chat.jsonl bypasses oRPC sanitization. Malformed expansion snapshots
+    // and legacy snapshots without an invoking ID are crash orphans.
     if (!isMcpPromptSnapshotBaseShape(snapshot) || snapshot.invokingMessageId === undefined) {
       return [];
     }

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -956,11 +956,7 @@ export interface QueuedMessage {
   hasCompactionRequest?: boolean;
 }
 
-/**
- * Synthetic snapshot rows (file @-mention, agent skill, MCP prompt) that precede
- * a user message. Edit truncation and history scans must treat them as part of
- * the user message they annotate, so every snapshot kind must be listed here.
- */
+/** Keep every snapshot kind here so history scans and edits retain it with its user message. */
 export function isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {
   return (
     message.role === "user" &&

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -373,15 +373,15 @@ function isMcpPromptSnapshotBaseShape(
  * exists and still references the same prompt.
  */
 export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMessage[] {
-  // Drop only genuine expansion rows, identified by the ID prefix or valid
-  // snapshot shape. Other rows may be corrupted with this field and must
-  // survive after it is stripped.
+  // Drop only genuine expansion rows: the reserved ID prefix marks one even
+  // when corruption removed its metadata, and synthetic rows with a valid
+  // snapshot shape cover legacy IDs. Other rows may be corrupted with this
+  // field and must survive after it is stripped.
   const isMcpSnapshotRow = (message: MuxMessage): boolean =>
     message.role === "user" &&
-    message.metadata?.synthetic === true &&
-    message.metadata.mcpPromptSnapshot !== undefined &&
     (message.id.startsWith(MCP_PROMPT_SNAPSHOT_MESSAGE_ID_PREFIX) ||
-      isMcpPromptSnapshotBaseShape(message.metadata.mcpPromptSnapshot));
+      (message.metadata?.synthetic === true &&
+        isMcpPromptSnapshotBaseShape(message.metadata.mcpPromptSnapshot)));
 
   const promptRefKeysByMessageId = new Map<string, Set<string>>();
   for (const message of messages) {
@@ -395,13 +395,13 @@ export function filterOrphanedMcpPromptSnapshots(messages: MuxMessage[]): MuxMes
   }
   return messages.flatMap((message): MuxMessage[] => {
     const snapshot: unknown = message.metadata?.mcpPromptSnapshot;
-    if (snapshot === undefined || message.metadata === undefined) return [message];
     if (!isMcpSnapshotRow(message)) {
+      if (snapshot === undefined || message.metadata === undefined) return [message];
       const { mcpPromptSnapshot: _stripped, ...metadata } = message.metadata;
       return [{ ...message, metadata }];
     }
-    // Raw chat.jsonl bypasses oRPC sanitization. Malformed expansion snapshots
-    // and legacy snapshots without an invoking ID are crash orphans.
+    // Raw chat.jsonl bypasses oRPC sanitization. Absent or malformed expansion
+    // snapshots and legacy snapshots without an invoking ID are crash orphans.
     if (!isMcpPromptSnapshotBaseShape(snapshot) || snapshot.invokingMessageId === undefined) {
       return [];
     }

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -300,11 +300,6 @@ export function getMcpPromptReferenceKey(serverName: string, promptName: string)
   return `${serverName}\u0000${promptName}`;
 }
 
-/**
- * Provider-visible user text for a slash MCP prompt invocation. The composer
- * persists this transformed text while displaying the raw slash command, so
- * retry paths must rebuild it with the same shape.
- */
 export function buildMcpPromptUserText(
   serverName: string,
   promptName: string,

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -314,6 +314,40 @@ export function buildMcpPromptUserText(
   return argumentText ? `${base}: ${argumentText}` : base;
 }
 
+export function isMcpPromptReference(value: unknown): value is MCPPromptReference {
+  if (value === null || typeof value !== "object") return false;
+  const ref = value as Partial<MCPPromptReference>;
+  return (
+    typeof ref.serverName === "string" &&
+    typeof ref.promptName === "string" &&
+    typeof ref.commandKey === "string" &&
+    (ref.source === "slash" || ref.source === "inline")
+  );
+}
+
+/**
+ * muxMetadata persists as z.any(), so one corrupted history line (e.g. [null])
+ * must be filtered at read time rather than crashing aggregation (self-healing rule).
+ */
+export function sanitizeMcpPromptRefs(value: unknown): MCPPromptReference[] {
+  return Array.isArray(value) ? value.filter(isMcpPromptReference) : [];
+}
+
+export function isAgentSkillReference(value: unknown): value is AgentSkillReference {
+  if (value === null || typeof value !== "object") return false;
+  const ref = value as Partial<AgentSkillReference>;
+  return (
+    typeof ref.skillName === "string" &&
+    typeof ref.scope === "string" &&
+    (ref.source === "slash" || ref.source === "inline")
+  );
+}
+
+/** Same read-time filtering as sanitizeMcpPromptRefs for the peer refs field. */
+export function sanitizeAgentSkillRefs(value: unknown): AgentSkillReference[] {
+  return Array.isArray(value) ? value.filter(isAgentSkillReference) : [];
+}
+
 export function dedupeMcpPromptRefs(refs: MCPPromptReference[]): MCPPromptReference[] {
   const deduped = new Map<string, MCPPromptReference>();
   for (const ref of refs) {
@@ -330,7 +364,7 @@ export function withMcpPromptRefs(
   metadata: MuxMessageMetadata | undefined,
   refs: MCPPromptReference[]
 ): MuxMessageMetadata | undefined {
-  const existingRefs = Array.isArray(metadata?.mcpPromptRefs) ? metadata.mcpPromptRefs : [];
+  const existingRefs = sanitizeMcpPromptRefs(metadata?.mcpPromptRefs);
   if (existingRefs.length === 0 && refs.length === 0) {
     return metadata;
   }

--- a/src/common/utils/tools/mcpPromptCommandKey.ts
+++ b/src/common/utils/tools/mcpPromptCommandKey.ts
@@ -7,23 +7,17 @@ export function isMcpPromptCommandKey(value: string): boolean {
   return /^mcp__[a-z0-9_]+$/.test(value);
 }
 
-/** Normalize a component for generated MCP tool names and prompt command keys. */
 export function normalizeMcpToolNamePart(input: string): string {
   const normalized = input
     .normalize("NFKD")
     .toLowerCase()
-    // Replace whitespace and any non-[a-z0-9_] characters with underscores.
-    // (Treat '-' as '_' too for maximum provider compatibility.)
     .replace(/[^a-z0-9_]+/g, "_")
-    // Collapse consecutive underscores.
     .replace(/_+/g, "_")
-    // Trim leading/trailing underscores.
     .replace(/^_+|_+$/g, "");
 
   return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
 }
 
-/** Normalized command key before collision/truncation suffixing. */
 export function buildMcpPromptBaseKey(serverName: string, promptName: string): string {
   return `mcp__${normalizeMcpToolNamePart(serverName)}__${normalizeMcpToolNamePart(promptName)}`;
 }

--- a/src/common/utils/tools/mcpPromptCommandKey.ts
+++ b/src/common/utils/tools/mcpPromptCommandKey.ts
@@ -1,5 +1,29 @@
-// Crypto-free on purpose: browser bundles (e.g. the VS Code webview) import this
-// matcher, while mcpToolName.ts pulls node:crypto for collision hashing.
+// Crypto-free on purpose: browser bundles (e.g. the VS Code webview) import
+// these helpers, while mcpToolName.ts pulls node:crypto for collision hashing.
+
+const DEFAULT_MCP_TOOL_NAME_PART = "unknown";
+
 export function isMcpPromptCommandKey(value: string): boolean {
   return /^mcp__[a-z0-9_]+$/.test(value);
+}
+
+/** Normalize a component for generated MCP tool names and prompt command keys. */
+export function normalizeMcpToolNamePart(input: string): string {
+  const normalized = input
+    .normalize("NFKD")
+    .toLowerCase()
+    // Replace whitespace and any non-[a-z0-9_] characters with underscores.
+    // (Treat '-' as '_' too for maximum provider compatibility.)
+    .replace(/[^a-z0-9_]+/g, "_")
+    // Collapse consecutive underscores.
+    .replace(/_+/g, "_")
+    // Trim leading/trailing underscores.
+    .replace(/^_+|_+$/g, "");
+
+  return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
+}
+
+/** Normalized command key before collision/truncation suffixing. */
+export function buildMcpPromptBaseKey(serverName: string, promptName: string): string {
+  return `mcp__${normalizeMcpToolNamePart(serverName)}__${normalizeMcpToolNamePart(promptName)}`;
 }

--- a/src/common/utils/tools/mcpPromptCommandKey.ts
+++ b/src/common/utils/tools/mcpPromptCommandKey.ts
@@ -1,0 +1,5 @@
+// Crypto-free on purpose: browser bundles (e.g. the VS Code webview) import this
+// matcher, while mcpToolName.ts pulls node:crypto for collision hashing.
+export function isMcpPromptCommandKey(value: string): boolean {
+  return /^mcp__[a-z0-9_]+$/.test(value);
+}

--- a/src/common/utils/tools/mcpToolName.test.ts
+++ b/src/common/utils/tools/mcpToolName.test.ts
@@ -5,6 +5,7 @@ import { uniqueSuffix } from "@/common/utils/hasher";
 import {
   buildMcpPromptCommandKey,
   buildMcpToolName,
+  isMcpPromptCommandKey,
   normalizeMcpToolNamePart,
 } from "./mcpToolName";
 
@@ -72,6 +73,12 @@ describe("mcpToolName", () => {
       expect(result!.toolName).toMatch(/^[a-z0-9_]+$/);
     });
   });
+  test("recognizes generated MCP prompt command keys", () => {
+    expect(isMcpPromptCommandKey("mcp__coder__review")).toBe(true);
+    expect(isMcpPromptCommandKey("coder_review")).toBe(false);
+    expect(isMcpPromptCommandKey("mcp__Coder__review")).toBe(false);
+  });
+
   test("builds namespaced prompt command keys and hashes normalized collisions", () => {
     const usedNames = new Set<string>();
     expect(

--- a/src/common/utils/tools/mcpToolName.test.ts
+++ b/src/common/utils/tools/mcpToolName.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { uniqueSuffix } from "@/common/utils/hasher";
 
+import { isMcpPromptCommandKey } from "./mcpPromptCommandKey";
 import {
   buildMcpPromptCommandKey,
   buildMcpToolName,
-  isMcpPromptCommandKey,
   normalizeMcpToolNamePart,
 } from "./mcpToolName";
 

--- a/src/common/utils/tools/mcpToolName.test.ts
+++ b/src/common/utils/tools/mcpToolName.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import { uniqueSuffix } from "@/common/utils/hasher";
 
-import { buildMcpToolName, normalizeMcpToolNamePart } from "./mcpToolName";
+import {
+  buildMcpPromptCommandKey,
+  buildMcpToolName,
+  normalizeMcpToolNamePart,
+} from "./mcpToolName";
 
 describe("mcpToolName", () => {
   describe("normalizeMcpToolNamePart", () => {
@@ -67,5 +71,23 @@ describe("mcpToolName", () => {
       expect(result!.toolName.endsWith(`_${expectedSuffix}`)).toBe(true);
       expect(result!.toolName).toMatch(/^[a-z0-9_]+$/);
     });
+  });
+  test("builds namespaced prompt command keys and hashes normalized collisions", () => {
+    const usedNames = new Set<string>();
+    expect(
+      buildMcpPromptCommandKey({
+        serverName: "Coder Server",
+        promptName: "Code Review",
+        usedNames,
+      })?.toolName
+    ).toBe("mcp__coder_server__code_review");
+
+    const collision = buildMcpPromptCommandKey({
+      serverName: "coder_server",
+      promptName: "code_review",
+      usedNames,
+    });
+    expect(collision?.wasSuffixed).toBe(true);
+    expect(collision?.toolName).toStartWith("mcp__coder_server__code_review_");
   });
 });

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -12,12 +12,7 @@ export interface BuildMcpPromptCommandKeyOptions {
   serverName: string;
   promptName: string;
   usedNames: Set<string>;
-  /**
-   * Force the identity hash suffix. Callers set this for every member of a
-   * normalized collision group so key assignment does not depend on catalog
-   * order: each member gets base + hash(own identity) regardless of which
-   * colliding sibling is listed first.
-   */
+  /** Forces identity suffixing so normalized collision groups stay independent of catalog order. */
   forceSuffix?: boolean;
 }
 
@@ -105,12 +100,7 @@ export function buildMcpToolName(options: BuildMcpToolNameOptions): BuildMcpTool
   });
 }
 
-/**
- * Identity-derived alias for a prompt: always hash-suffixed, so it never
- * changes with catalog membership. Composer matching falls back to it, which
- * keeps previously inserted collision-suffixed keys resolving after the
- * colliding sibling disappears and its survivor's commandKey loses the suffix.
- */
+/** Stable identity alias used to resolve suffixed keys after catalog membership changes. */
 export function buildMcpPromptStableKey(serverName: string, promptName: string): string | null {
   const result = buildMcpName({
     baseName: buildMcpPromptBaseKey(serverName, promptName),

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -1,27 +1,12 @@
 import { uniqueSuffix } from "@/common/utils/hasher";
+import { buildMcpPromptBaseKey, normalizeMcpToolNamePart } from "./mcpPromptCommandKey";
 
-const DEFAULT_MCP_TOOL_NAME_PART = "unknown";
+export { buildMcpPromptBaseKey, normalizeMcpToolNamePart };
 
 // Be conservative: some providers have strict tool-name validation and limits.
 export const MAX_MCP_TOOL_NAME_CHARS = 64;
 
 const MCP_TOOL_NAME_PATTERN = /^[a-z0-9_]+$/;
-
-/** Normalize a component for generated MCP tool names and prompt command keys. */
-export function normalizeMcpToolNamePart(input: string): string {
-  const normalized = input
-    .normalize("NFKD")
-    .toLowerCase()
-    // Replace whitespace and any non-[a-z0-9_] characters with underscores.
-    // (Treat '-' as '_' too for maximum provider compatibility.)
-    .replace(/[^a-z0-9_]+/g, "_")
-    // Collapse consecutive underscores.
-    .replace(/_+/g, "_")
-    // Trim leading/trailing underscores.
-    .replace(/^_+|_+$/g, "");
-
-  return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
-}
 
 export interface BuildMcpPromptCommandKeyOptions {
   serverName: string;
@@ -34,11 +19,6 @@ export interface BuildMcpPromptCommandKeyOptions {
    * colliding sibling is listed first.
    */
   forceSuffix?: boolean;
-}
-
-/** Normalized command key before collision/truncation suffixing. */
-export function buildMcpPromptBaseKey(serverName: string, promptName: string): string {
-  return `mcp__${normalizeMcpToolNamePart(serverName)}__${normalizeMcpToolNamePart(promptName)}`;
 }
 
 export interface BuildMcpToolNameOptions {

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -27,6 +27,12 @@ export function normalizeMcpToolNamePart(input: string): string {
   return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
 }
 
+export interface BuildMcpPromptCommandKeyOptions {
+  serverName: string;
+  promptName: string;
+  usedNames: Set<string>;
+}
+
 export interface BuildMcpToolNameOptions {
   serverName: string;
   toolName: string;
@@ -58,6 +64,34 @@ function buildMcpToolNameWithSuffix(baseName: string, suffix: string): string {
   return `${trimmedBase}${suffixWithSeparator}`;
 }
 
+function buildMcpName(options: {
+  baseName: string;
+  identityParts: string[];
+  usedNames: Set<string>;
+}): BuildMcpToolNameResult | null {
+  if (!MCP_TOOL_NAME_PATTERN.test(options.baseName)) return null;
+
+  let toolName = options.baseName;
+  let wasSuffixed = false;
+  if (toolName.length > MAX_MCP_TOOL_NAME_CHARS || options.usedNames.has(toolName)) {
+    wasSuffixed = true;
+    toolName = buildMcpToolNameWithSuffix(options.baseName, uniqueSuffix(options.identityParts));
+    if (options.usedNames.has(toolName)) {
+      toolName = buildMcpToolNameWithSuffix(
+        options.baseName,
+        uniqueSuffix([...options.identityParts, "2"])
+      );
+      if (options.usedNames.has(toolName)) return null;
+    }
+  }
+
+  if (!MCP_TOOL_NAME_PATTERN.test(toolName) || toolName.length > MAX_MCP_TOOL_NAME_CHARS) {
+    return null;
+  }
+  options.usedNames.add(toolName);
+  return { toolName, baseName: options.baseName, wasSuffixed };
+}
+
 /**
  * Build a provider-safe, collision-resistant MCP tool name.
  *
@@ -71,42 +105,19 @@ function buildMcpToolNameWithSuffix(baseName: string, suffix: string): string {
  * a stable hash suffix is appended.
  */
 export function buildMcpToolName(options: BuildMcpToolNameOptions): BuildMcpToolNameResult | null {
-  const serverPart = normalizeMcpToolNamePart(options.serverName);
-  const toolPart = normalizeMcpToolNamePart(options.toolName);
-  const baseName = `${serverPart}_${toolPart}`;
+  return buildMcpName({
+    baseName: `${normalizeMcpToolNamePart(options.serverName)}_${normalizeMcpToolNamePart(options.toolName)}`,
+    identityParts: [options.serverName, options.toolName],
+    usedNames: options.usedNames,
+  });
+}
 
-  if (!MCP_TOOL_NAME_PATTERN.test(baseName)) {
-    return null;
-  }
-
-  let finalName = baseName;
-  let wasSuffixed = false;
-
-  if (finalName.length > MAX_MCP_TOOL_NAME_CHARS || options.usedNames.has(finalName)) {
-    wasSuffixed = true;
-
-    // Use a stable suffix derived from the *original* server/tool names so that renaming
-    // only happens when necessary (collisions/length), and remains deterministic.
-    const suffix = uniqueSuffix([options.serverName, options.toolName]);
-    finalName = buildMcpToolNameWithSuffix(baseName, suffix);
-
-    // Extremely defensive: in the astronomically unlikely case of a hash collision,
-    // attempt a second derivation before giving up.
-    if (options.usedNames.has(finalName)) {
-      const suffix2 = uniqueSuffix([options.serverName, options.toolName, "2"]);
-      finalName = buildMcpToolNameWithSuffix(baseName, suffix2);
-
-      if (options.usedNames.has(finalName)) {
-        return null;
-      }
-    }
-  }
-
-  if (!MCP_TOOL_NAME_PATTERN.test(finalName) || finalName.length > MAX_MCP_TOOL_NAME_CHARS) {
-    return null;
-  }
-
-  options.usedNames.add(finalName);
-
-  return { toolName: finalName, baseName, wasSuffixed };
+export function buildMcpPromptCommandKey(
+  options: BuildMcpPromptCommandKeyOptions
+): BuildMcpToolNameResult | null {
+  return buildMcpName({
+    baseName: `mcp__${normalizeMcpToolNamePart(options.serverName)}__${normalizeMcpToolNamePart(options.promptName)}`,
+    identityParts: [options.serverName, options.promptName],
+    usedNames: options.usedNames,
+  });
 }

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -27,6 +27,18 @@ export interface BuildMcpPromptCommandKeyOptions {
   serverName: string;
   promptName: string;
   usedNames: Set<string>;
+  /**
+   * Force the identity hash suffix. Callers set this for every member of a
+   * normalized collision group so key assignment does not depend on catalog
+   * order: each member gets base + hash(own identity) regardless of which
+   * colliding sibling is listed first.
+   */
+  forceSuffix?: boolean;
+}
+
+/** Normalized command key before collision/truncation suffixing. */
+export function buildMcpPromptBaseKey(serverName: string, promptName: string): string {
+  return `mcp__${normalizeMcpToolNamePart(serverName)}__${normalizeMcpToolNamePart(promptName)}`;
 }
 
 export interface BuildMcpToolNameOptions {
@@ -64,12 +76,17 @@ function buildMcpName(options: {
   baseName: string;
   identityParts: string[];
   usedNames: Set<string>;
+  forceSuffix?: boolean;
 }): BuildMcpToolNameResult | null {
   if (!MCP_TOOL_NAME_PATTERN.test(options.baseName)) return null;
 
   let toolName = options.baseName;
   let wasSuffixed = false;
-  if (toolName.length > MAX_MCP_TOOL_NAME_CHARS || options.usedNames.has(toolName)) {
+  if (
+    options.forceSuffix === true ||
+    toolName.length > MAX_MCP_TOOL_NAME_CHARS ||
+    options.usedNames.has(toolName)
+  ) {
     wasSuffixed = true;
     toolName = buildMcpToolNameWithSuffix(options.baseName, uniqueSuffix(options.identityParts));
     if (options.usedNames.has(toolName)) {
@@ -112,8 +129,9 @@ export function buildMcpPromptCommandKey(
   options: BuildMcpPromptCommandKeyOptions
 ): BuildMcpToolNameResult | null {
   return buildMcpName({
-    baseName: `mcp__${normalizeMcpToolNamePart(options.serverName)}__${normalizeMcpToolNamePart(options.promptName)}`,
+    baseName: buildMcpPromptBaseKey(options.serverName, options.promptName),
     identityParts: [options.serverName, options.promptName],
     usedNames: options.usedNames,
+    ...(options.forceSuffix !== undefined ? { forceSuffix: options.forceSuffix } : {}),
   });
 }

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -125,6 +125,22 @@ export function buildMcpToolName(options: BuildMcpToolNameOptions): BuildMcpTool
   });
 }
 
+/**
+ * Identity-derived alias for a prompt: always hash-suffixed, so it never
+ * changes with catalog membership. Composer matching falls back to it, which
+ * keeps previously inserted collision-suffixed keys resolving after the
+ * colliding sibling disappears and its survivor's commandKey loses the suffix.
+ */
+export function buildMcpPromptStableKey(serverName: string, promptName: string): string | null {
+  const result = buildMcpName({
+    baseName: buildMcpPromptBaseKey(serverName, promptName),
+    identityParts: [serverName, promptName],
+    usedNames: new Set(),
+    forceSuffix: true,
+  });
+  return result?.toolName ?? null;
+}
+
 export function buildMcpPromptCommandKey(
   options: BuildMcpPromptCommandKeyOptions
 ): BuildMcpToolNameResult | null {

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -23,10 +23,6 @@ export function normalizeMcpToolNamePart(input: string): string {
   return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
 }
 
-export function isMcpPromptCommandKey(value: string): boolean {
-  return /^mcp__[a-z0-9_]+$/.test(value);
-}
-
 export interface BuildMcpPromptCommandKeyOptions {
   serverName: string;
   promptName: string;

--- a/src/common/utils/tools/mcpToolName.ts
+++ b/src/common/utils/tools/mcpToolName.ts
@@ -7,11 +7,7 @@ export const MAX_MCP_TOOL_NAME_CHARS = 64;
 
 const MCP_TOOL_NAME_PATTERN = /^[a-z0-9_]+$/;
 
-/**
- * Normalize a single component used to build an MCP tool name.
- *
- * Note: This is NOT user-facing. It's purely to ensure provider-safe tool keys.
- */
+/** Normalize a component for generated MCP tool names and prompt command keys. */
 export function normalizeMcpToolNamePart(input: string): string {
   const normalized = input
     .normalize("NFKD")
@@ -25,6 +21,10 @@ export function normalizeMcpToolNamePart(input: string): string {
     .replace(/^_+|_+$/g, "");
 
   return normalized.length > 0 ? normalized : DEFAULT_MCP_TOOL_NAME_PART;
+}
+
+export function isMcpPromptCommandKey(value: string): boolean {
+  return /^mcp__[a-z0-9_]+$/.test(value);
 }
 
 export interface BuildMcpPromptCommandKeyOptions {
@@ -42,7 +42,7 @@ export interface BuildMcpToolNameOptions {
 export interface BuildMcpToolNameResult {
   toolName: string;
   /**
-   * The normalized tool name without any collision/truncation suffix.
+   * The normalized identifier without any collision or truncation suffix.
    * Useful for debugging/logging.
    */
   baseName: string;

--- a/src/node/acp/streamTranslator.test.ts
+++ b/src/node/acp/streamTranslator.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentSideConnection } from "@agentclientprotocol/sdk";
+import { StreamTranslator } from "@/node/acp/streamTranslator";
+import { createMuxMessage } from "@/common/types/message";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
+
+async function replayThrough(events: WorkspaceChatMessage[]): Promise<unknown[]> {
+  const sessionUpdate = mock(() => Promise.resolve(undefined));
+  const translator = new StreamTranslator({ sessionUpdate } as unknown as AgentSideConnection);
+  async function* stream(): AsyncIterable<WorkspaceChatMessage> {
+    for (const event of events) yield await Promise.resolve(event);
+  }
+  await translator.consumeAndForward("session", stream());
+  return sessionUpdate.mock.calls.map((call) => (call as unknown[])[0]);
+}
+
+describe("StreamTranslator MCP prompt replay", () => {
+  test("replays the authored slash command instead of the transformed prompt text", async () => {
+    const userMessage = createMuxMessage("user-1", "user", "Using MCP prompt coder/review: src", {
+      muxMetadata: {
+        type: "normal",
+        rawCommand: "/mcp__coder__review src",
+        commandPrefix: "/mcp__coder__review",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+            arguments: { path: "src" },
+          },
+        ],
+      },
+    });
+
+    const updates = await replayThrough([{ ...userMessage, type: "message" }]);
+
+    expect(updates).toEqual([
+      {
+        sessionId: "session",
+        update: {
+          sessionUpdate: "user_message_chunk",
+          content: { type: "text", text: "/mcp__coder__review src" },
+        },
+      },
+    ]);
+  });
+
+  test("suppresses synthetic MCP prompt snapshot rows", async () => {
+    const snapshotMessage = createMuxMessage("mcp-prompt-snapshot-1", "user", "Expanded prompt", {
+      synthetic: true,
+      mcpPromptSnapshot: {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+      },
+    });
+
+    const updates = await replayThrough([{ ...snapshotMessage, type: "message" }]);
+
+    expect(updates).toEqual([]);
+  });
+});

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -344,9 +344,9 @@ export class StreamTranslator {
     event: Extract<WorkspaceChatMessage, { type: "message" }>,
     isReplayPhase: boolean
   ): UserMessageForwarding {
-    // Agent skill snapshots are synthetic context injections (<agent-skill ...>)
+    // Agent skill and MCP prompt snapshots are synthetic context injections
     // and should never be surfaced to ACP clients as user-visible text.
-    if (event.metadata?.agentSkillSnapshot != null) {
+    if (event.metadata?.agentSkillSnapshot != null || event.metadata?.mcpPromptSnapshot != null) {
       return { kind: "suppress" };
     }
 

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -696,9 +696,8 @@ function extractRawCommandFromFrontendMetadata(frontendMetadata: unknown): strin
     return null;
   }
 
-  // "normal" carries rawCommand for MCP prompt invocations and one-shot
-  // overrides; both persist transformed text, so replay the authored command
-  // like the desktop transcript's getRawCommand does.
+  // "normal" can carry rawCommand for transformed MCP prompts and one-shot
+  // overrides, so replay the authored command as the desktop transcript does.
   if (frontendMetadata.type !== "agent-skill" && frontendMetadata.type !== "normal") {
     return null;
   }

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -357,8 +357,8 @@ export class StreamTranslator {
       return { kind: "suppress" };
     }
 
-    const agentSkillCommand = extractAgentSkillRawCommand(event.metadata);
-    if (agentSkillCommand == null) {
+    const rawCommand = extractRawCommand(event.metadata);
+    if (rawCommand == null) {
       return { kind: "parts" };
     }
 
@@ -366,7 +366,7 @@ export class StreamTranslator {
     // transformed backend prompt so resumed transcripts remain user-readable.
     return {
       kind: "raw-command",
-      rawCommand: agentSkillCommand,
+      rawCommand,
     };
   }
 
@@ -678,9 +678,7 @@ export class StreamTranslator {
   }
 }
 
-function extractAgentSkillRawCommand(
-  metadata: MessageMetadataWithFrontendFields | undefined
-): string | null {
+function extractRawCommand(metadata: MessageMetadataWithFrontendFields | undefined): string | null {
   if (metadata == null) {
     return null;
   }
@@ -698,7 +696,10 @@ function extractRawCommandFromFrontendMetadata(frontendMetadata: unknown): strin
     return null;
   }
 
-  if (frontendMetadata.type !== "agent-skill") {
+  // "normal" carries rawCommand for MCP prompt invocations and one-shot
+  // overrides; both persist transformed text, so replay the authored command
+  // like the desktop transcript's getRawCommand does.
+  if (frontendMetadata.type !== "agent-skill" && frontendMetadata.type !== "normal") {
     return null;
   }
 

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5595,7 +5595,7 @@ export const router = (authToken?: string) => {
               if (!runtimeContextResult.success) {
                 throw new Error(formatSendMessageError(runtimeContextResult.error).message);
               }
-              const { runtime, workspacePath } = runtimeContextResult.data;
+              const { runtime, workspacePath, hostCheckoutRoot } = runtimeContextResult.data;
               // Fresh non-local runtimes (devcontainer, docker) reject exec until
               // per-instance readiness completes, and cold prompt discovery starts
               // stdio servers through runtime.exec (mirrors streamMessage).
@@ -5613,7 +5613,11 @@ export const router = (authToken?: string) => {
                   ? mergeMultiProjectSecrets(metadata, context.config)
                   : context.config.getEffectiveSecrets(metadata.projectPath)
               );
-              const agentPlugins = resolveAgentPluginsMcpContext(metadata, workspacePath);
+              // Plugin containers anchor at the checkout root, not the subProjectPath
+              // execution directory (same gating as streamMessage).
+              const agentPlugins = hostCheckoutRoot
+                ? resolveAgentPluginsMcpContext(metadata, hostCheckoutRoot)
+                : null;
               return context.mcpServerManager.getPromptsForWorkspace({
                 workspaceId: input.workspaceId,
                 projectPath: metadata.projectPath,

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5579,7 +5579,10 @@ export const router = (authToken?: string) => {
             .input(schemas.workspace.mcp.prompts.list.input)
             .output(schemas.workspace.mcp.prompts.list.output)
             .handler(async ({ context, input, signal }) => {
-              await context.aiService.waitForInit(input.workspaceId);
+              // Preflight waits (init, Coder/SSH/devcontainer startup) can take
+              // minutes; forward the handler signal so navigating away cancels
+              // the whole request, not just the MCP manager phase.
+              await context.aiService.waitForInit(input.workspaceId, signal);
               const metadataResult = await context.aiService.getWorkspaceMetadata(
                 input.workspaceId
               );
@@ -5598,7 +5601,9 @@ export const router = (authToken?: string) => {
               const { runtime, workspacePath, hostCheckoutRoot } = runtimeContextResult.data;
               // Cold prompt discovery can start stdio servers through runtime.exec,
               // so wait until the runtime is ready.
-              const readyResult = await runtime.ensureReady();
+              const readyResult = await runtime.ensureReady(
+                signal !== undefined ? { signal } : undefined
+              );
               if (!readyResult.ready) {
                 throw new Error(readyResult.error);
               }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3379,10 +3379,13 @@ export const router = (authToken?: string) => {
             input.projectPath,
             input.force ?? false
           );
-          if (result.success) {
-            context.mcpServerManager.forgetProjectTrust(input.projectPath);
+          if (!result.success) return result;
+          // Removal cascades to child projects, whose retained trust must also
+          // be forgotten or a re-registered path would inherit the old grant.
+          for (const removedPath of result.data.removedProjectPaths) {
+            context.mcpServerManager.forgetProjectTrust(removedPath);
           }
-          return result;
+          return Ok(undefined);
         }),
       secrets: {
         get: t

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3310,8 +3310,8 @@ export const router = (authToken?: string) => {
         .input(schemas.projects.setTrust.input)
         .output(schemas.projects.setTrust.output)
         .handler(async ({ context, input }) => {
+          const normalizedPath = stripTrailingSlashes(input.projectPath);
           await context.config.editConfig((config) => {
-            const normalizedPath = stripTrailingSlashes(input.projectPath);
             let project = config.projects.get(normalizedPath);
             if (!project) {
               // Create a minimal project entry so trust can be set before
@@ -3322,6 +3322,18 @@ export const router = (authToken?: string) => {
             project.trusted = input.trusted;
             return config;
           });
+          // Prompt invocation revives servers from recorded request options, so
+          // sync the trust change (owner plus inheriting children) immediately.
+          const affectedPaths = [normalizedPath];
+          for (const [projectPath, project] of context.config.loadConfigOrDefault().projects) {
+            if (
+              project.parentProjectPath !== undefined &&
+              stripTrailingSlashes(project.parentProjectPath) === normalizedPath
+            ) {
+              affectedPaths.push(projectPath);
+            }
+          }
+          context.mcpServerManager.applyProjectTrust(affectedPaths, input.trusted);
         }),
       setDisplayName: t
         .input(schemas.projects.setDisplayName.input)

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5596,9 +5596,8 @@ export const router = (authToken?: string) => {
                 throw new Error(formatSendMessageError(runtimeContextResult.error).message);
               }
               const { runtime, workspacePath, hostCheckoutRoot } = runtimeContextResult.data;
-              // Fresh non-local runtimes (devcontainer, docker) reject exec until
-              // per-instance readiness completes, and cold prompt discovery starts
-              // stdio servers through runtime.exec (mirrors streamMessage).
+              // Cold prompt discovery can start stdio servers through runtime.exec,
+              // so wait until the runtime is ready.
               const readyResult = await runtime.ensureReady();
               if (!readyResult.ready) {
                 throw new Error(readyResult.error);
@@ -5613,8 +5612,7 @@ export const router = (authToken?: string) => {
                   ? mergeMultiProjectSecrets(metadata, context.config)
                   : context.config.getEffectiveSecrets(metadata.projectPath)
               );
-              // Plugin containers anchor at the checkout root, not the subProjectPath
-              // execution directory (same gating as streamMessage).
+              // Agent Plugin containers anchor at the checkout root, not a subproject directory.
               const agentPlugins = hostCheckoutRoot
                 ? resolveAgentPluginsMcpContext(metadata, hostCheckoutRoot)
                 : null;

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5578,7 +5578,7 @@ export const router = (authToken?: string) => {
           list: t
             .input(schemas.workspace.mcp.prompts.list.input)
             .output(schemas.workspace.mcp.prompts.list.output)
-            .handler(async ({ context, input }) => {
+            .handler(async ({ context, input, signal }) => {
               await context.aiService.waitForInit(input.workspaceId);
               const metadataResult = await context.aiService.getWorkspaceMetadata(
                 input.workspaceId
@@ -5616,16 +5616,19 @@ export const router = (authToken?: string) => {
               const agentPlugins = hostCheckoutRoot
                 ? resolveAgentPluginsMcpContext(metadata, hostCheckoutRoot)
                 : null;
-              return context.mcpServerManager.getPromptsForWorkspace({
-                workspaceId: input.workspaceId,
-                projectPath: metadata.projectPath,
-                runtime,
-                workspacePath,
-                trusted: isWorkspaceProjectTrusted(context.config, metadata),
-                overrides,
-                projectSecrets,
-                agentPlugins,
-              });
+              return context.mcpServerManager.getPromptsForWorkspace(
+                {
+                  workspaceId: input.workspaceId,
+                  projectPath: metadata.projectPath,
+                  runtime,
+                  workspacePath,
+                  trusted: isWorkspaceProjectTrusted(context.config, metadata),
+                  overrides,
+                  projectSecrets,
+                  agentPlugins,
+                },
+                signal !== undefined ? { signal } : undefined
+              );
             }),
         },
         set: t

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3375,7 +3375,14 @@ export const router = (authToken?: string) => {
         .input(schemas.projects.remove.input)
         .output(schemas.projects.remove.output)
         .handler(async ({ context, input }) => {
-          return context.projectService.remove(input.projectPath, input.force ?? false);
+          const result = await context.projectService.remove(
+            input.projectPath,
+            input.force ?? false
+          );
+          if (result.success) {
+            context.mcpServerManager.forgetProjectTrust(input.projectPath);
+          }
+          return result;
         }),
       secrets: {
         get: t

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5586,6 +5586,13 @@ export const router = (authToken?: string) => {
               if (!metadataResult.success) throw new Error(metadataResult.error);
               const metadata = metadataResult.data;
               const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
+              // Fresh non-local runtimes (devcontainer, docker) reject exec until
+              // per-instance readiness completes, and cold prompt discovery starts
+              // stdio servers through runtime.exec (mirrors streamMessage).
+              const readyResult = await runtime.ensureReady();
+              if (!readyResult.ready) {
+                throw new Error(readyResult.error);
+              }
               const overrides = await context.workspaceMcpOverridesService.getOverridesForWorkspace(
                 input.workspaceId
               );

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5566,14 +5566,11 @@ export const router = (authToken?: string) => {
               if (!metadataResult.success) throw new Error(metadataResult.error);
               const metadata = metadataResult.data;
               const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
-              const overrides = await context.workspaceMcpOverridesService.getOverridesForWorkspace(
-                input.workspaceId
-              );
-              const agentPlugins = await resolveWorkspaceAgentPluginsMcpContext(
-                context,
-                input.workspaceId,
-                metadata.projectPath
-              );
+              const [overrides, projectSecrets] = await Promise.all([
+                context.workspaceMcpOverridesService.getOverridesForWorkspace(input.workspaceId),
+                secretsToRecord(context.config.getEffectiveSecrets(metadata.projectPath)),
+              ]);
+              const agentPlugins = resolveAgentPluginsMcpContext(metadata, workspacePath);
               return context.mcpServerManager.getPromptsForWorkspace({
                 workspaceId: input.workspaceId,
                 projectPath: metadata.projectPath,
@@ -5581,9 +5578,7 @@ export const router = (authToken?: string) => {
                 workspacePath,
                 trusted: isWorkspaceProjectTrusted(context.config, metadata),
                 overrides,
-                projectSecrets: await secretsToRecord(
-                  context.config.getEffectiveSecrets(metadata.projectPath)
-                ),
+                projectSecrets,
                 agentPlugins,
               });
             }),

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -44,7 +44,6 @@ import { createReplayBufferedStreamMessageRelay } from "./replayBufferedStreamMe
 import { createRuntime, checkRuntimeAvailability } from "@/node/runtime/runtimeFactory";
 import {
   appendSubProjectRelativePath,
-  createRuntimeContextForWorkspace,
   createRuntimeForWorkspace,
   resolveWorkspaceRootPath,
 } from "@/node/runtime/runtimeHelpers";
@@ -122,6 +121,7 @@ import {
   type SubagentTranscriptArtifactIndexEntry,
 } from "@/node/services/subagentTranscriptArtifacts";
 import { getErrorMessage } from "@/common/utils/errors";
+import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
 import { CHAT_FILE_NAME, CHAT_ARCHIVE_FILE_NAME } from "@/common/constants/paths";
 import { WorkflowRunStore } from "@/node/services/workflows/WorkflowRunStore";
 import { workflowRunStreamHub } from "@/node/services/workflows/workflowRunStreamHub";
@@ -5585,7 +5585,17 @@ export const router = (authToken?: string) => {
               );
               if (!metadataResult.success) throw new Error(metadataResult.error);
               const metadata = metadataResult.data;
-              const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
+              // Build the exact runtime context stream startup uses (including the
+              // multi-project shared root) so servers started here match the start
+              // signature streams later reuse.
+              const runtimeContextResult = context.aiService.createWorkspaceRuntimeContext(
+                input.workspaceId,
+                metadata
+              );
+              if (!runtimeContextResult.success) {
+                throw new Error(formatSendMessageError(runtimeContextResult.error).message);
+              }
+              const { runtime, workspacePath } = runtimeContextResult.data;
               // Fresh non-local runtimes (devcontainer, docker) reject exec until
               // per-instance readiness completes, and cold prompt discovery starts
               // stdio servers through runtime.exec (mirrors streamMessage).

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -44,6 +44,7 @@ import { createReplayBufferedStreamMessageRelay } from "./replayBufferedStreamMe
 import { createRuntime, checkRuntimeAvailability } from "@/node/runtime/runtimeFactory";
 import {
   appendSubProjectRelativePath,
+  createRuntimeContextForWorkspace,
   createRuntimeForWorkspace,
   resolveWorkspaceRootPath,
 } from "@/node/runtime/runtimeHelpers";
@@ -5553,6 +5554,40 @@ export const router = (authToken?: string) => {
               return {};
             }
           }),
+        prompts: {
+          list: t
+            .input(schemas.workspace.mcp.prompts.list.input)
+            .output(schemas.workspace.mcp.prompts.list.output)
+            .handler(async ({ context, input }) => {
+              await context.aiService.waitForInit(input.workspaceId);
+              const metadataResult = await context.aiService.getWorkspaceMetadata(
+                input.workspaceId
+              );
+              if (!metadataResult.success) throw new Error(metadataResult.error);
+              const metadata = metadataResult.data;
+              const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
+              const overrides = await context.workspaceMcpOverridesService.getOverridesForWorkspace(
+                input.workspaceId
+              );
+              const agentPlugins = await resolveWorkspaceAgentPluginsMcpContext(
+                context,
+                input.workspaceId,
+                metadata.projectPath
+              );
+              return context.mcpServerManager.getPromptsForWorkspace({
+                workspaceId: input.workspaceId,
+                projectPath: metadata.projectPath,
+                runtime,
+                workspacePath,
+                trusted: isWorkspaceProjectTrusted(context.config, metadata),
+                overrides,
+                projectSecrets: await secretsToRecord(
+                  context.config.getEffectiveSecrets(metadata.projectPath)
+                ),
+                agentPlugins,
+              });
+            }),
+        },
         set: t
           .input(schemas.workspace.mcp.set.input)
           .output(schemas.workspace.mcp.set.output)

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3324,8 +3324,7 @@ export const router = (authToken?: string) => {
           });
           // Prompt invocation revives servers from recorded request options, so
           // sync the trust change (owner plus inheriting children) immediately.
-          // Each path gets its post-edit EFFECTIVE trust: a child's own flag is
-          // ignored by isProjectTrusted when a parentProjectPath owns its trust.
+          // Child trust is inherited from parentProjectPath, not the child's stored flag.
           const affectedPaths = [normalizedPath];
           for (const [projectPath, project] of context.config.loadConfigOrDefault().projects) {
             if (

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3324,6 +3324,8 @@ export const router = (authToken?: string) => {
           });
           // Prompt invocation revives servers from recorded request options, so
           // sync the trust change (owner plus inheriting children) immediately.
+          // Each path gets its post-edit EFFECTIVE trust: a child's own flag is
+          // ignored by isProjectTrusted when a parentProjectPath owns its trust.
           const affectedPaths = [normalizedPath];
           for (const [projectPath, project] of context.config.loadConfigOrDefault().projects) {
             if (
@@ -3333,7 +3335,12 @@ export const router = (authToken?: string) => {
               affectedPaths.push(projectPath);
             }
           }
-          context.mcpServerManager.applyProjectTrust(affectedPaths, input.trusted);
+          context.mcpServerManager.applyProjectTrust(
+            affectedPaths.map((projectPath) => ({
+              projectPath,
+              trusted: isProjectTrusted(context.config, projectPath),
+            }))
+          );
         }),
       setDisplayName: t
         .input(schemas.projects.setDisplayName.input)

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5592,6 +5592,12 @@ export const router = (authToken?: string) => {
                 input.workspaceId,
                 input.overrides
               );
+              // Prompt invocation can hit cached servers before the next stream
+              // recomputes enablement, so sync the manager's view immediately.
+              await context.mcpServerManager.applyWorkspaceOverrides(
+                input.workspaceId,
+                input.overrides
+              );
               return { success: true, data: undefined };
             } catch (error) {
               const message = getErrorMessage(error);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -65,6 +65,8 @@ import type {
 } from "@/common/orpc/schemas/memory";
 import { memoryLogicalKey } from "@/node/services/memoryMeta";
 import { secretsToRecord } from "@/common/types/secrets";
+import { isMultiProject } from "@/common/utils/multiProject";
+import { mergeMultiProjectSecrets } from "@/node/services/utils/multiProjectSecrets";
 import { roundToBase2 } from "@/common/telemetry/utils";
 import { createAsyncEventQueue } from "@/common/utils/asyncEventIterator";
 import { withQueueHeartbeat } from "@/common/utils/withQueueHeartbeat";
@@ -5584,10 +5586,16 @@ export const router = (authToken?: string) => {
               if (!metadataResult.success) throw new Error(metadataResult.error);
               const metadata = metadataResult.data;
               const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
-              const [overrides, projectSecrets] = await Promise.all([
-                context.workspaceMcpOverridesService.getOverridesForWorkspace(input.workspaceId),
-                secretsToRecord(context.config.getEffectiveSecrets(metadata.projectPath)),
-              ]);
+              const overrides = await context.workspaceMcpOverridesService.getOverridesForWorkspace(
+                input.workspaceId
+              );
+              // Match streamMessage and the prompt-invocation resolver: multi-project
+              // workspaces need every project's secrets, not just the primary's.
+              const projectSecrets = await secretsToRecord(
+                isMultiProject(metadata)
+                  ? mergeMultiProjectSecrets(metadata, context.config)
+                  : context.config.getEffectiveSecrets(metadata.projectPath)
+              );
               const agentPlugins = resolveAgentPluginsMcpContext(metadata, workspacePath);
               return context.mcpServerManager.getPromptsForWorkspace({
                 workspaceId: input.workspaceId,

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -48,6 +48,7 @@ describe("AgentSession MCP prompt snapshots", () => {
         serverName: "coder",
         promptName: "review",
         commandKey: "mcp__coder__review",
+        invokingMessageId: history.data[1]?.id ?? "",
         description: "Review code",
       });
       expect(history.data[0]?.parts.find((part) => part.type === "text")?.text).toBe(

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -51,7 +51,13 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(history.data[0]?.parts.find((part) => part.type === "text")?.text).toBe(
         "Expanded prompt"
       );
-      expect(getPrompt).toHaveBeenCalledWith("workspace", "coder", "review", { path: "src" });
+      expect(getPrompt).toHaveBeenCalledWith(
+        "workspace",
+        "coder",
+        "review",
+        { path: "src" },
+        undefined
+      );
     } finally {
       harness.session.dispose();
       await harness.cleanup();

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -119,7 +119,7 @@ describe("AgentSession MCP prompt snapshots", () => {
     }
   });
 
-  test("drops failed prompt refs without blocking the user message", async () => {
+  test("fails the send visibly when a slash-selected prompt cannot expand", async () => {
     const harness = await createAgentSessionHarness({
       workspaceId: "workspace",
       mcpServerManager: {
@@ -132,6 +132,40 @@ describe("AgentSession MCP prompt snapshots", () => {
         model: "anthropic:claude-3-5-sonnet-latest",
         agentId: "exec",
         muxMetadata: promptMetadata(),
+      });
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected slash prompt send to fail");
+      expect(result.error.type).toBe("unknown");
+      expect(JSON.stringify(result.error)).toContain("Cannot expand MCP prompt 'coder/review'");
+
+      const history = await harness.historyService.getLastMessages("workspace", 10);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data).toHaveLength(0);
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
+  test("drops failed inline prompt refs without blocking the user message", async () => {
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      mcpServerManager: {
+        getPrompt: mock(() => Promise.reject(new Error("server unavailable"))),
+      } as unknown as MCPServerManager,
+    });
+
+    try {
+      const base = promptMetadata();
+      const metadata = {
+        ...base,
+        mcpPromptRefs: [{ ...base.mcpPromptRefs[0], source: "inline" as const }],
+      };
+      const result = await harness.session.sendMessage("Check $mcp__coder__review please", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        muxMetadata: metadata,
       });
       expect(result.success).toBe(true);
 

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -30,6 +30,7 @@ describe("AgentSession MCP prompt snapshots", () => {
     const harness = await createAgentSessionHarness({
       workspaceId: "workspace",
       mcpServerManager: { getPrompt } as unknown as MCPServerManager,
+      captureEvents: true,
     });
 
     try {
@@ -61,6 +62,16 @@ describe("AgentSession MCP prompt snapshots", () => {
         { path: "src" },
         undefined
       );
+
+      // The live transcript must receive the snapshot before the user row,
+      // not only after a history replay.
+      const emittedIds = harness.events
+        .filter((event) => "id" in event)
+        .map((event) => (event as { id: string }).id);
+      const snapshotId = history.data[0]?.id ?? "";
+      const userId = history.data[1]?.id ?? "";
+      expect(emittedIds.indexOf(snapshotId)).toBeGreaterThanOrEqual(0);
+      expect(emittedIds.indexOf(snapshotId)).toBeLessThan(emittedIds.indexOf(userId));
     } finally {
       harness.session.dispose();
       await harness.cleanup();

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -229,7 +229,6 @@ describe("AgentSession MCP prompt snapshots", () => {
     });
 
     try {
-      // Simulate a crash after snapshot persistence but before the user row.
       await harness.historyService.appendToHistory(
         "workspace",
         createMuxMessage("orphan-snap", "user", "Expanded prompt", {

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -173,7 +173,6 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(result.success).toBe(false);
       appendToHistory.mockRestore();
 
-      // The orphaned snapshot must not survive for later provider requests.
       const history = await harness.historyService.getLastMessages("workspace", 10);
       expect(history.success).toBe(true);
       if (!history.success) throw new Error(history.error);

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { createMuxMessage } from "@/common/types/message";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import { createAgentSessionHarness } from "@/node/services/agentSession.testHarness";
 
@@ -133,6 +134,48 @@ describe("AgentSession MCP prompt snapshots", () => {
       if (!history.success) throw new Error(history.error);
       expect(history.data).toHaveLength(1);
       expect(history.data[0]?.metadata?.mcpPromptSnapshot).toBeUndefined();
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
+  test("truncates edits starting from the preceding prompt snapshot", async () => {
+    const harness = await createAgentSessionHarness({ workspaceId: "workspace" });
+
+    try {
+      const snapshotId = "mcp-prompt-snapshot-0";
+      const userMessageId = "user-0";
+      await harness.historyService.appendToHistory(
+        "workspace",
+        createMuxMessage(snapshotId, "user", "Expanded prompt", {
+          historySequence: 0,
+          synthetic: true,
+          mcpPromptSnapshot: {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+          },
+        })
+      );
+      await harness.historyService.appendToHistory(
+        "workspace",
+        createMuxMessage(userMessageId, "user", "Using MCP prompt coder/review: src", {
+          historySequence: 1,
+          muxMetadata: promptMetadata(),
+        })
+      );
+
+      const truncateAfterMessage = spyOn(harness.historyService, "truncateAfterMessage");
+      const result = await harness.session.sendMessage("edited", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        editMessageId: userMessageId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(truncateAfterMessage.mock.calls).toHaveLength(1);
+      expect(truncateAfterMessage.mock.calls[0][1]).toBe(snapshotId);
     } finally {
       harness.session.dispose();
       await harness.cleanup();

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -63,8 +63,7 @@ describe("AgentSession MCP prompt snapshots", () => {
         undefined
       );
 
-      // The live transcript must receive the snapshot before the user row,
-      // not only after a history replay.
+      // The live transcript must also emit the snapshot before the user row.
       const emittedIds = harness.events
         .filter((event) => "id" in event)
         .map((event) => (event as { id: string }).id);

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { MCPServerManager } from "@/node/services/mcpServerManager";
+import { createAgentSessionHarness } from "@/node/services/agentSession.testHarness";
+
+function promptMetadata() {
+  return {
+    type: "normal" as const,
+    rawCommand: "/mcp__coder__review src",
+    commandPrefix: "/mcp__coder__review",
+    mcpPromptRefs: [
+      {
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+        source: "slash" as const,
+        arguments: { path: "src" },
+      },
+    ],
+  };
+}
+
+describe("AgentSession MCP prompt snapshots", () => {
+  test("persists the materialized prompt before the user row", async () => {
+    const getPrompt = mock(() =>
+      Promise.resolve({ text: "Expanded prompt", description: "Review code" })
+    );
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      mcpServerManager: { getPrompt } as unknown as MCPServerManager,
+    });
+
+    try {
+      const result = await harness.session.sendMessage("Using MCP prompt coder/review: src", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        muxMetadata: promptMetadata(),
+      });
+      expect(result.success).toBe(true);
+
+      const history = await harness.historyService.getLastMessages("workspace", 10);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data).toHaveLength(2);
+      expect(history.data[0]?.metadata?.mcpPromptSnapshot).toEqual({
+        serverName: "coder",
+        promptName: "review",
+        commandKey: "mcp__coder__review",
+        description: "Review code",
+      });
+      expect(history.data[0]?.parts.find((part) => part.type === "text")?.text).toBe(
+        "Expanded prompt"
+      );
+      expect(getPrompt).toHaveBeenCalledWith("workspace", "coder", "review", { path: "src" });
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
+  test("drops failed prompt refs without blocking the user message", async () => {
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      mcpServerManager: {
+        getPrompt: mock(() => Promise.reject(new Error("server unavailable"))),
+      } as unknown as MCPServerManager,
+    });
+
+    try {
+      const result = await harness.session.sendMessage("Using MCP prompt coder/review: src", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        muxMetadata: promptMetadata(),
+      });
+      expect(result.success).toBe(true);
+
+      const history = await harness.historyService.getLastMessages("workspace", 10);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data).toHaveLength(1);
+      expect(history.data[0]?.metadata?.mcpPromptSnapshot).toBeUndefined();
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+});

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import { createMuxMessage, type MuxMessage } from "@/common/types/message";
-import { Err } from "@/common/types/result";
+import { Err, Ok } from "@/common/types/result";
+import type { AIService } from "@/node/services/aiService";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import { createAgentSessionHarness } from "@/node/services/agentSession.testHarness";
 
@@ -209,6 +210,48 @@ describe("AgentSession MCP prompt snapshots", () => {
       if (!history.success) throw new Error(history.error);
       expect(history.data).toHaveLength(1);
       expect(history.data[0]?.metadata?.mcpPromptSnapshot).toBeUndefined();
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
+  test("excludes crash-orphaned snapshots from provider requests", async () => {
+    const streamMessage = mock((_args: { messages: MuxMessage[] }) =>
+      Promise.resolve(Ok(undefined))
+    );
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+
+    try {
+      // Simulate a crash after snapshot persistence but before the user row.
+      await harness.historyService.appendToHistory(
+        "workspace",
+        createMuxMessage("orphan-snap", "user", "Expanded prompt", {
+          historySequence: 0,
+          synthetic: true,
+          mcpPromptSnapshot: {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+          },
+        })
+      );
+
+      const result = await harness.session.sendMessage("Unrelated message", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+      });
+      expect(result.success).toBe(true);
+
+      expect(streamMessage.mock.calls).toHaveLength(1);
+      const requestMessages = streamMessage.mock.calls[0][0].messages;
+      expect(requestMessages.length).toBeGreaterThan(0);
+      expect(requestMessages.map((message) => message.id)).not.toContain("orphan-snap");
     } finally {
       harness.session.dispose();
       await harness.cleanup();

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -57,6 +57,61 @@ describe("AgentSession MCP prompt snapshots", () => {
     }
   });
 
+  test("materializes independent prompt refs concurrently while preserving order", async () => {
+    let resolveFirst: ((value: { text: string }) => void) | undefined;
+    const getPrompt = mock((_workspaceId: string, _serverName: string, promptName: string) => {
+      if (promptName === "first") {
+        return new Promise<{ text: string }>((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      resolveFirst?.({ text: "First prompt" });
+      return Promise.resolve({ text: "Second prompt" });
+    });
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      mcpServerManager: { getPrompt } as unknown as MCPServerManager,
+    });
+
+    try {
+      const result = await harness.session.sendMessage("Use both prompts", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        muxMetadata: {
+          type: "normal",
+          mcpPromptRefs: [
+            {
+              serverName: "coder",
+              promptName: "first",
+              commandKey: "mcp__coder__first",
+              source: "inline",
+            },
+            {
+              serverName: "coder",
+              promptName: "second",
+              commandKey: "mcp__coder__second",
+              source: "inline",
+            },
+          ],
+        },
+      });
+      expect(result.success).toBe(true);
+      expect(getPrompt).toHaveBeenCalledTimes(2);
+
+      const history = await harness.historyService.getLastMessages("workspace", 10);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(
+        history.data
+          .filter((message) => message.metadata?.mcpPromptSnapshot)
+          .map((message) => message.metadata?.mcpPromptSnapshot?.promptName)
+      ).toEqual(["first", "second"]);
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
   test("drops failed prompt refs without blocking the user message", async () => {
     const harness = await createAgentSessionHarness({
       workspaceId: "workspace",

--- a/src/node/services/agentSession.mcpPromptSnapshot.test.ts
+++ b/src/node/services/agentSession.mcpPromptSnapshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
-import { createMuxMessage } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import { Err } from "@/common/types/result";
 import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import { createAgentSessionHarness } from "@/node/services/agentSession.testHarness";
 
@@ -138,6 +139,41 @@ describe("AgentSession MCP prompt snapshots", () => {
       expect(result.error.type).toBe("unknown");
       expect(JSON.stringify(result.error)).toContain("Cannot expand MCP prompt 'coder/review'");
 
+      const history = await harness.historyService.getLastMessages("workspace", 10);
+      expect(history.success).toBe(true);
+      if (!history.success) throw new Error(history.error);
+      expect(history.data).toHaveLength(0);
+    } finally {
+      harness.session.dispose();
+      await harness.cleanup();
+    }
+  });
+
+  test("rolls back persisted snapshot rows when the user row append fails", async () => {
+    const getPrompt = mock(() => Promise.resolve({ text: "Expanded prompt" }));
+    const harness = await createAgentSessionHarness({
+      workspaceId: "workspace",
+      mcpServerManager: { getPrompt } as unknown as MCPServerManager,
+    });
+
+    try {
+      const realAppend = harness.historyService.appendToHistory.bind(harness.historyService);
+      const appendToHistory = spyOn(harness.historyService, "appendToHistory").mockImplementation(
+        async (workspaceId: string, message: MuxMessage) => {
+          if (message.metadata?.mcpPromptSnapshot) return realAppend(workspaceId, message);
+          return Err("disk full");
+        }
+      );
+
+      const result = await harness.session.sendMessage("Using MCP prompt coder/review: src", {
+        model: "anthropic:claude-3-5-sonnet-latest",
+        agentId: "exec",
+        muxMetadata: promptMetadata(),
+      });
+      expect(result.success).toBe(false);
+      appendToHistory.mockRestore();
+
+      // The orphaned snapshot must not survive for later provider requests.
       const history = await harness.historyService.getLastMessages("workspace", 10);
       expect(history.success).toBe(true);
       if (!history.success) throw new Error(history.error);

--- a/src/node/services/agentSession.testHarness.ts
+++ b/src/node/services/agentSession.testHarness.ts
@@ -12,6 +12,7 @@ import type { BackgroundProcessManager } from "@/node/services/backgroundProcess
 import type { WorkspaceGoalService } from "@/node/services/workspaceGoalService";
 import type { HistoryService } from "@/node/services/historyService";
 import type { InitStateManager } from "@/node/services/initStateManager";
+import type { MCPServerManager } from "@/node/services/mcpServerManager";
 import { createTestHistoryService } from "@/node/services/testHistoryService";
 
 function createAgentSessionTestConfig(sessionDir = "/tmp"): Config {
@@ -67,6 +68,7 @@ export interface AgentSessionHarnessOptions {
   backgroundProcessManager?: BackgroundProcessManager;
   backgroundProcessManagerOverrides?: Partial<BackgroundProcessManager>;
   workspaceGoalService?: WorkspaceGoalService;
+  mcpServerManager?: MCPServerManager;
   onCompactionComplete?: (metadata: CompactionCompletionMetadata) => void;
   captureEvents?: boolean;
 }
@@ -107,6 +109,7 @@ export async function createAgentSessionHarness(
     config,
     historyService,
     aiService,
+    mcpServerManager: options.mcpServerManager,
     initStateManager,
     workspaceGoalService: options.workspaceGoalService,
     backgroundProcessManager,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -6209,6 +6209,16 @@ export class AgentSession {
             },
           });
         } catch (error) {
+          // Cancellation is handled by cancelBeforeAcceptance after this returns.
+          if (cancelSignal?.aborted) return null;
+          // A slash-invoked prompt was explicitly selected; sending the turn
+          // without its expansion would silently change what the user asked
+          // for. Inline references degrade to the authored text instead.
+          if (ref.source === "slash") {
+            throw new Error(
+              `Cannot expand MCP prompt '${ref.serverName}/${ref.promptName}': ${getErrorMessage(error)}`
+            );
+          }
           log.debug("Failed to materialize MCP prompt reference", {
             workspaceId: this.workspaceId,
             serverName: ref.serverName,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -9,6 +9,7 @@ import type { Config } from "@/node/config";
 import type { AIService } from "@/node/services/aiService";
 import type { HistoryService } from "@/node/services/historyService";
 import type { InitStateManager } from "@/node/services/initStateManager";
+import type { MCPServerManager } from "@/node/services/mcpServerManager";
 
 import type { FrontendWorkspaceMetadata, WorkspaceMetadata } from "@/common/types/workspace";
 import type { RuntimeConfig } from "@/common/types/runtime";
@@ -45,6 +46,7 @@ import {
   createUserMessageId,
   createFileSnapshotMessageId,
   createAgentSkillSnapshotMessageId,
+  createMcpPromptSnapshotMessageId,
 } from "@/node/services/utils/messageIds";
 import {
   FileChangeTracker,
@@ -63,6 +65,7 @@ import type { ActiveTurnThinkingOverride } from "@/node/services/thinkingOverrid
 import {
   createMuxMessage,
   dedupeAgentSkillRefs,
+  dedupeMcpPromptRefs,
   isCompactionSummaryMetadata,
   pickPreservedSendOptions,
   pickStartupRetrySendOptions,
@@ -376,6 +379,7 @@ interface AgentSessionOptions {
   config: Config;
   historyService: HistoryService;
   aiService: AIService;
+  mcpServerManager?: MCPServerManager;
   initStateManager: InitStateManager;
   telemetryService?: TelemetryService;
   backgroundProcessManager: BackgroundProcessManager;
@@ -419,6 +423,7 @@ export class AgentSession {
   private readonly config: Config;
   private readonly historyService: HistoryService;
   private readonly aiService: AIService;
+  private readonly mcpServerManager?: MCPServerManager;
   private readonly initStateManager: InitStateManager;
   private readonly backgroundProcessManager: BackgroundProcessManager;
   private readonly workspaceGoalService?: WorkspaceGoalService;
@@ -632,6 +637,7 @@ export class AgentSession {
       config,
       historyService,
       aiService,
+      mcpServerManager,
       initStateManager,
       telemetryService,
       backgroundProcessManager,
@@ -650,6 +656,7 @@ export class AgentSession {
     this.config = config;
     this.historyService = historyService;
     this.aiService = aiService;
+    this.mcpServerManager = mcpServerManager;
     this.initStateManager = initStateManager;
     this.backgroundProcessManager = backgroundProcessManager;
     this.workspaceGoalService = workspaceGoalService;
@@ -3024,16 +3031,16 @@ export class AgentSession {
     // On on-send compaction paths, snapshots are deferred with the follow-up turn.
     const shouldPersistTurnSnapshots = autoCompactionMessage === null;
 
-    // Materialize skill snapshots only for turns that send immediately (see the
-    // compaction-decision comment above: deferred turns re-materialize on follow-up,
-    // and materialization may execute dynamic context directives).
+    // Deferral preserves send-time resolution for dynamic snapshot sources.
     let skillSnapshotMessages: MuxMessage[] = [];
+    let mcpPromptSnapshotMessages: MuxMessage[] = [];
     if (shouldPersistTurnSnapshots) {
       try {
         skillSnapshotMessages = await this.materializeAgentSkillSnapshots(
           typedMuxMetadata,
           options?.disableWorkspaceAgents
         );
+        mcpPromptSnapshotMessages = await this.materializeMcpPromptSnapshots(typedMuxMetadata);
       } catch (error) {
         return Err(createUnknownSendMessageError(getErrorMessage(error)));
       }
@@ -3069,6 +3076,20 @@ export class AgentSession {
         if (await cancelBeforeAcceptance()) {
           return Ok(undefined);
         }
+      }
+    }
+
+    if (shouldPersistTurnSnapshots && mcpPromptSnapshotMessages.length > 0) {
+      for (const snapshotMessage of mcpPromptSnapshotMessages) {
+        const appendResult = await this.historyService.appendToHistory(
+          this.workspaceId,
+          snapshotMessage
+        );
+        if (!appendResult.success) {
+          return Err(createUnknownSendMessageError(appendResult.error));
+        }
+        persistedCancelableMessageIds.push(snapshotMessage.id);
+        if (await cancelBeforeAcceptance()) return Ok(undefined);
       }
     }
 
@@ -6161,6 +6182,45 @@ export class AgentSession {
     });
 
     return { snapshotMessage, materializedTokens: tokens };
+  }
+
+  private async materializeMcpPromptSnapshots(
+    muxMetadata: MuxMessageMetadata | undefined
+  ): Promise<MuxMessage[]> {
+    if (!this.mcpServerManager || !Array.isArray(muxMetadata?.mcpPromptRefs)) return [];
+
+    const refs = dedupeMcpPromptRefs(muxMetadata.mcpPromptRefs);
+    const snapshots: MuxMessage[] = [];
+    for (const ref of refs) {
+      try {
+        const prompt = await this.mcpServerManager.getPrompt(
+          this.workspaceId,
+          ref.serverName,
+          ref.promptName,
+          ref.arguments ?? {}
+        );
+        snapshots.push(
+          createMuxMessage(createMcpPromptSnapshotMessageId(), "user", prompt.text, {
+            timestamp: Date.now(),
+            synthetic: true,
+            mcpPromptSnapshot: {
+              serverName: ref.serverName,
+              promptName: ref.promptName,
+              commandKey: ref.commandKey,
+              ...(prompt.description !== undefined ? { description: prompt.description } : {}),
+            },
+          })
+        );
+      } catch (error) {
+        log.debug("Failed to materialize MCP prompt reference", {
+          workspaceId: this.workspaceId,
+          serverName: ref.serverName,
+          promptName: ref.promptName,
+          error: getErrorMessage(error),
+        });
+      }
+    }
+    return snapshots;
   }
 
   private async materializeAgentSkillSnapshots(

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3031,7 +3031,10 @@ export class AgentSession {
           typedMuxMetadata,
           options?.disableWorkspaceAgents
         );
-        mcpPromptSnapshotMessages = await this.materializeMcpPromptSnapshots(typedMuxMetadata);
+        mcpPromptSnapshotMessages = await this.materializeMcpPromptSnapshots(
+          typedMuxMetadata,
+          cancelSignal
+        );
       } catch (error) {
         return Err(createUnknownSendMessageError(getErrorMessage(error)));
       }
@@ -6178,7 +6181,8 @@ export class AgentSession {
   }
 
   private async materializeMcpPromptSnapshots(
-    muxMetadata: MuxMessageMetadata | undefined
+    muxMetadata: MuxMessageMetadata | undefined,
+    cancelSignal: AbortSignal | undefined
   ): Promise<MuxMessage[]> {
     const mcpServerManager = this.mcpServerManager;
     if (!mcpServerManager || !Array.isArray(muxMetadata?.mcpPromptRefs)) return [];
@@ -6191,7 +6195,8 @@ export class AgentSession {
             this.workspaceId,
             ref.serverName,
             ref.promptName,
-            ref.arguments ?? {}
+            ref.arguments ?? {},
+            cancelSignal !== undefined ? { signal: cancelSignal } : undefined
           );
           return createMuxMessage(createMcpPromptSnapshotMessageId(), "user", prompt.text, {
             timestamp: Date.now(),

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3031,7 +3031,6 @@ export class AgentSession {
     // On on-send compaction paths, snapshots are deferred with the follow-up turn.
     const shouldPersistTurnSnapshots = autoCompactionMessage === null;
 
-    // Deferral preserves send-time resolution for dynamic snapshot sources.
     let skillSnapshotMessages: MuxMessage[] = [];
     let mcpPromptSnapshotMessages: MuxMessage[] = [];
     if (shouldPersistTurnSnapshots) {
@@ -3089,7 +3088,9 @@ export class AgentSession {
           return Err(createUnknownSendMessageError(appendResult.error));
         }
         persistedCancelableMessageIds.push(snapshotMessage.id);
-        if (await cancelBeforeAcceptance()) return Ok(undefined);
+        if (await cancelBeforeAcceptance()) {
+          return Ok(undefined);
+        }
       }
     }
 
@@ -6187,20 +6188,20 @@ export class AgentSession {
   private async materializeMcpPromptSnapshots(
     muxMetadata: MuxMessageMetadata | undefined
   ): Promise<MuxMessage[]> {
-    if (!this.mcpServerManager || !Array.isArray(muxMetadata?.mcpPromptRefs)) return [];
+    const mcpServerManager = this.mcpServerManager;
+    if (!mcpServerManager || !Array.isArray(muxMetadata?.mcpPromptRefs)) return [];
 
     const refs = dedupeMcpPromptRefs(muxMetadata.mcpPromptRefs);
-    const snapshots: MuxMessage[] = [];
-    for (const ref of refs) {
-      try {
-        const prompt = await this.mcpServerManager.getPrompt(
-          this.workspaceId,
-          ref.serverName,
-          ref.promptName,
-          ref.arguments ?? {}
-        );
-        snapshots.push(
-          createMuxMessage(createMcpPromptSnapshotMessageId(), "user", prompt.text, {
+    const snapshots = await Promise.all(
+      refs.map(async (ref): Promise<MuxMessage | null> => {
+        try {
+          const prompt = await mcpServerManager.getPrompt(
+            this.workspaceId,
+            ref.serverName,
+            ref.promptName,
+            ref.arguments ?? {}
+          );
+          return createMuxMessage(createMcpPromptSnapshotMessageId(), "user", prompt.text, {
             timestamp: Date.now(),
             synthetic: true,
             mcpPromptSnapshot: {
@@ -6209,18 +6210,19 @@ export class AgentSession {
               commandKey: ref.commandKey,
               ...(prompt.description !== undefined ? { description: prompt.description } : {}),
             },
-          })
-        );
-      } catch (error) {
-        log.debug("Failed to materialize MCP prompt reference", {
-          workspaceId: this.workspaceId,
-          serverName: ref.serverName,
-          promptName: ref.promptName,
-          error: getErrorMessage(error),
-        });
-      }
-    }
-    return snapshots;
+          });
+        } catch (error) {
+          log.debug("Failed to materialize MCP prompt reference", {
+            workspaceId: this.workspaceId,
+            serverName: ref.serverName,
+            promptName: ref.promptName,
+            error: getErrorMessage(error),
+          });
+          return null;
+        }
+      })
+    );
+    return snapshots.filter((snapshot): snapshot is MuxMessage => snapshot !== null);
   }
 
   private async materializeAgentSkillSnapshots(

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3051,6 +3051,7 @@ export class AgentSession {
         );
         mcpPromptSnapshotMessages = await this.materializeMcpPromptSnapshots(
           typedMuxMetadata,
+          userMessage.id,
           cancelSignal
         );
       } catch (error) {
@@ -6204,6 +6205,7 @@ export class AgentSession {
 
   private async materializeMcpPromptSnapshots(
     muxMetadata: MuxMessageMetadata | undefined,
+    invokingMessageId: string,
     cancelSignal: AbortSignal | undefined
   ): Promise<MuxMessage[]> {
     const mcpServerManager = this.mcpServerManager;
@@ -6227,6 +6229,7 @@ export class AgentSession {
               serverName: ref.serverName,
               promptName: ref.promptName,
               commandKey: ref.commandKey,
+              invokingMessageId,
               ...(prompt.description !== undefined ? { description: prompt.description } : {}),
             },
           });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -66,6 +66,7 @@ import {
   createMuxMessage,
   dedupeAgentSkillRefs,
   dedupeMcpPromptRefs,
+  filterOrphanedMcpPromptSnapshots,
   sanitizeAgentSkillRefs,
   sanitizeMcpPromptRefs,
   isCompactionSummaryMetadata,
@@ -3971,7 +3972,7 @@ export class AgentSession {
       return Ok(undefined);
     }
 
-    let historyResult = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
+    const historyResult = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
     if (isStartupAbortRequested()) {
       return Ok(undefined);
     }
@@ -3980,7 +3981,11 @@ export class AgentSession {
       return Err(createUnknownSendMessageError(historyResult.error));
     }
 
-    if (historyResult.data.length === 0) {
+    // A crash between snapshot and user-row appends can leave orphaned prompt
+    // expansions on disk; exclude them from every provider request.
+    let requestMessages = filterOrphanedMcpPromptSnapshots(historyResult.data);
+
+    if (requestMessages.length === 0) {
       return Err(
         createUnknownSendMessageError(
           "Cannot resume stream: workspace history is empty. Send a new message instead."
@@ -3993,7 +3998,7 @@ export class AgentSession {
     // Non-partial trailing assistants indicate a missing user message upstream — inject a
     // [CONTINUE] sentinel so the model has a valid conversation to respond to. This is
     // defense-in-depth; callers should prefer sendMessage() which persists a real user message.
-    const lastMsg = historyResult.data[historyResult.data.length - 1];
+    const lastMsg = requestMessages[requestMessages.length - 1];
     if (lastMsg?.role === "assistant" && !lastMsg.metadata?.partial) {
       log.warn("streamWithHistory: trailing non-partial assistant detected, injecting [CONTINUE]", {
         workspaceId: this.workspaceId,
@@ -4006,16 +4011,16 @@ export class AgentSession {
       await this.historyService.appendToHistory(this.workspaceId, sentinelMessage);
       const refreshed = await this.historyService.getHistoryFromLatestBoundary(this.workspaceId);
       if (refreshed.success) {
-        historyResult = refreshed;
+        requestMessages = filterOrphanedMcpPromptSnapshots(refreshed.data);
       }
     }
 
     // Capture the current user message id so retries are stable across assistant message ids.
-    const lastUserMessage = [...historyResult.data].reverse().find((m) => m.role === "user");
+    const lastUserMessage = [...requestMessages].reverse().find((m) => m.role === "user");
     this.activeStreamUserMessageId = lastUserMessage?.id;
 
     this.activeCompactionRequest = this.resolveCompactionRequest(
-      historyResult.data,
+      requestMessages,
       modelString,
       options
     );
@@ -4083,7 +4088,7 @@ export class AgentSession {
         : retryMuxMetadata?.type === "workspace-turn-task"
           ? retryMuxMetadata
           : retryMuxMetadata?.type === "bash-monitor-wake"
-            ? inheritOpenWorkspaceTurnMetadata(historyResult.data)
+            ? inheritOpenWorkspaceTurnMetadata(requestMessages)
             : undefined;
     // Mid-stream compaction runs after the original send options have already been resolved against
     // history (notably bash-monitor wakes). Persist the actual correlation used by this stream so the
@@ -4098,7 +4103,7 @@ export class AgentSession {
       extractAcpDelegatedTools(optionsMuxMetadata);
 
     const streamResult = await this.aiService.streamMessage({
-      messages: historyResult.data,
+      messages: requestMessages,
       workspaceId: this.workspaceId,
       modelString,
       abortSignal,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3175,6 +3175,12 @@ export class AgentSession {
       }
     }
 
+    if (shouldPersistTurnSnapshots && mcpPromptSnapshotMessages.length > 0) {
+      for (const snapshotMessage of mcpPromptSnapshotMessages) {
+        this.emitChatEvent({ ...snapshotMessage, type: "message" });
+      }
+    }
+
     // When on-send compaction triggers, the original user message is NOT emitted now —
     // it was not persisted and will be dispatched (persisted + emitted) as a follow-up
     // after compaction completes. Emitting it here would cause a duplicate in the

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -71,6 +71,7 @@ import {
   pickStartupRetrySendOptions,
   prepareUserMessageForSend,
   type AgentSkillReference,
+  isSyntheticSnapshotUserMessage,
   type CompactionFollowUpRequest,
   type MuxMessageMetadata,
   type MuxFilePart,
@@ -1309,15 +1310,6 @@ export class AgentSession {
     );
   }
 
-  private isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {
-    return (
-      message.role === "user" &&
-      message.metadata?.synthetic === true &&
-      (message.metadata.fileAtMentionSnapshot !== undefined ||
-        message.metadata.agentSkillSnapshot !== undefined)
-    );
-  }
-
   private isSyntheticGoalPauseBoundaryMessage(message: MuxMessage): boolean {
     return (
       message.role === "user" &&
@@ -1338,7 +1330,7 @@ export class AgentSession {
     let truncateTargetId = editMessageId;
     for (let i = editIndex - 1; i >= 0; i -= 1) {
       const message = messages[i];
-      if (!this.isSyntheticSnapshotUserMessage(message)) {
+      if (!isSyntheticSnapshotUserMessage(message)) {
         break;
       }
       truncateTargetId = message.id;
@@ -1383,7 +1375,7 @@ export class AgentSession {
       if (this.isSyntheticGoalPauseBoundaryMessage(candidate)) {
         continue;
       }
-      if (this.isSyntheticSnapshotUserMessage(candidate)) {
+      if (isSyntheticSnapshotUserMessage(candidate)) {
         continue;
       }
       return candidate;
@@ -1508,7 +1500,7 @@ export class AgentSession {
     if (this.isSyntheticGoalPauseBoundaryMessage(message)) {
       return false;
     }
-    if (this.isSyntheticSnapshotUserMessage(message)) {
+    if (isSyntheticSnapshotUserMessage(message)) {
       return false;
     }
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -2508,9 +2508,8 @@ export class AgentSession {
 
     const cancelSignal = internal?.cancelSignal;
     const persistedCancelableMessageIds: string[] = [];
-    // An append failure mid-preparation would otherwise orphan earlier synthetic
-    // snapshot rows in active history without their invoking user row, and later
-    // provider requests would read that context (best effort, mirrors cancellation).
+    // Roll back synthetic snapshots if the invoking user row fails to persist, or
+    // later provider requests could consume orphaned context.
     const rollbackPersistedTurnRows = async (): Promise<void> => {
       if (persistedCancelableMessageIds.length === 0) return;
       const rollbackResult = await this.historyService.deleteMessages(
@@ -6205,7 +6204,6 @@ export class AgentSession {
     const mcpServerManager = this.mcpServerManager;
     if (!mcpServerManager) return [];
 
-    // Corrupted persisted refs must not fail the send (self-healing rule).
     const refs = dedupeMcpPromptRefs(sanitizeMcpPromptRefs(muxMetadata?.mcpPromptRefs));
     const snapshots = await Promise.all(
       refs.map(async (ref): Promise<MuxMessage | null> => {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -66,6 +66,8 @@ import {
   createMuxMessage,
   dedupeAgentSkillRefs,
   dedupeMcpPromptRefs,
+  sanitizeAgentSkillRefs,
+  sanitizeMcpPromptRefs,
   isCompactionSummaryMetadata,
   pickPreservedSendOptions,
   pickStartupRetrySendOptions,
@@ -222,7 +224,7 @@ const ACP_DELEGATED_TOOLS_METADATA_KEY = "acpDelegatedTools";
 function extractAgentSkillRefs(metadata: MuxMessageMetadata | undefined): AgentSkillReference[] {
   if (!metadata) return [];
 
-  const refs = Array.isArray(metadata.agentSkillRefs) ? [...metadata.agentSkillRefs] : [];
+  const refs = sanitizeAgentSkillRefs(metadata.agentSkillRefs);
   if (metadata.type === "agent-skill") {
     const hasLegacySlashRef = refs.some(
       (ref) => ref.skillName === metadata.skillName && ref.source === "slash"
@@ -6185,9 +6187,10 @@ export class AgentSession {
     cancelSignal: AbortSignal | undefined
   ): Promise<MuxMessage[]> {
     const mcpServerManager = this.mcpServerManager;
-    if (!mcpServerManager || !Array.isArray(muxMetadata?.mcpPromptRefs)) return [];
+    if (!mcpServerManager) return [];
 
-    const refs = dedupeMcpPromptRefs(muxMetadata.mcpPromptRefs);
+    // Corrupted persisted refs must not fail the send (self-healing rule).
+    const refs = dedupeMcpPromptRefs(sanitizeMcpPromptRefs(muxMetadata?.mcpPromptRefs));
     const snapshots = await Promise.all(
       refs.map(async (ref): Promise<MuxMessage | null> => {
         try {

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -2508,6 +2508,22 @@ export class AgentSession {
 
     const cancelSignal = internal?.cancelSignal;
     const persistedCancelableMessageIds: string[] = [];
+    // An append failure mid-preparation would otherwise orphan earlier synthetic
+    // snapshot rows in active history without their invoking user row, and later
+    // provider requests would read that context (best effort, mirrors cancellation).
+    const rollbackPersistedTurnRows = async (): Promise<void> => {
+      if (persistedCancelableMessageIds.length === 0) return;
+      const rollbackResult = await this.historyService.deleteMessages(
+        this.workspaceId,
+        persistedCancelableMessageIds
+      );
+      if (!rollbackResult.success) {
+        log.error("Failed to roll back partially persisted turn rows", {
+          workspaceId: this.workspaceId,
+          error: rollbackResult.error,
+        });
+      }
+    };
     let cancellationHandled = false;
     let cancellationDisabled = false;
     const cancelBeforeAcceptance = async (): Promise<boolean> => {
@@ -3066,6 +3082,7 @@ export class AgentSession {
           snapshotMessage
         );
         if (!skillSnapshotAppendResult.success) {
+          await rollbackPersistedTurnRows();
           return Err(createUnknownSendMessageError(skillSnapshotAppendResult.error));
         }
         persistedCancelableMessageIds.push(snapshotMessage.id);
@@ -3082,6 +3099,7 @@ export class AgentSession {
           snapshotMessage
         );
         if (!appendResult.success) {
+          await rollbackPersistedTurnRows();
           return Err(createUnknownSendMessageError(appendResult.error));
         }
         persistedCancelableMessageIds.push(snapshotMessage.id);
@@ -3096,9 +3114,7 @@ export class AgentSession {
     if (!autoCompactionMessage) {
       const appendResult = await this.historyService.appendToHistory(this.workspaceId, userMessage);
       if (!appendResult.success) {
-        // Note: If we get here with snapshots, one or more snapshots may already be persisted but user message
-        // failed. This is a rare edge case (disk full mid-operation). The next edit will clean up
-        // the orphan via the truncation logic that removes preceding snapshots.
+        await rollbackPersistedTurnRows();
         return Err(createUnknownSendMessageError(appendResult.error));
       }
       persistedCancelableMessageIds.push(userMessage.id);

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1004,12 +1004,7 @@ export class AIService extends EventEmitter {
     return `Workspace ${workspaceId} reached multi-project AI runtime execution while ${EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES} is disabled`;
   }
 
-  /**
-   * Build the runtime and execution path exactly as stream startup does,
-   * including the shared-root MultiProjectRuntime for multi-project
-   * workspaces. Public so non-stream callers (MCP prompt discovery) start
-   * stdio servers with the same signature stream startup later reuses.
-   */
+  /** Builds the runtime context shared by stream startup and MCP prompt discovery. */
   createWorkspaceRuntimeContext(
     workspaceId: string,
     metadata: WorkspaceMetadata
@@ -1021,9 +1016,8 @@ export class AIService extends EventEmitter {
 
     const metadataWithPath = {
       ...metadata,
-      // Existing SSH workspaces may still live at a persisted root that differs from the canonical
-      // hashed project layout, so stream startup seeds the runtime from config for the current
-      // workspace instead of always reconstructing the path from project metadata.
+      // Existing SSH workspaces may use a persisted root that differs from the
+      // canonical hashed layout.
       namedWorkspacePath: workspace.workspacePath,
     };
 
@@ -1071,17 +1065,10 @@ export class AIService extends EventEmitter {
       singleProjectContext?.workspacePath ??
       (isSSHRuntime(metadata.runtimeConfig)
         ? resolveWorkspaceExecutionPath(metadataWithPath, runtime)
-        : // Non-SSH multi-project runtimes intentionally start from their shared container root so
-          // sibling repos stay addressable during agent/tool setup. SSH workspaces are the exception:
-          // upgraded legacy layouts must reuse the persisted root from config until remote layout
-          // detection seeds the new hashed paths.
+        : // Multi-project containers start at their shared root so sibling repos remain addressable.
           runtime.getWorkspacePath(metadata.projectPath, metadata.name));
 
-    // Host checkout root for single-project host workspaces. This differs
-    // from `workspacePath` for subProjectPath workspaces, whose execution
-    // path is a subdirectory of the checkout; Agent Plugins containers (MCP
-    // and skills) anchor at the checkout root, matching the oRPC listing
-    // paths (resolveWorkspaceRootPath).
+    // Agent Plugin containers use the host checkout root, not a subproject directory.
     const hostCheckoutRoot =
       singleProjectContext &&
       metadata.runtimeConfig.type !== "ssh" &&

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -41,6 +41,7 @@ import {
   createRuntimeForWorkspace,
   resolveWorkspaceExecutionPath,
   resolveWorkspaceRootPath,
+  type WorkspaceRuntimeContext,
 } from "@/node/runtime/runtimeHelpers";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { getWorkspacePathHintForProject } from "@/node/services/workspaceProjectRepos";
@@ -1003,6 +1004,94 @@ export class AIService extends EventEmitter {
     return `Workspace ${workspaceId} reached multi-project AI runtime execution while ${EXPERIMENT_IDS.MULTI_PROJECT_WORKSPACES} is disabled`;
   }
 
+  /**
+   * Build the runtime and execution path exactly as stream startup does,
+   * including the shared-root MultiProjectRuntime for multi-project
+   * workspaces. Public so non-stream callers (MCP prompt discovery) start
+   * stdio servers with the same signature stream startup later reuses.
+   */
+  createWorkspaceRuntimeContext(
+    workspaceId: string,
+    metadata: WorkspaceMetadata
+  ): Result<WorkspaceRuntimeContext & { hostCheckoutRoot: string | null }, SendMessageError> {
+    const workspace = this.config.findWorkspace(workspaceId);
+    if (!workspace) {
+      return Err({ type: "unknown", raw: `Workspace ${workspaceId} not found in config` });
+    }
+
+    const metadataWithPath = {
+      ...metadata,
+      // Existing SSH workspaces may still live at a persisted root that differs from the canonical
+      // hashed project layout, so stream startup seeds the runtime from config for the current
+      // workspace instead of always reconstructing the path from project metadata.
+      namedWorkspacePath: workspace.workspacePath,
+    };
+
+    const multiProjectExecutionGate = this.ensureMultiProjectRuntimeExecutionEnabled(
+      workspaceId,
+      metadata
+    );
+    if (!multiProjectExecutionGate.success) {
+      return multiProjectExecutionGate;
+    }
+
+    const singleProjectContext = isMultiProject(metadata)
+      ? undefined
+      : createRuntimeContextForWorkspace(metadataWithPath);
+    const runtime = singleProjectContext
+      ? singleProjectContext.runtime
+      : new MultiProjectRuntime(
+          new ContainerManager(getSrcBaseDir(metadata.runtimeConfig) ?? this.config.srcDir),
+          getProjects(metadata).map((project) => ({
+            projectPath: project.projectPath,
+            projectName: project.projectName,
+            runtime: createRuntime(metadata.runtimeConfig, {
+              projectPath: project.projectPath,
+              workspaceName: metadata.name,
+              workspacePath: isSSHRuntime(metadata.runtimeConfig)
+                ? getWorkspacePathHintForProject(
+                    {
+                      workspaceId,
+                      workspaceName: metadata.name,
+                      workspacePath: workspace.workspacePath,
+                      runtimeConfig: metadata.runtimeConfig,
+                      projectPath: metadata.projectPath,
+                      projectName: metadata.projectName,
+                      projects: metadata.projects,
+                    },
+                    project.projectPath
+                  )
+                : undefined,
+            }),
+          })),
+          metadata.name
+        );
+
+    const workspacePath =
+      singleProjectContext?.workspacePath ??
+      (isSSHRuntime(metadata.runtimeConfig)
+        ? resolveWorkspaceExecutionPath(metadataWithPath, runtime)
+        : // Non-SSH multi-project runtimes intentionally start from their shared container root so
+          // sibling repos stay addressable during agent/tool setup. SSH workspaces are the exception:
+          // upgraded legacy layouts must reuse the persisted root from config until remote layout
+          // detection seeds the new hashed paths.
+          runtime.getWorkspacePath(metadata.projectPath, metadata.name));
+
+    // Host checkout root for single-project host workspaces. This differs
+    // from `workspacePath` for subProjectPath workspaces, whose execution
+    // path is a subdirectory of the checkout; Agent Plugins containers (MCP
+    // and skills) anchor at the checkout root, matching the oRPC listing
+    // paths (resolveWorkspaceRootPath).
+    const hostCheckoutRoot =
+      singleProjectContext &&
+      metadata.runtimeConfig.type !== "ssh" &&
+      metadata.runtimeConfig.type !== "docker"
+        ? resolveWorkspaceRootPath(metadataWithPath, runtime)
+        : null;
+
+    return Ok({ runtime, workspacePath, hostCheckoutRoot });
+  }
+
   private ensureMultiProjectRuntimeExecutionEnabled(
     workspaceId: string,
     metadata: WorkspaceMetadata
@@ -1326,68 +1415,11 @@ export class AIService extends EventEmitter {
         });
       };
 
-      const workspace = this.config.findWorkspace(workspaceId);
-      if (!workspace) {
-        return Err({ type: "unknown", raw: `Workspace ${workspaceId} not found in config` });
+      const runtimeContextResult = this.createWorkspaceRuntimeContext(workspaceId, metadata);
+      if (!runtimeContextResult.success) {
+        return runtimeContextResult;
       }
-
-      const metadataWithPath = {
-        ...metadata,
-        // Existing SSH workspaces may still live at a persisted root that differs from the canonical
-        // hashed project layout, so stream startup seeds the runtime from config for the current
-        // workspace instead of always reconstructing the path from project metadata.
-        namedWorkspacePath: workspace.workspacePath,
-      };
-
-      const multiProjectExecutionGate = this.ensureMultiProjectRuntimeExecutionEnabled(
-        workspaceId,
-        metadata
-      );
-      if (!multiProjectExecutionGate.success) {
-        return multiProjectExecutionGate;
-      }
-
-      const singleProjectContext = isMultiProject(metadata)
-        ? undefined
-        : createRuntimeContextForWorkspace(metadataWithPath);
-      const runtime = singleProjectContext
-        ? singleProjectContext.runtime
-        : new MultiProjectRuntime(
-            new ContainerManager(getSrcBaseDir(metadata.runtimeConfig) ?? this.config.srcDir),
-            getProjects(metadata).map((project) => ({
-              projectPath: project.projectPath,
-              projectName: project.projectName,
-              runtime: createRuntime(metadata.runtimeConfig, {
-                projectPath: project.projectPath,
-                workspaceName: metadata.name,
-                workspacePath: isSSHRuntime(metadata.runtimeConfig)
-                  ? getWorkspacePathHintForProject(
-                      {
-                        workspaceId,
-                        workspaceName: metadata.name,
-                        workspacePath: workspace.workspacePath,
-                        runtimeConfig: metadata.runtimeConfig,
-                        projectPath: metadata.projectPath,
-                        projectName: metadata.projectName,
-                        projects: metadata.projects,
-                      },
-                      project.projectPath
-                    )
-                  : undefined,
-              }),
-            })),
-            metadata.name
-          );
-
-      const workspacePath =
-        singleProjectContext?.workspacePath ??
-        (isSSHRuntime(metadata.runtimeConfig)
-          ? resolveWorkspaceExecutionPath(metadataWithPath, runtime)
-          : // Non-SSH multi-project runtimes intentionally start from their shared container root so
-            // sibling repos stay addressable during agent/tool setup. SSH workspaces are the exception:
-            // upgraded legacy layouts must reuse the persisted root from config until remote layout
-            // detection seeds the new hashed paths.
-            runtime.getWorkspacePath(metadata.projectPath, metadata.name));
+      const { runtime, workspacePath, hostCheckoutRoot } = runtimeContextResult.data;
 
       // Wait for init to complete before any runtime I/O operations
       // (SSH/devcontainer may not be ready until init finishes pulling the container)
@@ -1580,18 +1612,6 @@ export class AIService extends EventEmitter {
         mcpOverrides = undefined;
       }
       recordStartupPhaseTiming("loadWorkspaceMcpOverridesMs", loadWorkspaceMcpOverridesStartedAt);
-
-      // Host checkout root for single-project host workspaces. This differs
-      // from `workspacePath` for subProjectPath workspaces, whose execution
-      // path is a subdirectory of the checkout; Agent Plugins containers (MCP
-      // and skills) anchor at the checkout root, matching the oRPC listing
-      // paths (resolveWorkspaceRootPath).
-      const hostCheckoutRoot =
-        singleProjectContext &&
-        metadata.runtimeConfig.type !== "ssh" &&
-        metadata.runtimeConfig.type !== "docker"
-          ? resolveWorkspaceRootPath(metadataWithPath, runtime)
-          : null;
 
       // Agent Plugins: discovery follows the active checkout and is disabled
       // for workspaces that exec off-host (SSH/Docker/devcontainer).

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -152,9 +152,8 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
     opts.policyService
   );
   aiService.setMCPServerManager(mcpServerManager);
-  // Prompt invocation refreshes from recorded request options, whose secrets
-  // snapshot goes stale on rotation. Mirror the stream path's resolution
-  // (multi-project merge when applicable) so refreshes carry current secrets.
+  // Recorded prompt options can hold stale secret snapshots, so prompt refreshes
+  // resolve credentials from current configuration.
   mcpServerManager.setSecretsResolver(async (workspaceId, projectPath) => {
     const metadataResult = await aiService.getWorkspaceMetadata(workspaceId);
     const metadata = metadataResult.success ? metadataResult.data : null;

--- a/src/node/services/coreServices.ts
+++ b/src/node/services/coreServices.ts
@@ -22,6 +22,9 @@ import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { createAgentPluginsMcpProvider } from "@/node/services/agentPlugins/mcpConfig";
 import { MCPConfigService } from "@/node/services/mcpConfigService";
 import { MCPServerManager, type MCPServerManagerOptions } from "@/node/services/mcpServerManager";
+import { mergeMultiProjectSecrets } from "@/node/services/utils/multiProjectSecrets";
+import { isMultiProject } from "@/common/utils/multiProject";
+import { secretsToRecord } from "@/common/types/secrets";
 import { ExtensionMetadataService } from "@/node/services/ExtensionMetadataService";
 import { WorkspaceService } from "@/node/services/workspaceService";
 import { TaskService } from "@/node/services/taskService";
@@ -149,6 +152,18 @@ export function createCoreServices(opts: CoreServicesOptions): CoreServices {
     opts.policyService
   );
   aiService.setMCPServerManager(mcpServerManager);
+  // Prompt invocation refreshes from recorded request options, whose secrets
+  // snapshot goes stale on rotation. Mirror the stream path's resolution
+  // (multi-project merge when applicable) so refreshes carry current secrets.
+  mcpServerManager.setSecretsResolver(async (workspaceId, projectPath) => {
+    const metadataResult = await aiService.getWorkspaceMetadata(workspaceId);
+    const metadata = metadataResult.success ? metadataResult.data : null;
+    const secrets =
+      metadata && isMultiProject(metadata)
+        ? mergeMultiProjectSecrets(metadata, config)
+        : config.getEffectiveSecrets(projectPath);
+    return secretsToRecord(secrets);
+  });
 
   const workspaceService = new WorkspaceService(
     config,

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -283,10 +283,9 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       return tools;
     },
     prompts: async (options) => {
-      // Cursorless listPrompts() aggregates every prompts/list page inside the
-      // SDK (capped by ClientOptions.listMaxPages), passing these options to
-      // each page request; tests/ipc/config/mcpPrompts.test.ts pins page-two
-      // coverage against a paginating fixture.
+      // Cursorless listPrompts() aggregates pages up to ClientOptions.listMaxPages
+      // and forwards these options to each request; the integration test covers
+      // page two.
       const result = await client.listPrompts(undefined, {
         timeout: PROMPT_LIST_TIMEOUT_MS,
         ...(options?.signal !== undefined ? { signal: options.signal } : {}),

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -45,6 +45,7 @@ export const MCP_TOOL_CALL_TIMEOUT_MS = 300_000;
  * always wins the race, while the SDK still cleans up abandoned requests.
  */
 const SDK_TOOL_CALL_TIMEOUT_MS = MCP_TOOL_CALL_TIMEOUT_MS + 5_000;
+const PROMPT_GET_TIMEOUT_MS = 30_000;
 
 export interface MCPHttpTransportConfig {
   type: "http" | "sse";
@@ -88,7 +89,11 @@ export interface MCPClientHandle {
   /** Fetch tools/list and build AI SDK tools whose execute calls tools/call. */
   tools(): Promise<Record<string, Tool>>;
   prompts(): Promise<MCPPrompt[]>;
-  getPrompt(name: string, args: Record<string, string>): Promise<MCPGetPromptResult>;
+  getPrompt(
+    name: string,
+    args: Record<string, string>,
+    options?: { signal?: AbortSignal }
+  ): Promise<MCPGetPromptResult>;
   /**
    * The MCP protocol revision negotiated at connect ("2026-07-28" once the
    * server/discover probe finds a modern server; "2025-11-25" or earlier on
@@ -280,11 +285,15 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       assert(Array.isArray(result.prompts), "MCP prompts/list result must carry a prompts array");
       return result.prompts;
     },
-    getPrompt: (name, args) =>
+    getPrompt: (name, args, options) =>
       client.getPrompt(
         { name, arguments: args },
         {
-          timeout: SDK_TOOL_CALL_TIMEOUT_MS,
+          // Prompt expansion blocks send preparation, so it gets a much
+          // tighter deadline than tool calls and honors the send's cancel
+          // signal for prompt recovery of the composer.
+          timeout: PROMPT_GET_TIMEOUT_MS,
+          ...(options?.signal !== undefined ? { signal: options.signal } : {}),
         }
       ),
     negotiatedProtocolVersion: () => client.getNegotiatedProtocolVersion(),

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -20,9 +20,8 @@ import assert from "@/common/utils/assert";
  * plain legacy `initialize` handshake, byte-identical to the previous wire
  * behavior, so existing user-configured servers see no change.
  *
- * This module intentionally mirrors the small surface mcpServerManager
- * consumed from @ai-sdk/mcp (createMCPClient -> { tools(), close() }) so the
- * manager's instance-cache/lease/recycle machinery stays unchanged.
+ * This module keeps transport and request details behind the small handle consumed by
+ * mcpServerManager, preserving its instance-cache, lease, and recycle machinery.
  */
 
 /** Client identity sent to servers (initialize request / clientInfo _meta). */
@@ -209,7 +208,7 @@ function mcpToModelOutput({
 }
 
 /**
- * Connect to an MCP server and return a handle exposing AI SDK tools.
+ * Connect to an MCP server and return a handle for tools and prompts.
  *
  * Version negotiation is per connection (and therefore per configured
  * server): connect() probes with `server/discover` and conservatively falls

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -82,9 +82,14 @@ export interface MCPClientConfig {
   prior?: PriorDiscovery;
 }
 
+export type MCPPrompt = Awaited<ReturnType<Client["listPrompts"]>>["prompts"][number];
+export type MCPGetPromptResult = Awaited<ReturnType<Client["getPrompt"]>>;
+
 export interface MCPClientHandle {
   /** Fetch tools/list and build AI SDK tools whose execute calls tools/call. */
   tools(): Promise<Record<string, Tool>>;
+  prompts(): Promise<MCPPrompt[]>;
+  getPrompt(name: string, args: Record<string, string>): Promise<MCPGetPromptResult>;
   /**
    * The MCP protocol revision negotiated at connect ("2026-07-28" once the
    * server/discover probe finds a modern server; "2025-11-25" or earlier on
@@ -271,6 +276,18 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       }
       return tools;
     },
+    prompts: async () => {
+      const result = await client.listPrompts();
+      assert(Array.isArray(result.prompts), "MCP prompts/list result must carry a prompts array");
+      return result.prompts;
+    },
+    getPrompt: (name, args) =>
+      client.getPrompt(
+        { name, arguments: args },
+        {
+          timeout: SDK_TOOL_CALL_TIMEOUT_MS,
+        }
+      ),
     negotiatedProtocolVersion: () => client.getNegotiatedProtocolVersion(),
     priorDiscovery: (): PriorDiscovery => {
       const discover = client.getDiscoverResult();

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -46,6 +46,8 @@ export const MCP_TOOL_CALL_TIMEOUT_MS = 300_000;
  */
 const SDK_TOOL_CALL_TIMEOUT_MS = MCP_TOOL_CALL_TIMEOUT_MS + 5_000;
 const PROMPT_GET_TIMEOUT_MS = 30_000;
+// One hung server must not stall the whole slash/inline prompt catalog.
+const PROMPT_LIST_TIMEOUT_MS = 10_000;
 
 export interface MCPHttpTransportConfig {
   type: "http" | "sse";
@@ -88,7 +90,7 @@ export type MCPGetPromptResult = Awaited<ReturnType<Client["getPrompt"]>>;
 export interface MCPClientHandle {
   /** Fetch tools/list and build AI SDK tools whose execute calls tools/call. */
   tools(): Promise<Record<string, Tool>>;
-  prompts(): Promise<MCPPrompt[]>;
+  prompts(options?: { signal?: AbortSignal }): Promise<MCPPrompt[]>;
   getPrompt(
     name: string,
     args: Record<string, string>,
@@ -280,8 +282,11 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       }
       return tools;
     },
-    prompts: async () => {
-      const result = await client.listPrompts();
+    prompts: async (options) => {
+      const result = await client.listPrompts(undefined, {
+        timeout: PROMPT_LIST_TIMEOUT_MS,
+        ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+      });
       assert(Array.isArray(result.prompts), "MCP prompts/list result must carry a prompts array");
       return result.prompts;
     },

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -289,9 +289,8 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       client.getPrompt(
         { name, arguments: args },
         {
-          // Prompt expansion blocks send preparation, so it gets a much
-          // tighter deadline than tool calls and honors the send's cancel
-          // signal for prompt recovery of the composer.
+          // Prompt expansion blocks send preparation, so use a shorter timeout than
+          // tool calls and honor send cancellation.
           timeout: PROMPT_GET_TIMEOUT_MS,
           ...(options?.signal !== undefined ? { signal: options.signal } : {}),
         }

--- a/src/node/services/mcpClient.ts
+++ b/src/node/services/mcpClient.ts
@@ -283,6 +283,10 @@ export async function createMCPClient(config: MCPClientConfig): Promise<MCPClien
       return tools;
     },
     prompts: async (options) => {
+      // Cursorless listPrompts() aggregates every prompts/list page inside the
+      // SDK (capped by ClientOptions.listMaxPages), passing these options to
+      // each page request; tests/ipc/config/mcpPrompts.test.ts pins page-two
+      // coverage against a paginating fixture.
       const result = await client.listPrompts(undefined, {
         timeout: PROMPT_LIST_TIMEOUT_MS,
         ...(options?.signal !== undefined ? { signal: options.signal } : {}),

--- a/src/node/services/mcpConfigService.ts
+++ b/src/node/services/mcpConfigService.ts
@@ -227,10 +227,8 @@ export class MCPConfigService {
   }
 
   /**
-   * Bumped after every successful global config write. Global mutations
-   * (setServerEnabled, removeServer) never replace per-workspace recorded
-   * request options, so MCPServerManager compares generations to detect
-   * mutations that land while a server startup is in flight.
+   * Incremented after successful global config writes. Prompt paths compare it
+   * across refreshes because global mutations do not replace workspace options.
    */
   private globalConfigGeneration = 0;
 

--- a/src/node/services/mcpConfigService.ts
+++ b/src/node/services/mcpConfigService.ts
@@ -223,6 +223,19 @@ export class MCPConfigService {
       encoding: "utf-8",
       mode: 0o600,
     });
+    this.globalConfigGeneration += 1;
+  }
+
+  /**
+   * Bumped after every successful global config write. Global mutations
+   * (setServerEnabled, removeServer) never replace per-workspace recorded
+   * request options, so MCPServerManager compares generations to detect
+   * mutations that land while a server startup is in flight.
+   */
+  private globalConfigGeneration = 0;
+
+  get configGeneration(): number {
+    return this.globalConfigGeneration;
   }
 
   /**

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1292,6 +1292,31 @@ describe("MCPServerManager", () => {
     expect(manager.getPrompt("workspace", "coder", "status", {})).rejects.toThrow("not connected");
   });
 
+  test("serializes config-change restarts across concurrent workspace requests", async () => {
+    configService.listServers = mock(() => Promise.resolve({ coder: stdioConfig("cmd-a") }));
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const startServersMock = mock(async () => {
+      if (startServersMock.mock.calls.length > 1) await startGate;
+      return startResult([["coder"]]);
+    });
+    access.startServers = startServersMock;
+
+    await manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    expect(startServersMock).toHaveBeenCalledTimes(1);
+
+    configService.listServers = mock(() => Promise.resolve({ coder: stdioConfig("cmd-b") }));
+    const first = manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    const second = manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    releaseStart();
+    await Promise.all([first, second]);
+
+    // One restart for the config change; the queued caller reuses its result.
+    expect(startServersMock).toHaveBeenCalledTimes(2);
+  });
+
   test("serializes cold-start server startup across concurrent workspace requests", async () => {
     configService.listServers = mock(() => Promise.resolve({ coder: stdioConfig("cmd") }));
     let releaseStart!: () => void;

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1220,19 +1220,15 @@ describe("MCPServerManager", () => {
       return new Map(descriptors.map((d) => [d.promptName, d.commandKey]));
     };
 
-    // "Code-Review" and "code_review" normalize to the same base key.
     const keys = await collectKeys(["Code-Review", "code_review", "status"]);
     const reversedKeys = await collectKeys(["code_review", "Code-Review", "status"]);
 
     expect(keys.get("Code-Review")).toMatch(/^mcp__coder__code_review_[0-9a-f]{8}$/);
     expect(keys.get("code_review")).toMatch(/^mcp__coder__code_review_[0-9a-f]{8}$/);
     expect(keys.get("Code-Review")).not.toBe(keys.get("code_review"));
-    // Keys derive from each prompt's own identity, so ordering cannot swap them.
     expect(reversedKeys).toEqual(keys);
     expect(keys.get("status")).toBe("mcp__coder__status");
 
-    // When the colliding sibling disappears, the survivor's commandKey drops the
-    // suffix, but its stableKey still equals the previously suffixed key.
     const soloDescriptors = await (async () => {
       access.workspaceServers.set("workspace", {
         enabledServerNames: new Set(["coder"]),
@@ -1252,7 +1248,6 @@ describe("MCPServerManager", () => {
       tools: {},
       stats: cachedStats(),
     });
-    // Leased deferred restart: the disabled server's stale client is still cached.
     access.workspaceServers.set("workspace", {
       enabledServerNames: new Set(["enabled"]),
       instances: new Map([
@@ -1354,7 +1349,6 @@ describe("MCPServerManager", () => {
     await manager.getToolsForWorkspace(workspaceRequest("workspace"));
     expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({ text: "Status" });
 
-    // Settings removes the server after the prompt reference was composed.
     configService.listServers = mock(() => Promise.resolve({}));
     // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
     await expect(manager.getPrompt("workspace", "coder", "status", {})).rejects.toThrow("disabled");

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1355,6 +1355,36 @@ describe("MCPServerManager", () => {
     expect(getPrompt).toHaveBeenCalledTimes(1);
   });
 
+  test("applyProjectTrust flips recorded trust so getPrompt refreshes untrusted", async () => {
+    const request = workspaceRequest("workspace", { trusted: true });
+    const otherRequest = workspaceRequest("other-workspace", {
+      projectPath: "/tmp/other-project",
+      trusted: true,
+    });
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+    access.lastWorkspaceRequestOptions.set("other-workspace", otherRequest);
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
+      (options: { workspaceId: string }) => {
+        access.workspaceServers.set(options.workspaceId, {
+          enabledServerNames: new Set(["coder"]),
+          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+        });
+        return Promise.resolve({ tools: {}, stats: cachedStats() });
+      }
+    );
+
+    manager.applyProjectTrust([`${PROJECT_PATH}/`], false);
+    await manager.getPrompt("workspace", "coder", "status", {});
+
+    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false });
+    expect(access.lastWorkspaceRequestOptions.get("other-workspace")).toBe(otherRequest);
+    getToolsSpy.mockRestore();
+  });
+
   test("getPrompt rejects promptly when aborted during refresh startup", async () => {
     access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
     const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -118,6 +118,7 @@ function cachedStats(overrides: Record<string, unknown> = {}) {
 describe("MCPServerManager", () => {
   let configService: {
     listServers: ReturnType<typeof mock>;
+    configGeneration: number;
   };
 
   let manager: MCPServerManager;
@@ -126,6 +127,7 @@ describe("MCPServerManager", () => {
   beforeEach(() => {
     configService = {
       listServers: mock(() => Promise.resolve({})),
+      configGeneration: 0,
     };
 
     manager = new MCPServerManager(configService as unknown as MCPConfigService);
@@ -1095,6 +1097,49 @@ describe("MCPServerManager", () => {
         ["server", { getPrompt }],
         ["stable", { getPrompt }],
       ]);
+    });
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    // Simulate an idle reap that retains recorded request options.
+    access.workspaceServers.delete(workspaceId);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
+  test("blocks prompt invocation when a global disable lands during cold startup", async () => {
+    const workspaceId = "ws-mid-startup-global-disable";
+    let globallyDisabled = false;
+    configService.listServers = mock(() =>
+      Promise.resolve(
+        globallyDisabled
+          ? { stable: stdioConfig("cmd-stable") }
+          : { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+      )
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    let startCount = 0;
+    access.startServers = mock(() => {
+      startCount += 1;
+      if (startCount === 2) {
+        // Global mcp.setEnabled(false) completes while the revival startup is
+        // in flight: it bumps the config generation but never replaces the
+        // recorded per-workspace request options.
+        globallyDisabled = true;
+        configService.configGeneration += 1;
+      }
+      return Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      );
     });
 
     await manager.getToolsForWorkspace(workspaceRequest(workspaceId));

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -961,7 +961,6 @@ describe("MCPServerManager", () => {
       await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
         "was reconfigured while a stream is active"
       );
-      // Unchanged sibling servers stay invocable.
       expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({
         text: "hi",
       });

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1176,6 +1176,44 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("excludes a server when trust is revoked while its prompt catalog refresh is pending", async () => {
+    const workspaceId = "ws-refresh-window-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+
+    // Revoke inside prompts/list: the pre-mutation enabled-instance copy was
+    // already taken when the mutation lands, so only a post-refresh counter
+    // recheck can drop the now-disabled server's descriptors.
+    let revokeOnFirstRefresh = true;
+    const refreshPrompts = mock(() => {
+      if (revokeOnFirstRefresh) {
+        revokeOnFirstRefresh = false;
+        manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      }
+      return Promise.resolve();
+    });
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { prompts: [{ name: "review" }], refreshPrompts }],
+          ["stable", { prompts: [{ name: "status" }], refreshPrompts }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+
+    const descriptors = await manager.getPromptsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: true })
+    );
+    expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
+  });
+
   test("prompt discovery forwards the abort signal to prompt refreshes", async () => {
     const workspaceId = "ws-discovery-signal";
     configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -425,7 +425,6 @@ describe("MCPServerManager", () => {
         () => undefined
       );
 
-      // Concurrent startups finish in nondeterministic order.
       expect(result.failedServerNames.sort()).toEqual(["broken-server", "slow-server"]);
       expect(result.timedOutServerNames).toEqual(["slow-server"]);
     } finally {
@@ -1456,8 +1455,6 @@ describe("MCPServerManager", () => {
     // Simulate an idle reap that retains recorded request options.
     access.workspaceServers.delete(workspaceId);
 
-    // getPrompt detects the mid-startup edit, restarts onto the edited
-    // config, and serves the prompt from the post-edit instance.
     expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
     const entry = access.workspaceServers.get(workspaceId) as { configSignature: string };
     expect(entry.configSignature).toContain("cmd-2");

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1376,7 +1376,12 @@ describe("MCPServerManager", () => {
       }
     );
 
-    manager.applyProjectTrust([`${PROJECT_PATH}/`], false);
+    // Per-path values: a child whose effective trust stays inherited-false must
+    // not pick up a sibling path's true.
+    manager.applyProjectTrust([
+      { projectPath: `${PROJECT_PATH}/`, trusted: false },
+      { projectPath: "/tmp/other-project", trusted: true },
+    ]);
     await manager.getPrompt("workspace", "coder", "status", {});
 
     expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false });

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -969,6 +969,42 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("blocks prompt invocation when trust is revoked during secret resolution", async () => {
+    const workspaceId = "ws-secrets-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+
+    manager.setSecretsResolver(() => {
+      manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      return Promise.resolve({});
+    });
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
   test("blocks prompt invocation on a server disabled during cold startup", async () => {
     const workspaceId = "ws-mid-startup-disable";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -359,6 +359,35 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("startServers overlaps slow startups instead of stacking them serially", async () => {
+    let active = 0;
+    let maxActive = 0;
+    access.startSingleServer = mock(async (name: unknown) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return testInstance(String(name));
+    });
+
+    const result = await access.startServers(
+      {
+        a: stdioConfig("cmd-a"),
+        b: stdioConfig("cmd-b"),
+        c: stdioConfig("cmd-c"),
+      },
+      TEST_RUNTIME,
+      PROJECT_PATH,
+      WORKSPACE_PATH,
+      undefined,
+      () => undefined
+    );
+
+    expect(maxActive).toBeGreaterThan(1);
+    // Concurrent completion order must not perturb the deterministic Map order.
+    expect([...result.instances.keys()]).toEqual(["a", "b", "c"]);
+  });
+
   test("startServers only marks startup timeouts as retryable", async () => {
     const never = Promise.withResolvers<unknown>();
     access.startSingleServerImpl = mock((name: unknown) => {
@@ -394,7 +423,8 @@ describe("MCPServerManager", () => {
         () => undefined
       );
 
-      expect(result.failedServerNames).toEqual(["slow-server", "broken-server"]);
+      // Concurrent startups finish in nondeterministic order.
+      expect(result.failedServerNames.sort()).toEqual(["broken-server", "slow-server"]);
       expect(result.timedOutServerNames).toEqual(["slow-server"]);
     } finally {
       setTimeoutSpy.mockRestore();

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1201,7 +1201,7 @@ describe("MCPServerManager", () => {
       description: "Expanded review",
       text: "Review src\n\n[assistant]\nUse the guide\n\n[assistant]\n[Image content omitted]",
     });
-    expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" });
+    expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" }, undefined);
   });
 
   test("suffixes every member of a colliding prompt key group, independent of order", async () => {

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1292,6 +1292,69 @@ describe("MCPServerManager", () => {
     expect(manager.getPrompt("workspace", "coder", "status", {})).rejects.toThrow("not connected");
   });
 
+  test("serializes cold-start server startup across concurrent workspace requests", async () => {
+    configService.listServers = mock(() => Promise.resolve({ coder: stdioConfig("cmd") }));
+    let releaseStart!: () => void;
+    const startGate = new Promise<void>((resolve) => {
+      releaseStart = resolve;
+    });
+    const startServersMock = mock(async () => {
+      await startGate;
+      return startResult([["coder"]]);
+    });
+    access.startServers = startServersMock;
+
+    const first = manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    const second = manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    releaseStart();
+    await Promise.all([first, second]);
+
+    expect(startServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("getPrompt re-evaluates current config before invoking a cached prompt", async () => {
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    configService.listServers = mock(() => Promise.resolve({ coder: stdioConfig("cmd") }));
+    access.startServers = mock((servers: unknown) => {
+      const names = Object.keys(servers as Record<string, unknown>);
+      return Promise.resolve(
+        startResult(
+          names.map((name) => [name, { getPrompt }] as [string, { getPrompt: typeof getPrompt }])
+        )
+      );
+    });
+
+    await manager.getToolsForWorkspace(workspaceRequest("workspace"));
+    expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({ text: "Status" });
+
+    // Settings removes the server after the prompt reference was composed.
+    configService.listServers = mock(() => Promise.resolve({}));
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt("workspace", "coder", "status", {})).rejects.toThrow("disabled");
+    expect(getPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("getPrompt rejects promptly when aborted during refresh startup", async () => {
+    access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
+      () => new Promise<never>(() => undefined)
+    );
+    const controller = new AbortController();
+    const promptPromise = manager.getPrompt(
+      "workspace",
+      "coder",
+      "status",
+      {},
+      { signal: controller.signal }
+    );
+    controller.abort();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(promptPromise).rejects.toThrow("was aborted");
+    getToolsSpy.mockRestore();
+  });
+
   test("flattens audio and binary resources as omission markers", () => {
     expect(
       flattenMcpPrompt({

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1141,6 +1141,7 @@ describe("MCPServerManager", () => {
       stats: cachedStats(),
     });
     access.workspaceServers.set("workspace", {
+      enabledServerNames: new Set(["Coder Server"]),
       instances: new Map([
         [
           "Coder Server",
@@ -1190,6 +1191,7 @@ describe("MCPServerManager", () => {
       })
     );
     access.workspaceServers.set("workspace", {
+      enabledServerNames: new Set(["coder"]),
       instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
     });
 
@@ -1207,6 +1209,7 @@ describe("MCPServerManager", () => {
     });
     const collectKeys = async (promptNames: string[]) => {
       access.workspaceServers.set("workspace", {
+        enabledServerNames: new Set(["coder"]),
         instances: new Map([
           ["coder", testInstance("coder", { prompts: promptNames.map((name) => ({ name })) })],
         ]),
@@ -1228,6 +1231,26 @@ describe("MCPServerManager", () => {
     getToolsSpy.mockRestore();
   });
 
+  test("excludes disabled servers from prompt discovery and getPrompt", async () => {
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+      tools: {},
+      stats: cachedStats(),
+    });
+    // Leased deferred restart: the disabled server's stale client is still cached.
+    access.workspaceServers.set("workspace", {
+      enabledServerNames: new Set(["enabled"]),
+      instances: new Map([
+        ["enabled", testInstance("enabled", { prompts: [{ name: "status" }] })],
+        ["disabled", testInstance("disabled", { prompts: [{ name: "review" }] })],
+      ]),
+    });
+
+    const descriptors = await manager.getPromptsForWorkspace(workspaceRequest("workspace"));
+    expect(descriptors.map((d) => d.commandKey)).toEqual(["mcp__enabled__status"]);
+    expect(manager.getPrompt("workspace", "disabled", "review", {})).rejects.toThrow("disabled");
+    getToolsSpy.mockRestore();
+  });
+
   test("getPrompt revives reaped servers from the last workspace request options", async () => {
     const getPrompt = mock(() =>
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
@@ -1235,6 +1258,7 @@ describe("MCPServerManager", () => {
     const request = workspaceRequest("workspace");
     const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(() => {
       access.workspaceServers.set("workspace", {
+        enabledServerNames: new Set(["coder"]),
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
       });
       return Promise.resolve({ tools: {}, stats: cachedStats() });

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -70,6 +70,7 @@ function testInstance(
     }>;
     getPrompt?: ReturnType<typeof mock>;
     refreshTools?: ReturnType<typeof mock>;
+    refreshPrompts?: ReturnType<typeof mock>;
     close?: ReturnType<typeof mock>;
     isClosed?: boolean;
   } = {}
@@ -82,6 +83,7 @@ function testInstance(
     prompts: options.prompts ?? [],
     getPrompt: options.getPrompt ?? mock(() => Promise.resolve({ messages: [] })),
     ...(options.refreshTools !== undefined ? { refreshTools: options.refreshTools } : {}),
+    ...(options.refreshPrompts !== undefined ? { refreshPrompts: options.refreshPrompts } : {}),
     isClosed: options.isClosed ?? false,
     close: options.close ?? mock(() => Promise.resolve(undefined)),
   };
@@ -1133,6 +1135,66 @@ describe("MCPServerManager", () => {
       "is disabled"
     );
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
+  test("excludes a server from prompt discovery when trust is revoked right after the refresh", async () => {
+    const workspaceId = "ws-post-refresh-discovery-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { prompts: [{ name: "review" }] }],
+          ["stable", { prompts: [{ name: "status" }] }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+
+    // Revoke in the gap after the discovery refresh resolves but before the
+    // enablement copy runs.
+    const originalEnsure = access.ensureWorkspaceServers.bind(manager);
+    let revokeAfterRefresh = true;
+    access.ensureWorkspaceServers = async (...args: unknown[]) => {
+      const result = await originalEnsure(...args);
+      if (revokeAfterRefresh) {
+        revokeAfterRefresh = false;
+        manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      }
+      return result;
+    };
+
+    const descriptors = await manager.getPromptsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: true })
+    );
+    expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
+  });
+
+  test("prompt discovery forwards the abort signal to prompt refreshes", async () => {
+    const workspaceId = "ws-discovery-signal";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+    const refreshPrompts = mock((_options?: { signal?: AbortSignal }) => Promise.resolve());
+    access.startServers = mock(() =>
+      Promise.resolve(startResult([["server", { refreshPrompts }]]))
+    );
+
+    const controller = new AbortController();
+    await manager.getPromptsForWorkspace(workspaceRequest(workspaceId), {
+      signal: controller.signal,
+    });
+    expect(refreshPrompts).toHaveBeenCalledWith({ signal: controller.signal });
+
+    controller.abort();
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(
+      manager.getPromptsForWorkspace(workspaceRequest(workspaceId), { signal: controller.signal })
+    ).rejects.toThrow("aborted");
   });
 
   test("blocks prompt invocation when trust is revoked right after the prompt refresh", async () => {

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1204,6 +1204,33 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("prompt discovery refreshes with resolver-provided secrets and retries on mid-flight rotation", async () => {
+    const request = workspaceRequest("workspace", { projectSecrets: { TOKEN: "recorded" } });
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+    // First resolution returns the pre-rotation token; every later one returns
+    // the rotated token, so the post-refresh recheck must force one retry.
+    let resolveCount = 0;
+    manager.setSecretsResolver(() => {
+      resolveCount += 1;
+      return Promise.resolve({ TOKEN: resolveCount === 1 ? "old" : "new" });
+    });
+    const ensureSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
+      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+        enabledServerNames: new Set(["coder"]),
+        instances: new Map([["coder", testInstance("coder", { prompts: [{ name: "status" }] })]]),
+      });
+      return Promise.resolve({ tools: {}, stats: cachedStats() });
+    });
+
+    const descriptors = await manager.getPromptsForWorkspace(workspaceRequest("workspace"));
+
+    expect(descriptors.map((descriptor) => descriptor.promptName)).toEqual(["status"]);
+    expect(ensureSpy).toHaveBeenCalledTimes(2);
+    expect(ensureSpy.mock.calls[0]?.[0]).toEqual({ ...request, projectSecrets: { TOKEN: "old" } });
+    expect(ensureSpy.mock.calls[1]?.[0]).toEqual({ ...request, projectSecrets: { TOKEN: "new" } });
+    ensureSpy.mockRestore();
+  });
+
   test("forgotten project trust no longer overrides a re-registered project's snapshot", async () => {
     const workspaceId = "ws-forgotten-trust";
     configService.listServers = mock((_projectPath: string, trusted: boolean) =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -969,6 +969,79 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("blocks prompt invocation on a server disabled during cold startup", async () => {
+    const workspaceId = "ws-mid-startup-disable";
+    configService.listServers = mock(() =>
+      Promise.resolve({
+        server: stdioConfig("cmd-1"),
+        stable: stdioConfig("cmd-stable"),
+      })
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    let startCount = 0;
+    access.startServers = mock(async () => {
+      startCount += 1;
+      if (startCount === 2) {
+        // Settings mutation lands while the revival startup is in flight.
+        await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["server"] });
+      }
+      return startResult([
+        ["server", { getPrompt }],
+        ["stable", { getPrompt }],
+      ]);
+    });
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    // Simulate an idle reap that retains recorded request options.
+    access.workspaceServers.delete(workspaceId);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
+  test("blocks prompt invocation when project trust is revoked during cold startup", async () => {
+    const workspaceId = "ws-mid-startup-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    let startCount = 0;
+    access.startServers = mock(() => {
+      startCount += 1;
+      if (startCount === 2) {
+        manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      }
+      return Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      );
+    });
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+    access.workspaceServers.delete(workspaceId);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
   test("getToolsForWorkspace restarts when cached instances are marked closed", async () => {
     const workspaceId = "ws-closed";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1308,7 +1308,6 @@ describe("MCPServerManager", () => {
     releaseStart();
     await Promise.all([first, second]);
 
-    // One restart for the config change; the queued caller reuses its result.
     expect(startServersMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1204,6 +1204,24 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("closes late-started servers instead of caching them for a removed workspace", async () => {
+    const workspaceId = "ws-removed-mid-startup";
+    const close = mock(() => Promise.resolve());
+    access.startServers = mock(async () => {
+      // Workspace removal lands while startup is in flight: abort-abandoned
+      // discovery keeps the startup running, and removal's stopServers finds
+      // no cache entry to close.
+      await manager.stopServers(workspaceId);
+      return startResult([["server", { close }]]);
+    });
+
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    expect(Object.keys(result.tools)).toEqual([]);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(access.workspaceServers.has(workspaceId)).toBe(false);
+  });
+
   test("prompt discovery refreshes with resolver-provided secrets and retries on mid-flight rotation", async () => {
     const request = workspaceRequest("workspace", { projectSecrets: { TOKEN: "recorded" } });
     access.lastWorkspaceRequestOptions.set("workspace", request);

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -929,6 +929,47 @@ describe("MCPServerManager", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  test("blocks prompt invocation on servers reconfigured while leased", async () => {
+    const workspaceId = "ws-stale-prompt";
+    let command = "cmd-1";
+    configService.listServers = mock(() =>
+      Promise.resolve({
+        server: { transport: "stdio", command, disabled: false },
+        stable: stdioConfig("cmd-stable"),
+      })
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    manager.acquireLease(workspaceId);
+    command = "cmd-2";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+      await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+        "was reconfigured while a stream is active"
+      );
+      // Unchanged sibling servers stay invocable.
+      expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({
+        text: "hi",
+      });
+    } finally {
+      manager.releaseLease(workspaceId);
+    }
+  });
+
   test("getToolsForWorkspace restarts when cached instances are marked closed", async () => {
     const workspaceId = "ws-closed";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1204,6 +1204,23 @@ describe("MCPServerManager", () => {
     expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" }, undefined);
   });
 
+  test("rejects empty and whitespace-only prompt expansions", async () => {
+    const getPrompt = mock(() =>
+      Promise.resolve({
+        messages: [{ role: "user", content: { type: "text", text: "   \n\n  " } }],
+      })
+    );
+    access.workspaceServers.set("workspace", {
+      enabledServerNames: new Set(["coder"]),
+      instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt("workspace", "coder", "review", {})).rejects.toThrow(
+      "MCP prompt 'coder/review' returned no text content"
+    );
+  });
+
   test("suffixes every member of a colliding prompt key group, independent of order", async () => {
     const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
       tools: {},

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -966,7 +966,7 @@ describe("MCPServerManager", () => {
     try {
       // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
       await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
-        "was reconfigured while a stream is active"
+        "was reconfigured"
       );
       expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({
         text: "hi",
@@ -1150,6 +1150,46 @@ describe("MCPServerManager", () => {
     await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
       "is disabled"
     );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
+  test("blocks prompt invocation when a server's config is edited during cold startup", async () => {
+    const workspaceId = "ws-mid-startup-config-edit";
+    let command = "cmd-1";
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig(command), stable: stdioConfig("cmd-stable") })
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    let startCount = 0;
+    access.startServers = mock(() => {
+      startCount += 1;
+      if (startCount === 2) {
+        // Settings edits the server command while the revival startup is in
+        // flight: the enabled set is unchanged, so only the start-config
+        // signature reveals that the just-started instance is stale.
+        command = "cmd-2";
+        configService.configGeneration += 1;
+      }
+      return Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      );
+    });
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    // Simulate an idle reap that retains recorded request options.
+    access.workspaceServers.delete(workspaceId);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "was reconfigured"
+    );
+    // The untouched sibling server keeps serving prompts.
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
   });
 

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1074,6 +1074,50 @@ describe("MCPServerManager", () => {
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
   });
 
+  test("blocks prompt invocation when trust is revoked right after the prompt refresh", async () => {
+    const workspaceId = "ws-post-refresh-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+
+    // Revoke in the gap after the prompt refresh resolves but before the
+    // enablement check runs.
+    const originalEnsure = access.ensureWorkspaceServers.bind(manager);
+    let revokeAfterRefresh = true;
+    access.ensureWorkspaceServers = async (...args: unknown[]) => {
+      const result = await originalEnsure(...args);
+      if (revokeAfterRefresh) {
+        revokeAfterRefresh = false;
+        manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      }
+      return result;
+    };
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
   test("blocks prompt invocation on a server disabled during cold startup", async () => {
     const workspaceId = "ws-mid-startup-disable";
     configService.listServers = mock(() =>
@@ -1185,12 +1229,11 @@ describe("MCPServerManager", () => {
     // Simulate an idle reap that retains recorded request options.
     access.workspaceServers.delete(workspaceId);
 
-    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
-    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
-      "was reconfigured"
-    );
-    // The untouched sibling server keeps serving prompts.
-    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+    // getPrompt detects the mid-startup edit, restarts onto the edited
+    // config, and serves the prompt from the post-edit instance.
+    expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
+    const entry = access.workspaceServers.get(workspaceId) as { configSignature: string };
+    expect(entry.configSignature).toContain("cmd-2");
   });
 
   test("blocks prompt invocation when project trust is revoked during cold startup", async () => {

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1385,6 +1385,53 @@ describe("MCPServerManager", () => {
     getToolsSpy.mockRestore();
   });
 
+  test("getPrompt refreshes with resolver-provided secrets instead of the recorded snapshot", async () => {
+    const request = workspaceRequest("workspace", { projectSecrets: { TOKEN: "old" } });
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+    manager.setSecretsResolver(() => Promise.resolve({ TOKEN: "new" }));
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
+      (options: { workspaceId: string }) => {
+        access.workspaceServers.set(options.workspaceId, {
+          enabledServerNames: new Set(["coder"]),
+          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+        });
+        return Promise.resolve({ tools: {}, stats: cachedStats() });
+      }
+    );
+
+    await manager.getPrompt("workspace", "coder", "status", {});
+
+    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, projectSecrets: { TOKEN: "new" } });
+    getToolsSpy.mockRestore();
+  });
+
+  test("getPrompt falls back to the recorded secrets snapshot when the resolver fails", async () => {
+    const request = workspaceRequest("workspace", { projectSecrets: { TOKEN: "old" } });
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+    manager.setSecretsResolver(() => Promise.reject(new Error("config unavailable")));
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
+      (options: { workspaceId: string }) => {
+        access.workspaceServers.set(options.workspaceId, {
+          enabledServerNames: new Set(["coder"]),
+          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+        });
+        return Promise.resolve({ tools: {}, stats: cachedStats() });
+      }
+    );
+
+    expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({ text: "Status" });
+    expect(getToolsSpy).toHaveBeenCalledWith(request);
+    getToolsSpy.mockRestore();
+  });
+
   test("getPrompt rejects promptly when aborted during refresh startup", async () => {
     access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
     const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1033,6 +1033,45 @@ describe("MCPServerManager", () => {
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
   });
 
+  test("blocks prompt invocation when trust is revoked during a same-signature refresh", async () => {
+    const workspaceId = "ws-cached-trust";
+    // Arm after cold start so revocation lands inside the prompt refresh's
+    // config derivation, where the same-signature fast path returns cached servers.
+    let revokeOnNextTrustedList = false;
+    configService.listServers = mock((_projectPath: string, trusted: boolean) => {
+      if (revokeOnNextTrustedList && trusted) {
+        revokeOnNextTrustedList = false;
+        manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+      }
+      return Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      );
+    });
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { getPrompt }],
+          ["stable", { getPrompt }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId, { trusted: true }));
+    revokeOnNextTrustedList = true;
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
   test("blocks prompt invocation on a server disabled during cold startup", async () => {
     const workspaceId = "ws-mid-startup-disable";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1200,6 +1200,34 @@ describe("MCPServerManager", () => {
     expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" });
   });
 
+  test("suffixes every member of a colliding prompt key group, independent of order", async () => {
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+      tools: {},
+      stats: cachedStats(),
+    });
+    const collectKeys = async (promptNames: string[]) => {
+      access.workspaceServers.set("workspace", {
+        instances: new Map([
+          ["coder", testInstance("coder", { prompts: promptNames.map((name) => ({ name })) })],
+        ]),
+      });
+      const descriptors = await manager.getPromptsForWorkspace(workspaceRequest("workspace"));
+      return new Map(descriptors.map((d) => [d.promptName, d.commandKey]));
+    };
+
+    // "Code-Review" and "code_review" normalize to the same base key.
+    const keys = await collectKeys(["Code-Review", "code_review", "status"]);
+    const reversedKeys = await collectKeys(["code_review", "Code-Review", "status"]);
+
+    expect(keys.get("Code-Review")).toMatch(/^mcp__coder__code_review_[0-9a-f]{8}$/);
+    expect(keys.get("code_review")).toMatch(/^mcp__coder__code_review_[0-9a-f]{8}$/);
+    expect(keys.get("Code-Review")).not.toBe(keys.get("code_review"));
+    // Keys derive from each prompt's own identity, so ordering cannot swap them.
+    expect(reversedKeys).toEqual(keys);
+    expect(keys.get("status")).toBe("mcp__coder__status");
+    getToolsSpy.mockRestore();
+  });
+
   test("getPrompt revives reaped servers from the last workspace request options", async () => {
     const getPrompt = mock(() =>
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1158,15 +1158,17 @@ describe("MCPServerManager", () => {
       ]),
     });
 
-    expect(await manager.getPromptsForWorkspace(workspaceRequest("workspace"))).toEqual([
-      {
-        commandKey: "mcp__coder_server__code_review",
-        serverName: "Coder Server",
-        promptName: "Code Review",
-        description: "Review code",
-        arguments: [{ name: "path", required: true }],
-      },
-    ]);
+    const listed = await manager.getPromptsForWorkspace(workspaceRequest("workspace"));
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.stableKey).toMatch(/^mcp__coder_server__code_review_[0-9a-f]{8}$/);
+    expect(listed[0]).toEqual({
+      commandKey: "mcp__coder_server__code_review",
+      stableKey: listed[0]?.stableKey ?? "",
+      serverName: "Coder Server",
+      promptName: "Code Review",
+      description: "Review code",
+      arguments: [{ name: "path", required: true }],
+    });
     getToolsSpy.mockRestore();
   });
 
@@ -1228,6 +1230,20 @@ describe("MCPServerManager", () => {
     // Keys derive from each prompt's own identity, so ordering cannot swap them.
     expect(reversedKeys).toEqual(keys);
     expect(keys.get("status")).toBe("mcp__coder__status");
+
+    // When the colliding sibling disappears, the survivor's commandKey drops the
+    // suffix, but its stableKey still equals the previously suffixed key.
+    const soloDescriptors = await (async () => {
+      access.workspaceServers.set("workspace", {
+        enabledServerNames: new Set(["coder"]),
+        instances: new Map([
+          ["coder", testInstance("coder", { prompts: [{ name: "code_review" }] })],
+        ]),
+      });
+      return manager.getPromptsForWorkspace(workspaceRequest("workspace"));
+    })();
+    expect(soloDescriptors[0]?.commandKey).toBe("mcp__coder__code_review");
+    expect(soloDescriptors[0]?.stableKey).toBe(keys.get("code_review") ?? "");
     getToolsSpy.mockRestore();
   });
 

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -21,6 +21,7 @@ import type { Tool } from "ai";
 
 interface MCPServerManagerTestAccess {
   workspaceServers: Map<string, unknown>;
+  lastWorkspaceRequestOptions: Map<string, unknown>;
   cleanupIdleServers: () => void;
   startServers: (...args: unknown[]) => Promise<{
     instances: Map<string, unknown>;
@@ -1197,6 +1198,30 @@ describe("MCPServerManager", () => {
       text: "Review src\n\n[assistant]\nUse the guide\n\n[assistant]\n[Image content omitted]",
     });
     expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" });
+  });
+
+  test("getPrompt revives reaped servers from the last workspace request options", async () => {
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
+    );
+    const request = workspaceRequest("workspace");
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(() => {
+      access.workspaceServers.set("workspace", {
+        instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+      });
+      return Promise.resolve({ tools: {}, stats: cachedStats() });
+    });
+    access.lastWorkspaceRequestOptions.set("workspace", request);
+
+    expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({
+      text: "Status",
+    });
+    expect(getToolsSpy).toHaveBeenCalledWith(request);
+    getToolsSpy.mockRestore();
+  });
+
+  test("getPrompt fails when the server is gone and no restart options are cached", () => {
+    expect(manager.getPrompt("workspace", "coder", "status", {})).rejects.toThrow("not connected");
   });
 
   test("flattens audio and binary resources as omission markers", () => {

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1074,6 +1074,37 @@ describe("MCPServerManager", () => {
     expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
   });
 
+  test("applies overrides recorded before the first workspace request (cold mutation)", async () => {
+    const workspaceId = "ws-cold-overrides";
+    configService.listServers = mock(() =>
+      Promise.resolve({ server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") })
+    );
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    access.startServers = mock((servers) =>
+      Promise.resolve(
+        startResult(
+          Object.keys(servers as Record<string, unknown>).map((name) => [name, { getPrompt }])
+        )
+      )
+    );
+
+    // workspace.mcp.set lands while the manager is cold (no recorded options,
+    // no cache entry), then a caller that read pre-mutation persisted
+    // overrides starts the workspace with a stale snapshot.
+    await manager.applyWorkspaceOverrides(workspaceId, { disabledServers: ["server"] });
+    const result = await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    expect(result.stats.enabledServerCount).toBe(1);
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- bun-types mistype .rejects.toThrow as void
+    await expect(manager.getPrompt(workspaceId, "server", "review", {})).rejects.toThrow(
+      "is disabled"
+    );
+    expect(await manager.getPrompt(workspaceId, "stable", "review", {})).toEqual({ text: "hi" });
+  });
+
   test("blocks prompt invocation when trust is revoked right after the prompt refresh", async () => {
     const workspaceId = "ws-post-refresh-trust";
     configService.listServers = mock((_projectPath: string, trusted: boolean) =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import * as mcpSdk from "@/node/services/mcpClient";
 import {
   MCPServerManager,
+  flattenMcpPrompt,
   isClosedClientError,
   prepareStdioLaunch,
   runMCPToolWithDeadline,
@@ -58,6 +59,12 @@ function testInstance(
   name: string,
   options: {
     tools?: Record<string, Tool>;
+    prompts?: Array<{
+      name: string;
+      description?: string;
+      arguments?: Array<{ name: string; description?: string; required?: boolean }>;
+    }>;
+    getPrompt?: ReturnType<typeof mock>;
     close?: ReturnType<typeof mock>;
     isClosed?: boolean;
   } = {}
@@ -67,6 +74,8 @@ function testInstance(
     resolvedTransport: "stdio" as const,
     autoFallbackUsed: false,
     tools: options.tools ?? {},
+    prompts: options.prompts ?? [],
+    getPrompt: options.getPrompt ?? mock(() => Promise.resolve({ messages: [] })),
     isClosed: options.isClosed ?? false,
     close: options.close ?? mock(() => Promise.resolve(undefined)),
   };
@@ -95,7 +104,7 @@ function cachedStats(overrides: Record<string, unknown> = {}) {
     hasStdio: false,
     hasHttp: false,
     hasSse: false,
-    transportMode: "none",
+    transportMode: "none" as const,
     ...overrides,
   };
 }
@@ -1125,6 +1134,88 @@ describe("MCPServerManager", () => {
     expect(Object.keys(firstStartedServers ?? {})).toEqual(["global"]);
     expect(Object.keys(secondStartedServers ?? {}).sort()).toEqual(["global", "repo"]);
   });
+  test("lists namespaced prompt descriptors from connected instances", async () => {
+    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+      tools: {},
+      stats: cachedStats(),
+    });
+    access.workspaceServers.set("workspace", {
+      instances: new Map([
+        [
+          "Coder Server",
+          testInstance("Coder Server", {
+            prompts: [
+              {
+                name: "Code Review",
+                description: "Review code",
+                arguments: [{ name: "path", required: true }],
+              },
+            ],
+          }),
+        ],
+      ]),
+    });
+
+    expect(await manager.getPromptsForWorkspace(workspaceRequest("workspace"))).toEqual([
+      {
+        commandKey: "mcp__coder_server__code_review",
+        serverName: "Coder Server",
+        promptName: "Code Review",
+        description: "Review code",
+        arguments: [{ name: "path", required: true }],
+      },
+    ]);
+    getToolsSpy.mockRestore();
+  });
+
+  test("forwards prompt arguments and flattens supported content", async () => {
+    const getPrompt = mock(() =>
+      Promise.resolve({
+        description: "Expanded review",
+        messages: [
+          { role: "user", content: { type: "text", text: "Review src" } },
+          {
+            role: "assistant",
+            content: {
+              type: "resource",
+              resource: { uri: "file:///guide", text: "Use the guide" },
+            },
+          },
+          {
+            role: "assistant",
+            content: { type: "image", data: "abc", mimeType: "image/png" },
+          },
+        ],
+      })
+    );
+    access.workspaceServers.set("workspace", {
+      instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+    });
+
+    expect(await manager.getPrompt("workspace", "coder", "review", { path: "src" })).toEqual({
+      description: "Expanded review",
+      text: "Review src\n\n[assistant]\nUse the guide\n\n[assistant]\n[Image content omitted]",
+    });
+    expect(getPrompt).toHaveBeenCalledWith("review", { path: "src" });
+  });
+
+  test("flattens audio and binary resources as omission markers", () => {
+    expect(
+      flattenMcpPrompt({
+        messages: [
+          {
+            role: "user",
+            content: { type: "audio", data: "abc", mimeType: "audio/wav" },
+          },
+          {
+            role: "user",
+            content: { type: "resource", resource: { uri: "file:///blob", blob: "abc" } },
+          },
+        ],
+      })
+    ).toBe("[Audio content omitted]\n\n[Resource content omitted]");
+  });
+
   test("test() includes oauthChallenge when server responds 401 + WWW-Authenticate Bearer", async () => {
     let baseUrl = "";
     let resourceMetadataUrl = "";

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1376,8 +1376,6 @@ describe("MCPServerManager", () => {
       }
     );
 
-    // Per-path values: a child whose effective trust stays inherited-false must
-    // not pick up a sibling path's true.
     manager.applyProjectTrust([
       { projectPath: `${PROJECT_PATH}/`, trusted: false },
       { projectPath: "/tmp/other-project", trusted: true },

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1204,6 +1204,35 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("forgotten project trust no longer overrides a re-registered project's snapshot", async () => {
+    const workspaceId = "ws-forgotten-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { prompts: [{ name: "review" }] }],
+          ["stable", { prompts: [{ name: "status" }] }],
+        ])
+      )
+    );
+
+    // A trust grant retained past project removal must not resurrect on the
+    // same path's next registration, which starts untrusted.
+    manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: true }]);
+    manager.forgetProjectTrust(PROJECT_PATH);
+
+    const descriptors = await manager.getPromptsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: false })
+    );
+    expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
+  });
+
   test("excludes servers reconfigured while leased from prompt discovery", async () => {
     const workspaceId = "ws-stale-prompt-discovery";
     let command = "cmd-1";

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -23,6 +23,9 @@ interface MCPServerManagerTestAccess {
   workspaceServers: Map<string, unknown>;
   lastWorkspaceRequestOptions: Map<string, unknown>;
   cleanupIdleServers: () => void;
+  ensureWorkspaceServers: (
+    ...args: unknown[]
+  ) => Promise<{ tools: Record<string, Tool>; stats: unknown }>;
   startServers: (...args: unknown[]) => Promise<{
     instances: Map<string, unknown>;
     failedServerNames: string[];
@@ -66,6 +69,7 @@ function testInstance(
       arguments?: Array<{ name: string; description?: string; required?: boolean }>;
     }>;
     getPrompt?: ReturnType<typeof mock>;
+    refreshTools?: ReturnType<typeof mock>;
     close?: ReturnType<typeof mock>;
     isClosed?: boolean;
   } = {}
@@ -77,6 +81,7 @@ function testInstance(
     tools: options.tools ?? {},
     prompts: options.prompts ?? [],
     getPrompt: options.getPrompt ?? mock(() => Promise.resolve({ messages: [] })),
+    ...(options.refreshTools !== undefined ? { refreshTools: options.refreshTools } : {}),
     isClosed: options.isClosed ?? false,
     close: options.close ?? mock(() => Promise.resolve(undefined)),
   };
@@ -969,6 +974,29 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("prompt paths skip cached tool catalog refreshes", async () => {
+    const workspaceId = "ws-skip-tool-refresh";
+    configService.listServers = mock(() => Promise.resolve({ server: stdioConfig("cmd-1") }));
+
+    const getPrompt = mock(() =>
+      Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "hi" } }] })
+    );
+    const refreshTools = mock(() => Promise.resolve(undefined));
+    access.startServers = mock(() =>
+      Promise.resolve(startResult([["server", { getPrompt, refreshTools }]]))
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    const toolPathRefreshCount = refreshTools.mock.calls.length;
+    expect(toolPathRefreshCount).toBeGreaterThan(0);
+
+    // A hung tools/list on any server must not stall prompt listing or invocation.
+    await manager.getPromptsForWorkspace(workspaceRequest(workspaceId));
+    expect(await manager.getPrompt(workspaceId, "server", "review", {})).toEqual({ text: "hi" });
+    expect(refreshTools).toHaveBeenCalledTimes(toolPathRefreshCount);
+  });
+
   test("blocks prompt invocation when trust is revoked during secret resolution", async () => {
     const workspaceId = "ws-secrets-trust";
     configService.listServers = mock((_projectPath: string, trusted: boolean) =>
@@ -1285,7 +1313,7 @@ describe("MCPServerManager", () => {
     expect(Object.keys(secondStartedServers ?? {}).sort()).toEqual(["global", "repo"]);
   });
   test("lists namespaced prompt descriptors from connected instances", async () => {
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
     });
@@ -1371,7 +1399,7 @@ describe("MCPServerManager", () => {
   });
 
   test("suffixes every member of a colliding prompt key group, independent of order", async () => {
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
     });
@@ -1410,7 +1438,7 @@ describe("MCPServerManager", () => {
   });
 
   test("excludes disabled servers from prompt discovery and getPrompt", async () => {
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockResolvedValue({
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockResolvedValue({
       tools: {},
       stats: cachedStats(),
     });
@@ -1433,7 +1461,7 @@ describe("MCPServerManager", () => {
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
     const request = workspaceRequest("workspace");
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(() => {
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation(() => {
       access.workspaceServers.set("workspace", {
         enabledServerNames: new Set(["coder"]),
         instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
@@ -1445,7 +1473,7 @@ describe("MCPServerManager", () => {
     expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({
       text: "Status",
     });
-    expect(getToolsSpy).toHaveBeenCalledWith(request);
+    expect(getToolsSpy).toHaveBeenCalledWith(request, false);
     getToolsSpy.mockRestore();
   });
 
@@ -1532,15 +1560,13 @@ describe("MCPServerManager", () => {
     const getPrompt = mock(() =>
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
-      (options: { workspaceId: string }) => {
-        access.workspaceServers.set(options.workspaceId, {
-          enabledServerNames: new Set(["coder"]),
-          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
-        });
-        return Promise.resolve({ tools: {}, stats: cachedStats() });
-      }
-    );
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
+      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+        enabledServerNames: new Set(["coder"]),
+        instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+      });
+      return Promise.resolve({ tools: {}, stats: cachedStats() });
+    });
 
     manager.applyProjectTrust([
       { projectPath: `${PROJECT_PATH}/`, trusted: false },
@@ -1548,7 +1574,7 @@ describe("MCPServerManager", () => {
     ]);
     await manager.getPrompt("workspace", "coder", "status", {});
 
-    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false });
+    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, trusted: false }, false);
     expect(access.lastWorkspaceRequestOptions.get("other-workspace")).toBe(otherRequest);
     getToolsSpy.mockRestore();
   });
@@ -1561,19 +1587,20 @@ describe("MCPServerManager", () => {
     const getPrompt = mock(() =>
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
-      (options: { workspaceId: string }) => {
-        access.workspaceServers.set(options.workspaceId, {
-          enabledServerNames: new Set(["coder"]),
-          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
-        });
-        return Promise.resolve({ tools: {}, stats: cachedStats() });
-      }
-    );
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
+      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+        enabledServerNames: new Set(["coder"]),
+        instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+      });
+      return Promise.resolve({ tools: {}, stats: cachedStats() });
+    });
 
     await manager.getPrompt("workspace", "coder", "status", {});
 
-    expect(getToolsSpy).toHaveBeenCalledWith({ ...request, projectSecrets: { TOKEN: "new" } });
+    expect(getToolsSpy).toHaveBeenCalledWith(
+      { ...request, projectSecrets: { TOKEN: "new" } },
+      false
+    );
     getToolsSpy.mockRestore();
   });
 
@@ -1585,24 +1612,22 @@ describe("MCPServerManager", () => {
     const getPrompt = mock(() =>
       Promise.resolve({ messages: [{ role: "user", content: { type: "text", text: "Status" } }] })
     );
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
-      (options: { workspaceId: string }) => {
-        access.workspaceServers.set(options.workspaceId, {
-          enabledServerNames: new Set(["coder"]),
-          instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
-        });
-        return Promise.resolve({ tools: {}, stats: cachedStats() });
-      }
-    );
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation((options) => {
+      access.workspaceServers.set((options as { workspaceId: string }).workspaceId, {
+        enabledServerNames: new Set(["coder"]),
+        instances: new Map([["coder", testInstance("coder", { getPrompt })]]),
+      });
+      return Promise.resolve({ tools: {}, stats: cachedStats() });
+    });
 
     expect(await manager.getPrompt("workspace", "coder", "status", {})).toEqual({ text: "Status" });
-    expect(getToolsSpy).toHaveBeenCalledWith(request);
+    expect(getToolsSpy).toHaveBeenCalledWith(request, false);
     getToolsSpy.mockRestore();
   });
 
   test("getPrompt rejects promptly when aborted during refresh startup", async () => {
     access.lastWorkspaceRequestOptions.set("workspace", workspaceRequest("workspace"));
-    const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation(
+    const getToolsSpy = spyOn(access, "ensureWorkspaceServers").mockImplementation(
       () => new Promise<never>(() => undefined)
     );
     const controller = new AbortController();

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1176,6 +1176,43 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("excludes servers reconfigured while leased from prompt discovery", async () => {
+    const workspaceId = "ws-stale-prompt-discovery";
+    let command = "cmd-1";
+    configService.listServers = mock(() =>
+      Promise.resolve({
+        server: { transport: "stdio", command, disabled: false },
+        stable: stdioConfig("cmd-stable"),
+      })
+    );
+
+    const refreshPrompts = mock(() => Promise.resolve());
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { prompts: [{ name: "review" }], refreshPrompts }],
+          ["stable", { prompts: [{ name: "status" }], refreshPrompts }],
+        ])
+      )
+    );
+
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+    manager.acquireLease(workspaceId);
+    command = "cmd-2";
+    await manager.getToolsForWorkspace(workspaceRequest(workspaceId));
+
+    try {
+      refreshPrompts.mockClear();
+      const descriptors = await manager.getPromptsForWorkspace(workspaceRequest(workspaceId));
+      expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
+      // The stale instance still points at the old endpoint; discovery must
+      // not send prompts/list there with potentially obsolete credentials.
+      expect(refreshPrompts).toHaveBeenCalledTimes(1);
+    } finally {
+      manager.releaseLease(workspaceId);
+    }
+  });
+
   test("excludes a server when trust is revoked while its prompt catalog refresh is pending", async () => {
     const workspaceId = "ws-refresh-window-trust";
     configService.listServers = mock((_projectPath: string, trusted: boolean) =>

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1176,6 +1176,35 @@ describe("MCPServerManager", () => {
     expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
   });
 
+  test("overlays a trust revocation recorded before a cold workspace's first request", async () => {
+    const workspaceId = "ws-cold-trust";
+    configService.listServers = mock((_projectPath: string, trusted: boolean) =>
+      Promise.resolve(
+        trusted
+          ? { server: stdioConfig("cmd-1"), stable: stdioConfig("cmd-stable") }
+          : { stable: stdioConfig("cmd-stable") }
+      )
+    );
+    access.startServers = mock(() =>
+      Promise.resolve(
+        startResult([
+          ["server", { prompts: [{ name: "review" }] }],
+          ["stable", { prompts: [{ name: "status" }] }],
+        ])
+      )
+    );
+
+    // Revocation lands while the workspace is cold (no recorded options), so
+    // only the retained per-project trust can correct the stale snapshot the
+    // stream captured before the revocation.
+    manager.applyProjectTrust([{ projectPath: PROJECT_PATH, trusted: false }]);
+
+    const descriptors = await manager.getPromptsForWorkspace(
+      workspaceRequest(workspaceId, { trusted: true })
+    );
+    expect(descriptors.map((descriptor) => descriptor.serverName)).toEqual(["stable"]);
+  });
+
   test("excludes servers reconfigured while leased from prompt discovery", async () => {
     const workspaceId = "ws-stale-prompt-discovery";
     let command = "cmd-1";

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1271,6 +1271,11 @@ export class MCPServerManager {
 
     this.lastWorkspaceRequestOptions.set(workspaceId, options);
 
+    // Global mutations (mcp.setEnabled / mcp.remove) bump the config
+    // generation without replacing recorded options; capture it before config
+    // reads so enablement repair can detect them.
+    const configGenerationUsed = this.configService.configGeneration;
+
     // Fetch full server info for project-level allowlists and server filtering
     const allServers = await this.getAllServers(projectPath, trusted, agentPlugins);
 
@@ -1477,7 +1482,12 @@ export class MCPServerManager {
       // A trust or settings mutation can land while getAllServers() runs above;
       // re-derive enablement so this cached return cannot leave a revoked
       // repo-local server invocable.
-      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, existing);
+      await this.repairEnablementAfterConcurrentMutation(
+        workspaceId,
+        options,
+        existing,
+        configGenerationUsed
+      );
 
       return {
         tools: this.collectTools(existing.instances, fullServerInfo, overrides),
@@ -1589,7 +1599,12 @@ export class MCPServerManager {
       );
       existing.stats = leasedStats;
       existing.enabledServerNames = enabledServerNames;
-      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, existing);
+      await this.repairEnablementAfterConcurrentMutation(
+        workspaceId,
+        options,
+        existing,
+        configGenerationUsed
+      );
 
       // The deferred restart retains same-named instances with the old config,
       // so record which servers changed to block prompt invocation on them.
@@ -1633,7 +1648,12 @@ export class MCPServerManager {
           }
           // Same cached-return hazard as the fast path above: a mutation may
           // have landed after the concurrent starter's repair ran.
-          await this.repairEnablementAfterConcurrentMutation(workspaceId, options, current);
+          await this.repairEnablementAfterConcurrentMutation(
+            workspaceId,
+            options,
+            current,
+            configGenerationUsed
+          );
           return {
             tools: this.collectTools(current.instances, fullServerInfo, overrides),
             stats: current.stats,
@@ -1683,7 +1703,12 @@ export class MCPServerManager {
         lastActivity: Date.now(),
       };
       this.workspaceServers.set(workspaceId, entry);
-      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, entry);
+      await this.repairEnablementAfterConcurrentMutation(
+        workspaceId,
+        options,
+        entry,
+        configGenerationUsed
+      );
 
       return {
         tools: this.collectTools(instances, fullServerInfo, overrides),
@@ -1751,11 +1776,18 @@ export class MCPServerManager {
   private async repairEnablementAfterConcurrentMutation(
     workspaceId: string,
     optionsUsed: MCPWorkspaceRequestOptions,
-    entry: WorkspaceServers
+    entry: WorkspaceServers,
+    configGenerationUsed: number
   ): Promise<void> {
     try {
       let recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
-      while (recorded !== undefined && recorded !== optionsUsed) {
+      // Workspace-scoped mutations (trust, overrides) replace the recorded
+      // options object; global config mutations only bump the generation.
+      // Either signals that the derived enablement may be stale.
+      let needsRepair =
+        recorded !== optionsUsed || this.configService.configGeneration !== configGenerationUsed;
+      while (recorded !== undefined && needsRepair) {
+        const generationRead = this.configService.configGeneration;
         const enabled = await this.listServers(
           recorded.projectPath,
           recorded.overrides,
@@ -1763,12 +1795,13 @@ export class MCPServerManager {
           recorded.agentPlugins
         );
         const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
-        if (latest === recorded) {
+        if (latest === recorded && this.configService.configGeneration === generationRead) {
           entry.enabledServerNames = new Set(Object.keys(enabled));
           return;
         }
         // Another mutation landed while we derived enablement; recompute.
         recorded = latest;
+        needsRepair = true;
       }
     } catch (error) {
       log.debug("[MCP] Failed to repair enablement after concurrent settings change", {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -851,6 +851,11 @@ interface WorkspaceServers {
   timedOutServerNames: string[];
   /** Prevent concurrent cached retries from stacking startup attempts for the same server. */
   retryingTimedOutServerNames: Set<string>;
+  /**
+   * Servers whose config changed while a lease deferred their restart. Prompt
+   * invocation must not reach these stale endpoints or credentials.
+   */
+  stalePromptServerNames?: Set<string>;
   lastActivity: number;
 }
 
@@ -1348,6 +1353,8 @@ export class MCPServerManager {
 
     if (existing?.configSignature === signature && !hasClosedInstance) {
       existing.lastActivity = Date.now();
+      // A reverted config change means cached instances match again.
+      delete existing.stalePromptServerNames;
 
       const timedOutServerNamesToRetry = this.getTimedOutServerNamesToRetry(
         existing,
@@ -1568,6 +1575,25 @@ export class MCPServerManager {
       existing.stats = leasedStats;
       existing.enabledServerNames = enabledServerNames;
 
+      // The deferred restart retains same-named instances with the old config,
+      // so record which servers changed to block prompt invocation on them.
+      if (signature === existing.configSignature) {
+        delete existing.stalePromptServerNames;
+      } else {
+        let previousEntries: Record<string, unknown> = {};
+        try {
+          previousEntries = JSON.parse(existing.configSignature) as Record<string, unknown>;
+        } catch {
+          // Unparseable prior signature: treat every server as changed.
+        }
+        existing.stalePromptServerNames = new Set(
+          Object.keys(signatureEntries).filter(
+            (name) =>
+              JSON.stringify(signatureEntries[name]) !== JSON.stringify(previousEntries[name])
+          )
+        );
+      }
+
       // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
       await this.refreshModernInstanceTools(instancesForTools);
 
@@ -1773,6 +1799,11 @@ export class MCPServerManager {
     const entry = this.workspaceServers.get(workspaceId);
     if (entry && !entry.enabledServerNames.has(serverName)) {
       throw new Error(`MCP server '${serverName}' is disabled`);
+    }
+    if (entry?.stalePromptServerNames?.has(serverName)) {
+      throw new Error(
+        `MCP server '${serverName}' was reconfigured while a stream is active; retry after the stream finishes`
+      );
     }
     const instance = entry?.instances.get(serverName);
     if (!instance || instance.isClosed) {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -2420,7 +2420,8 @@ export class MCPServerManager {
           autoFallbackUsed: false,
           tools,
           prompts: [],
-          getPrompt: (promptName, args) => readyClient.getPrompt(promptName, args),
+          getPrompt: (promptName, args, options) =>
+            readyClient.getPrompt(promptName, args, options),
           refreshPrompts: async () => {
             instance.prompts = await readyClient.prompts();
           },
@@ -2672,7 +2673,7 @@ export class MCPServerManager {
         autoFallbackUsed,
         tools,
         prompts: [],
-        getPrompt: (promptName, args) => activeClient.getPrompt(promptName, args),
+        getPrompt: (promptName, args, options) => activeClient.getPrompt(promptName, args, options),
         refreshPrompts: async () => {
           instance.prompts = await activeClient.prompts();
         },

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -928,9 +928,7 @@ export class MCPServerManager {
     );
   }
 
-  private async refreshModernInstancePrompts(
-    instances: Map<string, MCPServerInstance>
-  ): Promise<void> {
+  private async refreshInstancePrompts(instances: Map<string, MCPServerInstance>): Promise<void> {
     await Promise.all(
       [...instances.values()].map(async (instance) => {
         if (instance.isClosed || !instance.refreshPrompts) return;
@@ -1605,7 +1603,7 @@ export class MCPServerManager {
     const entry = this.workspaceServers.get(options.workspaceId);
     if (!entry) return [];
 
-    await this.refreshModernInstancePrompts(entry.instances);
+    await this.refreshInstancePrompts(entry.instances);
     const descriptors: MCPPromptDescriptor[] = [];
     const usedNames = new Set<string>();
     const instances = [...entry.instances.values()].sort((a, b) => a.name.localeCompare(b.name));
@@ -2270,15 +2268,6 @@ export class MCPServerManager {
         }
 
         const rawTools = await client.tools();
-        let prompts: MCPPrompt[] = [];
-        try {
-          prompts = await client.prompts();
-        } catch (error) {
-          log.debug("[MCP] Prompt list unavailable during startup", {
-            name,
-            error: getErrorMessage(error),
-          });
-        }
         if (signal.aborted) {
           await cleanupStartupResources();
           return null;
@@ -2313,17 +2302,17 @@ export class MCPServerManager {
           resolvedTransport: "stdio",
           autoFallbackUsed: false,
           tools,
-          prompts,
+          prompts: [],
           getPrompt: (promptName, args) => readyClient.getPrompt(promptName, args),
+          refreshPrompts: async () => {
+            instance.prompts = await readyClient.prompts();
+          },
           isClosed: transportClosed,
           ...(isModernEra(negotiatedPrior)
             ? {
                 refreshTools: async () => {
                   const raw = await readyClient.tools();
                   instance.tools = wrapRawTools(raw);
-                },
-                refreshPrompts: async () => {
-                  instance.prompts = await readyClient.prompts();
                 },
               }
             : {}),
@@ -2533,15 +2522,6 @@ export class MCPServerManager {
       }
 
       const rawTools = await activeClient.tools();
-      let prompts: MCPPrompt[] = [];
-      try {
-        prompts = await activeClient.prompts();
-      } catch (error) {
-        log.debug("[MCP] Prompt list unavailable during startup", {
-          name,
-          error: getErrorMessage(error),
-        });
-      }
       if (signal.aborted) {
         await cleanupStartupClient();
         return null;
@@ -2574,17 +2554,17 @@ export class MCPServerManager {
         resolvedTransport,
         autoFallbackUsed,
         tools,
-        prompts,
+        prompts: [],
         getPrompt: (promptName, args) => activeClient.getPrompt(promptName, args),
+        refreshPrompts: async () => {
+          instance.prompts = await activeClient.prompts();
+        },
         isClosed: transportErrored || clientClosed,
         ...(isModernEra(negotiatedPrior)
           ? {
               refreshTools: async () => {
                 const raw = await activeClient.tools();
                 instance.tools = wrapRawTools(raw);
-              },
-              refreshPrompts: async () => {
-                instance.prompts = await activeClient.prompts();
               },
             }
           : {}),

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -833,6 +833,12 @@ export interface MCPWorkspaceRequestOptions {
   agentPlugins?: AgentPluginsMcpContext | null;
 }
 
+/** Resolves current effective secrets for a workspace's prompt refresh. */
+export type MCPWorkspaceSecretsResolver = (
+  workspaceId: string,
+  projectPath: string
+) => Promise<Record<string, string>>;
+
 interface MCPToolsForWorkspaceResult {
   tools: Record<string, Tool>;
   stats: MCPWorkspaceStats;
@@ -875,10 +881,15 @@ export class MCPServerManager {
   private inlineServers: Record<string, string> = {};
   private readonly policyService: PolicyService | null;
   private mcpOauthService: McpOauthService | null = null;
+  private secretsResolver: MCPWorkspaceSecretsResolver | null = null;
   private ignoreConfigFile = false;
 
   setMcpOauthService(service: McpOauthService): void {
     this.mcpOauthService = service;
+  }
+
+  setSecretsResolver(resolver: MCPWorkspaceSecretsResolver): void {
+    this.secretsResolver = resolver;
   }
   constructor(
     private readonly configService: MCPConfigService,
@@ -1748,7 +1759,25 @@ export class MCPServerManager {
     // so idle cleanup can close it.
     const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (lastOptions) {
-      const refreshed = await raceWithAbortAndTimeout(this.getToolsForWorkspace(lastOptions), {
+      const refresh = async (): Promise<void> => {
+        // Re-resolve secrets so a rotated HTTP header credential changes the
+        // config signature and recycles the stale authenticated client; the
+        // recorded snapshot only reflects the last discovery.
+        let refreshOptions = lastOptions;
+        if (this.secretsResolver) {
+          try {
+            const projectSecrets = await this.secretsResolver(workspaceId, lastOptions.projectPath);
+            refreshOptions = { ...lastOptions, projectSecrets };
+          } catch (error) {
+            log.debug("[MCP] Failed to re-resolve secrets for prompt refresh", {
+              workspaceId,
+              error: getErrorMessage(error),
+            });
+          }
+        }
+        await this.getToolsForWorkspace(refreshOptions);
+      };
+      const refreshed = await raceWithAbortAndTimeout(refresh(), {
         ...(options?.signal !== undefined ? { signal: options.signal } : {}),
       });
       if (refreshed.kind === "aborted") {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -41,6 +41,7 @@ import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import {
   buildMcpPromptBaseKey,
   buildMcpPromptCommandKey,
+  buildMcpPromptStableKey,
   buildMcpToolName,
 } from "@/common/utils/tools/mcpToolName";
 import { getErrorMessage } from "@/common/utils/errors";
@@ -1652,9 +1653,11 @@ export class MCPServerManager {
           forceSuffix:
             (baseKeyCounts.get(buildMcpPromptBaseKey(instance.name, prompt.name)) ?? 0) > 1,
         });
-        if (!command) continue;
+        const stableKey = buildMcpPromptStableKey(instance.name, prompt.name);
+        if (!command || stableKey === null) continue;
         descriptors.push({
           commandKey: command.toolName,
+          stableKey,
           serverName: instance.name,
           promptName: prompt.name,
           ...(prompt.description !== undefined ? { description: prompt.description } : {}),

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -839,11 +839,7 @@ interface MCPToolsForWorkspaceResult {
 interface WorkspaceServers {
   configSignature: string;
   instances: Map<string, MCPServerInstance>;
-  /**
-   * Currently enabled server names. Under a lease, disabling a server defers its
-   * restart and leaves the stale client in `instances`; prompt surfaces filter
-   * on this set so they never expose or invoke a disabled server.
-   */
+  /** Filters prompts while leased restarts can leave disabled clients cached. */
   enabledServerNames: Set<string>;
   stats: MCPWorkspaceStats;
   timedOutServerNames: string[];
@@ -1651,8 +1647,7 @@ export class MCPServerManager {
     const entry = this.workspaceServers.get(options.workspaceId);
     if (!entry) return [];
 
-    // Mirror the leased tools path: a disabled server's stale client may still
-    // sit in entry.instances until its deferred restart.
+    // Disabled clients can remain cached until a leased restart, so filter prompts.
     const enabledInstances = new Map(
       [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
     );
@@ -1696,11 +1691,7 @@ export class MCPServerManager {
     return descriptors;
   }
 
-  /**
-   * Sync a workspace's saved MCP overrides into cached state. Stream-time tool
-   * discovery recomputes enablement anyway; this keeps getPrompt (which can run
-   * before any stream) from trusting a stale enabledServerNames set.
-   */
+  /** Keeps prompt invocation from using stale enablement before the next stream refresh. */
   async applyWorkspaceOverrides(
     workspaceId: string,
     overrides: WorkspaceMCPOverrides | undefined
@@ -1734,14 +1725,9 @@ export class MCPServerManager {
     args: Record<string, string>,
     options?: { signal?: AbortSignal }
   ): Promise<{ text: string; description?: string }> {
-    // Re-evaluate current config before invoking: Settings mutations (global or
-    // project add/remove/disable/edit) persist without touching this cache, so
-    // a cached instance could otherwise serve a disabled or stale server. The
-    // refresh recomputes enablement, restarts servers whose config changed, and
-    // revives instances reaped by idle cleanup. Racing the caller's signal
-    // keeps an interrupted send from blocking on sequential server startup; a
-    // startup that loses the race still completes into the cache, so its
-    // instances stay tracked for idle cleanup rather than leaking.
+    // Refresh cached state because it can outlive configuration changes. Race
+    // startup with cancellation, but let a losing startup finish into the cache
+    // so idle cleanup can close it.
     const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (lastOptions) {
       const refreshed = await raceWithAbortAndTimeout(this.getToolsForWorkspace(lastOptions), {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -873,18 +873,13 @@ export class MCPServerManager {
   // servers at send time; forgotten only on workspace removal.
   private readonly lastWorkspaceRequestOptions = new Map<string, MCPWorkspaceRequestOptions>();
   /**
-   * Bumped whenever a mutation replaces a workspace's recorded options.
-   * getPrompt compares it (plus the global config generation) across its
-   * refresh so a mutation completing after the refresh cannot pass the
-   * pre-dispatch enablement checks with stale state.
+   * Prompt paths compare this counter with global config generation across
+   * refreshes so workspace mutations cannot pass stale dispatch checks.
    */
   private readonly workspaceOptionsMutationCounts = new Map<string, number>();
   /**
-   * Newest overrides seen per workspace, recorded even when the workspace has
-   * no cache entry or recorded options yet (cold), where the sync in
-   * applyWorkspaceOverrides has nothing to update. ensureWorkspaceServers
-   * overlays this over caller-supplied overrides, whose persisted-state read
-   * may predate the mutation.
+   * Retains overrides for cold workspaces, where applyWorkspaceOverrides has no
+   * cached or recorded state to repair, so stale caller snapshots can be overlaid.
    */
   private readonly latestWorkspaceOverrides = new Map<string, WorkspaceMCPOverrides | undefined>();
   private readonly latestProjectTrust = new Map<string, boolean>();
@@ -1273,18 +1268,15 @@ export class MCPServerManager {
   }
 
   /**
-   * refreshToolCatalogs=false skips tools/list refreshes on cached instances;
-   * prompt paths use it so one stale unrelated server (60s SDK default
-   * timeout) cannot stall every prompt send in the workspace.
+   * Skips tools/list refreshes on cached instances so an unrelated server's
+   * 60-second SDK timeout cannot block prompt paths.
    */
   private async ensureWorkspaceServers(
     requestOptions: MCPWorkspaceRequestOptions,
     refreshToolCatalogs: boolean
   ): Promise<MCPToolsForWorkspaceResult> {
-    // workspace.mcp.set can land between a caller reading persisted overrides
-    // and reaching here; on a cold workspace there is no recorded state for
-    // that mutation to repair, so overlay the newest overrides the manager
-    // has seen over the caller's possibly stale snapshot.
+    // Cold workspaces have no recorded state for applyWorkspaceOverrides to repair.
+    // Overlay the newest overrides over a caller snapshot that may predate the mutation.
     let options = this.latestWorkspaceOverrides.has(requestOptions.workspaceId)
       ? {
           ...requestOptions,
@@ -1645,8 +1637,7 @@ export class MCPServerManager {
           if (refreshToolCatalogs) {
             await this.refreshModernInstanceTools(current.instances);
           }
-          // Same cached-return hazard as the fast path above: a mutation may
-          // have landed after the concurrent starter's repair ran.
+          // Repair again in case a mutation landed after the concurrent starter's check.
           await this.repairEnablementAfterConcurrentMutation(
             workspaceId,
             options,
@@ -1721,15 +1712,9 @@ export class MCPServerManager {
     callOptions?: { signal?: AbortSignal }
   ): Promise<MCPPromptDescriptor[]> {
     const workspaceId = options.workspaceId;
-    // Same post-refresh mutation gap as getPrompt, extended over the prompt
-    // catalog fetch: a trust or settings mutation completing while
-    // prompts/list is pending must not let a pre-mutation enabled-instance
-    // copy leak descriptors from a now-disabled server. Retry until both
-    // mutation counters are stable across one refresh plus catalog fetch;
-    // retries re-read recorded options so they pick up the mutation. Racing
-    // with the abort signal lets an abandoned discovery return promptly while
-    // a losing startup finishes into the cache (idle cleanup closes it),
-    // matching getPrompt's cancellation semantics.
+    // Keep refreshing until both mutation counters remain stable across catalog fetch,
+    // preventing a pre-mutation instance copy from leaking descriptors. Abort returns
+    // promptly while a losing startup may finish into the cache for idle cleanup.
     let enabledInstances: Map<string, MCPServerInstance>;
     for (;;) {
       const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
@@ -1747,10 +1732,9 @@ export class MCPServerManager {
       const entry = this.workspaceServers.get(workspaceId);
       if (!entry) return [];
 
-      // Disabled clients can remain cached until a leased restart, so filter
-      // prompts. Lease-deferred reconfigured servers stay stale until they
-      // restart; skip them so discovery neither queries the old endpoint nor
-      // returns its outdated catalog.
+      // Disabled clients may remain cached during leased restarts. Skip disabled and
+      // reconfigured instances so discovery neither queries stale endpoints nor
+      // returns outdated catalogs.
       enabledInstances = new Map(
         [...entry.instances].filter(
           ([serverName]) =>
@@ -1859,11 +1843,8 @@ export class MCPServerManager {
   }
 
   /**
-   * Settings mutations sync only an existing cache entry, so one landing while
-   * servers start would be lost: a disabled or trust-revoked server could stay
-   * invocable, and an edited server would keep serving its pre-edit instance.
-   * Re-derive enablement from the latest recorded options and block prompt
-   * invocation on servers whose start config changed until the next restart.
+   * Settings changes during startup can miss cache synchronization. Re-derive
+   * enablement and mark reconfigured clients stale before prompt dispatch.
    */
   private async repairEnablementAfterConcurrentMutation(
     workspaceId: string,
@@ -1873,9 +1854,8 @@ export class MCPServerManager {
   ): Promise<void> {
     try {
       let recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
-      // Workspace-scoped mutations (trust, overrides) replace the recorded
-      // options object; global config mutations only bump the generation.
-      // Either signals that the derived enablement may be stale.
+      // Workspace mutations replace recorded options; global mutations only bump a
+      // generation. Either can invalidate derived enablement.
       let needsRepair =
         recorded !== optionsUsed || this.configService.configGeneration !== configGenerationUsed;
       while (recorded !== undefined && needsRepair) {
@@ -1906,7 +1886,6 @@ export class MCPServerManager {
           }
           return;
         }
-        // Another mutation landed while we derived enablement; recompute.
         recorded = latest;
         needsRepair = true;
       }
@@ -2005,11 +1984,9 @@ export class MCPServerManager {
           false
         );
       };
-      // A mutation completing after a refresh resolves would pass the stale
-      // enablement checks below, so refresh until both mutation counters are
-      // stable across one refresh: only synchronous code then separates the
-      // checks from dispatch. A mutation landing after that is concurrent
-      // with the in-flight request, which no dispatch-side check can prevent.
+      // Refresh until both mutation counters remain stable so no mutation completes
+      // between refresh and the synchronous dispatch checks. Later mutations race
+      // with the in-flight request and cannot be prevented here.
       for (;;) {
         const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
         const generationBefore = this.configService.configGeneration;

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -833,7 +833,6 @@ export interface MCPWorkspaceRequestOptions {
   agentPlugins?: AgentPluginsMcpContext | null;
 }
 
-/** Resolves current effective secrets for a workspace's prompt refresh. */
 export type MCPWorkspaceSecretsResolver = (
   workspaceId: string,
   projectPath: string
@@ -1749,9 +1748,7 @@ export class MCPServerManager {
     const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (lastOptions) {
       const refresh = async (): Promise<void> => {
-        // Re-resolve secrets so a rotated HTTP header credential changes the
-        // config signature and recycles the stale authenticated client; the
-        // recorded snapshot only reflects the last discovery.
+        // Rotated header credentials must change the signature so stale clients are replaced.
         let refreshOptions = lastOptions;
         if (this.secretsResolver) {
           try {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -47,6 +47,7 @@ import {
 import { getErrorMessage } from "@/common/utils/errors";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
+import { stripTrailingSlashes } from "@/node/utils/pathUtils";
 
 const TEST_TIMEOUT_MS = 10_000;
 const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -1715,6 +1716,23 @@ export class MCPServerManager {
         workspaceId,
         error: getErrorMessage(error),
       });
+    }
+  }
+
+  /**
+   * Sync a project trust change into recorded workspace request options.
+   * getPrompt refreshes from those options before invoking, so a revoked
+   * project must not keep serving repo-local prompts from a stale
+   * trusted=true snapshot. Callers pass every affected project path (the
+   * trust owner plus children inheriting via parentProjectPath); scratch
+   * workspaces are untouched because their paths never match.
+   */
+  applyProjectTrust(projectPaths: string[], trusted: boolean): void {
+    const affected = new Set(projectPaths.map((projectPath) => stripTrailingSlashes(projectPath)));
+    for (const [workspaceId, options] of this.lastWorkspaceRequestOptions) {
+      if (!affected.has(stripTrailingSlashes(options.projectPath))) continue;
+      if ((options.trusted ?? false) === trusted) continue;
+      this.lastWorkspaceRequestOptions.set(workspaceId, { ...options, trusted });
     }
   }
 

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1711,13 +1711,16 @@ export class MCPServerManager {
     callOptions?: { signal?: AbortSignal }
   ): Promise<MCPPromptDescriptor[]> {
     const workspaceId = options.workspaceId;
-    // Same post-refresh mutation gap as getPrompt: a trust or settings
-    // mutation completing after the refresh resolves must not let this copy
-    // pre-mutation enablement. Retry until both mutation counters are stable
-    // across one refresh; retries re-read recorded options so they pick up
-    // the mutation. Racing with the abort signal lets an abandoned discovery
-    // return promptly while a losing startup finishes into the cache (idle
-    // cleanup closes it), matching getPrompt's cancellation semantics.
+    // Same post-refresh mutation gap as getPrompt, extended over the prompt
+    // catalog fetch: a trust or settings mutation completing while
+    // prompts/list is pending must not let a pre-mutation enabled-instance
+    // copy leak descriptors from a now-disabled server. Retry until both
+    // mutation counters are stable across one refresh plus catalog fetch;
+    // retries re-read recorded options so they pick up the mutation. Racing
+    // with the abort signal lets an abandoned discovery return promptly while
+    // a losing startup finishes into the cache (idle cleanup closes it),
+    // matching getPrompt's cancellation semantics.
+    let enabledInstances: Map<string, MCPServerInstance>;
     for (;;) {
       const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
       const generationBefore = this.configService.configGeneration;
@@ -1731,6 +1734,14 @@ export class MCPServerManager {
       if (refreshed.kind === "aborted") {
         throw new Error("MCP prompt discovery was aborted");
       }
+      const entry = this.workspaceServers.get(workspaceId);
+      if (!entry) return [];
+
+      // Disabled clients can remain cached until a leased restart, so filter prompts.
+      enabledInstances = new Map(
+        [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
+      );
+      await this.refreshInstancePrompts(enabledInstances, callOptions?.signal);
       if (
         (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
         this.configService.configGeneration === generationBefore
@@ -1738,14 +1749,6 @@ export class MCPServerManager {
         break;
       }
     }
-    const entry = this.workspaceServers.get(workspaceId);
-    if (!entry) return [];
-
-    // Disabled clients can remain cached until a leased restart, so filter prompts.
-    const enabledInstances = new Map(
-      [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
-    );
-    await this.refreshInstancePrompts(enabledInstances, callOptions?.signal);
     const descriptors: MCPPromptDescriptor[] = [];
     const usedNames = new Set<string>();
     const instances = [...enabledInstances.values()].sort((a, b) => a.name.localeCompare(b.name));

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1737,9 +1737,16 @@ export class MCPServerManager {
       const entry = this.workspaceServers.get(workspaceId);
       if (!entry) return [];
 
-      // Disabled clients can remain cached until a leased restart, so filter prompts.
+      // Disabled clients can remain cached until a leased restart, so filter
+      // prompts. Lease-deferred reconfigured servers stay stale until they
+      // restart; skip them so discovery neither queries the old endpoint nor
+      // returns its outdated catalog.
       enabledInstances = new Map(
-        [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
+        [...entry.instances].filter(
+          ([serverName]) =>
+            entry.enabledServerNames.has(serverName) &&
+            !entry.stalePromptServerNames?.has(serverName)
+        )
       );
       await this.refreshInstancePrompts(enabledInstances, callOptions?.signal);
       if (

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1926,6 +1926,14 @@ export class MCPServerManager {
     }
   }
 
+  /**
+   * Trust is retained by path, so removing a project must forget its entry or
+   * a later re-registration of the same path would inherit the old decision.
+   */
+  forgetProjectTrust(projectPath: string): void {
+    this.latestProjectTrust.delete(stripTrailingSlashes(projectPath));
+  }
+
   /** Updates recorded options so prompt refreshes cannot reuse stale project trust. */
   applyProjectTrust(updates: Array<{ projectPath: string; trusted: boolean }>): void {
     const trustByPath = new Map(

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -45,6 +45,8 @@ import {
   buildMcpToolName,
 } from "@/common/utils/tools/mcpToolName";
 import { getErrorMessage } from "@/common/utils/errors";
+import { MutexMap } from "@/node/utils/concurrency/mutexMap";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 
 const TEST_TIMEOUT_MS = 10_000;
 const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
@@ -862,6 +864,7 @@ export class MCPServerManager {
   // Survives idle cleanup so an explicit prompt invocation can revive reaped
   // servers at send time; forgotten only on workspace removal.
   private readonly lastWorkspaceRequestOptions = new Map<string, MCPWorkspaceRequestOptions>();
+  private readonly workspaceColdStartLocks = new MutexMap<string>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
    * Cached per-server protocol era verdicts, keyed by server config
@@ -1232,6 +1235,22 @@ export class MCPServerManager {
   }
 
   async getToolsForWorkspace(
+    options: MCPWorkspaceRequestOptions
+  ): Promise<MCPToolsForWorkspaceResult> {
+    // Cold start can race: composer prompt discovery and stream tool startup
+    // may both observe no cached entry, start duplicate servers, and the
+    // loser's entry would be overwritten without closing its instances.
+    // Serialize only that case; entry-present flows keep their existing
+    // concurrency semantics (leased deferred restarts, mid-retry replacement).
+    if (!this.workspaceServers.has(options.workspaceId)) {
+      return this.workspaceColdStartLocks.withLock(options.workspaceId, () =>
+        this.getToolsForWorkspaceImpl(options)
+      );
+    }
+    return this.getToolsForWorkspaceImpl(options);
+  }
+
+  private async getToolsForWorkspaceImpl(
     options: MCPWorkspaceRequestOptions
   ): Promise<MCPToolsForWorkspaceResult> {
     const {
@@ -1706,20 +1725,28 @@ export class MCPServerManager {
     args: Record<string, string>,
     options?: { signal?: AbortSignal }
   ): Promise<{ text: string; description?: string }> {
-    const currentEntry = this.workspaceServers.get(workspaceId);
-    if (currentEntry && !currentEntry.enabledServerNames.has(serverName)) {
-      throw new Error(`MCP server '${serverName}' is disabled`);
-    }
-    let instance = currentEntry?.instances.get(serverName);
-    if (!instance || instance.isClosed) {
-      // Idle cleanup may have reaped the client between composing the reference
-      // and sending; revive so the explicitly selected prompt is not dropped.
-      const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
-      if (lastOptions) {
-        await this.getToolsForWorkspace(lastOptions);
-        instance = this.workspaceServers.get(workspaceId)?.instances.get(serverName);
+    // Re-evaluate current config before invoking: Settings mutations (global or
+    // project add/remove/disable/edit) persist without touching this cache, so
+    // a cached instance could otherwise serve a disabled or stale server. The
+    // refresh recomputes enablement, restarts servers whose config changed, and
+    // revives instances reaped by idle cleanup. Racing the caller's signal
+    // keeps an interrupted send from blocking on sequential server startup; a
+    // startup that loses the race still completes into the cache, so its
+    // instances stay tracked for idle cleanup rather than leaking.
+    const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
+    if (lastOptions) {
+      const refreshed = await raceWithAbortAndTimeout(this.getToolsForWorkspace(lastOptions), {
+        ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+      });
+      if (refreshed.kind === "aborted") {
+        throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
       }
     }
+    const entry = this.workspaceServers.get(workspaceId);
+    if (entry && !entry.enabledServerNames.has(serverName)) {
+      throw new Error(`MCP server '${serverName}' is disabled`);
+    }
+    const instance = entry?.instances.get(serverName);
     if (!instance || instance.isClosed) {
       throw new Error(`MCP server '${serverName}' is not connected`);
     }

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -807,7 +807,7 @@ interface MCPServerInstance {
    * results carry no freshness hints).
    */
   refreshTools?: () => Promise<void>;
-  refreshPrompts?: () => Promise<void>;
+  refreshPrompts?: (options?: { signal?: AbortSignal }) => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -973,12 +973,15 @@ export class MCPServerManager {
     );
   }
 
-  private async refreshInstancePrompts(instances: Map<string, MCPServerInstance>): Promise<void> {
+  private async refreshInstancePrompts(
+    instances: Map<string, MCPServerInstance>,
+    signal?: AbortSignal
+  ): Promise<void> {
     await Promise.all(
       [...instances.values()].map(async (instance) => {
         if (instance.isClosed || !instance.refreshPrompts) return;
         try {
-          await instance.refreshPrompts();
+          await instance.refreshPrompts(signal !== undefined ? { signal } : undefined);
         } catch (error) {
           log.debug("[MCP] Prompt list refresh failed; keeping cached prompts", {
             name: instance.name,
@@ -1704,17 +1707,45 @@ export class MCPServerManager {
   }
 
   async getPromptsForWorkspace(
-    options: MCPWorkspaceRequestOptions
+    options: MCPWorkspaceRequestOptions,
+    callOptions?: { signal?: AbortSignal }
   ): Promise<MCPPromptDescriptor[]> {
-    await this.ensureWorkspaceServers(options, false);
-    const entry = this.workspaceServers.get(options.workspaceId);
+    const workspaceId = options.workspaceId;
+    // Same post-refresh mutation gap as getPrompt: a trust or settings
+    // mutation completing after the refresh resolves must not let this copy
+    // pre-mutation enablement. Retry until both mutation counters are stable
+    // across one refresh; retries re-read recorded options so they pick up
+    // the mutation. Racing with the abort signal lets an abandoned discovery
+    // return promptly while a losing startup finishes into the cache (idle
+    // cleanup closes it), matching getPrompt's cancellation semantics.
+    for (;;) {
+      const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
+      const generationBefore = this.configService.configGeneration;
+      const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? options;
+      const refreshed = await raceWithAbortAndTimeout(
+        this.ensureWorkspaceServers(currentOptions, false),
+        {
+          ...(callOptions?.signal !== undefined ? { signal: callOptions.signal } : {}),
+        }
+      );
+      if (refreshed.kind === "aborted") {
+        throw new Error("MCP prompt discovery was aborted");
+      }
+      if (
+        (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
+        this.configService.configGeneration === generationBefore
+      ) {
+        break;
+      }
+    }
+    const entry = this.workspaceServers.get(workspaceId);
     if (!entry) return [];
 
     // Disabled clients can remain cached until a leased restart, so filter prompts.
     const enabledInstances = new Map(
       [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
     );
-    await this.refreshInstancePrompts(enabledInstances);
+    await this.refreshInstancePrompts(enabledInstances, callOptions?.signal);
     const descriptors: MCPPromptDescriptor[] = [];
     const usedNames = new Set<string>();
     const instances = [...enabledInstances.values()].sort((a, b) => a.name.localeCompare(b.name));
@@ -2678,8 +2709,8 @@ export class MCPServerManager {
           prompts: [],
           getPrompt: (promptName, args, options) =>
             readyClient.getPrompt(promptName, args, options),
-          refreshPrompts: async () => {
-            instance.prompts = await readyClient.prompts();
+          refreshPrompts: async (options) => {
+            instance.prompts = await readyClient.prompts(options);
           },
           isClosed: transportClosed,
           ...(isModernEra(negotiatedPrior)
@@ -2930,8 +2961,8 @@ export class MCPServerManager {
         tools,
         prompts: [],
         getPrompt: (promptName, args, options) => activeClient.getPrompt(promptName, args, options),
-        refreshPrompts: async () => {
-          instance.prompts = await activeClient.prompts();
+        refreshPrompts: async (options) => {
+          instance.prompts = await activeClient.prompts(options);
         },
         isClosed: transportErrored || clientClosed,
         ...(isModernEra(negotiatedPrior)

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1725,11 +1725,13 @@ export class MCPServerManager {
   }
 
   /** Updates recorded options so prompt refreshes cannot reuse stale project trust. */
-  applyProjectTrust(projectPaths: string[], trusted: boolean): void {
-    const affected = new Set(projectPaths.map((projectPath) => stripTrailingSlashes(projectPath)));
+  applyProjectTrust(updates: Array<{ projectPath: string; trusted: boolean }>): void {
+    const trustByPath = new Map(
+      updates.map((update) => [stripTrailingSlashes(update.projectPath), update.trusted])
+    );
     for (const [workspaceId, options] of this.lastWorkspaceRequestOptions) {
-      if (!affected.has(stripTrailingSlashes(options.projectPath))) continue;
-      if ((options.trusted ?? false) === trusted) continue;
+      const trusted = trustByPath.get(stripTrailingSlashes(options.projectPath));
+      if (trusted === undefined || (options.trusted ?? false) === trusted) continue;
       this.lastWorkspaceRequestOptions.set(workspaceId, { ...options, trusted });
     }
   }

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1780,8 +1780,14 @@ export class MCPServerManager {
     }
     this.markActivity(workspaceId);
     const result = await instance.getPrompt(promptName, args, options);
+    const text = flattenMcpPrompt(result);
+    if (text.trim().length === 0) {
+      // Providers can reject empty user content, so fail expansion up front
+      // rather than persisting an empty synthetic user message.
+      throw new Error(`MCP prompt '${serverName}/${promptName}' returned no text content`);
+    }
     return {
-      text: flattenMcpPrompt(result),
+      text,
       ...(result.description !== undefined ? { description: result.description } : {}),
     };
   }

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -851,10 +851,7 @@ interface WorkspaceServers {
   timedOutServerNames: string[];
   /** Prevent concurrent cached retries from stacking startup attempts for the same server. */
   retryingTimedOutServerNames: Set<string>;
-  /**
-   * Servers whose config changed while a lease deferred their restart. Prompt
-   * invocation must not reach these stale endpoints or credentials.
-   */
+  /** Blocks prompt invocation on stale clients while an active lease defers restart. */
   stalePromptServerNames?: Set<string>;
   lastActivity: number;
 }
@@ -1353,7 +1350,6 @@ export class MCPServerManager {
 
     if (existing?.configSignature === signature && !hasClosedInstance) {
       existing.lastActivity = Date.now();
-      // A reverted config change means cached instances match again.
       delete existing.stalePromptServerNames;
 
       const timedOutServerNamesToRetry = this.getTimedOutServerNamesToRetry(
@@ -1580,12 +1576,8 @@ export class MCPServerManager {
       if (signature === existing.configSignature) {
         delete existing.stalePromptServerNames;
       } else {
-        let previousEntries: Record<string, unknown> = {};
-        try {
-          previousEntries = JSON.parse(existing.configSignature) as Record<string, unknown>;
-        } catch {
-          // Unparseable prior signature: treat every server as changed.
-        }
+        // configSignature is always in-process JSON.stringify output, so parsing cannot fail.
+        const previousEntries = JSON.parse(existing.configSignature) as Record<string, unknown>;
         existing.stalePromptServerNames = new Set(
           Object.keys(signatureEntries).filter(
             (name) =>

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -868,6 +868,13 @@ export class MCPServerManager {
   // Survives idle cleanup so an explicit prompt invocation can revive reaped
   // servers at send time; forgotten only on workspace removal.
   private readonly lastWorkspaceRequestOptions = new Map<string, MCPWorkspaceRequestOptions>();
+  /**
+   * Bumped whenever a mutation replaces a workspace's recorded options.
+   * getPrompt compares it (plus the global config generation) across its
+   * refresh so a mutation completing after the refresh cannot pass the
+   * pre-dispatch enablement checks with stale state.
+   */
+  private readonly workspaceOptionsMutationCounts = new Map<string, number>();
   private readonly workspaceRestartLocks = new MutexMap<string>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
@@ -1846,6 +1853,7 @@ export class MCPServerManager {
     const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (recorded) {
       this.lastWorkspaceRequestOptions.set(workspaceId, { ...recorded, overrides });
+      this.bumpWorkspaceOptionsMutationCount(workspaceId);
     }
     const entry = this.workspaceServers.get(workspaceId);
     if (!entry || !recorded) return;
@@ -1874,7 +1882,15 @@ export class MCPServerManager {
       const trusted = trustByPath.get(stripTrailingSlashes(options.projectPath));
       if (trusted === undefined || (options.trusted ?? false) === trusted) continue;
       this.lastWorkspaceRequestOptions.set(workspaceId, { ...options, trusted });
+      this.bumpWorkspaceOptionsMutationCount(workspaceId);
     }
+  }
+
+  private bumpWorkspaceOptionsMutationCount(workspaceId: string): void {
+    this.workspaceOptionsMutationCounts.set(
+      workspaceId,
+      (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) + 1
+    );
   }
 
   async getPrompt(
@@ -1910,11 +1926,26 @@ export class MCPServerManager {
           false
         );
       };
-      const refreshed = await raceWithAbortAndTimeout(refresh(), {
-        ...(options?.signal !== undefined ? { signal: options.signal } : {}),
-      });
-      if (refreshed.kind === "aborted") {
-        throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
+      // A mutation completing after a refresh resolves would pass the stale
+      // enablement checks below, so refresh until both mutation counters are
+      // stable across one refresh: only synchronous code then separates the
+      // checks from dispatch. A mutation landing after that is concurrent
+      // with the in-flight request, which no dispatch-side check can prevent.
+      for (;;) {
+        const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
+        const generationBefore = this.configService.configGeneration;
+        const refreshed = await raceWithAbortAndTimeout(refresh(), {
+          ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+        });
+        if (refreshed.kind === "aborted") {
+          throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
+        }
+        if (
+          (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
+          this.configService.configGeneration === generationBefore
+        ) {
+          break;
+        }
       }
     }
     const entry = this.workspaceServers.get(workspaceId);

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -864,7 +864,7 @@ export class MCPServerManager {
   // Survives idle cleanup so an explicit prompt invocation can revive reaped
   // servers at send time; forgotten only on workspace removal.
   private readonly lastWorkspaceRequestOptions = new Map<string, MCPWorkspaceRequestOptions>();
-  private readonly workspaceColdStartLocks = new MutexMap<string>();
+  private readonly workspaceRestartLocks = new MutexMap<string>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
    * Cached per-server protocol era verdicts, keyed by server config
@@ -1237,22 +1237,6 @@ export class MCPServerManager {
   async getToolsForWorkspace(
     options: MCPWorkspaceRequestOptions
   ): Promise<MCPToolsForWorkspaceResult> {
-    // Cold start can race: composer prompt discovery and stream tool startup
-    // may both observe no cached entry, start duplicate servers, and the
-    // loser's entry would be overwritten without closing its instances.
-    // Serialize only that case; entry-present flows keep their existing
-    // concurrency semantics (leased deferred restarts, mid-retry replacement).
-    if (!this.workspaceServers.has(options.workspaceId)) {
-      return this.workspaceColdStartLocks.withLock(options.workspaceId, () =>
-        this.getToolsForWorkspaceImpl(options)
-      );
-    }
-    return this.getToolsForWorkspaceImpl(options);
-  }
-
-  private async getToolsForWorkspaceImpl(
-    options: MCPWorkspaceRequestOptions
-  ): Promise<MCPToolsForWorkspaceResult> {
     const {
       workspaceId,
       projectPath,
@@ -1586,53 +1570,78 @@ export class MCPServerManager {
       };
     }
 
-    // Config changed, instance closed, or not started yet -> restart
-    if (enabledEntries.length > 0) {
-      log.info("[MCP] Starting servers", {
-        workspaceId,
-        servers: enabledEntries.map(([name]) => name),
+    // Config changed, instance closed, or not started yet -> restart.
+    //
+    // Serialized per workspace: concurrent callers (composer prompt discovery,
+    // stream tool startup, multi-ref getPrompt refreshes) could otherwise each
+    // stop/start the same servers and overwrite workspaceServers without
+    // closing the loser's instances. The cached same-signature retry path
+    // above intentionally stays outside this lock; it is guarded by
+    // retryingTimedOutServerNames and the mid-retry replacement reconciliation.
+    return this.workspaceRestartLocks.withLock(workspaceId, async () => {
+      // A queued caller may find the restart already done by the lock holder.
+      const current = this.workspaceServers.get(workspaceId);
+      if (current !== undefined) {
+        const currentHasClosedInstance = [...current.instances.values()].some(
+          (instance) => instance.isClosed
+        );
+        if (current.configSignature === signature && !currentHasClosedInstance) {
+          current.lastActivity = Date.now();
+          await this.refreshModernInstanceTools(current.instances);
+          return {
+            tools: this.collectTools(current.instances, fullServerInfo, overrides),
+            stats: current.stats,
+          };
+        }
+      }
+
+      if (enabledEntries.length > 0) {
+        log.info("[MCP] Starting servers", {
+          workspaceId,
+          servers: enabledEntries.map(([name]) => name),
+        });
+      }
+
+      if (existing && hasClosedInstance) {
+        log.info("[MCP] Restarting servers due to closed client", { workspaceId });
+      }
+
+      // Internal restart: retain the recorded request options so getPrompt can
+      // still revive servers reaped later; only workspace removal forgets them.
+      await this.stopServers(workspaceId, { retainRestartOptions: true });
+
+      const {
+        instances,
+        failedServerNames: startFailedNames,
+        timedOutServerNames: startTimedOutNames = [],
+      } = await this.startServers(
+        enabledServers,
+        runtime,
+        projectPath,
+        workspacePath,
+        projectSecrets,
+        () => this.markActivity(workspaceId),
+        workspaceId
+      );
+
+      const allFailedNames = [...restartFailedNames, ...startFailedNames];
+      const stats = this.createWorkspaceStats(enabledEntries.length, instances, allFailedNames);
+
+      this.workspaceServers.set(workspaceId, {
+        configSignature: signature,
+        instances,
+        enabledServerNames,
+        stats,
+        timedOutServerNames: startTimedOutNames,
+        retryingTimedOutServerNames: new Set(),
+        lastActivity: Date.now(),
       });
-    }
 
-    if (existing && hasClosedInstance) {
-      log.info("[MCP] Restarting servers due to closed client", { workspaceId });
-    }
-
-    // Internal restart: retain the recorded request options so getPrompt can
-    // still revive servers reaped later; only workspace removal forgets them.
-    await this.stopServers(workspaceId, { retainRestartOptions: true });
-
-    const {
-      instances,
-      failedServerNames: startFailedNames,
-      timedOutServerNames: startTimedOutNames = [],
-    } = await this.startServers(
-      enabledServers,
-      runtime,
-      projectPath,
-      workspacePath,
-      projectSecrets,
-      () => this.markActivity(workspaceId),
-      workspaceId
-    );
-
-    const allFailedNames = [...restartFailedNames, ...startFailedNames];
-    const stats = this.createWorkspaceStats(enabledEntries.length, instances, allFailedNames);
-
-    this.workspaceServers.set(workspaceId, {
-      configSignature: signature,
-      instances,
-      enabledServerNames,
-      stats,
-      timedOutServerNames: startTimedOutNames,
-      retryingTimedOutServerNames: new Set(),
-      lastActivity: Date.now(),
+      return {
+        tools: this.collectTools(instances, fullServerInfo, overrides),
+        stats,
+      };
     });
-
-    return {
-      tools: this.collectTools(instances, fullServerInfo, overrides),
-      stats,
-    };
   }
 
   async getPromptsForWorkspace(

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -7,6 +7,8 @@ import {
   isModernEra,
   MCP_TOOL_CALL_TIMEOUT_MS,
   type MCPClientHandle,
+  type MCPGetPromptResult,
+  type MCPPrompt,
 } from "@/node/services/mcpClient";
 import { log } from "@/node/services/log";
 import { MCPStdioTransport } from "@/node/services/mcpStdioTransport";
@@ -35,7 +37,8 @@ import {
 } from "@/node/services/mcpOauthService";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { transformMCPResult, type MCPCallToolResult } from "@/node/services/mcpResultTransform";
-import { buildMcpToolName } from "@/common/utils/tools/mcpToolName";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
+import { buildMcpPromptCommandKey, buildMcpToolName } from "@/common/utils/tools/mcpToolName";
 import { getErrorMessage } from "@/common/utils/errors";
 
 const TEST_TIMEOUT_MS = 10_000;
@@ -746,12 +749,41 @@ async function runServerTest(
   return Promise.race([testPromise, timeoutPromise]);
 }
 
+type MCPPromptContent = MCPGetPromptResult["messages"][number]["content"];
+
+function flattenPromptContent(content: MCPPromptContent): string {
+  switch (content.type) {
+    case "text":
+      return content.text;
+    case "resource":
+      return "text" in content.resource ? content.resource.text : "[Resource content omitted]";
+    case "image":
+      return "[Image content omitted]";
+    case "audio":
+      return "[Audio content omitted]";
+    default:
+      return "[Unsupported content omitted]";
+  }
+}
+
+export function flattenMcpPrompt(result: MCPGetPromptResult): string {
+  return result.messages
+    .map((message) => {
+      const text = flattenPromptContent(message.content);
+      return message.role === "user" ? text : `[${message.role}]\n${text}`;
+    })
+    .filter((message) => message.length > 0)
+    .join("\n\n");
+}
+
 interface MCPServerInstance {
   name: string;
   /** Resolved transport actually used (auto may fall back to sse). */
   resolvedTransport: ResolvedTransport;
   autoFallbackUsed: boolean;
   tools: Record<string, Tool>;
+  prompts: MCPPrompt[];
+  getPrompt: MCPClientHandle["getPrompt"];
   /** True once the underlying MCP client/transport has been closed. */
   isClosed: boolean;
   /**
@@ -763,6 +795,7 @@ interface MCPServerInstance {
    * results carry no freshness hints).
    */
   refreshTools?: () => Promise<void>;
+  refreshPrompts?: () => Promise<void>;
   close: () => Promise<void>;
 }
 
@@ -779,6 +812,17 @@ export interface MCPWorkspaceStats {
   hasHttp: boolean;
   hasSse: boolean;
   transportMode: MCPTransportMode;
+}
+
+export interface MCPWorkspaceRequestOptions {
+  workspaceId: string;
+  projectPath: string;
+  runtime: Runtime;
+  workspacePath: string;
+  trusted?: boolean;
+  overrides?: WorkspaceMCPOverrides;
+  projectSecrets?: Record<string, string>;
+  agentPlugins?: AgentPluginsMcpContext | null;
 }
 
 interface MCPToolsForWorkspaceResult {
@@ -866,28 +910,39 @@ export class MCPServerManager {
     this.eraVerdicts.set(key, { prior, cachedAtMs: Date.now() });
   }
 
-  /**
-   * Best-effort tools/list refresh for cached modern-era instances
-   * (SEP-2549): a still-fresh cached list is served by the SDK with zero
-   * round trips; a stale one refetches. Failures keep the existing tool set —
-   * tool availability must never regress because a refresh failed.
-   */
   private async refreshModernInstanceTools(
     instances: Map<string, MCPServerInstance>
   ): Promise<void> {
     await Promise.all(
-      [...instances.values()]
-        .filter((instance) => instance.refreshTools !== undefined && !instance.isClosed)
-        .map(async (instance) => {
-          try {
-            await instance.refreshTools!();
-          } catch (error) {
-            log.debug("[MCP] Tool list refresh failed; keeping cached tools", {
-              name: instance.name,
-              error: getErrorMessage(error),
-            });
-          }
-        })
+      [...instances.values()].map(async (instance) => {
+        if (instance.isClosed || !instance.refreshTools) return;
+        try {
+          await instance.refreshTools();
+        } catch (error) {
+          log.debug("[MCP] Tool list refresh failed; keeping cached tools", {
+            name: instance.name,
+            error: getErrorMessage(error),
+          });
+        }
+      })
+    );
+  }
+
+  private async refreshModernInstancePrompts(
+    instances: Map<string, MCPServerInstance>
+  ): Promise<void> {
+    await Promise.all(
+      [...instances.values()].map(async (instance) => {
+        if (instance.isClosed || !instance.refreshPrompts) return;
+        try {
+          await instance.refreshPrompts();
+        } catch (error) {
+          log.debug("[MCP] Prompt list refresh failed; keeping cached prompts", {
+            name: instance.name,
+            error: getErrorMessage(error),
+          });
+        }
+      })
     );
   }
 
@@ -1164,20 +1219,9 @@ export class MCPServerManager {
     return filtered;
   }
 
-  async getToolsForWorkspace(options: {
-    workspaceId: string;
-    projectPath: string;
-    runtime: Runtime;
-    workspacePath: string;
-    /** Whether repo-local MCP config is allowed for this project. */
-    trusted?: boolean;
-    /** Per-workspace MCP overrides (disabled servers, tool allowlists) */
-    overrides?: WorkspaceMCPOverrides;
-    /** Project secrets, used for resolving {secret: "KEY"} header references. */
-    projectSecrets?: Record<string, string>;
-    /** Agent Plugins discovery context (null = off-host workspace, no plugin servers). */
-    agentPlugins?: AgentPluginsMcpContext | null;
-  }): Promise<MCPToolsForWorkspaceResult> {
+  async getToolsForWorkspace(
+    options: MCPWorkspaceRequestOptions
+  ): Promise<MCPToolsForWorkspaceResult> {
     const {
       workspaceId,
       projectPath,
@@ -1386,8 +1430,7 @@ export class MCPServerManager {
         serverCount: enabledEntries.length,
       });
 
-      // Honor SEP-2549 freshness hints on modern-era connections instead of
-      // caching tool lists for the instance lifetime.
+      // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
       await this.refreshModernInstanceTools(existing.instances);
 
       return {
@@ -1500,8 +1543,7 @@ export class MCPServerManager {
       );
       existing.stats = leasedStats;
 
-      // Honor SEP-2549 freshness hints on modern-era connections instead of
-      // caching tool lists for the instance lifetime.
+      // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
       await this.refreshModernInstanceTools(instancesForTools);
 
       return {
@@ -1553,6 +1595,57 @@ export class MCPServerManager {
     return {
       tools: this.collectTools(instances, fullServerInfo, overrides),
       stats,
+    };
+  }
+
+  async getPromptsForWorkspace(
+    options: MCPWorkspaceRequestOptions
+  ): Promise<MCPPromptDescriptor[]> {
+    await this.getToolsForWorkspace(options);
+    const entry = this.workspaceServers.get(options.workspaceId);
+    if (!entry) return [];
+
+    await this.refreshModernInstancePrompts(entry.instances);
+    const descriptors: MCPPromptDescriptor[] = [];
+    const usedNames = new Set<string>();
+    const instances = [...entry.instances.values()].sort((a, b) => a.name.localeCompare(b.name));
+    for (const instance of instances) {
+      const prompts = [...instance.prompts].sort((a, b) => a.name.localeCompare(b.name));
+      for (const prompt of prompts) {
+        const command = buildMcpPromptCommandKey({
+          serverName: instance.name,
+          promptName: prompt.name,
+          usedNames,
+        });
+        if (!command) continue;
+        descriptors.push({
+          commandKey: command.toolName,
+          serverName: instance.name,
+          promptName: prompt.name,
+          ...(prompt.description !== undefined ? { description: prompt.description } : {}),
+          ...(prompt.arguments !== undefined ? { arguments: prompt.arguments } : {}),
+        });
+      }
+    }
+    return descriptors;
+  }
+
+  async getPrompt(
+    workspaceId: string,
+    serverName: string,
+    promptName: string,
+    args: Record<string, string>
+  ): Promise<{ text: string; description?: string }> {
+    const entry = this.workspaceServers.get(workspaceId);
+    const instance = entry?.instances.get(serverName);
+    if (!instance || instance.isClosed) {
+      throw new Error(`MCP server '${serverName}' is not connected`);
+    }
+    this.markActivity(workspaceId);
+    const result = await instance.getPrompt(promptName, args);
+    return {
+      text: flattenMcpPrompt(result),
+      ...(result.description !== undefined ? { description: result.description } : {}),
     };
   }
 
@@ -2177,6 +2270,15 @@ export class MCPServerManager {
         }
 
         const rawTools = await client.tools();
+        let prompts: MCPPrompt[] = [];
+        try {
+          prompts = await client.prompts();
+        } catch (error) {
+          log.debug("[MCP] Prompt list unavailable during startup", {
+            name,
+            error: getErrorMessage(error),
+          });
+        }
         if (signal.aborted) {
           await cleanupStartupResources();
           return null;
@@ -2211,12 +2313,17 @@ export class MCPServerManager {
           resolvedTransport: "stdio",
           autoFallbackUsed: false,
           tools,
+          prompts,
+          getPrompt: (promptName, args) => readyClient.getPrompt(promptName, args),
           isClosed: transportClosed,
           ...(isModernEra(negotiatedPrior)
             ? {
                 refreshTools: async () => {
                   const raw = await readyClient.tools();
                   instance.tools = wrapRawTools(raw);
+                },
+                refreshPrompts: async () => {
+                  instance.prompts = await readyClient.prompts();
                 },
               }
             : {}),
@@ -2426,6 +2533,15 @@ export class MCPServerManager {
       }
 
       const rawTools = await activeClient.tools();
+      let prompts: MCPPrompt[] = [];
+      try {
+        prompts = await activeClient.prompts();
+      } catch (error) {
+        log.debug("[MCP] Prompt list unavailable during startup", {
+          name,
+          error: getErrorMessage(error),
+        });
+      }
       if (signal.aborted) {
         await cleanupStartupClient();
         return null;
@@ -2458,12 +2574,17 @@ export class MCPServerManager {
         resolvedTransport,
         autoFallbackUsed,
         tools,
+        prompts,
+        getPrompt: (promptName, args) => activeClient.getPrompt(promptName, args),
         isClosed: transportErrored || clientClosed,
         ...(isModernEra(negotiatedPrior)
           ? {
               refreshTools: async () => {
                 const raw = await activeClient.tools();
                 instance.tools = wrapRawTools(raw);
+              },
+              refreshPrompts: async () => {
+                instance.prompts = await activeClient.prompts();
               },
             }
           : {}),

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1246,6 +1246,18 @@ export class MCPServerManager {
   async getToolsForWorkspace(
     options: MCPWorkspaceRequestOptions
   ): Promise<MCPToolsForWorkspaceResult> {
+    return this.ensureWorkspaceServers(options, true);
+  }
+
+  /**
+   * refreshToolCatalogs=false skips tools/list refreshes on cached instances;
+   * prompt paths use it so one stale unrelated server (60s SDK default
+   * timeout) cannot stall every prompt send in the workspace.
+   */
+  private async ensureWorkspaceServers(
+    options: MCPWorkspaceRequestOptions,
+    refreshToolCatalogs: boolean
+  ): Promise<MCPToolsForWorkspaceResult> {
     const {
       workspaceId,
       projectPath,
@@ -1457,8 +1469,10 @@ export class MCPServerManager {
         serverCount: enabledEntries.length,
       });
 
-      // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
-      await this.refreshModernInstanceTools(existing.instances);
+      if (refreshToolCatalogs) {
+        // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
+        await this.refreshModernInstanceTools(existing.instances);
+      }
 
       return {
         tools: this.collectTools(existing.instances, fullServerInfo, overrides),
@@ -1587,8 +1601,10 @@ export class MCPServerManager {
         );
       }
 
-      // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
-      await this.refreshModernInstanceTools(instancesForTools);
+      if (refreshToolCatalogs) {
+        // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
+        await this.refreshModernInstanceTools(instancesForTools);
+      }
 
       return {
         tools: this.collectTools(instancesForTools, fullServerInfo, overrides),
@@ -1607,7 +1623,9 @@ export class MCPServerManager {
         );
         if (current.configSignature === signature && !currentHasClosedInstance) {
           current.lastActivity = Date.now();
-          await this.refreshModernInstanceTools(current.instances);
+          if (refreshToolCatalogs) {
+            await this.refreshModernInstanceTools(current.instances);
+          }
           return {
             tools: this.collectTools(current.instances, fullServerInfo, overrides),
             stats: current.stats,
@@ -1669,7 +1687,7 @@ export class MCPServerManager {
   async getPromptsForWorkspace(
     options: MCPWorkspaceRequestOptions
   ): Promise<MCPPromptDescriptor[]> {
-    await this.getToolsForWorkspace(options);
+    await this.ensureWorkspaceServers(options, false);
     const entry = this.workspaceServers.get(options.workspaceId);
     if (!entry) return [];
 
@@ -1819,8 +1837,9 @@ export class MCPServerManager {
         // Re-read after the await: a settings mutation recorded while secrets
         // resolved must not be clobbered by the pre-await options snapshot.
         const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions;
-        await this.getToolsForWorkspace(
-          projectSecrets !== undefined ? { ...currentOptions, projectSecrets } : currentOptions
+        await this.ensureWorkspaceServers(
+          projectSecrets !== undefined ? { ...currentOptions, projectSecrets } : currentOptions,
+          false
         );
       };
       const refreshed = await raceWithAbortAndTimeout(refresh(), {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -894,6 +894,12 @@ export class MCPServerManager {
   private readonly latestWorkspaceOverrides = new Map<string, WorkspaceMCPOverrides | undefined>();
   private readonly latestProjectTrust = new Map<string, boolean>();
   private readonly workspaceRestartLocks = new MutexMap<string>();
+  // Bumped by removal-style stops (stopServers without retainRestartOptions).
+  // Startups run outside any lock shared with removal, so an abort-abandoned
+  // startup can finish after the workspace is gone; the epoch check makes it
+  // close its clients instead of caching them. Never pruned: a stale capture
+  // reading a reset baseline would close legitimately started servers.
+  private readonly workspaceStopEpochs = new Map<string, number>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
    * Cached per-server protocol era verdicts, keyed by server config
@@ -1637,6 +1643,7 @@ export class MCPServerManager {
     // without closing discarded instances. Same-signature retries remain outside
     // this lock because their replacement path reconciles concurrent changes.
     return this.workspaceRestartLocks.withLock(workspaceId, async () => {
+      const stopEpochBefore = this.workspaceStopEpochs.get(workspaceId) ?? 0;
       const current = this.workspaceServers.get(workspaceId);
       if (current !== undefined) {
         const currentHasClosedInstance = [...current.instances.values()].some(
@@ -1692,6 +1699,23 @@ export class MCPServerManager {
 
       const allFailedNames = [...restartFailedNames, ...startFailedNames];
       const stats = this.createWorkspaceStats(enabledEntries.length, instances, allFailedNames);
+
+      // A removal-style stop landing mid-startup found no cache entry to
+      // close, so caching now would leave the removed workspace's processes
+      // alive until idle cleanup. Close the late clients instead.
+      if ((this.workspaceStopEpochs.get(workspaceId) ?? 0) !== stopEpochBefore) {
+        for (const instance of instances.values()) {
+          try {
+            await instance.close();
+          } catch (error) {
+            log.warn("Failed to stop late MCP server for removed workspace", {
+              error,
+              name: instance.name,
+            });
+          }
+        }
+        return { tools: {}, stats };
+      }
 
       const entry: WorkspaceServers = {
         configSignature: signature,
@@ -2086,6 +2110,10 @@ export class MCPServerManager {
     options?: { retainRestartOptions?: boolean }
   ): Promise<void> {
     if (options?.retainRestartOptions !== true) {
+      this.workspaceStopEpochs.set(
+        workspaceId,
+        (this.workspaceStopEpochs.get(workspaceId) ?? 0) + 1
+      );
       this.lastWorkspaceRequestOptions.delete(workspaceId);
       this.workspaceOptionsMutationCounts.delete(workspaceId);
       this.latestWorkspaceOverrides.delete(workspaceId);

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1570,6 +1570,7 @@ export class MCPServerManager {
       );
       existing.stats = leasedStats;
       existing.enabledServerNames = enabledServerNames;
+      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, existing);
 
       // The deferred restart retains same-named instances with the old config,
       // so record which servers changed to block prompt invocation on them.
@@ -1646,7 +1647,7 @@ export class MCPServerManager {
       const allFailedNames = [...restartFailedNames, ...startFailedNames];
       const stats = this.createWorkspaceStats(enabledEntries.length, instances, allFailedNames);
 
-      this.workspaceServers.set(workspaceId, {
+      const entry: WorkspaceServers = {
         configSignature: signature,
         instances,
         enabledServerNames,
@@ -1654,7 +1655,9 @@ export class MCPServerManager {
         timedOutServerNames: startTimedOutNames,
         retryingTimedOutServerNames: new Set(),
         lastActivity: Date.now(),
-      });
+      };
+      this.workspaceServers.set(workspaceId, entry);
+      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, entry);
 
       return {
         tools: this.collectTools(instances, fullServerInfo, overrides),
@@ -1712,6 +1715,41 @@ export class MCPServerManager {
       }
     }
     return descriptors;
+  }
+
+  /**
+   * Settings mutations sync only an existing cache entry, so one landing while
+   * servers start would be lost and could leave a disabled or trust-revoked
+   * server invocable. Re-derive enablement from the latest recorded options.
+   */
+  private async repairEnablementAfterConcurrentMutation(
+    workspaceId: string,
+    optionsUsed: MCPWorkspaceRequestOptions,
+    entry: WorkspaceServers
+  ): Promise<void> {
+    try {
+      let recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+      while (recorded !== undefined && recorded !== optionsUsed) {
+        const enabled = await this.listServers(
+          recorded.projectPath,
+          recorded.overrides,
+          recorded.trusted ?? false,
+          recorded.agentPlugins
+        );
+        const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
+        if (latest === recorded) {
+          entry.enabledServerNames = new Set(Object.keys(enabled));
+          return;
+        }
+        // Another mutation landed while we derived enablement; recompute.
+        recorded = latest;
+      }
+    } catch (error) {
+      log.debug("[MCP] Failed to repair enablement after concurrent settings change", {
+        workspaceId,
+        error: getErrorMessage(error),
+      });
+    }
   }
 
   /** Keeps prompt invocation from using stale enablement before the next stream refresh. */

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -45,6 +45,7 @@ import {
   buildMcpToolName,
 } from "@/common/utils/tools/mcpToolName";
 import { getErrorMessage } from "@/common/utils/errors";
+import { AsyncSemaphore } from "@/node/utils/concurrency/asyncSemaphore";
 import { MutexMap } from "@/node/utils/concurrency/mutexMap";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 import { stripTrailingSlashes } from "@/node/utils/pathUtils";
@@ -63,6 +64,9 @@ const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const LEGACY_ERA_VERDICT_TTL_MS = 24 * 60 * 60 * 1000;
 const IDLE_CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
 const MCP_STARTUP_TIMEOUT_MS = 60_000; // 60s — generous for npx package downloads
+// Bounded so a burst of stdio spawns (npx downloads) cannot thrash the host,
+// while several unhealthy servers' startup deadlines overlap instead of stacking.
+const MCP_STARTUP_CONCURRENCY = 4;
 const MCP_STARTUP_CLEANUP_WAIT_TIMEOUT_MS = 5_000; // fail-safe so timeout error cannot hang forever
 
 /** Detect errors from the MCP SDK indicating the client/transport is closed.
@@ -2242,28 +2246,42 @@ export class MCPServerManager {
     const timedOutServerNames: string[] = [];
     const entries = Object.entries(servers);
 
-    for (const [name, info] of entries) {
-      try {
-        const instance = await this.startSingleServer(
-          name,
-          info,
-          runtime,
-          projectPath,
-          workspacePath,
-          projectSecrets,
-          onActivity,
-          workspaceId
-        );
-        if (instance) {
-          instances.set(name, instance);
+    // Bounded concurrency so one unresponsive server's 60s startup deadline
+    // cannot stack serially and stall tool/prompt availability for minutes.
+    const semaphore = new AsyncSemaphore(MCP_STARTUP_CONCURRENCY);
+    const results = await Promise.all(
+      entries.map(async ([name, info]): Promise<MCPServerInstance | null> => {
+        const slot = await semaphore.acquire();
+        try {
+          return await this.startSingleServer(
+            name,
+            info,
+            runtime,
+            projectPath,
+            workspacePath,
+            projectSecrets,
+            onActivity,
+            workspaceId
+          );
+        } catch (error) {
+          const message = getErrorMessage(error);
+          log.error("Failed to start MCP server", { name, error: message });
+          failedServerNames.push(name);
+          if (isMCPStartupTimeoutError(error)) {
+            timedOutServerNames.push(name);
+          }
+          return null;
+        } finally {
+          slot.release();
         }
-      } catch (error) {
-        const message = getErrorMessage(error);
-        log.error("Failed to start MCP server", { name, error: message });
-        failedServerNames.push(name);
-        if (isMCPStartupTimeoutError(error)) {
-          timedOutServerNames.push(name);
-        }
+      })
+    );
+    // Insert in the caller's (sorted) entry order so Map iteration stays
+    // deterministic regardless of which startups finish first.
+    for (const [index, [name]] of entries.entries()) {
+      const instance = results[index];
+      if (instance) {
+        instances.set(name, instance);
       }
     }
 

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -875,6 +875,14 @@ export class MCPServerManager {
    * pre-dispatch enablement checks with stale state.
    */
   private readonly workspaceOptionsMutationCounts = new Map<string, number>();
+  /**
+   * Newest overrides seen per workspace, recorded even when the workspace has
+   * no cache entry or recorded options yet (cold), where the sync in
+   * applyWorkspaceOverrides has nothing to update. ensureWorkspaceServers
+   * overlays this over caller-supplied overrides, whose persisted-state read
+   * may predate the mutation.
+   */
+  private readonly latestWorkspaceOverrides = new Map<string, WorkspaceMCPOverrides | undefined>();
   private readonly workspaceRestartLocks = new MutexMap<string>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
@@ -1262,9 +1270,19 @@ export class MCPServerManager {
    * timeout) cannot stall every prompt send in the workspace.
    */
   private async ensureWorkspaceServers(
-    options: MCPWorkspaceRequestOptions,
+    requestOptions: MCPWorkspaceRequestOptions,
     refreshToolCatalogs: boolean
   ): Promise<MCPToolsForWorkspaceResult> {
+    // workspace.mcp.set can land between a caller reading persisted overrides
+    // and reaching here; on a cold workspace there is no recorded state for
+    // that mutation to repair, so overlay the newest overrides the manager
+    // has seen over the caller's possibly stale snapshot.
+    const options = this.latestWorkspaceOverrides.has(requestOptions.workspaceId)
+      ? {
+          ...requestOptions,
+          overrides: this.latestWorkspaceOverrides.get(requestOptions.workspaceId),
+        }
+      : requestOptions;
     const {
       workspaceId,
       projectPath,
@@ -1850,10 +1868,11 @@ export class MCPServerManager {
     workspaceId: string,
     overrides: WorkspaceMCPOverrides | undefined
   ): Promise<void> {
+    this.latestWorkspaceOverrides.set(workspaceId, overrides);
+    this.bumpWorkspaceOptionsMutationCount(workspaceId);
     const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (recorded) {
       this.lastWorkspaceRequestOptions.set(workspaceId, { ...recorded, overrides });
-      this.bumpWorkspaceOptionsMutationCount(workspaceId);
     }
     const entry = this.workspaceServers.get(workspaceId);
     if (!entry || !recorded) return;
@@ -1981,6 +2000,8 @@ export class MCPServerManager {
   ): Promise<void> {
     if (options?.retainRestartOptions !== true) {
       this.lastWorkspaceRequestOptions.delete(workspaceId);
+      this.workspaceOptionsMutationCounts.delete(workspaceId);
+      this.latestWorkspaceOverrides.delete(workspaceId);
     }
     const entry = this.workspaceServers.get(workspaceId);
     if (!entry) return;

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1805,11 +1805,10 @@ export class MCPServerManager {
     if (lastOptions) {
       const refresh = async (): Promise<void> => {
         // Rotated header credentials must change the signature so stale clients are replaced.
-        let refreshOptions = lastOptions;
+        let projectSecrets: Record<string, string> | undefined;
         if (this.secretsResolver) {
           try {
-            const projectSecrets = await this.secretsResolver(workspaceId, lastOptions.projectPath);
-            refreshOptions = { ...lastOptions, projectSecrets };
+            projectSecrets = await this.secretsResolver(workspaceId, lastOptions.projectPath);
           } catch (error) {
             log.debug("[MCP] Failed to re-resolve secrets for prompt refresh", {
               workspaceId,
@@ -1817,7 +1816,12 @@ export class MCPServerManager {
             });
           }
         }
-        await this.getToolsForWorkspace(refreshOptions);
+        // Re-read after the await: a settings mutation recorded while secrets
+        // resolved must not be clobbered by the pre-await options snapshot.
+        const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions;
+        await this.getToolsForWorkspace(
+          projectSecrets !== undefined ? { ...currentOptions, projectSecrets } : currentOptions
+        );
       };
       const refreshed = await raceWithAbortAndTimeout(refresh(), {
         ...(options?.signal !== undefined ? { signal: options.signal } : {}),

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1578,16 +1578,10 @@ export class MCPServerManager {
       };
     }
 
-    // Config changed, instance closed, or not started yet -> restart.
-    //
-    // Serialized per workspace: concurrent callers (composer prompt discovery,
-    // stream tool startup, multi-ref getPrompt refreshes) could otherwise each
-    // stop/start the same servers and overwrite workspaceServers without
-    // closing the loser's instances. The cached same-signature retry path
-    // above intentionally stays outside this lock; it is guarded by
-    // retryingTimedOutServerNames and the mid-retry replacement reconciliation.
+    // Serialize restarts so concurrent callers cannot overwrite cached servers
+    // without closing discarded instances. Same-signature retries remain outside
+    // this lock because their replacement path reconciles concurrent changes.
     return this.workspaceRestartLocks.withLock(workspaceId, async () => {
-      // A queued caller may find the restart already done by the lock holder.
       const current = this.workspaceServers.get(workspaceId);
       if (current !== undefined) {
         const currentHasClosedInstance = [...current.instances.values()].some(
@@ -1730,14 +1724,7 @@ export class MCPServerManager {
     }
   }
 
-  /**
-   * Sync a project trust change into recorded workspace request options.
-   * getPrompt refreshes from those options before invoking, so a revoked
-   * project must not keep serving repo-local prompts from a stale
-   * trusted=true snapshot. Callers pass every affected project path (the
-   * trust owner plus children inheriting via parentProjectPath); scratch
-   * workspaces are untouched because their paths never match.
-   */
+  /** Updates recorded options so prompt refreshes cannot reuse stale project trust. */
   applyProjectTrust(projectPaths: string[], trusted: boolean): void {
     const affected = new Set(projectPaths.map((projectPath) => stripTrailingSlashes(projectPath)));
     for (const [workspaceId, options] of this.lastWorkspaceRequestOptions) {

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -237,6 +237,16 @@ type ResolvedHeaders = Record<string, string> | undefined;
 
 type ResolvedTransport = "stdio" | "http" | "sse";
 
+function secretRecordsEqual(
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  const aKeys = Object.keys(a);
+  return aKeys.length === Object.keys(b).length && aKeys.every((key) => b[key] === a[key]);
+}
+
 function resolveHeaders(
   headers: Record<string, MCPHeaderValue> | undefined,
   projectSecrets: Record<string, string> | undefined
@@ -1712,16 +1722,28 @@ export class MCPServerManager {
     callOptions?: { signal?: AbortSignal }
   ): Promise<MCPPromptDescriptor[]> {
     const workspaceId = options.workspaceId;
-    // Keep refreshing until both mutation counters remain stable across catalog fetch,
-    // preventing a pre-mutation instance copy from leaking descriptors. Abort returns
-    // promptly while a losing startup may finish into the cache for idle cleanup.
+    // Keep refreshing until both mutation counters and resolved secrets remain
+    // stable across the catalog fetch, preventing a pre-mutation instance copy
+    // from leaking descriptors. Secrets are resolved fresh each attempt and
+    // participate in the check because rotation bumps neither counter. Abort
+    // returns promptly while a losing startup may finish into the cache for
+    // idle cleanup.
     let enabledInstances: Map<string, MCPServerInstance>;
     for (;;) {
       const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
       const generationBefore = this.configService.configGeneration;
       const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? options;
+      const secretsUsed = await this.resolveSecretsForRefresh(
+        workspaceId,
+        currentOptions.projectPath
+      );
       const refreshed = await raceWithAbortAndTimeout(
-        this.ensureWorkspaceServers(currentOptions, false),
+        this.ensureWorkspaceServers(
+          secretsUsed !== undefined
+            ? { ...currentOptions, projectSecrets: secretsUsed }
+            : currentOptions,
+          false
+        ),
         {
           ...(callOptions?.signal !== undefined ? { signal: callOptions.signal } : {}),
         }
@@ -1743,9 +1765,14 @@ export class MCPServerManager {
         )
       );
       await this.refreshInstancePrompts(enabledInstances, callOptions?.signal);
+      const secretsNow = await this.resolveSecretsForRefresh(
+        workspaceId,
+        currentOptions.projectPath
+      );
       if (
         (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
-        this.configService.configGeneration === generationBefore
+        this.configService.configGeneration === generationBefore &&
+        secretRecordsEqual(secretsUsed, secretsNow)
       ) {
         break;
       }
@@ -1959,6 +1986,23 @@ export class MCPServerManager {
     );
   }
 
+  /** Rotated header credentials must change the signature so stale clients are replaced. */
+  private async resolveSecretsForRefresh(
+    workspaceId: string,
+    projectPath: string
+  ): Promise<Record<string, string> | undefined> {
+    if (!this.secretsResolver) return undefined;
+    try {
+      return await this.secretsResolver(workspaceId, projectPath);
+    } catch (error) {
+      log.debug("[MCP] Failed to re-resolve secrets for prompt refresh", {
+        workspaceId,
+        error: getErrorMessage(error),
+      });
+      return undefined;
+    }
+  }
+
   async getPrompt(
     workspaceId: string,
     serverName: string,
@@ -1971,42 +2015,40 @@ export class MCPServerManager {
     // so idle cleanup can close it.
     const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
     if (lastOptions) {
-      const refresh = async (): Promise<void> => {
-        // Rotated header credentials must change the signature so stale clients are replaced.
-        let projectSecrets: Record<string, string> | undefined;
-        if (this.secretsResolver) {
-          try {
-            projectSecrets = await this.secretsResolver(workspaceId, lastOptions.projectPath);
-          } catch (error) {
-            log.debug("[MCP] Failed to re-resolve secrets for prompt refresh", {
-              workspaceId,
-              error: getErrorMessage(error),
-            });
-          }
-        }
-        // Re-read after the await: a settings mutation recorded while secrets
-        // resolved must not be clobbered by the pre-await options snapshot.
+      const refresh = async (projectSecrets: Record<string, string> | undefined): Promise<void> => {
+        // Re-read after the resolver await: a settings mutation recorded while
+        // secrets resolved must not be clobbered by a pre-await options snapshot.
         const currentOptions = this.lastWorkspaceRequestOptions.get(workspaceId) ?? lastOptions;
         await this.ensureWorkspaceServers(
           projectSecrets !== undefined ? { ...currentOptions, projectSecrets } : currentOptions,
           false
         );
       };
-      // Refresh until both mutation counters remain stable so no mutation completes
-      // between refresh and the synchronous dispatch checks. Later mutations race
-      // with the in-flight request and cannot be prevented here.
+      // Refresh until both mutation counters and resolved secrets remain stable
+      // so neither a settings mutation nor a secret rotation completing during
+      // the refresh leaves this dispatch on pre-mutation state. Later mutations
+      // race with the in-flight request and cannot be prevented here.
       for (;;) {
         const optionsMutationsBefore = this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0;
         const generationBefore = this.configService.configGeneration;
-        const refreshed = await raceWithAbortAndTimeout(refresh(), {
+        const secretsUsed = await this.resolveSecretsForRefresh(
+          workspaceId,
+          lastOptions.projectPath
+        );
+        const refreshed = await raceWithAbortAndTimeout(refresh(secretsUsed), {
           ...(options?.signal !== undefined ? { signal: options.signal } : {}),
         });
         if (refreshed.kind === "aborted") {
           throw new Error(`MCP prompt request for '${serverName}/${promptName}' was aborted`);
         }
+        const secretsNow = await this.resolveSecretsForRefresh(
+          workspaceId,
+          lastOptions.projectPath
+        );
         if (
           (this.workspaceOptionsMutationCounts.get(workspaceId) ?? 0) === optionsMutationsBefore &&
-          this.configService.configGeneration === generationBefore
+          this.configService.configGeneration === generationBefore &&
+          secretRecordsEqual(secretsUsed, secretsNow)
         ) {
           break;
         }

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -836,6 +836,12 @@ interface MCPToolsForWorkspaceResult {
 interface WorkspaceServers {
   configSignature: string;
   instances: Map<string, MCPServerInstance>;
+  /**
+   * Currently enabled server names. Under a lease, disabling a server defers its
+   * restart and leaves the stale client in `instances`; prompt surfaces filter
+   * on this set so they never expose or invoke a disabled server.
+   */
+  enabledServerNames: Set<string>;
   stats: MCPWorkspaceStats;
   timedOutServerNames: string[];
   /** Prevent concurrent cached retries from stacking startup attempts for the same server. */
@@ -1549,6 +1555,7 @@ export class MCPServerManager {
         failedServerNames
       );
       existing.stats = leasedStats;
+      existing.enabledServerNames = enabledServerNames;
 
       // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
       await this.refreshModernInstanceTools(instancesForTools);
@@ -1571,7 +1578,9 @@ export class MCPServerManager {
       log.info("[MCP] Restarting servers due to closed client", { workspaceId });
     }
 
-    await this.stopServers(workspaceId);
+    // Internal restart: retain the recorded request options so getPrompt can
+    // still revive servers reaped later; only workspace removal forgets them.
+    await this.stopServers(workspaceId, { retainRestartOptions: true });
 
     const {
       instances,
@@ -1593,6 +1602,7 @@ export class MCPServerManager {
     this.workspaceServers.set(workspaceId, {
       configSignature: signature,
       instances,
+      enabledServerNames,
       stats,
       timedOutServerNames: startTimedOutNames,
       retryingTimedOutServerNames: new Set(),
@@ -1612,10 +1622,15 @@ export class MCPServerManager {
     const entry = this.workspaceServers.get(options.workspaceId);
     if (!entry) return [];
 
-    await this.refreshInstancePrompts(entry.instances);
+    // Mirror the leased tools path: a disabled server's stale client may still
+    // sit in entry.instances until its deferred restart.
+    const enabledInstances = new Map(
+      [...entry.instances].filter(([serverName]) => entry.enabledServerNames.has(serverName))
+    );
+    await this.refreshInstancePrompts(enabledInstances);
     const descriptors: MCPPromptDescriptor[] = [];
     const usedNames = new Set<string>();
-    const instances = [...entry.instances.values()].sort((a, b) => a.name.localeCompare(b.name));
+    const instances = [...enabledInstances.values()].sort((a, b) => a.name.localeCompare(b.name));
 
     // Suffix every member of a normalized collision group so a prompt's key
     // never depends on catalog order or which colliding sibling is enabled.
@@ -1656,7 +1671,11 @@ export class MCPServerManager {
     promptName: string,
     args: Record<string, string>
   ): Promise<{ text: string; description?: string }> {
-    let instance = this.workspaceServers.get(workspaceId)?.instances.get(serverName);
+    const currentEntry = this.workspaceServers.get(workspaceId);
+    if (currentEntry && !currentEntry.enabledServerNames.has(serverName)) {
+      throw new Error(`MCP server '${serverName}' is disabled`);
+    }
+    let instance = currentEntry?.instances.get(serverName);
     if (!instance || instance.isClosed) {
       // Idle cleanup may have reaped the client between composing the reference
       // and sending; revive so the explicitly selected prompt is not dropped.

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1304,53 +1304,7 @@ export class MCPServerManager {
 
     // Signature is based on *start config* only (not tool allowlists), so changing allowlists
     // does not force a server restart.
-    const signatureEntries: Record<string, unknown> = {};
-    for (const [name, info] of enabledEntries) {
-      if (info.transport === "stdio") {
-        // args/env/cwd participate so plugin mcp.json edits recycle servers.
-        signatureEntries[name] = {
-          transport: "stdio",
-          command: info.command,
-          args: info.args ?? null,
-          env: info.env ?? null,
-          cwd: info.cwd ?? null,
-        };
-        continue;
-      }
-
-      // OAuth status affects whether we can attach authProvider during server start.
-      // Include this (redacted) information in the signature so we retry starting
-      // remote servers after a user logs in/out.
-      let hasOauthTokens = false;
-      if (this.mcpOauthService) {
-        try {
-          hasOauthTokens = await this.mcpOauthService.hasAuthTokens({
-            serverUrl: info.url,
-          });
-        } catch (error) {
-          log.debug("[MCP] Failed to resolve MCP OAuth status", { name, error });
-        }
-      }
-
-      try {
-        const { headers } = resolveHeaders(info.headers, projectSecrets);
-        signatureEntries[name] = {
-          transport: info.transport,
-          url: info.url,
-          headers,
-          hasOauthTokens,
-        };
-      } catch {
-        // Missing secrets or invalid header config. Keep signature stable but avoid leaking details.
-        signatureEntries[name] = {
-          transport: info.transport,
-          url: info.url,
-          headers: null,
-          hasOauthTokens,
-        };
-      }
-    }
-
+    const signatureEntries = await this.computeSignatureEntries(enabledEntries, projectSecrets);
     const signature = JSON.stringify(signatureEntries);
 
     const existing = this.workspaceServers.get(workspaceId);
@@ -1599,12 +1553,6 @@ export class MCPServerManager {
       );
       existing.stats = leasedStats;
       existing.enabledServerNames = enabledServerNames;
-      await this.repairEnablementAfterConcurrentMutation(
-        workspaceId,
-        options,
-        existing,
-        configGenerationUsed
-      );
 
       // The deferred restart retains same-named instances with the old config,
       // so record which servers changed to block prompt invocation on them.
@@ -1620,6 +1568,15 @@ export class MCPServerManager {
           )
         );
       }
+
+      // Runs after the staleness recompute so the delete above cannot clobber
+      // staleness detected from a mutation newer than this call's config read.
+      await this.repairEnablementAfterConcurrentMutation(
+        workspaceId,
+        options,
+        existing,
+        configGenerationUsed
+      );
 
       if (refreshToolCatalogs) {
         // Honor SEP-2549 freshness hints instead of caching tool lists for the instance lifetime.
@@ -1768,10 +1725,65 @@ export class MCPServerManager {
     return descriptors;
   }
 
+  private async computeSignatureEntries(
+    enabledEntries: Array<[string, MCPServerInfo]>,
+    projectSecrets: Record<string, string> | undefined
+  ): Promise<Record<string, unknown>> {
+    const signatureEntries: Record<string, unknown> = {};
+    for (const [name, info] of enabledEntries) {
+      if (info.transport === "stdio") {
+        // args/env/cwd participate so plugin mcp.json edits recycle servers.
+        signatureEntries[name] = {
+          transport: "stdio",
+          command: info.command,
+          args: info.args ?? null,
+          env: info.env ?? null,
+          cwd: info.cwd ?? null,
+        };
+        continue;
+      }
+
+      // OAuth status affects whether we can attach authProvider during server start.
+      // Include this (redacted) information in the signature so we retry starting
+      // remote servers after a user logs in/out.
+      let hasOauthTokens = false;
+      if (this.mcpOauthService) {
+        try {
+          hasOauthTokens = await this.mcpOauthService.hasAuthTokens({
+            serverUrl: info.url,
+          });
+        } catch (error) {
+          log.debug("[MCP] Failed to resolve MCP OAuth status", { name, error });
+        }
+      }
+
+      try {
+        const { headers } = resolveHeaders(info.headers, projectSecrets);
+        signatureEntries[name] = {
+          transport: info.transport,
+          url: info.url,
+          headers,
+          hasOauthTokens,
+        };
+      } catch {
+        // Missing secrets or invalid header config. Keep signature stable but avoid leaking details.
+        signatureEntries[name] = {
+          transport: info.transport,
+          url: info.url,
+          headers: null,
+          hasOauthTokens,
+        };
+      }
+    }
+    return signatureEntries;
+  }
+
   /**
    * Settings mutations sync only an existing cache entry, so one landing while
-   * servers start would be lost and could leave a disabled or trust-revoked
-   * server invocable. Re-derive enablement from the latest recorded options.
+   * servers start would be lost: a disabled or trust-revoked server could stay
+   * invocable, and an edited server would keep serving its pre-edit instance.
+   * Re-derive enablement from the latest recorded options and block prompt
+   * invocation on servers whose start config changed until the next restart.
    */
   private async repairEnablementAfterConcurrentMutation(
     workspaceId: string,
@@ -1794,9 +1806,24 @@ export class MCPServerManager {
           recorded.trusted ?? false,
           recorded.agentPlugins
         );
+        const signatureEntries = await this.computeSignatureEntries(
+          Object.entries(enabled).sort(([a], [b]) => a.localeCompare(b)),
+          recorded.projectSecrets
+        );
         const latest = this.lastWorkspaceRequestOptions.get(workspaceId);
         if (latest === recorded && this.configService.configGeneration === generationRead) {
           entry.enabledServerNames = new Set(Object.keys(enabled));
+          // configSignature is always in-process JSON.stringify output, so parsing cannot fail.
+          const previousEntries = JSON.parse(entry.configSignature) as Record<string, unknown>;
+          const reconfigured = Object.keys(signatureEntries).filter(
+            (name) =>
+              JSON.stringify(signatureEntries[name]) !== JSON.stringify(previousEntries[name])
+          );
+          if (reconfigured.length > 0) {
+            const stale = entry.stalePromptServerNames ?? new Set<string>();
+            for (const name of reconfigured) stale.add(name);
+            entry.stalePromptServerNames = stale;
+          }
           return;
         }
         // Another mutation landed while we derived enablement; recompute.
@@ -1896,7 +1923,7 @@ export class MCPServerManager {
     }
     if (entry?.stalePromptServerNames?.has(serverName)) {
       throw new Error(
-        `MCP server '${serverName}' was reconfigured while a stream is active; retry after the stream finishes`
+        `MCP server '${serverName}' was reconfigured while this request was being prepared; retry`
       );
     }
     const instance = entry?.instances.get(serverName);

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1474,6 +1474,11 @@ export class MCPServerManager {
         await this.refreshModernInstanceTools(existing.instances);
       }
 
+      // A trust or settings mutation can land while getAllServers() runs above;
+      // re-derive enablement so this cached return cannot leave a revoked
+      // repo-local server invocable.
+      await this.repairEnablementAfterConcurrentMutation(workspaceId, options, existing);
+
       return {
         tools: this.collectTools(existing.instances, fullServerInfo, overrides),
         stats: existing.stats,
@@ -1626,6 +1631,9 @@ export class MCPServerManager {
           if (refreshToolCatalogs) {
             await this.refreshModernInstanceTools(current.instances);
           }
+          // Same cached-return hazard as the fast path above: a mutation may
+          // have landed after the concurrent starter's repair ran.
+          await this.repairEnablementAfterConcurrentMutation(workspaceId, options, current);
           return {
             tools: this.collectTools(current.instances, fullServerInfo, overrides),
             stats: current.stats,

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -848,6 +848,9 @@ export interface MCPServerManagerOptions {
 
 export class MCPServerManager {
   private readonly workspaceServers = new Map<string, WorkspaceServers>();
+  // Survives idle cleanup so an explicit prompt invocation can revive reaped
+  // servers at send time; forgotten only on workspace removal.
+  private readonly lastWorkspaceRequestOptions = new Map<string, MCPWorkspaceRequestOptions>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
    * Cached per-server protocol era verdicts, keyed by server config
@@ -999,7 +1002,7 @@ export class MCPServerManager {
           workspaceId,
           idleMinutes: Math.round(idleMs / 60_000),
         });
-        void this.stopServers(workspaceId);
+        void this.stopServers(workspaceId, { retainRestartOptions: true });
       }
     }
   }
@@ -1230,6 +1233,8 @@ export class MCPServerManager {
       projectSecrets,
       agentPlugins,
     } = options;
+
+    this.lastWorkspaceRequestOptions.set(workspaceId, options);
 
     // Fetch full server info for project-level allowlists and server filtering
     const allServers = await this.getAllServers(projectPath, trusted, agentPlugins);
@@ -1634,8 +1639,16 @@ export class MCPServerManager {
     promptName: string,
     args: Record<string, string>
   ): Promise<{ text: string; description?: string }> {
-    const entry = this.workspaceServers.get(workspaceId);
-    const instance = entry?.instances.get(serverName);
+    let instance = this.workspaceServers.get(workspaceId)?.instances.get(serverName);
+    if (!instance || instance.isClosed) {
+      // Idle cleanup may have reaped the client between composing the reference
+      // and sending; revive so the explicitly selected prompt is not dropped.
+      const lastOptions = this.lastWorkspaceRequestOptions.get(workspaceId);
+      if (lastOptions) {
+        await this.getToolsForWorkspace(lastOptions);
+        instance = this.workspaceServers.get(workspaceId)?.instances.get(serverName);
+      }
+    }
     if (!instance || instance.isClosed) {
       throw new Error(`MCP server '${serverName}' is not connected`);
     }
@@ -1647,7 +1660,13 @@ export class MCPServerManager {
     };
   }
 
-  async stopServers(workspaceId: string): Promise<void> {
+  async stopServers(
+    workspaceId: string,
+    options?: { retainRestartOptions?: boolean }
+  ): Promise<void> {
+    if (options?.retainRestartOptions !== true) {
+      this.lastWorkspaceRequestOptions.delete(workspaceId);
+    }
     const entry = this.workspaceServers.get(workspaceId);
     if (!entry) return;
 

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -887,6 +887,7 @@ export class MCPServerManager {
    * may predate the mutation.
    */
   private readonly latestWorkspaceOverrides = new Map<string, WorkspaceMCPOverrides | undefined>();
+  private readonly latestProjectTrust = new Map<string, boolean>();
   private readonly workspaceRestartLocks = new MutexMap<string>();
   private readonly workspaceLeases = new Map<string, number>();
   /**
@@ -1284,12 +1285,21 @@ export class MCPServerManager {
     // and reaching here; on a cold workspace there is no recorded state for
     // that mutation to repair, so overlay the newest overrides the manager
     // has seen over the caller's possibly stale snapshot.
-    const options = this.latestWorkspaceOverrides.has(requestOptions.workspaceId)
+    let options = this.latestWorkspaceOverrides.has(requestOptions.workspaceId)
       ? {
           ...requestOptions,
           overrides: this.latestWorkspaceOverrides.get(requestOptions.workspaceId),
         }
       : requestOptions;
+    // Same cold-workspace gap for project trust: a revocation landing while a
+    // stream's pre-await trusted snapshot is still in flight has no recorded
+    // options to repair, so overlay the newest trust the manager has seen.
+    const latestTrust = this.latestProjectTrust.get(
+      stripTrailingSlashes(requestOptions.projectPath)
+    );
+    if (latestTrust !== undefined && (options.trusted ?? false) !== latestTrust) {
+      options = { ...options, trusted: latestTrust };
+    }
     const {
       workspaceId,
       projectPath,
@@ -1942,6 +1952,11 @@ export class MCPServerManager {
     const trustByPath = new Map(
       updates.map((update) => [stripTrailingSlashes(update.projectPath), update.trusted])
     );
+    // Retained by project path so cold workspaces (no recorded options yet)
+    // pick up the mutation when their first request reaches the manager.
+    for (const [path, trusted] of trustByPath) {
+      this.latestProjectTrust.set(path, trusted);
+    }
     for (const [workspaceId, options] of this.lastWorkspaceRequestOptions) {
       const trusted = trustByPath.get(stripTrailingSlashes(options.projectPath));
       if (trusted === undefined || (options.trusted ?? false) === trusted) continue;

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -1668,11 +1668,43 @@ export class MCPServerManager {
     return descriptors;
   }
 
+  /**
+   * Sync a workspace's saved MCP overrides into cached state. Stream-time tool
+   * discovery recomputes enablement anyway; this keeps getPrompt (which can run
+   * before any stream) from trusting a stale enabledServerNames set.
+   */
+  async applyWorkspaceOverrides(
+    workspaceId: string,
+    overrides: WorkspaceMCPOverrides | undefined
+  ): Promise<void> {
+    const recorded = this.lastWorkspaceRequestOptions.get(workspaceId);
+    if (recorded) {
+      this.lastWorkspaceRequestOptions.set(workspaceId, { ...recorded, overrides });
+    }
+    const entry = this.workspaceServers.get(workspaceId);
+    if (!entry || !recorded) return;
+    try {
+      const enabled = await this.listServers(
+        recorded.projectPath,
+        overrides,
+        recorded.trusted ?? false,
+        recorded.agentPlugins
+      );
+      entry.enabledServerNames = new Set(Object.keys(enabled));
+    } catch (error) {
+      log.debug("[MCP] Failed to sync workspace overrides into cached state", {
+        workspaceId,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+
   async getPrompt(
     workspaceId: string,
     serverName: string,
     promptName: string,
-    args: Record<string, string>
+    args: Record<string, string>,
+    options?: { signal?: AbortSignal }
   ): Promise<{ text: string; description?: string }> {
     const currentEntry = this.workspaceServers.get(workspaceId);
     if (currentEntry && !currentEntry.enabledServerNames.has(serverName)) {
@@ -1692,7 +1724,7 @@ export class MCPServerManager {
       throw new Error(`MCP server '${serverName}' is not connected`);
     }
     this.markActivity(workspaceId);
-    const result = await instance.getPrompt(promptName, args);
+    const result = await instance.getPrompt(promptName, args, options);
     return {
       text: flattenMcpPrompt(result),
       ...(result.description !== undefined ? { description: result.description } : {}),

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -38,7 +38,11 @@ import {
 import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { transformMCPResult, type MCPCallToolResult } from "@/node/services/mcpResultTransform";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
-import { buildMcpPromptCommandKey, buildMcpToolName } from "@/common/utils/tools/mcpToolName";
+import {
+  buildMcpPromptBaseKey,
+  buildMcpPromptCommandKey,
+  buildMcpToolName,
+} from "@/common/utils/tools/mcpToolName";
 import { getErrorMessage } from "@/common/utils/errors";
 
 const TEST_TIMEOUT_MS = 10_000;
@@ -1612,6 +1616,17 @@ export class MCPServerManager {
     const descriptors: MCPPromptDescriptor[] = [];
     const usedNames = new Set<string>();
     const instances = [...entry.instances.values()].sort((a, b) => a.name.localeCompare(b.name));
+
+    // Suffix every member of a normalized collision group so a prompt's key
+    // never depends on catalog order or which colliding sibling is enabled.
+    const baseKeyCounts = new Map<string, number>();
+    for (const instance of instances) {
+      for (const prompt of instance.prompts) {
+        const baseKey = buildMcpPromptBaseKey(instance.name, prompt.name);
+        baseKeyCounts.set(baseKey, (baseKeyCounts.get(baseKey) ?? 0) + 1);
+      }
+    }
+
     for (const instance of instances) {
       const prompts = [...instance.prompts].sort((a, b) => a.name.localeCompare(b.name));
       for (const prompt of prompts) {
@@ -1619,6 +1634,8 @@ export class MCPServerManager {
           serverName: instance.name,
           promptName: prompt.name,
           usedNames,
+          forceSuffix:
+            (baseKeyCounts.get(buildMcpPromptBaseKey(instance.name, prompt.name)) ?? 0) > 1,
         });
         if (!command) continue;
         descriptors.push({

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -750,6 +750,64 @@ describe("MessageQueue", () => {
       expect((second.options?.muxMetadata as MuxMessageMetadata).type).toBe("agent-skill");
     });
 
+    it("should queue an MCP prompt invocation after a normal message as its own entry", () => {
+      queue.add("First message");
+
+      const metadata: MuxMessageMetadata = {
+        type: "normal",
+        rawCommand: "/mcp__coder__review src",
+        mcpPromptRefs: [
+          {
+            serverName: "coder",
+            promptName: "review",
+            commandKey: "mcp__coder__review",
+            source: "slash",
+            arguments: { path: "src" },
+          },
+        ],
+      };
+
+      // Batching keeps only an entry's first muxMetadata, which would drop the
+      // prompt refs and skip snapshot materialization at dispatch.
+      expect(
+        queue.add("Using MCP prompt coder/review: src", {
+          model: "claude-3-5-sonnet-20241022",
+          agentId: "exec",
+          muxMetadata: metadata,
+        })
+      ).toBe(true);
+
+      const first = queue.dequeueNext();
+      expect(first.message).toBe("First message");
+      expect(first.options?.muxMetadata).toBeUndefined();
+
+      const second = queue.dequeueNext();
+      expect((second.options?.muxMetadata as MuxMessageMetadata).mcpPromptRefs).toHaveLength(1);
+    });
+
+    it("should queue an inline skill reference after a normal message as its own entry", () => {
+      queue.add("First message");
+
+      const metadata: MuxMessageMetadata = {
+        type: "normal",
+        agentSkillRefs: [{ skillName: "tdd", scope: "global", source: "inline" }],
+      };
+
+      expect(
+        queue.add("Apply $tdd here", {
+          model: "claude-3-5-sonnet-20241022",
+          agentId: "exec",
+          muxMetadata: metadata,
+        })
+      ).toBe(true);
+
+      const first = queue.dequeueNext();
+      expect(first.options?.muxMetadata).toBeUndefined();
+
+      const second = queue.dequeueNext();
+      expect((second.options?.muxMetadata as MuxMessageMetadata).agentSkillRefs).toHaveLength(1);
+    });
+
     it("should queue a normal message behind an agent-skill invocation without leaking metadata", () => {
       const metadata: MuxMessageMetadata = {
         type: "agent-skill",

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -26,6 +26,18 @@ function isAgentSkillMetadata(meta: unknown): meta is AgentSkillMetadata {
   return true;
 }
 
+// MCP prompt and inline skill refs ride on type "normal" metadata but are
+// consumed only from an entry's first muxMetadata, so batching them into an
+// existing entry would silently skip snapshot materialization at dispatch.
+function hasSnapshotRefs(meta: unknown): boolean {
+  if (typeof meta !== "object" || meta === null) return false;
+  const obj = meta as Record<string, unknown>;
+  return (
+    (Array.isArray(obj.mcpPromptRefs) && obj.mcpPromptRefs.length > 0) ||
+    (Array.isArray(obj.agentSkillRefs) && obj.agentSkillRefs.length > 0)
+  );
+}
+
 function isCompactionMetadata(meta: unknown): meta is CompactionMetadata {
   if (typeof meta !== "object" || meta === null) return false;
   const obj = meta as Record<string, unknown>;
@@ -312,6 +324,7 @@ export class MessageQueue {
       internal?.removableDedupeKey === true ||
       isAgentSkillMetadata(options?.muxMetadata) ||
       isWorkspaceTurnMetadata(options?.muxMetadata) ||
+      hasSnapshotRefs(options?.muxMetadata) ||
       incomingHasAcceptedCallbacks;
     // Compaction starts its own entry (its metadata must not adopt earlier batched
     // texts), but stays open so a follow-up typed behind a pending /compact batches

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -1866,6 +1866,26 @@ exit 1
       expect(result.error.type).toBe("project_not_found");
     });
 
+    it("reports cascade-removed sub-project paths so callers can drop per-path state", async () => {
+      // Retained MCP trust is keyed by path; omitting a cascaded child here
+      // would let a re-registered path inherit the removed project's grant.
+      const parentPath = "/fake/parent";
+      const childPath = "/fake/parent/packages/api";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(parentPath, { workspaces: [] });
+      cfg.projects.set(childPath, { workspaces: [], parentProjectPath: parentPath });
+      await config.editConfig(() => cfg);
+
+      const result = await service.remove(parentPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error("Expected success");
+      expect(result.data.removedProjectPaths.sort()).toEqual([parentPath, childPath]);
+      const after = config.loadConfigOrDefault();
+      expect(after.projects.has(parentPath)).toBe(false);
+      expect(after.projects.has(childPath)).toBe(false);
+    });
+
     const forceRemovalCases = [
       {
         name: "with force=true cascade-deletes archived workspaces then removes project",

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -1059,7 +1059,11 @@ export class ProjectService {
     return Err("Clone did not return a completion event");
   }
 
-  async remove(projectPath: string, force = false): Promise<Result<void, ProjectRemoveError>> {
+  /** Success carries every removed path (cascade included) so callers can drop per-path state. */
+  async remove(
+    projectPath: string,
+    force = false
+  ): Promise<Result<{ removedProjectPaths: string[] }, ProjectRemoveError>> {
     try {
       const normalizedPath = stripTrailingSlashes(projectPath);
       let config = this.config.loadConfigOrDefault();
@@ -1092,7 +1096,7 @@ export class ProjectService {
           freshConfig.projects.delete(normalizedPath);
           return freshConfig;
         });
-        return Ok(undefined);
+        return Ok({ removedProjectPaths: [normalizedPath] });
       }
 
       // Self-healing: purge workspace entries whose backing directories no longer exist.
@@ -1267,7 +1271,7 @@ export class ProjectService {
         log.error(`Failed to clean up secrets for project ${normalizedPath}:`, error);
       }
 
-      return Ok(undefined);
+      return Ok({ removedProjectPaths: [normalizedPath, ...removedSubProjectPaths] });
     } catch (error) {
       const message = getErrorMessage(error);
       return Err({ type: "unknown" as const, message: `Failed to remove project: ${message}` });

--- a/src/node/services/timelineMapper.ts
+++ b/src/node/services/timelineMapper.ts
@@ -123,7 +123,11 @@ function isUnloggedMachineTurn(
   if (metadata?.synthetic !== true) {
     return false;
   }
-  if (metadata.agentSkillSnapshot != null || metadata.fileAtMentionSnapshot != null) {
+  if (
+    metadata.agentSkillSnapshot != null ||
+    metadata.fileAtMentionSnapshot != null ||
+    metadata.mcpPromptSnapshot != null
+  ) {
     return true;
   }
   if (metadata.kind === GOAL_CONTINUATION_KIND || metadata.kind === GOAL_BUDGET_LIMIT_KIND) {

--- a/src/node/services/utils/messageIds.ts
+++ b/src/node/services/utils/messageIds.ts
@@ -5,6 +5,8 @@
  * Prefixes are preserved for backward compatibility with existing history.
  */
 
+import { MCP_PROMPT_SNAPSHOT_MESSAGE_ID_PREFIX } from "@/common/types/message";
+
 const randomSuffix = (len = 9) =>
   Math.random()
     .toString(36)
@@ -25,7 +27,7 @@ export const createAgentSkillSnapshotMessageId = (): string =>
   `agent-skill-snapshot-${Date.now()}-${randomSuffix(7)}`;
 
 export const createMcpPromptSnapshotMessageId = (): string =>
-  `mcp-prompt-snapshot-${Date.now()}-${randomSuffix(7)}`;
+  `${MCP_PROMPT_SNAPSHOT_MESSAGE_ID_PREFIX}${Date.now()}-${randomSuffix(7)}`;
 
 /** Compaction summary message IDs: summary-{timestamp}-{random} */
 export const createCompactionSummaryMessageId = (): string =>

--- a/src/node/services/utils/messageIds.ts
+++ b/src/node/services/utils/messageIds.ts
@@ -24,6 +24,9 @@ export const createFileSnapshotMessageId = (): string =>
 export const createAgentSkillSnapshotMessageId = (): string =>
   `agent-skill-snapshot-${Date.now()}-${randomSuffix(7)}`;
 
+export const createMcpPromptSnapshotMessageId = (): string =>
+  `mcp-prompt-snapshot-${Date.now()}-${randomSuffix(7)}`;
+
 /** Compaction summary message IDs: summary-{timestamp}-{random} */
 export const createCompactionSummaryMessageId = (): string =>
   `summary-${Date.now()}-${randomSuffix(9)}`;

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -24,8 +24,8 @@ import {
 import type { GoalBoardEntry, GoalBoardSnapshot, GoalBoardV1 } from "@/common/types/goal";
 import {
   createMuxMessage,
+  isSyntheticSnapshotUserMessage,
   pickStartupRetrySendOptions,
-  type MuxMessage,
 } from "@/common/types/message";
 import type { ProvidersConfigMap, SendMessageOptions } from "@/common/orpc/types";
 import { isWorkspaceArchived } from "@/common/utils/archive";
@@ -475,15 +475,6 @@ export class WorkspaceGoalService {
     this.streamInterrupter = interrupter;
   }
 
-  private isSyntheticSnapshotUserMessage(message: MuxMessage): boolean {
-    return (
-      message.role === "user" &&
-      message.metadata?.synthetic === true &&
-      (message.metadata.fileAtMentionSnapshot !== undefined ||
-        message.metadata.agentSkillSnapshot !== undefined)
-    );
-  }
-
   private async readChatTailGoalMode(workspaceId: string): Promise<ChatTailGoalModeResult> {
     const historyResult = await this.historyService.getLastMessages(workspaceId, 100);
     if (!historyResult.success) {
@@ -500,7 +491,7 @@ export class WorkspaceGoalService {
 
     for (let index = historyResult.data.length - 1; index >= 0; index -= 1) {
       const message = historyResult.data[index];
-      if (message.role !== "user" || this.isSyntheticSnapshotUserMessage(message)) {
+      if (message.role !== "user" || isSyntheticSnapshotUserMessage(message)) {
         continue;
       }
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -3496,6 +3496,7 @@ export class WorkspaceService extends EventEmitter {
       config: this.config,
       historyService: this.historyService,
       aiService: this.aiService,
+      mcpServerManager: this.mcpServerManager,
       telemetryService: this.telemetryService,
       initStateManager: this.initStateManager,
       workspaceGoalService: this.workspaceGoalService,

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -145,18 +145,26 @@ describeIntegration("MCP prompts", () => {
 
       const manager = env.services.mcpServerManager;
       const seenSecrets: Array<Record<string, string> | undefined> = [];
-      const realGetTools = manager.getToolsForWorkspace.bind(manager);
-      const getToolsSpy = jest
-        .spyOn(manager, "getToolsForWorkspace")
-        .mockImplementation((options) => {
+      // getPrompt refreshes through the private ensureWorkspaceServers seam
+      // (it skips tool catalog refreshes), so observe secrets there.
+      const access = manager as unknown as {
+        ensureWorkspaceServers: (
+          options: { projectSecrets?: Record<string, string> },
+          refreshToolCatalogs: boolean
+        ) => Promise<unknown>;
+      };
+      const realEnsure = access.ensureWorkspaceServers.bind(manager);
+      const ensureSpy = jest
+        .spyOn(access, "ensureWorkspaceServers")
+        .mockImplementation((options, refreshToolCatalogs) => {
           seenSecrets.push(options.projectSecrets);
-          return realGetTools(options);
+          return realEnsure(options, refreshToolCatalogs);
         });
 
       const prompt = await manager.getPrompt(workspaceId, "prompt server", "status", {});
       expect(prompt.text).toBe("Report workspace status");
       expect(seenSecrets[0]?.MCP_TOKEN).toBe("new");
-      getToolsSpy.mockRestore();
+      ensureSpy.mockRestore();
     } finally {
       await cleanup();
     }

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -78,6 +78,47 @@ describeIntegration("MCP prompts", () => {
     }
   }, 60_000);
 
+  test("aborting a send cancels an in-flight prompts/get", async () => {
+    const { env, workspaceId, cleanup } = await setupWorkspaceWithoutProvider("mcp-prompts-abort");
+    env.services.aiService.enableMockMode();
+    const client = resolveOrpcClient(env);
+
+    try {
+      const addResult = await client.mcp.add({
+        name: "prompt server",
+        command: MCP_SERVER_COMMAND,
+      });
+      expect(addResult.success).toBe(true);
+
+      // Start servers and record workspace request options for getPrompt.
+      await client.workspace.mcp.prompts.list({ workspaceId });
+
+      const controller = new AbortController();
+      const promptPromise = env.services.mcpServerManager.getPrompt(
+        workspaceId,
+        "prompt server",
+        "hang",
+        {},
+        { signal: controller.signal }
+      );
+      setTimeout(() => controller.abort(), 250);
+
+      const startedAt = Date.now();
+      let rejected = false;
+      try {
+        await promptPromise;
+      } catch {
+        rejected = true;
+      }
+      expect(rejected).toBe(true);
+      // Well under PROMPT_GET_TIMEOUT_MS: proves the abort signal reached the
+      // SDK request instead of being dropped by the instance wrapper.
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
   test("lists prompts from a server without the tools capability", async () => {
     const { env, workspaceId, cleanup } = await setupWorkspaceWithoutProvider("mcp-prompts-only");
     env.services.aiService.enableMockMode();

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -29,6 +29,14 @@ describeIntegration("MCP prompts", () => {
           { name: "focus", description: "Optional review focus", required: false },
         ],
       });
+      // The fixture serves prompts/list one prompt per page; status lives on
+      // page two, so its presence pins whole-catalog pagination.
+      expect(prompts).toContainEqual({
+        commandKey: "mcp__prompt_server__status",
+        serverName: "prompt server",
+        promptName: "status",
+        description: "Build a no-argument status prompt for tests.",
+      });
 
       const sendResult = await sendMessageWithModel(
         env,
@@ -63,6 +71,28 @@ describeIntegration("MCP prompts", () => {
       expect(snapshot?.parts.find((part) => part.type === "text")?.text).toBe(
         "Review src with focus on security"
       );
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  test("lists prompts from a server without the tools capability", async () => {
+    const { env, workspaceId, cleanup } = await setupWorkspaceWithoutProvider("mcp-prompts-only");
+    env.services.aiService.enableMockMode();
+    const client = resolveOrpcClient(env);
+
+    try {
+      const addResult = await client.mcp.add({
+        name: "prompt only",
+        command: `${MCP_SERVER_COMMAND} --prompts-only`,
+      });
+      expect(addResult.success).toBe(true);
+
+      const prompts = await client.workspace.mcp.prompts.list({ workspaceId });
+      expect(prompts.map((prompt) => prompt.commandKey)).toEqual([
+        "mcp__prompt_only__review",
+        "mcp__prompt_only__status",
+      ]);
     } finally {
       await cleanup();
     }

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { shouldRunIntegrationTests, setupWorkspaceWithoutProvider } from "../setup";
@@ -113,6 +114,48 @@ describeIntegration("MCP prompts", () => {
       expect(rejected).toBe(true);
       // The bound distinguishes cancellation from the prompt timeout.
       expect(Date.now() - startedAt).toBeLessThan(10_000);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  test("rotated project secrets reach the prompt-invocation refresh", async () => {
+    const { env, workspaceId, tempGitRepo, cleanup } =
+      await setupWorkspaceWithoutProvider("mcp-prompts-secrets");
+    env.services.aiService.enableMockMode();
+    const client = resolveOrpcClient(env);
+
+    try {
+      const addResult = await client.mcp.add({
+        name: "prompt server",
+        command: MCP_SERVER_COMMAND,
+      });
+      expect(addResult.success).toBe(true);
+      await client.secrets.update({
+        projectPath: tempGitRepo,
+        secrets: [{ key: "MCP_TOKEN", value: "old" }],
+      });
+
+      // Record workspace request options with the pre-rotation snapshot.
+      await client.workspace.mcp.prompts.list({ workspaceId });
+
+      await client.secrets.update({
+        projectPath: tempGitRepo,
+        secrets: [{ key: "MCP_TOKEN", value: "new" }],
+      });
+
+      const manager = env.services.mcpServerManager;
+      const seenSecrets: Array<Record<string, string> | undefined> = [];
+      const realGetTools = manager.getToolsForWorkspace.bind(manager);
+      const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation((options) => {
+        seenSecrets.push(options.projectSecrets);
+        return realGetTools(options);
+      });
+
+      const prompt = await manager.getPrompt(workspaceId, "prompt server", "status", {});
+      expect(prompt.text).toBe("Report workspace status");
+      expect(seenSecrets[0]?.MCP_TOKEN).toBe("new");
+      getToolsSpy.mockRestore();
     } finally {
       await cleanup();
     }

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -21,6 +21,7 @@ describeIntegration("MCP prompts", () => {
       const prompts = await client.workspace.mcp.prompts.list({ workspaceId });
       expect(prompts).toContainEqual({
         commandKey: "mcp__prompt_server__review",
+        stableKey: expect.stringMatching(/^mcp__prompt_server__review_[0-9a-f]{8}$/),
         serverName: "prompt server",
         promptName: "review",
         description: "Build a deterministic review prompt for tests.",
@@ -33,6 +34,7 @@ describeIntegration("MCP prompts", () => {
       // page two, so its presence pins whole-catalog pagination.
       expect(prompts).toContainEqual({
         commandKey: "mcp__prompt_server__status",
+        stableKey: expect.stringMatching(/^mcp__prompt_server__status_[0-9a-f]{8}$/),
         serverName: "prompt server",
         promptName: "status",
         description: "Build a no-argument status prompt for tests.",

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -1,0 +1,70 @@
+import * as path from "node:path";
+import { shouldRunIntegrationTests, setupWorkspaceWithoutProvider } from "../setup";
+import { HAIKU_MODEL, readChatHistory, resolveOrpcClient, sendMessageWithModel } from "../helpers";
+
+const describeIntegration = shouldRunIntegrationTests() ? describe : describe.skip;
+const MCP_SERVER_COMMAND = `node "${path.join(__dirname, "..", "fixtures", "mcp-screenshot-server.js")}"`;
+
+describeIntegration("MCP prompts", () => {
+  test("lists and materializes prompts through workspace IPC", async () => {
+    const { env, workspaceId, cleanup } = await setupWorkspaceWithoutProvider("mcp-prompts");
+    env.services.aiService.enableMockMode();
+    const client = resolveOrpcClient(env);
+
+    try {
+      const addResult = await client.mcp.add({
+        name: "prompt server",
+        command: MCP_SERVER_COMMAND,
+      });
+      expect(addResult.success).toBe(true);
+
+      const prompts = await client.workspace.mcp.prompts.list({ workspaceId });
+      expect(prompts).toContainEqual({
+        commandKey: "mcp__prompt_server__review",
+        serverName: "prompt server",
+        promptName: "review",
+        description: "Build a deterministic review prompt for tests.",
+        arguments: [
+          { name: "path", description: "Path to review", required: true },
+          { name: "focus", description: "Optional review focus", required: false },
+        ],
+      });
+
+      const sendResult = await sendMessageWithModel(
+        env,
+        workspaceId,
+        "Using MCP prompt prompt server/review: src security",
+        HAIKU_MODEL,
+        {
+          agentId: "exec",
+          muxMetadata: {
+            type: "normal",
+            rawCommand: "/mcp__prompt_server__review src security",
+            commandPrefix: "/mcp__prompt_server__review",
+            mcpPromptRefs: [
+              {
+                serverName: "prompt server",
+                promptName: "review",
+                commandKey: "mcp__prompt_server__review",
+                source: "slash",
+                arguments: { path: "src", focus: "security" },
+              },
+            ],
+          },
+        }
+      );
+      expect(sendResult.success).toBe(true);
+
+      const history = await readChatHistory(env.tempDir, workspaceId);
+      const snapshot = history.find((message) => {
+        const metadata = (message as { metadata?: Record<string, unknown> }).metadata;
+        return metadata?.mcpPromptSnapshot !== undefined;
+      });
+      expect(snapshot?.parts.find((part) => part.type === "text")?.text).toBe(
+        "Review src with focus on security"
+      );
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+});

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { shouldRunIntegrationTests, setupWorkspaceWithoutProvider } from "../setup";
@@ -147,10 +146,12 @@ describeIntegration("MCP prompts", () => {
       const manager = env.services.mcpServerManager;
       const seenSecrets: Array<Record<string, string> | undefined> = [];
       const realGetTools = manager.getToolsForWorkspace.bind(manager);
-      const getToolsSpy = spyOn(manager, "getToolsForWorkspace").mockImplementation((options) => {
-        seenSecrets.push(options.projectSecrets);
-        return realGetTools(options);
-      });
+      const getToolsSpy = jest
+        .spyOn(manager, "getToolsForWorkspace")
+        .mockImplementation((options) => {
+          seenSecrets.push(options.projectSecrets);
+          return realGetTools(options);
+        });
 
       const prompt = await manager.getPrompt(workspaceId, "prompt server", "status", {});
       expect(prompt.text).toBe("Report workspace status");

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { shouldRunIntegrationTests, setupWorkspaceWithoutProvider } from "../setup";
 import { HAIKU_MODEL, readChatHistory, resolveOrpcClient, sendMessageWithModel } from "../helpers";
@@ -112,6 +113,37 @@ describeIntegration("MCP prompts", () => {
       expect(rejected).toBe(true);
       // The bound distinguishes cancellation from the prompt timeout.
       expect(Date.now() - startedAt).toBeLessThan(10_000);
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+
+  test("revoking project trust blocks cached repo-local prompt invocation", async () => {
+    const { env, workspaceId, tempGitRepo, cleanup } =
+      await setupWorkspaceWithoutProvider("mcp-prompts-trust");
+    env.services.aiService.enableMockMode();
+    const client = resolveOrpcClient(env);
+
+    try {
+      await fs.mkdir(path.join(tempGitRepo, ".mux"), { recursive: true });
+      await fs.writeFile(
+        path.join(tempGitRepo, ".mux", "mcp.jsonc"),
+        JSON.stringify({ servers: { "repo server": { command: MCP_SERVER_COMMAND } } })
+      );
+      await client.projects.setTrust({ projectPath: tempGitRepo, trusted: true });
+
+      const prompts = await client.workspace.mcp.prompts.list({ workspaceId });
+      expect(prompts.some((prompt) => prompt.serverName === "repo server")).toBe(true);
+
+      await client.projects.setTrust({ projectPath: tempGitRepo, trusted: false });
+
+      let rejection: unknown;
+      try {
+        await env.services.mcpServerManager.getPrompt(workspaceId, "repo server", "status", {});
+      } catch (error) {
+        rejection = error;
+      }
+      expect(String(rejection)).toMatch(/disabled|not connected/);
     } finally {
       await cleanup();
     }

--- a/tests/ipc/config/mcpPrompts.test.ts
+++ b/tests/ipc/config/mcpPrompts.test.ts
@@ -90,7 +90,6 @@ describeIntegration("MCP prompts", () => {
       });
       expect(addResult.success).toBe(true);
 
-      // Start servers and record workspace request options for getPrompt.
       await client.workspace.mcp.prompts.list({ workspaceId });
 
       const controller = new AbortController();
@@ -111,8 +110,7 @@ describeIntegration("MCP prompts", () => {
         rejected = true;
       }
       expect(rejected).toBe(true);
-      // Well under PROMPT_GET_TIMEOUT_MS: proves the abort signal reached the
-      // SDK request instead of being dropped by the instance wrapper.
+      // The bound distinguishes cancellation from the prompt timeout.
       expect(Date.now() - startedAt).toBeLessThan(10_000);
     } finally {
       await cleanup();

--- a/tests/ipc/fixtures/mcp-screenshot-server.js
+++ b/tests/ipc/fixtures/mcp-screenshot-server.js
@@ -123,6 +123,10 @@ rl.on("line", (line) => {
 
       case "prompts/get": {
         const promptName = message.params?.name;
+        // Unlisted prompt that never responds, for client-side abort tests.
+        if (promptName === "hang") {
+          return;
+        }
         if (!PROMPTS.some((prompt) => prompt.name === promptName)) {
           send({
             jsonrpc: "2.0",

--- a/tests/ipc/fixtures/mcp-screenshot-server.js
+++ b/tests/ipc/fixtures/mcp-screenshot-server.js
@@ -37,6 +37,21 @@ const TOOLS = [
   },
 ];
 
+const PROMPTS = [
+  {
+    name: "review",
+    description: "Build a deterministic review prompt for tests.",
+    arguments: [
+      { name: "path", description: "Path to review", required: true },
+      { name: "focus", description: "Optional review focus", required: false },
+    ],
+  },
+  {
+    name: "status",
+    description: "Build a no-argument status prompt for tests.",
+  },
+];
+
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
 rl.on("line", (line) => {
@@ -68,7 +83,7 @@ rl.on("line", (line) => {
           id,
           result: {
             protocolVersion,
-            capabilities: { tools: {} },
+            capabilities: { tools: {}, prompts: {} },
             serverInfo: SERVER_INFO,
           },
         });
@@ -77,6 +92,52 @@ rl.on("line", (line) => {
 
       case "tools/list": {
         send({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+        return;
+      }
+
+      case "prompts/list": {
+        send({ jsonrpc: "2.0", id, result: { prompts: PROMPTS } });
+        return;
+      }
+
+      case "prompts/get": {
+        const promptName = message.params?.name;
+        if (!PROMPTS.some((prompt) => prompt.name === promptName)) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32602, message: `Unknown prompt: ${promptName}` },
+          });
+          return;
+        }
+        const args = message.params?.arguments ?? {};
+        if (promptName === "review" && !args.path) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32602, message: "path is required" },
+          });
+          return;
+        }
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            description: `Expanded ${promptName} prompt`,
+            messages: [
+              {
+                role: "user",
+                content: {
+                  type: "text",
+                  text:
+                    promptName === "review"
+                      ? `Review ${args.path}${args.focus ? ` with focus on ${args.focus}` : ""}`
+                      : "Report workspace status",
+                },
+              },
+            ],
+          },
+        });
         return;
       }
 

--- a/tests/ipc/fixtures/mcp-screenshot-server.js
+++ b/tests/ipc/fixtures/mcp-screenshot-server.js
@@ -1,10 +1,10 @@
 // Minimal MCP server used by integration tests.
 //
-// Intentionally tiny + dependency-free: it speaks JSON-RPC over stdio
-// (newline-delimited JSON) and exposes a single screenshot tool.
+// Intentionally tiny and dependency-free: it speaks JSON-RPC over stdio
+// (newline-delimited JSON) and exposes a screenshot tool plus deterministic prompts.
 //
-// This lets us test the MCP → AI SDK image transformation without relying on
-// launching a real browser in CI.
+// This lets integration tests cover MCP image conversion and prompt invocation without
+// launching a real browser or external MCP service.
 
 const readline = require("readline");
 

--- a/tests/ipc/fixtures/mcp-screenshot-server.js
+++ b/tests/ipc/fixtures/mcp-screenshot-server.js
@@ -19,6 +19,10 @@ function send(message) {
 
 const SERVER_INFO = { name: "mux-test-screenshot-mcp", version: "0.0.0" };
 
+// Simulates a conforming prompt-only server: advertises no tools capability and
+// rejects tools/list outright.
+const PROMPTS_ONLY = process.argv.includes("--prompts-only");
+
 const TOOLS = [
   {
     name: "take_screenshot",
@@ -83,7 +87,7 @@ rl.on("line", (line) => {
           id,
           result: {
             protocolVersion,
-            capabilities: { tools: {}, prompts: {} },
+            capabilities: PROMPTS_ONLY ? { prompts: {} } : { tools: {}, prompts: {} },
             serverInfo: SERVER_INFO,
           },
         });
@@ -91,12 +95,29 @@ rl.on("line", (line) => {
       }
 
       case "tools/list": {
+        if (PROMPTS_ONLY) {
+          send({
+            jsonrpc: "2.0",
+            id,
+            error: { code: -32601, message: "Method not found: tools/list" },
+          });
+          return;
+        }
         send({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
         return;
       }
 
       case "prompts/list": {
-        send({ jsonrpc: "2.0", id, result: { prompts: PROMPTS } });
+        // One prompt per page so integration tests pin whole-catalog pagination.
+        const cursor = message.params?.cursor;
+        const index = cursor === undefined ? 0 : Number.parseInt(cursor, 10);
+        const prompts = PROMPTS.slice(index, index + 1);
+        const nextCursor = index + 1 < PROMPTS.length ? String(index + 1) : undefined;
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: { prompts, ...(nextCursor !== undefined ? { nextCursor } : {}) },
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary

MCP servers that advertise the `prompts` capability now surface those prompts in the chat composer. Prompts are discoverable and invokable through the same two surfaces agent skills use: a slash command (`/mcp__<server>__<prompt> args`) with positional arguments, and an inline `$mcp__<server>__<prompt>` reference for prompts without required arguments.

## Background

The MCP client only called `tools/list`, so prompts advertised by connected servers (e.g. the `coder` server) never appeared anywhere. The MCP spec treats prompts as user-controlled, so they belong in the composer rather than the model-facing tool catalog.

## Implementation

Mirrors the agent-skills architecture: invocations attach `mcpPromptRefs` metadata, and the backend materializes each ref at send time by calling `prompts/get` through `MCPServerManager`, persisting a synthetic `mcpPromptSnapshot` row (flattened prompt text) before the user row. The UI attaches snapshot content to the invocation message, same as skill snapshots.

- Command keys reuse the `buildMcpToolName` normalization (`mcp__<server>__<prompt>`, hash suffix on collision/truncation); the `mcp__` prefix cannot collide with kebab-case skill names.
- Slash arguments map positionally onto the prompt's declared arguments (quoted tokens supported, last argument consumes the remainder); missing required arguments error in the composer before send. Inline `$` suggestions list only prompts with no required arguments.
- Prompt lists are fetched lazily on first `prompts.list` per instance (with refresh on later lists for all transports) instead of at instance startup, keeping server startup on the tools-only fast path.
- Materialization failures (server down, args rejected) drop the ref with a debug log; the user message still sends.
- Content flattening (v1): text and embedded-resource text blocks with role markers; image/audio noted and skipped. Deferred to a follow-up: native multi-role injection of returned messages, image/audio content as attachments, `prompts/list_changed` handling, and per-prompt allowlists.

## Validation

Beyond unit/IPC suites: manual UAT in a sandboxed dev server with a prompts-capable stdio fixture covering slash discovery, required-argument validation, positional/remainder mapping, snapshot persistence and rendering, inline references, silence for a server without the prompts capability, and send-time failure tolerance (ref dropped, message still sent).

## Risks

Medium-touch on the send path (`agentSession` snapshot persistence) and composer resolution (`ChatInput/utils`). The skill-ref path is shared but changes are additive alongside it; the main regression surface is slash/inline suggestion resolution and compaction retry metadata, both covered by tests.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->

