### PR TITLE
🤖 feat: show workflow name, current step, and active-only counts in sidebar sub-agent summary

### DIFF
--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -96,6 +96,7 @@ function makeHiddenSummary(
     runningWorkflowAgentCount: 0,
     queuedWorkflowAgentCount: 0,
     workflowRunIds: new Set(),
+    workflowNamesByRunId: new Map(),
     ...overrides,
   };
 }
@@ -566,7 +567,7 @@ describe("AgentListItem", () => {
     expect(rowView.queryByText("Workflow running · 1 sub-agent active")).toBeNull();
   });
 
-  test("summarizes hidden sub-agents with total and active counts", () => {
+  test("summarizes hidden sub-agents with only the active count", () => {
     const { row } = renderWorkspaceItem({
       delegatedActivity: {
         activeCount: 1,
@@ -580,7 +581,7 @@ describe("AgentListItem", () => {
 
     expect(row.querySelector(".workspace-status-dot-active")).toBeTruthy();
     const indicator = rowView.getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`);
-    expect(indicator.textContent).toBe("3 sub-agents · 1 active");
+    expect(indicator.textContent).toBe("1 sub-agent active");
     expect(indicator.querySelector("svg")).toBeTruthy();
     expect(rowView.queryByTestId(`workspace-delegated-activity-${TEST_WORKSPACE_ID}`)).toBeNull();
   });
@@ -607,6 +608,56 @@ describe("AgentListItem", () => {
     expect(rowView.queryByText("Workflow running")).toBeNull();
   });
 
+  test("shows the workflow name and current step for a single running worker", () => {
+    const { row } = renderWorkspaceItem({
+      hiddenSubAgentsSummary: makeHiddenSummary({
+        runningWorkflowRunCount: 1,
+        runningWorkflowAgentCount: 1,
+        workflowRunIds: new Set(["run-1"]),
+        workflowName: "Deep Research",
+        runningWorkflowStepTitle: "Implementer",
+      }),
+    });
+
+    expect(
+      within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
+    ).toBe("Deep Research · Implementer");
+  });
+
+  test("appends queued workers after the current step label", () => {
+    const { row } = renderWorkspaceItem({
+      hiddenSubAgentsSummary: makeHiddenSummary({
+        runningWorkflowRunCount: 1,
+        runningWorkflowAgentCount: 1,
+        queuedWorkflowAgentCount: 2,
+        workflowRunIds: new Set(["run-1"]),
+        workflowName: "Deep Research",
+        runningWorkflowStepTitle: "Implementer",
+      }),
+    });
+
+    expect(
+      within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
+    ).toBe("Deep Research · Implementer · 2 queued");
+  });
+
+  test("labels a lone gap-only run with its remembered workflow name", () => {
+    mockWorkspaceSidebarState = createWorkspaceSidebarState({
+      activeWorkflowRunIds: ["run-gap"],
+      activeWorkflowRunCount: 1,
+    });
+
+    const { row } = renderWorkspaceItem({
+      hiddenSubAgentsSummary: makeHiddenSummary({
+        workflowNamesByRunId: new Map([["run-gap", "Deep Research"]]),
+      }),
+    });
+
+    expect(
+      within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
+    ).toBe("Deep Research running");
+  });
+
   test("shows the hidden sub-agents summary while the coordinator itself streams", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       canInterrupt: true,
@@ -619,7 +670,7 @@ describe("AgentListItem", () => {
     const rowView = within(row);
 
     expect(rowView.getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent).toBe(
-      "2 sub-agents · 2 active"
+      "2 sub-agents active"
     );
     expect(rowView.queryByTestId(`workspace-status-indicator-${TEST_WORKSPACE_ID}`)).toBeNull();
     // The row's own streaming state still shows through the green dot.
@@ -635,7 +686,7 @@ describe("AgentListItem", () => {
     const rowView = within(row);
 
     expect(rowView.getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent).toBe(
-      "2 sub-agents · 2 active"
+      "2 sub-agents active"
     );
     expect(rowView.queryByText("Watching background bash")).toBeNull();
   });
@@ -651,7 +702,7 @@ describe("AgentListItem", () => {
 
     expect(
       within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
-    ).toBe("3 sub-agents · 1 active · 2 queued");
+    ).toBe("1 sub-agent active · 2 queued");
   });
 
   test("labels a workflow with only queued workers as queued, not running", () => {
@@ -774,7 +825,7 @@ describe("AgentListItem", () => {
 
     expect(
       within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
-    ).toBe("2 sub-agents · 1 active · Deep Research queued (2 agents)");
+    ).toBe("1 sub-agent active · Deep Research queued (2 agents)");
   });
 
   test("keeps a running workflow ahead of running sub-agents in the combined line", () => {
@@ -796,7 +847,7 @@ describe("AgentListItem", () => {
 
     expect(
       within(row).getByTestId(`workspace-hidden-subagents-${TEST_WORKSPACE_ID}`).textContent
-    ).toBe("Deep Research running (3 agents) · 2 sub-agents · 1 active");
+    ).toBe("Deep Research running (3 agents) · 1 sub-agent active");
   });
 
   test("falls back to the normal status line when hidden sub-agents are all inactive", () => {

--- a/src/browser/components/AgentListItem/AgentListItem.test.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.test.tsx
@@ -96,7 +96,6 @@ function makeHiddenSummary(
     runningWorkflowAgentCount: 0,
     queuedWorkflowAgentCount: 0,
     workflowRunIds: new Set(),
-    workflowNamesByRunId: new Map(),
     ...overrides,
   };
 }
@@ -272,6 +271,7 @@ function renderWorkspaceItem(
     isWorkspaceLiveActive?: boolean;
     delegatedActivity?: WorkspaceDelegatedActivity;
     hiddenSubAgentsSummary?: WorkspaceSubAgentsSummary;
+    getWorkflowRunName?: (runId: string) => string | undefined;
     completedChildrenExpanded?: boolean;
     onToggleCompletedChildren?: (workspaceId: string) => void;
     onSelectWorkspace?: (selection: WorkspaceSelection) => void;
@@ -292,6 +292,7 @@ function renderWorkspaceItem(
       isWorkspaceLiveActive={options.isWorkspaceLiveActive}
       delegatedActivity={options.delegatedActivity}
       hiddenSubAgentsSummary={options.hiddenSubAgentsSummary}
+      getWorkflowRunName={options.getWorkflowRunName}
       completedChildrenExpanded={options.completedChildrenExpanded}
       onToggleCompletedChildren={options.onToggleCompletedChildren}
       onSelectWorkspace={options.onSelectWorkspace ?? (() => undefined)}
@@ -641,16 +642,15 @@ describe("AgentListItem", () => {
     ).toBe("Deep Research · Implementer · 2 queued");
   });
 
-  test("labels a lone gap-only run with its remembered workflow name", () => {
+  test("labels a lone gap-only run with its retained workflow name", () => {
     mockWorkspaceSidebarState = createWorkspaceSidebarState({
       activeWorkflowRunIds: ["run-gap"],
       activeWorkflowRunCount: 1,
     });
 
     const { row } = renderWorkspaceItem({
-      hiddenSubAgentsSummary: makeHiddenSummary({
-        workflowNamesByRunId: new Map([["run-gap", "Deep Research"]]),
-      }),
+      hiddenSubAgentsSummary: makeHiddenSummary(),
+      getWorkflowRunName: (runId) => (runId === "run-gap" ? "Deep Research" : undefined),
     });
 
     expect(
@@ -804,6 +804,7 @@ describe("AgentListItem", () => {
         workflowRunIds: new Set(["run-queued"]),
         workflowName: "Deep Research",
       }),
+      getWorkflowRunName: (runId) => (runId === "run-queued" ? "Deep Research" : undefined),
     });
 
     expect(

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -253,10 +253,8 @@ function formatHiddenSubAgentsPresentation(
   // before its first worker spawns) is still in progress; count it as running
   // so a concurrent run's workers cannot make it look finished while its rows
   // are hidden.
-  const gapRunCount = ownActiveWorkflowRunIds.filter(
-    (runId) => !summary.workflowRunIds.has(runId)
-  ).length;
-  const runningRunCount = summary.runningWorkflowRunCount + gapRunCount;
+  const gapRunIds = ownActiveWorkflowRunIds.filter((runId) => !summary.workflowRunIds.has(runId));
+  const runningRunCount = summary.runningWorkflowRunCount + gapRunIds.length;
 
   let workflowText: string | null = null;
   if (runningRunCount > 0 || summary.queuedWorkflowRunCount > 0) {
@@ -266,34 +264,50 @@ function formatHiddenSubAgentsPresentation(
     const verb = hasRunningRun ? "running" : "queued";
     const runCount = hasRunningRun ? runningRunCount : summary.queuedWorkflowRunCount;
     // With no running worker, summary.workflowName is a queued run's name; a
-    // gap-only running label must not borrow it.
+    // gap-only running label must not borrow it, but the sole gap run's own
+    // remembered name may label it.
     const workflowName =
-      hasRunningRun && summary.runningWorkflowRunCount === 0 ? undefined : summary.workflowName;
-    const base =
-      runCount === 1 ? `${workflowName ?? "Workflow"} ${verb}` : `${runCount} workflows ${verb}`;
-    const agentCount = hasRunningRun
-      ? summary.runningWorkflowAgentCount
-      : summary.queuedWorkflowAgentCount;
-    // Gap-only runs have no countable workers; skip the "(0 agents)" noise.
-    const agentSuffix =
-      agentCount > 0 ? ` (${agentCount} agent${agentCount === 1 ? "" : "s"})` : "";
-    const queuedSuffix =
-      hasRunningRun && summary.queuedWorkflowAgentCount > 0
-        ? ` · ${summary.queuedWorkflowAgentCount} queued`
-        : "";
-    workflowText = `${base}${agentSuffix}${queuedSuffix}`;
+      hasRunningRun && summary.runningWorkflowRunCount === 0
+        ? gapRunIds.length === 1
+          ? summary.workflowNamesByRunId.get(gapRunIds[0])
+          : undefined
+        : summary.workflowName;
+    // The lone running worker's title is the run's current step; counts only
+    // add signal once several workers or runs are in flight.
+    if (
+      hasRunningRun &&
+      runCount === 1 &&
+      summary.runningWorkflowAgentCount === 1 &&
+      summary.runningWorkflowStepTitle != null
+    ) {
+      const queuedSuffix =
+        summary.queuedWorkflowAgentCount > 0 ? ` · ${summary.queuedWorkflowAgentCount} queued` : "";
+      workflowText = `${workflowName ?? "Workflow"} · ${summary.runningWorkflowStepTitle}${queuedSuffix}`;
+    } else {
+      const base =
+        runCount === 1 ? `${workflowName ?? "Workflow"} ${verb}` : `${runCount} workflows ${verb}`;
+      const agentCount = hasRunningRun
+        ? summary.runningWorkflowAgentCount
+        : summary.queuedWorkflowAgentCount;
+      // Gap-only runs have no countable workers; skip the "(0 agents)" noise.
+      const agentSuffix =
+        agentCount > 0 ? ` (${agentCount} agent${agentCount === 1 ? "" : "s"})` : "";
+      const queuedSuffix =
+        hasRunningRun && summary.queuedWorkflowAgentCount > 0
+          ? ` · ${summary.queuedWorkflowAgentCount} queued`
+          : "";
+      workflowText = `${base}${agentSuffix}${queuedSuffix}`;
+    }
   }
 
   let subAgentText: string | null = null;
-  if (summary.runningSubAgentCount > 0 || summary.queuedSubAgentCount > 0) {
-    const parts = [`${summary.subAgentCount} sub-agent${summary.subAgentCount === 1 ? "" : "s"}`];
-    if (summary.runningSubAgentCount > 0) {
-      parts.push(`${summary.runningSubAgentCount} active`);
-    }
+  if (summary.runningSubAgentCount > 0) {
+    subAgentText = formatSubAgentCount(summary.runningSubAgentCount, "active");
     if (summary.queuedSubAgentCount > 0) {
-      parts.push(`${summary.queuedSubAgentCount} queued`);
+      subAgentText += ` · ${summary.queuedSubAgentCount} queued`;
     }
-    subAgentText = parts.join(" · ");
+  } else if (summary.queuedSubAgentCount > 0) {
+    subAgentText = formatSubAgentCount(summary.queuedSubAgentCount, "queued");
   }
 
   if (workflowText != null && subAgentText != null) {

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -135,6 +135,11 @@ export interface AgentListItemProps extends AgentListItemBaseProps {
   isWorkspaceLiveActive?: boolean;
   delegatedActivity?: WorkspaceDelegatedActivity;
   hiddenSubAgentsSummary?: WorkspaceSubAgentsSummary;
+  /**
+   * Workflow name for an own active run, retained beyond worker lifetimes so
+   * a run between sequential steps (no live worker) stays labeled.
+   */
+  getWorkflowRunName?: (runId: string) => string | undefined;
   completedChildrenExpanded?: boolean;
   onToggleCompletedChildren?: (workspaceId: string) => void;
   onSelectWorkspace: (selection: WorkspaceSelection) => void;
@@ -247,7 +252,8 @@ const EMPTY_WORKFLOW_RUN_IDS: readonly string[] = [];
  */
 function formatHiddenSubAgentsPresentation(
   summary: WorkspaceSubAgentsSummary,
-  ownActiveWorkflowRunIds: readonly string[]
+  ownActiveWorkflowRunIds: readonly string[],
+  getWorkflowRunName?: (runId: string) => string | undefined
 ): { icon: LucideIcon; text: string } | null {
   // An own active run without a live worker (between sequential steps, or
   // before its first worker spawns) is still in progress; count it as running
@@ -264,11 +270,11 @@ function formatHiddenSubAgentsPresentation(
     const verb = hasRunningRun ? "running" : "queued";
     const runCount = hasRunningRun ? runningRunCount : summary.queuedWorkflowRunCount;
     // When only gap runs are active, summary.workflowName may belong to a queued run.
-    // Only a single gap run has an unambiguous remembered name.
+    // Only a single gap run has an unambiguous name.
     const workflowName =
       hasRunningRun && summary.runningWorkflowRunCount === 0
         ? gapRunIds.length === 1
-          ? summary.workflowNamesByRunId.get(gapRunIds[0])
+          ? getWorkflowRunName?.(gapRunIds[0])
           : undefined
         : summary.workflowName;
     // The lone running worker's title is the run's current step; counts only
@@ -564,6 +570,7 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
     rowRenderMeta,
     delegatedActivity,
     hiddenSubAgentsSummary,
+    getWorkflowRunName,
     completedChildrenExpanded,
     onToggleCompletedChildren,
     onSelectWorkspace,
@@ -774,7 +781,8 @@ function RegularAgentListItemInner(props: AgentListItemProps) {
   const hiddenSubAgentsPresentation = hiddenSubAgentsSummary
     ? formatHiddenSubAgentsPresentation(
         hiddenSubAgentsSummary,
-        activeWorkflowRunIds ?? EMPTY_WORKFLOW_RUN_IDS
+        activeWorkflowRunIds ?? EMPTY_WORKFLOW_RUN_IDS,
+        getWorkflowRunName
       )
     : null;
   // With sub-agent rows hidden, the summary outranks the coordinator's own

--- a/src/browser/components/AgentListItem/AgentListItem.tsx
+++ b/src/browser/components/AgentListItem/AgentListItem.tsx
@@ -263,9 +263,8 @@ function formatHiddenSubAgentsPresentation(
     const hasRunningRun = runningRunCount > 0;
     const verb = hasRunningRun ? "running" : "queued";
     const runCount = hasRunningRun ? runningRunCount : summary.queuedWorkflowRunCount;
-    // With no running worker, summary.workflowName is a queued run's name; a
-    // gap-only running label must not borrow it, but the sole gap run's own
-    // remembered name may label it.
+    // When only gap runs are active, summary.workflowName may belong to a queued run.
+    // Only a single gap run has an unambiguous remembered name.
     const workflowName =
       hasRunningRun && summary.runningWorkflowRunCount === 0
         ? gapRunIds.length === 1

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -125,6 +125,7 @@ interface MockAgentListItemProps {
   rowRenderMeta?: AgentRowRenderMeta;
   delegatedActivity?: { activeCount: number; queuedCount: number };
   hiddenSubAgentsSummary?: WorkspaceSubAgentsSummary;
+  getWorkflowRunName?: (runId: string) => string | undefined;
   subAgentConnectorLayout?: "default" | "task-group-member";
   completedChildrenExpanded?: boolean;
   onToggleCompletedChildren?: (workspaceId: string) => void;
@@ -358,6 +359,11 @@ function installProjectSidebarTestDoubles() {
                 )
               : undefined
           }
+          data-run-names={JSON.stringify(
+            (activeWorkflowRunIdsByWorkspaceId.get(metadata.id) ?? []).map(
+              (runId: string) => props.getWorkflowRunName?.(runId) ?? null
+            )
+          )}
         >
           <span>{displayTitle}</span>
           {hasCompletedChildren && props.onToggleCompletedChildren ? (
@@ -955,7 +961,6 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       runningWorkflowAgentCount: 0,
       queuedWorkflowAgentCount: 0,
       workflowRunIds: [],
-      workflowNamesByRunId: {},
     });
     // The delegated activity still reaches the parent row for its live dot.
     expect(parentRow.dataset.delegatedActive).toBe("1");
@@ -1026,9 +1031,64 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       queuedWorkflowAgentCount: 1,
       workflowRunIds: ["wfr_alpha"],
       workflowName: "review-pipeline",
-      workflowNamesByRunId: { wfr_alpha: "review-pipeline" },
       runningWorkflowStepTitle: "Extract claims",
     });
+  });
+
+  test("retains a hidden run's workflow name across workerless step gaps", () => {
+    window.localStorage.setItem(SIDEBAR_HIDE_SUBAGENTS_KEY, JSON.stringify(true));
+    window.localStorage.setItem(EXPANDED_PROJECTS_KEY, JSON.stringify(["/projects/demo-project"]));
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([["/projects/demo-project", { workspaces: [] }]]),
+      hasAnyProject: true,
+      resolveNewChatProjectPath: () => "/projects/demo-project",
+    });
+
+    const singleProjectRefs = [
+      { projectPath: "/projects/demo-project", projectName: "demo-project" },
+    ];
+    const parentWorkspace = {
+      ...createWorkspace("parent", { title: "Parent workspace" }),
+      projects: singleProjectRefs,
+    };
+    const worker = {
+      ...createWorkspace("worker-1", {
+        parentWorkspaceId: "parent",
+        taskStatus: "running",
+        title: "Extract claims",
+        workflowTask: { runId: "wfr_alpha", stepId: "claims", workflowName: "review-pipeline" },
+      }),
+      projects: singleProjectRefs,
+    };
+    const renderProps = (child?: FrontendWorkspaceMetadata) =>
+      ({
+        collapsed: false,
+        onToggleCollapsed: () => undefined,
+        sortedWorkspacesByProject: new Map([
+          ["/projects/demo-project", [parentWorkspace, ...(child ? [child] : [])]],
+        ]),
+        workspaceRecency: { parent: Date.now(), "worker-1": Date.now() },
+      }) as const;
+
+    activeWorkflowRunIdsByWorkspaceId.set("parent", ["wfr_alpha"]);
+    const view = render(<ProjectSidebar {...renderProps(worker)} />);
+    const runNames = () =>
+      JSON.parse(view.getByTestId(agentItemTestId("parent")).dataset.runNames ?? "null") as Array<
+        string | null
+      > | null;
+    expect(runNames()).toEqual(["review-pipeline"]);
+
+    // Workers are deleted after reporting, so the inter-step render contains
+    // only the parent; the name must come from retained run-level state.
+    view.rerender(<ProjectSidebar {...renderProps()} />);
+    expect(runNames()).toEqual(["review-pipeline"]);
+
+    // Run completion prunes the retained name.
+    activeWorkflowRunIdsByWorkspaceId.set("parent", []);
+    view.rerender(<ProjectSidebar {...renderProps()} />);
+    activeWorkflowRunIdsByWorkspaceId.set("parent", ["wfr_alpha"]);
+    view.rerender(<ProjectSidebar {...renderProps()} />);
+    expect(runNames()).toEqual([null]);
   });
 
   test("keeps promoted active descendants in the visible ancestor connector group", () => {

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -350,7 +350,11 @@ function installProjectSidebarTestDoubles() {
           data-hidden-subagents={
             props.hiddenSubAgentsSummary
               ? JSON.stringify(props.hiddenSubAgentsSummary, (_key, value: unknown) =>
-                  value instanceof Set ? [...value] : value
+                  value instanceof Set
+                    ? [...value]
+                    : value instanceof Map
+                      ? Object.fromEntries(value as Map<string, string>)
+                      : value
                 )
               : undefined
           }
@@ -951,6 +955,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       runningWorkflowAgentCount: 0,
       queuedWorkflowAgentCount: 0,
       workflowRunIds: [],
+      workflowNamesByRunId: {},
     });
     // The delegated activity still reaches the parent row for its live dot.
     expect(parentRow.dataset.delegatedActive).toBe("1");
@@ -1021,6 +1026,8 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       queuedWorkflowAgentCount: 1,
       workflowRunIds: ["wfr_alpha"],
       workflowName: "review-pipeline",
+      workflowNamesByRunId: { wfr_alpha: "review-pipeline" },
+      runningWorkflowStepTitle: "Extract claims",
     });
   });
 

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -174,7 +174,6 @@ const EMPTY_HIDDEN_SUBAGENTS_SUMMARY: WorkspaceSubAgentsSummary = {
   runningWorkflowAgentCount: 0,
   queuedWorkflowAgentCount: 0,
   workflowRunIds: new Set<string>(),
-  workflowNamesByRunId: new Map<string, string>(),
 };
 
 // Re-export WorkspaceSelection for backwards compatibility
@@ -902,6 +901,12 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   // an active workflow keeps a stable sidebar header between sequential steps after its worker row
   // has been deleted; inactive child rows themselves remain absent.
   const retainedWorkflowTaskGroupsRef = useRef<Map<string, SidebarTaskGroupModel>>(new Map());
+  // Same transience problem for the hidden-sub-agents summary: retain each
+  // run's workflow name past its workers so runs between sequential steps stay
+  // labeled; entries are pruned once the owning workspace drops the run.
+  const workflowRunNamesRef = useRef<Map<string, { ownerWorkspaceId: string; name: string }>>(
+    new Map()
+  );
   const toggleTaskGroupExpansion = (storageKey: string, isCurrentlyExpanded: boolean) => {
     setExpandedTaskGroups((prev) => ({
       ...prev,
@@ -1668,6 +1673,24 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   const isWorkflowRunActive = (workspaceId: string, runId: string): boolean =>
     getActiveWorkflowRunIds(workspaceId).includes(runId);
   const allSidebarWorkspaces = Array.from(sortedWorkspacesByProject.values()).flat();
+  // Learn run names while a worker row still carries them (workers are deleted
+  // after reporting), then drop names whose run is no longer active.
+  for (const workspace of allSidebarWorkspaces) {
+    const workflowTask = workspace.workflowTask;
+    if (workflowTask?.workflowName != null && workspace.parentWorkspaceId != null) {
+      workflowRunNamesRef.current.set(workflowTask.runId, {
+        ownerWorkspaceId: workspace.parentWorkspaceId,
+        name: workflowTask.workflowName,
+      });
+    }
+  }
+  for (const [runId, entry] of workflowRunNamesRef.current) {
+    if (!isWorkflowRunActive(entry.ownerWorkspaceId, runId)) {
+      workflowRunNamesRef.current.delete(runId);
+    }
+  }
+  const getWorkflowRunName = (runId: string): string | undefined =>
+    workflowRunNamesRef.current.get(runId)?.name;
   const delegatedActivityByWorkspaceId = computeDelegatedActivityByWorkspaceId(
     allSidebarWorkspaces,
     { isWorkspaceLiveActive }
@@ -1676,6 +1699,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     ? computeSubAgentsSummaryByWorkspaceId(allSidebarWorkspaces, {
         isWorkspaceLiveActive,
         getActiveWorkflowRunIds,
+        getWorkflowRunName,
       })
     : null;
   // In hide mode every row gets at least the empty summary: rows without
@@ -2035,6 +2059,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                             isWorkspaceLiveActive={isWorkspaceLiveActive(metadata.id)}
                             delegatedActivity={delegatedActivityByWorkspaceId.get(metadata.id)}
                             hiddenSubAgentsSummary={getHiddenSubAgentsSummary(metadata.id)}
+                            getWorkflowRunName={getWorkflowRunName}
                             completedChildrenExpanded={expandedCompletedParentIds.has(metadata.id)}
                             onToggleCompletedChildren={toggleCompletedChildrenExpansion}
                           />
@@ -2117,6 +2142,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                               isWorkspaceLiveActive={isWorkspaceLiveActive(metadata.id)}
                               delegatedActivity={delegatedActivityByWorkspaceId.get(metadata.id)}
                               hiddenSubAgentsSummary={getHiddenSubAgentsSummary(metadata.id)}
+                              getWorkflowRunName={getWorkflowRunName}
                               completedChildrenExpanded={expandedCompletedParentIds.has(
                                 metadata.id
                               )}
@@ -2511,6 +2537,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
                                       metadata.id
                                     )}
                                     hiddenSubAgentsSummary={getHiddenSubAgentsSummary(metadata.id)}
+                                    getWorkflowRunName={getWorkflowRunName}
                                     completedChildrenExpanded={expandedCompletedParentIds.has(
                                       metadata.id
                                     )}

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -174,6 +174,7 @@ const EMPTY_HIDDEN_SUBAGENTS_SUMMARY: WorkspaceSubAgentsSummary = {
   runningWorkflowAgentCount: 0,
   queuedWorkflowAgentCount: 0,
   workflowRunIds: new Set<string>(),
+  workflowNamesByRunId: new Map<string, string>(),
 };
 
 // Re-export WorkspaceSelection for backwards compatibility

--- a/src/browser/utils/ui/workspaceFiltering.test.ts
+++ b/src/browser/utils/ui/workspaceFiltering.test.ts
@@ -981,7 +981,6 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(),
       workflowName: undefined,
-      workflowNamesByRunId: new Map(),
     });
   });
 
@@ -1021,7 +1020,6 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 1,
       workflowRunIds: new Set(["run-1", "run-2"]),
       workflowName: "Deep Research",
-      workflowNamesByRunId: new Map([["run-1", "Deep Research"]]),
       runningWorkflowStepTitle: "workspace-worker-a",
     });
   });
@@ -1047,7 +1045,6 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(["run-1"]),
       workflowName: undefined,
-      workflowNamesByRunId: new Map(),
       runningWorkflowStepTitle: "workspace-worker",
     });
   });
@@ -1074,28 +1071,22 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(),
       workflowName: undefined,
-      workflowNamesByRunId: new Map(),
     });
   });
 
-  it("remembers run names from finished workers for workerless active runs", () => {
+  it("labels a workerless active run through the retained-name lookup", () => {
     const workspaces = [
       createWorkspace("parent"),
       createWorkspace("owner-child", { parentWorkspaceId: "parent", taskStatus: "running" }),
-      createWorkspace("finished-worker", {
-        parentWorkspaceId: "parent",
-        taskStatus: "reported",
-        workflowTask: { runId: "run-gap", stepId: "step-1", workflowName: "Deep Research" },
-      }),
     ];
 
     const summary = computeSubAgentsSummaryByWorkspaceId(workspaces, {
       getActiveWorkflowRunIds: (workspaceId) => (workspaceId === "owner-child" ? ["run-gap"] : []),
+      getWorkflowRunName: (runId) => (runId === "run-gap" ? "Deep Research" : undefined),
     }).get("parent");
 
     expect(summary?.runningWorkflowRunCount).toBe(1);
     expect(summary?.workflowName).toBe("Deep Research");
-    expect(summary?.workflowNamesByRunId).toEqual(new Map([["run-gap", "Deep Research"]]));
   });
 
   it("counts a hidden owner's workerless active run as running", () => {

--- a/src/browser/utils/ui/workspaceFiltering.test.ts
+++ b/src/browser/utils/ui/workspaceFiltering.test.ts
@@ -981,6 +981,7 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(),
       workflowName: undefined,
+      workflowNamesByRunId: new Map(),
     });
   });
 
@@ -1020,6 +1021,8 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 1,
       workflowRunIds: new Set(["run-1", "run-2"]),
       workflowName: "Deep Research",
+      workflowNamesByRunId: new Map([["run-1", "Deep Research"]]),
+      runningWorkflowStepTitle: "workspace-worker-a",
     });
   });
 
@@ -1044,6 +1047,8 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(["run-1"]),
       workflowName: undefined,
+      workflowNamesByRunId: new Map(),
+      runningWorkflowStepTitle: "workspace-worker",
     });
   });
 
@@ -1069,7 +1074,28 @@ describe("hidden sub-agents summary roll-up", () => {
       queuedWorkflowAgentCount: 0,
       workflowRunIds: new Set(),
       workflowName: undefined,
+      workflowNamesByRunId: new Map(),
     });
+  });
+
+  it("remembers run names from finished workers for workerless active runs", () => {
+    const workspaces = [
+      createWorkspace("parent"),
+      createWorkspace("owner-child", { parentWorkspaceId: "parent", taskStatus: "running" }),
+      createWorkspace("finished-worker", {
+        parentWorkspaceId: "parent",
+        taskStatus: "reported",
+        workflowTask: { runId: "run-gap", stepId: "step-1", workflowName: "Deep Research" },
+      }),
+    ];
+
+    const summary = computeSubAgentsSummaryByWorkspaceId(workspaces, {
+      getActiveWorkflowRunIds: (workspaceId) => (workspaceId === "owner-child" ? ["run-gap"] : []),
+    }).get("parent");
+
+    expect(summary?.runningWorkflowRunCount).toBe(1);
+    expect(summary?.workflowName).toBe("Deep Research");
+    expect(summary?.workflowNamesByRunId).toEqual(new Map([["run-gap", "Deep Research"]]));
   });
 
   it("counts a hidden owner's workerless active run as running", () => {

--- a/src/browser/utils/ui/workspaceFiltering.ts
+++ b/src/browser/utils/ui/workspaceFiltering.ts
@@ -394,6 +394,14 @@ export interface WorkspaceSubAgentsSummary {
   workflowRunIds: ReadonlySet<string>;
   /** Name of the first running workflow run, or first queued run when none run. */
   workflowName?: string;
+  /**
+   * Workflow display names keyed by run ID, remembered from every
+   * workflow-owned descendant (active or not) so a run between steps with no
+   * live worker can still be labeled.
+   */
+  workflowNamesByRunId: ReadonlyMap<string, string>;
+  /** Title of the first running workflow worker, the run's current step. */
+  runningWorkflowStepTitle?: string;
 }
 
 interface SubAgentsSummaryOptions extends DelegatedActivityOptions {
@@ -432,6 +440,7 @@ export function computeSubAgentsSummaryByWorkspaceId(
   interface WorkflowRunRollup {
     hasRunning: boolean;
     name?: string;
+    runningStepTitle?: string;
   }
 
   interface MutableSummary {
@@ -441,6 +450,7 @@ export function computeSubAgentsSummaryByWorkspaceId(
     runningWorkflowAgentCount: number;
     queuedWorkflowAgentCount: number;
     workflowRunsById: Map<string, WorkflowRunRollup>;
+    workflowNamesByRunId: Map<string, string>;
   }
 
   const result = new Map<string, WorkspaceSubAgentsSummary>();
@@ -459,12 +469,14 @@ export function computeSubAgentsSummaryByWorkspaceId(
       runningWorkflowAgentCount: 0,
       queuedWorkflowAgentCount: 0,
       workflowRunsById: new Map(),
+      workflowNamesByRunId: new Map(),
     };
 
     const mergeWorkflowRun = (runId: string, rollup: WorkflowRunRollup): void => {
       const run = summary.workflowRunsById.get(runId) ?? { hasRunning: false };
       run.hasRunning ||= rollup.hasRunning;
       run.name ??= rollup.name;
+      run.runningStepTitle ??= rollup.runningStepTitle;
       summary.workflowRunsById.set(runId, run);
     };
 
@@ -474,6 +486,15 @@ export function computeSubAgentsSummaryByWorkspaceId(
       const childWorkflowRunId = child.workflowTask?.runId ?? ancestorWorkflowRunId;
       const isRunning = isWorkspaceDelegatedActivityActive(child, options);
       const isQueued = !isRunning && isWorkspaceDelegatedActivityQueued(child);
+
+      // Remember run names from inactive workers too, so a run whose workers
+      // all finished (between sequential steps) can still be labeled.
+      if (child.workflowTask?.workflowName != null) {
+        const namedRunId = child.workflowTask.runId;
+        if (!summary.workflowNamesByRunId.has(namedRunId)) {
+          summary.workflowNamesByRunId.set(namedRunId, child.workflowTask.workflowName);
+        }
+      }
 
       if (childWorkflowRunId == null) {
         summary.subAgentCount += 1;
@@ -491,6 +512,7 @@ export function computeSubAgentsSummaryByWorkspaceId(
         mergeWorkflowRun(childWorkflowRunId, {
           hasRunning: isRunning,
           name: child.workflowTask?.workflowName,
+          runningStepTitle: isRunning ? (child.title ?? child.name) : undefined,
         });
       }
 
@@ -502,6 +524,11 @@ export function computeSubAgentsSummaryByWorkspaceId(
       summary.queuedWorkflowAgentCount += childSummary.queuedWorkflowAgentCount;
       for (const [runId, rollup] of childSummary.workflowRunsById) {
         mergeWorkflowRun(runId, rollup);
+      }
+      for (const [runId, name] of childSummary.workflowNamesByRunId) {
+        if (!summary.workflowNamesByRunId.has(runId)) {
+          summary.workflowNamesByRunId.set(runId, name);
+        }
       }
 
       // A run the child owns that has no tracked worker (between sequential
@@ -520,13 +547,18 @@ export function computeSubAgentsSummaryByWorkspaceId(
       let queuedWorkflowRunCount = 0;
       let runningWorkflowName: string | undefined;
       let queuedWorkflowName: string | undefined;
-      for (const run of summary.workflowRunsById.values()) {
+      let runningWorkflowStepTitle: string | undefined;
+      for (const [runId, run] of summary.workflowRunsById) {
+        // A run tracked only through its owner (no live worker) has no rollup
+        // name; fall back to the name remembered from its finished workers.
+        const runName = run.name ?? summary.workflowNamesByRunId.get(runId);
         if (run.hasRunning) {
           runningWorkflowRunCount += 1;
-          runningWorkflowName ??= run.name;
+          runningWorkflowName ??= runName;
+          runningWorkflowStepTitle ??= run.runningStepTitle;
         } else {
           queuedWorkflowRunCount += 1;
-          queuedWorkflowName ??= run.name;
+          queuedWorkflowName ??= runName;
         }
       }
 
@@ -541,6 +573,8 @@ export function computeSubAgentsSummaryByWorkspaceId(
         workflowRunIds: new Set(summary.workflowRunsById.keys()),
         // A queued-only run must never lend its name to the running label.
         workflowName: runningWorkflowRunCount > 0 ? runningWorkflowName : queuedWorkflowName,
+        workflowNamesByRunId: new Map(summary.workflowNamesByRunId),
+        runningWorkflowStepTitle,
       });
     }
     return summary;

--- a/src/browser/utils/ui/workspaceFiltering.ts
+++ b/src/browser/utils/ui/workspaceFiltering.ts
@@ -394,11 +394,7 @@ export interface WorkspaceSubAgentsSummary {
   workflowRunIds: ReadonlySet<string>;
   /** Name of the first running workflow run, or first queued run when none run. */
   workflowName?: string;
-  /**
-   * Workflow display names keyed by run ID, remembered from every
-   * workflow-owned descendant (active or not) so a run between steps with no
-   * live worker can still be labeled.
-   */
+  /** Names retained after workers finish so active runs between steps remain labeled. */
   workflowNamesByRunId: ReadonlyMap<string, string>;
   /** Title of the first running workflow worker, the run's current step. */
   runningWorkflowStepTitle?: string;
@@ -549,8 +545,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
       let queuedWorkflowName: string | undefined;
       let runningWorkflowStepTitle: string | undefined;
       for (const [runId, run] of summary.workflowRunsById) {
-        // A run tracked only through its owner (no live worker) has no rollup
-        // name; fall back to the name remembered from its finished workers.
         const runName = run.name ?? summary.workflowNamesByRunId.get(runId);
         if (run.hasRunning) {
           runningWorkflowRunCount += 1;

--- a/src/browser/utils/ui/workspaceFiltering.ts
+++ b/src/browser/utils/ui/workspaceFiltering.ts
@@ -394,8 +394,6 @@ export interface WorkspaceSubAgentsSummary {
   workflowRunIds: ReadonlySet<string>;
   /** Name of the first running workflow run, or first queued run when none run. */
   workflowName?: string;
-  /** Names retained after workers finish so active runs between steps remain labeled. */
-  workflowNamesByRunId: ReadonlyMap<string, string>;
   /** Title of the first running workflow worker, the run's current step. */
   runningWorkflowStepTitle?: string;
 }
@@ -407,6 +405,12 @@ interface SubAgentsSummaryOptions extends DelegatedActivityOptions {
    * between sequential steps and has no countable workers.
    */
   getActiveWorkflowRunIds?: (workspaceId: string) => readonly string[];
+  /**
+   * Workflow name for a run, from state retained beyond worker lifetimes.
+   * Workers are deleted after reporting, so a run between sequential steps
+   * has no descendant carrying its name.
+   */
+  getWorkflowRunName?: (runId: string) => string | undefined;
 }
 
 /** Roll a hidden-descendant census up to each ancestor workspace. */
@@ -446,7 +450,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
     runningWorkflowAgentCount: number;
     queuedWorkflowAgentCount: number;
     workflowRunsById: Map<string, WorkflowRunRollup>;
-    workflowNamesByRunId: Map<string, string>;
   }
 
   const result = new Map<string, WorkspaceSubAgentsSummary>();
@@ -465,7 +468,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
       runningWorkflowAgentCount: 0,
       queuedWorkflowAgentCount: 0,
       workflowRunsById: new Map(),
-      workflowNamesByRunId: new Map(),
     };
 
     const mergeWorkflowRun = (runId: string, rollup: WorkflowRunRollup): void => {
@@ -482,15 +484,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
       const childWorkflowRunId = child.workflowTask?.runId ?? ancestorWorkflowRunId;
       const isRunning = isWorkspaceDelegatedActivityActive(child, options);
       const isQueued = !isRunning && isWorkspaceDelegatedActivityQueued(child);
-
-      // Remember run names from inactive workers too, so a run whose workers
-      // all finished (between sequential steps) can still be labeled.
-      if (child.workflowTask?.workflowName != null) {
-        const namedRunId = child.workflowTask.runId;
-        if (!summary.workflowNamesByRunId.has(namedRunId)) {
-          summary.workflowNamesByRunId.set(namedRunId, child.workflowTask.workflowName);
-        }
-      }
 
       if (childWorkflowRunId == null) {
         summary.subAgentCount += 1;
@@ -521,11 +514,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
       for (const [runId, rollup] of childSummary.workflowRunsById) {
         mergeWorkflowRun(runId, rollup);
       }
-      for (const [runId, name] of childSummary.workflowNamesByRunId) {
-        if (!summary.workflowNamesByRunId.has(runId)) {
-          summary.workflowNamesByRunId.set(runId, name);
-        }
-      }
 
       // A run the child owns that has no tracked worker (between sequential
       // steps) is still in progress and must count as running; runs already
@@ -545,7 +533,7 @@ export function computeSubAgentsSummaryByWorkspaceId(
       let queuedWorkflowName: string | undefined;
       let runningWorkflowStepTitle: string | undefined;
       for (const [runId, run] of summary.workflowRunsById) {
-        const runName = run.name ?? summary.workflowNamesByRunId.get(runId);
+        const runName = run.name ?? options.getWorkflowRunName?.(runId);
         if (run.hasRunning) {
           runningWorkflowRunCount += 1;
           runningWorkflowName ??= runName;
@@ -567,7 +555,6 @@ export function computeSubAgentsSummaryByWorkspaceId(
         workflowRunIds: new Set(summary.workflowRunsById.keys()),
         // A queued-only run must never lend its name to the running label.
         workflowName: runningWorkflowRunCount > 0 ? runningWorkflowName : queuedWorkflowName,
-        workflowNamesByRunId: new Map(summary.workflowNamesByRunId),
         runningWorkflowStepTitle,
       });
     }


### PR DESCRIPTION
## Summary

Makes the collapsed "hidden sub-agents" summary row in the projects sidebar more informative: workflow runs now show the workflow name and the currently running step, and sub-agent counts report only active agents instead of the total.

## Background

With "hide sub-agents in sidebar" enabled, the parent workspace row summarized delegated activity as e.g. `implement-flow running (1 agent)` and `3 sub-agents · 1 active`. The total sub-agent count includes finished workers, which is noise; and the workflow label omitted what the workflow is currently doing.

## Implementation

- `summarizeHiddenSubAgents` (workspaceFiltering.ts) now tracks per-run worker titles. ProjectSidebar retains `runId → workflowName` in a ref (mirroring `retainedWorkflowTaskGroupsRef`), since workflow workers are deleted after reporting; the lookup is threaded to the rollup and `AgentListItem`, so a run between sequential steps still shows its name (`implement-flow running`) instead of the generic `Workflow running`.
- `AgentListItem` renders a single-run/single-worker rollup as `implement-flow · Implementer` (workflow name + running worker's title, matching the step title in the Workflows tab), with queued workers appended as `· N queued`. Multi-run/multi-worker cases keep the count-style label since one step title would be ambiguous.
- Standalone sub-agent counts drop the total: `1 sub-agent active · 2 queued` instead of `3 sub-agents · 1 active · 2 queued`; queued-only shows `2 sub-agents queued`.

Frontend-only: everything is derived from workspace metadata already delivered to the sidebar. Workflow `phase()` labels are not surfaced (that would need new backend activity plumbing); the running worker's title is the step proxy.

## Risks

Low: display-only changes to the sidebar summary line. Behavior is covered by unit tests for the rollup logic and label rendering, including the worker-gap and queued-suffix cases.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->

