### PR TITLE
🤖 fix: exclude sub-agent rows from sidebar agent counts

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -1881,6 +1881,53 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
   });
 });
 
+describe("ProjectSidebar project agent count", () => {
+  const demoProjectPath = "/projects/demo-project";
+
+  beforeEach(() => setupProjectSidebarDom(demoProjectPath));
+  afterEach(cleanupProjectSidebarDom);
+
+  test("counts only top-level agents, not sub-agent descendants", () => {
+    const createProjectWorkspace = (
+      id: string,
+      parentWorkspaceId?: string
+    ): FrontendWorkspaceMetadata => ({
+      id,
+      name: `${id}-name`,
+      title: id,
+      projectName: "demo-project",
+      projectPath: demoProjectPath,
+      namedWorkspacePath: `${demoProjectPath}/${id}`,
+      runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+      parentWorkspaceId,
+    });
+
+    const view = render(
+      <ProjectSidebar
+        collapsed={false}
+        onToggleCollapsed={() => undefined}
+        sortedWorkspacesByProject={
+          new Map([
+            [
+              demoProjectPath,
+              [
+                createProjectWorkspace("root"),
+                createProjectWorkspace("child-a", "root"),
+                createProjectWorkspace("child-b", "root"),
+                createProjectWorkspace("grandchild", "child-a"),
+              ],
+            ],
+          ])
+        }
+        workspaceRecency={{}}
+      />
+    );
+
+    const projectLabel = view.getByText("demo-project");
+    expect(projectLabel.parentElement?.textContent).toBe("demo-project(1)");
+  });
+});
+
 describe("ProjectSidebar archive confirmations", () => {
   beforeEach(() => setupProjectSidebarDom());
   afterEach(cleanupProjectSidebarDom);

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1717,9 +1717,10 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const scratchWorkspaces = orderMultiProjectSectionRows(
     Array.from(scratchWorkspacesById.values())
   );
-  const scratchRowsForDisplay = hideSubAgentRows
-    ? excludeSubAgentRows(scratchWorkspaces)
-    : scratchWorkspaces;
+  // Sub-agent rows render nested under their parent, so section counts skip
+  // them (orphans and malformed-cycle rows still count, matching display).
+  const topLevelScratchWorkspaces = excludeSubAgentRows(scratchWorkspaces);
+  const scratchRowsForDisplay = hideSubAgentRows ? topLevelScratchWorkspaces : scratchWorkspaces;
   const scratchDepthByWorkspaceId = computeWorkspaceDepthMap(scratchRowsForDisplay);
   const visibleScratchWorkspaces = filterVisibleAgentRows(
     scratchRowsForDisplay,
@@ -1742,8 +1743,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const multiProjectWorkspaces = orderMultiProjectSectionRows(
     Array.from(multiProjectWorkspacesById.values())
   );
+  const topLevelMultiProjectWorkspaces = excludeSubAgentRows(multiProjectWorkspaces);
   const multiProjectRowsForDisplay = hideSubAgentRows
-    ? excludeSubAgentRows(multiProjectWorkspaces)
+    ? topLevelMultiProjectWorkspaces
     : multiProjectWorkspaces;
   const multiProjectDepthByWorkspaceId = computeWorkspaceDepthMap(multiProjectRowsForDisplay);
   const visibleMultiProjectWorkspaces = filterVisibleAgentRows(
@@ -1954,7 +1956,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                       <span className="text-foreground truncate text-sm font-medium">Chats</span>
                       {(scratchWorkspaces.length > 0 || scratchDrafts.length > 0) && (
                         <span className="text-muted ml-2 text-xs">
-                          ({scratchWorkspaces.length + scratchDrafts.length})
+                          ({topLevelScratchWorkspaces.length + scratchDrafts.length})
                         </span>
                       )}
                     </div>
@@ -2078,7 +2080,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                           Multi-Project
                         </span>
                         <span className="text-muted ml-2 text-xs">
-                          ({multiProjectWorkspaces.length})
+                          ({topLevelMultiProjectWorkspaces.length})
                         </span>
                       </div>
                     </div>
@@ -2161,7 +2163,8 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                     const isEditingProjectDisplayName = editingProjectPath === projectPath;
                     const projectWorkspaces =
                       singleProjectWorkspacesByProject.get(projectPath) ?? [];
-                    const projectAgentCount = projectWorkspaces.length;
+                    const topLevelProjectWorkspaces = excludeSubAgentRows(projectWorkspaces);
+                    const projectAgentCount = topLevelProjectWorkspaces.length;
                     const projectHasAttention = projectWorkspaces.some(
                       (workspace) => workspaceAttentionById.get(workspace.id) === true
                     );
@@ -2375,7 +2378,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                 Object.values(activeDraftPromotions).map((metadata) => metadata.id)
                               );
                               const projectRowsForDisplay = hideSubAgentRows
-                                ? excludeSubAgentRows(projectWorkspaces)
+                                ? topLevelProjectWorkspaces
                                 : projectWorkspaces;
                               const workspacesForNormalRendering = projectRowsForDisplay.filter(
                                 (workspace) => !promotedWorkspaceIds.has(workspace.id)


### PR DESCRIPTION
## Summary

Sidebar agent counts (the `(N)` next to each project name, the Chats section, and the Multi-Project section) included sub-agent descendant workspaces, so a project with one root agent running seven sub-agents showed `(8)`. Counts now include only top-level agents.

## Background

Sub-agent rows render nested under their parent row (or are hidden entirely behind a parent summary), so counting them at the section level overstated how many agents the user actually has in a project.

## Implementation

Reuse the existing `excludeSubAgentRows` helper, which already powers the "hide sub-agents in sidebar" display filter, for all three section counts. It intentionally keeps promoted orphans and malformed-parent-cycle rows countable, matching what actually renders. The per-project filtered list is computed once and shared between the count and the hidden-row display path.

## Validation

Red-green: the new test (1 root + 2 children + 1 grandchild asserts the header shows `(1)`) fails with `demo-project(4)` when the fix is stashed.

## Risks

Low: display-only change scoped to sidebar section counts; row rendering, attention dots, and archive/removal counts are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
