### PR TITLE
🤖 fix: clone read-only GitHub repos without write-capable credentials

### DIFF
--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -53,20 +53,30 @@ async function withEnv<T>(
   }
 }
 
-async function writeFakeGitCloneShim(fakeGitPath: string): Promise<void> {
-  await fs.writeFile(
-    fakeGitPath,
-    `#!/bin/sh
+const DEFAULT_FAKE_GIT_SHIM = `#!/bin/sh
 printf '%s\n' "$@" > "$FAKE_GIT_ARGS_LOG"
 if [ "$1" = "clone" ]; then
   mkdir -p "$5/.git"
   exit 0
 fi
 exit 1
-`,
-    "utf-8"
-  );
+`;
+
+async function installFakeGit(tempDir: string, testCaseId: string, shimBody: string) {
+  const fakeBinDir = path.join(tempDir, `fake-bin-${testCaseId}`);
+  const fakeGitArgsLogPath = path.join(tempDir, `fake-git-${testCaseId}-args.log`);
+  await fs.mkdir(fakeBinDir, { recursive: true });
+  const fakeGitPath = path.join(fakeBinDir, "git");
+  await fs.writeFile(fakeGitPath, shimBody, "utf-8");
   await fs.chmod(fakeGitPath, 0o755);
+  return {
+    fakeGitArgsLogPath,
+    env: {
+      PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      FAKE_GIT_ARGS_LOG: fakeGitArgsLogPath,
+      HOME: tempDir,
+    },
+  };
 }
 
 async function cloneWithFakeGit(
@@ -79,25 +89,51 @@ async function cloneWithFakeGit(
     return null;
   }
 
-  const fakeBinDir = path.join(tempDir, `fake-bin-${input.testCaseId}`);
-  const fakeGitArgsLogPath = path.join(tempDir, `fake-git-${input.testCaseId}-args.log`);
-  await fs.mkdir(fakeBinDir, { recursive: true });
-  await writeFakeGitCloneShim(path.join(fakeBinDir, "git"));
+  const fakeGit = await installFakeGit(tempDir, input.testCaseId, DEFAULT_FAKE_GIT_SHIM);
 
-  const result = await withEnv(
-    {
-      PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      FAKE_GIT_ARGS_LOG: fakeGitArgsLogPath,
-      HOME: tempDir,
-      SSH_AUTH_SOCK: input.sshAuthSock,
-    },
-    () => service.clone({ repoUrl: input.repoUrl, cloneParentDir: input.cloneParentDir })
+  const result = await withEnv({ ...fakeGit.env, SSH_AUTH_SOCK: input.sshAuthSock }, () =>
+    service.clone({ repoUrl: input.repoUrl, cloneParentDir: input.cloneParentDir })
   );
 
   expect(result.success).toBe(true);
   if (!result.success) throw new Error("Expected success");
-  const loggedArgs = (await fs.readFile(fakeGitArgsLogPath, "utf-8")).trim().split("\n");
+  const loggedArgs = (await fs.readFile(fakeGit.fakeGitArgsLogPath, "utf-8")).trim().split("\n");
   return { result, loggedArgs, cloneWorkPath: loggedArgs[4] ?? "" };
+}
+
+async function collectCloneEvents(
+  tempDir: string,
+  service: ProjectService,
+  input: {
+    testCaseId: string;
+    repoUrl: string;
+    cloneParentDir: string;
+    sshAuthSock?: string;
+    gitShimBody: string;
+    signal?: AbortSignal;
+    onEvent?: (event: CloneEvent) => void;
+  }
+) {
+  if (process.platform === "win32") {
+    // These tests rely on a POSIX shell shim named "git" in PATH.
+    return null;
+  }
+
+  const fakeGit = await installFakeGit(tempDir, input.testCaseId, input.gitShimBody);
+
+  const events: CloneEvent[] = [];
+  await withEnv({ ...fakeGit.env, SSH_AUTH_SOCK: input.sshAuthSock }, async () => {
+    for await (const event of service.cloneWithProgress(
+      { repoUrl: input.repoUrl, cloneParentDir: input.cloneParentDir },
+      input.signal
+    )) {
+      events.push(event);
+      input.onEvent?.(event);
+    }
+  });
+
+  const clonedUrls = (await fs.readFile(fakeGit.fakeGitArgsLogPath, "utf-8")).trim().split("\n");
+  return { events, clonedUrls };
 }
 
 describe("ProjectService", () => {
@@ -486,6 +522,133 @@ describe("ProjectService", () => {
       expect(captured.result.data.normalizedPath).toBe(
         path.resolve(cloneParentDir, expectedFolderName)
       );
+    });
+
+    it("falls back to GitHub HTTPS when the SSH shorthand clone fails", async () => {
+      const cloneParentDir = path.join(tempDir, "fallback-transport-clones");
+      const captured = await collectCloneEvents(tempDir, service, {
+        testCaseId: "ssh-to-https-fallback",
+        repoUrl: "owner/repo",
+        cloneParentDir,
+        sshAuthSock: path.join(tempDir, "fake-ssh-agent.sock"),
+        gitShimBody: `#!/bin/sh
+printf '%s\\n' "$4" >> "$FAKE_GIT_ARGS_LOG"
+case "$4" in
+  git@github.com:*)
+    echo "git@github.com: Permission denied (publickey)." >&2
+    exit 128
+    ;;
+esac
+mkdir -p "$5/.git"
+exit 0
+`,
+      });
+      if (!captured) return;
+
+      expect(captured.clonedUrls).toEqual([
+        "git@github.com:owner/repo.git",
+        "https://github.com/owner/repo.git",
+      ]);
+      const progressLines = captured.events
+        .filter((event) => event.type === "progress")
+        .map((event) => event.line);
+      expect(
+        progressLines.some((line) =>
+          line.includes("retrying with https://github.com/owner/repo.git")
+        )
+      ).toBe(true);
+
+      const lastEvent = captured.events.at(-1);
+      expect(lastEvent?.type).toBe("success");
+      if (lastEvent?.type !== "success") throw new Error("Expected success event");
+      const expectedProjectPath = path.resolve(cloneParentDir, "repo");
+      expect(lastEvent.normalizedPath).toBe(expectedProjectPath);
+      expect(config.loadConfigOrDefault().projects.has(expectedProjectPath)).toBe(true);
+    });
+
+    it("does not start the fallback clone when aborted between attempts", async () => {
+      const cloneParentDir = path.join(tempDir, "abort-between-attempts-clones");
+      const abortController = new AbortController();
+      const captured = await collectCloneEvents(tempDir, service, {
+        testCaseId: "abort-between-attempts",
+        repoUrl: "owner/repo",
+        cloneParentDir,
+        sshAuthSock: path.join(tempDir, "fake-ssh-agent.sock"),
+        signal: abortController.signal,
+        onEvent: (event) => {
+          if (event.type === "progress" && event.line.includes("retrying with")) {
+            abortController.abort();
+          }
+        },
+        gitShimBody: `#!/bin/sh
+printf '%s\n' "$4" >> "$FAKE_GIT_ARGS_LOG"
+case "$4" in
+  git@github.com:*)
+    echo "git@github.com: Permission denied (publickey)." >&2
+    exit 128
+    ;;
+esac
+mkdir -p "$5/.git"
+exit 0
+`,
+      });
+      if (!captured) return;
+
+      expect(captured.clonedUrls).toEqual(["git@github.com:owner/repo.git"]);
+      const lastEvent = captured.events.at(-1);
+      expect(lastEvent?.type).toBe("error");
+      if (lastEvent?.type !== "error") throw new Error("Expected error event");
+      expect(lastEvent.error).toBe("Clone cancelled");
+      const leftovers = (await fs.readdir(cloneParentDir)).filter((name) =>
+        name.includes(".mux-clone-")
+      );
+      expect(leftovers).toEqual([]);
+      expect(config.loadConfigOrDefault().projects.size).toBe(0);
+    });
+
+    it("does not fall back to HTTPS for explicit SSH clone URLs", async () => {
+      const cloneParentDir = path.join(tempDir, "explicit-ssh-clones");
+      const captured = await collectCloneEvents(tempDir, service, {
+        testCaseId: "explicit-ssh-no-fallback",
+        repoUrl: "git@github.com:owner/private.git",
+        cloneParentDir,
+        gitShimBody: `#!/bin/sh
+printf '%s\\n' "$4" >> "$FAKE_GIT_ARGS_LOG"
+echo "git@github.com: Permission denied (publickey)." >&2
+exit 128
+`,
+      });
+      if (!captured) return;
+
+      expect(captured.clonedUrls).toEqual(["git@github.com:owner/private.git"]);
+      const lastEvent = captured.events.at(-1);
+      expect(lastEvent?.type).toBe("error");
+      if (lastEvent?.type !== "error") throw new Error("Expected error event");
+      expect(lastEvent.error).toContain("Permission denied");
+      expect(lastEvent.error).not.toContain("read access");
+    });
+
+    it("explains GitHub's misleading write-access error on failed clones", async () => {
+      const cloneParentDir = path.join(tempDir, "write-access-clones");
+      const captured = await collectCloneEvents(tempDir, service, {
+        testCaseId: "write-access-hint",
+        repoUrl: "https://github.com/owner/private.git",
+        cloneParentDir,
+        gitShimBody: `#!/bin/sh
+printf '%s\\n' "$4" >> "$FAKE_GIT_ARGS_LOG"
+echo "remote: Write access to repository not granted." >&2
+echo "fatal: unable to access 'https://github.com/owner/private.git/': The requested URL returned error: 403" >&2
+exit 128
+`,
+      });
+      if (!captured) return;
+
+      expect(captured.clonedUrls).toEqual(["https://github.com/owner/private.git"]);
+      const lastEvent = captured.events.at(-1);
+      expect(lastEvent?.type).toBe("error");
+      if (lastEvent?.type !== "error") throw new Error("Expected error event");
+      expect(lastEvent.error).toContain("Write access to repository not granted");
+      expect(lastEvent.error).toContain("Cloning needs only read access");
     });
 
     it("returns error when clone destination already exists", async () => {

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -28,6 +28,7 @@ import { createMediatedAskpassSession } from "@/node/runtime/openSshPromptMediat
 import {
   classifySshCloneFailure,
   summarizeCloneStderr,
+  withCloneReadAccessHint,
   type CloneErrorCode,
 } from "./sshCloneFailure";
 import type { BranchListResult } from "@/common/orpc/types";
@@ -241,7 +242,10 @@ function hasLikelySshCredentials(): boolean {
  * Expands "owner/repo" shorthand to either SSH or HTTPS based on likely local credentials.
  * All other inputs (HTTPS URLs, SSH URLs, SCP-style, etc.) pass through unchanged.
  */
-function normalizeRepoUrlForClone(repoUrl: string): string {
+function normalizeRepoUrlForClone(repoUrl: string): {
+  cloneUrl: string;
+  fallbackCloneUrl?: string;
+} {
   const trimmedRepoUrl = repoUrl.trim();
   const shorthandCandidate = trimmedRepoUrl.replace(/[\\/]+$/, "");
 
@@ -254,23 +258,26 @@ function normalizeRepoUrlForClone(repoUrl: string): string {
   if (GITHUB_SHORTHAND_PATTERN.test(shorthandCandidate)) {
     // Strip existing .git suffix before appending to avoid double .git (e.g. owner/repo.git → owner/repo.git.git)
     const withoutGitSuffix = shorthandCandidate.replace(/\.git$/i, "");
+    const httpsUrl = `https://github.com/${withoutGitSuffix}.git`;
 
     // Prefer SSH for shorthand only when the current session has an active SSH agent.
     // This avoids assuming GitHub access from unrelated key files on disk.
     if (hasLikelySshCredentials()) {
-      return `git@github.com:${withoutGitSuffix}.git`;
+      // GitHub SSH requires a recognized key even for public repositories, and an agent
+      // socket does not prove one is available. Keep HTTPS as a fallback for readable repos.
+      return { cloneUrl: `git@github.com:${withoutGitSuffix}.git`, fallbackCloneUrl: httpsUrl };
     }
 
-    return `https://github.com/${withoutGitSuffix}.git`;
+    return { cloneUrl: httpsUrl };
   }
 
   // Strip query strings and fragments only from URL-like inputs (protocol:// or git@),
   // not from local paths where # and ? may be valid filename characters.
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmedRepoUrl) || trimmedRepoUrl.startsWith("git@")) {
-    return trimmedRepoUrl.replace(/[?#].*$/, "");
+    return { cloneUrl: trimmedRepoUrl.replace(/[?#].*$/, "") };
   }
 
-  return trimmedRepoUrl;
+  return { cloneUrl: trimmedRepoUrl };
 }
 
 function parseScpStyleSshUrl(url: string): { host: string } | undefined {
@@ -656,9 +663,12 @@ export class ProjectService {
     }));
   }
 
-  private validateAndPrepareClone(
-    input: CloneProjectParams
-  ): Result<{ cloneUrl: string; normalizedPath: string; cloneParentDir: string }> {
+  private validateAndPrepareClone(input: CloneProjectParams): Result<{
+    cloneUrl: string;
+    fallbackCloneUrl?: string;
+    normalizedPath: string;
+    cloneParentDir: string;
+  }> {
     try {
       const repoUrl = input.repoUrl.trim();
       if (!repoUrl) {
@@ -683,7 +693,7 @@ export class ProjectService {
       }
 
       return Ok({
-        cloneUrl: normalizeRepoUrlForClone(repoUrl),
+        ...normalizeRepoUrlForClone(repoUrl),
         normalizedPath,
         cloneParentDir,
       });
@@ -703,12 +713,9 @@ export class ProjectService {
       return;
     }
 
-    const { cloneUrl, normalizedPath, cloneParentDir } = prepared.data;
+    const { cloneUrl, fallbackCloneUrl, normalizedPath, cloneParentDir } = prepared.data;
     const cloneWorkPath = `${normalizedPath}.mux-clone-${randomBytes(6).toString("hex")}`;
     let cloneSucceeded = false;
-    // Preserve full stderr so failed clones can surface git's fatal message instead of only exit code 128.
-    let collectedStderr = "";
-    let askpass: Awaited<ReturnType<typeof createMediatedAskpassSession>> | undefined;
 
     const cleanupPartialClone = async () => {
       if (cloneSucceeded) {
@@ -779,21 +786,164 @@ export class ProjectService {
 
       await fsPromises.mkdir(cloneParentDir, { recursive: true });
 
-      // Set up SSH askpass mediation for SSH clone URLs.
-      // This allows clone to surface host-key and credential prompts through the
-      // same in-app dialog used by SSH runtime probes.
-      askpass =
-        isSshCloneUrl(cloneUrl) && this.sshPromptService
-          ? await createMediatedAskpassSession({
-              sshPromptService: this.sshPromptService,
-              promptPolicy: { allowHostKey: true, allowCredential: true },
-              // Deduplicate host-key prompts by SSH endpoint identity (host:port),
-              // not by full repo path, so concurrent clones to the same host coalesce.
-              dedupeKey: deriveSshClonePromptDedupeKey(cloneUrl),
-              getStderrContext: () => collectedStderr,
-            })
-          : undefined;
+      const attemptUrls = fallbackCloneUrl != null ? [cloneUrl, fallbackCloneUrl] : [cloneUrl];
 
+      for (const [attemptIndex, attemptUrl] of attemptUrls.entries()) {
+        const outcome = yield* this.runGitCloneAttempt(attemptUrl, cloneWorkPath, signal);
+        if (outcome.kind === "success") {
+          break;
+        }
+
+        await cleanupPartialClone();
+
+        if (outcome.kind === "cancelled") {
+          yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
+          return;
+        }
+
+        // Do not bypass a rejected host key or cancelled credential by retrying over HTTPS.
+        const nextUrl = attemptUrls[attemptIndex + 1];
+        if (nextUrl != null && outcome.code === "clone_failed") {
+          yield {
+            type: "progress",
+            line: `\nClone from ${attemptUrl} failed; retrying with ${nextUrl}...\n`,
+          };
+          continue;
+        }
+
+        yield { type: "error", code: outcome.code, error: outcome.error };
+        return;
+      }
+
+      if (signal?.aborted) {
+        await cleanupPartialClone();
+        yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
+        return;
+      }
+
+      try {
+        await fsPromises.rename(cloneWorkPath, normalizedPath);
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code === "EEXIST" || err.code === "ENOTEMPTY") {
+          await cleanupPartialClone();
+
+          let existingDestinationStat: Stats | null = null;
+          try {
+            existingDestinationStat = await fsPromises.stat(normalizedPath);
+          } catch (statError) {
+            const statErr = statError as NodeJS.ErrnoException;
+            if (statErr.code !== "ENOENT") {
+              throw statError;
+            }
+          }
+
+          if (existingDestinationStat?.isDirectory()) {
+            yield {
+              type: "error",
+              code: "destination_exists",
+              error: `Destination already exists: ${normalizedPath}`,
+              normalizedPath,
+            };
+          } else {
+            yield {
+              type: "error",
+              code: "clone_failed",
+              error: `Destination already exists: ${normalizedPath}`,
+            };
+          }
+          return;
+        }
+        throw error;
+      }
+
+      if (signal?.aborted) {
+        // Abort won the race after rename but before config mutation.
+        // Remove the newly materialized destination so cancellation remains authoritative.
+        try {
+          await fsPromises.rm(normalizedPath, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup only.
+        }
+        yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
+        return;
+      }
+
+      const projectConfig: ProjectConfig = { workspaces: [] };
+      await this.config.editConfig((freshConfig) => {
+        if (freshConfig.projects.has(normalizedPath)) {
+          return freshConfig;
+        }
+        const updatedProjects = new Map(freshConfig.projects);
+        updatedProjects.set(normalizedPath, projectConfig);
+        return { ...freshConfig, projects: updatedProjects };
+      });
+
+      if (!this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
+        // Config persistence (editConfig → private saveConfig) logs-and-continues on write
+        // failures, so verify persistence explicitly before reporting success.
+        try {
+          await fsPromises.rm(normalizedPath, { recursive: true, force: true });
+        } catch {
+          // Best-effort rollback only.
+        }
+        yield {
+          type: "error",
+          code: "clone_failed",
+          error: "Failed to persist cloned project configuration",
+        };
+        return;
+      }
+
+      cloneSucceeded = true;
+      yield { type: "success", projectConfig, normalizedPath };
+    } catch (error) {
+      const message = getErrorMessage(error);
+      yield {
+        type: "error",
+        code: "clone_failed",
+        error: `Failed to clone repository: ${message}`,
+      };
+    } finally {
+      await cleanupPartialClone();
+    }
+  }
+
+  private async *runGitCloneAttempt(
+    cloneUrl: string,
+    cloneWorkPath: string,
+    signal?: AbortSignal
+  ): AsyncGenerator<
+    Extract<CloneEvent, { type: "progress" }>,
+    | { kind: "success" }
+    | { kind: "cancelled" }
+    | { kind: "failure"; code: CloneErrorCode; error: string }
+  > {
+    // An abort delivered between attempts (e.g. while the caller yielded the retry
+    // notice) must not spawn another clone.
+    if (signal?.aborted) {
+      return { kind: "cancelled" };
+    }
+
+    // Preserve full stderr so failed clones can surface git's fatal message instead of only exit code 128.
+    let collectedStderr = "";
+
+    // Set up SSH askpass mediation for SSH clone URLs.
+    // This allows clone to surface host-key and credential prompts through the
+    // same in-app dialog used by SSH runtime probes.
+    const askpass =
+      isSshCloneUrl(cloneUrl) && this.sshPromptService
+        ? await createMediatedAskpassSession({
+            sshPromptService: this.sshPromptService,
+            promptPolicy: { allowHostKey: true, allowCredential: true },
+            // Deduplicate host-key prompts by SSH endpoint identity (host:port),
+            // not by full repo path, so concurrent clones to the same host coalesce.
+            dedupeKey: deriveSshClonePromptDedupeKey(cloneUrl),
+            getStderrContext: () => collectedStderr,
+          })
+        : undefined;
+
+    try {
       const child = spawn("git", ["clone", "--progress", "--", cloneUrl, cloneWorkPath], {
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env, GIT_TERMINAL_PROMPT: "0", ...(askpass?.env ?? {}) },
@@ -915,131 +1065,39 @@ export class ProjectService {
       }
 
       if (spawnErrorMessage != null) {
-        await cleanupPartialClone();
-        const errorMessage = summarizeStderr() ?? spawnErrorMessage;
-        yield { type: "error", code: "clone_failed", error: errorMessage };
-        return;
+        return {
+          kind: "failure",
+          code: "clone_failed",
+          error: summarizeStderr() ?? spawnErrorMessage,
+        };
       }
 
       if (signal?.aborted) {
-        await cleanupPartialClone();
-        yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
-        return;
+        return { kind: "cancelled" };
       }
 
       const exitCode = child.exitCode;
       const exitSignal = child.signalCode;
 
       if (exitCode !== 0 || exitSignal != null) {
-        await cleanupPartialClone();
         const errorMessage =
           summarizeStderr() ??
           (exitSignal != null
             ? `Clone failed: process terminated by signal ${String(exitSignal)}`
             : `Clone failed with exit code ${exitCode ?? "unknown"}`);
-        yield {
-          type: "error",
+        return {
+          kind: "failure",
           code: classifySshCloneFailure({
             stderr: collectedStderr,
             promptOutcome: askpass?.getLastPromptOutcome() ?? null,
           }),
-          error: errorMessage,
+          error: withCloneReadAccessHint(errorMessage, collectedStderr),
         };
-        return;
       }
 
-      if (signal?.aborted) {
-        await cleanupPartialClone();
-        yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
-        return;
-      }
-
-      try {
-        await fsPromises.rename(cloneWorkPath, normalizedPath);
-      } catch (error) {
-        const err = error as NodeJS.ErrnoException;
-        if (err.code === "EEXIST" || err.code === "ENOTEMPTY") {
-          await cleanupPartialClone();
-
-          let existingDestinationStat: Stats | null = null;
-          try {
-            existingDestinationStat = await fsPromises.stat(normalizedPath);
-          } catch (statError) {
-            const statErr = statError as NodeJS.ErrnoException;
-            if (statErr.code !== "ENOENT") {
-              throw statError;
-            }
-          }
-
-          if (existingDestinationStat?.isDirectory()) {
-            yield {
-              type: "error",
-              code: "destination_exists",
-              error: `Destination already exists: ${normalizedPath}`,
-              normalizedPath,
-            };
-          } else {
-            yield {
-              type: "error",
-              code: "clone_failed",
-              error: `Destination already exists: ${normalizedPath}`,
-            };
-          }
-          return;
-        }
-        throw error;
-      }
-
-      if (signal?.aborted) {
-        // Abort won the race after rename but before config mutation.
-        // Remove the newly materialized destination so cancellation remains authoritative.
-        try {
-          await fsPromises.rm(normalizedPath, { recursive: true, force: true });
-        } catch {
-          // Best-effort cleanup only.
-        }
-        yield { type: "error", code: "clone_failed", error: "Clone cancelled" };
-        return;
-      }
-
-      const projectConfig: ProjectConfig = { workspaces: [] };
-      await this.config.editConfig((freshConfig) => {
-        if (freshConfig.projects.has(normalizedPath)) {
-          return freshConfig;
-        }
-        const updatedProjects = new Map(freshConfig.projects);
-        updatedProjects.set(normalizedPath, projectConfig);
-        return { ...freshConfig, projects: updatedProjects };
-      });
-
-      if (!this.config.loadConfigOrDefault().projects.has(normalizedPath)) {
-        // Config persistence (editConfig → private saveConfig) logs-and-continues on write
-        // failures, so verify persistence explicitly before reporting success.
-        try {
-          await fsPromises.rm(normalizedPath, { recursive: true, force: true });
-        } catch {
-          // Best-effort rollback only.
-        }
-        yield {
-          type: "error",
-          code: "clone_failed",
-          error: "Failed to persist cloned project configuration",
-        };
-        return;
-      }
-
-      cloneSucceeded = true;
-      yield { type: "success", projectConfig, normalizedPath };
-    } catch (error) {
-      const message = getErrorMessage(error);
-      yield {
-        type: "error",
-        code: "clone_failed",
-        error: `Failed to clone repository: ${message}`,
-      };
+      return { kind: "success" };
     } finally {
       askpass?.cleanup();
-      await cleanupPartialClone();
     }
   }
 

--- a/src/node/services/sshCloneFailure.ts
+++ b/src/node/services/sshCloneFailure.ts
@@ -41,6 +41,23 @@ export function classifySshCloneFailure(ctx: CloneFailureContext): CloneErrorCod
 }
 
 /**
+ * GitHub may answer a clone/fetch with "Write access to repository not granted."
+ * when the credential cannot read the repository. Clarify that cloning needs
+ * only read access instead of surfacing the misleading message alone.
+ */
+export function withCloneReadAccessHint(errorMessage: string, stderr: string): string {
+  if (!/write access to repository not granted/i.test(stderr)) {
+    return errorMessage;
+  }
+  return (
+    `${errorMessage}\n` +
+    "Cloning needs only read access. GitHub sends this misleading error when the " +
+    "credential Git presented cannot read the repository (often a fine-grained or " +
+    "under-scoped token). Check which credential Git is using, or clone via a different protocol."
+  );
+}
+
+/**
  * Return the last few meaningful stderr lines as a compact summary.
  * Preserves enough context for actionable diagnostics without dumping
  * the entire output into the UI.


### PR DESCRIPTION
## Summary

Cloning a GitHub repo you can read but not write to could fail in the Clone dialog. This PR adds an HTTPS fallback when `owner/repo` shorthand SSH clones fail, and clarifies GitHub's misleading `remote: Write access to repository not granted.` error.

## Background

Two mechanisms broke read-only clones:

1. `owner/repo` shorthand expanded to `git@github.com:owner/repo.git` whenever `SSH_AUTH_SOCK` existed (near-universal on macOS). GitHub SSH requires a recognized key even for public repos, so readable repos failed with `Permission denied (publickey)` with no fallback.
2. GitHub answers HTTPS clones with `remote: Write access to repository not granted.` (403) when the presented credential cannot _read_ the repo (typically an under-scoped or fine-grained token). Mux surfaced that verbatim, which reads exactly like "cloning requires write access". Mux never requires write access to clone.

## Implementation

- `normalizeRepoUrlForClone` now returns an optional `fallbackCloneUrl`: shorthand still prefers SSH when an agent socket exists, but carries the HTTPS URL as a fallback. Explicit URLs are never rewritten.
- `cloneWithProgress` loops over the attempt URLs via a new private `runGitCloneAttempt` generator (single-attempt spawn/stream logic moved there; abort/cleanup/askpass semantics preserved per attempt). User-driven cancellations (rejected host key, cancelled credential prompt, abort) do not trigger the fallback; only organic clone failures do.
- `withCloneReadAccessHint` appends a clarification when stderr contains GitHub's "Write access to repository not granted": cloning needs only read access and the credential Git presented cannot read the repo.

## Validation

Behavioral tests cover: fallback ordering and success, no fallback for explicit SSH URLs, abort between attempts spawns no second clone and leaves no debris, and hint gating on the exact GitHub stderr (including a negative case where SSH `Permission denied` gets no hint).

## Risks

Clone flow only. The riskiest part is the retry loop refactor in `cloneWithProgress`; a regression there could double-spawn clones or leak temp dirs on abort, both covered by tests. Explicit-URL flows are pass-through and unaffected.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
