### PR TITLE
🤖 fix: route downloads through the iOS share sheet in home-screen web apps

### DIFF
--- a/src/browser/components/DebugLlmRequestModal/DebugLlmRequestModal.tsx
+++ b/src/browser/components/DebugLlmRequestModal/DebugLlmRequestModal.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/browser/components/Button/Button";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
 import { copyToClipboard } from "@/browser/utils/clipboard";
+import { downloadBlob } from "@/browser/utils/downloadFile";
 import { getErrorMessage } from "@/common/utils/errors";
 
 const JsonOutput: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -72,15 +73,7 @@ export const DebugLlmRequestModal: React.FC<DebugLlmRequestModalProps> = ({
     if (!snapshot) return;
     const timestamp = new Date(snapshot.capturedAt).toISOString().replace(/[:.]/g, "-");
     const fileName = `mux-llm-request-${workspaceId}-${timestamp}.json`;
-    const blob = new Blob([json], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = fileName;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(url);
+    downloadBlob(new Blob([json], { type: "application/json" }), fileName);
   };
 
   return (

--- a/src/browser/components/DebugLlmRequestModal/DebugLlmRequestModal.tsx
+++ b/src/browser/components/DebugLlmRequestModal/DebugLlmRequestModal.tsx
@@ -73,7 +73,7 @@ export const DebugLlmRequestModal: React.FC<DebugLlmRequestModalProps> = ({
     if (!snapshot) return;
     const timestamp = new Date(snapshot.capturedAt).toISOString().replace(/[:.]/g, "-");
     const fileName = `mux-llm-request-${workspaceId}-${timestamp}.json`;
-    downloadBlob(new Blob([json], { type: "application/json" }), fileName);
+    void downloadBlob(new Blob([json], { type: "application/json" }), fileName);
   };
 
   return (

--- a/src/browser/components/ImageLightbox.tsx
+++ b/src/browser/components/ImageLightbox.tsx
@@ -96,11 +96,18 @@ export function ImageLightbox(props: ImageLightboxProps) {
                   {copied ? "Copied" : "Copy"}
                   <ShortcutHint keybind={KEYBINDS.IMAGE_COPY} />
                 </button>
-                <a href={src} download={downloadFilename} className={ACTION_BUTTON_CLASS}>
+                {/* Button, not <a download>: iOS home-screen web apps silently
+                    drop anchor downloads; downloadDataUrl routes them to the
+                    native share sheet instead. */}
+                <button
+                  type="button"
+                  onClick={() => downloadDataUrl(src, downloadFilename)}
+                  className={ACTION_BUTTON_CLASS}
+                >
                   <Download className="h-3 w-3" />
                   Download
                   <ShortcutHint keybind={KEYBINDS.IMAGE_DOWNLOAD} />
-                </a>
+                </button>
               </div>
             </div>
           </>

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -107,30 +107,45 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const workspaceContext = useOptionalWorkspaceContext();
   const workspaceId = workspaceContext?.selectedWorkspace?.workspaceId ?? null;
 
+  // Tracks the workspace this message currently renders for (null once
+  // unmounted), so an in-flight download fetch can detect that the user
+  // navigated away and must not fire a share sheet for the old workspace.
+  const activeWorkspaceIdRef = React.useRef<string | null>(workspaceId);
+  React.useEffect(() => {
+    activeWorkspaceIdRef.current = workspaceId;
+    return () => {
+      activeWorkspaceIdRef.current = null;
+    };
+  }, [workspaceId]);
+
   // Forked workspaces copy staged attachments under the same relative path,
   // so the cache key needs the workspaceId to avoid serving another
   // workspace's bytes after navigation.
   const handleDownloadStagedAttachment = (attachment: DisplayStagedAttachment) =>
-    stagedDownloads.download(`${workspaceId ?? ""}:${attachment.stagedPath}`, async () => {
-      if (api == null || workspaceId == null) {
-        console.warn("Cannot download staged attachment without an active workspace connection.");
-        return null;
-      }
+    stagedDownloads.download(
+      `${workspaceId ?? ""}:${attachment.stagedPath}`,
+      async () => {
+        if (api == null || workspaceId == null) {
+          console.warn("Cannot download staged attachment without an active workspace connection.");
+          return null;
+        }
 
-      const result = await api.workspace.downloadStagedAttachment({
-        workspaceId,
-        stagedPath: attachment.stagedPath,
-      });
-      if (!result.success) {
-        console.error("Failed to download staged attachment:", result.error);
-        return null;
-      }
+        const result = await api.workspace.downloadStagedAttachment({
+          workspaceId,
+          stagedPath: attachment.stagedPath,
+        });
+        if (!result.success) {
+          console.error("Failed to download staged attachment:", result.error);
+          return null;
+        }
 
-      return {
-        blob: base64ToBlob(result.data.dataBase64, result.data.mediaType),
-        filename: result.data.filename || attachment.filename,
-      };
-    });
+        return {
+          blob: base64ToBlob(result.data.dataBase64, result.data.mediaType),
+          filename: result.data.filename || attachment.filename,
+        };
+      },
+      () => activeWorkspaceIdRef.current === workspaceId
+    );
 
   console.assert(
     typeof clipboardWriteText === "function",

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -107,8 +107,11 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const workspaceContext = useOptionalWorkspaceContext();
   const workspaceId = workspaceContext?.selectedWorkspace?.workspaceId ?? null;
 
+  // Forked workspaces copy staged attachments under the same relative path,
+  // so the cache key needs the workspaceId to avoid serving another
+  // workspace's bytes after navigation.
   const handleDownloadStagedAttachment = (attachment: DisplayStagedAttachment) =>
-    stagedDownloads.download(attachment.stagedPath, async () => {
+    stagedDownloads.download(`${workspaceId ?? ""}:${attachment.stagedPath}`, async () => {
       if (api == null || workspaceId == null) {
         console.warn("Cannot download staged attachment without an active workspace connection.");
         return null;

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -67,6 +67,11 @@ interface UserMessageProps {
   navigation?: UserMessageNavigation;
 }
 
+// Module-level so all messages share one retry slot, bounding retained
+// staged-attachment bytes to a single blob renderer-wide (iOS share-sheet
+// retries only ever target the most recent tap).
+const stagedDownloads = createDownloadRetryCache();
+
 export const UserMessage: React.FC<UserMessageProps> = ({
   message,
   className,
@@ -101,11 +106,6 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const api = apiState?.api ?? null;
   const workspaceContext = useOptionalWorkspaceContext();
   const workspaceId = workspaceContext?.selectedWorkspace?.workspaceId ?? null;
-
-  // Retry cache: if the backend fetch outlives iOS's transient-activation
-  // window, the share sheet is blocked; the cached bytes let the user's retry
-  // tap share synchronously within its own gesture.
-  const [stagedDownloads] = React.useState(createDownloadRetryCache);
 
   const handleDownloadStagedAttachment = (attachment: DisplayStagedAttachment) =>
     stagedDownloads.download(attachment.stagedPath, async () => {

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -20,7 +20,7 @@ import { TerminalOutput } from "./TerminalOutput";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
 import { copyToClipboard } from "@/browser/utils/clipboard";
-import { downloadBlob } from "@/browser/utils/downloadFile";
+import { createDownloadRetryCache } from "@/browser/utils/downloadFile";
 import {
   buildEditingStateFromDisplayed,
   canEditDisplayedUserMessage,
@@ -102,26 +102,32 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const workspaceContext = useOptionalWorkspaceContext();
   const workspaceId = workspaceContext?.selectedWorkspace?.workspaceId ?? null;
 
-  const handleDownloadStagedAttachment = async (attachment: DisplayStagedAttachment) => {
-    if (api == null || workspaceId == null) {
-      console.warn("Cannot download staged attachment without an active workspace connection.");
-      return;
-    }
+  // Retry cache: if the backend fetch outlives iOS's transient-activation
+  // window, the share sheet is blocked; the cached bytes let the user's retry
+  // tap share synchronously within its own gesture.
+  const [stagedDownloads] = React.useState(createDownloadRetryCache);
 
-    const result = await api.workspace.downloadStagedAttachment({
-      workspaceId,
-      stagedPath: attachment.stagedPath,
+  const handleDownloadStagedAttachment = (attachment: DisplayStagedAttachment) =>
+    stagedDownloads.download(attachment.stagedPath, async () => {
+      if (api == null || workspaceId == null) {
+        console.warn("Cannot download staged attachment without an active workspace connection.");
+        return null;
+      }
+
+      const result = await api.workspace.downloadStagedAttachment({
+        workspaceId,
+        stagedPath: attachment.stagedPath,
+      });
+      if (!result.success) {
+        console.error("Failed to download staged attachment:", result.error);
+        return null;
+      }
+
+      return {
+        blob: base64ToBlob(result.data.dataBase64, result.data.mediaType),
+        filename: result.data.filename || attachment.filename,
+      };
     });
-    if (!result.success) {
-      console.error("Failed to download staged attachment:", result.error);
-      return;
-    }
-
-    downloadBlob(
-      base64ToBlob(result.data.dataBase64, result.data.mediaType),
-      result.data.filename || attachment.filename
-    );
-  };
 
   console.assert(
     typeof clipboardWriteText === "function",

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -20,6 +20,7 @@ import { TerminalOutput } from "./TerminalOutput";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
 import { copyToClipboard } from "@/browser/utils/clipboard";
+import { downloadBlob } from "@/browser/utils/downloadFile";
 import {
   buildEditingStateFromDisplayed,
   canEditDisplayedUserMessage,
@@ -44,17 +45,6 @@ function base64ToBlob(dataBase64: string, mediaType: string): Blob {
     bytes[i] = binary.charCodeAt(i);
   }
   return new Blob([bytes], { type: mediaType });
-}
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const blobUrl = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = blobUrl;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
 }
 
 /** Navigation info for navigating between user messages */

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -14,6 +14,7 @@ import {
   HoverCardTrigger,
 } from "@/browser/components/HoverCard/HoverCard";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import { downloadBlob } from "@/browser/utils/downloadFile";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 import { AgentSkillBadge } from "./AgentSkillBadge";
 import { buildAgentSkillSnapshotMarkdown } from "./agentSkillSnapshotMarkdown";
@@ -242,24 +243,19 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
 
                   event.preventDefault();
 
-                  const blobUrl = URL.createObjectURL(blob);
-
                   if (isDesktopMode()) {
                     // In desktop mode, new windows are routed via shell.openExternal.
                     // blob: URLs are tied to this renderer and won't resolve externally,
                     // so download the file in-app instead.
-                    const link = document.createElement("a");
-                    link.href = blobUrl;
-                    link.download =
+                    downloadBlob(
+                      blob,
                       part.filename ??
-                      (baseMediaType === "application/pdf" ? "attachment.pdf" : "attachment");
-                    document.body.appendChild(link);
-                    link.click();
-                    link.remove();
-                    setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+                        (baseMediaType === "application/pdf" ? "attachment.pdf" : "attachment")
+                    );
                     return;
                   }
 
+                  const blobUrl = URL.createObjectURL(blob);
                   window.open(blobUrl, "_blank", "noopener,noreferrer");
 
                   // Keep the blob URL alive long enough for the new tab to load.

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -247,7 +247,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
                     // In desktop mode, new windows are routed via shell.openExternal.
                     // blob: URLs are tied to this renderer and won't resolve externally,
                     // so download the file in-app instead.
-                    downloadBlob(
+                    void downloadBlob(
                       blob,
                       part.filename ??
                         (baseMediaType === "application/pdf" ? "attachment.pdf" : "attachment")

--- a/src/browser/features/Tools/AttachFileToolCall.test.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.test.tsx
@@ -46,7 +46,7 @@ describe("AttachFileToolCall", () => {
     URL.revokeObjectURL = originalRevokeObjectURL;
   });
 
-  test("renders display-only markdown files with preview and download", async () => {
+  test("renders display-only markdown files with preview and download", () => {
     const markdown = "# Release Notes\n\n- Added **markdown** preview.\n";
     const data = Buffer.from(markdown).toString("base64");
 
@@ -79,9 +79,10 @@ describe("AttachFileToolCall", () => {
     fireEvent.click(view.getByRole("button", { name: /Download/ }));
     expect(clickedAnchors).toHaveLength(1);
     expect(clickedAnchors[0].getAttribute("download")).toBe("release-notes.md");
-    expect(downloadedBlobs).toHaveLength(1);
-    expect(downloadedBlobs[0].type).toBe("text/markdown");
-    expect(await downloadedBlobs[0].text()).toBe(markdown);
+    // Outside iOS standalone mode the anchor uses the data URL directly, so
+    // no Blob/object URL is created.
+    expect(downloadedBlobs).toHaveLength(0);
+    expect(clickedAnchors[0].getAttribute("href")).toBe(`data:text/markdown;base64,${data}`);
   });
 
   test("renders image attachments with a filename caption", () => {
@@ -137,7 +138,7 @@ describe("AttachFileToolCall", () => {
     fireEvent.click(view.getByRole("button", { name: /Download/ }));
     expect(clickedAnchors).toHaveLength(1);
     expect(clickedAnchors[0].getAttribute("download")).toBe("report.pdf");
-    expect(downloadedBlobs).toHaveLength(1);
-    expect(downloadedBlobs[0].type).toBe("application/pdf");
+    expect(downloadedBlobs).toHaveLength(0);
+    expect(clickedAnchors[0].getAttribute("href")).toBe(`data:application/pdf;base64,${data}`);
   });
 });

--- a/src/browser/features/Tools/AttachFileToolCall.test.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { createDisplayOnlyFilePart } from "@/common/utils/attachments/displayOnlyFileParts";
@@ -8,22 +8,45 @@ import { AttachFileToolCall } from "./AttachFileToolCall";
 describe("AttachFileToolCall", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+  let downloadedBlobs: Blob[];
+  let clickedAnchors: HTMLAnchorElement[];
 
   beforeEach(() => {
     originalWindow = globalThis.window;
     originalDocument = globalThis.document;
+    originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
 
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
+
+    // Capture blob downloads (object URL + anchor click) without navigating.
+    downloadedBlobs = [];
+    clickedAnchors = [];
+    URL.createObjectURL = (blob: Blob | MediaSource) => {
+      downloadedBlobs.push(blob as Blob);
+      return "blob:mock";
+    };
+    URL.revokeObjectURL = () => undefined;
+    const anchorPrototype = (
+      globalThis.window as unknown as { HTMLAnchorElement: { prototype: HTMLAnchorElement } }
+    ).HTMLAnchorElement.prototype;
+    anchorPrototype.click = function (this: HTMLAnchorElement) {
+      clickedAnchors.push(this);
+    };
   });
 
   afterEach(() => {
     cleanup();
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
   });
 
-  test("renders display-only markdown files with preview and download", () => {
+  test("renders display-only markdown files with preview and download", async () => {
     const markdown = "# Release Notes\n\n- Added **markdown** preview.\n";
     const data = Buffer.from(markdown).toString("base64");
 
@@ -53,9 +76,12 @@ describe("AttachFileToolCall", () => {
     expect(view.getByText(/Added/)).toBeTruthy();
     expect(view.getByText(/Shown to the user only/)).toBeTruthy();
 
-    const download = view.getByRole("link", { name: /Download/ });
-    expect(download.getAttribute("download")).toBe("release-notes.md");
-    expect(download.getAttribute("href")).toBe(`data:text/markdown;base64,${data}`);
+    fireEvent.click(view.getByRole("button", { name: /Download/ }));
+    expect(clickedAnchors).toHaveLength(1);
+    expect(clickedAnchors[0].getAttribute("download")).toBe("release-notes.md");
+    expect(downloadedBlobs).toHaveLength(1);
+    expect(downloadedBlobs[0].type).toBe("text/markdown");
+    expect(await downloadedBlobs[0].text()).toBe(markdown);
   });
 
   test("renders image attachments with a filename caption", () => {
@@ -108,8 +134,10 @@ describe("AttachFileToolCall", () => {
     expect(view.queryByRole("img")).toBeNull();
     // ...but the attachment is surfaced as a download card instead of being invisible.
     expect(view.getByText("report.pdf")).toBeTruthy();
-    const download = view.getByRole("link", { name: /Download/ });
-    expect(download.getAttribute("download")).toBe("report.pdf");
-    expect(download.getAttribute("href")).toBe(`data:application/pdf;base64,${data}`);
+    fireEvent.click(view.getByRole("button", { name: /Download/ }));
+    expect(clickedAnchors).toHaveLength(1);
+    expect(clickedAnchors[0].getAttribute("download")).toBe("report.pdf");
+    expect(downloadedBlobs).toHaveLength(1);
+    expect(downloadedBlobs[0].type).toBe("application/pdf");
   });
 });

--- a/src/browser/features/Tools/AttachFileToolCall.tsx
+++ b/src/browser/features/Tools/AttachFileToolCall.tsx
@@ -6,6 +6,7 @@ import {
   normalizeAttachmentMediaType,
 } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import { formatBytes } from "@/common/utils/formatBytes";
+import { downloadDataUrl } from "@/browser/utils/imageActions";
 import { isToolContentResult } from "@/common/utils/tools/toolContentResult";
 import {
   getDisplayOnlyFileMetadata,
@@ -83,6 +84,21 @@ function decodeBase64Utf8(data: string): string | null {
   }
 }
 
+/**
+ * Button, not <a download>: iOS home-screen web apps silently drop anchor
+ * downloads; downloadDataUrl routes them to the native share sheet instead.
+ */
+const AttachmentDownloadButton: React.FC<{ dataUrl: string; filename?: string }> = (props) => (
+  <button
+    type="button"
+    onClick={() => downloadDataUrl(props.dataUrl, props.filename ?? "attachment")}
+    className="border-border-light hover:bg-surface flex items-center gap-1 rounded border px-2 py-1 text-[var(--color-text)]"
+  >
+    <Download className="h-3 w-3" />
+    Download
+  </button>
+);
+
 function createMarkdownPreview(markdown: string): { content: string; truncated: boolean } {
   if (markdown.length <= MARKDOWN_PREVIEW_CHAR_LIMIT) {
     return { content: markdown, truncated: false };
@@ -136,14 +152,7 @@ const DisplayOnlyFile: React.FC<{ file: DisplayOnlyFilePart }> = (props) => {
         <span>Shown to the user only; not sent to the model as a file attachment.</span>
         {dataUrl == null && <span>File data is unavailable for preview or download.</span>}
         {dataUrl != null && (
-          <a
-            href={dataUrl}
-            download={props.file.filename ?? "attachment"}
-            className="border-border-light hover:bg-surface flex items-center gap-1 rounded border px-2 py-1 text-[var(--color-text)]"
-          >
-            <Download className="h-3 w-3" />
-            Download
-          </a>
+          <AttachmentDownloadButton dataUrl={dataUrl} filename={props.file.filename} />
         )}
       </div>
     </div>
@@ -174,14 +183,7 @@ const MediaAttachmentDownloadCard: React.FC<{ media: MediaContent }> = (props) =
         <span>Attached for the model; inline preview is not available for this file type.</span>
         {dataUrl == null && <span>File data is unavailable for download.</span>}
         {dataUrl != null && (
-          <a
-            href={dataUrl}
-            download={props.media.filename ?? "attachment"}
-            className="border-border-light hover:bg-surface flex items-center gap-1 rounded border px-2 py-1 text-[var(--color-text)]"
-          >
-            <Download className="h-3 w-3" />
-            Download
-          </a>
+          <AttachmentDownloadButton dataUrl={dataUrl} filename={props.media.filename} />
         )}
       </div>
     </div>

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
-import { downloadBlob } from "./downloadFile";
+import { createDownloadRetryCache, downloadBlob } from "./downloadFile";
 
 interface AnchorStub {
   href: string;
@@ -8,55 +8,55 @@ interface AnchorStub {
   remove: ReturnType<typeof mock>;
 }
 
+let originalNavigator: typeof globalThis.navigator;
+let originalDocument: typeof globalThis.document;
+let originalCreateObjectURL: typeof URL.createObjectURL;
+let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+let anchor: AnchorStub;
+let createElement: ReturnType<typeof mock>;
+
+function installNavigator(nav: {
+  standalone?: boolean;
+  canShare?: (data: { files: File[] }) => boolean;
+  share?: (data: { files: File[] }) => Promise<void>;
+}) {
+  globalThis.navigator = nav as unknown as Navigator;
+}
+
+beforeEach(() => {
+  originalNavigator = globalThis.navigator;
+  originalDocument = globalThis.document;
+  originalCreateObjectURL = URL.createObjectURL.bind(URL);
+  originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+
+  anchor = {
+    href: "",
+    download: "",
+    click: mock(() => undefined),
+    remove: mock(() => undefined),
+  };
+  createElement = mock(() => anchor);
+  globalThis.document = {
+    createElement,
+    body: { appendChild: mock(() => undefined) },
+  } as unknown as Document;
+  URL.createObjectURL = mock(() => "blob:test");
+  URL.revokeObjectURL = mock(() => undefined);
+});
+
+afterEach(() => {
+  globalThis.navigator = originalNavigator;
+  globalThis.document = originalDocument;
+  URL.createObjectURL = originalCreateObjectURL;
+  URL.revokeObjectURL = originalRevokeObjectURL;
+});
+
 describe("downloadBlob", () => {
-  let originalNavigator: typeof globalThis.navigator;
-  let originalDocument: typeof globalThis.document;
-  let originalCreateObjectURL: typeof URL.createObjectURL;
-  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
-  let anchor: AnchorStub;
-  let createElement: ReturnType<typeof mock>;
-
-  function installNavigator(nav: {
-    standalone?: boolean;
-    canShare?: (data: { files: File[] }) => boolean;
-    share?: (data: { files: File[] }) => Promise<void>;
-  }) {
-    globalThis.navigator = nav as unknown as Navigator;
-  }
-
-  beforeEach(() => {
-    originalNavigator = globalThis.navigator;
-    originalDocument = globalThis.document;
-    originalCreateObjectURL = URL.createObjectURL.bind(URL);
-    originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
-
-    anchor = {
-      href: "",
-      download: "",
-      click: mock(() => undefined),
-      remove: mock(() => undefined),
-    };
-    createElement = mock(() => anchor);
-    globalThis.document = {
-      createElement,
-      body: { appendChild: mock(() => undefined) },
-    } as unknown as Document;
-    URL.createObjectURL = mock(() => "blob:test");
-    URL.revokeObjectURL = mock(() => undefined);
-  });
-
-  afterEach(() => {
-    globalThis.navigator = originalNavigator;
-    globalThis.document = originalDocument;
-    URL.createObjectURL = originalCreateObjectURL;
-    URL.revokeObjectURL = originalRevokeObjectURL;
-  });
-
-  it("routes through the share sheet in iOS home-screen web apps", () => {
+  it("routes through the share sheet in iOS home-screen web apps", async () => {
     const share = mock((_data: { files: File[] }) => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => true, share });
 
-    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
 
     expect(share).toHaveBeenCalledTimes(1);
     const [{ files }] = share.mock.calls[0];
@@ -66,11 +66,28 @@ describe("downloadBlob", () => {
     expect(createElement).not.toHaveBeenCalled();
   });
 
-  it("uses an anchor download outside iOS standalone mode even when share is available", () => {
+  it("treats a dismissed share sheet as delivered", async () => {
+    const share = mock(() => Promise.reject(new DOMException("dismissed", "AbortError")));
+    installNavigator({ standalone: true, canShare: () => true, share });
+
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
+    expect(createElement).not.toHaveBeenCalled();
+  });
+
+  it("reports a blocked share sheet without falling back to an anchor", async () => {
+    // WebKit rejects with NotAllowedError when transient activation expired.
+    const share = mock(() => Promise.reject(new DOMException("denied", "NotAllowedError")));
+    installNavigator({ standalone: true, canShare: () => true, share });
+
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(false);
+    expect(createElement).not.toHaveBeenCalled();
+  });
+
+  it("uses an anchor download outside iOS standalone mode even when share is available", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ canShare: () => true, share });
 
-    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
 
     expect(share).not.toHaveBeenCalled();
     expect(anchor.href).toBe("blob:test");
@@ -78,13 +95,68 @@ describe("downloadBlob", () => {
     expect(anchor.click).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to an anchor download when the environment cannot share the file", () => {
+  it("falls back to an anchor download when the environment cannot share the file", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });
 
-    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
 
     expect(share).not.toHaveBeenCalled();
     expect(anchor.click).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createDownloadRetryCache", () => {
+  const fetchedFile = () => ({ blob: new Blob(["x"], { type: "image/png" }), filename: "a.png" });
+
+  it("serves a retry from cache after a blocked share, then clears it once delivered", async () => {
+    let shareCalls = 0;
+    const share = mock(() => {
+      shareCalls += 1;
+      return shareCalls === 1
+        ? Promise.reject(new DOMException("denied", "NotAllowedError"))
+        : Promise.resolve();
+    });
+    installNavigator({ standalone: true, canShare: () => true, share });
+    const fetchFile = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    // First tap: fetch runs, share is blocked, bytes get cached.
+    await downloads.download("key", fetchFile);
+    expect(fetchFile).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledTimes(1);
+
+    // Retry tap: shares from cache without refetching.
+    await downloads.download("key", fetchFile);
+    expect(fetchFile).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledTimes(2);
+
+    // Delivered, so the cache entry is gone and a new tap refetches.
+    await downloads.download("key", fetchFile);
+    expect(fetchFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache when the share succeeds immediately", async () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => true, share });
+    const fetchFile = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    await downloads.download("key", fetchFile);
+    await downloads.download("key", fetchFile);
+
+    expect(fetchFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the download when the fetch fails", async () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => true, share });
+    const fetchFile = mock(() => Promise.resolve(null));
+    const downloads = createDownloadRetryCache();
+
+    await downloads.download("key", fetchFile);
+
+    expect(share).not.toHaveBeenCalled();
+    expect(createElement).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -16,6 +16,7 @@ let originalDocument: typeof globalThis.document;
 let originalWindow: typeof globalThis.window;
 let alertMock: ReturnType<typeof mock>;
 let originalCreateObjectURL: typeof URL.createObjectURL;
+let createObjectURLMock: ReturnType<typeof mock>;
 let originalRevokeObjectURL: typeof URL.revokeObjectURL;
 let anchor: AnchorStub;
 let createElement: ReturnType<typeof mock>;
@@ -49,7 +50,8 @@ beforeEach(() => {
     createElement,
     body: { appendChild: mock(() => undefined) },
   } as unknown as Document;
-  URL.createObjectURL = mock(() => "blob:test");
+  createObjectURLMock = mock(() => "blob:test");
+  URL.createObjectURL = createObjectURLMock;
   URL.revokeObjectURL = mock(() => undefined);
 });
 
@@ -160,7 +162,7 @@ describe("downloadDataUrl", () => {
     downloadDataUrl(PNG_DATA_URL, "shot.png");
 
     expect(share).not.toHaveBeenCalled();
-    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(createObjectURLMock).not.toHaveBeenCalled();
     expect(anchor.href).toBe(PNG_DATA_URL);
     expect(anchor.download).toBe("shot.png");
     expect(anchor.click).toHaveBeenCalledTimes(1);

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -253,9 +253,13 @@ describe("createDownloadRetryCache", () => {
     const pendingA = downloads.download("a", fetchA);
     await downloads.download("b", fetchB);
 
-    // A's fetch finally resolves and gets blocked, but must not steal B's slot.
+    const sharesBeforeA = share.mock.calls.length;
+
+    // A's fetch finally resolves, but the superseded call must not share,
+    // alert, or steal B's slot.
     resolveA(fetchedFile());
     await pendingA;
+    expect(share.mock.calls.length).toBe(sharesBeforeA);
 
     await downloads.download("b", fetchB);
     expect(fetchB).toHaveBeenCalledTimes(1);

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { createDownloadRetryCache, downloadBlob } from "./downloadFile";
+import { downloadDataUrl } from "./imageActions";
+
+const PNG_DATA_URL = `data:image/png;base64,${btoa("x")}`;
 
 interface AnchorStub {
   href: string;
@@ -95,14 +98,39 @@ describe("downloadBlob", () => {
     expect(anchor.click).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to an anchor download when the environment cannot share the file", async () => {
+  it("reports failure instead of an unusable anchor when iOS standalone cannot share the file", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(false);
 
     expect(share).not.toHaveBeenCalled();
+    expect(anchor.click).not.toHaveBeenCalled();
+  });
+});
+
+describe("downloadDataUrl", () => {
+  it("uses the data URL directly as anchor href outside iOS standalone, without decoding", () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ canShare: () => true, share });
+
+    downloadDataUrl(PNG_DATA_URL, "shot.png");
+
+    expect(share).not.toHaveBeenCalled();
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(anchor.href).toBe(PNG_DATA_URL);
+    expect(anchor.download).toBe("shot.png");
     expect(anchor.click).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes and shares in iOS standalone mode", () => {
+    const share = mock((_data: { files: File[] }) => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => true, share });
+
+    downloadDataUrl(PNG_DATA_URL, "shot.png");
+
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(anchor.click).not.toHaveBeenCalled();
   });
 });
 

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { downloadBlob } from "./downloadFile";
+
+interface AnchorStub {
+  href: string;
+  download: string;
+  click: ReturnType<typeof mock>;
+  remove: ReturnType<typeof mock>;
+}
+
+describe("downloadBlob", () => {
+  let originalNavigator: typeof globalThis.navigator;
+  let originalDocument: typeof globalThis.document;
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+  let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+  let anchor: AnchorStub;
+  let createElement: ReturnType<typeof mock>;
+
+  function installNavigator(nav: {
+    standalone?: boolean;
+    canShare?: (data: { files: File[] }) => boolean;
+    share?: (data: { files: File[] }) => Promise<void>;
+  }) {
+    globalThis.navigator = nav as unknown as Navigator;
+  }
+
+  beforeEach(() => {
+    originalNavigator = globalThis.navigator;
+    originalDocument = globalThis.document;
+    originalCreateObjectURL = URL.createObjectURL.bind(URL);
+    originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+
+    anchor = {
+      href: "",
+      download: "",
+      click: mock(() => undefined),
+      remove: mock(() => undefined),
+    };
+    createElement = mock(() => anchor);
+    globalThis.document = {
+      createElement,
+      body: { appendChild: mock(() => undefined) },
+    } as unknown as Document;
+    URL.createObjectURL = mock(() => "blob:test");
+    URL.revokeObjectURL = mock(() => undefined);
+  });
+
+  afterEach(() => {
+    globalThis.navigator = originalNavigator;
+    globalThis.document = originalDocument;
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it("routes through the share sheet in iOS home-screen web apps", () => {
+    const share = mock((_data: { files: File[] }) => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => true, share });
+
+    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+
+    expect(share).toHaveBeenCalledTimes(1);
+    const [{ files }] = share.mock.calls[0];
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("shot.png");
+    expect(files[0].type).toBe("image/png");
+    expect(createElement).not.toHaveBeenCalled();
+  });
+
+  it("uses an anchor download outside iOS standalone mode even when share is available", () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ canShare: () => true, share });
+
+    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+
+    expect(share).not.toHaveBeenCalled();
+    expect(anchor.href).toBe("blob:test");
+    expect(anchor.download).toBe("shot.png");
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to an anchor download when the environment cannot share the file", () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => false, share });
+
+    downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png");
+
+    expect(share).not.toHaveBeenCalled();
+    expect(anchor.click).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -265,6 +265,25 @@ describe("createDownloadRetryCache", () => {
     expect(fetchB).toHaveBeenCalledTimes(1);
   });
 
+  it("drops a resolved fetch without sharing when the caller's context is gone", async () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => true, share });
+    let resolveFetch: (file: FetchedFileForTest) => void = () => undefined;
+    const fetchFile = mock(
+      () => new Promise<FetchedFileForTest>((resolve) => (resolveFetch = resolve))
+    );
+    const downloads = createDownloadRetryCache();
+
+    let contextAlive = true;
+    const pending = downloads.download("key", fetchFile, () => contextAlive);
+    contextAlive = false;
+    resolveFetch(fetchedFile());
+    await pending;
+
+    expect(share).not.toHaveBeenCalled();
+    expect(alertMock).not.toHaveBeenCalled();
+  });
+
   it("does not cache unshareable files, since no retry can succeed", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -181,6 +181,7 @@ describe("downloadDataUrl", () => {
 
 describe("createDownloadRetryCache", () => {
   const fetchedFile = () => ({ blob: new Blob(["x"], { type: "image/png" }), filename: "a.png" });
+  type FetchedFileForTest = ReturnType<typeof fetchedFile>;
 
   it("serves a retry from cache after a blocked share, then clears it once delivered", async () => {
     let shareCalls = 0;
@@ -238,6 +239,26 @@ describe("createDownloadRetryCache", () => {
     // "b" was evicted by the second blocked "a", so it refetches too.
     await downloads.download("b", fetchB);
     expect(fetchB).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a slower earlier fetch that resolves after a later tap claimed the slot", async () => {
+    const share = mock(() => Promise.reject(new DOMException("denied", "NotAllowedError")));
+    installNavigator({ standalone: true, canShare: () => true, share });
+    let resolveA: (file: FetchedFileForTest) => void = () => undefined;
+    const fetchA = mock(() => new Promise<FetchedFileForTest>((resolve) => (resolveA = resolve)));
+    const fetchB = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    // Tap A (fetch hangs), then tap B (blocked, claims the slot).
+    const pendingA = downloads.download("a", fetchA);
+    await downloads.download("b", fetchB);
+
+    // A's fetch finally resolves and gets blocked, but must not steal B's slot.
+    resolveA(fetchedFile());
+    await pendingA;
+
+    await downloads.download("b", fetchB);
+    expect(fetchB).toHaveBeenCalledTimes(1);
   });
 
   it("does not cache unshareable files, since no retry can succeed", async () => {

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -221,6 +221,25 @@ describe("createDownloadRetryCache", () => {
     expect(fetchFile).toHaveBeenCalledTimes(2);
   });
 
+  it("evicts an abandoned blocked entry when a different download gets blocked", async () => {
+    const share = mock(() => Promise.reject(new DOMException("denied", "NotAllowedError")));
+    installNavigator({ standalone: true, canShare: () => true, share });
+    const fetchA = mock(() => Promise.resolve(fetchedFile()));
+    const fetchB = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    await downloads.download("a", fetchA);
+    await downloads.download("b", fetchB);
+
+    // "b" now owns the single retry slot, so retrying "a" refetches.
+    await downloads.download("a", fetchA);
+    expect(fetchA).toHaveBeenCalledTimes(2);
+
+    // "b" was evicted by the second blocked "a", so it refetches too.
+    await downloads.download("b", fetchB);
+    expect(fetchB).toHaveBeenCalledTimes(2);
+  });
+
   it("does not cache unshareable files, since no retry can succeed", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -284,6 +284,22 @@ describe("createDownloadRetryCache", () => {
     expect(alertMock).not.toHaveBeenCalled();
   });
 
+  it("delivers concurrent downloads independently outside iOS standalone", async () => {
+    installNavigator({});
+    let resolveA: (file: FetchedFileForTest) => void = () => undefined;
+    const fetchA = mock(() => new Promise<FetchedFileForTest>((resolve) => (resolveA = resolve)));
+    const fetchB = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    // Tap A (fetch hangs), then tap B; both must reach the anchor.
+    const pendingA = downloads.download("a", fetchA);
+    await downloads.download("b", fetchB);
+    resolveA(fetchedFile());
+    await pendingA;
+
+    expect(anchor.click).toHaveBeenCalledTimes(2);
+  });
+
   it("does not cache unshareable files, since no retry can succeed", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -24,6 +24,7 @@ function installNavigator(nav: {
   standalone?: boolean;
   canShare?: (data: { files: File[] }) => boolean;
   share?: (data: { files: File[] }) => Promise<void>;
+  userActivation?: { isActive: boolean };
 }) {
   globalThis.navigator = nav as unknown as Navigator;
 }
@@ -96,6 +97,31 @@ describe("downloadBlob", () => {
     expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe("blocked");
     expect(alertMock).toHaveBeenCalledTimes(1);
     expect(createElement).not.toHaveBeenCalled();
+  });
+
+  it("treats NotAllowedError with live user activation as a permanent denial", async () => {
+    const share = mock(() => Promise.reject(new DOMException("denied", "NotAllowedError")));
+    installNavigator({
+      standalone: true,
+      canShare: () => true,
+      share,
+      userActivation: { isActive: true },
+    });
+
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "unshareable"
+    );
+    expect(alertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats non-activation share rejections as permanent", async () => {
+    const share = mock(() => Promise.reject(new TypeError("invalid share data")));
+    installNavigator({ standalone: true, canShare: () => true, share });
+
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "unshareable"
+    );
+    expect(alertMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses an anchor download outside iOS standalone mode even when share is available", async () => {

--- a/src/browser/utils/downloadFile.test.ts
+++ b/src/browser/utils/downloadFile.test.ts
@@ -13,6 +13,8 @@ interface AnchorStub {
 
 let originalNavigator: typeof globalThis.navigator;
 let originalDocument: typeof globalThis.document;
+let originalWindow: typeof globalThis.window;
+let alertMock: ReturnType<typeof mock>;
 let originalCreateObjectURL: typeof URL.createObjectURL;
 let originalRevokeObjectURL: typeof URL.revokeObjectURL;
 let anchor: AnchorStub;
@@ -29,6 +31,9 @@ function installNavigator(nav: {
 beforeEach(() => {
   originalNavigator = globalThis.navigator;
   originalDocument = globalThis.document;
+  originalWindow = globalThis.window;
+  alertMock = mock(() => undefined);
+  globalThis.window = { alert: alertMock } as unknown as Window & typeof globalThis;
   originalCreateObjectURL = URL.createObjectURL.bind(URL);
   originalRevokeObjectURL = URL.revokeObjectURL.bind(URL);
 
@@ -50,6 +55,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.navigator = originalNavigator;
   globalThis.document = originalDocument;
+  globalThis.window = originalWindow;
   URL.createObjectURL = originalCreateObjectURL;
   URL.revokeObjectURL = originalRevokeObjectURL;
 });
@@ -59,7 +65,9 @@ describe("downloadBlob", () => {
     const share = mock((_data: { files: File[] }) => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => true, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "delivered"
+    );
 
     expect(share).toHaveBeenCalledTimes(1);
     const [{ files }] = share.mock.calls[0];
@@ -73,16 +81,20 @@ describe("downloadBlob", () => {
     const share = mock(() => Promise.reject(new DOMException("dismissed", "AbortError")));
     installNavigator({ standalone: true, canShare: () => true, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "delivered"
+    );
+    expect(alertMock).not.toHaveBeenCalled();
     expect(createElement).not.toHaveBeenCalled();
   });
 
-  it("reports a blocked share sheet without falling back to an anchor", async () => {
+  it("reports a blocked share sheet, alerting instead of falling back to an anchor", async () => {
     // WebKit rejects with NotAllowedError when transient activation expired.
     const share = mock(() => Promise.reject(new DOMException("denied", "NotAllowedError")));
     installNavigator({ standalone: true, canShare: () => true, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(false);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe("blocked");
+    expect(alertMock).toHaveBeenCalledTimes(1);
     expect(createElement).not.toHaveBeenCalled();
   });
 
@@ -90,7 +102,9 @@ describe("downloadBlob", () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ canShare: () => true, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(true);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "delivered"
+    );
 
     expect(share).not.toHaveBeenCalled();
     expect(anchor.href).toBe("blob:test");
@@ -98,13 +112,16 @@ describe("downloadBlob", () => {
     expect(anchor.click).toHaveBeenCalledTimes(1);
   });
 
-  it("reports failure instead of an unusable anchor when iOS standalone cannot share the file", async () => {
+  it("alerts and reports unshareable instead of an unusable anchor when iOS standalone cannot share the file", async () => {
     const share = mock(() => Promise.resolve());
     installNavigator({ standalone: true, canShare: () => false, share });
 
-    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(false);
+    expect(await downloadBlob(new Blob(["x"], { type: "image/png" }), "shot.png")).toBe(
+      "unshareable"
+    );
 
     expect(share).not.toHaveBeenCalled();
+    expect(alertMock).toHaveBeenCalledTimes(1);
     expect(anchor.click).not.toHaveBeenCalled();
   });
 });
@@ -174,6 +191,21 @@ describe("createDownloadRetryCache", () => {
     await downloads.download("key", fetchFile);
 
     expect(fetchFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache unshareable files, since no retry can succeed", async () => {
+    const share = mock(() => Promise.resolve());
+    installNavigator({ standalone: true, canShare: () => false, share });
+    const fetchFile = mock(() => Promise.resolve(fetchedFile()));
+    const downloads = createDownloadRetryCache();
+
+    await downloads.download("key", fetchFile);
+    await downloads.download("key", fetchFile);
+
+    // Each tap refetches: nothing was cached for the unshareable file.
+    expect(fetchFile).toHaveBeenCalledTimes(2);
+    expect(share).not.toHaveBeenCalled();
+    expect(alertMock).toHaveBeenCalledTimes(2);
   });
 
   it("skips the download when the fetch fails", async () => {

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -97,26 +97,29 @@ interface FetchedFile {
 /**
  * Download coordinator for flows that fetch a file's bytes asynchronously
  * after the user gesture. If the fetch outlives iOS's transient-activation
- * window, the share sheet is blocked; the fetched bytes are cached so the
+ * window, the share sheet is blocked; the fetched bytes are kept so the
  * user's retry tap shares synchronously within its own activation window
- * instead of repeating the fetch and failing again. Only "blocked" failures
- * are cached: unshareable files can never succeed, so retaining their bytes
- * would only grow renderer memory.
+ * instead of repeating the fetch and failing again.
+ *
+ * Holds a single retry slot: only the most recent "blocked" download is
+ * retained (a retry alert only ever refers to the last tap), so abandoned
+ * retries are evicted by the next blocked download and retained memory is
+ * bounded to one blob. Unshareable files can never succeed and are never
+ * cached.
  */
 export function createDownloadRetryCache() {
-  const cache = new Map<string, FetchedFile>();
+  let entry: { key: string; file: FetchedFile } | null = null;
   return {
     async download(key: string, fetchFile: () => Promise<FetchedFile | null>): Promise<void> {
-      const cached = cache.get(key);
-      if (cached) {
-        if ((await downloadBlob(cached.blob, cached.filename)) !== "blocked") {
-          cache.delete(key);
+      if (entry?.key === key) {
+        if ((await downloadBlob(entry.file.blob, entry.file.filename)) !== "blocked") {
+          entry = null;
         }
         return;
       }
       const fetched = await fetchFile();
       if (fetched && (await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {
-        cache.set(key, fetched);
+        entry = { key, file: fetched };
       }
     },
   };

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -111,7 +111,17 @@ export function createDownloadRetryCache() {
   let entry: { key: string; file: FetchedFile } | null = null;
   let latestCall = 0;
   return {
-    async download(key: string, fetchFile: () => Promise<FetchedFile | null>): Promise<void> {
+    /**
+     * stillWanted is re-checked after the fetch resolves; callers should
+     * return false once their originating context is gone (e.g. the user
+     * navigated to another workspace) so a slow fetch cannot fire a share
+     * sheet or alert about a context the user already left.
+     */
+    async download(
+      key: string,
+      fetchFile: () => Promise<FetchedFile | null>,
+      stillWanted?: () => boolean
+    ): Promise<void> {
       const call = ++latestCall;
       if (entry?.key === key) {
         if ((await downloadBlob(entry.file.blob, entry.file.filename)) !== "blocked") {
@@ -120,10 +130,10 @@ export function createDownloadRetryCache() {
         return;
       }
       const fetched = await fetchFile();
-      // A fetch superseded by a later tap must not open the share sheet (it
-      // could hijack the newer tap's activation or alert without owning the
-      // slot); drop it before any side effect.
-      if (!fetched || call !== latestCall) {
+      // A fetch superseded by a later tap or an abandoned context must not
+      // open the share sheet (it could hijack the newer tap's activation or
+      // alert without owning the slot); drop it before any side effect.
+      if (!fetched || call !== latestCall || stillWanted?.() === false) {
         return;
       }
       if ((await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -109,8 +109,10 @@ interface FetchedFile {
  */
 export function createDownloadRetryCache() {
   let entry: { key: string; file: FetchedFile } | null = null;
+  let latestCall = 0;
   return {
     async download(key: string, fetchFile: () => Promise<FetchedFile | null>): Promise<void> {
+      const call = ++latestCall;
       if (entry?.key === key) {
         if ((await downloadBlob(entry.file.blob, entry.file.filename)) !== "blocked") {
           entry = null;
@@ -119,7 +121,11 @@ export function createDownloadRetryCache() {
       }
       const fetched = await fetchFile();
       if (fetched && (await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {
-        entry = { key, file: fetched };
+        // A slower earlier fetch must not overwrite the slot after a later
+        // tap already claimed it; the retry alert refers to the last tap.
+        if (call === latestCall) {
+          entry = { key, file: fetched };
+        }
       }
     },
   };

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -10,7 +10,7 @@
  * launched from a Home Screen icon, so this never matches desktop PWAs or
  * Android, where anchor downloads work.
  */
-function isIosStandaloneWebApp(): boolean {
+export function isIosStandaloneWebApp(): boolean {
   return (navigator as Navigator & { standalone?: unknown }).standalone === true;
 }
 
@@ -18,39 +18,48 @@ function canShareFile(file: File): boolean {
   return typeof navigator.share === "function" && navigator.canShare?.({ files: [file] }) === true;
 }
 
+/** Trigger a plain anchor download. Unusable in iOS standalone mode. */
+export function downloadViaAnchor(href: string, filename: string): void {
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
 /**
  * Trigger a download of a blob, using the share sheet on iOS home-screen web
  * apps. Runs synchronously up to the share-sheet call, so invoking it inside
  * a click handler keeps the share within the gesture's transient activation.
  *
- * Resolves false only when the share sheet was blocked (WebKit rejects with
- * NotAllowedError once transient activation expires, e.g. after a slow
- * fetch); callers that fetch bytes asynchronously can cache them and retry
- * within a fresh user gesture (see createDownloadRetryCache).
+ * Resolves false when the file was not delivered: the share sheet was blocked
+ * (WebKit rejects with NotAllowedError once transient activation expires,
+ * e.g. after a slow fetch), or iOS standalone mode cannot share this file at
+ * all (anchor downloads silently abort there, so there is no fallback).
+ * Callers that fetch bytes asynchronously can cache them and retry within a
+ * fresh user gesture (see createDownloadRetryCache).
  */
 export async function downloadBlob(blob: Blob, filename: string): Promise<boolean> {
   if (isIosStandaloneWebApp()) {
     const file = new File([blob], filename, { type: blob.type });
-    if (canShareFile(file)) {
-      try {
-        await navigator.share({ files: [file] });
-      } catch (err) {
-        // AbortError means the user dismissed the share sheet.
-        if (err instanceof DOMException && err.name === "AbortError") return true;
-        console.error("Failed to share file:", err);
-        return false;
-      }
-      return true;
+    if (!canShareFile(file)) {
+      console.error(`iOS home-screen web app cannot share or download ${blob.type} files.`);
+      return false;
     }
+    try {
+      await navigator.share({ files: [file] });
+    } catch (err) {
+      // AbortError means the user dismissed the share sheet.
+      if (err instanceof DOMException && err.name === "AbortError") return true;
+      console.error("Failed to share file:", err);
+      return false;
+    }
+    return true;
   }
 
   const objectUrl = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = objectUrl;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
+  downloadViaAnchor(objectUrl, filename);
   // Delay revocation so the browser can start the download first.
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
   return true;

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -29,7 +29,7 @@ function isTransientActivationExpiry(err: unknown): boolean {
   if (!(err instanceof DOMException) || err.name !== "NotAllowedError") return false;
   const activation = (navigator as Navigator & { userActivation?: { isActive?: boolean } })
     .userActivation;
-  return activation == null || activation.isActive !== true;
+  return activation?.isActive !== true;
 }
 
 /** Trigger a plain anchor download. Unusable in iOS standalone mode. */

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -120,12 +120,14 @@ export function createDownloadRetryCache() {
         return;
       }
       const fetched = await fetchFile();
-      if (fetched && (await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {
-        // A slower earlier fetch must not overwrite the slot after a later
-        // tap already claimed it; the retry alert refers to the last tap.
-        if (call === latestCall) {
-          entry = { key, file: fetched };
-        }
+      // A fetch superseded by a later tap must not open the share sheet (it
+      // could hijack the newer tap's activation or alert without owning the
+      // slot); drop it before any side effect.
+      if (!fetched || call !== latestCall) {
+        return;
+      }
+      if ((await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {
+        entry = { key, file: fetched };
       }
     },
   };

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -1,11 +1,8 @@
 /**
- * Shared blob-download helper for surfaces that offer "Download" buttons
- * (image lightbox, attachment cards, debug snapshots).
- *
- * iOS home-screen web apps have no download manager: clicking an anchor with
- * a `download` attribute silently aborts (WebKit limitation), so we present
- * the native share sheet instead, where "Save Image" / "Save to Files" is
- * available.
+ * Shared blob-download helper. iOS home-screen web apps have no download
+ * manager: clicking an anchor with a `download` attribute silently aborts
+ * (WebKit limitation), so downloads are offered through the native share
+ * sheet ("Save Image" / "Save to Files") there.
  */
 
 /**
@@ -17,7 +14,6 @@ function isIosStandaloneWebApp(): boolean {
   return (navigator as Navigator & { standalone?: unknown }).standalone === true;
 }
 
-/** Returns false when this environment cannot share the file, so callers can fall back. */
 function shareFileViaShareSheet(file: File): boolean {
   if (typeof navigator.share !== "function" || navigator.canShare?.({ files: [file] }) !== true) {
     return false;

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -130,10 +130,15 @@ export function createDownloadRetryCache() {
         return;
       }
       const fetched = await fetchFile();
-      // A fetch superseded by a later tap or an abandoned context must not
-      // open the share sheet (it could hijack the newer tap's activation or
-      // alert without owning the slot); drop it before any side effect.
-      if (!fetched || call !== latestCall || stillWanted?.() === false) {
+      if (!fetched) {
+        return;
+      }
+      // Only the iOS share-sheet path is side-effect sensitive: a fetch
+      // superseded by a later tap or an abandoned context must not open the
+      // sheet (hijacking the newer tap's activation) or alert without owning
+      // the slot. Ordinary anchor downloads elsewhere are independent and
+      // must all be delivered, even concurrently.
+      if (isIosStandaloneWebApp() && (call !== latestCall || stillWanted?.() === false)) {
         return;
       }
       if ((await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared blob-download helper for surfaces that offer "Download" buttons
+ * (image lightbox, attachment cards, debug snapshots).
+ *
+ * iOS home-screen web apps have no download manager: clicking an anchor with
+ * a `download` attribute silently aborts (WebKit limitation), so we present
+ * the native share sheet instead, where "Save Image" / "Save to Files" is
+ * available.
+ */
+
+/**
+ * `navigator.standalone` exists only on iOS WebKit and is true only when
+ * launched from a Home Screen icon, so this never matches desktop PWAs or
+ * Android, where anchor downloads work.
+ */
+function isIosStandaloneWebApp(): boolean {
+  return (navigator as Navigator & { standalone?: unknown }).standalone === true;
+}
+
+/** Returns false when this environment cannot share the file, so callers can fall back. */
+function shareFileViaShareSheet(file: File): boolean {
+  if (typeof navigator.share !== "function" || navigator.canShare?.({ files: [file] }) !== true) {
+    return false;
+  }
+  navigator.share({ files: [file] }).catch((err: unknown) => {
+    // AbortError means the user dismissed the share sheet.
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    console.error("Failed to share file:", err);
+  });
+  return true;
+}
+
+/** Trigger a download of a blob, using the share sheet on iOS home-screen web apps. */
+export function downloadBlob(blob: Blob, filename: string): void {
+  if (
+    isIosStandaloneWebApp() &&
+    shareFileViaShareSheet(new File([blob], filename, { type: blob.type }))
+  ) {
+    return;
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  // Delay revocation so the browser can start the download first.
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+}

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -18,6 +18,20 @@ function canShareFile(file: File): boolean {
   return typeof navigator.share === "function" && navigator.canShare?.({ files: [file] }) === true;
 }
 
+/**
+ * WebKit rejects share() with NotAllowedError when the gesture's transient
+ * activation has expired (e.g. after a slow fetch); only that failure is
+ * retryable with a fresh tap. Where the UA exposes userActivation, a
+ * NotAllowedError with activation still live is a permanent denial (e.g.
+ * permissions policy), not an expiry.
+ */
+function isTransientActivationExpiry(err: unknown): boolean {
+  if (!(err instanceof DOMException) || err.name !== "NotAllowedError") return false;
+  const activation = (navigator as Navigator & { userActivation?: { isActive?: boolean } })
+    .userActivation;
+  return activation == null || activation.isActive !== true;
+}
+
 /** Trigger a plain anchor download. Unusable in iOS standalone mode. */
 export function downloadViaAnchor(href: string, filename: string): void {
   const anchor = document.createElement("a");
@@ -57,11 +71,13 @@ export async function downloadBlob(blob: Blob, filename: string): Promise<Downlo
     } catch (err) {
       // AbortError means the user dismissed the share sheet.
       if (err instanceof DOMException && err.name === "AbortError") return "delivered";
-      // Typically NotAllowedError: WebKit blocks share() once the gesture's
-      // transient activation expires (e.g. after a slow fetch).
       console.error("Failed to share file:", err);
-      window.alert("Saving was interrupted. Tap the download again to save.");
-      return "blocked";
+      if (isTransientActivationExpiry(err)) {
+        window.alert("Saving was interrupted. Tap the download again to save.");
+        return "blocked";
+      }
+      window.alert("This file can't be saved from this app.");
+      return "unshareable";
     }
     return "delivered";
   }

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -29,40 +29,48 @@ export function downloadViaAnchor(href: string, filename: string): void {
 }
 
 /**
+ * "blocked" is retryable within a fresh user gesture; "unshareable" is
+ * permanent for the file in the current environment.
+ */
+export type DownloadBlobResult = "delivered" | "blocked" | "unshareable";
+
+/**
  * Trigger a download of a blob, using the share sheet on iOS home-screen web
  * apps. Runs synchronously up to the share-sheet call, so invoking it inside
  * a click handler keeps the share within the gesture's transient activation.
  *
- * Resolves false when the file was not delivered: the share sheet was blocked
- * (WebKit rejects with NotAllowedError once transient activation expires,
- * e.g. after a slow fetch), or iOS standalone mode cannot share this file at
- * all (anchor downloads silently abort there, so there is no fallback).
- * Callers that fetch bytes asynchronously can cache them and retry within a
- * fresh user gesture (see createDownloadRetryCache).
+ * Both failure branches alert the user here, at the shared boundary, so
+ * fire-and-forget callers cannot silently drop a failed download; the result
+ * exists for callers that manage retries (see createDownloadRetryCache).
  */
-export async function downloadBlob(blob: Blob, filename: string): Promise<boolean> {
+export async function downloadBlob(blob: Blob, filename: string): Promise<DownloadBlobResult> {
   if (isIosStandaloneWebApp()) {
     const file = new File([blob], filename, { type: blob.type });
     if (!canShareFile(file)) {
-      console.error(`iOS home-screen web app cannot share or download ${blob.type} files.`);
-      return false;
+      // Anchor downloads silently abort in iOS standalone mode, so there is
+      // no usable fallback for unshareable files.
+      window.alert(`This file type (${blob.type || "unknown"}) can't be saved from this app.`);
+      return "unshareable";
     }
     try {
       await navigator.share({ files: [file] });
     } catch (err) {
       // AbortError means the user dismissed the share sheet.
-      if (err instanceof DOMException && err.name === "AbortError") return true;
+      if (err instanceof DOMException && err.name === "AbortError") return "delivered";
+      // Typically NotAllowedError: WebKit blocks share() once the gesture's
+      // transient activation expires (e.g. after a slow fetch).
       console.error("Failed to share file:", err);
-      return false;
+      window.alert("Saving was interrupted. Tap the download again to save.");
+      return "blocked";
     }
-    return true;
+    return "delivered";
   }
 
   const objectUrl = URL.createObjectURL(blob);
   downloadViaAnchor(objectUrl, filename);
   // Delay revocation so the browser can start the download first.
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
-  return true;
+  return "delivered";
 }
 
 interface FetchedFile {
@@ -75,7 +83,9 @@ interface FetchedFile {
  * after the user gesture. If the fetch outlives iOS's transient-activation
  * window, the share sheet is blocked; the fetched bytes are cached so the
  * user's retry tap shares synchronously within its own activation window
- * instead of repeating the fetch and failing again.
+ * instead of repeating the fetch and failing again. Only "blocked" failures
+ * are cached: unshareable files can never succeed, so retaining their bytes
+ * would only grow renderer memory.
  */
 export function createDownloadRetryCache() {
   const cache = new Map<string, FetchedFile>();
@@ -83,13 +93,13 @@ export function createDownloadRetryCache() {
     async download(key: string, fetchFile: () => Promise<FetchedFile | null>): Promise<void> {
       const cached = cache.get(key);
       if (cached) {
-        if (await downloadBlob(cached.blob, cached.filename)) {
+        if ((await downloadBlob(cached.blob, cached.filename)) !== "blocked") {
           cache.delete(key);
         }
         return;
       }
       const fetched = await fetchFile();
-      if (fetched && !(await downloadBlob(fetched.blob, fetched.filename))) {
+      if (fetched && (await downloadBlob(fetched.blob, fetched.filename)) === "blocked") {
         cache.set(key, fetched);
       }
     },

--- a/src/browser/utils/downloadFile.ts
+++ b/src/browser/utils/downloadFile.ts
@@ -14,25 +14,34 @@ function isIosStandaloneWebApp(): boolean {
   return (navigator as Navigator & { standalone?: unknown }).standalone === true;
 }
 
-function shareFileViaShareSheet(file: File): boolean {
-  if (typeof navigator.share !== "function" || navigator.canShare?.({ files: [file] }) !== true) {
-    return false;
-  }
-  navigator.share({ files: [file] }).catch((err: unknown) => {
-    // AbortError means the user dismissed the share sheet.
-    if (err instanceof DOMException && err.name === "AbortError") return;
-    console.error("Failed to share file:", err);
-  });
-  return true;
+function canShareFile(file: File): boolean {
+  return typeof navigator.share === "function" && navigator.canShare?.({ files: [file] }) === true;
 }
 
-/** Trigger a download of a blob, using the share sheet on iOS home-screen web apps. */
-export function downloadBlob(blob: Blob, filename: string): void {
-  if (
-    isIosStandaloneWebApp() &&
-    shareFileViaShareSheet(new File([blob], filename, { type: blob.type }))
-  ) {
-    return;
+/**
+ * Trigger a download of a blob, using the share sheet on iOS home-screen web
+ * apps. Runs synchronously up to the share-sheet call, so invoking it inside
+ * a click handler keeps the share within the gesture's transient activation.
+ *
+ * Resolves false only when the share sheet was blocked (WebKit rejects with
+ * NotAllowedError once transient activation expires, e.g. after a slow
+ * fetch); callers that fetch bytes asynchronously can cache them and retry
+ * within a fresh user gesture (see createDownloadRetryCache).
+ */
+export async function downloadBlob(blob: Blob, filename: string): Promise<boolean> {
+  if (isIosStandaloneWebApp()) {
+    const file = new File([blob], filename, { type: blob.type });
+    if (canShareFile(file)) {
+      try {
+        await navigator.share({ files: [file] });
+      } catch (err) {
+        // AbortError means the user dismissed the share sheet.
+        if (err instanceof DOMException && err.name === "AbortError") return true;
+        console.error("Failed to share file:", err);
+        return false;
+      }
+      return true;
+    }
   }
 
   const objectUrl = URL.createObjectURL(blob);
@@ -44,4 +53,36 @@ export function downloadBlob(blob: Blob, filename: string): void {
   anchor.remove();
   // Delay revocation so the browser can start the download first.
   setTimeout(() => URL.revokeObjectURL(objectUrl), 1000);
+  return true;
+}
+
+interface FetchedFile {
+  blob: Blob;
+  filename: string;
+}
+
+/**
+ * Download coordinator for flows that fetch a file's bytes asynchronously
+ * after the user gesture. If the fetch outlives iOS's transient-activation
+ * window, the share sheet is blocked; the fetched bytes are cached so the
+ * user's retry tap shares synchronously within its own activation window
+ * instead of repeating the fetch and failing again.
+ */
+export function createDownloadRetryCache() {
+  const cache = new Map<string, FetchedFile>();
+  return {
+    async download(key: string, fetchFile: () => Promise<FetchedFile | null>): Promise<void> {
+      const cached = cache.get(key);
+      if (cached) {
+        if (await downloadBlob(cached.blob, cached.filename)) {
+          cache.delete(key);
+        }
+        return;
+      }
+      const fetched = await fetchFile();
+      if (fetched && !(await downloadBlob(fetched.blob, fetched.filename))) {
+        cache.set(key, fetched);
+      }
+    },
+  };
 }

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -143,8 +143,8 @@ export function downloadDataUrl(dataUrl: string, filename: string): void {
   if (isIosStandaloneWebApp()) {
     const blob = dataUrlToBlob(dataUrl);
     if (blob) {
-      // In-gesture call with in-memory bytes: the share path cannot be blocked
-      // by expired activation, so the result needs no handling.
+      // downloadBlob alerts the user on failure itself, so fire-and-forget
+      // cannot silently drop the download.
       void downloadBlob(blob, filename);
       return;
     }

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import { KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import { downloadBlob } from "@/browser/utils/downloadFile";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 
 /**
@@ -128,8 +129,18 @@ export function handleImageActionKeyDown(
   return false;
 }
 
-/** Trigger a browser download of a data URL via a temporary anchor element. */
+/**
+ * Trigger a download of a data URL. Routed through downloadBlob so iOS
+ * home-screen web apps (which drop anchor downloads) get the share sheet.
+ */
 export function downloadDataUrl(dataUrl: string, filename: string): void {
+  const blob = dataUrlToBlob(dataUrl);
+  if (blob) {
+    downloadBlob(blob, filename);
+    return;
+  }
+
+  // Non-base64 sources: fall back to a direct anchor download.
   const anchor = document.createElement("a");
   anchor.href = dataUrl;
   anchor.download = filename;

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -136,7 +136,9 @@ export function handleImageActionKeyDown(
 export function downloadDataUrl(dataUrl: string, filename: string): void {
   const blob = dataUrlToBlob(dataUrl);
   if (blob) {
-    downloadBlob(blob, filename);
+    // In-gesture call with in-memory bytes: the share path cannot be blocked
+    // by expired activation, so the result needs no handling.
+    void downloadBlob(blob, filename);
     return;
   }
 

--- a/src/browser/utils/imageActions.ts
+++ b/src/browser/utils/imageActions.ts
@@ -1,7 +1,11 @@
 import type React from "react";
 import { normalizeAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import { KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
-import { downloadBlob } from "@/browser/utils/downloadFile";
+import {
+  downloadBlob,
+  downloadViaAnchor,
+  isIosStandaloneWebApp,
+} from "@/browser/utils/downloadFile";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 
 /**
@@ -130,23 +134,21 @@ export function handleImageActionKeyDown(
 }
 
 /**
- * Trigger a download of a data URL. Routed through downloadBlob so iOS
- * home-screen web apps (which drop anchor downloads) get the share sheet.
+ * Trigger a download of a data URL. iOS home-screen web apps drop anchor
+ * downloads, so only there the payload is decoded into a Blob for the share
+ * sheet; everywhere else the anchor uses the data URL directly, avoiding a
+ * synchronous base64 decode of potentially multi-MB attachments.
  */
 export function downloadDataUrl(dataUrl: string, filename: string): void {
-  const blob = dataUrlToBlob(dataUrl);
-  if (blob) {
-    // In-gesture call with in-memory bytes: the share path cannot be blocked
-    // by expired activation, so the result needs no handling.
-    void downloadBlob(blob, filename);
-    return;
+  if (isIosStandaloneWebApp()) {
+    const blob = dataUrlToBlob(dataUrl);
+    if (blob) {
+      // In-gesture call with in-memory bytes: the share path cannot be blocked
+      // by expired activation, so the result needs no handling.
+      void downloadBlob(blob, filename);
+      return;
+    }
   }
 
-  // Non-base64 sources: fall back to a direct anchor download.
-  const anchor = document.createElement("a");
-  anchor.href = dataUrl;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
+  downloadViaAnchor(dataUrl, filename);
 }


### PR DESCRIPTION
## Summary

Downloads (images, markdown, PDFs, attachments) now work in iOS home-screen web apps by routing through the native share sheet, instead of silently failing.

## Background

iOS standalone ("Add to Home Screen") web apps have no download manager: clicking an `<a download>` anchor starts a navigation that WebKit aborts, so the screen flashes and nothing is saved. Every download surface in mux used that anchor pattern, so downloads were fully broken in the iOS PWA.

## Implementation

New shared helper `src/browser/utils/downloadFile.ts`:

- `downloadBlob(blob, filename)` detects iOS standalone mode via `navigator.standalone === true` (an iOS-WebKit-only property, so desktop PWAs and Android are unaffected) and shares via `navigator.share({ files })`; the share sheet offers "Save Image" / "Save to Files". Elsewhere it keeps the standard anchor + object-URL download.
- It reports a discriminated result ("delivered" | "blocked" | "unshareable") and surfaces failures to the user itself (alert at the shared boundary), so fire-and-forget callers cannot silently drop a download. Only a NotAllowedError with lapsed user activation counts as retryable "blocked"; everything else is permanent.
- `createDownloadRetryCache()` handles flows that fetch bytes over IPC after the tap (staged attachments): if the fetch outlives iOS's transient-activation window, the bytes are kept in a single most-recent retry slot so the user's next tap shares synchronously within its own gesture. Entries are workspace-scoped (forks reuse staged paths), a superseded or navigated-away fetch is dropped before any side effect, and the guards apply only in iOS standalone mode so concurrent desktop/Android downloads all deliver.
- `downloadDataUrl` decodes base64 to a Blob only in iOS standalone mode; elsewhere anchors use the data URL directly (no synchronous multi-MB decode).

All download surfaces route through the helper: image lightbox button, image context menu + Cmd+S, `attach_file` markdown/PDF download cards, staged-attachment chips, the debug LLM request modal, and the desktop-mode attachment branch in `UserMessageContent`.

## Validation

- Unit tests cover the share/anchor routing, dismissed vs blocked vs unshareable share outcomes, retry-cache caching/eviction/race/liveness branches, and non-iOS concurrent delivery.
- Not physically verified on an iOS device; the share-sheet approach is the standard workaround for this WebKit limitation.

## Risks

Low. Desktop and Android keep the pre-PR anchor behavior; only the iOS-standalone branch is new. Worst case there is the prior state (no download).

> Mux acted on Mike's behalf to create this PR and drive the Codex review loop.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
