### PR TITLE
🤖 fix: dedupe timeline preview text and sub-agent rows, tint agent event categories

### DIFF
--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
@@ -142,7 +142,7 @@ const MIXED_EVENTS: TimelineEvent[] = [
 ];
 
 const CATEGORY_EVENTS: TimelineEvent[] = [
-  makeEvent("agent-blocker", "agent.event", 25, {
+  makeEvent("agent-blocker", "agent.event", 36, {
     source: { system: "agent", key: "timeline-event:blocker" },
     data: {
       description: "PR #87 checks reached terminal state with six failures matching the baseline",
@@ -150,7 +150,11 @@ const CATEGORY_EVENTS: TimelineEvent[] = [
     },
     anchor: { toolCallId: "tool-timeline-event-blocker" },
   }),
-  makeEvent("agent-milestone", "agent.event", 24, {
+  makeEvent("rule-blocker", "turn.completed", 35, {
+    status: "completed",
+    data: { durationMs: 60_000 },
+  }),
+  makeEvent("agent-milestone", "agent.event", 34, {
     source: { system: "agent", key: "timeline-event:milestone" },
     data: {
       description: "Landed the retry backoff refactor with green checks",
@@ -158,7 +162,11 @@ const CATEGORY_EVENTS: TimelineEvent[] = [
     },
     anchor: { toolCallId: "tool-timeline-event-milestone" },
   }),
-  makeEvent("agent-decision", "agent.event", 23, {
+  makeEvent("rule-milestone", "turn.completed", 33, {
+    status: "completed",
+    data: { durationMs: 60_000 },
+  }),
+  makeEvent("agent-decision", "agent.event", 32, {
     source: { system: "agent", key: "timeline-event:decision" },
     data: {
       description: "Chose client-side grouping over rewriting the append-only log",
@@ -166,7 +174,11 @@ const CATEGORY_EVENTS: TimelineEvent[] = [
     },
     anchor: { toolCallId: "tool-timeline-event-decision" },
   }),
-  makeEvent("agent-handoff-2", "agent.event", 22, {
+  makeEvent("rule-decision", "turn.completed", 31, {
+    status: "completed",
+    data: { durationMs: 60_000 },
+  }),
+  makeEvent("agent-handoff-2", "agent.event", 30, {
     source: { system: "agent", key: "timeline-event:handoff-2" },
     data: {
       description: "Pushed mike/timeline and opened PR #4821",
@@ -174,7 +186,11 @@ const CATEGORY_EVENTS: TimelineEvent[] = [
     },
     anchor: { toolCallId: "tool-timeline-event-handoff-2" },
   }),
-  makeEvent("agent-picked-up-2", "agent.event", 21, {
+  makeEvent("rule-handoff-2", "turn.completed", 29, {
+    status: "completed",
+    data: { durationMs: 60_000 },
+  }),
+  makeEvent("agent-picked-up-2", "agent.event", 28, {
     source: { system: "agent", key: "timeline-event:picked-up-2" },
     data: {
       description: "Picked up review feedback on the retry backoff",
@@ -182,7 +198,11 @@ const CATEGORY_EVENTS: TimelineEvent[] = [
     },
     anchor: { toolCallId: "tool-timeline-event-picked-up-2" },
   }),
-  makeEvent("agent-uncategorized", "agent.event", 20, {
+  makeEvent("rule-picked-up-2", "turn.completed", 27, {
+    status: "completed",
+    data: { durationMs: 60_000 },
+  }),
+  makeEvent("agent-uncategorized", "agent.event", 26, {
     source: { system: "agent", key: "timeline-event:uncategorized" },
     data: { description: "Recorded a note without a category" },
     anchor: { toolCallId: "tool-timeline-event-uncategorized" },
@@ -196,7 +216,18 @@ const STORY_STORE: TimelineWorkspaceStore = {
   retryTimeline: () => undefined,
 };
 
-const STORY_API = createMockORPCClient();
+// The shared mock resolves previews to null; return a transcript excerpt that extends the
+// user-turn digest so selecting that row exercises the digest-vs-excerpt dedupe path.
+const STORY_API = (() => {
+  const api = createMockORPCClient();
+  api.workspace.timeline.preview = () =>
+    Promise.resolve({
+      role: "user",
+      textExcerpt:
+        "Add Timeline behavior coverage and responsive stories so the panel is validated at phone widths as well as desktop.",
+    });
+  return api;
+})();
 
 const meta = {
   title: "Features/RightSidebar/TimelinePanel",

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
@@ -216,18 +216,15 @@ const STORY_STORE: TimelineWorkspaceStore = {
   retryTimeline: () => undefined,
 };
 
-// The shared mock resolves previews to null; return a transcript excerpt that extends the
-// user-turn digest so selecting that row exercises the digest-vs-excerpt dedupe path.
-const STORY_API = (() => {
-  const api = createMockORPCClient();
-  api.workspace.timeline.preview = () =>
-    Promise.resolve({
-      role: "user",
-      textExcerpt:
-        "Add Timeline behavior coverage and responsive stories so the panel is validated at phone widths as well as desktop.",
-    });
-  return api;
-})();
+// Override the shared null preview so selecting the user-turn row demonstrates the
+// digest-vs-excerpt dedupe.
+const STORY_API = createMockORPCClient();
+STORY_API.workspace.timeline.preview = () =>
+  Promise.resolve({
+    role: "user",
+    textExcerpt:
+      "Add Timeline behavior coverage and responsive stories so the panel is validated at phone widths as well as desktop.",
+  });
 
 const meta = {
   title: "Features/RightSidebar/TimelinePanel",

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.stories.tsx
@@ -141,6 +141,54 @@ const MIXED_EVENTS: TimelineEvent[] = [
   }),
 ];
 
+const CATEGORY_EVENTS: TimelineEvent[] = [
+  makeEvent("agent-blocker", "agent.event", 25, {
+    source: { system: "agent", key: "timeline-event:blocker" },
+    data: {
+      description: "PR #87 checks reached terminal state with six failures matching the baseline",
+      category: "blocker",
+    },
+    anchor: { toolCallId: "tool-timeline-event-blocker" },
+  }),
+  makeEvent("agent-milestone", "agent.event", 24, {
+    source: { system: "agent", key: "timeline-event:milestone" },
+    data: {
+      description: "Landed the retry backoff refactor with green checks",
+      category: "milestone",
+    },
+    anchor: { toolCallId: "tool-timeline-event-milestone" },
+  }),
+  makeEvent("agent-decision", "agent.event", 23, {
+    source: { system: "agent", key: "timeline-event:decision" },
+    data: {
+      description: "Chose client-side grouping over rewriting the append-only log",
+      category: "decision",
+    },
+    anchor: { toolCallId: "tool-timeline-event-decision" },
+  }),
+  makeEvent("agent-handoff-2", "agent.event", 22, {
+    source: { system: "agent", key: "timeline-event:handoff-2" },
+    data: {
+      description: "Pushed mike/timeline and opened PR #4821",
+      category: "handoff",
+    },
+    anchor: { toolCallId: "tool-timeline-event-handoff-2" },
+  }),
+  makeEvent("agent-picked-up-2", "agent.event", 21, {
+    source: { system: "agent", key: "timeline-event:picked-up-2" },
+    data: {
+      description: "Picked up review feedback on the retry backoff",
+      category: "picked_up",
+    },
+    anchor: { toolCallId: "tool-timeline-event-picked-up-2" },
+  }),
+  makeEvent("agent-uncategorized", "agent.event", 20, {
+    source: { system: "agent", key: "timeline-event:uncategorized" },
+    data: { description: "Recorded a note without a category" },
+    anchor: { toolCallId: "tool-timeline-event-uncategorized" },
+  }),
+];
+
 const STORY_STORE: TimelineWorkspaceStore = {
   getWorkspaceState: () => ({ messages: [], muxMessages: [], hasOlderHistory: false }),
   loadOlderHistory: () => Promise.resolve("exhausted"),
@@ -219,6 +267,14 @@ export const Phone390: Story = {
     pixel: {
       matrix: { viewports: ["phone"] },
     },
+  },
+};
+
+export const AgentEventCategories: Story = {
+  args: {
+    workspaceId: `${WORKSPACE_ID}-categories`,
+    timeline: { ...populatedTimeline, events: CATEGORY_EVENTS },
+    workspaceStore: STORY_STORE,
   },
 };
 

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -35,6 +35,7 @@ import {
   getTimelineDayLabel,
   getTimelineEventCategories,
   getTimelineEventKind,
+  getAgentEventIcon,
   getAgentEventTint,
   getTimelineEventTitle,
   getTimelinePresentation,
@@ -351,12 +352,14 @@ function TimelineEventRow(props: {
   onSelect: (eventId: string) => void;
 }) {
   const presentation = getTimelinePresentation(getTimelineEventKind(props.event));
-  const Icon = presentation.icon;
   const title = getTimelineEventTitle(props.event);
   const detail = getEventDetail(props.event);
   const agentAuthored = props.event.source.system === "agent";
   const badge = props.event.data?.category?.replace(/_/g, " ") ?? "Agent";
   const tint = getAgentEventTint(props.event.data?.category);
+  const Icon =
+    (agentAuthored ? getAgentEventIcon(props.event.data?.category) : undefined) ??
+    presentation.icon;
   const failed = props.event.status === "failed";
   const interrupted = props.event.status === "interrupted";
 

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -33,6 +33,7 @@ import {
   getTimelineDayLabel,
   getTimelineEventCategories,
   getTimelineEventKind,
+  getAgentEventTint,
   getTimelineEventTitle,
   getTimelinePresentation,
   isMachineryKind,
@@ -218,6 +219,36 @@ function isCollapsedRun(item: DayItem): item is CollapsedRun {
   return "events" in item;
 }
 
+const TASK_LIFECYCLE_KINDS = new Set([
+  "task.created",
+  "task.progress",
+  "task.reported",
+  "task.failed",
+  "task.interrupted",
+]);
+
+// A sub-agent's bare "started" row and its later updates or report describe the same task, so once
+// any newer row for that task is on the feed the started row only doubles it. Updates and reports
+// keep their own rows: each carries distinct content, and a persistent child can report several
+// times. An in-flight task with no other rows still shows that it started.
+function dropSupersededTaskStarts(newestFirst: TimelineEvent[]): TimelineEvent[] {
+  const supersededTaskIds = new Set<string>();
+  return newestFirst.filter((event) => {
+    const taskId = event.anchor?.taskId;
+    if (taskId == null) {
+      return true;
+    }
+    const kind = getTimelineEventKind(event);
+    if (kind === "task.created" && supersededTaskIds.has(taskId)) {
+      return false;
+    }
+    if (TASK_LIFECYCLE_KINDS.has(kind)) {
+      supersededTaskIds.add(taskId);
+    }
+    return true;
+  });
+}
+
 function getEventDetail(event: TimelineEvent): string | null {
   const data = event.data;
   if (!data) return null;
@@ -312,6 +343,7 @@ function TimelineEventRow(props: {
   const detail = getEventDetail(props.event);
   const agentAuthored = props.event.source.system === "agent";
   const badge = props.event.data?.category?.replace(/_/g, " ") ?? "Agent";
+  const tint = getAgentEventTint(props.event.data?.category);
   const failed = props.event.status === "failed";
   const interrupted = props.event.status === "interrupted";
 
@@ -326,7 +358,7 @@ function TimelineEventRow(props: {
       className={cn(
         "grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 rounded-md border border-transparent px-2 py-2 text-left transition-colors",
         "hover:bg-hover focus-visible:ring-accent focus-visible:ring-1 focus-visible:outline-none",
-        agentAuthored && "border-ask-mode/25 bg-ask-mode-alpha",
+        agentAuthored && tint.row,
         failed && "border-danger/40 bg-danger-overlay",
         interrupted && !failed && "border-warning/40 bg-warning-overlay",
         props.selected && "border-accent/60 bg-accent/10"
@@ -335,7 +367,7 @@ function TimelineEventRow(props: {
       <span
         className={cn(
           "border-border bg-surface-secondary text-content-secondary mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border",
-          agentAuthored && "border-ask-mode/40 text-ask-mode",
+          agentAuthored && tint.icon,
           failed && "border-danger/50 text-danger",
           interrupted && !failed && "border-warning/50 text-warning"
         )}
@@ -349,7 +381,12 @@ function TimelineEventRow(props: {
         {agentAuthored || detail ? (
           <span className="mt-0.5 flex min-w-0 items-center gap-1.5">
             {agentAuthored ? (
-              <span className="border-ask-mode/30 text-ask-mode shrink-0 rounded border px-1 py-px text-[9px] font-medium uppercase">
+              <span
+                className={cn(
+                  "shrink-0 rounded border px-1 py-px text-[9px] font-medium uppercase",
+                  tint.badge
+                )}
+              >
                 {badge}
               </span>
             ) : null}
@@ -569,8 +606,12 @@ function TimelinePreviewCard(props: {
 
   const title = getTimelineEventTitle(props.event);
   const digest = props.event.data?.description ?? props.event.data?.digest ?? null;
-  const eventText = digest === title ? null : digest;
   const excerpt = previewState.status === "ready" ? previewState.preview.textExcerpt : "";
+  // The digest is a shorter cut of the same normalized text the excerpt holds, so when the loaded
+  // excerpt starts with it (ellipsis aside) showing both would render the prompt twice.
+  const digestShownByExcerpt =
+    digest != null && excerpt !== "" && excerpt.startsWith(digest.replace(/\.\.\.$/, ""));
+  const eventText = digest === title || digestShownByExcerpt ? null : digest;
 
   return (
     <div className="border-border bg-surface-secondary mx-3 mb-3 shrink-0 rounded-md border p-3">
@@ -663,8 +704,10 @@ export function TimelinePanelView(props: TimelinePanelViewProps) {
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [expandedRuns, setExpandedRuns] = useState<Record<string, boolean>>({});
   const filter = isTimelineFilter(storedFilter) ? storedFilter : "all";
-  const filteredEvents = timeline.events.filter(
-    (event) => filter === "all" || getTimelineEventCategories(event).includes(filter)
+  const filteredEvents = dropSupersededTaskStarts(
+    timeline.events.filter(
+      (event) => filter === "all" || getTimelineEventCategories(event).includes(filter)
+    )
   );
   const selectedEvent = filteredEvents.find((event) => event.id === selectedEventId);
   const dayGroups = groupEventsByDay(filteredEvents);

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -21,10 +21,12 @@ import { KEYBINDS, isEditableElement, matchesKeybind } from "@/browser/utils/ui/
 import { cn } from "@/common/lib/utils";
 import { capitalize } from "@/common/utils/capitalize";
 import { formatDuration } from "@/common/utils/formatDuration";
-import type {
-  TimelineAnchor,
-  TimelineEvent,
-  TimelinePreview,
+import {
+  TIMELINE_ROW_DIGEST_MAX_LENGTH,
+  TIMELINE_TEXT_MAX_LENGTH,
+  type TimelineAnchor,
+  type TimelineEvent,
+  type TimelinePreview,
 } from "@/common/orpc/schemas/timeline";
 
 import {
@@ -227,10 +229,8 @@ const TASK_LIFECYCLE_KINDS = new Set([
   "task.interrupted",
 ]);
 
-// A sub-agent's bare "started" row and its later updates or report describe the same task, so once
-// any newer row for that task is on the feed the started row only doubles it. Updates and reports
-// keep their own rows: each carries distinct content, and a persistent child can report several
-// times. An in-flight task with no other rows still shows that it started.
+// An older task.created row adds no unique information once the same task has a newer lifecycle
+// row on the feed; an in-flight task with no other rows still shows that it started.
 function dropSupersededTaskStarts(newestFirst: TimelineEvent[]): TimelineEvent[] {
   const supersededTaskIds = new Set<string>();
   return newestFirst.filter((event) => {
@@ -264,6 +264,19 @@ function getEventDetail(event: TimelineEvent): string | null {
 
 function hasTranscriptAnchor(anchor: TimelineAnchor | undefined): boolean {
   return anchor?.toolCallId != null || anchor?.messageId != null || anchor?.historySequence != null;
+}
+
+// Producers cut digests to fixed lengths with a "..." suffix, so only a digest at exactly one of
+// those lengths is treated as truncated; a digest that naturally ends in "..." must match in full.
+function stripTruncationSuffix(text: string): string {
+  const truncated =
+    text.endsWith("...") &&
+    (text.length === TIMELINE_ROW_DIGEST_MAX_LENGTH || text.length === TIMELINE_TEXT_MAX_LENGTH);
+  return truncated ? text.slice(0, -3) : text;
+}
+
+function excerptCovers(excerpt: string, text: string | null): boolean {
+  return text != null && text !== "" && excerpt.startsWith(stripTruncationSuffix(text));
 }
 
 function TimelineRuleRow(props: {
@@ -606,12 +619,11 @@ function TimelinePreviewCard(props: {
 
   const title = getTimelineEventTitle(props.event);
   const digest = props.event.data?.description ?? props.event.data?.digest ?? null;
-  const excerpt = previewState.status === "ready" ? previewState.preview.textExcerpt : "";
-  // The digest is a shorter cut of the same normalized text the excerpt holds, so when the loaded
-  // excerpt starts with it (ellipsis aside) showing both would render the prompt twice.
-  const digestShownByExcerpt =
-    digest != null && excerpt !== "" && excerpt.startsWith(digest.replace(/\.\.\.$/, ""));
-  const eventText = digest === title || digestShownByExcerpt ? null : digest;
+  const loadedExcerpt = previewState.status === "ready" ? previewState.preview.textExcerpt : "";
+  // Each stretch of text renders once: the excerpt supersedes a digest it covers, and an excerpt
+  // that only repeats the card title (agent events preview their own description) adds nothing.
+  const excerpt = excerptCovers(loadedExcerpt, title) ? "" : loadedExcerpt;
+  const eventText = digest === title || excerptCovers(loadedExcerpt, digest) ? null : digest;
 
   return (
     <div className="border-border bg-surface-secondary mx-3 mb-3 shrink-0 rounded-md border p-3">

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -231,23 +231,53 @@ const TASK_LIFECYCLE_KINDS = new Set([
 ]);
 
 // An older task.created row adds no unique information once the same task has a newer lifecycle
-// row on the feed; an in-flight task with no other rows still shows that it started.
+// row on the feed; an in-flight task with no other rows still shows that it started. The started
+// row is the only one anchored to the spawning tool call, so rows that cannot reveal a transcript
+// target themselves inherit that anchor before the started row is dropped.
 function dropSupersededTaskStarts(newestFirst: TimelineEvent[]): TimelineEvent[] {
+  const startAnchors = new Map<string, TimelineAnchor>();
+  for (const event of newestFirst) {
+    const anchor = event.anchor;
+    if (
+      anchor?.taskId != null &&
+      getTimelineEventKind(event) === "task.created" &&
+      hasTranscriptAnchor(anchor)
+    ) {
+      startAnchors.set(anchor.taskId, anchor);
+    }
+  }
+
   const supersededTaskIds = new Set<string>();
-  return newestFirst.filter((event) => {
+  const events: TimelineEvent[] = [];
+  for (const event of newestFirst) {
     const taskId = event.anchor?.taskId;
     if (taskId == null) {
-      return true;
+      events.push(event);
+      continue;
     }
     const kind = getTimelineEventKind(event);
     if (kind === "task.created" && supersededTaskIds.has(taskId)) {
-      return false;
+      continue;
     }
     if (TASK_LIFECYCLE_KINDS.has(kind)) {
       supersededTaskIds.add(taskId);
+      const start = startAnchors.get(taskId);
+      if (kind !== "task.created" && start != null && !hasTranscriptAnchor(event.anchor)) {
+        events.push({
+          ...event,
+          anchor: {
+            ...event.anchor,
+            ...(start.historySequence != null ? { historySequence: start.historySequence } : {}),
+            ...(start.messageId != null ? { messageId: start.messageId } : {}),
+            ...(start.toolCallId != null ? { toolCallId: start.toolCallId } : {}),
+          },
+        });
+        continue;
+      }
     }
-    return true;
-  });
+    events.push(event);
+  }
+  return events;
 }
 
 function getEventDetail(event: TimelineEvent): string | null {
@@ -624,8 +654,13 @@ function TimelinePreviewCard(props: {
   const digest = props.event.data?.description ?? props.event.data?.digest ?? null;
   const loadedExcerpt = previewState.status === "ready" ? previewState.preview.textExcerpt : "";
   // Each stretch of text renders once: the excerpt supersedes a digest it covers, and an excerpt
-  // that only repeats the card title (agent events preview their own description) adds nothing.
-  const excerpt = excerptCovers(loadedExcerpt, title) ? "" : loadedExcerpt;
+  // that only repeats a description-backed title (agent events preview their own description) adds
+  // nothing. A generic kind-label title never suppresses the excerpt, since a prompt can happen to
+  // open with those same words.
+  const excerpt =
+    props.event.data?.description != null && excerptCovers(loadedExcerpt, title)
+      ? ""
+      : loadedExcerpt;
   const eventText = digest === title || excerptCovers(loadedExcerpt, digest) ? null : digest;
 
   return (

--- a/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
+++ b/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
@@ -10,16 +10,21 @@ import {
   CircleX,
   ClipboardCheck,
   Forward,
+  Handshake,
   HeartPulse,
   Inbox,
   Layers,
   ListTodo,
   Map,
   MessageSquare,
+  Milestone,
+  OctagonAlert,
   PackageCheck,
+  PackageOpen,
   Radar,
   RefreshCcw,
   RotateCcw,
+  Scale,
   Send,
   Settings2,
   Sparkles,
@@ -154,6 +159,20 @@ const AGENT_EVENT_TINTS: Partial<Record<string, TimelineRowTint>> = {
 
 export function getAgentEventTint(category: string | undefined): TimelineRowTint {
   return (category != null ? AGENT_EVENT_TINTS[category] : undefined) ?? DEFAULT_AGENT_TINT;
+}
+
+// Category glyphs pair with the tints above; events without a recognized category keep the
+// generic agent.event icon.
+const AGENT_EVENT_ICONS: Partial<Record<string, LucideIcon>> = {
+  milestone: Milestone,
+  decision: Scale,
+  blocker: OctagonAlert,
+  handoff: Handshake,
+  picked_up: PackageOpen,
+};
+
+export function getAgentEventIcon(category: string | undefined): LucideIcon | undefined {
+  return category != null ? AGENT_EVENT_ICONS[category] : undefined;
 }
 
 const knownKinds = new Set<string>(TIMELINE_EVENT_KINDS);

--- a/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
+++ b/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
@@ -115,6 +115,47 @@ export function isMachineryKind(kind: string): boolean {
   return MACHINERY_KINDS.has(kind);
 }
 
+export interface TimelineRowTint {
+  row: string;
+  icon: string;
+  badge: string;
+}
+
+const DEFAULT_AGENT_TINT: TimelineRowTint = {
+  row: "border-ask-mode/25 bg-ask-mode-alpha",
+  icon: "border-ask-mode/40 text-ask-mode",
+  badge: "border-ask-mode/30 text-ask-mode",
+};
+
+// Attention-worthy categories get their own hue so a blocker reads differently from a milestone at
+// a glance. Routine categories (picked_up) and uncategorized events keep the generic agent tint.
+const AGENT_EVENT_TINTS: Record<string, TimelineRowTint> = {
+  milestone: {
+    row: "border-success/25 bg-success/10",
+    icon: "border-success/40 text-success",
+    badge: "border-success/30 text-success",
+  },
+  decision: {
+    row: "border-info/25 bg-info/10",
+    icon: "border-info/40 text-info",
+    badge: "border-info/30 text-info",
+  },
+  blocker: {
+    row: "border-danger/25 bg-danger/10",
+    icon: "border-danger/40 text-danger",
+    badge: "border-danger/30 text-danger",
+  },
+  handoff: {
+    row: "border-warning/25 bg-warning/10",
+    icon: "border-warning/40 text-warning",
+    badge: "border-warning/30 text-warning",
+  },
+};
+
+export function getAgentEventTint(category: string | undefined): TimelineRowTint {
+  return (category != null ? AGENT_EVENT_TINTS[category] : undefined) ?? DEFAULT_AGENT_TINT;
+}
+
 const knownKinds = new Set<string>(TIMELINE_EVENT_KINDS);
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {

--- a/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
+++ b/src/browser/features/RightSidebar/Timeline/timelinePresentation.ts
@@ -115,7 +115,7 @@ export function isMachineryKind(kind: string): boolean {
   return MACHINERY_KINDS.has(kind);
 }
 
-export interface TimelineRowTint {
+interface TimelineRowTint {
   row: string;
   icon: string;
   badge: string;
@@ -129,7 +129,7 @@ const DEFAULT_AGENT_TINT: TimelineRowTint = {
 
 // Attention-worthy categories get their own hue so a blocker reads differently from a milestone at
 // a glance. Routine categories (picked_up) and uncategorized events keep the generic agent tint.
-const AGENT_EVENT_TINTS: Record<string, TimelineRowTint> = {
+const AGENT_EVENT_TINTS: Partial<Record<string, TimelineRowTint>> = {
   milestone: {
     row: "border-success/25 bg-success/10",
     icon: "border-success/40 text-success",

--- a/src/common/orpc/schemas/timeline.ts
+++ b/src/common/orpc/schemas/timeline.ts
@@ -80,6 +80,10 @@ export const TimelineStatusSchema = z.enum([
  */
 export const TIMELINE_TEXT_MAX_LENGTH = 600;
 
+// Row digests are truncated by the mapper to this length. The preview card relies on the exact
+// producer lengths to tell truncation apart from a digest that naturally ends in "...".
+export const TIMELINE_ROW_DIGEST_MAX_LENGTH = 120;
+
 export function truncateTimelineDigest(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
   return normalized.length <= TIMELINE_TEXT_MAX_LENGTH

--- a/src/node/services/timelineMapper.ts
+++ b/src/node/services/timelineMapper.ts
@@ -1,4 +1,7 @@
-import { subagentReportSourceKey } from "@/common/orpc/schemas/timeline";
+import {
+  TIMELINE_ROW_DIGEST_MAX_LENGTH,
+  subagentReportSourceKey,
+} from "@/common/orpc/schemas/timeline";
 import type {
   TimelineAnchor,
   TimelineEventData,
@@ -50,7 +53,9 @@ function streamKey(workspaceId: string, messageId: string): string {
 
 function truncateDigest(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized.length <= 120 ? normalized : `${normalized.slice(0, 117)}...`;
+  return normalized.length <= TIMELINE_ROW_DIGEST_MAX_LENGTH
+    ? normalized
+    : `${normalized.slice(0, TIMELINE_ROW_DIGEST_MAX_LENGTH - 3)}...`;
 }
 
 function messageTimestamp(

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -421,6 +421,50 @@ describe("TimelinePanel", () => {
     expect(view.getAllByText(truncatedDigest)).toHaveLength(1);
   });
 
+  test("keeps the reveal path when the retained task row lacks a transcript anchor", async () => {
+    const events = [
+      makeEvent("report", "task.reported", 2, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { title: "Auditor finished" },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("start", "task.created", 1, {
+        source: { system: "task", key: "task-created:task-a" },
+        status: "started",
+        anchor: { taskId: "task-a", toolCallId: "spawn-call", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+    expect(view.container.querySelector('[data-timeline-event-id="start"]')).toBeNull();
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="report"]')!);
+
+    // The report row inherited the started row's spawning tool-call anchor, so the reveal
+    // action stays available even though TaskService recorded the report without one.
+    await waitFor(() => view.getByTestId("timeline-reveal"));
+  });
+
+  test("does not hide the excerpt behind a generic title the prompt happens to open with", async () => {
+    const view = renderTimeline({
+      events: [
+        makeEvent("prompt", "turn.user", 1, {
+          data: { digest: "User prompt: reproduce the issue" },
+          anchor: { messageId: "user-1" },
+        }),
+      ],
+      preview: {
+        role: "user",
+        textExcerpt: "User prompt: reproduce the issue with the beta build",
+      },
+    });
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="prompt"]')!);
+
+    await waitFor(() => view.getByText("User prompt: reproduce the issue with the beta build"));
+  });
+
   test("keeps a digest whose natural trailing ellipsis is not a truncation marker", async () => {
     const view = renderTimeline({
       events: [

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -12,7 +12,7 @@ import {
   type WorkspaceTimelineSnapshot,
 } from "@/browser/stores/WorkspaceStore";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
-import type { TimelineEvent } from "@/common/orpc/schemas/timeline";
+import type { TimelineEvent, TimelinePreview } from "@/common/orpc/schemas/timeline";
 import { BACKGROUND_WORK_WAKE_OPENINGS } from "@/common/utils/machineTurnPrompts";
 
 import { installDom } from "../dom";
@@ -64,7 +64,7 @@ function renderTimeline(params: {
   loadOlderHistory?: jest.Mock<Promise<"loaded">, [string]>;
   snapshot?: Partial<WorkspaceTimelineSnapshot>;
   hasOlderHistory?: boolean;
-  preview?: { role: "system" | "user" | "assistant"; textExcerpt: string };
+  preview?: TimelinePreview;
 }) {
   const loadOlderHistory = params.loadOlderHistory ?? jest.fn().mockResolvedValue("loaded");
   const workspaceState: { messages: unknown[]; muxMessages: unknown[]; hasOlderHistory: boolean } =
@@ -401,21 +401,62 @@ describe("TimelinePanel", () => {
   });
 
   test("shows a single representation when the preview excerpt duplicates the digest", async () => {
+    // Mirror the producer: a >120-char prompt is digested to a 117-char cut plus "...".
+    const longPrompt = "alpha beta gamma delta epsilon ".repeat(8).trim();
+    const truncatedDigest = `${longPrompt.slice(0, 117)}...`;
     const view = renderTimeline({
       events: [
         makeEvent("prompt", "turn.user", 1, {
-          data: { digest: "alpha beta gam..." },
+          data: { digest: truncatedDigest },
           anchor: { messageId: "user-1" },
         }),
       ],
-      preview: { role: "user", textExcerpt: "alpha beta gamma delta epsilon" },
+      preview: { role: "user", textExcerpt: longPrompt },
     });
 
     fireEvent.click(view.container.querySelector('[data-timeline-event-id="prompt"]')!);
-    await waitFor(() => view.getByText("alpha beta gamma delta epsilon"));
+    await waitFor(() => view.getByText(longPrompt));
 
-    // The row detail is the only place the digest still renders; the card shows just the excerpt.
-    expect(view.getAllByText("alpha beta gam...")).toHaveLength(1);
+    // The digest still renders in the row detail; the card itself shows only the excerpt.
+    expect(view.getAllByText(truncatedDigest)).toHaveLength(1);
+  });
+
+  test("keeps a digest whose natural trailing ellipsis is not a truncation marker", async () => {
+    const view = renderTimeline({
+      events: [
+        makeEvent("prompt", "turn.user", 1, {
+          data: { digest: "Investigate..." },
+          anchor: { messageId: "user-1" },
+        }),
+      ],
+      preview: { role: "user", textExcerpt: "Investigate the logs" },
+    });
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="prompt"]')!);
+    await waitFor(() => view.getByText("Investigate the logs"));
+
+    expect(view.getAllByText("Investigate...")).toHaveLength(2);
+  });
+
+  test("hides an excerpt that only repeats an agent event's description", async () => {
+    const view = renderTimeline({
+      events: [
+        makeEvent("agent-note", "agent.event", 1, {
+          source: { system: "agent", key: "timeline-event:note" },
+          data: { description: "Pushed the branch and opened the PR", category: "handoff" },
+          anchor: { toolCallId: "tool-1" },
+        }),
+      ],
+      preview: { role: "assistant", textExcerpt: "Pushed the branch and opened the PR" },
+    });
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="agent-note"]')!);
+    await waitFor(() => view.getByTestId("timeline-reveal"));
+    await waitFor(() => {
+      if (view.queryByText("Loading preview…")) throw new Error("Preview still loading");
+    });
+
+    expect(view.getAllByText("Pushed the branch and opened the PR")).toHaveLength(2);
   });
 
   test("keeps a digest the preview excerpt does not cover", async () => {

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -64,6 +64,7 @@ function renderTimeline(params: {
   loadOlderHistory?: jest.Mock<Promise<"loaded">, [string]>;
   snapshot?: Partial<WorkspaceTimelineSnapshot>;
   hasOlderHistory?: boolean;
+  preview?: { role: "system" | "user" | "assistant"; textExcerpt: string };
 }) {
   const loadOlderHistory = params.loadOlderHistory ?? jest.fn().mockResolvedValue("loaded");
   const workspaceState: { messages: unknown[]; muxMessages: unknown[]; hasOlderHistory: boolean } =
@@ -88,10 +89,12 @@ function renderTimeline(params: {
   const api = {
     workspace: {
       timeline: {
-        preview: jest.fn().mockResolvedValue({
-          role: "assistant",
-          textExcerpt: "Preview fixture",
-        }),
+        preview: jest.fn().mockResolvedValue(
+          params.preview ?? {
+            role: "assistant",
+            textExcerpt: "Preview fixture",
+          }
+        ),
       },
     },
   };
@@ -366,6 +369,72 @@ describe("TimelinePanel", () => {
 
     expect(view.container.querySelector('[data-timeline-event-id="wake"]')).not.toBeNull();
     expect(view.container.querySelector('[data-timeline-event-id="continuation"]')).not.toBeNull();
+  });
+
+  test("drops the sub-agent started row once a newer row for its task lands", () => {
+    const events = [
+      makeEvent("done-report", "task.reported", 3, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { title: "Auditor finished", digest: "Found two issues" },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("done-start", "task.created", 2, {
+        source: { system: "task", key: "task-created:task-a" },
+        status: "started",
+        anchor: { taskId: "task-a", toolCallId: "call-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("inflight-start", "task.created", 1, {
+        source: { system: "task", key: "task-created:task-b" },
+        status: "started",
+        anchor: { taskId: "task-b", toolCallId: "call-b", childWorkspaceId: "task-b" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="done-start"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="done-report"]')).not.toBeNull();
+    expect(
+      view.container.querySelector('[data-timeline-event-id="inflight-start"]')
+    ).not.toBeNull();
+  });
+
+  test("shows a single representation when the preview excerpt duplicates the digest", async () => {
+    const view = renderTimeline({
+      events: [
+        makeEvent("prompt", "turn.user", 1, {
+          data: { digest: "alpha beta gam..." },
+          anchor: { messageId: "user-1" },
+        }),
+      ],
+      preview: { role: "user", textExcerpt: "alpha beta gamma delta epsilon" },
+    });
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="prompt"]')!);
+    await waitFor(() => view.getByText("alpha beta gamma delta epsilon"));
+
+    // The row detail is the only place the digest still renders; the card shows just the excerpt.
+    expect(view.getAllByText("alpha beta gam...")).toHaveLength(1);
+  });
+
+  test("keeps a digest the preview excerpt does not cover", async () => {
+    const view = renderTimeline({
+      events: [
+        makeEvent("report", "task.reported", 1, {
+          source: { system: "task", key: "task-report:task-c" },
+          status: "completed",
+          data: { digest: "Report digest text" },
+          anchor: { messageId: "report-1", taskId: "task-c" },
+        }),
+      ],
+      preview: { role: "assistant", textExcerpt: "Unrelated transcript excerpt" },
+    });
+
+    fireEvent.click(view.container.querySelector('[data-timeline-event-id="report"]')!);
+    await waitFor(() => view.getByText("Unrelated transcript excerpt"));
+
+    expect(view.getAllByText("Report digest text")).toHaveLength(2);
   });
 
   test("drops the abandoned-retry row that duplicates an adjacent interruption", () => {


### PR DESCRIPTION
## Summary

Removes duplicated information from the Timeline panel and gives agent-event categories distinct colors.

## Background

Three feed-quality issues reported from dogfooding:

1. Selecting a prompt showed the same text twice in the preview card: the event digest and the transcript excerpt.
2. A sub-agent produced both a "Sub-agent started" and a "Sub-agent reported" row for the same task, doubling every delegation.
3. Every agent-event badge (blocker, milestone, decision, handoff) rendered in the same indigo, so attention-worthy events did not stand out.

## Implementation

- Preview card: the loaded excerpt supersedes a digest it covers, and an excerpt that only repeats the card title (agent events preview their own description) is hidden. Digest truncation is recognized only at the exact producer lengths (120 for row digests, 600 for bounded text), shared via `TIMELINE_ROW_DIGEST_MAX_LENGTH`, so a digest that naturally ends in "..." must match in full.
- Feed: `task.created` rows are dropped once the same `anchor.taskId` has a newer lifecycle row (progress, report, failure, interruption). In-flight tasks still show their started row. Filtering is client-side per render, so pagination and cross-day grouping are unaffected, and the append-only log is untouched.
- Colors: blocker (red), milestone (green), decision (blue), and handoff (amber) tints for the row, icon, and badge, driven by existing theme tokens; picked_up and uncategorized events keep the generic agent tint.
- Icons: each recognized category also gets its own glyph (octagon alert, milestone marker, scales, handshake, open package); uncategorized events keep the generic agent.event icon.

## Validation

- New behavioral tests (each red-checked against the reverted fix): started-row suppression, digest-covered-by-excerpt, natural trailing ellipsis kept, title-only excerpt hidden.
- Storybook UAT with agent-browser screenshots for the category tints, the deduped feed, and the single-representation preview card; new `AgentEventCategories` story covers all tints.

## Risks

Low. Rendering-only changes scoped to the Timeline panel; the timeline log and its producers are unchanged except for extracting the digest length constant.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->

