### PR TITLE
🤖 fix: show hidden sub-agents summary while the coordinator streams

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -607,16 +607,37 @@ describe("AgentListItem", () => {
     expect(rowView.queryByText("Workflow running")).toBeNull();
   });
 
-  test("keeps coordinator streaming copy ahead of the hidden sub-agents summary", () => {
-    mockWorkspaceSidebarState = createWorkspaceSidebarState({ canInterrupt: true });
+  test("shows the hidden sub-agents summary while the coordinator itself streams", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({
+      canInterrupt: true,
+      agentStatus: { emoji: "🔄", message: "Validating and packaging" },
+    });
 
     const { row } = renderWorkspaceItem({
       hiddenSubAgentsSummary: makeHiddenSummary({ subAgentCount: 2, runningSubAgentCount: 2 }),
     });
     const rowView = within(row);
 
-    expect(rowView.getByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeTruthy();
-    expect(rowView.queryByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`)).toBeNull();
+    expect(rowView.getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent).toBe(
+      "2 sub-agents · 2 active"
+    );
+    expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
+    // The row's own streaming state still shows through the green dot.
+    expect(row.querySelector(".bg-content-success")).toBeTruthy();
+  });
+
+  test("shows the hidden sub-agents summary over an armed bash monitor", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({ activeBashMonitorCount: 1 });
+
+    const { row } = renderWorkspaceItem({
+      hiddenSubAgentsSummary: makeHiddenSummary({ subAgentCount: 2, runningSubAgentCount: 2 }),
+    });
+    const rowView = within(row);
+
+    expect(rowView.getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent).toBe(
+      "2 sub-agents · 2 active"
+    );
+    expect(rowView.queryByText("Watching background bash")).toBeNull();
   });
 
   test("distinguishes queued from running hidden sub-agents", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -764,15 +764,11 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
         activeWorkflowRunIds ?? EMPTY_WORKFLOW_RUN_IDS
       )
     : null;
-  // The summary supersedes the plain delegated/workflow lines; questions,
-  // streaming, deletion, an armed bash monitor, and errors still win.
+  // With sub-agent rows hidden, the summary outranks the coordinator's own
+  // streaming/todo/bash-monitor status text (the status dot still shows own
+  // work). Questions, deletion, and errors still win.
   const shouldShowHiddenSubAgentsStatus =
-    hiddenSubAgentsPresentation != null &&
-    !awaitingUserQuestion &&
-    displayStreamingStatusPhase === null &&
-    !isRemoving &&
-    !shouldShowBashMonitorStatus &&
-    !hasError;
+    hiddenSubAgentsPresentation != null && !awaitingUserQuestion && !isRemoving && !hasError;
   const visualState = getVisualState({
     awaitingUserQuestion,
     isInitializing,


### PR DESCRIPTION
## Summary

Fixes the just-merged "hide sub-agents in the sidebar" setting (#3847): the hidden-descendants summary never appeared in the primary scenario because it was gated on the parent workspace being idle. Coordinators stream for nearly the whole time their background sub-agents run, so users who enabled the setting saw hidden rows and no census, i.e. zero delegated-work visibility.

## Background

Field report from Mike: 4+ active background sub-agents, setting enabled, and the parent row showed only its todo-derived status. `shouldShowHiddenSubAgentsStatus` required `displayStreamingStatusPhase === null` and no armed bash monitor, which excludes exactly the orchestration window the summary exists for.

## Implementation

Drop the streaming and bash-monitor gates so the census outranks the row's own streaming/todo/bash-monitor status text whenever hidden descendants are active or queued. Questions, deletion, and errors still win, and the status dot still reflects the parent's own work. When all descendants go inactive, the row falls back to the normal status line as before.

## Validation

Flipped the old "streaming wins over summary" test to assert the summary renders while the coordinator streams with an `agentStatus` set (the reported scenario), and added a bash-monitor regression test.

## Risks

Low. One boolean gate change in `AgentListItem`; the summary only renders when the opt-in setting provides a `hiddenSubAgentsSummary`, so default-off behavior is untouched. Tradeoff: while any hidden descendant is active, the parent's todo status text is superseded by the census.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
