### PR TITLE
[task-service] 🤖 preserve nested workspace-turn correlation

### DIFF
--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -92,6 +92,8 @@ export type StartupRetrySendOptions = Pick<
   | "disableWorkspaceAgents"
   | "allowAgentSetGoal"
 > & {
+  /** Correlation for a delegated workspace turn that must survive restart recovery. */
+  muxMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
   /** Internal-only Copilot billing override for startup auto-retry. */
   agentInitiated?: boolean;
   /** Internal goal continuation classification for startup auto-retry accounting. */
@@ -107,6 +109,9 @@ export function pickStartupRetrySendOptions(
   agentInitiated?: boolean,
   goalKind?: GoalSyntheticMessageKind
 ): StartupRetrySendOptions {
+  const workspaceTurnMuxMetadata = options.muxMetadata as
+    | Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+    | undefined;
   return {
     model: options.model,
     agentId: options.agentId,
@@ -119,6 +124,7 @@ export function pickStartupRetrySendOptions(
     experiments: options.experiments,
     disableWorkspaceAgents: options.disableWorkspaceAgents,
     allowAgentSetGoal: options.allowAgentSetGoal,
+    ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
     ...(agentInitiated === true ? { agentInitiated: true } : {}),
     ...(goalKind != null ? { goalKind } : {}),
   };

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -109,9 +109,9 @@ export function pickStartupRetrySendOptions(
   agentInitiated?: boolean,
   goalKind?: GoalSyntheticMessageKind
 ): StartupRetrySendOptions {
-  const workspaceTurnMuxMetadata = options.muxMetadata as
-    | Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
-    | undefined;
+  const typedMuxMetadata = options.muxMetadata as MuxMessageMetadata | undefined;
+  const workspaceTurnMuxMetadata =
+    typedMuxMetadata?.type === "workspace-turn-task" ? typedMuxMetadata : undefined;
   return {
     model: options.model,
     agentId: options.agentId,

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import { Err, Ok } from "@/common/types/result";
 import type { WorkspaceGoalService } from "./workspaceGoalService";
 import { createAgentSessionHarness } from "./agentSession.testHarness";
+import type { AIService } from "./aiService";
 
 const TEST_MODEL = "anthropic:claude-sonnet-4-5";
 
@@ -53,6 +54,39 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 500): Prom
 }
 
 describe("AgentSession queued message tool-call dispatch", () => {
+  test("counts a direct preparing send as a superseding predecessor", async () => {
+    const sessionHolder: {
+      current?: { hasQueuedOrDispatchingEntry(): boolean };
+    } = {};
+    let preparingSeen = false;
+    const streamMessage = mock(() => {
+      preparingSeen = sessionHolder.current?.hasQueuedOrDispatchingEntry() === true;
+      return Promise.resolve(Ok(undefined));
+    });
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "queue-dispatch-preparing-predecessor",
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+    sessionHolder.current = session;
+
+    try {
+      expect(session.hasQueuedOrDispatchingEntry()).toBe(false);
+      const result = await session.sendMessage("direct send", {
+        model: TEST_MODEL,
+        agentId: "exec",
+      });
+
+      expect(result.success).toBe(true);
+      expect(preparingSeen).toBe(true);
+      expect(session.hasQueuedOrDispatchingEntry()).toBe(false);
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("waits for stream-end instead of interrupting between sibling tool results", async () => {
     const workspaceId = "queue-dispatch-full-step";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, mock, spyOn, test } from "bun:test";
 
+import type { MuxMessageMetadata } from "@/common/types/message";
 import { Err, Ok } from "@/common/types/result";
 import type { WorkspaceGoalService } from "./workspaceGoalService";
 import { createAgentSessionHarness } from "./agentSession.testHarness";
 import type { AIService } from "./aiService";
 
 const TEST_MODEL = "anthropic:claude-sonnet-4-5";
+const WORKSPACE_TURN_CORRELATION = {
+  type: "workspace-turn-task",
+  taskHandleId: "wst_preparing",
+  ownerWorkspaceId: "owner-workspace",
+  turnId: "turn-preparing",
+} as const;
 
 function toolCallEndEvent(workspaceId: string): Record<string, unknown> {
   return {
@@ -54,13 +61,28 @@ async function waitForCondition(condition: () => boolean, timeoutMs = 500): Prom
 }
 
 describe("AgentSession queued message tool-call dispatch", () => {
-  test("counts a direct preparing send as a superseding predecessor", async () => {
+  test("counts only a different direct preparing send as a superseding predecessor", async () => {
     const sessionHolder: {
-      current?: { hasQueuedOrDispatchingEntry(): boolean };
+      current?: {
+        hasQueuedOrDispatchingEntry(
+          continuationMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+        ): boolean;
+      };
     } = {};
-    let preparingSeen = false;
+    let preparingState:
+      | { sameTurn: boolean; differentTurn: boolean; uncorrelated: boolean }
+      | undefined;
     const streamMessage = mock(() => {
-      preparingSeen = sessionHolder.current?.hasQueuedOrDispatchingEntry() === true;
+      const session = sessionHolder.current;
+      preparingState = {
+        sameTurn: session?.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION) === true,
+        differentTurn:
+          session?.hasQueuedOrDispatchingEntry({
+            ...WORKSPACE_TURN_CORRELATION,
+            turnId: "turn-different",
+          }) === true,
+        uncorrelated: session?.hasQueuedOrDispatchingEntry() === true,
+      };
       return Promise.resolve(Ok(undefined));
     });
     const { session, cleanup } = await createAgentSessionHarness({
@@ -76,10 +98,11 @@ describe("AgentSession queued message tool-call dispatch", () => {
       const result = await session.sendMessage("direct send", {
         model: TEST_MODEL,
         agentId: "exec",
+        muxMetadata: WORKSPACE_TURN_CORRELATION,
       });
 
       expect(result.success).toBe(true);
-      expect(preparingSeen).toBe(true);
+      expect(preparingState).toEqual({ sameTurn: false, differentTurn: true, uncorrelated: true });
       expect(session.hasQueuedOrDispatchingEntry()).toBe(false);
     } finally {
       session.dispose();

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -110,6 +110,35 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
+  test("preserves correlation for same-turn queued and dequeued predecessors", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "queue-dispatch-same-turn-predecessor",
+    });
+    const differentCorrelation = {
+      ...WORKSPACE_TURN_CORRELATION,
+      turnId: "turn-different",
+    };
+
+    try {
+      session.queueMessage(
+        "queued continuation",
+        { model: TEST_MODEL, agentId: "exec", muxMetadata: WORKSPACE_TURN_CORRELATION },
+        { synthetic: true }
+      );
+      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(false);
+      expect(session.hasQueuedOrDispatchingEntry(differentCorrelation)).toBe(true);
+
+      const sendMessage = spyOn(session, "sendMessage").mockResolvedValue(Ok(undefined));
+      session.sendQueuedMessages();
+      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(false);
+      expect(session.hasQueuedOrDispatchingEntry(differentCorrelation)).toBe(true);
+      sendMessage.mockRestore();
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("waits for stream-end instead of interrupting between sibling tool results", async () => {
     const workspaceId = "queue-dispatch-full-step";
     const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -67,10 +67,19 @@ describe("AgentSession queued message tool-call dispatch", () => {
         hasQueuedOrDispatchingEntry(
           continuationMetadata?: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
         ): boolean;
+        hasPendingWorkspaceTurnContinuation(
+          continuationMetadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+        ): boolean;
       };
     } = {};
     let preparingState:
-      | { sameTurn: boolean; differentTurn: boolean; uncorrelated: boolean }
+      | {
+          sameTurn: boolean;
+          differentTurn: boolean;
+          uncorrelated: boolean;
+          pendingSameTurn: boolean;
+          pendingDifferentTurn: boolean;
+        }
       | undefined;
     const streamMessage = mock(() => {
       const session = sessionHolder.current;
@@ -82,6 +91,13 @@ describe("AgentSession queued message tool-call dispatch", () => {
             turnId: "turn-different",
           }) === true,
         uncorrelated: session?.hasQueuedOrDispatchingEntry() === true,
+        pendingSameTurn:
+          session?.hasPendingWorkspaceTurnContinuation(WORKSPACE_TURN_CORRELATION) === true,
+        pendingDifferentTurn:
+          session?.hasPendingWorkspaceTurnContinuation({
+            ...WORKSPACE_TURN_CORRELATION,
+            turnId: "turn-different",
+          }) === true,
       };
       return Promise.resolve(Ok(undefined));
     });
@@ -102,7 +118,13 @@ describe("AgentSession queued message tool-call dispatch", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(preparingState).toEqual({ sameTurn: false, differentTurn: true, uncorrelated: true });
+      expect(preparingState).toEqual({
+        sameTurn: false,
+        differentTurn: true,
+        uncorrelated: true,
+        pendingSameTurn: true,
+        pendingDifferentTurn: false,
+      });
       expect(session.hasQueuedOrDispatchingEntry()).toBe(false);
     } finally {
       session.dispose();

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -128,9 +128,25 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(false);
       expect(session.hasQueuedOrDispatchingEntry(differentCorrelation)).toBe(true);
 
+      session.queueMessage(
+        "second queued continuation",
+        { model: TEST_MODEL, agentId: "exec", muxMetadata: WORKSPACE_TURN_CORRELATION },
+        { synthetic: true }
+      );
+      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(false);
+
+      session.queueMessage(
+        "unrelated predecessor",
+        { model: TEST_MODEL, agentId: "exec" },
+        {
+          synthetic: true,
+        }
+      );
+      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(true);
+
       const sendMessage = spyOn(session, "sendMessage").mockResolvedValue(Ok(undefined));
       session.sendQueuedMessages();
-      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(false);
+      expect(session.hasQueuedOrDispatchingEntry(WORKSPACE_TURN_CORRELATION)).toBe(true);
       expect(session.hasQueuedOrDispatchingEntry(differentCorrelation)).toBe(true);
       sendMessage.mockRestore();
     } finally {

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -9,7 +9,7 @@ import type { HistoryService } from "./historyService";
 import type { Config } from "@/node/config";
 import type { InitStateManager } from "./initStateManager";
 import type { WorkspaceChatMessage, SendMessageOptions } from "@/common/orpc/types";
-import { createMuxMessage } from "@/common/types/message";
+import { createMuxMessage, pickStartupRetrySendOptions } from "@/common/types/message";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
 import { Ok } from "@/common/types/result";
@@ -283,16 +283,21 @@ describe("AgentSession startup auto-retry recovery", () => {
     const workspaceId = "startup-retry-workflow-result-metadata";
     const { session, historyService, aiService, cleanup } = await createSessionBundle(workspaceId);
     cleanups.push(cleanup);
+    const workflowMetadata = {
+      type: "workflow-result" as const,
+      rawCommand: "/deep-research mux",
+      runId: "wfr_1",
+    };
     const appendResult = await historyService.appendToHistory(
       workspaceId,
       createMuxMessage("user-1", "user", "Use the workflow result", {
         timestamp: Date.now(),
-        retrySendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-        muxMetadata: {
-          type: "workflow-result",
-          rawCommand: "/deep-research mux",
-          runId: "wfr_1",
-        },
+        retrySendOptions: pickStartupRetrySendOptions({
+          model: "openai:gpt-4o",
+          agentId: "exec",
+          muxMetadata: workflowMetadata,
+        }),
+        muxMetadata: workflowMetadata,
       })
     );
     expect(appendResult.success).toBe(true);

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -269,7 +269,7 @@ describe("AgentSession startup auto-retry recovery", () => {
 
     session.ensureStartupAutoRetryCheck();
     await privateSession.startupAutoRetryCheckPromise;
-    expect(privateSession.lastAutoRetryResumeRequest?.options.muxMetadata).toBeUndefined();
+    expect(privateSession.lastAutoRetryResumeRequest?.options.muxMetadata).toEqual(muxMetadata);
 
     await privateSession.retryActiveStream();
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5283,6 +5283,8 @@ export class AgentSession {
     internal?: {
       synthetic?: boolean;
       agentInitiated?: boolean;
+      /** True only for a report that continues an existing workspace turn. */
+      workspaceTurnContinuation?: boolean;
       /** Coalescing: drop the message when an entry with the same key is already queued. */
       dedupeKey?: string;
       /** Isolate this keyed message so it can be selectively superseded later. */

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5441,7 +5441,7 @@ export class AgentSession {
       if (continuationMetadata == null) {
         return true;
       }
-      return !this.messageQueue.hasNextWorkspaceTurnContinuation(
+      return !this.messageQueue.hasAllWorkspaceTurnContinuations(
         continuationMetadata.taskHandleId,
         continuationMetadata.ownerWorkspaceId,
         continuationMetadata.turnId

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5388,6 +5388,31 @@ export class AgentSession {
     return dispatching?.type === "bash-monitor-wake";
   }
 
+  /**
+   * Whether a queued or dispatching entry continues the exact workspace-turn correlation.
+   */
+  hasPendingWorkspaceTurnContinuation(
+    metadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+  ): boolean {
+    if (
+      this.messageQueue.hasNextWorkspaceTurnContinuation(
+        metadata.taskHandleId,
+        metadata.ownerWorkspaceId,
+        metadata.turnId
+      )
+    ) {
+      return true;
+    }
+
+    const dispatching = this.dispatchingQueuedEntryMuxMetadata as MuxMessageMetadata | undefined;
+    return (
+      dispatching?.type === "workspace-turn-task" &&
+      dispatching.taskHandleId === metadata.taskHandleId &&
+      dispatching.ownerWorkspaceId === metadata.ownerWorkspaceId &&
+      dispatching.turnId === metadata.turnId
+    );
+  }
+
   /** Whether a message queued with this dedupe key is still pending (see MessageQueue.addOnce). */
   hasQueuedDedupeKey(dedupeKey: string): boolean {
     assert(dedupeKey.length > 0, "hasQueuedDedupeKey requires a dedupeKey");

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5415,16 +5415,40 @@ export class AgentSession {
   }
 
   /**
-   * Whether a queued entry, a dequeued entry, or a different direct send is preparing.
+   * Whether an earlier queued, dequeued, or direct send supersedes a continuation.
    *
-   * A direct send with the same workspace-turn correlation remains the current
-   * continuation and does not supersede the proposed report.
+   * A predecessor with the same workspace-turn correlation remains part of the
+   * continuation chain and does not supersede the proposed report.
    */
   hasQueuedOrDispatchingEntry(continuationMetadata?: WorkspaceTurnMuxMetadata): boolean {
     const hasDifferentPreparingSend =
       this.turnPhase === TurnPhase.PREPARING &&
       !hasSameWorkspaceTurnCorrelation(this.preparingWorkspaceTurnMetadata, continuationMetadata);
-    return hasDifferentPreparingSend || this.dispatchingQueuedEntry || !this.messageQueue.isEmpty();
+    if (hasDifferentPreparingSend) {
+      return true;
+    }
+
+    if (this.dispatchingQueuedEntry) {
+      const dispatchingMetadata = getWorkspaceTurnMuxMetadata(
+        this.dispatchingQueuedEntryMuxMetadata
+      );
+      if (!hasSameWorkspaceTurnCorrelation(dispatchingMetadata, continuationMetadata)) {
+        return true;
+      }
+    }
+
+    if (!this.messageQueue.isEmpty()) {
+      if (continuationMetadata == null) {
+        return true;
+      }
+      return !this.messageQueue.hasNextWorkspaceTurnContinuation(
+        continuationMetadata.taskHandleId,
+        continuationMetadata.ownerWorkspaceId,
+        continuationMetadata.turnId
+      );
+    }
+
+    return false;
   }
 
   /**

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5477,6 +5477,10 @@ export class AgentSession {
   hasPendingWorkspaceTurnContinuation(
     metadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
   ): boolean {
+    if (hasSameWorkspaceTurnCorrelation(this.preparingWorkspaceTurnMetadata, metadata)) {
+      return true;
+    }
+
     if (
       this.messageQueue.hasNextWorkspaceTurnContinuation(
         metadata.taskHandleId,

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5384,13 +5384,17 @@ export class AgentSession {
   }
 
   /**
-   * Whether a queued entry or a dequeued entry is still preparing.
+   * Whether a queued entry, a dequeued entry, or a direct send is still preparing.
    *
    * This distinguishes a report queued behind another entry from a report queued
    * directly behind the active stream.
    */
   hasQueuedOrDispatchingEntry(): boolean {
-    return this.dispatchingQueuedEntry || !this.messageQueue.isEmpty();
+    return (
+      this.turnPhase === TurnPhase.PREPARING ||
+      this.dispatchingQueuedEntry ||
+      !this.messageQueue.isEmpty()
+    );
   }
 
   /**

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -605,6 +605,7 @@ export class AgentSession {
    * Lets hasPendingBashMonitorWakeContinuation see a wake continuation during
    * the dequeue→stream-start window without consulting stale stream context.
    */
+  private dispatchingQueuedEntry = false;
   private dispatchingQueuedEntryMuxMetadata?: unknown;
 
   /** Context needed to retry the current stream (cleared on stream end/abort/error). */
@@ -4638,6 +4639,8 @@ export class AgentSession {
 
     forward("stream-start", (payload) => {
       if (payload.type === "stream-start") {
+        this.dispatchingQueuedEntry = false;
+        this.dispatchingQueuedEntryMuxMetadata = undefined;
         this.activeStreamStartedAtMs = payload.startTime;
         this.queuedProviderToolEndAbortInFlight = false;
         this.activeToolCallIds.clear();
@@ -5131,6 +5134,8 @@ export class AgentSession {
     this.emitStreamLifecycleIfChanged();
 
     if (next === TurnPhase.IDLE) {
+      this.dispatchingQueuedEntry = false;
+      this.dispatchingQueuedEntryMuxMetadata = undefined;
       // Turn ended: expire any mid-turn thinking override. Safe unconditionally
       // because a replacement turn (e.g. an edit) only creates its holder after
       // the preempted turn has already been transitioned to IDLE.
@@ -5379,6 +5384,16 @@ export class AgentSession {
   }
 
   /**
+   * Whether a queued entry or a dequeued entry is still preparing.
+   *
+   * This distinguishes a report queued behind another entry from a report queued
+   * directly behind the active stream.
+   */
+  hasQueuedOrDispatchingEntry(): boolean {
+    return this.dispatchingQueuedEntry || !this.messageQueue.isEmpty();
+  }
+
+  /**
    * Whether a bash-monitor-wake continuation is pending dispatch: the next
    * queued entry is a wake, or a dequeued wake is mid-dispatch (dequeue →
    * stream start). Wake sends are the only input that inherits an open
@@ -5603,6 +5618,7 @@ export class AgentSession {
       // skills, workspace-turn follow-ups) own their turn, and anything queued
       // behind them dispatches on a later drain instead of batching into them.
       const { message, options, internal } = this.messageQueue.dequeueNext();
+      this.dispatchingQueuedEntry = true;
       this.dispatchingQueuedEntryMuxMetadata = options?.muxMetadata;
       this.emitQueuedMessageChanged();
 
@@ -5621,10 +5637,9 @@ export class AgentSession {
 
       void this.sendMessage(message, options, internal)
         .then(async (result) => {
-          // Dispatch settled: on success the stream is registered (TaskService
-          // switches to matching the active stream's correlation), on failure
-          // there is no continuation to wait for.
-          this.dispatchingQueuedEntryMuxMetadata = undefined;
+          // Keep the dispatch marker through the dequeue-to-stream-start window. A background
+          // send can resolve before startup emits stream-start, and later reports must not claim
+          // that window as the next continuation.
           // If sendMessage fails before it can start streaming, ensure we don't
           // leave the session stuck in PREPARING and notify correlated internal callers.
           if (!result.success) {
@@ -5648,6 +5663,7 @@ export class AgentSession {
           }
         })
         .catch(() => {
+          this.dispatchingQueuedEntry = false;
           this.dispatchingQueuedEntryMuxMetadata = undefined;
           if (this.turnPhase === TurnPhase.PREPARING) {
             this.setTurnPhase(TurnPhase.IDLE);

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -292,6 +292,26 @@ function extractAcpDelegatedTools(muxMetadata: unknown): string[] | undefined {
     (muxMetadata as Record<string, unknown>)[ACP_DELEGATED_TOOLS_METADATA_KEY]
   );
 }
+type WorkspaceTurnMuxMetadata = Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>;
+
+function getWorkspaceTurnMuxMetadata(muxMetadata: unknown): WorkspaceTurnMuxMetadata | undefined {
+  const metadata = muxMetadata as MuxMessageMetadata | undefined;
+  return metadata?.type === "workspace-turn-task" ? metadata : undefined;
+}
+
+function hasSameWorkspaceTurnCorrelation(
+  first: WorkspaceTurnMuxMetadata | undefined,
+  second: WorkspaceTurnMuxMetadata | undefined
+): boolean {
+  return (
+    first != null &&
+    second != null &&
+    first.taskHandleId === second.taskHandleId &&
+    first.ownerWorkspaceId === second.ownerWorkspaceId &&
+    first.turnId === second.turnId
+  );
+}
+
 /**
  * Find the still-open workspace-turn correlation for a bash-monitor-wake
  * continuation stream.
@@ -607,6 +627,9 @@ export class AgentSession {
    */
   private dispatchingQueuedEntry = false;
   private dispatchingQueuedEntryMuxMetadata?: unknown;
+
+  /** Correlation of the direct send currently in the PREPARING phase, if any. */
+  private preparingWorkspaceTurnMetadata?: WorkspaceTurnMuxMetadata;
 
   /** Context needed to retry the current stream (cleared on stream end/abort/error). */
   private activeStreamContext?: {
@@ -3198,6 +3221,7 @@ export class AgentSession {
 
     const preparedTurnAbortController = new AbortController();
     this.activePreparedTurnAbortController = preparedTurnAbortController;
+    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
     this.setTurnPhase(TurnPhase.PREPARING);
 
     const startPreparedStream = async (): Promise<Result<void, SendMessageError>> => {
@@ -3339,6 +3363,7 @@ export class AgentSession {
     // A resumed attempt becomes the latest live resume request as soon as we
     // accept its options, even if startup fails before the stream fully begins.
     this.setAutoRetryResumeState(optionsForStream, internal?.agentInitiated, internal?.goalKind);
+    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(optionsForStream.muxMetadata);
     this.setTurnPhase(TurnPhase.PREPARING);
     // Open the mid-turn thinking override window for the resumed turn (after
     // setTurnPhase(PREPARING), which clears the holder on the IDLE transition).
@@ -4335,6 +4360,9 @@ export class AgentSession {
 
     await this.finalizeCompactionRetry(data.messageId);
     this.setAutoRetryResumeState(retryOptionsForResume, retryAgentInitiated, retryGoalKind);
+    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(
+      retryOptionsForResume.muxMetadata
+    );
     this.setTurnPhase(TurnPhase.PREPARING);
     let retryResult: Result<void, SendMessageError>;
     try {
@@ -4429,6 +4457,7 @@ export class AgentSession {
     await this.clearFailedAssistantMessage(data.messageId, "post-compaction-retry");
 
     // Retry the same request, but without post-compaction injection.
+    this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(context.options?.muxMetadata);
     this.setTurnPhase(TurnPhase.PREPARING);
     let retryResult: Result<void, SendMessageError>;
     try {
@@ -4641,6 +4670,7 @@ export class AgentSession {
       if (payload.type === "stream-start") {
         this.dispatchingQueuedEntry = false;
         this.dispatchingQueuedEntryMuxMetadata = undefined;
+        this.preparingWorkspaceTurnMetadata = undefined;
         this.activeStreamStartedAtMs = payload.startTime;
         this.queuedProviderToolEndAbortInFlight = false;
         this.activeToolCallIds.clear();
@@ -5136,6 +5166,7 @@ export class AgentSession {
     if (next === TurnPhase.IDLE) {
       this.dispatchingQueuedEntry = false;
       this.dispatchingQueuedEntryMuxMetadata = undefined;
+      this.preparingWorkspaceTurnMetadata = undefined;
       // Turn ended: expire any mid-turn thinking override. Safe unconditionally
       // because a replacement turn (e.g. an edit) only creates its holder after
       // the preempted turn has already been transitioned to IDLE.
@@ -5384,17 +5415,16 @@ export class AgentSession {
   }
 
   /**
-   * Whether a queued entry, a dequeued entry, or a direct send is still preparing.
+   * Whether a queued entry, a dequeued entry, or a different direct send is preparing.
    *
-   * This distinguishes a report queued behind another entry from a report queued
-   * directly behind the active stream.
+   * A direct send with the same workspace-turn correlation remains the current
+   * continuation and does not supersede the proposed report.
    */
-  hasQueuedOrDispatchingEntry(): boolean {
-    return (
-      this.turnPhase === TurnPhase.PREPARING ||
-      this.dispatchingQueuedEntry ||
-      !this.messageQueue.isEmpty()
-    );
+  hasQueuedOrDispatchingEntry(continuationMetadata?: WorkspaceTurnMuxMetadata): boolean {
+    const hasDifferentPreparingSend =
+      this.turnPhase === TurnPhase.PREPARING &&
+      !hasSameWorkspaceTurnCorrelation(this.preparingWorkspaceTurnMetadata, continuationMetadata);
+    return hasDifferentPreparingSend || this.dispatchingQueuedEntry || !this.messageQueue.isEmpty();
   }
 
   /**
@@ -5637,6 +5667,7 @@ export class AgentSession {
 
       // Set PREPARING synchronously before the async sendMessage to prevent
       // incoming messages from bypassing the queue during the await gap.
+      this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
       this.setTurnPhase(TurnPhase.PREPARING);
 
       void this.sendMessage(message, options, internal)

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1659,10 +1659,18 @@ export class AgentSession {
       return compactionRequest;
     }
 
+    const workspaceTurnMuxMetadata =
+      lastUserMuxMetadata?.type === "workspace-turn-task"
+        ? lastUserMuxMetadata
+        : persistedRetrySendOptions?.muxMetadata;
+
     const retryRequest: StartupRetrySendOptions = {
       model: baseModel,
       agentId: baseAgentId,
     };
+    if (workspaceTurnMuxMetadata != null) {
+      retryRequest.muxMetadata = workspaceTurnMuxMetadata;
+    }
     if (baseThinkingLevel) {
       retryRequest.thinkingLevel = baseThinkingLevel;
     }

--- a/src/node/services/agentSession.workspaceTurnInheritance.test.ts
+++ b/src/node/services/agentSession.workspaceTurnInheritance.test.ts
@@ -184,6 +184,46 @@ describe("AgentSession workspace-turn correlation inheritance", () => {
     expect(streamed).toBeUndefined();
   });
 
+  test("workspace-turn correlation persists in startup retry options", async () => {
+    const workspaceId = "workspace-turn-retry-metadata";
+    const streamMessage = mock((_opts: StreamMessageOptions) => Promise.resolve(Ok(undefined)));
+    const { session, cleanup, historyService } = await createAgentSessionHarness({
+      workspaceId,
+      aiServiceOverrides: {
+        streamMessage: streamMessage as unknown as AIService["streamMessage"],
+      },
+    });
+    try {
+      const result = await session.sendMessage(
+        "Nested terminal report",
+        {
+          model: "anthropic:claude-sonnet-4-5",
+          agentId: "exec",
+          muxMetadata: correlation,
+        },
+        { synthetic: true, agentInitiated: true }
+      );
+      expect(result.success).toBe(true);
+
+      const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(historyResult.success).toBe(true);
+      if (!historyResult.success) throw new Error("history read failed");
+      const userMessage = historyResult.data.find(
+        (message) =>
+          message.role === "user" &&
+          message.parts.some(
+            (part) => part.type === "text" && part.text === "Nested terminal report"
+          )
+      );
+      expect(userMessage?.metadata?.retrySendOptions).toMatchObject({
+        muxMetadata: correlation,
+      });
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("on-send compaction consuming a wake stamps the correlation on the follow-up", async () => {
     const workspaceId = "workspace-turn-compaction-stamp";
     const streamMessage = mock((_opts: StreamMessageOptions) => Promise.resolve(Ok(undefined)));

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -461,6 +461,21 @@ describe("MessageQueue", () => {
       ).toBe(false);
     });
 
+    it("should reject a same-turn continuation when any queued predecessor is unrelated", () => {
+      queue.add("First follow up", { model: "gpt-4", agentId: "exec", muxMetadata: metadata });
+      queue.add("Second follow up", { model: "gpt-4", agentId: "exec", muxMetadata: metadata });
+
+      expect(
+        queue.hasAllWorkspaceTurnContinuations("wst_followup", "parent-workspace", "turn-1")
+      ).toBe(true);
+
+      queue.add("Unrelated message");
+
+      expect(
+        queue.hasAllWorkspaceTurnContinuations("wst_followup", "parent-workspace", "turn-1")
+      ).toBe(false);
+    });
+
     it("should preserve internal workspace-turn callbacks", () => {
       const onAccepted = () => undefined;
       const onAcceptedPreStreamFailure = () => undefined;

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -476,6 +476,33 @@ describe("MessageQueue", () => {
       ).toBe(false);
     });
 
+    it("should strip correlation when queue reordering moves user input ahead", () => {
+      const onCanceled = () => undefined;
+      const onAcceptedPreStreamFailure = () => undefined;
+      queue.add(
+        "Background report",
+        { model: "gpt-4", agentId: "exec", muxMetadata: metadata },
+        {
+          synthetic: true,
+          agentInitiated: true,
+          onCanceled,
+          onAcceptedPreStreamFailure,
+        }
+      );
+      queue.add("User send now", { model: "gpt-4", agentId: "exec" });
+
+      expect(queue.setVisibleQueueDispatchMode("tool-end")).toBe(true);
+
+      const first = queue.dequeueNext();
+      expect(first.message).toBe("User send now");
+
+      const second = queue.dequeueNext();
+      expect(second.message).toBe("Background report");
+      expect(second.options?.muxMetadata).toBeUndefined();
+      expect(second.internal?.onCanceled).toBeUndefined();
+      expect(second.internal?.onAcceptedPreStreamFailure).toBeUndefined();
+    });
+
     it("should preserve internal workspace-turn callbacks", () => {
       const onAccepted = () => undefined;
       const onAcceptedPreStreamFailure = () => undefined;

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -485,6 +485,7 @@ describe("MessageQueue", () => {
         {
           synthetic: true,
           agentInitiated: true,
+          workspaceTurnContinuation: true,
           onCanceled,
           onAcceptedPreStreamFailure,
         }
@@ -501,6 +502,28 @@ describe("MessageQueue", () => {
       expect(second.options?.muxMetadata).toBeUndefined();
       expect(second.internal?.onCanceled).toBeUndefined();
       expect(second.internal?.onAcceptedPreStreamFailure).toBeUndefined();
+    });
+
+    it("should preserve an original queued workspace-turn prompt during reordering", () => {
+      const onAccepted = () => undefined;
+      const onCanceled = () => undefined;
+      queue.add(
+        "Original workspace-turn prompt",
+        { model: "gpt-4", agentId: "exec", muxMetadata: metadata },
+        { agentInitiated: true, onAccepted, onCanceled }
+      );
+      queue.add("User send now", { model: "gpt-4", agentId: "exec" });
+
+      expect(queue.setVisibleQueueDispatchMode("tool-end")).toBe(true);
+
+      const first = queue.dequeueNext();
+      expect(first.message).toBe("User send now");
+
+      const second = queue.dequeueNext();
+      expect(second.message).toBe("Original workspace-turn prompt");
+      expect(second.options?.muxMetadata).toEqual(metadata);
+      expect(second.internal?.onAccepted).toBe(onAccepted);
+      expect(second.internal?.onCanceled).toBe(onCanceled);
     });
 
     it("should preserve internal workspace-turn callbacks", () => {

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -444,6 +444,23 @@ describe("MessageQueue", () => {
       expect(queue.hasWorkspaceTurn("wst_followup")).toBe(false);
     });
 
+    it("should detect only the next entry with the exact workspace-turn correlation", () => {
+      queue.add("Normal message");
+      queue.add("Follow up", { model: "gpt-4", agentId: "exec", muxMetadata: metadata });
+
+      expect(
+        queue.hasNextWorkspaceTurnContinuation("wst_followup", "parent-workspace", "turn-1")
+      ).toBe(false);
+
+      queue.dequeueNext();
+      expect(
+        queue.hasNextWorkspaceTurnContinuation("wst_followup", "parent-workspace", "turn-1")
+      ).toBe(true);
+      expect(
+        queue.hasNextWorkspaceTurnContinuation("wst_other", "parent-workspace", "turn-1")
+      ).toBe(false);
+    });
+
     it("should preserve internal workspace-turn callbacks", () => {
       const onAccepted = () => undefined;
       const onAcceptedPreStreamFailure = () => undefined;

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -248,6 +248,44 @@ export class MessageQueue {
   }
 
   /**
+   * Remove workspace-turn metadata from entries that now follow an unrelated predecessor.
+   *
+   * Queue reordering can move user input ahead of a report after the report was enqueued.
+   * Clear the correlation callbacks with the metadata so the stale report cannot settle
+   * the superseded workspace turn when it later dispatches.
+   */
+  private revalidateWorkspaceTurnCorrelations(): void {
+    let hasPriorEntries = false;
+    let allPriorEntriesShareCorrelation = true;
+    let priorCorrelation: WorkspaceTurnMetadata | undefined;
+
+    for (const entry of this.entries) {
+      const metadata = isWorkspaceTurnMetadata(entry.muxMetadata) ? entry.muxMetadata : undefined;
+      const preservesCorrelation =
+        metadata != null &&
+        (!hasPriorEntries ||
+          (allPriorEntriesShareCorrelation &&
+            priorCorrelation != null &&
+            metadata.taskHandleId === priorCorrelation.taskHandleId &&
+            metadata.ownerWorkspaceId === priorCorrelation.ownerWorkspaceId &&
+            metadata.turnId === priorCorrelation.turnId));
+
+      if (metadata != null && !preservesCorrelation) {
+        entry.muxMetadata = undefined;
+        entry.onCanceled = undefined;
+        entry.onAcceptedPreStreamFailure = undefined;
+        allPriorEntriesShareCorrelation = false;
+      } else if (metadata == null) {
+        allPriorEntriesShareCorrelation = false;
+      } else if (!hasPriorEntries) {
+        priorCorrelation = metadata;
+      }
+
+      hasPriorEntries = true;
+    }
+  }
+
+  /**
    * Update the dispatch boundary for every user-visible queued entry represented by the
    * aggregate queued-message card. Hidden synthetic/background entries keep their own mode.
    */
@@ -269,6 +307,7 @@ export class MessageQueue {
     // The user explicitly chose when the aggregate visible card should dispatch. Keep those
     // entries together at the FIFO head so a hidden predecessor cannot contradict that choice.
     this.entries = [...visibleEntries, ...hiddenEntries];
+    this.revalidateWorkspaceTurnCorrelations();
     return true;
   }
 
@@ -632,6 +671,7 @@ export class MessageQueue {
     if (index > 0) {
       const [entry] = this.entries.splice(index, 1);
       this.entries.unshift(entry);
+      this.revalidateWorkspaceTurnCorrelations();
     }
     return true;
   }

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -177,6 +177,23 @@ export class MessageQueue {
   }
 
   /**
+   * Whether the next entry continues the exact workspace turn correlation.
+   */
+  hasNextWorkspaceTurnContinuation(
+    taskHandleId: string,
+    ownerWorkspaceId: string,
+    turnId: string
+  ): boolean {
+    const metadata = this.entries[0]?.muxMetadata;
+    return (
+      isWorkspaceTurnMetadata(metadata) &&
+      metadata.taskHandleId === taskHandleId &&
+      metadata.ownerWorkspaceId === ownerWorkspaceId &&
+      metadata.turnId === turnId
+    );
+  }
+
+  /**
    * Whether the next entry to dispatch is a bash-monitor wake. Wake sends are
    * the only queued input that continues an open delegated workspace turn
    * (see AgentSession.inheritOpenWorkspaceTurnMetadata); any other head entry

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -177,6 +177,31 @@ export class MessageQueue {
   }
 
   /**
+   * Whether every queued entry continues the exact workspace turn correlation.
+   *
+   * The caller uses this for a new continuation that has not entered the queue.
+   * An unrelated entry anywhere ahead of it supersedes the correlation.
+   */
+  hasAllWorkspaceTurnContinuations(
+    taskHandleId: string,
+    ownerWorkspaceId: string,
+    turnId: string
+  ): boolean {
+    return (
+      this.entries.length > 0 &&
+      this.entries.every((entry) => {
+        const metadata = entry.muxMetadata;
+        return (
+          isWorkspaceTurnMetadata(metadata) &&
+          metadata.taskHandleId === taskHandleId &&
+          metadata.ownerWorkspaceId === ownerWorkspaceId &&
+          metadata.turnId === turnId
+        );
+      })
+    );
+  }
+
+  /**
    * Whether the next entry continues the exact workspace turn correlation.
    */
   hasNextWorkspaceTurnContinuation(

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -71,6 +71,8 @@ type QueueDispatchMode = NonNullable<SendMessageOptions["queueDispatchMode"]>;
 interface QueuedMessageInternalOptions {
   synthetic?: boolean;
   agentInitiated?: boolean;
+  /** True only for a report that continues an existing workspace turn. */
+  workspaceTurnContinuation?: boolean;
   /** Keep this queued add isolated so its dedupe key can be removed without affecting siblings. */
   sealed?: boolean;
   /** Dedupe-keyed maintenance sends are removable by prefix without changing global queue rules. */
@@ -114,6 +116,8 @@ interface QueueEntry {
   sealed: boolean;
   /** User-originated entries are the only ones exposed to/restored into the composer. */
   userAuthored: boolean;
+  /** True only for a report that continues an existing workspace turn. */
+  workspaceTurnContinuation: boolean;
   addCount: number;
   syntheticCount: number;
   agentInitiatedCount: number;
@@ -255,33 +259,31 @@ export class MessageQueue {
    * the superseded workspace turn when it later dispatches.
    */
   private revalidateWorkspaceTurnCorrelations(): void {
-    let hasPriorEntries = false;
-    let allPriorEntriesShareCorrelation = true;
+    let hasUnrelatedPredecessor = false;
     let priorCorrelation: WorkspaceTurnMetadata | undefined;
 
     for (const entry of this.entries) {
       const metadata = isWorkspaceTurnMetadata(entry.muxMetadata) ? entry.muxMetadata : undefined;
-      const preservesCorrelation =
+      const matchesPriorCorrelation =
         metadata != null &&
-        (!hasPriorEntries ||
-          (allPriorEntriesShareCorrelation &&
-            priorCorrelation != null &&
-            metadata.taskHandleId === priorCorrelation.taskHandleId &&
+        !hasUnrelatedPredecessor &&
+        (priorCorrelation == null ||
+          (metadata.taskHandleId === priorCorrelation.taskHandleId &&
             metadata.ownerWorkspaceId === priorCorrelation.ownerWorkspaceId &&
             metadata.turnId === priorCorrelation.turnId));
 
-      if (metadata != null && !preservesCorrelation) {
-        entry.muxMetadata = undefined;
-        entry.onCanceled = undefined;
-        entry.onAcceptedPreStreamFailure = undefined;
-        allPriorEntriesShareCorrelation = false;
-      } else if (metadata == null) {
-        allPriorEntriesShareCorrelation = false;
-      } else if (!hasPriorEntries) {
-        priorCorrelation = metadata;
+      if (metadata == null) {
+        hasUnrelatedPredecessor = true;
+      } else if (!matchesPriorCorrelation) {
+        hasUnrelatedPredecessor = true;
+        if (entry.workspaceTurnContinuation) {
+          entry.muxMetadata = undefined;
+          entry.onCanceled = undefined;
+          entry.onAcceptedPreStreamFailure = undefined;
+        }
+      } else {
+        priorCorrelation ??= metadata;
       }
-
-      hasPriorEntries = true;
     }
   }
 
@@ -422,6 +424,7 @@ export class MessageQueue {
         dispatchMode: incomingMode,
         sealed: incomingIsSealed,
         userAuthored: incomingIsUserAuthored,
+        workspaceTurnContinuation: internal?.workspaceTurnContinuation === true,
         addCount: 0,
         syntheticCount: 0,
         agentInitiatedCount: 0,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -385,6 +385,7 @@ function createWorkspaceServiceMocks(
     isBusyForMessage: ReturnType<typeof mock>;
     hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
     hasPendingBashMonitorWakeContinuation: ReturnType<typeof mock>;
+    hasPendingWorkspaceTurnContinuation: ReturnType<typeof mock>;
     hasPendingAutoRetry: ReturnType<typeof mock>;
     waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
     waitForIdle: ReturnType<typeof mock>;
@@ -417,6 +418,7 @@ function createWorkspaceServiceMocks(
   waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
   waitForIdle: ReturnType<typeof mock>;
   hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
+  hasPendingWorkspaceTurnContinuation: ReturnType<typeof mock>;
   hasPendingAutoRetry: ReturnType<typeof mock>;
   waitForPendingCompactionCompletionDecision: ReturnType<typeof mock>;
   waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
@@ -450,6 +452,8 @@ function createWorkspaceServiceMocks(
     overrides?.hasPendingQueuedOrPreparingTurn ?? mock(() => false);
   const hasPendingBashMonitorWakeContinuation =
     overrides?.hasPendingBashMonitorWakeContinuation ?? mock(() => false);
+  const hasPendingWorkspaceTurnContinuation =
+    overrides?.hasPendingWorkspaceTurnContinuation ?? mock(() => false);
   const hasPendingAutoRetry = overrides?.hasPendingAutoRetry ?? mock(() => false);
   const waitForIdleAndNoQueuedMessages =
     overrides?.waitForIdleAndNoQueuedMessages ?? mock((): Promise<void> => Promise.resolve());
@@ -504,6 +508,7 @@ function createWorkspaceServiceMocks(
       hasQueuedMessages,
       hasPendingQueuedOrPreparingTurn,
       hasPendingBashMonitorWakeContinuation,
+      hasPendingWorkspaceTurnContinuation,
       hasPendingAutoRetry,
       waitForIdleAndNoQueuedMessages,
       waitForIdle,
@@ -533,6 +538,7 @@ function createWorkspaceServiceMocks(
     hasQueuedMessages,
     isBusyForMessage,
     hasPendingQueuedOrPreparingTurn,
+    hasPendingWorkspaceTurnContinuation,
     hasPendingAutoRetry,
     waitForIdleAndNoQueuedMessages,
     waitForIdle,
@@ -685,6 +691,7 @@ describe("TaskService", () => {
       hasQueuedMessages?: ReturnType<typeof mock>;
       hasPendingQueuedOrPreparingTurn?: ReturnType<typeof mock>;
       hasPendingBashMonitorWakeContinuation?: ReturnType<typeof mock>;
+      hasPendingWorkspaceTurnContinuation?: ReturnType<typeof mock>;
       hasPendingAutoRetry?: ReturnType<typeof mock>;
       waitForPendingStreamErrorRecoveryDecision?: ReturnType<typeof mock>;
     } = {}
@@ -727,6 +734,9 @@ describe("TaskService", () => {
         ? {
             hasPendingBashMonitorWakeContinuation: options.hasPendingBashMonitorWakeContinuation,
           }
+        : {}),
+      ...(options.hasPendingWorkspaceTurnContinuation != null
+        ? { hasPendingWorkspaceTurnContinuation: options.hasPendingWorkspaceTurnContinuation }
         : {}),
       ...(options.hasPendingAutoRetry != null
         ? { hasPendingAutoRetry: options.hasPendingAutoRetry }
@@ -3876,6 +3886,159 @@ describe("TaskService", () => {
       messageId: "msg_continuation_final",
       reportMarkdown: "Final review report",
     });
+  });
+
+  test("nested agent progress preserves workspace-turn correlation", async () => {
+    const hasPendingWorkspaceTurnContinuation = mock(
+      (
+        workspaceId: string,
+        metadata: { taskHandleId: string; ownerWorkspaceId: string; turnId: string }
+      ) =>
+        workspaceId === "childworkspace" &&
+        metadata.taskHandleId === "wst_handle" &&
+        metadata.turnId === "turn"
+    );
+    const { config, parentId, taskService, workspaceMocks } = await startWorkspaceTurnForTest({
+      hasPendingWorkspaceTurnContinuation,
+    });
+    const correlation = {
+      type: "workspace-turn-task",
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
+    } as const;
+
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      project.workspaces.push({
+        path: path.join(rootDir, "repo", "nested-agent"),
+        id: "nested-agent",
+        name: "nested-agent",
+        createdAt: "2026-06-19T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+        parentWorkspaceId: "childworkspace",
+        taskStatus: "running",
+        agentType: "explore",
+        taskModelString: "anthropic:claude-opus-4-6",
+      });
+      return cfg;
+    });
+
+    await taskService.reportAgentProgress("nested-agent", "progress-call", {
+      reportMarkdown: "The nested agent found the issue.",
+    });
+    expect(workspaceMocks.sendMessage).toHaveBeenCalledTimes(2);
+    expect(workspaceMocks.sendMessage.mock.calls[1]?.[2]).toMatchObject({
+      muxMetadata: correlation,
+    });
+
+    const internal = taskService as unknown as {
+      handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
+    };
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_nested_report_cut",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "tool-calls",
+        muxMetadata: correlation,
+      },
+      parts: [{ type: "text", text: "Nested report interrupted the turn" }],
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "running",
+    });
+
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      const nestedAgent = project.workspaces.find((workspace) => workspace.id === "nested-agent");
+      assert(nestedAgent, "nested agent must exist");
+      nestedAgent.taskStatus = "reported";
+      nestedAgent.reportedAt = "2026-06-19T00:00:01.000Z";
+      return cfg;
+    });
+
+    await internal.handleStreamEnd({
+      type: "stream-end",
+      workspaceId: "childworkspace",
+      messageId: "msg_nested_report_final",
+      metadata: {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "stop",
+        muxMetadata: correlation,
+      },
+      parts: [{ type: "text", text: "Nested report continuation completed" }],
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "completed",
+      reportMarkdown: "Nested report continuation completed",
+    });
+  });
+
+  test("terminal nested agent report resumes a workspace turn with correlation", async () => {
+    const { config, parentId, taskService, workspaceMocks } = await startWorkspaceTurnForTest();
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      project.workspaces.push({
+        path: path.join(rootDir, "repo", "nested-terminal-agent"),
+        id: "nested-terminal-agent",
+        name: "nested-terminal-agent",
+        createdAt: "2026-06-19T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+        parentWorkspaceId: "childworkspace",
+        taskStatus: "running",
+        agentType: "explore",
+        taskModelString: "anthropic:claude-opus-4-6",
+      });
+      return cfg;
+    });
+
+    await handleTaskServiceStreamEndForTest(taskService, {
+      type: "stream-end",
+      workspaceId: "nested-terminal-agent",
+      messageId: "assistant-nested-terminal-agent",
+      metadata: { model: "anthropic:claude-opus-4-6", finishReason: "stop" },
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "nested-report-call",
+          toolName: "agent_report",
+          input: { reportMarkdown: "The nested terminal report is complete." },
+          state: "output-available",
+          output: {
+            success: true,
+            report: { reportMarkdown: "The nested terminal report is complete." },
+          },
+        },
+        { type: "text", text: "The nested terminal report is complete." },
+      ],
+    });
+
+    await Promise.all([
+      ...(taskService as unknown as { pendingTerminalAttentionDrains: Set<Promise<void>> })
+        .pendingTerminalAttentionDrains,
+    ]);
+
+    expect(workspaceMocks.resumeStream).toHaveBeenCalledWith(
+      "childworkspace",
+      expect.objectContaining({
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: "wst_handle",
+          ownerWorkspaceId: parentId,
+          turnId: "turn",
+        },
+      }),
+      { agentInitiated: true }
+    );
   });
 
   test("workspace-turn tool-calls stream-end with superseding queued input settles error", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4060,6 +4060,86 @@ describe("TaskService", () => {
     );
   });
 
+  test("backfills workspace-turn correlation on an existing terminal report", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = "parent-restart-backfill";
+    const workspaceTurnId = "workspace-turn-restart-backfill";
+    const nestedTaskId = "nested-restart-backfill";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId),
+        projectWorkspace(projectPath, "workspace-turn", workspaceTurnId),
+        projectWorkspace(projectPath, "nested-agent", nestedTaskId, {
+          parentWorkspaceId: workspaceTurnId,
+          taskStatus: "reported",
+          reportedAt: "2026-08-14T00:00:01.000Z",
+          agentType: "explore",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    const { historyService, taskService } = createTaskServiceHarness(config);
+    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+      .taskHandleStore;
+    await taskHandleStore.upsertWorkspaceTurn({
+      kind: "workspace_turn",
+      handleId: "wst_restart_backfill",
+      ownerWorkspaceId: parentId,
+      workspaceId: workspaceTurnId,
+      turnId: "turn-restart-backfill",
+      status: "running",
+      createdAt: "2026-08-14T00:00:00.000Z",
+      updatedAt: "2026-08-14T00:00:00.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+    });
+
+    const reportMessage = createMuxMessage(
+      "existing-terminal-report",
+      "user",
+      formatSubagentReportEnvelope({
+        taskId: nestedTaskId,
+        agentType: "explore",
+        status: "completed",
+        title: "Existing result",
+        reportMarkdown: "The existing report survived the restart.",
+      }),
+      { timestamp: Date.now(), synthetic: true, uiVisible: true }
+    );
+    await historyService.appendToHistory(workspaceTurnId, reportMessage);
+
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    const notification = await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: workspaceTurnId,
+      sourceKind: "agent_task",
+      sourceId: nestedTaskId,
+    });
+    assert(notification, "terminal attention notification must be created");
+
+    const internal = taskService as unknown as {
+      ensureAgentTerminalMessages: (
+        ownerWorkspaceId: string,
+        notifications: ReadonlyArray<typeof notification>
+      ) => Promise<unknown>;
+    };
+    await internal.ensureAgentTerminalMessages(workspaceTurnId, [notification]);
+
+    const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceTurnId);
+    expect(historyResult.success).toBe(true);
+    if (!historyResult.success) throw new Error("workspace-turn history read failed");
+    const updatedReport = historyResult.data.find((message) => message.id === reportMessage.id);
+    expect(updatedReport?.metadata?.muxMetadata).toEqual({
+      type: "workspace-turn-task",
+      taskHandleId: "wst_restart_backfill",
+      ownerWorkspaceId: parentId,
+      turnId: "turn-restart-backfill",
+    });
+  });
+
   test("workspace-turn tool-calls stream-end with superseding queued input settles error", async () => {
     // Ordinary queued input (manual message, bare /compact) also cuts the
     // stream at a tool boundary, but it supersedes the delegated turn instead

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3982,6 +3982,93 @@ describe("TaskService", () => {
     });
   });
 
+  test("failed nested agent progress settles the correlated workspace turn", async () => {
+    let sendCount = 0;
+    const sendMessage = mock(
+      async (...args: unknown[]): Promise<Result<void, SendMessageError>> => {
+        sendCount += 1;
+        if (sendCount === 2) {
+          const internal = args[3] as
+            | { onAcceptedPreStreamFailure?: (error: SendMessageError) => Promise<void> | void }
+            | undefined;
+          await internal?.onAcceptedPreStreamFailure?.({
+            type: "unknown",
+            raw: "Progress wake failed",
+          });
+        }
+        return Ok(undefined);
+      }
+    );
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest({ sendMessage });
+
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      project.workspaces.push({
+        path: path.join(rootDir, "repo", "nested-progress-failure"),
+        id: "nested-progress-failure",
+        name: "nested-progress-failure",
+        createdAt: "2026-06-19T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+        parentWorkspaceId: "childworkspace",
+        taskStatus: "running",
+        agentType: "explore",
+      });
+      return cfg;
+    });
+
+    await taskService.reportAgentProgress("nested-progress-failure", "progress-call", {
+      reportMarkdown: "The progress wake cannot start.",
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "error",
+      error: "Progress wake failed",
+    });
+  });
+
+  test("canceled nested agent progress interrupts the correlated workspace turn", async () => {
+    let sendCount = 0;
+    const sendMessage = mock(
+      async (...args: unknown[]): Promise<Result<void, SendMessageError>> => {
+        sendCount += 1;
+        if (sendCount === 2) {
+          const internal = args[3] as
+            | { onCanceled?: (reason: string) => Promise<void> | void }
+            | undefined;
+          await internal?.onCanceled?.("Progress wake was canceled");
+        }
+        return Ok(undefined);
+      }
+    );
+    const { config, parentId, taskService } = await startWorkspaceTurnForTest({ sendMessage });
+
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(path.join(rootDir, "repo"));
+      assert(project, "test project must exist");
+      project.workspaces.push({
+        path: path.join(rootDir, "repo", "nested-progress-canceled"),
+        id: "nested-progress-canceled",
+        name: "nested-progress-canceled",
+        createdAt: "2026-06-19T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+        parentWorkspaceId: "childworkspace",
+        taskStatus: "running",
+        agentType: "explore",
+      });
+      return cfg;
+    });
+
+    await taskService.reportAgentProgress("nested-progress-canceled", "progress-call", {
+      reportMarkdown: "The progress wake was canceled.",
+    });
+
+    expect(await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle")).toMatchObject({
+      status: "interrupted",
+      error: "Progress wake was canceled",
+    });
+  });
+
   test("terminal nested agent report resumes a workspace turn with correlation", async () => {
     const { config, parentId, taskService, workspaceMocks, historyService } =
       await startWorkspaceTurnForTest();
@@ -4138,6 +4225,87 @@ describe("TaskService", () => {
       ownerWorkspaceId: parentId,
       turnId: "turn-restart-backfill",
     });
+  });
+
+  test("preserves an existing terminal report correlation from an earlier workspace turn", async () => {
+    const config = await createTestConfig(rootDir);
+    const projectPath = path.join(rootDir, "repo");
+    const parentId = "parent-restart-preserve";
+    const workspaceTurnId = "workspace-turn-restart-preserve";
+    const nestedTaskId = "nested-restart-preserve";
+    await saveWorkspaces(
+      config,
+      projectPath,
+      [
+        projectWorkspace(projectPath, "parent", parentId),
+        projectWorkspace(projectPath, "workspace-turn", workspaceTurnId),
+        projectWorkspace(projectPath, "nested-agent", nestedTaskId, {
+          parentWorkspaceId: workspaceTurnId,
+          taskStatus: "reported",
+          reportedAt: "2026-08-14T00:00:01.000Z",
+          agentType: "explore",
+        }),
+      ],
+      testTaskSettings()
+    );
+
+    const { historyService, taskService } = createTaskServiceHarness(config);
+    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+      .taskHandleStore;
+    await taskHandleStore.upsertWorkspaceTurn({
+      kind: "workspace_turn",
+      handleId: "wst_restart_preserve",
+      ownerWorkspaceId: parentId,
+      workspaceId: workspaceTurnId,
+      turnId: "turn-restart-preserve",
+      status: "running",
+      createdAt: "2026-08-14T00:00:00.000Z",
+      updatedAt: "2026-08-14T00:00:00.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+    });
+
+    const previousCorrelation = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_previous_turn",
+      ownerWorkspaceId: parentId,
+      turnId: "turn-previous",
+    };
+    const reportMessage = createMuxMessage(
+      "existing-terminal-report-previous-turn",
+      "user",
+      formatSubagentReportEnvelope({
+        taskId: nestedTaskId,
+        agentType: "explore",
+        status: "completed",
+        title: "Previous result",
+        reportMarkdown: "This report belongs to the previous turn.",
+      }),
+      { timestamp: Date.now(), synthetic: true, uiVisible: true, muxMetadata: previousCorrelation }
+    );
+    await historyService.appendToHistory(workspaceTurnId, reportMessage);
+
+    const terminalAttentionStore = new TerminalAttentionStore(config);
+    const notification = await terminalAttentionStore.enqueueIfAbsent({
+      ownerWorkspaceId: workspaceTurnId,
+      sourceKind: "agent_task",
+      sourceId: nestedTaskId,
+    });
+    assert(notification, "terminal attention notification must be created");
+
+    const internal = taskService as unknown as {
+      ensureAgentTerminalMessages: (
+        ownerWorkspaceId: string,
+        notifications: ReadonlyArray<typeof notification>
+      ) => Promise<unknown>;
+    };
+    await internal.ensureAgentTerminalMessages(workspaceTurnId, [notification]);
+
+    const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceTurnId);
+    expect(historyResult.success).toBe(true);
+    if (!historyResult.success) throw new Error("workspace-turn history read failed");
+    const preservedReport = historyResult.data.find((message) => message.id === reportMessage.id);
+    expect(preservedReport?.metadata?.muxMetadata).toEqual(previousCorrelation);
   });
 
   test("workspace-turn tool-calls stream-end with superseding queued input settles error", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3983,7 +3983,8 @@ describe("TaskService", () => {
   });
 
   test("terminal nested agent report resumes a workspace turn with correlation", async () => {
-    const { config, parentId, taskService, workspaceMocks } = await startWorkspaceTurnForTest();
+    const { config, parentId, taskService, workspaceMocks, historyService } =
+      await startWorkspaceTurnForTest();
     await config.editConfig((cfg) => {
       const project = cfg.projects.get(path.join(rootDir, "repo"));
       assert(project, "test project must exist");
@@ -4020,6 +4021,24 @@ describe("TaskService", () => {
         },
         { type: "text", text: "The nested terminal report is complete." },
       ],
+    });
+
+    const childHistory = await historyService.getHistoryFromLatestBoundary("childworkspace");
+    expect(childHistory.success).toBe(true);
+    if (!childHistory.success) throw new Error("child history read failed");
+    const reportMessage = childHistory.data.find(
+      (message) =>
+        message.role === "user" &&
+        message.parts.some(
+          (part) =>
+            part.type === "text" && part.text.includes("The nested terminal report is complete.")
+        )
+    );
+    expect(reportMessage?.metadata?.muxMetadata).toEqual({
+      type: "workspace-turn-task",
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
     });
 
     await Promise.all([

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4297,9 +4297,15 @@ describe("TaskService", () => {
       ensureAgentTerminalMessages: (
         ownerWorkspaceId: string,
         notifications: ReadonlyArray<typeof notification>
-      ) => Promise<unknown>;
+      ) => Promise<{ deliverableNotificationIds: Set<string> }>;
     };
-    await internal.ensureAgentTerminalMessages(workspaceTurnId, [notification]);
+    const ensureResult = await internal.ensureAgentTerminalMessages(workspaceTurnId, [
+      notification,
+    ]);
+    expect(ensureResult.deliverableNotificationIds.has(notification.id)).toBe(false);
+    expect(await terminalAttentionStore.get(workspaceTurnId, notification.id)).toMatchObject({
+      status: "superseded",
+    });
 
     const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceTurnId);
     expect(historyResult.success).toBe(true);

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -6174,12 +6174,15 @@ export class TaskService {
       entry,
       defaultModel
     );
+    const workspaceTurnMuxMetadata =
+      await this.getActiveWorkspaceTurnMuxMetadataForWorkspace(ownerWorkspaceId);
 
     const sendOptions = {
       model: resumeOptions.model,
       agentId: resumeOptions.agentId,
       thinkingLevel: resumeOptions.thinkingLevel,
       reasoningMode: resumeOptions.reasoningMode,
+      ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
     };
     if (prompt.length === 0) {
       assert(agentNotifications.length > 0, "prompt-free terminal drain requires sub-agent work");
@@ -7078,6 +7081,8 @@ export class TaskService {
         parentEntry,
         defaultModel
       );
+      const workspaceTurnMuxMetadata =
+        await this.getActiveWorkspaceTurnMuxMetadataForWorkspace(parentWorkspaceId);
 
       // A progress report is itself the wake-up message. Unlike terminal attention, it must be
       // allowed through while this child is still active so review findings and other incremental
@@ -7090,6 +7095,7 @@ export class TaskService {
           agentId: resumeOptions.agentId,
           thinkingLevel: resumeOptions.thinkingLevel,
           reasoningMode: resumeOptions.reasoningMode,
+          ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
         },
         {
           skipAutoResumeReset: true,
@@ -10218,17 +10224,21 @@ export class TaskService {
   }
 
   /**
-   * Whether a bash-monitor-wake continuation of this exact delegated turn is
-   * pending or already streaming. Pending: the wake is queued next or
-   * mid-dispatch (AgentSession-owned state). Streaming: the active stream —
-   * necessarily newer than the ended one, since a stream leaves the
-   * STARTING/STREAMING states before its stream-end is emitted — inherited
-   * this turn's correlation metadata.
+   * Whether a continuation of this exact delegated turn is pending or streaming.
+   * Pending entries must carry the same correlation metadata as the ended stream.
    */
-  private hasSameTurnWakeContinuation(
+  private hasSameTurnContinuation(
     event: StreamEndEvent,
     correlation: { taskHandleId: string; ownerWorkspaceId: string; turnId: string }
   ): boolean {
+    if (
+      this.workspaceService.hasPendingWorkspaceTurnContinuation(event.workspaceId, {
+        type: "workspace-turn-task",
+        ...correlation,
+      })
+    ) {
+      return true;
+    }
     if (this.workspaceService.hasPendingBashMonitorWakeContinuation(event.workspaceId)) {
       return true;
     }
@@ -10283,17 +10293,16 @@ export class TaskService {
       return true;
     }
 
-    // A queued bash-monitor wake stops the in-flight stream at a tool boundary
-    // with finishReason "tool-calls" and immediately continues the same
-    // delegated turn in a follow-up stream that inherits this turn's
-    // correlation (see AgentSession.inheritOpenWorkspaceTurnMetadata). Defer
-    // settlement to the continuation's terminal stream-end instead of
-    // reporting a false "ended before completion" failure to the owner.
-    // Only wake continuations count: any other queued input (manual message,
-    // /compact) supersedes the turn and must settle the old outcome here.
+    // A queued continuation can stop the in-flight stream at a tool boundary with
+    // finishReason "tool-calls" and continue the same delegated turn. Report
+    // wake-ups carry the exact correlation explicitly; bash-monitor wakes inherit
+    // it from history. Defer settlement until the continuation's terminal
+    // stream-end instead of reporting a false completion failure to the owner.
+    // Any other queued input (manual message, /compact) supersedes the turn and
+    // must settle the old outcome here.
     if (
       event.metadata.finishReason === "tool-calls" &&
-      this.hasSameTurnWakeContinuation(event, metadata)
+      this.hasSameTurnContinuation(event, metadata)
     ) {
       await this.markWorkspaceTurnStreamEndDeferred(event);
       return true;
@@ -10774,7 +10783,7 @@ export class TaskService {
         active.ownerWorkspaceId,
         active.handleId
       );
-      if (record != null) {
+      if (record?.workspaceId === workspaceId && isActiveWorkspaceTurnTaskStatus(record.status)) {
         return record;
       }
       this.activeWorkspaceTurnHandleByWorkspaceId.delete(workspaceId);
@@ -10784,6 +10793,37 @@ export class TaskService {
       statuses: ["starting", "running"],
     });
     return records.toReversed().find((record) => record.workspaceId === workspaceId) ?? null;
+  }
+
+  private async getActiveWorkspaceTurnMuxMetadataForWorkspace(
+    workspaceId: string
+  ): Promise<WorkspaceTurnMuxMetadata | undefined> {
+    const candidate = await this.getActiveWorkspaceTurnRecordForWorkspace(workspaceId);
+    if (candidate == null) {
+      return undefined;
+    }
+
+    return await this.workspaceTurnSettlementLocks.withLock(candidate.handleId, async () => {
+      const current = await this.taskHandleStore.getWorkspaceTurn(
+        candidate.ownerWorkspaceId,
+        candidate.handleId
+      );
+      const active = this.activeWorkspaceTurnHandleByWorkspaceId.get(workspaceId);
+      if (
+        current?.workspaceId !== workspaceId ||
+        !isActiveWorkspaceTurnTaskStatus(current?.status)
+      ) {
+        if (
+          active?.handleId === candidate.handleId &&
+          active.ownerWorkspaceId === candidate.ownerWorkspaceId
+        ) {
+          this.activeWorkspaceTurnHandleByWorkspaceId.delete(workspaceId);
+        }
+        return undefined;
+      }
+
+      return this.buildWorkspaceTurnMuxMetadata(current);
+    });
   }
 
   private async hasRecoverableWorkspaceTurnRetryInFlight(

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5887,6 +5887,7 @@ export class TaskService {
     if (!historyResult.success) {
       return { deliverableNotificationIds, latestMessageTimestampByTaskId };
     }
+    const existingReportMessages = new Map<string, MuxMessage>();
     const existingTaskIds = new Set<string>();
     for (const message of historyResult.data) {
       if (message.role !== "user" || message.metadata?.synthetic !== true) continue;
@@ -5898,6 +5899,7 @@ export class TaskService {
       );
       if (taskId == null) continue;
       existingTaskIds.add(taskId);
+      existingReportMessages.set(taskId, message);
       const timestamp = message.metadata?.timestamp;
       if (typeof timestamp === "number" && Number.isFinite(timestamp)) {
         latestMessageTimestampByTaskId.set(
@@ -5912,6 +5914,43 @@ export class TaskService {
     const sessionDir = this.config.getSessionDir(ownerWorkspaceId);
     for (const notification of notifications) {
       if (existingTaskIds.has(notification.sourceId)) {
+        const existingMessage = existingReportMessages.get(notification.sourceId);
+        if (existingMessage != null && workspaceTurnMuxMetadata != null) {
+          const existingCorrelation = this.getWorkspaceTurnMetadataFromValue(
+            existingMessage.metadata?.muxMetadata
+          );
+          const hasMatchingCorrelation =
+            existingCorrelation?.taskHandleId === workspaceTurnMuxMetadata.taskHandleId &&
+            existingCorrelation.ownerWorkspaceId === workspaceTurnMuxMetadata.ownerWorkspaceId &&
+            existingCorrelation.turnId === workspaceTurnMuxMetadata.turnId;
+          if (!hasMatchingCorrelation) {
+            const updatedMessage: MuxMessage = {
+              ...existingMessage,
+              metadata: {
+                ...existingMessage.metadata,
+                muxMetadata: workspaceTurnMuxMetadata,
+              },
+            };
+            const updateResult = await this.historyService.updateHistory(
+              ownerWorkspaceId,
+              updatedMessage
+            );
+            if (updateResult.success) {
+              existingReportMessages.set(notification.sourceId, updatedMessage);
+              this.workspaceService.emitChatEvent(ownerWorkspaceId, {
+                ...updatedMessage,
+                type: "message",
+              });
+            } else {
+              log.warn("Failed to backfill workspace-turn metadata on terminal report", {
+                ownerWorkspaceId,
+                taskId: notification.sourceId,
+                error: updateResult.error,
+              });
+            }
+          }
+        }
+
         // Report/failure delivery necessarily precedes terminal-attention enqueue. Presence in parent
         // history is therefore authoritative here; continuation freshness is checked separately
         // against the private execution's createdAt before suppressing its workspace-turn wake.

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5907,6 +5907,8 @@ export class TaskService {
       }
     }
 
+    const workspaceTurnMuxMetadata =
+      await this.getActiveWorkspaceTurnMuxMetadataForWorkspace(ownerWorkspaceId);
     const sessionDir = this.config.getSessionDir(ownerWorkspaceId);
     for (const notification of notifications) {
       if (existingTaskIds.has(notification.sourceId)) {
@@ -5957,7 +5959,12 @@ export class TaskService {
         report != null ? createTaskReportMessageId() : createTaskFailureMessageId(),
         "user",
         content,
-        { timestamp, synthetic: true, uiVisible: true }
+        {
+          timestamp,
+          synthetic: true,
+          uiVisible: true,
+          ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
+        }
       );
       const appendResult = await this.historyService.appendToHistory(ownerWorkspaceId, message);
       if (!appendResult.success) {
@@ -12865,11 +12872,14 @@ export class TaskService {
         : {}),
     });
 
+    const workspaceTurnMuxMetadata =
+      await this.getActiveWorkspaceTurnMuxMetadataForWorkspace(parentWorkspaceId);
     const messageId = createTaskReportMessageId();
     const reportMessage = createMuxMessage(messageId, "user", reportContent, {
       timestamp: Date.now(),
       synthetic: true,
       uiVisible: true,
+      ...(workspaceTurnMuxMetadata != null ? { muxMetadata: workspaceTurnMuxMetadata } : {}),
     });
 
     const appendResult = await this.historyService.appendToHistory(

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -129,7 +129,7 @@ import {
 import { secretsToRecord } from "@/common/types/secrets";
 import { getErrorMessage } from "@/common/utils/errors";
 import { isNonRetryableStreamError } from "@/common/utils/messages/retryEligibility";
-import type { StreamErrorType } from "@/common/types/errors";
+import type { SendMessageError, StreamErrorType } from "@/common/types/errors";
 import { hasCompletedAgentReport } from "@/common/utils/agentTaskCompletion";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import { CONTEXT_BOUNDARY_KINDS } from "@/common/constants/contextBoundary";
@@ -5919,11 +5919,9 @@ export class TaskService {
           const existingCorrelation = this.getWorkspaceTurnMetadataFromValue(
             existingMessage.metadata?.muxMetadata
           );
-          const hasMatchingCorrelation =
-            existingCorrelation?.taskHandleId === workspaceTurnMuxMetadata.taskHandleId &&
-            existingCorrelation.ownerWorkspaceId === workspaceTurnMuxMetadata.ownerWorkspaceId &&
-            existingCorrelation.turnId === workspaceTurnMuxMetadata.turnId;
-          if (!hasMatchingCorrelation) {
+          // A report can outlive its original turn. Only repair reports without correlation;
+          // replacing a valid correlation could deliver an old result to a later turn.
+          if (existingCorrelation == null) {
             const updatedMessage: MuxMessage = {
               ...existingMessage,
               metadata: {
@@ -7150,10 +7148,38 @@ export class TaskService {
           startStreamInBackground: true,
           queueDedupeKey: `agent-report:${childWorkspaceId}:${toolCallId}`,
           removableQueueDedupeKey: true,
+          ...(workspaceTurnMuxMetadata != null
+            ? {
+                onCanceled: async (reason: string) => {
+                  await this.settleWorkspaceTurnContinuationFailure(
+                    parentWorkspaceId,
+                    workspaceTurnMuxMetadata,
+                    "interrupted",
+                    reason
+                  );
+                },
+                onAcceptedPreStreamFailure: async (error: SendMessageError) => {
+                  await this.settleWorkspaceTurnContinuationFailure(
+                    parentWorkspaceId,
+                    workspaceTurnMuxMetadata,
+                    "error",
+                    formatSendMessageError(error).message
+                  );
+                },
+              }
+            : {}),
         }
       );
       if (!sendResult.success) {
         const formattedError = formatSendMessageError(sendResult.error);
+        if (workspaceTurnMuxMetadata != null) {
+          await this.settleWorkspaceTurnContinuationFailure(
+            parentWorkspaceId,
+            workspaceTurnMuxMetadata,
+            "error",
+            formattedError.message
+          );
+        }
         throw new Error(
           `agent_report failed to wake the parent workspace: ${formattedError.message}`
         );
@@ -10869,6 +10895,40 @@ export class TaskService {
       }
 
       return this.buildWorkspaceTurnMuxMetadata(current);
+    });
+  }
+
+  // A queued report can defer the preceding stream-end. If dispatch then fails, settle that
+  // exact turn here because no replacement stream-end can arrive.
+  private async settleWorkspaceTurnContinuationFailure(
+    workspaceId: string,
+    muxMetadata: WorkspaceTurnMuxMetadata,
+    status: "interrupted" | "error",
+    error: string
+  ): Promise<void> {
+    const record = await this.taskHandleStore.getWorkspaceTurn(
+      muxMetadata.ownerWorkspaceId,
+      muxMetadata.taskHandleId
+    );
+    if (
+      record?.workspaceId !== workspaceId ||
+      record?.turnId !== muxMetadata.turnId ||
+      !isActiveWorkspaceTurnTaskStatus(record?.status)
+    ) {
+      return;
+    }
+
+    const next: WorkspaceTurnTaskHandleRecord = {
+      ...record,
+      status,
+      updatedAt: getIsoNow(),
+      error,
+    };
+    delete next.deferredMessageIds;
+    await this.settleWorkspaceTurn({
+      record,
+      next,
+      waiterSettlement: { status: "error", error: new Error(error) },
     });
   }
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5919,9 +5919,17 @@ export class TaskService {
           const existingCorrelation = this.getWorkspaceTurnMetadataFromValue(
             existingMessage.metadata?.muxMetadata
           );
-          // A report can outlive its original turn. Only repair reports without correlation;
-          // replacing a valid correlation could deliver an old result to a later turn.
-          if (existingCorrelation == null) {
+          if (existingCorrelation != null) {
+            const matchesActiveTurn =
+              existingCorrelation.taskHandleId === workspaceTurnMuxMetadata.taskHandleId &&
+              existingCorrelation.ownerWorkspaceId === workspaceTurnMuxMetadata.ownerWorkspaceId &&
+              existingCorrelation.turnId === workspaceTurnMuxMetadata.turnId;
+            if (!matchesActiveTurn) {
+              // Keep the old report visible, but do not let it wake or settle a later turn.
+              await this.terminalAttentionStore.markSuperseded(ownerWorkspaceId, notification.id);
+              continue;
+            }
+          } else {
             const updatedMessage: MuxMessage = {
               ...existingMessage,
               metadata: {
@@ -7146,6 +7154,7 @@ export class TaskService {
           synthetic: true,
           agentInitiated: true,
           startStreamInBackground: true,
+          workspaceTurnContinuation: workspaceTurnMuxMetadata != null,
           queueDedupeKey: `agent-report:${childWorkspaceId}:${toolCallId}`,
           removableQueueDedupeKey: true,
           ...(workspaceTurnMuxMetadata != null

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -6,6 +6,7 @@ import { ExtensionMetadataService } from "@/node/services/ExtensionMetadataServi
 import { WorkspaceGoalService, type GoalContinuationRuntimeBridge } from "./workspaceGoalService";
 import { IdleDispatcher } from "./idleDispatcher";
 import { createTestHistoryService } from "./testHistoryService";
+import type { SendMessageOptions } from "@/common/orpc/types";
 import type { HistoryService } from "./historyService";
 import type { GoalRecordV1, GoalStatus } from "@/common/types/goal";
 import {
@@ -554,6 +555,37 @@ describe("WorkspaceGoalService", () => {
       "goal_continuation_fired",
       expect.objectContaining({ source: "stream_end_idle_dispatch" })
     );
+  });
+
+  test("does not carry workspace-turn metadata into goal continuations", async () => {
+    await setGoalOk(service, { workspaceId, objective: "Start a new goal continuation" });
+    const dispatcher = new IdleDispatcher();
+    const seenOptions: SendMessageOptions[] = [];
+    service.registerGoalContinuationConsumer(
+      dispatcher,
+      continuationBridge((input) => {
+        seenOptions.push(input.options);
+        return Promise.resolve(true);
+      })
+    );
+
+    await service.requestContinuationAfterStreamEnd({
+      workspaceId,
+      sendOptions: {
+        model: "openai:gpt-4o",
+        agentId: "exec",
+        muxMetadata: {
+          type: "workspace-turn-task",
+          taskHandleId: "delegated-task",
+          ownerWorkspaceId: "owner-workspace",
+          turnId: "delegated-turn",
+        },
+      },
+      streamEndedAtMs: 10_000,
+    });
+
+    expect(seenOptions).toHaveLength(1);
+    expect(seenOptions[0]?.muxMetadata).toBeUndefined();
   });
 
   test("can suppress setGoal kickoff continuation for CLI-controlled kickoff", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -374,6 +374,8 @@ function continuationSendOptions(sendOptions: SendMessageOptions): SendMessageOp
     ...pickStartupRetrySendOptions(sendOptions),
     allowAgentSetGoal: undefined,
   };
+  // Startup retries preserve workspace-turn correlation, but goal continuations start a new turn.
+  delete options.muxMetadata;
   return options;
 }
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -5323,6 +5323,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
   let fakeSession: {
     isBusy: ReturnType<typeof mock>;
     hasQueuedMessages: ReturnType<typeof mock>;
+    hasQueuedOrDispatchingEntry: ReturnType<typeof mock>;
     dropQueuedMessageWithOnlyDedupeKey: ReturnType<typeof mock>;
     queueMessage: ReturnType<typeof mock>;
     sendMessage: ReturnType<typeof mock>;
@@ -5395,6 +5396,7 @@ describe("WorkspaceService sendMessage status clearing", () => {
     fakeSession = {
       isBusy: mock(() => true),
       hasQueuedMessages: mock(() => false),
+      hasQueuedOrDispatchingEntry: mock(() => false),
       dropQueuedMessageWithOnlyDedupeKey: mock(() => false),
       queueMessage: mock(() => "tool-end" as const),
       sendMessage: mock(() => Promise.resolve(Ok(undefined))),
@@ -5680,6 +5682,73 @@ describe("WorkspaceService sendMessage status clearing", () => {
     expect(result.success).toBe(true);
     expect(fakeSession.queueMessage).toHaveBeenCalled();
     expect(resetAutoResumeCount).not.toHaveBeenCalled();
+  });
+
+  test("strips stale workspace-turn correlation behind an earlier queued entry", async () => {
+    fakeSession.hasQueuedOrDispatchingEntry.mockReturnValue(true);
+    const onCanceled = mock(() => undefined);
+    const onAcceptedPreStreamFailure = mock(() => undefined);
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_stale_progress",
+      ownerWorkspaceId: "owner-workspace",
+      turnId: "turn-stale-progress",
+    };
+
+    const result = await workspaceService.sendMessage(
+      "test-workspace",
+      "nested progress",
+      { model: "openai:gpt-4o-mini", agentId: "exec", muxMetadata },
+      {
+        synthetic: true,
+        agentInitiated: true,
+        workspaceTurnContinuation: true,
+        onCanceled,
+        onAcceptedPreStreamFailure,
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fakeSession.queueMessage).toHaveBeenCalledWith(
+      "nested progress",
+      expect.not.objectContaining({ muxMetadata }),
+      expect.objectContaining({
+        onCanceled: undefined,
+        onAcceptedPreStreamFailure: undefined,
+      })
+    );
+  });
+
+  test("keeps workspace-turn correlation for the next queued continuation", async () => {
+    fakeSession.hasQueuedOrDispatchingEntry.mockReturnValue(false);
+    const onCanceled = mock(() => undefined);
+    const onAcceptedPreStreamFailure = mock(() => undefined);
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_next_progress",
+      ownerWorkspaceId: "owner-workspace",
+      turnId: "turn-next-progress",
+    };
+
+    const result = await workspaceService.sendMessage(
+      "test-workspace",
+      "nested progress",
+      { model: "openai:gpt-4o-mini", agentId: "exec", muxMetadata },
+      {
+        synthetic: true,
+        agentInitiated: true,
+        workspaceTurnContinuation: true,
+        onCanceled,
+        onAcceptedPreStreamFailure,
+      }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fakeSession.queueMessage).toHaveBeenCalledWith(
+      "nested progress",
+      expect.objectContaining({ muxMetadata }),
+      expect.objectContaining({ onCanceled, onAcceptedPreStreamFailure })
+    );
   });
 
   test("synthetic queued sends leave a pending interactive question intact", async () => {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8721,6 +8721,7 @@ export class WorkspaceService extends EventEmitter {
           {
             synthetic: internal?.synthetic,
             agentInitiated: internal?.agentInitiated,
+            workspaceTurnContinuation: internal?.workspaceTurnContinuation,
             dedupeKey: internal?.queueDedupeKey,
             removableDedupeKey: internal?.removableQueueDedupeKey,
             cancelState: internal?.cancelState,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9499,6 +9499,17 @@ export class WorkspaceService extends EventEmitter {
   }
 
   /**
+   * Whether a queued or dispatching entry continues the exact workspace-turn correlation.
+   */
+  hasPendingWorkspaceTurnContinuation(
+    workspaceId: string,
+    metadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+  ): boolean {
+    const session = this.sessions.get(workspaceId.trim());
+    return session?.hasPendingWorkspaceTurnContinuation(metadata) ?? false;
+  }
+
+  /**
    * Narrow check for an actual scheduled/starting auto-retry, excluding queued
    * manual messages and preparing turns. Callers that must distinguish "the
    * same turn will resume on its own" from "some other queued work exists"

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8482,6 +8482,8 @@ export class WorkspaceService extends EventEmitter {
       startStreamInBackground?: boolean;
       /** When true, reject instead of queueing if the workspace is busy. */
       requireIdle?: boolean;
+      /** Preserve workspace-turn correlation only when this send is the next continuation. */
+      workspaceTurnContinuation?: boolean;
       /** Coalescing for queued sends: drop the message when the same key is already queued. */
       queueDedupeKey?: string;
       /** Keep this dedupe-keyed queue entry isolated so it can be selectively superseded. */
@@ -8585,6 +8587,28 @@ export class WorkspaceService extends EventEmitter {
 
       const normalizedOptions = this.normalizeSendMessageAgentId(options);
 
+      const isWorkspaceTurnContinuation = internal?.workspaceTurnContinuation === true;
+      const stripWorkspaceTurnCorrelation = (
+        sendOptions: SendMessageOptions & { fileParts?: FilePart[] }
+      ): SendMessageOptions & { fileParts?: FilePart[] } => {
+        const withoutCorrelation = { ...sendOptions };
+        delete withoutCorrelation.muxMetadata;
+        return withoutCorrelation;
+      };
+      const getContinuationSendState = () => {
+        const preserveCorrelation =
+          !isWorkspaceTurnContinuation || !session.hasQueuedOrDispatchingEntry();
+        return {
+          options: preserveCorrelation
+            ? normalizedOptions
+            : stripWorkspaceTurnCorrelation(normalizedOptions),
+          onCanceled: preserveCorrelation ? internal?.onCanceled : undefined,
+          onAcceptedPreStreamFailure: preserveCorrelation
+            ? internal?.onAcceptedPreStreamFailure
+            : undefined,
+        };
+      };
+
       // Reject before any settings persistence so an unpriced model can never
       // be saved for a budgeted resumable goal — including via direct callers
       // that bypass the client-side guard. Manual sends still delegate into
@@ -8686,17 +8710,22 @@ export class WorkspaceService extends EventEmitter {
         // This must happen after queueMessage succeeds — if enqueue fails (throws),
         // we must not cancel foreground waits. Use the queue's effective dispatch mode
         // (not incoming options) because MessageQueue makes tool-end sticky.
-        const effectiveQueueDispatchMode = session.queueMessage(message, normalizedOptions, {
-          synthetic: internal?.synthetic,
-          agentInitiated: internal?.agentInitiated,
-          dedupeKey: internal?.queueDedupeKey,
-          removableDedupeKey: internal?.removableQueueDedupeKey,
-          cancelState: internal?.cancelState,
-          cancelSignal: internal?.cancelSignal,
-          onCanceled: internal?.onCanceled,
-          onAccepted: internal?.onAccepted,
-          onAcceptedPreStreamFailure: internal?.onAcceptedPreStreamFailure,
-        });
+        const continuationSendState = getContinuationSendState();
+        const effectiveQueueDispatchMode = session.queueMessage(
+          message,
+          continuationSendState.options,
+          {
+            synthetic: internal?.synthetic,
+            agentInitiated: internal?.agentInitiated,
+            dedupeKey: internal?.queueDedupeKey,
+            removableDedupeKey: internal?.removableQueueDedupeKey,
+            cancelState: internal?.cancelState,
+            cancelSignal: internal?.cancelSignal,
+            onCanceled: continuationSendState.onCanceled,
+            onAccepted: internal?.onAccepted,
+            onAcceptedPreStreamFailure: continuationSendState.onAcceptedPreStreamFailure,
+          }
+        );
 
         // A dedupe-keyed send that raced an already-pending duplicate is a quiet success:
         // the pending queue entry already covers it (coalescing), so don't double-queue.
@@ -8735,6 +8764,7 @@ export class WorkspaceService extends EventEmitter {
         });
       }
 
+      const continuationSendState = getContinuationSendState();
       const onAcceptedPreStreamFailure = async (error: SendMessageError) => {
         if (resumedInterruptedTask && normalizedOptions?.editMessageId) {
           try {
@@ -8750,7 +8780,7 @@ export class WorkspaceService extends EventEmitter {
             );
           }
         }
-        await internal?.onAcceptedPreStreamFailure?.(error);
+        await continuationSendState.onAcceptedPreStreamFailure?.(error);
       };
 
       const shouldRunPendingAutoTitle =
@@ -8763,7 +8793,7 @@ export class WorkspaceService extends EventEmitter {
         claimedAutoTitle = true;
       }
 
-      const result = await session.sendMessage(message, normalizedOptions, {
+      const result = await session.sendMessage(message, continuationSendState.options, {
         synthetic: internal?.synthetic,
         agentInitiated: internal?.agentInitiated,
         goalKind: internal?.goalKind,
@@ -8771,7 +8801,7 @@ export class WorkspaceService extends EventEmitter {
         startStreamInBackground: internal?.startStreamInBackground,
         cancelState: internal?.cancelState,
         cancelSignal: internal?.cancelSignal,
-        onCanceled: internal?.onCanceled,
+        onCanceled: continuationSendState.onCanceled,
         onAccepted: internal?.onAccepted,
         onAcceptedPreStreamFailure,
       });
@@ -9408,6 +9438,10 @@ export class WorkspaceService extends EventEmitter {
       log.error("Unexpected error in removeQueuedWorkspaceTurn handler:", error);
       return Err(`Failed to remove queued workspace turn: ${errorMessage}`);
     }
+  }
+
+  hasQueuedOrDispatchingEntry(workspaceId: string): boolean {
+    return this.sessions.get(workspaceId.trim())?.hasQueuedOrDispatchingEntry() ?? false;
   }
 
   hasQueuedMessages(workspaceId: string, dispatchMode?: "tool-end" | "turn-end"): boolean {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -8586,6 +8586,9 @@ export class WorkspaceService extends EventEmitter {
       }
 
       const normalizedOptions = this.normalizeSendMessageAgentId(options);
+      const normalizedMuxMetadata = normalizedOptions.muxMetadata as MuxMessageMetadata | undefined;
+      const workspaceTurnContinuationMetadata =
+        normalizedMuxMetadata?.type === "workspace-turn-task" ? normalizedMuxMetadata : undefined;
 
       const isWorkspaceTurnContinuation = internal?.workspaceTurnContinuation === true;
       const stripWorkspaceTurnCorrelation = (
@@ -8597,7 +8600,8 @@ export class WorkspaceService extends EventEmitter {
       };
       const getContinuationSendState = () => {
         const preserveCorrelation =
-          !isWorkspaceTurnContinuation || !session.hasQueuedOrDispatchingEntry();
+          !isWorkspaceTurnContinuation ||
+          !session.hasQueuedOrDispatchingEntry(workspaceTurnContinuationMetadata);
         return {
           options: preserveCorrelation
             ? normalizedOptions


### PR DESCRIPTION
## Summary

Preserve workspace-turn correlation when a spawned workspace receives nested agent reports.

## Background

A spawned workspace can create a nested agent.

The nested agent can send progress or a terminal report.

Those reports start a stream in the spawned workspace.

The stream lacked the active workspace-turn metadata.

TaskService then marked the parent workspace turn as interrupted or incomplete.

An app restart could also lose the correlation before the continuation finished.

Older terminal report rows can also exist without the new metadata.

## Implementation

- Resolve the active workspace-turn handle from the durable handle store.
- Pass exact metadata through progress report wake-ups.
- Pass exact metadata through terminal attention resumes.
- Persist exact metadata on new synthetic terminal report history rows.
- Backfill metadata only when an existing terminal report lacks correlation.
- Preserve valid correlation from an earlier workspace turn.
- Settle a correlated turn when progress wake dispatch is canceled or fails before streaming.
- Persist exact metadata in startup retry options.
- Re-derive the correlation from history during startup retry recovery.
- Detect queued continuations with the same handle, owner, and turn IDs.
- Keep manual messages and unrelated queued work as superseding input.

## Validation

- `make static-check`
- Full `src/node/services/taskService.test.ts`
- Focused workspace-turn regression tests
- `src/node/services/messageQueue.test.ts`
- `src/node/services/agentSession.workspaceTurnInheritance.test.ts`

## Risks

The change touches stream-end and queued-message lifecycle logic.

Exact metadata matching limits the change to the affected workspace turn.

History updates preserve the original history sequence.

Failed correlated report dispatches now settle instead of leaving a turn running.

Existing uncorrelated stream behavior remains covered by regression tests.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `max` • Cost: `$7.74`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=max costs=7.74 -->
