### PR TITLE
🤖 ci: retry bun teardown crashes and npm registry publication skew

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -219,8 +219,21 @@ jobs:
           # segfaults Bun on the runner (exit 132, "Bun has crashed", zero failing assertions)
           # while leaving the file transition as the only suspect, and these files are already
           # here because they do not survive sharing a process.
+          # Even isolated, Bun can segfault at teardown after every test passed
+          # (signal exits >= 128, e.g. 132 SIGILL / 139 SIGSEGV). Retry only those;
+          # genuine test failures exit 1 and must not be retried.
           for isolated_unit_test in "${isolated_unit_tests[@]}"; do
-            bun test --max-concurrency=1 "$isolated_unit_test"
+            for attempt in 1 2 3; do
+              exit_code=0
+              bun test --max-concurrency=1 "$isolated_unit_test" || exit_code=$?
+              if [[ "$exit_code" -eq 0 ]]; then
+                break
+              fi
+              if [[ "$exit_code" -lt 128 || "$attempt" -eq 3 ]]; then
+                exit "$exit_code"
+              fi
+              echo "bun crashed (exit $exit_code) on $isolated_unit_test, retrying (attempt $attempt of 3)..."
+            done
           done
 
           mapfile -d '' unit_files < <(

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -219,9 +219,8 @@ jobs:
           # segfaults Bun on the runner (exit 132, "Bun has crashed", zero failing assertions)
           # while leaving the file transition as the only suspect, and these files are already
           # here because they do not survive sharing a process.
-          # Even isolated, Bun can segfault at teardown after every test passed
-          # (signal exits >= 128, e.g. 132 SIGILL / 139 SIGSEGV). Retry only those;
-          # genuine test failures exit 1 and must not be retried.
+          # Bun can also crash at teardown after every test passed (e.g. exit 132).
+          # Retry only signal exits (>= 128); genuine test failures exit 1.
           for isolated_unit_test in "${isolated_unit_tests[@]}"; do
             for attempt in 1 2 3; do
               exit_code=0

--- a/scripts/check-bench-agent.sh
+++ b/scripts/check-bench-agent.sh
@@ -105,8 +105,7 @@ node -e "
   require('fs').writeFileSync('$CHECK_DIR/package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 
-# Registry publication skew (e.g. AWS SDK waves) can make a fresh resolve ask for
-# a sibling version that is not visible yet; retry before treating it as breakage.
+# Publish waves (e.g. AWS SDK) can transiently request sibling versions not yet visible on the registry.
 if ! (cd "$CHECK_DIR" && "$REPO_ROOT/scripts/retry.sh" 5 60 bun install --ignore-scripts); then
   echo "❌ Error: bun install (lockfile-free) failed"
   exit 1

--- a/scripts/check-bench-agent.sh
+++ b/scripts/check-bench-agent.sh
@@ -105,9 +105,10 @@ node -e "
   require('fs').writeFileSync('$CHECK_DIR/package.json', JSON.stringify(pkg, null, 2) + '\n');
 "
 
-if ! install_output=$(cd "$CHECK_DIR" && bun install --ignore-scripts 2>&1); then
-  echo "❌ Error: bun install (lockfile-free) failed:"
-  echo "$install_output"
+# Registry publication skew (e.g. AWS SDK waves) can make a fresh resolve ask for
+# a sibling version that is not visible yet; retry before treating it as breakage.
+if ! (cd "$CHECK_DIR" && "$REPO_ROOT/scripts/retry.sh" 5 60 bun install --ignore-scripts); then
+  echo "❌ Error: bun install (lockfile-free) failed"
   exit 1
 fi
 

--- a/scripts/generate-npm-shrinkwrap.sh
+++ b/scripts/generate-npm-shrinkwrap.sh
@@ -12,8 +12,7 @@ echo "Generating npm-shrinkwrap.json (production dependencies only)..."
 
 rm -f package-lock.json npm-shrinkwrap.json
 
-# Registry publication skew (e.g. AWS SDK waves) can make a fresh resolve fail
-# transiently; retry before failing.
+# Publish waves (e.g. AWS SDK) can transiently request sibling versions not yet visible on the registry.
 "$ROOT_DIR/scripts/retry.sh" 5 60 npm install --package-lock-only --omit=dev --ignore-scripts --no-audit --no-fund --legacy-peer-deps
 
 if [[ ! -f package-lock.json ]]; then

--- a/scripts/generate-npm-shrinkwrap.sh
+++ b/scripts/generate-npm-shrinkwrap.sh
@@ -12,7 +12,9 @@ echo "Generating npm-shrinkwrap.json (production dependencies only)..."
 
 rm -f package-lock.json npm-shrinkwrap.json
 
-npm install --package-lock-only --omit=dev --ignore-scripts --no-audit --no-fund --legacy-peer-deps
+# Registry publication skew (e.g. AWS SDK waves) can make a fresh resolve fail
+# transiently; retry before failing.
+"$ROOT_DIR/scripts/retry.sh" 5 60 npm install --package-lock-only --omit=dev --ignore-scripts --no-audit --no-fund --legacy-peer-deps
 
 if [[ ! -f package-lock.json ]]; then
   echo "package-lock.json was not generated." >&2

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -123,8 +123,7 @@ if [[ "$SKIP_SHRINKWRAP" == "1" ]]; then
   log_info "Repacked tarball without shrinkwrap: $PACKAGE_TARBALL"
 fi
 
-# Install the package. Registry publication skew (e.g. AWS SDK waves) can make
-# fresh resolution transiently fail; retry before failing.
+# Publish waves (e.g. AWS SDK) can transiently request sibling versions not yet visible on the registry.
 log_info "Installing package..."
 if ! "$SCRIPT_DIR/retry.sh" 5 60 npm install --no-save "$PACKAGE_TARBALL"; then
   log_error "Failed to install package"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -121,9 +123,10 @@ if [[ "$SKIP_SHRINKWRAP" == "1" ]]; then
   log_info "Repacked tarball without shrinkwrap: $PACKAGE_TARBALL"
 fi
 
-# Install the package
+# Install the package. Registry publication skew (e.g. AWS SDK waves) can make
+# fresh resolution transiently fail; retry before failing.
 log_info "Installing package..."
-if ! npm install --no-save "$PACKAGE_TARBALL"; then
+if ! "$SCRIPT_DIR/retry.sh" 5 60 npm install --no-save "$PACKAGE_TARBALL"; then
   log_error "Failed to install package"
   exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes the two CI flake classes that dequeued #3854 from the merge queue twice on 2026-08-14 (runs 31829008751 and 31831156227).

## Background

1. **Bun teardown crash**: in `Test / Unit`, bun 1.3.5 crashed (`Illegal instruction`, exit 132) at process teardown in an isolated `WorkflowRunner.test.ts` run *after every test passed* ("0 fail", panic during shutdown). The same signature dequeued another PR on Aug 13.
2. **Registry publication skew**: during an AWS SDK publish wave, the lockfile-free resolves in `Static Checks` (`check-bench-agent.sh`) and `Smoke / Server` (`npm install` of the packed tarball) requested `@aws-sdk/credential-provider-ini@^3.973.14` seconds before it was visible on the registry (`ETARGET` / "No version matching ... (but package exists)").

## Implementation

- `pr.yml`: isolated unit-test files retry up to 3 times, but **only on signal exits (>= 128)**. Genuine test failures (exit 1) still fail immediately on the first attempt, so no flaky-test masking is possible. The existing `scripts/retry.sh` was not reused here because it retries every nonzero exit.
- `check-bench-agent.sh`, `smoke-test.sh`, `generate-npm-shrinkwrap.sh`: the three registry-facing installs (all resolve fresh from npm) are wrapped in the existing `scripts/retry.sh` with 5 attempts x 60s, enough to ride out a multi-minute publish wave.

Considered and rejected: scoping the smoke-test retry to `SKIP_SHRINKWRAP=1` only. The observed incident hit the *shrinkwrapped* `Smoke / Server` install, so that scoping would leave the observed flake unfixed. Also considered a 3x30 retry budget to match `dist-mac`'s; kept 5x60 because publish waves span minutes and the extra delay only applies to genuinely broken resolution, which lockfile-based jobs never hit.

## Validation

- Behavioral test of the crash-retry loop with a fake `bun` (crash-then-pass recovers; exit 1 fails immediately with a single invocation; persistent crash exits 132 after 3 attempts; clean pass runs once).
- `make static-check`, `shellcheck` on all three scripts, `actionlint`, `zizmor`: all green.
- `check-bench-agent.sh` and `generate-npm-shrinkwrap.sh` run end-to-end locally through the retry wrapper.

## Risks

Low. The unit-test retry cannot mask real failures (exit-code gated). The install retries add up to 4 minutes before surfacing a genuine resolution failure in `Static Checks` / `Smoke` / npm publish; publication skew is far more common than genuine breakage on those lockfile-free paths.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
