### PR TITLE
🤖 fix: drop superseded sub-agent update rows from the timeline feed

### DIFF
--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -230,12 +230,18 @@ const TASK_LIFECYCLE_KINDS = new Set([
   "task.interrupted",
 ]);
 
-// Started and progress rows are provisional: an in-progress update repeats what the terminal
-// report will say, so once the same task has a newer lifecycle row on the feed they add no unique
-// information and only the newest row per task survives. Terminal rows always stay, since a
-// reawakened sub-agent can report more than once. The started row is the only one anchored to the
-// spawning tool call, so rows that cannot reveal a transcript target themselves inherit that
-// anchor before the started row is dropped.
+// Keep the dedupe key's field order aligned with getEventDetail: title before digest.
+function taskRowContentKey(event: TimelineEvent): string {
+  return event.data?.title ?? event.data?.digest ?? "";
+}
+
+// Started rows are provisional: once the same task has a newer lifecycle row on the feed they add
+// no unique information. Update rows dedupe by content key: a checkpoint whose key reappears on a
+// newer lifecycle row for the task is redundant, while updates with distinct keys stay visible
+// because a child may report several times with different findings. Terminal rows always stay,
+// since a reawakened sub-agent can report more than once. The started row is the only one
+// anchored to the spawning tool call, so rows that cannot reveal a transcript target themselves
+// inherit that anchor before the started row is dropped.
 function dropSupersededTaskRows(newestFirst: TimelineEvent[]): TimelineEvent[] {
   const startAnchors = new Map<string, TimelineAnchor>();
   for (const event of newestFirst) {
@@ -250,6 +256,7 @@ function dropSupersededTaskRows(newestFirst: TimelineEvent[]): TimelineEvent[] {
   }
 
   const supersededTaskIds = new Set<string>();
+  const newerRowKeys = new Set<string>();
   const events: TimelineEvent[] = [];
   for (const event of newestFirst) {
     const taskId = event.anchor?.taskId;
@@ -258,11 +265,16 @@ function dropSupersededTaskRows(newestFirst: TimelineEvent[]): TimelineEvent[] {
       continue;
     }
     const kind = getTimelineEventKind(event);
-    if ((kind === "task.created" || kind === "task.progress") && supersededTaskIds.has(taskId)) {
+    if (kind === "task.created" && supersededTaskIds.has(taskId)) {
+      continue;
+    }
+    const contentKey = `${taskId}:${taskRowContentKey(event)}`;
+    if (kind === "task.progress" && newerRowKeys.has(contentKey)) {
       continue;
     }
     if (TASK_LIFECYCLE_KINDS.has(kind)) {
       supersededTaskIds.add(taskId);
+      newerRowKeys.add(contentKey);
       const start = startAnchors.get(taskId);
       if (kind !== "task.created" && start != null && !hasTranscriptAnchor(event.anchor)) {
         events.push({

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -24,10 +24,12 @@ import { formatDuration } from "@/common/utils/formatDuration";
 import {
   TIMELINE_ROW_DIGEST_MAX_LENGTH,
   TIMELINE_TEXT_MAX_LENGTH,
+  truncateTimelineRowDigest,
   type TimelineAnchor,
   type TimelineEvent,
   type TimelinePreview,
 } from "@/common/orpc/schemas/timeline";
+import { isSubagentFallbackTitle } from "@/common/utils/subagentReportEnvelope";
 
 import {
   TIMELINE_CATEGORIES,
@@ -230,10 +232,17 @@ const TASK_LIFECYCLE_KINDS = new Set([
   "task.interrupted",
 ]);
 
-// Untitled agent_report calls from the same task share a default title while the distinct finding
-// lives in the digest, so the dedupe key must include both fields.
+// Mapper and TaskService rows encode untitled reports and digest lengths differently, so
+// canonicalize both fields before cross-producer dedupe; the digest distinguishes untitled
+// updates because they share a fallback title. Comparing capped previews is a deliberate
+// tradeoff: rows store only the capped digest, so reports that diverge past the cap collapse
+// into one row while their full text stays in the transcript.
 function taskRowContentKey(event: TimelineEvent): string {
-  return `${event.data?.title ?? ""}\u0000${event.data?.digest ?? ""}`;
+  const title = event.data?.title;
+  const canonicalTitle = title == null || isSubagentFallbackTitle(title) ? "" : title;
+  const digest = event.data?.digest;
+  const canonicalDigest = digest == null ? "" : truncateTimelineRowDigest(digest);
+  return `${canonicalTitle}\u0000${canonicalDigest}`;
 }
 
 // A newer lifecycle row makes task.created redundant, but its transcript anchor may still be the

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -230,11 +230,13 @@ const TASK_LIFECYCLE_KINDS = new Set([
   "task.interrupted",
 ]);
 
-// An older task.created row adds no unique information once the same task has a newer lifecycle
-// row on the feed; an in-flight task with no other rows still shows that it started. The started
-// row is the only one anchored to the spawning tool call, so rows that cannot reveal a transcript
-// target themselves inherit that anchor before the started row is dropped.
-function dropSupersededTaskStarts(newestFirst: TimelineEvent[]): TimelineEvent[] {
+// Started and progress rows are provisional: an in-progress update repeats what the terminal
+// report will say, so once the same task has a newer lifecycle row on the feed they add no unique
+// information and only the newest row per task survives. Terminal rows always stay, since a
+// reawakened sub-agent can report more than once. The started row is the only one anchored to the
+// spawning tool call, so rows that cannot reveal a transcript target themselves inherit that
+// anchor before the started row is dropped.
+function dropSupersededTaskRows(newestFirst: TimelineEvent[]): TimelineEvent[] {
   const startAnchors = new Map<string, TimelineAnchor>();
   for (const event of newestFirst) {
     const anchor = event.anchor;
@@ -256,7 +258,7 @@ function dropSupersededTaskStarts(newestFirst: TimelineEvent[]): TimelineEvent[]
       continue;
     }
     const kind = getTimelineEventKind(event);
-    if (kind === "task.created" && supersededTaskIds.has(taskId)) {
+    if ((kind === "task.created" || kind === "task.progress") && supersededTaskIds.has(taskId)) {
       continue;
     }
     if (TASK_LIFECYCLE_KINDS.has(kind)) {
@@ -754,7 +756,7 @@ export function TimelinePanelView(props: TimelinePanelViewProps) {
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [expandedRuns, setExpandedRuns] = useState<Record<string, boolean>>({});
   const filter = isTimelineFilter(storedFilter) ? storedFilter : "all";
-  const filteredEvents = dropSupersededTaskStarts(
+  const filteredEvents = dropSupersededTaskRows(
     timeline.events.filter(
       (event) => filter === "all" || getTimelineEventCategories(event).includes(filter)
     )

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -230,18 +230,15 @@ const TASK_LIFECYCLE_KINDS = new Set([
   "task.interrupted",
 ]);
 
-// Keep the dedupe key's field order aligned with getEventDetail: title before digest.
+// Untitled agent_report calls from the same task share a default title while the distinct finding
+// lives in the digest, so the dedupe key must include both fields.
 function taskRowContentKey(event: TimelineEvent): string {
-  return event.data?.title ?? event.data?.digest ?? "";
+  return `${event.data?.title ?? ""}\u0000${event.data?.digest ?? ""}`;
 }
 
-// Started rows are provisional: once the same task has a newer lifecycle row on the feed they add
-// no unique information. Update rows dedupe by content key: a checkpoint whose key reappears on a
-// newer lifecycle row for the task is redundant, while updates with distinct keys stay visible
-// because a child may report several times with different findings. Terminal rows always stay,
-// since a reawakened sub-agent can report more than once. The started row is the only one
-// anchored to the spawning tool call, so rows that cannot reveal a transcript target themselves
-// inherit that anchor before the started row is dropped.
+// A newer lifecycle row makes task.created redundant, but its transcript anchor may still be the
+// task's only reveal target. Deduplicate only task.progress rows whose title and digest match a
+// newer row for that task; terminal rows remain because a reawakened task can report again.
 function dropSupersededTaskRows(newestFirst: TimelineEvent[]): TimelineEvent[] {
   const startAnchors = new Map<string, TimelineAnchor>();
   for (const event of newestFirst) {

--- a/src/common/orpc/schemas/timeline.ts
+++ b/src/common/orpc/schemas/timeline.ts
@@ -84,11 +84,19 @@ export const TIMELINE_TEXT_MAX_LENGTH = 600;
 // producer lengths to tell truncation apart from a digest that naturally ends in "...".
 export const TIMELINE_ROW_DIGEST_MAX_LENGTH = 120;
 
-export function truncateTimelineDigest(value: string): string {
+function truncateNormalized(value: string, maxLength: number): string {
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized.length <= TIMELINE_TEXT_MAX_LENGTH
-    ? normalized
-    : `${normalized.slice(0, TIMELINE_TEXT_MAX_LENGTH - 3)}...`;
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 3)}...`;
+}
+
+// TaskService stores longer digests than mapped rows, so cross-producer comparisons must reapply
+// this cap.
+export function truncateTimelineRowDigest(value: string): string {
+  return truncateNormalized(value, TIMELINE_ROW_DIGEST_MAX_LENGTH);
+}
+
+export function truncateTimelineDigest(value: string): string {
+  return truncateNormalized(value, TIMELINE_TEXT_MAX_LENGTH);
 }
 
 // A completed sub-agent report is recorded by TaskService and is also injected into parent history,

--- a/src/common/utils/subagentReportEnvelope.ts
+++ b/src/common/utils/subagentReportEnvelope.ts
@@ -17,6 +17,20 @@ export interface SubagentReportEnvelope {
 
 export const SUBAGENT_FAILURE_ENVELOPE_TAG = "<mux_subagent_failure>";
 
+// Fallback titles for untitled reports; the matcher lives here so consumers (timeline dedupe) can
+// treat them as absent titles without drifting from the builders.
+export function subagentUpdateFallbackTitle(agentType: string): string {
+  return `Subagent (${agentType}) update`;
+}
+
+export function subagentReportFallbackTitle(agentType: string): string {
+  return `Subagent (${agentType}) report`;
+}
+
+export function isSubagentFallbackTitle(title: string): boolean {
+  return /^Subagent \(.+\) (?:update|report)$/.test(title);
+}
+
 const ROOT_OPEN = "<mux_subagent_report>";
 const ROOT_CLOSE = "</mux_subagent_report>";
 const STRUCTURED_OUTPUT_START = "\n<structured_output_json>\n";

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -22,6 +22,8 @@ import {
   SUBAGENT_FAILURE_ENVELOPE_TAG,
   formatSubagentReportEnvelope,
   parseSubagentReportEnvelope,
+  subagentReportFallbackTitle,
+  subagentUpdateFallbackTitle,
 } from "@/common/utils/subagentReportEnvelope";
 import { BACKGROUND_WORK_WAKE_OPENINGS } from "@/common/utils/machineTurnPrompts";
 import { WORKSPACE_TURN_TASK_TAGS } from "@/constants/workspaceTags";
@@ -7119,7 +7121,7 @@ export class TaskService {
       }
 
       const agentType = coerceNonEmptyString(childEntry.workspace.agentType) ?? "agent";
-      const title = coerceNonEmptyString(report.title) ?? `Subagent (${agentType}) update`;
+      const title = coerceNonEmptyString(report.title) ?? subagentUpdateFallbackTitle(agentType);
       const reportContent = formatSubagentReportUserMessage({
         childWorkspaceId,
         agentType,
@@ -12976,7 +12978,7 @@ export class TaskService {
     const titlePrefix =
       typeof report.title === "string" && report.title.trim().length > 0
         ? report.title
-        : `Subagent (${agentType}) report`;
+        : subagentReportFallbackTitle(agentType);
     const reportContent = formatSubagentReportUserMessage({
       childWorkspaceId,
       agentType,

--- a/src/node/services/timelineMapper.ts
+++ b/src/node/services/timelineMapper.ts
@@ -1,7 +1,4 @@
-import {
-  TIMELINE_ROW_DIGEST_MAX_LENGTH,
-  subagentReportSourceKey,
-} from "@/common/orpc/schemas/timeline";
+import { subagentReportSourceKey, truncateTimelineRowDigest } from "@/common/orpc/schemas/timeline";
 import type {
   TimelineAnchor,
   TimelineEventData,
@@ -49,13 +46,6 @@ function eventKey(...parts: Array<string | number | undefined>): string {
 
 function streamKey(workspaceId: string, messageId: string): string {
   return eventKey(workspaceId, messageId);
-}
-
-function truncateDigest(value: string): string {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized.length <= TIMELINE_ROW_DIGEST_MAX_LENGTH
-    ? normalized
-    : `${normalized.slice(0, TIMELINE_ROW_DIGEST_MAX_LENGTH - 3)}...`;
 }
 
 function messageTimestamp(
@@ -216,7 +206,7 @@ function classifyMachineTurn(
       ...(completed ? { key: subagentReportSourceKey(report.taskId) } : {}),
       status: completed ? "completed" : "started",
       anchor: { taskId: report.taskId, childWorkspaceId: report.taskId },
-      data: { title: report.title, digest: truncateDigest(report.reportMarkdown) },
+      data: { title: report.title, digest: truncateTimelineRowDigest(report.reportMarkdown) },
     };
   }
 
@@ -271,7 +261,7 @@ function mapMessage(
       .join("\n");
 
     if (!machineAuthored) {
-      const digest = truncateDigest(text);
+      const digest = truncateTimelineRowDigest(text);
       return [
         {
           ts,
@@ -287,7 +277,7 @@ function mapMessage(
     // An unrecognized machine turn still belongs on the feed: its prompt is the only record of what
     // was dispatched on the agent's behalf.
     const row = classifyMachineTurn(event, text) ?? { kind: "turn.synthetic" };
-    const digest = row.data?.digest ?? truncateDigest(text);
+    const digest = row.data?.digest ?? truncateTimelineRowDigest(text);
     const data: TimelineEventData = { ...row.data, ...(digest !== "" ? { digest } : {}) };
     return [
       {

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -444,6 +444,28 @@ describe("TimelinePanel", () => {
     expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
   });
 
+  test("keeps default-titled updates whose digests differ", () => {
+    const events = [
+      makeEvent("update-late", "task.progress", 2, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Subagent (explore) update", digest: "Cache poisoning suspected" },
+        anchor: { taskId: "task-a", messageId: "msg-2", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update-early", "task.progress", 1, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Subagent (explore) update", digest: "Found a race in the loader" },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="update-late"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="update-early"]')).not.toBeNull();
+  });
+
   test("collapses duplicate update rows while keeping distinct checkpoints", () => {
     const events = [
       makeEvent("update-late", "task.progress", 4, {

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -422,9 +422,37 @@ describe("TimelinePanel", () => {
     expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
   });
 
-  test("keeps only the newest update row for an in-flight task", () => {
+  test("keeps earlier updates with distinct findings after the report lands", () => {
     const events = [
-      makeEvent("update-late", "task.progress", 3, {
+      makeEvent("report", "task.reported", 2, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { title: "Final summary", digest: "All checks pass" },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("finding", "task.progress", 1, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Important finding", digest: "Found a race in the loader" },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="finding"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
+  });
+
+  test("collapses duplicate update rows while keeping distinct checkpoints", () => {
+    const events = [
+      makeEvent("update-late", "task.progress", 4, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Second checkpoint" },
+        anchor: { taskId: "task-a", messageId: "msg-3", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update-dupe", "task.progress", 3, {
         source: { system: "task" },
         status: "started",
         data: { title: "Second checkpoint" },
@@ -446,7 +474,8 @@ describe("TimelinePanel", () => {
     const view = renderTimeline({ events });
 
     expect(view.container.querySelector('[data-timeline-event-id="update-late"]')).not.toBeNull();
-    expect(view.container.querySelector('[data-timeline-event-id="update-early"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="update-dupe"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="update-early"]')).not.toBeNull();
     expect(view.container.querySelector('[data-timeline-event-id="start"]')).toBeNull();
   });
 

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -466,6 +466,53 @@ describe("TimelinePanel", () => {
     expect(view.container.querySelector('[data-timeline-event-id="update-early"]')).not.toBeNull();
   });
 
+  test("drops an untitled update when the terminal report repeats its content", () => {
+    // Mapper update rows carry the producer fallback title; TaskService terminal rows omit it.
+    const events = [
+      makeEvent("report", "task.reported", 2, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { digest: "All timeline suites pass" },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update", "task.progress", 1, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Subagent (explore) update", digest: "All timeline suites pass" },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="update"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
+  });
+
+  test("drops an update whose report repeats it beyond the row digest cap", () => {
+    const reportMarkdown = "finding detail ".repeat(20).trim();
+    const rowCapped = `${reportMarkdown.slice(0, 117)}...`;
+    const events = [
+      makeEvent("report", "task.reported", 2, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { title: "Audit result", digest: reportMarkdown },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update", "task.progress", 1, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Audit result", digest: rowCapped },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="update"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
+  });
+
   test("collapses duplicate update rows while keeping distinct checkpoints", () => {
     const events = [
       makeEvent("update-late", "task.progress", 4, {

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -400,6 +400,56 @@ describe("TimelinePanel", () => {
     ).not.toBeNull();
   });
 
+  test("drops the sub-agent update row once the same task's report lands", () => {
+    const events = [
+      makeEvent("report", "task.reported", 2, {
+        source: { system: "task", key: "task-report:task-a" },
+        status: "completed",
+        data: { title: "Comment audit finding", digest: "No must-fix issues" },
+        anchor: { taskId: "task-a", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update", "task.progress", 1, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Comment audit finding", digest: "No must-fix issues" },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="update"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="report"]')).not.toBeNull();
+  });
+
+  test("keeps only the newest update row for an in-flight task", () => {
+    const events = [
+      makeEvent("update-late", "task.progress", 3, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "Second checkpoint" },
+        anchor: { taskId: "task-a", messageId: "msg-2", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("update-early", "task.progress", 2, {
+        source: { system: "task" },
+        status: "started",
+        data: { title: "First checkpoint" },
+        anchor: { taskId: "task-a", messageId: "msg-1", childWorkspaceId: "task-a" },
+      }),
+      makeEvent("start", "task.created", 1, {
+        source: { system: "task", key: "task-created:task-a" },
+        status: "started",
+        anchor: { taskId: "task-a", toolCallId: "call-a", childWorkspaceId: "task-a" },
+      }),
+    ];
+
+    const view = renderTimeline({ events });
+
+    expect(view.container.querySelector('[data-timeline-event-id="update-late"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="update-early"]')).toBeNull();
+    expect(view.container.querySelector('[data-timeline-event-id="start"]')).toBeNull();
+  });
+
   test("shows a single representation when the preview excerpt duplicates the digest", async () => {
     // Mirror the producer: a >120-char prompt is digested to a 117-char cut plus "...".
     const longPrompt = "alpha beta gamma delta epsilon ".repeat(8).trim();


### PR DESCRIPTION
## Summary

Extends the timeline's render-time deduplication so that redundant sub-agent "update" (`task.progress`) rows are dropped along with superseded "started" (`task.created`) rows, while updates that carry distinct findings stay visible.

## Background

PR #3861 suppressed superseded `task.created` rows, but a sub-agent that posts an in-progress report leaves a "Sub-agent update" row behind. When the terminal report lands moments later, both rows show with the same title, so every reporting sub-agent still produced near-duplicate feed entries.

## Implementation

`dropSupersededTaskStarts` is renamed to `dropSupersededTaskRows`:

- Started rows keep the PR #3861 rule: dropped once any newer lifecycle row for the task exists.
- Update rows dedupe by a canonical per-task content key: an update whose content reappears on a newer lifecycle row of the same task collapses, while updates with distinct findings stay, since a child may call `agent_report` several times with different content.
- The key canonicalizes across the two row producers, which disagree on defaults: mapper rows always carry a title (a producer fallback when the report was untitled) and a 120-cap digest, while TaskService-recorded terminal rows omit the title of an untitled report and keep up to 600 digest chars. Fallback titles are treated as absent via a matcher colocated with the producers' title builders (`subagentReportEnvelope.ts`), and digests are compared through the shared row cap (`truncateTimelineRowDigest`, also used by the mapper).
- Terminal rows (`reported`/`failed`/`interrupted`) are never dropped, since a reawakened persistent sub-agent can legitimately report more than once.
- Suppression stays render-time only, so it also cleans up already-written logs; the append-only timeline log is untouched.

## Validation

Every dedupe mechanism is guarded by a red-checked test: duplicates return with the drop condition reverted to `task.created` only, distinct findings are hidden with a blanket superseded-drop, default-titled updates with distinct digests collapse under a title-first key, the untitled cross-producer flow fails without fallback-title canonicalization, and long identical reports fail without digest-cap canonicalization.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
