### PR TITLE
🤖 feat: collapse scheduler machinery noise in the timeline panel

### DIFF
--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -35,6 +35,7 @@ import {
   getTimelineEventKind,
   getTimelineEventTitle,
   getTimelinePresentation,
+  isMachineryKind,
   type TimelineCategory,
 } from "./timelinePresentation";
 
@@ -83,6 +84,15 @@ function isRuleKind(kind: string): boolean {
   return kind === TURN_END_KIND || BOUNDARY_KINDS.has(kind);
 }
 
+// Rules a machinery turn produces itself (its completion, auto-compaction cycles) would otherwise
+// split machinery stretches apart. Deliberate boundaries (context.reset, history.cleared) stay out
+// so they always break a group.
+const ABSORBED_RULE_KINDS = new Set([
+  TURN_END_KIND,
+  "compaction.triggered",
+  "compaction.completed",
+]);
+
 const FILTERS: Array<{ value: TimelineFilter; label: string }> = [
   { value: "all", label: "All" },
   ...TIMELINE_CATEGORIES.map((category) => ({
@@ -114,13 +124,73 @@ function groupEventsByDay(events: TimelineEvent[]): DayGroup[] {
   return Array.from(groups.values());
 }
 
-function collapseConsecutiveEvents(events: TimelineEvent[]): DayItem[] {
+// An interruption abandons the in-flight retry, so both rows tell the same story. Dropping the
+// retry row only when its interruption renders next to it keeps it visible under the Errors
+// filter, where the interruption row is filtered out.
+function isRedundantAbandonedRetry(event: TimelineEvent, next: TimelineEvent | undefined): boolean {
+  return (
+    getTimelineEventKind(event) === "retry.abandoned" &&
+    event.data?.reason === "aborted" &&
+    next != null &&
+    getTimelineEventKind(next) === "turn.interrupted"
+  );
+}
+
+function dominantMachineryKind(run: TimelineEvent[]): string {
+  const counts = new Map<string, number>();
+  let dominant = getTimelineEventKind(run[0]);
+  for (const event of run) {
+    const kind = getTimelineEventKind(event);
+    if (!isMachineryKind(kind)) continue;
+    const count = (counts.get(kind) ?? 0) + 1;
+    counts.set(kind, count);
+    if (count > (counts.get(dominant) ?? 0)) dominant = kind;
+  }
+  return dominant;
+}
+
+// Timeline pages render newest-first, but the scan reasons chronologically: a machinery turn's
+// completion rule lands after the event that dispatched it. Reverse in and back out instead of
+// teaching every rule the inverted direction.
+function collapseConsecutiveEvents(newestFirst: TimelineEvent[]): DayItem[] {
+  const chronological = newestFirst.toReversed();
+  const events = chronological.filter(
+    (event, index) => !isRedundantAbandonedRetry(event, chronological[index + 1])
+  );
   const items: DayItem[] = [];
   let index = 0;
 
   while (index < events.length) {
     const event = events[index];
     const kind = getTimelineEventKind(event);
+
+    if (isMachineryKind(kind)) {
+      const run: TimelineEvent[] = [event];
+      let machineryCount = 1;
+      let end = index + 1;
+      while (end < events.length) {
+        const nextKind = getTimelineEventKind(events[end]);
+        if (isMachineryKind(nextKind)) {
+          machineryCount++;
+        } else if (!ABSORBED_RULE_KINDS.has(nextKind)) {
+          break;
+        }
+        run.push(events[end]);
+        end++;
+      }
+      if (machineryCount >= 2) {
+        items.push({
+          key: `${event.id}:machinery`,
+          kind: dominantMachineryKind(run),
+          events: run.reverse(),
+        });
+      } else {
+        items.push(...run);
+      }
+      index = end;
+      continue;
+    }
+
     if (isRuleKind(kind)) {
       items.push(event);
       index++;
@@ -134,14 +204,14 @@ function collapseConsecutiveEvents(events: TimelineEvent[]): DayItem[] {
 
     const run = events.slice(index, end);
     if (run.length >= 3) {
-      items.push({ key: `${event.id}:${kind}`, kind, events: run });
+      items.push({ key: `${event.id}:${kind}`, kind, events: run.reverse() });
     } else {
       items.push(...run);
     }
     index = end;
   }
 
-  return items;
+  return items.reverse();
 }
 
 function isCollapsedRun(item: DayItem): item is CollapsedRun {
@@ -308,6 +378,11 @@ function CollapsedEventRun(props: {
 }) {
   const presentation = getTimelinePresentation(props.run.kind);
   const Icon = presentation.icon;
+  // Count only machinery events (absorbed rules are decoration) and use a neutral label when no
+  // single kind represents the group.
+  const counted = props.run.events.filter((event) => !isRuleKind(getTimelineEventKind(event)));
+  const mixed = new Set(counted.map((event) => getTimelineEventKind(event))).size > 1;
+  const label = mixed ? "automatic" : presentation.label;
 
   if (props.expanded) {
     return (
@@ -316,22 +391,31 @@ function CollapsedEventRun(props: {
           type="button"
           aria-expanded="true"
           data-timeline-collapsed-kind={props.run.kind}
-          data-timeline-collapsed-count={props.run.events.length}
+          data-timeline-collapsed-count={counted.length}
           onClick={() => props.onToggle(props.run.key)}
           className="text-muted hover:bg-hover focus-visible:ring-accent flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] focus-visible:ring-1 focus-visible:outline-none"
         >
           <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-          <span className="counter-nums shrink-0">{props.run.events.length}</span>
-          <span className="min-w-0 truncate">{presentation.label} events</span>
+          <span className="counter-nums shrink-0">{counted.length}</span>
+          <span className="min-w-0 truncate">{label} events</span>
         </button>
-        {props.run.events.map((event) => (
-          <TimelineEventRow
-            key={event.id}
-            event={event}
-            selected={props.selectedEventId === event.id}
-            onSelect={props.onSelect}
-          />
-        ))}
+        {props.run.events.map((event) =>
+          isRuleKind(getTimelineEventKind(event)) ? (
+            <TimelineRuleRow
+              key={event.id}
+              event={event}
+              selected={props.selectedEventId === event.id}
+              onSelect={props.onSelect}
+            />
+          ) : (
+            <TimelineEventRow
+              key={event.id}
+              event={event}
+              selected={props.selectedEventId === event.id}
+              onSelect={props.onSelect}
+            />
+          )
+        )}
       </div>
     );
   }
@@ -341,7 +425,7 @@ function CollapsedEventRun(props: {
       type="button"
       aria-expanded="false"
       data-timeline-collapsed-kind={props.run.kind}
-      data-timeline-collapsed-count={props.run.events.length}
+      data-timeline-collapsed-count={counted.length}
       onClick={() => props.onToggle(props.run.key)}
       className="border-border bg-surface-secondary/50 hover:bg-hover focus-visible:ring-accent grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2 py-2 text-left focus-visible:ring-1 focus-visible:outline-none"
     >
@@ -349,8 +433,7 @@ function CollapsedEventRun(props: {
         <Icon className="h-3.5 w-3.5" />
       </span>
       <span className="text-content-secondary min-w-0 truncate text-xs">
-        <span className="counter-nums font-medium">{props.run.events.length}</span>{" "}
-        {presentation.label} events
+        <span className="counter-nums font-medium">{counted.length}</span> {label} events
       </span>
       <ChevronRight className="text-muted h-3.5 w-3.5 shrink-0" />
     </button>

--- a/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
+++ b/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
@@ -97,6 +97,24 @@ const TIMELINE_PRESENTATION: Record<TimelineEventKind, TimelinePresentation> = {
   "agent.notified": { label: "Notification sent", icon: Bell, category: "agent" },
 };
 
+/**
+ * Scheduler machinery rather than narrative: wakes, dispatch churn, and heartbeats record how the
+ * loop kept moving, not what the work accomplished, so the panel collapses contiguous stretches
+ * into one expandable group instead of rendering each row.
+ */
+const MACHINERY_KINDS: ReadonlySet<string> = new Set<TimelineEventKind>([
+  "turn.monitor_wake",
+  "turn.background_wake",
+  "turn.synthetic",
+  "goal.continuation_dispatched",
+  "heartbeat.dispatched",
+  "heartbeat.skipped",
+]);
+
+export function isMachineryKind(kind: string): boolean {
+  return MACHINERY_KINDS.has(kind);
+}
+
 const knownKinds = new Set<string>(TIMELINE_EVENT_KINDS);
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -303,6 +303,94 @@ describe("TimelinePanel", () => {
     ).toBe("true");
   });
 
+  // Production timeline pages are newest-first, so these fixtures list descending seq.
+  test("collapses wake/turn-completed churn into one expandable group", () => {
+    const events = [
+      makeEvent("report", "task.reported", 5, { source: { system: "task" } }),
+      makeEvent("turn-2", "turn.completed", 4),
+      makeEvent("wake-2", "turn.monitor_wake", 3),
+      makeEvent("turn-1", "turn.completed", 2),
+      makeEvent("wake-1", "turn.monitor_wake", 1),
+    ];
+
+    const view = renderTimeline({ events });
+    const collapsedRun = view.container.querySelector<HTMLElement>(
+      '[data-timeline-collapsed-kind="turn.monitor_wake"][data-timeline-collapsed-count="2"]'
+    );
+
+    expect(collapsedRun).not.toBeNull();
+    expect(view.container.querySelectorAll('[role="separator"]')).toHaveLength(0);
+    expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
+
+    fireEvent.click(collapsedRun!);
+
+    expect(
+      view.container.querySelectorAll('[data-timeline-event-kind="turn.monitor_wake"]')
+    ).toHaveLength(2);
+    expect(view.container.querySelectorAll('[role="separator"]')).toHaveLength(2);
+  });
+
+  test("keeps a lone machinery event as a plain row with its turn rule", () => {
+    const events = [
+      makeEvent("report", "task.reported", 3, { source: { system: "task" } }),
+      makeEvent("turn", "turn.completed", 2),
+      makeEvent("wake", "turn.monitor_wake", 1),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector("[data-timeline-collapsed-kind]")).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="wake"]')).not.toBeNull();
+    expect(view.container.querySelectorAll('[role="separator"]')).toHaveLength(1);
+  });
+
+  test("groups adjacent machinery events across different kinds", () => {
+    const events = [
+      makeEvent("report", "task.reported", 3, { source: { system: "task" } }),
+      makeEvent("continuation", "goal.continuation_dispatched", 2, {
+        source: { system: "goal" },
+      }),
+      makeEvent("wake", "turn.monitor_wake", 1),
+    ];
+
+    const view = renderTimeline({ events });
+    const collapsedRun = view.container.querySelector<HTMLElement>(
+      '[data-timeline-collapsed-count="2"]'
+    );
+
+    expect(collapsedRun).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="wake"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="continuation"]')).toBeNull();
+
+    fireEvent.click(collapsedRun!);
+
+    expect(view.container.querySelector('[data-timeline-event-id="wake"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="continuation"]')).not.toBeNull();
+  });
+
+  test("drops the abandoned-retry row that duplicates an adjacent interruption", () => {
+    const events = [
+      makeEvent("retry-real", "retry.abandoned", 3, { data: { reason: "max retries" } }),
+      makeEvent("stop", "turn.interrupted", 2, { status: "interrupted" }),
+      makeEvent("retry", "retry.abandoned", 1, { data: { reason: "aborted" } }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="retry"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="stop"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="retry-real"]')).not.toBeNull();
+
+    // Under the Errors filter the interruption row is gone, so the retry row must come back.
+    const errorsFilter = Array.from(view.container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Errors"
+    );
+    if (!errorsFilter) throw new Error("Expected the errors filter control");
+    fireEvent.click(errorsFilter);
+
+    expect(view.container.querySelector('[data-timeline-event-id="retry"]')).not.toBeNull();
+  });
+
   test("stops reveal pagination at the page cap when the target remains unavailable", async () => {
     const loadOlderHistory = jest.fn<Promise<"loaded">, [string]>().mockResolvedValue("loaded");
     const event = makeEvent("anchored", "turn.completed", 1, {


### PR DESCRIPTION
## Summary

Collapses scheduler machinery in the Timeline tab so the timeline reads as a birds-eye narrative of the chat instead of watcher spam. Monitor wakes, background-work wakes, synthetic continue prompts, goal continuations, and heartbeat dispatches now group into a single expandable row per contiguous stretch, absorbing the `turn.completed` and compaction rules those turns produce.

## Background

Real timelines are dominated by loop machinery. Sampling recent workspaces: `turn.completed` is 34% of all events and `turn.monitor_wake` 16%; one chat rendered 155 individual "Monitor wake" rows (median 3.9 minutes apart) out of 618 visible items. The existing same-kind run collapse could not help because the dominant pattern is alternating `wake -> turn.completed -> wake`, and rule rows break same-kind runs.

## Implementation

Presentation-layer only; the recorder still persists every event, so existing timelines benefit retroactively and nothing is lost for debugging.

- `timelinePresentation.ts` gains `isMachineryKind` classifying the six machinery kinds.
- `collapseConsecutiveEvents` groups contiguous machinery stretches (2+) across kinds, absorbing completion/compaction rules produced by those turns. Deliberate boundaries (`context.reset`, `history.cleared`) still break groups. Timeline pages are newest-first, so the scan reverses to chronological order internally and back out.
- A `retry.abandoned(reason=aborted)` row adjacent to its `turn.interrupted` duplicates it and is dropped, except under the Errors filter where the interruption row is absent.
- Collapsed group rows count only machinery events and use a neutral "automatic" label for mixed-kind groups.

Measured on the noisiest sampled real timeline: 661 events, 618 visible items before, 304 after, with all 155 wake rows folded into expandable groups.

## Validation

Simulated the new algorithm against real persisted `timeline.jsonl` files from four recent workspaces to confirm the wake/turn churn actually folds (numbers above).

## Risks

Low: rendering-only change in the Timeline tab. The main behavioral risk is over-grouping (absorbing a rule a user cares about); expansion always reveals the full underlying rows, and deliberate context boundaries never collapse. Pixel snapshots for TimelinePanel stories change intentionally.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
