### PR TITLE
🤖 feat: add shared agent-foundation layer (event spine, journal kit, sandbox host, capability grants)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -196,6 +196,7 @@ jobs:
             # when sharing the monolithic process; keep them in fresh isolated processes.
             src/node/services/workflows/WorkflowRunner.test.ts
             src/node/services/ptc/quickjsRuntime.test.ts
+            src/node/services/sandbox/sandboxHostService.test.ts
             src/node/orpc/router.test.ts
             src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
             src/browser/features/Messages/InlineSkillMarkdown.test.tsx

--- a/src/common/types/capabilityGrants.test.ts
+++ b/src/common/types/capabilityGrants.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { tool } from "ai";
+import { z } from "zod";
+import {
+  FULL_GRANTS,
+  LEAST_PRIVILEGE_GRANTS,
+  isBridgeToolGranted,
+  resolveCapabilityGrants,
+  type CapabilityGrants,
+} from "./capabilityGrants";
+import { applyCapabilityGrants } from "@/common/utils/tools/capabilityGrants";
+
+function makeTool(): ReturnType<typeof tool> {
+  return tool({
+    description: "t",
+    inputSchema: z.object({}),
+    execute: () => Promise.resolve({}),
+  });
+}
+
+describe("capability grants", () => {
+  test("session scope resolves to full grants; project scope to least privilege", () => {
+    expect(resolveCapabilityGrants({ scope: "session" })).toEqual(FULL_GRANTS);
+    expect(resolveCapabilityGrants({ scope: "project" })).toEqual(LEAST_PRIVILEGE_GRANTS);
+  });
+
+  test("isBridgeToolGranted honors allow-all and allow-lists", () => {
+    expect(isBridgeToolGranted(FULL_GRANTS, "bash")).toBe(true);
+    expect(isBridgeToolGranted(LEAST_PRIVILEGE_GRANTS, "bash")).toBe(false);
+
+    const narrow: CapabilityGrants = {
+      version: 1,
+      bridgeTools: { allow: ["file_read"] },
+      vars: false,
+      hostEvents: false,
+    };
+    expect(isBridgeToolGranted(narrow, "file_read")).toBe(true);
+    expect(isBridgeToolGranted(narrow, "bash")).toBe(false);
+  });
+
+  test("applyCapabilityGrants filters assembled tools (grant/deny branches)", () => {
+    const tools = { file_read: makeTool(), bash: makeTool(), web_fetch: makeTool() };
+
+    // Allow-all passes through untouched (same reference: zero-cost ceiling).
+    expect(applyCapabilityGrants(tools, FULL_GRANTS)).toBe(tools);
+
+    const narrow: CapabilityGrants = {
+      version: 1,
+      bridgeTools: { allow: ["file_read", "web_fetch"] },
+      vars: false,
+      hostEvents: false,
+    };
+    expect(Object.keys(applyCapabilityGrants(tools, narrow)).sort()).toEqual([
+      "file_read",
+      "web_fetch",
+    ]);
+
+    // Least privilege denies everything.
+    expect(Object.keys(applyCapabilityGrants(tools, LEAST_PRIVILEGE_GRANTS))).toEqual([]);
+  });
+});

--- a/src/common/types/capabilityGrants.test.ts
+++ b/src/common/types/capabilityGrants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tool } from "ai";
+import type { Tool } from "ai";
 import { z } from "zod";
 import {
   FULL_GRANTS,
@@ -10,12 +10,12 @@ import {
 } from "./capabilityGrants";
 import { applyCapabilityGrants } from "@/common/utils/tools/capabilityGrants";
 
-function makeTool(): ReturnType<typeof tool> {
-  return tool({
+function makeTool(): Tool {
+  return {
     description: "t",
     inputSchema: z.object({}),
     execute: () => Promise.resolve({}),
-  });
+  };
 }
 
 describe("capability grants", () => {

--- a/src/common/types/capabilityGrants.ts
+++ b/src/common/types/capabilityGrants.ts
@@ -1,0 +1,67 @@
+/**
+ * Capability grants (substrate 4 of the shared agent foundation): one small
+ * vocabulary for "what can this guest / hook / tool-set do".
+ *
+ * Enforced at two points:
+ * - the sandbox bridge boundary (ToolBridge filters + re-checks per call), and
+ * - tool assembly (applyCapabilityGrants filter over the assembled tool set).
+ *
+ * Scope model (surfaces through existing Project Trust concepts):
+ * - `session` scope: model-authored code running in the user's own session
+ *   (PTC code_execution). Gets the full bridge — matches pre-grants behavior.
+ * - `project` scope: repo-controlled code (future Tier-1 plugin hooks).
+ *   Defaults to least privilege; an untrusted project always resolves to
+ *   least privilege regardless of requested scope.
+ */
+
+export interface CapabilityGrants {
+  version: 1;
+  /** Which mux.* bridge tools the guest may invoke. */
+  bridgeTools: { allow: "all" } | { allow: readonly string[] };
+  /** Guest-visible persistent `vars` namespace. */
+  vars: boolean;
+  /** Host→guest event queue + drain. */
+  hostEvents: boolean;
+}
+
+/** Everything the session's own agent code may already do today. */
+export const FULL_GRANTS: CapabilityGrants = {
+  version: 1,
+  bridgeTools: { allow: "all" },
+  vars: true,
+  hostEvents: true,
+};
+
+/** Deny-by-default: no bridge tools, no vars, no host events. */
+export const LEAST_PRIVILEGE_GRANTS: CapabilityGrants = {
+  version: 1,
+  bridgeTools: { allow: [] },
+  vars: false,
+  hostEvents: false,
+};
+
+export interface ResolveCapabilityGrantsOptions {
+  /** Who authored the code the grants govern. */
+  scope: "session" | "project";
+}
+
+/**
+ * Resolve default grants from code scope. Session-scoped (model-authored)
+ * code keeps the full bridge; project-scoped (repo-controlled) code is least
+ * privilege — capabilities must be granted explicitly (e.g. via a future
+ * plugin manifest gated on Project Trust), never implicitly.
+ */
+export function resolveCapabilityGrants(options: ResolveCapabilityGrantsOptions): CapabilityGrants {
+  if (options.scope === "session") {
+    return FULL_GRANTS;
+  }
+  return LEAST_PRIVILEGE_GRANTS;
+}
+
+/** Check whether a mux.* bridge tool is granted. */
+export function isBridgeToolGranted(grants: CapabilityGrants, toolName: string): boolean {
+  if (grants.bridgeTools.allow === "all") {
+    return true;
+  }
+  return grants.bridgeTools.allow.includes(toolName);
+}

--- a/src/common/types/durableEvent.ts
+++ b/src/common/types/durableEvent.ts
@@ -1,0 +1,123 @@
+/**
+ * Durable agent event record schema — the joint design constraint shared by
+ * the plugin-architecture track (turn envelopes, hook-injected context) and
+ * the RLM track (refinement journal, offloaded result handles).
+ *
+ * Rows are appended to per-session JSONL journals via the journal kit
+ * (src/node/utils/journal/). Invariants:
+ * - "model-visible ⟺ logged": anything the model can see must exist as a
+ *   durable row first (append-time materialization, never request-time
+ *   injection), so log replay can reconstruct requests byte-for-byte.
+ * - Large payloads (full prompt text, offloaded values, vars snapshots) are
+ *   content-addressed in the blob store and referenced by BlobRef.
+ * - Readers are tolerant: malformed lines and unknown kinds are skipped
+ *   (self-heal doctrine), so new kinds can be added without breaking readers.
+ */
+
+import { z } from "zod";
+import { JsonValueSchema } from "@/common/orpc/schemas/workflow";
+
+export const DURABLE_EVENT_VERSION = 1;
+
+/** Reference into a content-addressed blob store: `sha256:<64 hex chars>`. */
+export const BlobRefSchema = z.string().regex(/^sha256:[0-9a-f]{64}$/);
+export type BlobRef = z.infer<typeof BlobRefSchema>;
+
+/**
+ * Turn envelope: the request fingerprint for one stream turn. Full prompt text
+ * is content-addressed; the row stores only hashes so envelope comparison is
+ * cheap and the journal stays small.
+ */
+export const TurnEnvelopeDataSchema = z.object({
+  systemPromptHash: BlobRefSchema,
+  /** Sorted by tool name; schemaHash fingerprints the tool's input schema. */
+  toolsetManifest: z.array(z.object({ name: z.string(), schemaHash: z.string() })),
+  modelString: z.string(),
+  providerOptionsHash: z.string(),
+  thinkingLevel: z.string(),
+});
+
+/**
+ * Refinement journal entry: an auditable, invertible harness edit.
+ * `data.kind` is the refinement's own taxonomy (e.g. "skill-edit"); the
+ * envelope `kind` stays the discriminator, which is why payloads are nested.
+ */
+export const RefinementDataSchema = z.object({
+  kind: z.string(),
+  action: JsonValueSchema,
+  inverse: JsonValueSchema,
+  evidence: JsonValueSchema.optional(),
+  /** Envelope `id` of the entry this one rolls back. */
+  rollbackOf: z.string().optional(),
+});
+
+/**
+ * Offloaded result handle: a large tool result stored instead of returned.
+ * The row is the durable source of the model-visible text (handle + preview +
+ * size), so "model-visible ⟺ logged" holds for offloads.
+ */
+export const ResultHandleDataSchema = z.object({
+  handle: z.string(),
+  preview: z.string(),
+  blobHash: BlobRefSchema,
+  size: z.number().int().nonnegative(),
+});
+
+/**
+ * Hook-injected context: content a hook adds to a request. Materialized at
+ * append time; exactly one of `text` (small) or `blobHash` (large) is set.
+ */
+export const HookContextDataSchema = z
+  .object({
+    hookId: z.string(),
+    /** Where the content lands, e.g. "system-prompt" or "user-context". */
+    placement: z.string(),
+    text: z.string().optional(),
+    blobHash: BlobRefSchema.optional(),
+  })
+  .refine((data) => (data.text === undefined) !== (data.blobHash === undefined), {
+    message: "hook-context requires exactly one of text or blobHash",
+  });
+
+/** Sandbox persistent-mount `vars` snapshot (JSON text stored in blob store). */
+export const SandboxVarsSnapshotDataSchema = z.object({
+  scopeKey: z.string(),
+  blobHash: BlobRefSchema,
+  size: z.number().int().nonnegative(),
+});
+
+/** Envelope shared by all durable agent events (one JSONL row each). */
+const envelopeBase = {
+  v: z.literal(DURABLE_EVENT_VERSION),
+  /** Per-journal monotonic sequence, assigned at append. */
+  seq: z.number().int().nonnegative(),
+  /** Stable unique id; dedupe key on read. */
+  id: z.string().min(1),
+  /** Epoch milliseconds. */
+  ts: z.number(),
+  workspaceId: z.string().min(1),
+};
+
+export const DurableEventSchema = z.discriminatedUnion("kind", [
+  z.object({ ...envelopeBase, kind: z.literal("turn-envelope"), data: TurnEnvelopeDataSchema }),
+  z.object({ ...envelopeBase, kind: z.literal("refinement"), data: RefinementDataSchema }),
+  z.object({ ...envelopeBase, kind: z.literal("result-handle"), data: ResultHandleDataSchema }),
+  z.object({ ...envelopeBase, kind: z.literal("hook-context"), data: HookContextDataSchema }),
+  z.object({
+    ...envelopeBase,
+    kind: z.literal("sandbox-vars-snapshot"),
+    data: SandboxVarsSnapshotDataSchema,
+  }),
+]);
+
+export type DurableEvent = z.infer<typeof DurableEventSchema>;
+export type DurableEventKind = DurableEvent["kind"];
+
+/** Omit that distributes over union members, preserving the discriminant pairing. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/** Fields callers provide to append; seq/ts/v are assigned by the journal kit
+ * (id too, unless the caller supplies a stable one). */
+export type DurableEventDraft = DistributiveOmit<DurableEvent, "v" | "seq" | "id" | "ts"> & {
+  id?: string;
+};

--- a/src/common/utils/tools/capabilityGrants.ts
+++ b/src/common/utils/tools/capabilityGrants.ts
@@ -1,0 +1,30 @@
+/**
+ * Tool-assembly enforcement of capability grants: the second of the two
+ * enforcement points (the first is the sandbox bridge boundary in
+ * src/node/services/ptc/toolBridge.ts). One vocabulary — CapabilityGrants —
+ * drives both, replacing hard-coded posture sets with a filter.
+ */
+
+import type { Tool } from "ai";
+import { isBridgeToolGranted, type CapabilityGrants } from "@/common/types/capabilityGrants";
+
+/**
+ * Filter an assembled tool set down to the granted tools. Grants are a
+ * ceiling: they only remove tools and compose with tool policy (which can
+ * narrow further but never re-add a non-granted tool).
+ */
+export function applyCapabilityGrants(
+  tools: Record<string, Tool>,
+  grants: CapabilityGrants
+): Record<string, Tool> {
+  if (grants.bridgeTools.allow === "all") {
+    return tools;
+  }
+  const filtered: Record<string, Tool> = {};
+  for (const [name, tool] of Object.entries(tools)) {
+    if (isBridgeToolGranted(grants, name)) {
+      filtered[name] = tool;
+    }
+  }
+  return filtered;
+}

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, unlink, writeFile } from "fs/promises";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import { PlatformPaths } from "@/common/utils/paths";
 import { log } from "@/node/services/log";
+import { eventSpine } from "@/node/services/events/eventSpine";
 import type { Config } from "@/node/config";
 import type { AIService } from "@/node/services/aiService";
 import type { HistoryService } from "@/node/services/historyService";
@@ -721,6 +722,7 @@ export class AgentSession {
 
     this.attachAiListeners();
     this.attachInitListeners();
+    eventSpine.emit("session.start", { workspaceId: this.workspaceId });
   }
 
   dispose(): void {
@@ -753,6 +755,7 @@ export class AgentSession {
     }
     this.initListeners.length = 0;
     this.emitter.removeAllListeners();
+    eventSpine.emit("session.end", { workspaceId: this.workspaceId });
   }
 
   onChatEvent(listener: (event: AgentSessionChatEvent) => void): () => void {
@@ -3027,6 +3030,13 @@ export class AgentSession {
           workspaceTurnMetadata: inheritedWorkspaceTurnMetadata,
         });
 
+        // Waterfall hook point: lets registered middleware (e.g. refinement
+        // journaling) run before context is compacted away. No-op when empty.
+        await eventSpine.run("compaction.prepare", {
+          workspaceId: this.workspaceId,
+          reason: "on-send",
+        });
+
         const autoCompactionRequest = this.buildAutoCompactionRequest({
           followUpContent,
           baseOptions: optionsForStream,
@@ -3879,6 +3889,12 @@ export class AgentSession {
         modelForStream: streamContext.modelString,
         muxMetadata: streamContext.workspaceTurnMetadata,
       });
+      // Waterfall hook point: see the on-send compaction.prepare run above.
+      await eventSpine.run("compaction.prepare", {
+        workspaceId: this.workspaceId,
+        reason: "mid-stream",
+      });
+
       const autoCompactionRequest = this.buildAutoCompactionRequest({
         followUpContent,
         baseOptions: streamContext.options,

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -174,6 +174,7 @@ import {
   type SimulationContext,
 } from "./streamSimulation";
 import { applyToolPolicyAndExperiments, captureMcpToolTelemetry } from "./toolAssembly";
+import { eventSpine, type RequestAssembleContext } from "@/node/services/events/eventSpine";
 import { getErrorMessage } from "@/common/utils/errors";
 import { validateJsonSchemaSubsetSchema } from "@/common/utils/jsonSchemaSubset";
 import { isTerminalWorkflowRunStatus } from "@/common/types/workflow";
@@ -2745,6 +2746,29 @@ export class AIService extends EventEmitter {
         const metadataModel = resolveModelForMetadata(modelString, requestProvidersConfig);
         const tokenizer = await getTokenizerForModel(modelString, metadataModel);
         systemMessageTokens = await tokenizer.countTokens(systemMessage);
+      }
+
+      // Waterfall hook point: registered middleware may rewrite the final system
+      // prompt or filter the toolset. Contract for future consumers: any content
+      // middleware adds to a request must exist as a durable event first
+      // (append-time materialization) — see eventSpine module docs. Gated on
+      // hasMiddleware so the empty-pipeline hot path skips ctx construction.
+      if (eventSpine.hasMiddleware("request.assemble")) {
+        const assembleCtx: RequestAssembleContext = {
+          workspaceId,
+          modelString,
+          systemMessage,
+          tools,
+        };
+        await eventSpine.run("request.assemble", assembleCtx);
+        tools = assembleCtx.tools;
+        if (assembleCtx.systemMessage !== systemMessage) {
+          systemMessage = assembleCtx.systemMessage;
+          // Keep context-size estimation accurate after middleware mutation.
+          const metadataModel = resolveModelForMetadata(modelString, requestProvidersConfig);
+          const tokenizer = await getTokenizerForModel(modelString, metadataModel);
+          systemMessageTokens = await tokenizer.countTokens(systemMessage);
+        }
       }
 
       // Re-activate deferred tools discovered by tool_catalog_search in earlier turns

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -176,6 +176,7 @@ import {
 import {
   applyToolPolicyAndExperiments,
   captureMcpToolTelemetry,
+  reconcileHookReplacedCodeExecution,
   retargetCodeExecution,
 } from "./toolAssembly";
 import { eventSpine, type RequestAssembleContext } from "@/node/services/events/eventSpine";
@@ -1085,11 +1086,21 @@ export class AIService extends EventEmitter {
     // the PRE-hook instance the wrapper delegates to. code_execution reads its
     // bridge late-bound at call time, so this retargets the wrapper's
     // delegation path (even a captured execute reference) to the post-hook
-    // toolset instead of leaving it closed over the stale bridge.
+    // toolset instead of leaving it closed over the stale bridge. Then
+    // reconcile model-facing metadata a spread-style wrapper inherited from
+    // the pre-hook instance (description advertising removed tools).
     if (hookReplacedCodeExecution && hookCodeExecution !== undefined) {
       const rebuiltCodeExecution = rebuilt.code_execution;
       if (rebuiltCodeExecution !== undefined && preHookTools.code_execution !== undefined) {
         await retargetCodeExecution(preHookTools.code_execution, rebuiltCodeExecution);
+        return {
+          ...rebuilt,
+          code_execution: reconcileHookReplacedCodeExecution(
+            preHookTools.code_execution,
+            hookCodeExecution,
+            rebuiltCodeExecution
+          ),
+        };
       }
       return { ...rebuilt, code_execution: hookCodeExecution };
     }

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -3429,6 +3429,30 @@ export class AIService extends EventEmitter {
                     nextSystemTokens = await nextTokenizer.countTokens(nextSystem);
                   }
 
+                  // Waterfall hook point: the fallback request is rebuilt from
+                  // scratch, so middleware-applied tool restrictions / prompt
+                  // context from the primary run would otherwise be lost — run
+                  // request.assemble over the rebuilt request too (see the
+                  // primary-path run above).
+                  if (eventSpine.hasMiddleware("request.assemble")) {
+                    const nextAssembleCtx: RequestAssembleContext = {
+                      workspaceId,
+                      modelString: nextModelString,
+                      systemMessage: nextSystem,
+                      tools: nextTools,
+                    };
+                    await eventSpine.run("request.assemble", nextAssembleCtx);
+                    nextTools = nextAssembleCtx.tools;
+                    if (nextAssembleCtx.systemMessage !== nextSystem) {
+                      nextSystem = nextAssembleCtx.systemMessage;
+                      const nextTokenizer = await getTokenizerForModel(
+                        nextModelString,
+                        nextCapabilityModelString
+                      );
+                      nextSystemTokens = await nextTokenizer.countTokens(nextSystem);
+                    }
+                  }
+
                   const { providerRequestMessages: nextProviderRequestMessages } =
                     prepareProviderRequestMessages(
                       fallbackSourceMessages,

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -173,7 +173,11 @@ import {
   simulateToolPolicyNoop,
   type SimulationContext,
 } from "./streamSimulation";
-import { applyToolPolicyAndExperiments, captureMcpToolTelemetry } from "./toolAssembly";
+import {
+  applyToolPolicyAndExperiments,
+  captureMcpToolTelemetry,
+  retargetCodeExecution,
+} from "./toolAssembly";
 import { eventSpine, type RequestAssembleContext } from "@/node/services/events/eventSpine";
 import { getErrorMessage } from "@/common/utils/errors";
 import { validateJsonSchemaSubsetSchema } from "@/common/utils/jsonSchemaSubset";
@@ -1038,9 +1042,11 @@ export class AIService extends EventEmitter {
    * same-name replacement such as an audit wrapper), the pre-hook
    * code_execution instance closes over a stale ToolBridge — rebuild it from
    * the post-hook record. When the hook replaced code_execution ITSELF, its
-   * replacement wins (never silently drop a middleware wrapper); such
-   * middleware owns bridge consistency for any other tool edits it makes in
-   * the same run.
+   * replacement wins (never silently drop a middleware wrapper) — but such a
+   * wrapper typically delegates to the PRE-hook instance, so that instance is
+   * retargeted in place onto the rebuilt bridge/mount. Delegation through the
+   * wrapper then reaches the post-hook toolset even when the wrapper captured
+   * the original execute function directly.
    */
   private async rebuildCodeExecutionAfterAssembleHook(opts: {
     preHookTools: Record<string, Tool>;
@@ -1075,8 +1081,16 @@ export class AIService extends EventEmitter {
       sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
     });
     // Reinstate a middleware-provided code_execution replacement over the
-    // freshly built instance.
+    // freshly built instance — but first graft the rebuilt bridge/mount onto
+    // the PRE-hook instance the wrapper delegates to. code_execution reads its
+    // bridge late-bound at call time, so this retargets the wrapper's
+    // delegation path (even a captured execute reference) to the post-hook
+    // toolset instead of leaving it closed over the stale bridge.
     if (hookReplacedCodeExecution && hookCodeExecution !== undefined) {
+      const rebuiltCodeExecution = rebuilt.code_execution;
+      if (rebuiltCodeExecution !== undefined && preHookTools.code_execution !== undefined) {
+        await retargetCodeExecution(preHookTools.code_execution, rebuiltCodeExecution);
+      }
       return { ...rebuilt, code_execution: hookCodeExecution };
     }
     return rebuilt;

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -3390,11 +3390,6 @@ export class AIService extends EventEmitter {
                       nextTools = rest;
                     }
                   }
-                  // Same active-set scoping as the primary sentinel: never
-                  // advertise deferred, not-yet-activated MCP tools.
-                  const nextToolNamesForSentinel = (
-                    computeActiveToolNames(toolSearchRuntime?.state) ?? Object.keys(nextTools)
-                  ).sort();
                   const nextMemoryToolAvailable = nextTools.memory !== undefined;
                   // Raw identity for prompt rebuilding too (the main path
                   // passes its raw modelString): "Model:"-scoped instructions
@@ -3452,6 +3447,15 @@ export class AIService extends EventEmitter {
                       nextSystemTokens = await nextTokenizer.countTokens(nextSystem);
                     }
                   }
+
+                  // Same active-set scoping as the primary sentinel: never
+                  // advertise deferred, not-yet-activated MCP tools. Computed
+                  // AFTER the request.assemble hook (like the primary path) so
+                  // transition guidance never advertises middleware-removed
+                  // tools.
+                  const nextToolNamesForSentinel = (
+                    computeActiveToolNames(toolSearchRuntime?.state) ?? Object.keys(nextTools)
+                  ).sort();
 
                   const { providerRequestMessages: nextProviderRequestMessages } =
                     prepareProviderRequestMessages(

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2755,7 +2755,10 @@ export class AIService extends EventEmitter {
       // (append-time materialization) — see eventSpine module docs. Gated on
       // hasMiddleware so the empty-pipeline hot path skips ctx construction.
       if (eventSpine.hasMiddleware("request.assemble")) {
-        const preHookToolNames = Object.keys(tools).sort().join(",");
+        // Shallow copy: detects added/removed names AND same-name
+        // replacements (e.g. middleware wrapping a tool with an audit check),
+        // which a key-only comparison would miss.
+        const preHookTools = { ...tools };
         const assembleCtx: RequestAssembleContext = {
           workspaceId,
           modelString,
@@ -2764,14 +2767,17 @@ export class AIService extends EventEmitter {
         };
         await eventSpine.run("request.assemble", assembleCtx);
         tools = assembleCtx.tools;
+        const toolsetChanged =
+          Object.keys(tools).length !== Object.keys(preHookTools).length ||
+          Object.entries(tools).some(([name, t]) => preHookTools[name] !== t);
         // Supplement-mode PTC: the code_execution instance created during
         // assembly closes over a ToolBridge built from the PRE-hook toolset
-        // (and its description advertises those tools), so a hook-removed
-        // bridgeable tool would remain reachable via mux.*. Rebuild
-        // code_execution from the post-hook record. Exclusive mode is
+        // (and its description advertises those tools), so a hook-removed or
+        // hook-replaced bridgeable tool would remain reachable via mux.*.
+        // Rebuild code_execution from the post-hook record. Exclusive mode is
         // unaffected: bridgeable tools are not in the hook-visible record.
         if (
-          Object.keys(tools).sort().join(",") !== preHookToolNames &&
+          toolsetChanged &&
           experiments?.programmaticToolCalling === true &&
           experiments?.programmaticToolCallingExclusive !== true &&
           tools.code_execution !== undefined
@@ -3464,7 +3470,9 @@ export class AIService extends EventEmitter {
                   // request.assemble over the rebuilt request too (see the
                   // primary-path run above).
                   if (eventSpine.hasMiddleware("request.assemble")) {
-                    const preHookNextToolNames = Object.keys(nextTools).sort().join(",");
+                    // Shallow copy: same identity-aware change detection as
+                    // the primary path (names AND same-name replacements).
+                    const preHookNextTools = { ...nextTools };
                     const nextAssembleCtx: RequestAssembleContext = {
                       workspaceId,
                       modelString: nextModelString,
@@ -3473,11 +3481,14 @@ export class AIService extends EventEmitter {
                     };
                     await eventSpine.run("request.assemble", nextAssembleCtx);
                     nextTools = nextAssembleCtx.tools;
-                    // Same rebuild as the primary path: hook-removed tools
-                    // must not stay reachable via a stale code_execution
-                    // bridge (supplement mode only).
+                    const nextToolsetChanged =
+                      Object.keys(nextTools).length !== Object.keys(preHookNextTools).length ||
+                      Object.entries(nextTools).some(([name, t]) => preHookNextTools[name] !== t);
+                    // Same rebuild as the primary path: hook-removed or
+                    // hook-replaced tools must not stay reachable via a stale
+                    // code_execution bridge (supplement mode only).
                     if (
-                      Object.keys(nextTools).sort().join(",") !== preHookNextToolNames &&
+                      nextToolsetChanged &&
                       experiments?.programmaticToolCalling === true &&
                       experiments?.programmaticToolCallingExclusive !== true &&
                       nextTools.code_execution !== undefined

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1032,6 +1032,56 @@ export class AIService extends EventEmitter {
     });
   }
 
+  /**
+   * Supplement-mode PTC reconcile after the request.assemble waterfall: when
+   * middleware changed any tool the bridge exposes (added/removed names OR a
+   * same-name replacement such as an audit wrapper), the pre-hook
+   * code_execution instance closes over a stale ToolBridge — rebuild it from
+   * the post-hook record. When the hook replaced code_execution ITSELF, its
+   * replacement wins (never silently drop a middleware wrapper); such
+   * middleware owns bridge consistency for any other tool edits it makes in
+   * the same run.
+   */
+  private async rebuildCodeExecutionAfterAssembleHook(opts: {
+    preHookTools: Record<string, Tool>;
+    postHookTools: Record<string, Tool>;
+    effectiveToolPolicy: ToolPolicy | undefined;
+    experiments: SendMessageOptions["experiments"];
+    emitNestedToolEvent: (event: PTCEventWithParent) => void;
+    workspaceId: string;
+  }): Promise<Record<string, Tool>> {
+    const { preHookTools, postHookTools, workspaceId } = opts;
+    const hookReplacedCodeExecution =
+      postHookTools.code_execution !== undefined &&
+      preHookTools.code_execution !== undefined &&
+      postHookTools.code_execution !== preHookTools.code_execution;
+    // Identity-aware change detection over everything EXCEPT code_execution
+    // (the instance this rebuild replaces): names and same-name replacements.
+    const bridgeRelevantChanged =
+      Object.keys(postHookTools).filter((n) => n !== "code_execution").length !==
+        Object.keys(preHookTools).filter((n) => n !== "code_execution").length ||
+      Object.entries(postHookTools).some(
+        ([name, t]) => name !== "code_execution" && preHookTools[name] !== t
+      );
+    if (!bridgeRelevantChanged) {
+      return postHookTools;
+    }
+    const { code_execution: hookCodeExecution, ...bridgeInputTools } = postHookTools;
+    const rebuilt = await applyToolPolicyAndExperiments({
+      allTools: bridgeInputTools,
+      effectiveToolPolicy: opts.effectiveToolPolicy,
+      experiments: opts.experiments,
+      emitNestedToolEvent: opts.emitNestedToolEvent,
+      sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
+    });
+    // Reinstate a middleware-provided code_execution replacement over the
+    // freshly built instance.
+    if (hookReplacedCodeExecution && hookCodeExecution !== undefined) {
+      return { ...rebuilt, code_execution: hookCodeExecution };
+    }
+    return rebuilt;
+  }
+
   private wrapToolsForDelegation(
     workspaceId: string,
     tools: Record<string, Tool>,
@@ -2767,9 +2817,6 @@ export class AIService extends EventEmitter {
         };
         await eventSpine.run("request.assemble", assembleCtx);
         tools = assembleCtx.tools;
-        const toolsetChanged =
-          Object.keys(tools).length !== Object.keys(preHookTools).length ||
-          Object.entries(tools).some(([name, t]) => preHookTools[name] !== t);
         // Supplement-mode PTC: the code_execution instance created during
         // assembly closes over a ToolBridge built from the PRE-hook toolset
         // (and its description advertises those tools), so a hook-removed or
@@ -2777,18 +2824,17 @@ export class AIService extends EventEmitter {
         // Rebuild code_execution from the post-hook record. Exclusive mode is
         // unaffected: bridgeable tools are not in the hook-visible record.
         if (
-          toolsetChanged &&
           experiments?.programmaticToolCalling === true &&
           experiments?.programmaticToolCallingExclusive !== true &&
           tools.code_execution !== undefined
         ) {
-          const { code_execution: _staleCodeExecution, ...postHookTools } = tools;
-          tools = await applyToolPolicyAndExperiments({
-            allTools: postHookTools,
+          tools = await this.rebuildCodeExecutionAfterAssembleHook({
+            preHookTools,
+            postHookTools: tools,
             effectiveToolPolicy,
             experiments,
             emitNestedToolEvent: emitNestedPtcToolEvent,
-            sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
+            workspaceId,
           });
         }
         // Tool-search state was classified from the pre-hook record; a hook
@@ -3481,29 +3527,21 @@ export class AIService extends EventEmitter {
                     };
                     await eventSpine.run("request.assemble", nextAssembleCtx);
                     nextTools = nextAssembleCtx.tools;
-                    const nextToolsetChanged =
-                      Object.keys(nextTools).length !== Object.keys(preHookNextTools).length ||
-                      Object.entries(nextTools).some(([name, t]) => preHookNextTools[name] !== t);
                     // Same rebuild as the primary path: hook-removed or
                     // hook-replaced tools must not stay reachable via a stale
                     // code_execution bridge (supplement mode only).
                     if (
-                      nextToolsetChanged &&
                       experiments?.programmaticToolCalling === true &&
                       experiments?.programmaticToolCallingExclusive !== true &&
                       nextTools.code_execution !== undefined
                     ) {
-                      const { code_execution: _staleNextCodeExecution, ...postHookNextTools } =
-                        nextTools;
-                      nextTools = await applyToolPolicyAndExperiments({
-                        allTools: postHookNextTools,
+                      nextTools = await this.rebuildCodeExecutionAfterAssembleHook({
+                        preHookTools: preHookNextTools,
+                        postHookTools: nextTools,
                         effectiveToolPolicy,
                         experiments,
                         emitNestedToolEvent: emitNestedPtcToolEvent,
-                        sandbox: {
-                          workspaceId,
-                          sessionDir: this.config.getSessionDir(workspaceId),
-                        },
+                        workspaceId,
                       });
                     }
                     // Same reconcile as the primary path: tool-search state

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2763,6 +2763,18 @@ export class AIService extends EventEmitter {
         };
         await eventSpine.run("request.assemble", assembleCtx);
         tools = assembleCtx.tools;
+        // Tool-search state was classified from the pre-hook record; a hook
+        // that added/removed tools would leave allToolNames/deferred/active
+        // sets stale (prepareStep scoping + sentinel names both read them).
+        // Rebuild in place so the state describes the post-hook toolset.
+        if (toolSearchRuntime?.state) {
+          tools = rebuildToolSearchState(toolSearchRuntime.state, {
+            tools,
+            mcpToolNames: Object.keys(mcpTools ?? {}),
+            toolPolicy: effectiveToolPolicy,
+            ptcEnabled,
+          }).tools;
+        }
         if (assembleCtx.systemMessage !== systemMessage) {
           systemMessage = assembleCtx.systemMessage;
           // Keep context-size estimation accurate after middleware mutation.
@@ -3438,6 +3450,16 @@ export class AIService extends EventEmitter {
                     };
                     await eventSpine.run("request.assemble", nextAssembleCtx);
                     nextTools = nextAssembleCtx.tools;
+                    // Same reconcile as the primary path: tool-search state
+                    // must describe the post-hook toolset.
+                    if (toolSearchRuntime?.state) {
+                      nextTools = rebuildToolSearchState(toolSearchRuntime.state, {
+                        tools: nextTools,
+                        mcpToolNames: Object.keys(mcpTools ?? {}),
+                        toolPolicy: effectiveToolPolicy,
+                        ptcEnabled,
+                      }).tools;
+                    }
                     if (nextAssembleCtx.systemMessage !== nextSystem) {
                       nextSystem = nextAssembleCtx.systemMessage;
                       const nextTokenizer = await getTokenizerForModel(

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2668,6 +2668,7 @@ export class AIService extends EventEmitter {
         effectiveToolPolicy,
         experiments,
         emitNestedToolEvent: emitNestedPtcToolEvent,
+        sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
       });
       recordStartupPhaseTiming(
         "applyToolPolicyAndExperimentsMs",
@@ -3364,6 +3365,7 @@ export class AIService extends EventEmitter {
                     effectiveToolPolicy,
                     experiments,
                     emitNestedToolEvent: emitNestedPtcToolEvent,
+                    sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
                   });
                   // Tool search: keep the per-stream state consistent with the
                   // fallback model's re-assembled toolset. rebuildToolSearchState

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2755,6 +2755,7 @@ export class AIService extends EventEmitter {
       // (append-time materialization) — see eventSpine module docs. Gated on
       // hasMiddleware so the empty-pipeline hot path skips ctx construction.
       if (eventSpine.hasMiddleware("request.assemble")) {
+        const preHookToolNames = Object.keys(tools).sort().join(",");
         const assembleCtx: RequestAssembleContext = {
           workspaceId,
           modelString,
@@ -2763,6 +2764,27 @@ export class AIService extends EventEmitter {
         };
         await eventSpine.run("request.assemble", assembleCtx);
         tools = assembleCtx.tools;
+        // Supplement-mode PTC: the code_execution instance created during
+        // assembly closes over a ToolBridge built from the PRE-hook toolset
+        // (and its description advertises those tools), so a hook-removed
+        // bridgeable tool would remain reachable via mux.*. Rebuild
+        // code_execution from the post-hook record. Exclusive mode is
+        // unaffected: bridgeable tools are not in the hook-visible record.
+        if (
+          Object.keys(tools).sort().join(",") !== preHookToolNames &&
+          experiments?.programmaticToolCalling === true &&
+          experiments?.programmaticToolCallingExclusive !== true &&
+          tools.code_execution !== undefined
+        ) {
+          const { code_execution: _staleCodeExecution, ...postHookTools } = tools;
+          tools = await applyToolPolicyAndExperiments({
+            allTools: postHookTools,
+            effectiveToolPolicy,
+            experiments,
+            emitNestedToolEvent: emitNestedPtcToolEvent,
+            sandbox: { workspaceId, sessionDir: this.config.getSessionDir(workspaceId) },
+          });
+        }
         // Tool-search state was classified from the pre-hook record; a hook
         // that added/removed tools would leave allToolNames/deferred/active
         // sets stale (prepareStep scoping + sentinel names both read them).
@@ -3442,6 +3464,7 @@ export class AIService extends EventEmitter {
                   // request.assemble over the rebuilt request too (see the
                   // primary-path run above).
                   if (eventSpine.hasMiddleware("request.assemble")) {
+                    const preHookNextToolNames = Object.keys(nextTools).sort().join(",");
                     const nextAssembleCtx: RequestAssembleContext = {
                       workspaceId,
                       modelString: nextModelString,
@@ -3450,6 +3473,28 @@ export class AIService extends EventEmitter {
                     };
                     await eventSpine.run("request.assemble", nextAssembleCtx);
                     nextTools = nextAssembleCtx.tools;
+                    // Same rebuild as the primary path: hook-removed tools
+                    // must not stay reachable via a stale code_execution
+                    // bridge (supplement mode only).
+                    if (
+                      Object.keys(nextTools).sort().join(",") !== preHookNextToolNames &&
+                      experiments?.programmaticToolCalling === true &&
+                      experiments?.programmaticToolCallingExclusive !== true &&
+                      nextTools.code_execution !== undefined
+                    ) {
+                      const { code_execution: _staleNextCodeExecution, ...postHookNextTools } =
+                        nextTools;
+                      nextTools = await applyToolPolicyAndExperiments({
+                        allTools: postHookNextTools,
+                        effectiveToolPolicy,
+                        experiments,
+                        emitNestedToolEvent: emitNestedPtcToolEvent,
+                        sandbox: {
+                          workspaceId,
+                          sessionDir: this.config.getSessionDir(workspaceId),
+                        },
+                      });
+                    }
                     // Same reconcile as the primary path: tool-search state
                     // must describe the post-hook toolset.
                     if (toolSearchRuntime?.state) {

--- a/src/node/services/events/eventSpine.test.ts
+++ b/src/node/services/events/eventSpine.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import { EventSpine, type ToolExecuteContext, type ToolExecutionHost } from "./eventSpine";
 import type { Runtime } from "@/node/runtime/Runtime";
 
+// The spine never touches the host runtime; a null-backed stub is sufficient.
+const stubRuntime = null as unknown as Runtime;
+
 function makeToolCtx(overrides?: Partial<ToolExecuteContext>): ToolExecuteContext {
-  // The spine never touches the host; a stub is sufficient for pipeline tests.
   const host: ToolExecutionHost = {
-    runtime: {} as Runtime,
+    runtime: stubRuntime,
     runtimeTempDir: "/tmp",
     cwd: "/tmp",
     workspaceId: "ws-test",
@@ -17,7 +19,7 @@ describe("EventSpine waterfall", () => {
   test("runs terminal when no middleware is registered", async () => {
     const spine = new EventSpine();
     const ctx = makeToolCtx();
-    await spine.run("tool.execute", ctx, async (c) => {
+    await spine.run("tool.execute", ctx, (c) => {
       c.result = "ran";
       c.executed = true;
     });
@@ -38,7 +40,7 @@ describe("EventSpine waterfall", () => {
       await next();
       calls.push("b:after");
     });
-    await spine.run("tool.execute", makeToolCtx(), async () => {
+    await spine.run("tool.execute", makeToolCtx(), () => {
       calls.push("terminal");
     });
     expect(calls).toEqual(["a:before", "b:before", "terminal", "b:after", "a:after"]);
@@ -70,7 +72,7 @@ describe("EventSpine waterfall", () => {
   test("blocking middleware skips terminal and downstream middleware", async () => {
     const spine = new EventSpine();
     const calls: string[] = [];
-    spine.use("tool.execute", async (ctx, _next) => {
+    spine.use("tool.execute", (ctx, _next) => {
       ctx.blocked = { result: { error: "denied" } };
       calls.push("blocker");
     });
@@ -79,7 +81,7 @@ describe("EventSpine waterfall", () => {
       await next();
     });
     const ctx = makeToolCtx();
-    await spine.run("tool.execute", ctx, async () => {
+    await spine.run("tool.execute", ctx, () => {
       calls.push("terminal");
     });
     expect(calls).toEqual(["blocker"]);
@@ -95,7 +97,7 @@ describe("EventSpine waterfall", () => {
       ctx.result = `${String(ctx.result)}+audited`;
     });
     const ctx = makeToolCtx();
-    await spine.run("tool.execute", ctx, async (c) => {
+    await spine.run("tool.execute", ctx, (c) => {
       c.result = `ran(${JSON.stringify(c.args)})`;
       c.executed = true;
     });
@@ -108,9 +110,12 @@ describe("EventSpine waterfall", () => {
       await next();
       await next();
     });
-    await expect(spine.run("tool.execute", makeToolCtx())).rejects.toThrow(
-      /called next\(\) more than once/
-    );
+    try {
+      await spine.run("tool.execute", makeToolCtx());
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("called next() more than once");
+    }
   });
 
   test("useBefore/useAfter sugar wraps the pipeline; after is skipped when blocked", async () => {
@@ -126,7 +131,7 @@ describe("EventSpine waterfall", () => {
       calls.push("after");
     });
 
-    await spine.run("tool.execute", makeToolCtx(), async (c) => {
+    await spine.run("tool.execute", makeToolCtx(), (c) => {
       calls.push("terminal");
       c.executed = true;
     });
@@ -134,7 +139,7 @@ describe("EventSpine waterfall", () => {
 
     calls.length = 0;
     const blockedCtx = makeToolCtx({ toolName: "blocked_tool" });
-    await spine.run("tool.execute", blockedCtx, async (c) => {
+    await spine.run("tool.execute", blockedCtx, (c) => {
       calls.push("terminal");
       c.executed = true;
     });

--- a/src/node/services/events/eventSpine.test.ts
+++ b/src/node/services/events/eventSpine.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { EventSpine, type ToolExecuteContext, type ToolExecutionHost } from "./eventSpine";
+import type { Runtime } from "@/node/runtime/Runtime";
+
+function makeToolCtx(overrides?: Partial<ToolExecuteContext>): ToolExecuteContext {
+  // The spine never touches the host; a stub is sufficient for pipeline tests.
+  const host: ToolExecutionHost = {
+    runtime: {} as Runtime,
+    runtimeTempDir: "/tmp",
+    cwd: "/tmp",
+    workspaceId: "ws-test",
+  };
+  return { toolName: "test_tool", args: { a: 1 }, host, executed: false, ...overrides };
+}
+
+describe("EventSpine waterfall", () => {
+  test("runs terminal when no middleware is registered", async () => {
+    const spine = new EventSpine();
+    const ctx = makeToolCtx();
+    await spine.run("tool.execute", ctx, async (c) => {
+      c.result = "ran";
+      c.executed = true;
+    });
+    expect(ctx.result).toBe("ran");
+    expect(ctx.executed).toBe(true);
+  });
+
+  test("middleware composes around the terminal in registration order", async () => {
+    const spine = new EventSpine();
+    const calls: string[] = [];
+    spine.use("tool.execute", async (_ctx, next) => {
+      calls.push("a:before");
+      await next();
+      calls.push("a:after");
+    });
+    spine.use("tool.execute", async (_ctx, next) => {
+      calls.push("b:before");
+      await next();
+      calls.push("b:after");
+    });
+    await spine.run("tool.execute", makeToolCtx(), async () => {
+      calls.push("terminal");
+    });
+    expect(calls).toEqual(["a:before", "b:before", "terminal", "b:after", "a:after"]);
+  });
+
+  test("explicit order overrides registration order", async () => {
+    const spine = new EventSpine();
+    const calls: string[] = [];
+    spine.use(
+      "tool.execute",
+      async (_ctx, next) => {
+        calls.push("late");
+        await next();
+      },
+      { order: 10 }
+    );
+    spine.use(
+      "tool.execute",
+      async (_ctx, next) => {
+        calls.push("early");
+        await next();
+      },
+      { order: -10 }
+    );
+    await spine.run("tool.execute", makeToolCtx());
+    expect(calls).toEqual(["early", "late"]);
+  });
+
+  test("blocking middleware skips terminal and downstream middleware", async () => {
+    const spine = new EventSpine();
+    const calls: string[] = [];
+    spine.use("tool.execute", async (ctx, _next) => {
+      ctx.blocked = { result: { error: "denied" } };
+      calls.push("blocker");
+    });
+    spine.use("tool.execute", async (_ctx, next) => {
+      calls.push("downstream");
+      await next();
+    });
+    const ctx = makeToolCtx();
+    await spine.run("tool.execute", ctx, async () => {
+      calls.push("terminal");
+    });
+    expect(calls).toEqual(["blocker"]);
+    expect(ctx.blocked?.result).toEqual({ error: "denied" });
+    expect(ctx.executed).toBe(false);
+  });
+
+  test("middleware may rewrite args before terminal and result after", async () => {
+    const spine = new EventSpine();
+    spine.use("tool.execute", async (ctx, next) => {
+      ctx.args = { a: 2 };
+      await next();
+      ctx.result = `${String(ctx.result)}+audited`;
+    });
+    const ctx = makeToolCtx();
+    await spine.run("tool.execute", ctx, async (c) => {
+      c.result = `ran(${JSON.stringify(c.args)})`;
+      c.executed = true;
+    });
+    expect(ctx.result).toBe('ran({"a":2})+audited');
+  });
+
+  test("calling next() twice throws", async () => {
+    const spine = new EventSpine();
+    spine.use("tool.execute", async (_ctx, next) => {
+      await next();
+      await next();
+    });
+    await expect(spine.run("tool.execute", makeToolCtx())).rejects.toThrow(
+      /called next\(\) more than once/
+    );
+  });
+
+  test("useBefore/useAfter sugar wraps the pipeline; after is skipped when blocked", async () => {
+    const spine = new EventSpine();
+    const calls: string[] = [];
+    spine.useBefore("tool.execute", (ctx) => {
+      calls.push("before");
+      if (ctx.toolName === "blocked_tool") {
+        ctx.blocked = { result: { error: "no" } };
+      }
+    });
+    spine.useAfter("tool.execute", () => {
+      calls.push("after");
+    });
+
+    await spine.run("tool.execute", makeToolCtx(), async (c) => {
+      calls.push("terminal");
+      c.executed = true;
+    });
+    expect(calls).toEqual(["before", "terminal", "after"]);
+
+    calls.length = 0;
+    const blockedCtx = makeToolCtx({ toolName: "blocked_tool" });
+    await spine.run("tool.execute", blockedCtx, async (c) => {
+      calls.push("terminal");
+      c.executed = true;
+    });
+    expect(calls).toEqual(["before"]);
+    expect(blockedCtx.executed).toBe(false);
+  });
+
+  test("unregister removes middleware", async () => {
+    const spine = new EventSpine();
+    const calls: string[] = [];
+    const unregister = spine.use("tool.execute", async (_ctx, next) => {
+      calls.push("mw");
+      await next();
+    });
+    expect(spine.hasMiddleware("tool.execute")).toBe(true);
+    unregister();
+    expect(spine.hasMiddleware("tool.execute")).toBe(false);
+    await spine.run("tool.execute", makeToolCtx());
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("EventSpine observers", () => {
+  test("fan-out delivers payloads and unsubscribe stops delivery", () => {
+    const spine = new EventSpine();
+    const seen: string[] = [];
+    const unsubscribe = spine.subscribe("workspace.created", (p) => seen.push(p.workspaceId));
+    spine.emit("workspace.created", { workspaceId: "ws-1" });
+    unsubscribe();
+    spine.emit("workspace.created", { workspaceId: "ws-2" });
+    expect(seen).toEqual(["ws-1"]);
+  });
+
+  test("a throwing observer does not break the emitter or other observers", () => {
+    const spine = new EventSpine();
+    const seen: string[] = [];
+    spine.subscribe("stream.start", () => {
+      throw new Error("bad observer");
+    });
+    spine.subscribe("stream.start", (p) => seen.push(p.messageId));
+    expect(() => spine.emit("stream.start", { workspaceId: "ws", messageId: "m1" })).not.toThrow();
+    expect(seen).toEqual(["m1"]);
+  });
+});

--- a/src/node/services/events/eventSpine.test.ts
+++ b/src/node/services/events/eventSpine.test.ts
@@ -183,4 +183,19 @@ describe("EventSpine observers", () => {
     expect(() => spine.emit("stream.start", { workspaceId: "ws", messageId: "m1" })).not.toThrow();
     expect(seen).toEqual(["m1"]);
   });
+
+  test("a rejecting async observer does not break the emitter or other observers", async () => {
+    const spine = new EventSpine();
+    const seen: string[] = [];
+    spine.subscribe("stream.start", async () => {
+      await Promise.resolve();
+      throw new Error("bad async observer");
+    });
+    spine.subscribe("stream.start", (p) => seen.push(p.messageId));
+    expect(() => spine.emit("stream.start", { workspaceId: "ws", messageId: "m1" })).not.toThrow();
+    expect(seen).toEqual(["m1"]);
+    // Let the rejection settle: it must be captured (logged), not surface as
+    // an unhandled rejection that could take down the main process.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 });

--- a/src/node/services/events/eventSpine.ts
+++ b/src/node/services/events/eventSpine.ts
@@ -102,7 +102,8 @@ export interface WaterfallPointMap {
 }
 
 export type WaterfallNext = () => Promise<void>;
-export type WaterfallMiddleware<C> = (ctx: C, next: WaterfallNext) => Promise<void>;
+/** Middleware may be sync or async; the runner awaits either way. */
+export type WaterfallMiddleware<C> = (ctx: C, next: WaterfallNext) => void | Promise<void>;
 
 /** Simple callback shape used by the before/after registration sugar. */
 export type HookCallback<C> = (ctx: C) => void | Promise<void>;
@@ -238,7 +239,7 @@ export class EventSpine {
   async run<K extends keyof WaterfallPointMap>(
     point: K,
     ctx: WaterfallPointMap[K],
-    terminal?: (ctx: WaterfallPointMap[K]) => Promise<void>
+    terminal?: (ctx: WaterfallPointMap[K]) => void | Promise<void>
   ): Promise<void> {
     const registrations = this.waterfalls.get(point) ?? [];
     const dispatch = async (index: number): Promise<void> => {

--- a/src/node/services/events/eventSpine.ts
+++ b/src/node/services/events/eventSpine.ts
@@ -1,0 +1,268 @@
+/**
+ * Typed event spine for the main process.
+ *
+ * dsh-inspired three-way event split (shared foundation for the plugin and RLM
+ * experiment tracks):
+ *
+ * - **Durable events**: rows appended to session journals. The spine does not
+ *   persist anything itself — see the record schema in
+ *   `src/common/types/durableEvent.ts` and the append/read utilities in
+ *   `src/node/utils/journal/`.
+ * - **Live waterfall hooks**: ordered, mutating, async middleware (next()-style)
+ *   around tool execution and request assembly. Middleware may rewrite the
+ *   context before calling `next()` and may rewrite results after it returns.
+ * - **Observer events**: read-only fan-out of lifecycle facts. Listeners must
+ *   not mutate anything on the hot path; thrown errors are logged and swallowed
+ *   so a bad observer can never break the emitting code path.
+ *
+ * The tool-execution pipeline is around-style: `run("tool.execute", ctx,
+ * terminal)` composes middleware around a terminal that executes the tool.
+ * This models the legacy `.mux/tool_hook` protocol (which inherently wraps
+ * execution) with the same primitive as pre/post hooks. The handoff's
+ * `tool.execute.before` / `tool.execute.after` vocabulary is exposed as
+ * first-class registration sugar that composes onto the around pipeline.
+ */
+
+import assert from "node:assert";
+import { EventEmitter } from "node:events";
+import type { Tool } from "ai";
+import type { Runtime } from "@/node/runtime/Runtime";
+import { log } from "@/node/services/log";
+
+// ---------------------------------------------------------------------------
+// Observer events (read-only fan-out)
+// ---------------------------------------------------------------------------
+
+export interface ObserverEventMap {
+  "workspace.created": { workspaceId: string };
+  "workspace.archived": { workspaceId: string };
+  /** A sub-agent task delivered its terminal report. */
+  "task.reported": { workspaceId: string; taskId: string };
+  /** AgentSession lifecycle. Construction/disposal are synchronous, so session
+   * lifecycle is observer-only for now; a waterfall variant can be added when a
+   * mutating consumer lands. */
+  "session.start": { workspaceId: string };
+  "session.end": { workspaceId: string };
+  "stream.start": { workspaceId: string; messageId: string };
+  "stream.end": { workspaceId: string; messageId: string };
+}
+
+// ---------------------------------------------------------------------------
+// Waterfall hook points (ordered, mutating, async middleware)
+// ---------------------------------------------------------------------------
+
+/** Host execution context a tool runs in (shell hooks need all of these). */
+export interface ToolExecutionHost {
+  runtime: Runtime;
+  /** Runtime temp dir for hook scratch files (paths in the runtime's context). */
+  runtimeTempDir: string;
+  /** Working directory where hooks are discovered. */
+  cwd: string;
+  workspaceId: string;
+  /** Additional environment variables to pass to hooks. */
+  env?: Record<string, string>;
+}
+
+export interface ToolExecuteContext {
+  readonly toolName: string;
+  /** Mutable before the terminal runs: middleware may rewrite tool args. */
+  args: unknown;
+  readonly host: ToolExecutionHost;
+  readonly abortSignal?: AbortSignal;
+  /** Set by the terminal after the tool actually executed. */
+  executed: boolean;
+  /** Set by the terminal; mutable after next() returns (middleware may augment). */
+  result?: unknown;
+  /**
+   * Set by middleware to block tool execution; the pipeline skips the terminal
+   * and `blocked.result` is returned to the model. Middleware that sets this
+   * must not call next().
+   */
+  blocked?: { result: unknown };
+}
+
+export interface RequestAssembleContext {
+  readonly workspaceId: string;
+  readonly modelString: string;
+  /** Mutable: final system prompt text sent to the provider. */
+  systemMessage: string;
+  /** Mutable: final toolset for the request (middleware may filter). */
+  tools: Record<string, Tool>;
+}
+
+export interface CompactionPrepareContext {
+  readonly workspaceId: string;
+  readonly reason: "on-send" | "mid-stream";
+}
+
+export interface WaterfallPointMap {
+  "tool.execute": ToolExecuteContext;
+  "request.assemble": RequestAssembleContext;
+  "compaction.prepare": CompactionPrepareContext;
+}
+
+export type WaterfallNext = () => Promise<void>;
+export type WaterfallMiddleware<C> = (ctx: C, next: WaterfallNext) => Promise<void>;
+
+/** Simple callback shape used by the before/after registration sugar. */
+export type HookCallback<C> = (ctx: C) => void | Promise<void>;
+
+interface Registration {
+  // Stored type-erased; `use()` is the only writer and it is fully typed.
+  middleware: WaterfallMiddleware<unknown>;
+  order: number;
+  seq: number;
+}
+
+/** Duck-check for contexts that support blocking (currently tool.execute). */
+function isBlocked(ctx: unknown): boolean {
+  return (
+    typeof ctx === "object" &&
+    ctx !== null &&
+    "blocked" in ctx &&
+    (ctx as { blocked?: unknown }).blocked != null
+  );
+}
+
+export class EventSpine {
+  private readonly observers = new EventEmitter();
+  private readonly waterfalls = new Map<string, Registration[]>();
+  private registrationSeq = 0;
+
+  constructor() {
+    // Unbounded read-only fan-out; listener count is not a leak signal here.
+    this.observers.setMaxListeners(0);
+  }
+
+  // --- Observer events ---
+
+  emit<K extends keyof ObserverEventMap>(event: K, payload: ObserverEventMap[K]): void {
+    this.observers.emit(event, payload);
+  }
+
+  /** Subscribe to a read-only observer event. Returns an unsubscribe function. */
+  subscribe<K extends keyof ObserverEventMap>(
+    event: K,
+    listener: (payload: ObserverEventMap[K]) => void
+  ): () => void {
+    // Observers are read-only fan-out: a throwing listener must never break
+    // the emitting code path (stream loop, workspace lifecycle, ...).
+    const wrapped = (payload: ObserverEventMap[K]) => {
+      try {
+        listener(payload);
+      } catch (error) {
+        log.error(`EventSpine observer for '${event}' threw`, { error });
+      }
+    };
+    this.observers.on(event, wrapped);
+    return () => this.observers.off(event, wrapped);
+  }
+
+  // --- Waterfall hooks ---
+
+  /** Register around-style middleware on a hook point. Returns an unregister function. */
+  use<K extends keyof WaterfallPointMap>(
+    point: K,
+    middleware: WaterfallMiddleware<WaterfallPointMap[K]>,
+    opts?: { order?: number }
+  ): () => void {
+    const registrations = this.waterfalls.get(point) ?? [];
+    const registration: Registration = {
+      middleware: middleware as WaterfallMiddleware<unknown>,
+      order: opts?.order ?? 0,
+      seq: this.registrationSeq++,
+    };
+    registrations.push(registration);
+    // Stable order: explicit order first, then registration sequence.
+    registrations.sort((a, b) => a.order - b.order || a.seq - b.seq);
+    this.waterfalls.set(point, registrations);
+    return () => {
+      const current = this.waterfalls.get(point);
+      if (!current) return;
+      const index = current.indexOf(registration);
+      if (index !== -1) current.splice(index, 1);
+    };
+  }
+
+  /**
+   * Registration sugar for the handoff/OpenCode hook vocabulary:
+   * - `tool.execute.before` runs before the tool executes; if the callback sets
+   *   `ctx.blocked`, the rest of the pipeline (including the tool) is skipped.
+   * - `tool.execute.after` runs after the tool executed; skipped when blocked.
+   */
+  useBefore<K extends keyof WaterfallPointMap>(
+    point: K,
+    callback: HookCallback<WaterfallPointMap[K]>,
+    opts?: { order?: number }
+  ): () => void {
+    return this.use(
+      point,
+      async (ctx, next) => {
+        await callback(ctx);
+        if (!isBlocked(ctx)) {
+          await next();
+        }
+      },
+      opts
+    );
+  }
+
+  useAfter<K extends keyof WaterfallPointMap>(
+    point: K,
+    callback: HookCallback<WaterfallPointMap[K]>,
+    opts?: { order?: number }
+  ): () => void {
+    return this.use(
+      point,
+      async (ctx, next) => {
+        await next();
+        if (!isBlocked(ctx)) {
+          await callback(ctx);
+        }
+      },
+      opts
+    );
+  }
+
+  /** True when at least one middleware is registered on the point. Lets hot
+   * paths skip context construction entirely when the pipeline is empty. */
+  hasMiddleware(point: keyof WaterfallPointMap): boolean {
+    return (this.waterfalls.get(point)?.length ?? 0) > 0;
+  }
+
+  /**
+   * Run the waterfall for a hook point. Middleware is composed around the
+   * optional terminal. Contract: a context with a truthy `blocked` property
+   * never reaches the terminal.
+   */
+  async run<K extends keyof WaterfallPointMap>(
+    point: K,
+    ctx: WaterfallPointMap[K],
+    terminal?: (ctx: WaterfallPointMap[K]) => Promise<void>
+  ): Promise<void> {
+    const registrations = this.waterfalls.get(point) ?? [];
+    const dispatch = async (index: number): Promise<void> => {
+      if (index < registrations.length) {
+        let nextCalled = false;
+        const next: WaterfallNext = () => {
+          assert(!nextCalled, `EventSpine '${point}' middleware called next() more than once`);
+          nextCalled = true;
+          return dispatch(index + 1);
+        };
+        await registrations[index].middleware(ctx, next);
+        return;
+      }
+      if (terminal && !isBlocked(ctx)) {
+        await terminal(ctx);
+      }
+    };
+    await dispatch(0);
+  }
+}
+
+/**
+ * Process-wide spine singleton (mirrors the workflowRunStreamHub pattern).
+ * Main-process services emit into it; middleware/observers are registered by
+ * built-in consumers (shell tool hooks) and, later, plugin/experiment tracks.
+ */
+export const eventSpine = new EventSpine();

--- a/src/node/services/events/eventSpine.ts
+++ b/src/node/services/events/eventSpine.ts
@@ -142,15 +142,25 @@ export class EventSpine {
   }
 
   /** Subscribe to a read-only observer event. Returns an unsubscribe function. */
+  // The listener returns `unknown` (not `void`) so async listeners and
+  // expression-bodied arrows both typecheck; return values are ignored except
+  // promises, whose rejections are captured below.
   subscribe<K extends keyof ObserverEventMap>(
     event: K,
-    listener: (payload: ObserverEventMap[K]) => void
+    listener: (payload: ObserverEventMap[K]) => unknown
   ): () => void {
-    // Observers are read-only fan-out: a throwing listener must never break
-    // the emitting code path (stream loop, workspace lifecycle, ...).
+    // Observers are read-only fan-out: a throwing OR rejecting listener must
+    // never break the emitting code path (stream loop, workspace lifecycle,
+    // ...). Async listener rejections are logged, not awaited — emission
+    // stays non-blocking.
     const wrapped = (payload: ObserverEventMap[K]) => {
       try {
-        listener(payload);
+        const result = listener(payload);
+        if (result instanceof Promise) {
+          result.catch((error: unknown) => {
+            log.error(`EventSpine observer for '${event}' rejected`, { error });
+          });
+        }
       } catch (error) {
         log.error(`EventSpine observer for '${event}' threw`, { error });
       }

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -491,6 +491,37 @@ describe("QuickJSRuntime", () => {
       for (const run of gatedRuns) run();
     });
 
+    it("re-registering an object retargets guest-saved method references", async () => {
+      runtime.registerObject("mux", {
+        bash: () => Promise.resolve("original"),
+      });
+      const saved = await runtime.eval("globalThis.savedBash = mux.bash; return savedBash();");
+      expect(saved.success).toBe(true);
+      expect(saved.result).toBe("original");
+
+      // Same-name replacement (e.g. middleware audit wrapper): the saved
+      // reference must dispatch to the NEW implementation, not pin the old.
+      runtime.registerObject("mux", {
+        bash: () => Promise.resolve("wrapped"),
+      });
+      const rewired = await runtime.eval("return globalThis.savedBash();");
+      expect(rewired.success).toBe(true);
+      expect(rewired.result).toBe("wrapped");
+
+      // Removal: the saved reference must fail closed, not run the old impl.
+      runtime.registerObject("mux", {});
+      const removed = await runtime.eval(`
+        try {
+          globalThis.savedBash();
+          return "no error";
+        } catch (e) {
+          return e.message;
+        }
+      `);
+      expect(removed.success).toBe(true);
+      expect(removed.result).toBe("mux.bash is no longer available in this sandbox");
+    });
+
     it("still reports a genuinely stuck pending Promise", async () => {
       const result = await runtime.eval("return new Promise(() => {});");
       expect(result.success).toBe(false);

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -465,6 +465,32 @@ describe("QuickJSRuntime", () => {
       expect(first.toolCalls[0]?.toolName).toBe("lateCap");
     });
 
+    it("routes late-settlement continuations through the pending-job gate", async () => {
+      const gatedRuns: Array<() => void> = [];
+      runtime.setPendingJobGate((run) => gatedRuns.push(run));
+
+      let resolveHost: (() => void) | undefined;
+      runtime.registerPromiseFunction("lateGate", async () => {
+        await new Promise<void>((resolve) => {
+          resolveHost = resolve;
+        });
+        return "done";
+      });
+
+      // Fire-and-forget: the eval returns while the capability is pending.
+      const result = await runtime.eval('lateGate(); return "first";');
+      expect(result.success).toBe(true);
+
+      // Settle AFTER the eval returned: the continuation must be handed to
+      // the gate (owner-serialized) instead of executing immediately.
+      expect(resolveHost).toBeDefined();
+      resolveHost?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(gatedRuns.length).toBe(1);
+      // Running the gated job must be safe.
+      for (const run of gatedRuns) run();
+    });
+
     it("still reports a genuinely stuck pending Promise", async () => {
       const result = await runtime.eval("return new Promise(() => {});");
       expect(result.success).toBe(false);

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -435,6 +435,36 @@ describe("QuickJSRuntime", () => {
       expect(result.result).toBe("caught: capability exploded");
     });
 
+    it("attributes a late-settling fire-and-forget capability to its originating eval", async () => {
+      // Manually-gated host promise: settles only after BOTH evals returned.
+      let resolveHost: (() => void) | undefined;
+      runtime.registerPromiseFunction("lateCap", async () => {
+        await new Promise<void>((resolve) => {
+          resolveHost = resolve;
+        });
+        return "late";
+      });
+
+      // Fire-and-forget: eval returns while the capability is still pending.
+      const first = await runtime.eval('lateCap(); return "first";');
+      expect(first.success).toBe(true);
+      expect(first.toolCalls).toHaveLength(0);
+
+      // A second eval swaps the runtime's per-eval state.
+      const second = await runtime.eval('return "second";');
+      expect(second.success).toBe(true);
+
+      expect(resolveHost).toBeDefined();
+      resolveHost?.();
+      // Let the settlement bookkeeping run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The record must land on the ORIGINATING eval, never on a later one.
+      expect(second.toolCalls).toHaveLength(0);
+      expect(first.toolCalls).toHaveLength(1);
+      expect(first.toolCalls[0]?.toolName).toBe("lateCap");
+    });
+
     it("still reports a genuinely stuck pending Promise", async () => {
       const result = await runtime.eval("return new Promise(() => {});");
       expect(result.success).toBe(false);

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -573,6 +573,97 @@ describe("QuickJSRuntime", () => {
       expect(third.result).toBe(3);
     });
 
+    it("attributes cross-eval promise reactions to the consuming eval", async () => {
+      const mutex = new AsyncMutex();
+      runtime.setPendingJobGate((run) => {
+        void (async () => {
+          await using _lock = await mutex.acquire();
+          run();
+        })();
+      });
+
+      let resolveHost: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveHost = resolve;
+          })
+      );
+
+      const first = await runtime.eval('globalThis.p = lateCap(); return "stored";');
+      expect(first.success).toBe(true);
+
+      {
+        await using _lock = await mutex.acquire();
+        // The .then() reaction is created by THIS eval on the prior eval's
+        // stored promise: its console output must land on the consuming
+        // eval, not retroactively on the already-returned originating one.
+        const evalPromise = runtime.eval(
+          'return globalThis.p.then((v) => { console.log("consumed", v); return v; });'
+        );
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(resolveHost).toBeDefined();
+        resolveHost?.("late-value");
+        const second = await evalPromise;
+        expect(second.success).toBe(true);
+        expect(second.result).toBe("late-value");
+        expect(second.consoleOutput.some((c) => c.args[0] === "consumed")).toBe(true);
+        expect(first.consoleOutput).toHaveLength(0);
+      }
+    });
+
+    it("queues a prior-eval settlement arriving during an unrelated asyncified call", async () => {
+      const mutex = new AsyncMutex();
+      runtime.setPendingJobGate((run) => {
+        void (async () => {
+          await using _lock = await mutex.acquire();
+          run();
+        })();
+      });
+
+      let resolveHost: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveHost = resolve;
+          })
+      );
+      let resolveBash: ((value: string) => void) | undefined;
+      runtime.registerObject("mux", {
+        bash: () =>
+          new Promise<string>((resolve) => {
+            resolveBash = resolve;
+          }),
+      });
+
+      const first = await runtime.eval('globalThis.p = lateCap(); return "stored";');
+      expect(first.success).toBe(true);
+
+      {
+        await using _lock = await mutex.acquire();
+        // The eval suspends inside the asyncified mux.bash call (unwound
+        // WASM stack)...
+        const evalPromise = runtime.eval("const r = mux.bash({}); return globalThis.p;");
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        // ...and the prior eval's capability settles during that suspension:
+        // touching the VM now would re-enter suspended WASM, so the
+        // settlement must queue until a safe drain point.
+        expect(resolveHost).toBeDefined();
+        resolveHost?.("cross-eval");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // Resume the asyncified call; the resolve loop drains the queued
+        // settlement so the returned prior-eval promise is consumable.
+        expect(resolveBash).toBeDefined();
+        resolveBash?.("bash-done");
+        const second = await evalPromise;
+        expect(second.success).toBe(true);
+        expect(second.result).toBe("cross-eval");
+      }
+    });
+
     it("re-registering an object retargets guest-saved method references", async () => {
       runtime.registerObject("mux", {
         bash: () => Promise.resolve("original"),

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -853,6 +853,70 @@ describe("QuickJSRuntime", () => {
       expect(last.consoleOutput.some((c) => c.args[0] === "genuine-owner")).toBe(false);
     });
 
+    it("invokes tagged promise handlers with an undefined receiver (strict-mode semantics)", async () => {
+      // The tagging wrapper must not leak its sloppy-mode globalThis into
+      // strict handlers: native reactions call handlers with undefined this.
+      const result = await runtime.eval(`
+        return Promise.resolve(1).then(function () {
+          "use strict";
+          return this === undefined;
+        });
+      `);
+      expect(result.success).toBe(true);
+      expect(result.result).toBe(true);
+    });
+
+    it("releases the retain when reaction registration throws", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        globalThis.p.then((v) => console.log("survivor-owner", v));
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+
+      // 70 evals each throw during reaction REGISTRATION (non-promise
+      // receiver): no wrapper can ever run, so a leaked retain would keep
+      // these generations falsely alive past the hard cap and evict the
+      // genuinely-outstanding one above.
+      for (let i = 0; i < 70; i++) {
+        const filler = await runtime.eval(`
+          try { Promise.prototype.then.call({}, () => {}); } catch (e) {}
+          return ${i};
+        `);
+        expect(filler.success).toBe(true);
+      }
+
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveP).toBeDefined();
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveUnrelated).toBeDefined();
+      resolveUnrelated?.("done");
+      const last = await evalPromise;
+      expect(last.success).toBe(true);
+
+      expect(first.consoleOutput.some((c) => c.args[0] === "survivor-owner")).toBe(true);
+      expect(last.consoleOutput.some((c) => c.args[0] === "survivor-owner")).toBe(false);
+    });
+
     it("queues a prior-eval settlement arriving during an unrelated asyncified call", async () => {
       const mutex = new AsyncMutex();
       runtime.setPendingJobGate((run) => {

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -370,6 +370,85 @@ describe("QuickJSRuntime", () => {
     });
   });
 
+  describe("async capability bridge (registerPromiseFunction)", () => {
+    it("returns a real Promise into the guest that resolves via await", async () => {
+      runtime.registerPromiseFunction("slowDouble", async (n) => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return (n as number) * 2;
+      });
+
+      // Guest awaits the capability promise inside an async IIFE; eval's
+      // resolve loop must wait for the host settlement instead of reporting a
+      // stuck pending Promise.
+      const result = await runtime.eval(`
+        return (async () => {
+          const doubled = await slowDouble(21);
+          return { doubled };
+        })();
+      `);
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ doubled: 42 });
+    });
+
+    it("supports fire-and-forget: returns immediately without awaiting", async () => {
+      let settled = false;
+      runtime.registerPromiseFunction("background", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        settled = true;
+        return "done";
+      });
+
+      const result = await runtime.eval(`
+        const p = background();
+        return { startedImmediately: typeof p.then === "function" };
+      `);
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ startedImmediately: true });
+      // The guest did not wait for the host promise.
+      expect(settled).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(settled).toBe(true);
+    });
+
+    it("propagates capability rejection as a catchable guest error", async () => {
+      runtime.registerPromiseFunction("failAsync", () => {
+        return Promise.reject(new Error("capability exploded"));
+      });
+
+      const result = await runtime.eval(`
+        return (async () => {
+          try {
+            await failAsync();
+            return "no error";
+          } catch (e) {
+            return "caught: " + e.message;
+          }
+        })();
+      `);
+      expect(result.success).toBe(true);
+      expect(result.result).toBe("caught: capability exploded");
+    });
+
+    it("still reports a genuinely stuck pending Promise", async () => {
+      const result = await runtime.eval("return new Promise(() => {});");
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("pending Promise");
+    });
+
+    it("enforces the deadline while awaiting a capability promise", async () => {
+      runtime.setLimits({ timeoutMs: 100 });
+      runtime.registerPromiseFunction("never", () => new Promise(() => {}));
+      const result = await runtime.eval(`
+        return (async () => {
+          await never();
+          return "unreachable";
+        })();
+      `);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timeout");
+    });
+  });
+
   describe("dispose", () => {
     it("throws on eval after dispose", async () => {
       runtime.dispose();

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -799,6 +799,60 @@ describe("QuickJSRuntime", () => {
       expect(last.consoleOutput.some((c) => c.args[0] === "retained-owner")).toBe(false);
     });
 
+    it("releases retained owners when single-handler reactions settle through the opposite branch", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+
+      // Eval 1 holds the only GENUINELY outstanding reaction.
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        globalThis.p.then((v) => console.log("genuine-owner", v));
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+
+      // 70 evals (past the 64-context hard cap) each register a rejection
+      // handler on a FULFILLING promise: the handler never runs, so a leaked
+      // retain would keep every one of these generations falsely alive and
+      // push eval 1's genuinely-retained context out of the hard cap.
+      for (let i = 0; i < 70; i++) {
+        const filler = await runtime.eval(
+          `Promise.resolve(1).then(undefined, () => {}); return ${i};`
+        );
+        expect(filler.success).toBe(true);
+      }
+
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveP).toBeDefined();
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveUnrelated).toBeDefined();
+      resolveUnrelated?.("done");
+      const last = await evalPromise;
+      expect(last.success).toBe(true);
+
+      // Eval 1's context must have survived: the opposite-branch settlements
+      // released their retains, so only genuinely-outstanding generations
+      // count against retention.
+      expect(first.consoleOutput.some((c) => c.args[0] === "genuine-owner")).toBe(true);
+      expect(last.consoleOutput.some((c) => c.args[0] === "genuine-owner")).toBe(false);
+    });
+
     it("queues a prior-eval settlement arriving during an unrelated asyncified call", async () => {
       const mutex = new AsyncMutex();
       runtime.setPendingJobGate((run) => {

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -391,9 +391,13 @@ describe("QuickJSRuntime", () => {
     });
 
     it("supports fire-and-forget: returns immediately without awaiting", async () => {
+      // Manually-resolved host promise: deterministic under load (no timers).
+      let resolveHost: (() => void) | undefined;
       let settled = false;
       runtime.registerPromiseFunction("background", async () => {
-        await new Promise((resolve) => setTimeout(resolve, 30));
+        await new Promise<void>((resolve) => {
+          resolveHost = resolve;
+        });
         settled = true;
         return "done";
       });
@@ -404,9 +408,11 @@ describe("QuickJSRuntime", () => {
       `);
       expect(result.success).toBe(true);
       expect(result.result).toEqual({ startedImmediately: true });
-      // The guest did not wait for the host promise.
+      // The guest did not wait for the host promise - it is still unresolved.
       expect(settled).toBe(false);
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(resolveHost).toBeDefined();
+      resolveHost?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(settled).toBe(true);
     });
 
@@ -437,7 +443,8 @@ describe("QuickJSRuntime", () => {
 
     it("enforces the deadline while awaiting a capability promise", async () => {
       runtime.setLimits({ timeoutMs: 100 });
-      runtime.registerPromiseFunction("never", () => new Promise(() => {}));
+      runtime.registerPromiseFunction("never", () => new Promise(() => undefined));
+      const start = Date.now();
       const result = await runtime.eval(`
         return (async () => {
           await never();
@@ -445,7 +452,11 @@ describe("QuickJSRuntime", () => {
         })();
       `);
       expect(result.success).toBe(false);
-      expect(result.error).toContain("timeout");
+      // The deadline timer both aborts and marks timeout; at millisecond
+      // resolution either message can win the race - the contract is that the
+      // eval fails promptly instead of hanging on the pending capability.
+      expect(result.error).toMatch(/timeout|aborted/);
+      expect(Date.now() - start).toBeLessThan(5000);
     });
   });
 

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
 import { QuickJSRuntime, QuickJSRuntimeFactory } from "./quickjsRuntime";
 import type { PTCEvent } from "./types";
+import { AsyncMutex } from "@/node/utils/concurrency/asyncMutex";
 
 describe("QuickJSRuntime", () => {
   let runtime: QuickJSRuntime;
@@ -489,6 +490,87 @@ describe("QuickJSRuntime", () => {
       expect(gatedRuns.length).toBe(1);
       // Running the gated job must be safe.
       for (const run of gatedRuns) run();
+    });
+
+    it("lets a later eval consume a promise stored by a prior eval (settlement mid-eval)", async () => {
+      // Mirror SandboxMount's gate: serialize gated runs on the mount lock.
+      const mutex = new AsyncMutex();
+      runtime.setPendingJobGate((run) => {
+        void (async () => {
+          await using _lock = await mutex.acquire();
+          run();
+        })();
+      });
+
+      let resolveHost: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveHost = resolve;
+          })
+      );
+
+      const first = await runtime.eval('globalThis.p = lateCap(); return "stored";');
+      expect(first.success).toBe(true);
+
+      // The next code_execution call holds the mount lock for its whole
+      // register→eval→persist sequence; settle while ITS eval is running.
+      // Routing this settlement through the gate would self-deadlock (the
+      // gate waits on the lock the awaiting eval holds).
+      {
+        await using _lock = await mutex.acquire();
+        const evalPromise = runtime.eval("return globalThis.p;");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        expect(resolveHost).toBeDefined();
+        resolveHost?.("late-value");
+        const second = await evalPromise;
+        expect(second.success).toBe(true);
+        expect(second.result).toBe("late-value");
+      }
+    });
+
+    it("drains a gate-queued settlement at eval start when the gate lost the lock race", async () => {
+      const mutex = new AsyncMutex();
+      runtime.setPendingJobGate((run) => {
+        void (async () => {
+          await using _lock = await mutex.acquire();
+          run();
+        })();
+      });
+
+      let resolveHost: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveHost = resolve;
+          })
+      );
+
+      const first = await runtime.eval('globalThis.q = lateCap(); return "stored";');
+      expect(first.success).toBe(true);
+
+      {
+        await using _lock = await mutex.acquire();
+        // Settle BETWEEN evals while the next call already holds the lock:
+        // the settlement is handed to the gate, which cannot run yet.
+        expect(resolveHost).toBeDefined();
+        resolveHost?.("queued-value");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // The eval must land the queued settlement itself at start.
+        const second = await runtime.eval("return globalThis.q;");
+        expect(second.success).toBe(true);
+        expect(second.result).toBe("queued-value");
+      }
+
+      // After release, the gate's drain finds an empty queue and must no-op;
+      // the runtime stays usable.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const third = await runtime.eval("return 3;");
+      expect(third.success).toBe(true);
+      expect(third.result).toBe(3);
     });
 
     it("re-registering an object retargets guest-saved method references", async () => {

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -702,6 +702,103 @@ describe("QuickJSRuntime", () => {
       expect(second.toolCalls.map((c) => c.toolName)).not.toContain("nestedCap");
     });
 
+    it("attributes await continuations registered by a prior eval to that eval", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+
+      // Eval 1 fire-and-forgets an async function that AWAITS the capability
+      // promise: the continuation is registered via the engine's internal
+      // reaction path, not an explicit .then call.
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        (async () => {
+          const v = await globalThis.p;
+          console.log("await-owned", v);
+        })();
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+      expect(first.consoleOutput).toHaveLength(0);
+
+      // Eval 2 parks in its resolve loop; the prior eval's promise settles
+      // during that drain window.
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveP).toBeDefined();
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveUnrelated).toBeDefined();
+      resolveUnrelated?.("done");
+      const second = await evalPromise;
+      expect(second.success).toBe(true);
+      expect(second.result).toBe("done");
+
+      // The await continuation belongs to eval 1 (which started the async
+      // function), not to the eval whose drain executed it.
+      expect(first.consoleOutput.some((c) => c.args[0] === "await-owned")).toBe(true);
+      expect(second.consoleOutput.some((c) => c.args[0] === "await-owned")).toBe(false);
+    });
+
+    it("retains a registering eval's attribution context across many later evals", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        globalThis.p.then((v) => console.log("retained-owner", v));
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+
+      // Push well past the idle-context soft cap: the registering generation
+      // must be retained because its reaction is still outstanding.
+      for (let i = 0; i < 12; i++) {
+        const filler = await runtime.eval(`return ${i};`);
+        expect(filler.success).toBe(true);
+      }
+
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveP).toBeDefined();
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveUnrelated).toBeDefined();
+      resolveUnrelated?.("done");
+      const last = await evalPromise;
+      expect(last.success).toBe(true);
+
+      expect(first.consoleOutput.some((c) => c.args[0] === "retained-owner")).toBe(true);
+      expect(last.consoleOutput.some((c) => c.args[0] === "retained-owner")).toBe(false);
+    });
+
     it("queues a prior-eval settlement arriving during an unrelated asyncified call", async () => {
       const mutex = new AsyncMutex();
       runtime.setPendingJobGate((run) => {

--- a/src/node/services/ptc/quickjsRuntime.test.ts
+++ b/src/node/services/ptc/quickjsRuntime.test.ts
@@ -613,6 +613,95 @@ describe("QuickJSRuntime", () => {
       }
     });
 
+    it("attributes reactions registered by a prior eval to that eval", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+
+      // Eval 1 registers ITS OWN reaction on the capability promise.
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        globalThis.p.then((v) => console.log("prior-owned", v));
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+      expect(first.consoleOutput).toHaveLength(0);
+
+      // Eval 2 parks in its resolve loop on an unrelated capability; the
+      // prior eval's promise settles during that drain window.
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveP).toBeDefined();
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(resolveUnrelated).toBeDefined();
+      resolveUnrelated?.("done");
+      const second = await evalPromise;
+      expect(second.success).toBe(true);
+      expect(second.result).toBe("done");
+
+      // The reaction was REGISTERED by eval 1: its console output must land
+      // there, not on the eval whose drain executed the job.
+      expect(first.consoleOutput.some((c) => c.args[0] === "prior-owned")).toBe(true);
+      expect(second.consoleOutput.some((c) => c.args[0] === "prior-owned")).toBe(false);
+    });
+
+    it("attributes nested capabilities started by a prior eval's reaction to that eval", async () => {
+      let resolveP: ((value: string) => void) | undefined;
+      let resolveUnrelated: ((value: string) => void) | undefined;
+      runtime.registerPromiseFunction(
+        "lateCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveP = resolve;
+          })
+      );
+      runtime.registerPromiseFunction(
+        "unrelatedCap",
+        () =>
+          new Promise<string>((resolve) => {
+            resolveUnrelated = resolve;
+          })
+      );
+      runtime.registerPromiseFunction("nestedCap", () => Promise.resolve("nested-done"));
+
+      const first = await runtime.eval(`
+        globalThis.p = lateCap();
+        globalThis.p.then(() => { nestedCap(); });
+        return "stored";
+      `);
+      expect(first.success).toBe(true);
+      expect(first.toolCalls).toHaveLength(0);
+
+      const evalPromise = runtime.eval("return unrelatedCap();");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      resolveP?.("late");
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      resolveUnrelated?.("done");
+      const second = await evalPromise;
+      expect(second.success).toBe(true);
+
+      // Give the nested capability's settlement bookkeeping time to land.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      // The nested capability was started inside eval 1's reaction: its
+      // record belongs to eval 1 even though eval 2's drain ran the job.
+      expect(first.toolCalls.map((c) => c.toolName)).toContain("nestedCap");
+      expect(second.toolCalls.map((c) => c.toolName)).not.toContain("nestedCap");
+    });
+
     it("queues a prior-eval settlement arriving during an unrelated asyncified call", async () => {
       const mutex = new AsyncMutex();
       runtime.setPendingJobGate((run) => {

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -94,7 +94,10 @@ const REACTION_TAGGING_SCRIPT = `
         tagEpoch += 1;
         const myEpoch = tagEpoch;
         try {
-          return typeof fn === "function" ? fn.call(this, value) : fallback(value);
+          // Plain call (no receiver): native reactions invoke handlers with
+          // an undefined this — forwarding the sloppy-mode wrapper's
+          // globalThis would change strict-mode handler semantics.
+          return typeof fn === "function" ? fn(value) : fallback(value);
         } finally {
           releaseOnce();
           // Deferred one-hop restore: jobs this callback enqueued run
@@ -111,11 +114,19 @@ const REACTION_TAGGING_SCRIPT = `
         }
       };
     retain(owner);
-    return origThen.call(
-      this,
-      wrap(onFulfilled, (value) => value),
-      wrap(onRejected, (reason) => { throw reason; })
-    );
+    try {
+      return origThen.call(
+        this,
+        wrap(onFulfilled, (value) => value),
+        wrap(onRejected, (reason) => { throw reason; })
+      );
+    } catch (registrationError) {
+      // Registration failed (non-promise receiver, throwing Symbol.species
+      // constructor, ...): no wrapper will ever run, so release the retain
+      // here or the owner's context leaks toward the hard cap.
+      releaseOnce();
+      throw registrationError;
+    }
   };
   // Subclass wrapper for capability promises: \`await\` on a promise whose
   // constructor is not %Promise% takes the spec's thenable path, which calls

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -39,16 +39,25 @@ export class QuickJSRuntime implements IJSRuntime {
   /** Serializes late-settlement guest continuations; see setPendingJobGate. */
   private pendingJobGate?: (run: () => void) => void;
   /** Monotonic eval counter + the generation currently inside eval() (null
-   * between evals). Used to detect LATE capability settlements that must be
-   * routed through the pending-job gate instead of touching the VM directly. */
+   * between evals). Distinguishes settlements arriving mid-eval (queued for
+   * the eval's own drain points; reactions attribute to the consuming eval)
+   * from truly-late ones between evals (gated; reactions attribute to their
+   * originating eval). */
   private evalGeneration = 0;
   private activeEvalGeneration: number | null = null;
-  /** Late settlements handed to the pending-job gate but not yet run. eval()
-   * drains this at start: the gate serializes on the scope lock, so a
-   * settlement queued between calls can lose the lock race to the next
-   * code_execution call — without the drain, that eval could never consume
-   * the guest-visible promise (the tracked host promise resolves at gate
-   * hand-off, so the resolve loop has nothing left to wait on). */
+  /** True only while eval()'s returned-value resolve loop coordinates VM
+   * access (evalCodeAsync completed, VM idle at the top level). Settlements
+   * may touch the VM directly ONLY then: during asyncified suspension the
+   * WASM stack is unwound and re-entry would corrupt it, and between evals
+   * another call may own the runtime. */
+  private directSettleAllowed = false;
+  /** VM-facing settlements that could not safely touch the VM on arrival:
+   * either the active eval was suspended inside an asyncified call, or the
+   * settlement landed between evals and must serialize through the
+   * pending-job gate (whose lock acquisition can lose the race to the next
+   * code_execution call). Drained at eval start, by the resolve loop, at
+   * eval end, and by the gate — whichever runs first; later drains see an
+   * empty queue. */
   private readonly queuedLateSettlements: Array<() => void> = [];
   /** Current registration per registerObject name; guest methods dispatch
    * through this at call time so re-registration retargets saved references. */
@@ -214,22 +223,31 @@ export class QuickJSRuntime implements IJSRuntime {
       });
 
       // VM-facing settlement: marshal + resolve/reject + drain continuations.
-      // Runs directly while ANY eval is active: that eval's resolve loop
-      // coordinates VM access and may itself be awaiting this settlement
-      // (e.g. a later call returning a promise stored by a prior call), so
-      // routing through the gate would deadlock — the gate serializes on the
-      // mount lock held by that very eval. Settlements between evals go
-      // through the gate so they cannot re-enter the shared QuickJS context
-      // unserialized; they are queued so the next eval can drain them if its
-      // call wins the mount-lock race against the gate.
+      // May touch the VM directly ONLY while an eval's resolve loop is
+      // coordinating (directSettleAllowed): during asyncified suspension the
+      // WASM stack is unwound and re-entry would corrupt it, and between
+      // evals another call may own the runtime. Routing through the gate
+      // while an eval holds the mount lock would deadlock (the gate waits on
+      // that very lock), so mid-eval arrivals are queued for the eval's own
+      // drain points instead.
       const settleInVm = (run: () => void) => {
-        const guarded = () => {
+        const execute = () => {
           if (this.disposed) return;
-          // Bind the resumed guest continuation to its ORIGINATING eval's
-          // attribution state: console.log and nested capability calls inside
-          // the continuation read the runtime's mutable fields, which by now
-          // may belong to a later eval. Swap for the duration of the drain,
-          // then restore (no-op while the originating eval is still active).
+          if (this.activeEvalGeneration !== null) {
+            // A consuming eval is draining this settlement: the pending
+            // reactions include continuations IT created (e.g.
+            // `return p.then(...)` on a prior eval's stored promise), so
+            // they run under the CURRENT eval's attribution state. The
+            // originating eval still owns the tool-call record itself via
+            // the captured arrays above.
+            run();
+            this.ctx.runtime.executePendingJobs();
+            return;
+          }
+          // Between evals: bind the drained continuations to their
+          // ORIGINATING eval's attribution state — console.log and nested
+          // capability calls read the runtime's mutable fields, which by now
+          // may have been swapped by later evals. Restore afterwards.
           const prevToolCalls = this.toolCalls;
           const prevConsoleOutput = this.consoleOutput;
           const prevEventHandler = this.eventHandler;
@@ -245,16 +263,27 @@ export class QuickJSRuntime implements IJSRuntime {
             this.eventHandler = prevEventHandler;
           }
         };
+        if (this.directSettleAllowed) {
+          // The active eval is parked in its resolve loop: the VM is idle at
+          // the top level and this call's owner holds the mount lock, so the
+          // settlement may land now (the loop may itself be awaiting it).
+          execute();
+          return;
+        }
+        this.queuedLateSettlements.push(execute);
         if (this.activeEvalGeneration !== null) {
-          // Attribution stays bound to the ORIGINATING eval either way: for a
-          // different active generation, guarded() swaps in the captured
-          // per-eval state for the duration of the drain.
-          guarded();
-        } else if (this.pendingJobGate) {
-          this.queuedLateSettlements.push(guarded);
+          // The active eval is suspended inside an asyncified capability
+          // call: touching the VM would re-enter the unwound WASM stack.
+          // The eval's resolve loop or finally-block drain lands the queue.
+          return;
+        }
+        if (this.pendingJobGate) {
+          // Between evals on a shared runtime: schedule a serialized drain.
           this.pendingJobGate(() => this.drainQueuedLateSettlements());
         } else {
-          guarded();
+          // Between evals on a single-owner (ephemeral) runtime: the VM is
+          // idle and nothing else can hold it — land immediately.
+          this.drainQueuedLateSettlements();
         }
       };
 
@@ -452,7 +481,6 @@ export class QuickJSRuntime implements IJSRuntime {
     this.abortController = new AbortController();
     this.toolCalls = [];
     this.consoleOutput = [];
-    this.activeEvalGeneration = ++this.evalGeneration;
 
     // Honor abort requests made before eval() was called
     if (this.abortRequested) {
@@ -494,8 +522,11 @@ export class QuickJSRuntime implements IJSRuntime {
     // runs so a promise stored by a prior eval is consumable here; the gate's
     // eventual drain then finds an empty queue and no-ops. Placed after the
     // interrupt handler + timer setup so the drain runs under THIS eval's
-    // deadline, not a stale one.
+    // deadline (not a stale one), and BEFORE the generation is marked active
+    // so the drained reactions — all created by prior evals — bind to their
+    // originating attribution state.
     this.drainQueuedLateSettlements();
+    this.activeEvalGeneration = ++this.evalGeneration;
 
     // Wrap code in function to allow return statements.
     // With asyncify, async host functions appear synchronous to QuickJS,
@@ -504,6 +535,10 @@ export class QuickJSRuntime implements IJSRuntime {
 
     try {
       const evalResult = await this.ctx.evalCodeAsync(wrappedCode);
+      // Top-level guest execution finished: the VM is idle and this call
+      // still owns the runtime, so settlements may now land directly (the
+      // resolve loop below coordinates, and may itself await them).
+      this.directSettleAllowed = true;
 
       if (evalResult.error) {
         const errObj: unknown = this.ctx.dump(evalResult.error) as unknown;
@@ -559,8 +594,20 @@ export class QuickJSRuntime implements IJSRuntime {
       // across calls, and a sticky flag would poison every later eval.
       this.abortRequested = false;
       // Settlements arriving from here on are LATE (post-eval) and must be
-      // gated; see registerPromiseFunction.
+      // queued; see settleInVm in registerPromiseFunction.
+      this.directSettleAllowed = false;
       this.activeEvalGeneration = null;
+      // Land settlements queued while guest code was suspended inside an
+      // asyncified call and not consumed by the resolve loop (e.g. the guest
+      // returned a plain value or threw). Serialized through the gate when
+      // present; a gateless (ephemeral) runtime is single-owner and idle.
+      if (this.queuedLateSettlements.length > 0) {
+        if (this.pendingJobGate) {
+          this.pendingJobGate(() => this.drainQueuedLateSettlements());
+        } else {
+          this.drainQueuedLateSettlements();
+        }
+      }
     }
   }
 
@@ -595,15 +642,19 @@ export class QuickJSRuntime implements IJSRuntime {
     }
   }
 
-  /** Run queued late settlements in arrival order. Called from eval() start
-   * (under the caller's mount lock) and from the pending-job gate (under the
-   * gate's own lock acquisition) — whichever wins the race; the loser sees an
-   * empty queue. Each entry is a guarded() that no-ops after dispose. */
-  private drainQueuedLateSettlements(): void {
+  /** Run queued late settlements in arrival order; returns whether any ran.
+   * Called from eval() start, the resolve loop, and eval() end (all under
+   * the caller's mount lock) and from the pending-job gate (under the gate's
+   * own lock acquisition) — whichever runs first; later drains see an empty
+   * queue. Each entry no-ops after dispose. */
+  private drainQueuedLateSettlements(): boolean {
+    let drained = false;
     while (this.queuedLateSettlements.length > 0) {
       const run = this.queuedLateSettlements.shift();
       run?.();
+      drained = true;
     }
+    return drained;
   }
 
   private async resolveReturnedValue(
@@ -619,6 +670,10 @@ export class QuickJSRuntime implements IJSRuntime {
           error: this.getErrorMessage("Execution interrupted", deadline, timeoutMs),
         };
       }
+      // Land settlements queued while guest code was suspended inside an
+      // asyncified call (see settleInVm): the returned value may be a prior
+      // eval's promise that only these settlements can resolve.
+      const drainedQueued = this.drainQueuedLateSettlements();
       if (this.ctx.runtime.hasPendingJob()) {
         const pendingJobs = this.ctx.runtime.executePendingJobs();
         if (pendingJobs.error) {
@@ -628,12 +683,12 @@ export class QuickJSRuntime implements IJSRuntime {
           return { success: false, error };
         }
         pendingJobs.dispose();
-      } else if (this.pendingHostPromises.size > 0) {
+      } else if (!drainedQueued && this.pendingHostPromises.size > 0) {
         // The returned value may depend on an in-flight async capability
         // (registerPromiseFunction). Wait for any settlement, bounded by the
         // deadline/abort; each settlement schedules executePendingJobs.
         await this.waitForAnyHostPromise(deadline);
-      } else {
+      } else if (!drainedQueued) {
         // Nothing can ever settle this promise.
         break;
       }

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -41,6 +41,13 @@ export class QuickJSRuntime implements IJSRuntime {
   private toolCalls: PTCToolCallRecord[] = [];
   private consoleOutput: PTCConsoleRecord[] = [];
 
+  // In-flight async-capability promises (registerPromiseFunction). eval()'s
+  // resolve loop awaits these when the returned value is still pending, so a
+  // guest `await` on a capability promise is not misreported as stuck.
+  // NOT reset per eval: fire-and-forget capabilities from a previous call on a
+  // persistent mount may legitimately still be settling.
+  private readonly pendingHostPromises = new Set<Promise<void>>();
+
   private constructor(private readonly ctx: QuickJSAsyncContext) {}
 
   static async create(): Promise<QuickJSRuntime> {
@@ -154,6 +161,113 @@ export class QuickJSRuntime implements IJSRuntime {
 
     this.ctx.setProp(this.ctx.global, name, handle);
     handle.dispose();
+  }
+
+  registerPromiseFunction(name: string, fn: (...args: unknown[]) => Promise<unknown>): void {
+    this.assertNotDisposed("registerPromiseFunction");
+
+    // Plain (non-asyncified) host function: it must return synchronously, so
+    // it hands the guest a deferred VM promise and settles it when the host
+    // promise settles. This is the async capability bridge: the guest can
+    // fire-and-forget or await the returned Promise.
+    const fnHandle = this.ctx.newFunction(name, (...argHandles) => {
+      const args: unknown[] = argHandles.map((h) => this.ctx.dump(h) as unknown);
+      const startTime = Date.now();
+      const callId = generateCallId();
+      const deferred = this.ctx.newPromise();
+
+      this.eventHandler?.({
+        type: "tool-call-start",
+        callId,
+        toolName: name,
+        args: args[0],
+        startTime,
+      });
+
+      const settle = (async () => {
+        try {
+          const result = await fn(...args);
+          const endTime = Date.now();
+          this.toolCalls.push({
+            toolName: name,
+            args: args[0],
+            result,
+            duration_ms: endTime - startTime,
+          });
+          this.eventHandler?.({
+            type: "tool-call-end",
+            callId,
+            toolName: name,
+            args: args[0],
+            result,
+            startTime,
+            endTime,
+          });
+          if (this.disposed) return;
+          const valueHandle = this.marshal(result);
+          deferred.resolve(valueHandle);
+          valueHandle.dispose();
+        } catch (error) {
+          const endTime = Date.now();
+          const errorStr = error instanceof Error ? error.message : String(error);
+          this.toolCalls.push({
+            toolName: name,
+            args: args[0],
+            error: errorStr,
+            duration_ms: endTime - startTime,
+          });
+          this.eventHandler?.({
+            type: "tool-call-end",
+            callId,
+            toolName: name,
+            args: args[0],
+            error: errorStr,
+            startTime,
+            endTime,
+          });
+          if (this.disposed) return;
+          const errorHandle = this.marshal({ name: "Error", message: errorStr });
+          deferred.reject(errorHandle);
+          errorHandle.dispose();
+        }
+      })();
+
+      // Track settlement so eval()'s resolve loop can wait on it. The tracked
+      // promise never rejects (settle() catches everything above).
+      const tracked: Promise<void> = settle.finally(() => {
+        this.pendingHostPromises.delete(tracked);
+      });
+      this.pendingHostPromises.add(tracked);
+
+      // Run guest continuations (.then/await) once the deferred settles.
+      deferred.settled
+        .then(() => {
+          if (!this.disposed) {
+            this.ctx.runtime.executePendingJobs();
+          }
+        })
+        .catch(() => undefined);
+
+      // Ownership of deferred.handle transfers to the wrapper (return value).
+      return deferred.handle;
+    });
+
+    this.ctx.setProp(this.ctx.global, name, fnHandle);
+    fnHandle.dispose();
+  }
+
+  registerSyncFunction(name: string, fn: (...args: unknown[]) => unknown): void {
+    this.assertNotDisposed("registerSyncFunction");
+
+    const fnHandle = this.ctx.newFunction(name, (...argHandles) => {
+      const args: unknown[] = argHandles.map((h) => this.ctx.dump(h) as unknown);
+      // Host exceptions propagate to the guest as thrown errors.
+      const result = fn(...args);
+      return this.marshal(result);
+    });
+
+    this.ctx.setProp(this.ctx.global, name, fnHandle);
+    fnHandle.dispose();
   }
 
   registerObject(
@@ -305,7 +419,7 @@ export class QuickJSRuntime implements IJSRuntime {
         };
       }
 
-      const resolvedValue = this.resolveReturnedValue(evalResult.value, deadline, timeoutMs);
+      const resolvedValue = await this.resolveReturnedValue(evalResult.value, deadline, timeoutMs);
       evalResult.value.dispose();
 
       if (!resolvedValue.success) {
@@ -338,6 +452,10 @@ export class QuickJSRuntime implements IJSRuntime {
       };
     } finally {
       clearTimeout(timeoutId);
+      // An abort applies to the eval it interrupted (or the one about to
+      // start), not to future evals: persistent mounts reuse this runtime
+      // across calls, and a sticky flag would poison every later eval.
+      this.abortRequested = false;
     }
   }
 
@@ -369,21 +487,37 @@ export class QuickJSRuntime implements IJSRuntime {
     }
   }
 
-  private resolveReturnedValue(
+  private async resolveReturnedValue(
     handle: QuickJSHandle,
     deadline: number,
     timeoutMs: number
-  ): { success: true; value: unknown } | { success: false; error: string } {
+  ): Promise<{ success: true; value: unknown } | { success: false; error: string }> {
     let promiseState = this.ctx.getPromiseState(handle);
-    while (promiseState.type === "pending" && this.ctx.runtime.hasPendingJob()) {
-      const pendingJobs = this.ctx.runtime.executePendingJobs();
-      if (pendingJobs.error) {
-        const errorObj: unknown = pendingJobs.error.context.dump(pendingJobs.error) as unknown;
-        const error = this.getErrorMessage(errorObj, deadline, timeoutMs);
-        pendingJobs.dispose();
-        return { success: false, error };
+    while (promiseState.type === "pending") {
+      if (this.abortController?.signal.aborted || Date.now() > deadline) {
+        return {
+          success: false,
+          error: this.getErrorMessage("Execution interrupted", deadline, timeoutMs),
+        };
       }
-      pendingJobs.dispose();
+      if (this.ctx.runtime.hasPendingJob()) {
+        const pendingJobs = this.ctx.runtime.executePendingJobs();
+        if (pendingJobs.error) {
+          const errorObj: unknown = pendingJobs.error.context.dump(pendingJobs.error) as unknown;
+          const error = this.getErrorMessage(errorObj, deadline, timeoutMs);
+          pendingJobs.dispose();
+          return { success: false, error };
+        }
+        pendingJobs.dispose();
+      } else if (this.pendingHostPromises.size > 0) {
+        // The returned value may depend on an in-flight async capability
+        // (registerPromiseFunction). Wait for any settlement, bounded by the
+        // deadline/abort; each settlement schedules executePendingJobs.
+        await this.waitForAnyHostPromise(deadline);
+      } else {
+        // Nothing can ever settle this promise.
+        break;
+      }
       promiseState = this.ctx.getPromiseState(handle);
     }
 
@@ -405,6 +539,29 @@ export class QuickJSRuntime implements IJSRuntime {
         promiseState.value.dispose();
       }
     }
+  }
+
+  /**
+   * Wait until any in-flight async-capability promise settles, the deadline
+   * passes, or the execution is aborted. Tracked promises never reject.
+   */
+  private async waitForAnyHostPromise(deadline: number): Promise<void> {
+    const abortSignal = this.abortController?.signal;
+    await new Promise<void>((resolve) => {
+      let done = false;
+      const finish = () => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        abortSignal?.removeEventListener("abort", finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, Math.max(0, deadline - Date.now()) + 1);
+      abortSignal?.addEventListener("abort", finish, { once: true });
+      for (const pending of this.pendingHostPromises) {
+        void pending.then(finish);
+      }
+    });
   }
 
   /**

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -391,7 +391,7 @@ export class QuickJSRuntime implements IJSRuntime {
             // The originating eval still owns the tool-call record via the
             // attribution captured at call time above.
             run();
-            this.ctx.runtime.executePendingJobs();
+            this.drainPendingJobs();
             this.clearReactionOwner();
             return;
           }
@@ -406,7 +406,7 @@ export class QuickJSRuntime implements IJSRuntime {
           this.eventHandler = eventHandler;
           try {
             run();
-            this.ctx.runtime.executePendingJobs();
+            this.drainPendingJobs();
             this.clearReactionOwner();
           } finally {
             this.toolCalls = prevToolCalls;
@@ -779,14 +779,9 @@ export class QuickJSRuntime implements IJSRuntime {
       // a capability promise registers through the patched then here) must
       // tag with THIS eval as owner, not whichever eval drains them later.
       if (!this.disposed) {
-        const leftoverJobs = this.ctx.runtime.executePendingJobs();
-        if (leftoverJobs.error) {
-          // Fire-and-forget guest job failed; surfacing it would mask the
-          // eval result. Drop it — same policy as the gate's drain.
-          leftoverJobs.error.dispose();
-        } else {
-          leftoverJobs.dispose();
-        }
+        // A failed fire-and-forget guest job is dropped (surfacing it would
+        // mask the eval result) — same policy as the gate's drain.
+        this.drainPendingJobs();
         this.clearReactionOwner();
       }
       // Settlements arriving from here on are LATE (post-eval) and must be
@@ -835,6 +830,20 @@ export class QuickJSRuntime implements IJSRuntime {
   private assertNotDisposed(method: string): void {
     if (this.disposed) {
       throw new Error(`Cannot call ${method} on disposed QuickJSRuntime`);
+    }
+  }
+
+  /** Execute pending guest jobs and dispose the disposable result in both
+   * the success and error cases — dropping it leaks QuickJS handles, which
+   * accumulates across repeated capability settlements on persistent mounts.
+   * Fire-and-forget drain: a failed guest job here has nothing to report to
+   * (same policy as eval()'s finally drain). */
+  private drainPendingJobs(): void {
+    const result = this.ctx.runtime.executePendingJobs();
+    if (result.error) {
+      result.error.dispose();
+    } else {
+      result.dispose();
     }
   }
 

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -25,6 +25,60 @@ function generateCallId(): string {
   return crypto.randomBytes(5).toString("hex");
 }
 
+/** Guest globals used for per-reaction attribution (see REACTION_TAGGING_SCRIPT). */
+const EVAL_GENERATION_GLOBAL = "__muxEvalGeneration";
+const REACTION_OWNER_GLOBAL = "__muxReactionOwner";
+
+/**
+ * Installed once per context: tags every promise reaction with the eval
+ * generation that REGISTERED it. Persistent mounts share one context across
+ * evals, and a capability promise from eval N can settle while eval M runs —
+ * QuickJS's job queue carries no per-job ownership, so registration is the
+ * only point where the owner is knowable. The wrapper sets the owner global
+ * for the duration of the callback; host entry points (console, capability
+ * calls) read it to route records to the owning eval's context. catch()/
+ * finally() delegate to then() per spec, so patching then() covers them.
+ * Best-effort observability, not a security boundary: guests can overwrite
+ * the patch, and await-registered continuations use the engine-internal
+ * reaction path (no .then call), falling back to the drain context.
+ */
+const REACTION_TAGGING_SCRIPT = `
+(() => {
+  const origThen = Promise.prototype.then;
+  Promise.prototype.then = function (onFulfilled, onRejected) {
+    const owner =
+      globalThis.${REACTION_OWNER_GLOBAL} !== undefined
+        ? globalThis.${REACTION_OWNER_GLOBAL}
+        : globalThis.${EVAL_GENERATION_GLOBAL};
+    const wrap = (fn) =>
+      typeof fn === "function"
+        ? function (value) {
+            const prev = globalThis.${REACTION_OWNER_GLOBAL};
+            globalThis.${REACTION_OWNER_GLOBAL} = owner;
+            try {
+              return fn(value);
+            } finally {
+              globalThis.${REACTION_OWNER_GLOBAL} = prev;
+            }
+          }
+        : fn;
+    return origThen.call(this, wrap(onFulfilled), wrap(onRejected));
+  };
+})();
+`;
+
+/** Per-eval attribution sinks; see generationContexts. */
+interface AttributionContext {
+  toolCalls: PTCToolCallRecord[];
+  consoleOutput: PTCConsoleRecord[];
+  eventHandler: ((event: PTCEvent) => void) | undefined;
+}
+
+/** Bound on retained per-eval attribution contexts (persistent mounts run
+ * many evals; reactions rarely outlive a handful of calls). Evicted
+ * generations fall back to the drain context. */
+const MAX_GENERATION_CONTEXTS = 8;
+
 /**
  * QuickJS-based JavaScript runtime for PTC.
  * Uses Asyncify build for async host function support.
@@ -40,11 +94,17 @@ export class QuickJSRuntime implements IJSRuntime {
   private pendingJobGate?: (run: () => void) => void;
   /** Monotonic eval counter + the generation currently inside eval() (null
    * between evals). Distinguishes settlements arriving mid-eval (queued for
-   * the eval's own drain points; reactions attribute to the consuming eval)
-   * from truly-late ones between evals (gated; reactions attribute to their
-   * originating eval). */
+   * the eval's own drain points) from truly-late ones between evals (gated).
+   * Reaction attribution is per-registration via REACTION_TAGGING_SCRIPT +
+   * generationContexts; the drain-context swaps are only the fallback for
+   * untagged (await-registered) continuations. */
   private evalGeneration = 0;
   private activeEvalGeneration: number | null = null;
+  /** Attribution sinks per eval generation. Tagged reactions route their
+   * console output and nested capability records to the eval that REGISTERED
+   * them, no matter which eval's drain executes the job. Bounded by
+   * MAX_GENERATION_CONTEXTS (oldest evicted; fallback is the drain context). */
+  private readonly generationContexts = new Map<number, AttributionContext>();
   /** True only while eval()'s returned-value resolve loop coordinates VM
    * access (evalCodeAsync completed, VM idle at the top level). Settlements
    * may touch the VM directly ONLY then: during asyncified suspension the
@@ -209,10 +269,14 @@ export class QuickJSRuntime implements IJSRuntime {
       // can settle after its originating eval() returned (timeout/abort or
       // un-awaited call). eval() swaps this.toolCalls/this.eventHandler per
       // execution, so consulting them at settlement would report the record
-      // under a later eval and emit it to the wrong handler.
-      const toolCalls = this.toolCalls;
-      const consoleOutput = this.consoleOutput;
-      const eventHandler = this.eventHandler;
+      // under a later eval and emit it to the wrong handler. Resolved via
+      // currentAttribution(): a capability started inside a tagged reaction
+      // records to the eval that REGISTERED the reaction, not whichever
+      // eval's drain happens to execute it.
+      const attribution = this.currentAttribution();
+      const toolCalls = attribution.toolCalls;
+      const consoleOutput = attribution.consoleOutput;
+      const eventHandler = attribution.eventHandler;
 
       eventHandler?.({
         type: "tool-call-start",
@@ -233,21 +297,23 @@ export class QuickJSRuntime implements IJSRuntime {
       const settleInVm = (run: () => void) => {
         const execute = () => {
           if (this.disposed) return;
+          // Reaction attribution is per-registration: tagged callbacks route
+          // console output and nested capability records to the eval that
+          // registered them via currentAttribution(), regardless of which
+          // drain executes the job. The branches below only choose the
+          // FALLBACK context for untagged (await-registered) continuations.
           if (this.activeEvalGeneration !== null) {
-            // A consuming eval is draining this settlement: the pending
-            // reactions include continuations IT created (e.g.
-            // `return p.then(...)` on a prior eval's stored promise), so
-            // they run under the CURRENT eval's attribution state. The
-            // originating eval still owns the tool-call record itself via
-            // the captured arrays above.
+            // A consuming eval is draining: fall back to its state (it may
+            // have created untagged continuations on this promise itself).
+            // The originating eval still owns the tool-call record via the
+            // attribution captured at call time above.
             run();
             this.ctx.runtime.executePendingJobs();
             return;
           }
-          // Between evals: bind the drained continuations to their
-          // ORIGINATING eval's attribution state — console.log and nested
-          // capability calls read the runtime's mutable fields, which by now
-          // may have been swapped by later evals. Restore afterwards.
+          // Between evals: fall back to the ORIGINATING eval's attribution
+          // state — the runtime's mutable fields may have been swapped by
+          // later evals. Restore afterwards.
           const prevToolCalls = this.toolCalls;
           const prevConsoleOutput = this.consoleOutput;
           const prevEventHandler = this.eventHandler;
@@ -487,9 +553,10 @@ export class QuickJSRuntime implements IJSRuntime {
       this.abortController.abort();
     }
 
-    // Set up console capturing (only once)
+    // Set up console capturing + reaction tagging (only once)
     if (!this.consoleSetup) {
       this.setupConsole();
+      this.setupReactionTagging();
       this.consoleSetup = true;
     }
 
@@ -527,6 +594,24 @@ export class QuickJSRuntime implements IJSRuntime {
     // originating attribution state.
     this.drainQueuedLateSettlements();
     this.activeEvalGeneration = ++this.evalGeneration;
+
+    // Register this eval's attribution sinks and expose the generation to
+    // the guest so reactions registered from here on are tagged with it
+    // (REACTION_TAGGING_SCRIPT). Placed after the drain: drained reactions
+    // belong to prior generations.
+    this.generationContexts.set(this.activeEvalGeneration, {
+      toolCalls: this.toolCalls,
+      consoleOutput: this.consoleOutput,
+      eventHandler: this.eventHandler,
+    });
+    while (this.generationContexts.size > MAX_GENERATION_CONTEXTS) {
+      const oldest: number | undefined = this.generationContexts.keys().next().value;
+      if (oldest === undefined) break;
+      this.generationContexts.delete(oldest);
+    }
+    const generationHandle = this.ctx.newNumber(this.activeEvalGeneration);
+    this.ctx.setProp(this.ctx.global, EVAL_GENERATION_GLOBAL, generationHandle);
+    generationHandle.dispose();
 
     // Wrap code in function to allow return statements.
     // With asyncify, async host functions appear synchronous to QuickJS,
@@ -801,11 +886,11 @@ export class QuickJSRuntime implements IJSRuntime {
         const args: unknown[] = argHandles.map((h) => this.ctx.dump(h) as unknown);
         const timestamp = Date.now();
 
-        // Record console output
-        this.consoleOutput.push({ level, args, timestamp });
-
-        // Emit console event
-        this.eventHandler?.({
+        // Route to the eval that registered the enclosing reaction (falls
+        // back to the current drain context for untagged code).
+        const attribution = this.currentAttribution();
+        attribution.consoleOutput.push({ level, args, timestamp });
+        attribution.eventHandler?.({
           type: "console",
           level,
           args,
@@ -818,6 +903,48 @@ export class QuickJSRuntime implements IJSRuntime {
 
     this.ctx.setProp(this.ctx.global, "console", consoleObj);
     consoleObj.dispose();
+  }
+
+  /** Install the promise-reaction tagging patch; see REACTION_TAGGING_SCRIPT. */
+  private setupReactionTagging(): void {
+    const result = this.ctx.evalCode(REACTION_TAGGING_SCRIPT);
+    if (result.error) {
+      const errObj: unknown = this.ctx.dump(result.error) as unknown;
+      result.error.dispose();
+      // Startup invariant — the script is static; crash fast if it breaks.
+      throw new Error(`Failed to install reaction tagging: ${this.formatError(errObj)}`);
+    }
+    result.value.dispose();
+  }
+
+  /** Generation of the eval that registered the currently-running promise
+   * reaction, or undefined outside tagged callbacks. */
+  private readReactionOwner(): number | undefined {
+    const handle = this.ctx.getProp(this.ctx.global, REACTION_OWNER_GLOBAL);
+    try {
+      const value: unknown = this.ctx.dump(handle) as unknown;
+      return typeof value === "number" ? value : undefined;
+    } finally {
+      handle.dispose();
+    }
+  }
+
+  /** Attribution sinks for the code executing RIGHT NOW: the registering
+   * eval's context when inside a tagged reaction, else the current drain
+   * context (the runtime's mutable fields, possibly swapped by settleInVm). */
+  private currentAttribution(): AttributionContext {
+    const owner = this.readReactionOwner();
+    if (owner !== undefined) {
+      const context = this.generationContexts.get(owner);
+      if (context) {
+        return context;
+      }
+    }
+    return {
+      toolCalls: this.toolCalls,
+      consoleOutput: this.consoleOutput,
+      eventHandler: this.eventHandler,
+    };
   }
 
   /**

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -75,42 +75,47 @@ const REACTION_TAGGING_SCRIPT = `
     if (owner === undefined) {
       return origThen.call(this, onFulfilled, onRejected);
     }
+    if (typeof onFulfilled !== "function" && typeof onRejected !== "function") {
+      // No user callback can run; nothing to tag or retain.
+      return origThen.call(this, onFulfilled, onRejected);
+    }
     let released = false;
     const releaseOnce = () => {
       if (!released) { released = true; release(owner); }
     };
-    const wrap = (fn) =>
-      typeof fn === "function"
-        ? function (value) {
-            const prev = globalThis.${REACTION_OWNER_GLOBAL};
-            globalThis.${REACTION_OWNER_GLOBAL} = owner;
-            tagEpoch += 1;
-            const myEpoch = tagEpoch;
-            try {
-              return fn.call(this, value);
-            } finally {
-              releaseOnce();
-              // Deferred one-hop restore: jobs this callback enqueued run
-              // before the restore job, inheriting its owner. Epoch-guarded
-              // so a restore from an EARLIER callback in a settlement
-              // cascade cannot clear the owner out from under a LATER
-              // callback's still-queued continuations (the host resets the
-              // owner at every drain-batch boundary regardless).
-              origThen.call(origResolve(), () => {
-                if (tagEpoch === myEpoch) {
-                  globalThis.${REACTION_OWNER_GLOBAL} = prev;
-                }
-              });
+    // BOTH branches are wrapped (with the spec's identity/rethrow defaults
+    // for missing handlers) so exactly one wrapper runs at settlement and
+    // the retain is ALWAYS released — a single-handler reaction settling
+    // through the opposite branch must not leak its owner refcount.
+    const wrap = (fn, fallback) =>
+      function (value) {
+        const prev = globalThis.${REACTION_OWNER_GLOBAL};
+        globalThis.${REACTION_OWNER_GLOBAL} = owner;
+        tagEpoch += 1;
+        const myEpoch = tagEpoch;
+        try {
+          return typeof fn === "function" ? fn.call(this, value) : fallback(value);
+        } finally {
+          releaseOnce();
+          // Deferred one-hop restore: jobs this callback enqueued run
+          // before the restore job, inheriting its owner. Epoch-guarded
+          // so a restore from an EARLIER callback in a settlement
+          // cascade cannot clear the owner out from under a LATER
+          // callback's still-queued continuations (the host resets the
+          // owner at every drain-batch boundary regardless).
+          origThen.call(origResolve(), () => {
+            if (tagEpoch === myEpoch) {
+              globalThis.${REACTION_OWNER_GLOBAL} = prev;
             }
-          }
-        : fn;
-    const wrappedFulfilled = wrap(onFulfilled);
-    const wrappedRejected = wrap(onRejected);
-    if (wrappedFulfilled === onFulfilled && wrappedRejected === onRejected) {
-      return origThen.call(this, onFulfilled, onRejected);
-    }
+          });
+        }
+      };
     retain(owner);
-    return origThen.call(this, wrappedFulfilled, wrappedRejected);
+    return origThen.call(
+      this,
+      wrap(onFulfilled, (value) => value),
+      wrap(onRejected, (reason) => { throw reason; })
+    );
   };
   // Subclass wrapper for capability promises: \`await\` on a promise whose
   // constructor is not %Promise% takes the spec's thenable path, which calls

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -43,6 +43,12 @@ export class QuickJSRuntime implements IJSRuntime {
    * routed through the pending-job gate instead of touching the VM directly. */
   private evalGeneration = 0;
   private activeEvalGeneration: number | null = null;
+  /** Current registration per registerObject name; guest methods dispatch
+   * through this at call time so re-registration retargets saved references. */
+  private readonly registeredObjects = new Map<
+    string,
+    Record<string, (...args: unknown[]) => Promise<unknown>>
+  >();
 
   // Execution state (reset per eval)
   private toolCalls: PTCToolCallRecord[] = [];
@@ -339,13 +345,27 @@ export class QuickJSRuntime implements IJSRuntime {
   ): void {
     this.assertNotDisposed("registerObject");
 
+    // Store the CURRENT registration: guest-side methods dispatch through
+    // this map at call time, so re-registering (persistent mounts re-register
+    // the tool bridge every call) retargets even guest-saved references like
+    // `savedBash = mux.bash` to the newest implementation. A saved reference
+    // can therefore never pin a replaced tool or bypass a wrapper installed
+    // by a later registration.
+    this.registeredObjects.set(name, obj);
+
     // Create object in QuickJS
     const objHandle = this.ctx.newObject();
 
-    for (const [methodName, fn] of Object.entries(obj)) {
+    for (const methodName of Object.keys(obj)) {
       const fnHandle = this.ctx.newAsyncifiedFunction(methodName, async (...argHandles) => {
         if (this.abortController?.signal.aborted) {
           throw new Error("Execution aborted");
+        }
+
+        // Late-bound dispatch (see registeredObjects note above).
+        const fn = this.registeredObjects.get(name)?.[methodName];
+        if (fn === undefined) {
+          throw new Error(`${name}.${methodName} is no longer available in this sandbox`);
         }
 
         // Convert QuickJS handles to JS values - cast to unknown at the FFI boundary

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -176,7 +176,15 @@ export class QuickJSRuntime implements IJSRuntime {
       const callId = generateCallId();
       const deferred = this.ctx.newPromise();
 
-      this.eventHandler?.({
+      // Capture per-eval attribution state NOW: a fire-and-forget capability
+      // can settle after its originating eval() returned (timeout/abort or
+      // un-awaited call). eval() swaps this.toolCalls/this.eventHandler per
+      // execution, so consulting them at settlement would report the record
+      // under a later eval and emit it to the wrong handler.
+      const toolCalls = this.toolCalls;
+      const eventHandler = this.eventHandler;
+
+      eventHandler?.({
         type: "tool-call-start",
         callId,
         toolName: name,
@@ -188,13 +196,13 @@ export class QuickJSRuntime implements IJSRuntime {
         try {
           const result = await fn(...args);
           const endTime = Date.now();
-          this.toolCalls.push({
+          toolCalls.push({
             toolName: name,
             args: args[0],
             result,
             duration_ms: endTime - startTime,
           });
-          this.eventHandler?.({
+          eventHandler?.({
             type: "tool-call-end",
             callId,
             toolName: name,
@@ -210,13 +218,13 @@ export class QuickJSRuntime implements IJSRuntime {
         } catch (error) {
           const endTime = Date.now();
           const errorStr = error instanceof Error ? error.message : String(error);
-          this.toolCalls.push({
+          toolCalls.push({
             toolName: name,
             args: args[0],
             error: errorStr,
             duration_ms: endTime - startTime,
           });
-          this.eventHandler?.({
+          eventHandler?.({
             type: "tool-call-end",
             callId,
             toolName: name,

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -38,6 +38,11 @@ export class QuickJSRuntime implements IJSRuntime {
   private consoleSetup = false;
   /** Serializes late-settlement guest continuations; see setPendingJobGate. */
   private pendingJobGate?: (run: () => void) => void;
+  /** Monotonic eval counter + the generation currently inside eval() (null
+   * between evals). Used to detect LATE capability settlements that must be
+   * routed through the pending-job gate instead of touching the VM directly. */
+  private evalGeneration = 0;
+  private activeEvalGeneration: number | null = null;
 
   // Execution state (reset per eval)
   private toolCalls: PTCToolCallRecord[] = [];
@@ -185,6 +190,11 @@ export class QuickJSRuntime implements IJSRuntime {
       // under a later eval and emit it to the wrong handler.
       const toolCalls = this.toolCalls;
       const eventHandler = this.eventHandler;
+      // Generation of the eval this capability originated from: settlement
+      // may touch the VM directly only while that same eval is still running
+      // (its resolve loop coordinates); otherwise the VM-facing settlement
+      // must be routed through the pending-job gate.
+      const originGeneration = this.activeEvalGeneration;
 
       eventHandler?.({
         type: "tool-call-start",
@@ -193,6 +203,27 @@ export class QuickJSRuntime implements IJSRuntime {
         args: args[0],
         startTime,
       });
+
+      // VM-facing settlement: marshal + resolve/reject + drain continuations.
+      // Runs directly when the ORIGINATING eval is still active (routing
+      // through the gate would deadlock: the gate serializes on the mount
+      // lock held by that very call, whose resolve loop awaits this
+      // settlement). Any later settlement goes through the gate so it cannot
+      // re-enter the shared QuickJS context while another eval is running.
+      const settleInVm = (run: () => void) => {
+        const guarded = () => {
+          if (this.disposed) return;
+          run();
+          this.ctx.runtime.executePendingJobs();
+        };
+        if (this.activeEvalGeneration === originGeneration && originGeneration !== null) {
+          guarded();
+        } else if (this.pendingJobGate) {
+          this.pendingJobGate(guarded);
+        } else {
+          guarded();
+        }
+      };
 
       const settle = (async () => {
         try {
@@ -213,10 +244,11 @@ export class QuickJSRuntime implements IJSRuntime {
             startTime,
             endTime,
           });
-          if (this.disposed) return;
-          const valueHandle = this.marshal(result);
-          deferred.resolve(valueHandle);
-          valueHandle.dispose();
+          settleInVm(() => {
+            const valueHandle = this.marshal(result);
+            deferred.resolve(valueHandle);
+            valueHandle.dispose();
+          });
         } catch (error) {
           const endTime = Date.now();
           const errorStr = error instanceof Error ? error.message : String(error);
@@ -235,40 +267,27 @@ export class QuickJSRuntime implements IJSRuntime {
             startTime,
             endTime,
           });
-          if (this.disposed) return;
-          const errorHandle = this.marshal({ name: "Error", message: errorStr });
-          deferred.reject(errorHandle);
-          errorHandle.dispose();
+          settleInVm(() => {
+            const errorHandle = this.marshal({ name: "Error", message: errorStr });
+            deferred.reject(errorHandle);
+            errorHandle.dispose();
+          });
         }
       })();
 
       // Track settlement so eval()'s resolve loop can wait on it. The tracked
-      // promise never rejects (settle() catches everything above).
+      // promise never rejects (settle() catches everything above). Note: for
+      // gated late settlements this resolves when the settlement is HANDED to
+      // the gate; the VM effect lands when the gate runs it under the lock.
       const tracked: Promise<void> = settle.finally(() => {
         this.pendingHostPromises.delete(tracked);
       });
       this.pendingHostPromises.add(tracked);
 
-      // Run guest continuations (.then/await) once the deferred settles.
-      // Routed through the pending-job gate when set: on shared (persistent)
-      // runtimes a LATE settlement must not re-enter the QuickJS context
-      // while a later eval is running — the gate serializes the run under the
-      // owner's exclusive lock. In-eval settlements are unaffected: eval's
-      // resolve loop drains pending jobs itself.
-      deferred.settled
-        .then(() => {
-          const run = () => {
-            if (!this.disposed) {
-              this.ctx.runtime.executePendingJobs();
-            }
-          };
-          if (this.pendingJobGate) {
-            this.pendingJobGate(run);
-          } else {
-            run();
-          }
-        })
-        .catch(() => undefined);
+      // Consume the settled promise: nothing chains on it anymore (the gate
+      // handles continuation draining), and an unconsumed rejection would be
+      // reported as unhandled.
+      deferred.settled.catch(() => undefined);
 
       // Ownership of deferred.handle transfers to the wrapper (return value).
       return deferred.handle;
@@ -386,6 +405,7 @@ export class QuickJSRuntime implements IJSRuntime {
     this.abortController = new AbortController();
     this.toolCalls = [];
     this.consoleOutput = [];
+    this.activeEvalGeneration = ++this.evalGeneration;
 
     // Honor abort requests made before eval() was called
     if (this.abortRequested) {
@@ -482,6 +502,9 @@ export class QuickJSRuntime implements IJSRuntime {
       // start), not to future evals: persistent mounts reuse this runtime
       // across calls, and a sticky flag would poison every later eval.
       this.abortRequested = false;
+      // Settlements arriving from here on are LATE (post-eval) and must be
+      // gated; see registerPromiseFunction.
+      this.activeEvalGeneration = null;
     }
   }
 

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -36,6 +36,8 @@ export class QuickJSRuntime implements IJSRuntime {
   private abortRequested = false; // Track abort requests before eval() starts
   private limits: RuntimeLimits = {};
   private consoleSetup = false;
+  /** Serializes late-settlement guest continuations; see setPendingJobGate. */
+  private pendingJobGate?: (run: () => void) => void;
 
   // Execution state (reset per eval)
   private toolCalls: PTCToolCallRecord[] = [];
@@ -248,10 +250,22 @@ export class QuickJSRuntime implements IJSRuntime {
       this.pendingHostPromises.add(tracked);
 
       // Run guest continuations (.then/await) once the deferred settles.
+      // Routed through the pending-job gate when set: on shared (persistent)
+      // runtimes a LATE settlement must not re-enter the QuickJS context
+      // while a later eval is running — the gate serializes the run under the
+      // owner's exclusive lock. In-eval settlements are unaffected: eval's
+      // resolve loop drains pending jobs itself.
       deferred.settled
         .then(() => {
-          if (!this.disposed) {
-            this.ctx.runtime.executePendingJobs();
+          const run = () => {
+            if (!this.disposed) {
+              this.ctx.runtime.executePendingJobs();
+            }
+          };
+          if (this.pendingJobGate) {
+            this.pendingJobGate(run);
+          } else {
+            run();
           }
         })
         .catch(() => undefined);
@@ -262,6 +276,10 @@ export class QuickJSRuntime implements IJSRuntime {
 
     this.ctx.setProp(this.ctx.global, name, fnHandle);
     fnHandle.dispose();
+  }
+
+  setPendingJobGate(gate: (run: () => void) => void): void {
+    this.pendingJobGate = gate;
   }
 
   registerSyncFunction(name: string, fn: (...args: unknown[]) => unknown): void {

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -189,6 +189,7 @@ export class QuickJSRuntime implements IJSRuntime {
       // execution, so consulting them at settlement would report the record
       // under a later eval and emit it to the wrong handler.
       const toolCalls = this.toolCalls;
+      const consoleOutput = this.consoleOutput;
       const eventHandler = this.eventHandler;
       // Generation of the eval this capability originated from: settlement
       // may touch the VM directly only while that same eval is still running
@@ -213,8 +214,25 @@ export class QuickJSRuntime implements IJSRuntime {
       const settleInVm = (run: () => void) => {
         const guarded = () => {
           if (this.disposed) return;
-          run();
-          this.ctx.runtime.executePendingJobs();
+          // Bind the resumed guest continuation to its ORIGINATING eval's
+          // attribution state: console.log and nested capability calls inside
+          // the continuation read the runtime's mutable fields, which by now
+          // may belong to a later eval. Swap for the duration of the drain,
+          // then restore (no-op while the originating eval is still active).
+          const prevToolCalls = this.toolCalls;
+          const prevConsoleOutput = this.consoleOutput;
+          const prevEventHandler = this.eventHandler;
+          this.toolCalls = toolCalls;
+          this.consoleOutput = consoleOutput;
+          this.eventHandler = eventHandler;
+          try {
+            run();
+            this.ctx.runtime.executePendingJobs();
+          } finally {
+            this.toolCalls = prevToolCalls;
+            this.consoleOutput = prevConsoleOutput;
+            this.eventHandler = prevEventHandler;
+          }
         };
         if (this.activeEvalGeneration === originGeneration && originGeneration !== null) {
           guarded();

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -28,42 +28,95 @@ function generateCallId(): string {
 /** Guest globals used for per-reaction attribution (see REACTION_TAGGING_SCRIPT). */
 const EVAL_GENERATION_GLOBAL = "__muxEvalGeneration";
 const REACTION_OWNER_GLOBAL = "__muxReactionOwner";
+const RETAIN_GENERATION_FN = "__muxRetainGeneration";
+const RELEASE_GENERATION_FN = "__muxReleaseGeneration";
+const WRAP_PROMISE_FN = "__muxWrapPromise";
 
 /**
  * Installed once per context: tags every promise reaction with the eval
  * generation that REGISTERED it. Persistent mounts share one context across
  * evals, and a capability promise from eval N can settle while eval M runs —
  * QuickJS's job queue carries no per-job ownership, so registration is the
- * only point where the owner is knowable. The wrapper sets the owner global
- * for the duration of the callback; host entry points (console, capability
- * calls) read it to route records to the owning eval's context. catch()/
- * finally() delegate to then() per spec, so patching then() covers them.
- * Best-effort observability, not a security boundary: guests can overwrite
- * the patch, and await-registered continuations use the engine-internal
- * reaction path (no .then call), falling back to the drain context.
+ * only point where the owner is knowable.
+ *
+ * Mechanics:
+ * - Promise.prototype.then is patched (catch()/finally() delegate to then()
+ *   per spec) to wrap callbacks: the owner global is set for the callback's
+ *   duration, and a restore job is enqueued AFTER the callback instead of
+ *   restoring synchronously — so jobs the callback itself enqueued (await
+ *   resumptions it resolved) still run under its owner (one-hop ownership
+ *   propagation).
+ * - Each tagged registration retains its owner's attribution context via a
+ *   host refcount (RETAIN/RELEASE_GENERATION_FN) so contexts live exactly as
+ *   long as outstanding reactions, not a fixed eval count.
+ * - Capability promises are wrapped in a Promise SUBCLASS (WRAP_PROMISE_FN):
+ *   `await` on a non-%Promise%-constructor promise goes through the thenable
+ *   path, which calls the PATCHED then — so await continuations on
+ *   capability promises are tagged too, not just explicit .then chains.
+ *
+ * Host entry points (console, capability calls) read the owner global to
+ * route records to the owning eval's context. Best-effort observability, not
+ * a security boundary: guests can overwrite the patch, and exotic untagged
+ * chains (await on plain guest promises) fall back to the drain context.
  */
 const REACTION_TAGGING_SCRIPT = `
 (() => {
   const origThen = Promise.prototype.then;
+  const origResolve = Promise.resolve.bind(Promise);
+  const retain = globalThis.${RETAIN_GENERATION_FN};
+  const release = globalThis.${RELEASE_GENERATION_FN};
+  // Monotonic count of tagged-callback runs; guards deferred restores.
+  let tagEpoch = 0;
   Promise.prototype.then = function (onFulfilled, onRejected) {
     const owner =
       globalThis.${REACTION_OWNER_GLOBAL} !== undefined
         ? globalThis.${REACTION_OWNER_GLOBAL}
         : globalThis.${EVAL_GENERATION_GLOBAL};
+    if (owner === undefined) {
+      return origThen.call(this, onFulfilled, onRejected);
+    }
+    let released = false;
+    const releaseOnce = () => {
+      if (!released) { released = true; release(owner); }
+    };
     const wrap = (fn) =>
       typeof fn === "function"
         ? function (value) {
             const prev = globalThis.${REACTION_OWNER_GLOBAL};
             globalThis.${REACTION_OWNER_GLOBAL} = owner;
+            tagEpoch += 1;
+            const myEpoch = tagEpoch;
             try {
-              return fn(value);
+              return fn.call(this, value);
             } finally {
-              globalThis.${REACTION_OWNER_GLOBAL} = prev;
+              releaseOnce();
+              // Deferred one-hop restore: jobs this callback enqueued run
+              // before the restore job, inheriting its owner. Epoch-guarded
+              // so a restore from an EARLIER callback in a settlement
+              // cascade cannot clear the owner out from under a LATER
+              // callback's still-queued continuations (the host resets the
+              // owner at every drain-batch boundary regardless).
+              origThen.call(origResolve(), () => {
+                if (tagEpoch === myEpoch) {
+                  globalThis.${REACTION_OWNER_GLOBAL} = prev;
+                }
+              });
             }
           }
         : fn;
-    return origThen.call(this, wrap(onFulfilled), wrap(onRejected));
+    const wrappedFulfilled = wrap(onFulfilled);
+    const wrappedRejected = wrap(onRejected);
+    if (wrappedFulfilled === onFulfilled && wrappedRejected === onRejected) {
+      return origThen.call(this, onFulfilled, onRejected);
+    }
+    retain(owner);
+    return origThen.call(this, wrappedFulfilled, wrappedRejected);
   };
+  // Subclass wrapper for capability promises: \`await\` on a promise whose
+  // constructor is not %Promise% takes the spec's thenable path, which calls
+  // the PATCHED then — tagging await continuations at registration time.
+  class MuxCapabilityPromise extends Promise {}
+  globalThis.${WRAP_PROMISE_FN} = (promise) => MuxCapabilityPromise.resolve(promise);
 })();
 `;
 
@@ -74,10 +127,18 @@ interface AttributionContext {
   eventHandler: ((event: PTCEvent) => void) | undefined;
 }
 
-/** Bound on retained per-eval attribution contexts (persistent mounts run
- * many evals; reactions rarely outlive a handful of calls). Evicted
- * generations fall back to the drain context. */
-const MAX_GENERATION_CONTEXTS = 8;
+/** Attribution context plus the number of outstanding tagged reactions that
+ * still reference it (guest-driven retain/release). */
+interface GenerationContextEntry {
+  context: AttributionContext;
+  refs: number;
+}
+
+/** Soft cap on retained IDLE (refs === 0) attribution contexts. Generations
+ * with outstanding reactions are always retained; a hard cap bounds memory
+ * against pathological never-settling registrations. */
+const MAX_IDLE_GENERATION_CONTEXTS = 8;
+const MAX_GENERATION_CONTEXTS = 64;
 
 /**
  * QuickJS-based JavaScript runtime for PTC.
@@ -102,9 +163,10 @@ export class QuickJSRuntime implements IJSRuntime {
   private activeEvalGeneration: number | null = null;
   /** Attribution sinks per eval generation. Tagged reactions route their
    * console output and nested capability records to the eval that REGISTERED
-   * them, no matter which eval's drain executes the job. Bounded by
-   * MAX_GENERATION_CONTEXTS (oldest evicted; fallback is the drain context). */
-  private readonly generationContexts = new Map<number, AttributionContext>();
+   * them, no matter which eval's drain executes the job. Retention is
+   * refcount-driven (outstanding tagged reactions), with a soft cap on idle
+   * entries and a hard memory bound; see pruneGenerationContexts. */
+  private readonly generationContexts = new Map<number, GenerationContextEntry>();
   /** True only while eval()'s returned-value resolve loop coordinates VM
    * access (evalCodeAsync completed, VM idle at the top level). Settlements
    * may touch the VM directly ONLY then: during asyncified suspension the
@@ -137,7 +199,12 @@ export class QuickJSRuntime implements IJSRuntime {
   // persistent mount may legitimately still be settling.
   private readonly pendingHostPromises = new Set<Promise<void>>();
 
-  private constructor(private readonly ctx: QuickJSAsyncContext) {}
+  private constructor(private readonly ctx: QuickJSAsyncContext) {
+    // Install per-reaction attribution before ANY registration or eval:
+    // registerPromiseFunction wraps its returned promises via the guest
+    // helper this script defines.
+    this.setupReactionTagging();
+  }
 
   static async create(): Promise<QuickJSRuntime> {
     // Create the async variant manually due to bun's package export resolution issues.
@@ -309,6 +376,7 @@ export class QuickJSRuntime implements IJSRuntime {
             // attribution captured at call time above.
             run();
             this.ctx.runtime.executePendingJobs();
+            this.clearReactionOwner();
             return;
           }
           // Between evals: fall back to the ORIGINATING eval's attribution
@@ -323,6 +391,7 @@ export class QuickJSRuntime implements IJSRuntime {
           try {
             run();
             this.ctx.runtime.executePendingJobs();
+            this.clearReactionOwner();
           } finally {
             this.toolCalls = prevToolCalls;
             this.consoleOutput = prevConsoleOutput;
@@ -417,8 +486,20 @@ export class QuickJSRuntime implements IJSRuntime {
       // reported as unhandled.
       deferred.settled.catch(() => undefined);
 
-      // Ownership of deferred.handle transfers to the wrapper (return value).
-      return deferred.handle;
+      // Hand the guest a tagged capability promise (Promise subclass) so
+      // `await` continuations are attributed at registration time; see
+      // REACTION_TAGGING_SCRIPT. Fall back to the raw promise if wrapping
+      // fails (attribution degrades; behavior does not).
+      const wrapFnHandle = this.ctx.getProp(this.ctx.global, WRAP_PROMISE_FN);
+      const wrapResult = this.ctx.callFunction(wrapFnHandle, this.ctx.undefined, deferred.handle);
+      wrapFnHandle.dispose();
+      if (wrapResult.error) {
+        wrapResult.error.dispose();
+        // Ownership of deferred.handle transfers to the wrapper (return value).
+        return deferred.handle;
+      }
+      deferred.handle.dispose();
+      return wrapResult.value;
     });
 
     this.ctx.setProp(this.ctx.global, name, fnHandle);
@@ -553,10 +634,10 @@ export class QuickJSRuntime implements IJSRuntime {
       this.abortController.abort();
     }
 
-    // Set up console capturing + reaction tagging (only once)
+    // Set up console capturing (only once; reaction tagging is installed in
+    // the constructor because registrations precede the first eval)
     if (!this.consoleSetup) {
       this.setupConsole();
-      this.setupReactionTagging();
       this.consoleSetup = true;
     }
 
@@ -600,15 +681,14 @@ export class QuickJSRuntime implements IJSRuntime {
     // (REACTION_TAGGING_SCRIPT). Placed after the drain: drained reactions
     // belong to prior generations.
     this.generationContexts.set(this.activeEvalGeneration, {
-      toolCalls: this.toolCalls,
-      consoleOutput: this.consoleOutput,
-      eventHandler: this.eventHandler,
+      context: {
+        toolCalls: this.toolCalls,
+        consoleOutput: this.consoleOutput,
+        eventHandler: this.eventHandler,
+      },
+      refs: 0,
     });
-    while (this.generationContexts.size > MAX_GENERATION_CONTEXTS) {
-      const oldest: number | undefined = this.generationContexts.keys().next().value;
-      if (oldest === undefined) break;
-      this.generationContexts.delete(oldest);
-    }
+    this.pruneGenerationContexts();
     const generationHandle = this.ctx.newNumber(this.activeEvalGeneration);
     this.ctx.setProp(this.ctx.global, EVAL_GENERATION_GLOBAL, generationHandle);
     generationHandle.dispose();
@@ -678,6 +758,21 @@ export class QuickJSRuntime implements IJSRuntime {
       // start), not to future evals: persistent mounts reuse this runtime
       // across calls, and a sticky flag would poison every later eval.
       this.abortRequested = false;
+      // Run microtasks this eval enqueued BEFORE dropping its generation:
+      // fire-and-forget reactions and internal thenable jobs (an `await` on
+      // a capability promise registers through the patched then here) must
+      // tag with THIS eval as owner, not whichever eval drains them later.
+      if (!this.disposed) {
+        const leftoverJobs = this.ctx.runtime.executePendingJobs();
+        if (leftoverJobs.error) {
+          // Fire-and-forget guest job failed; surfacing it would mask the
+          // eval result. Drop it — same policy as the gate's drain.
+          leftoverJobs.error.dispose();
+        } else {
+          leftoverJobs.dispose();
+        }
+        this.clearReactionOwner();
+      }
       // Settlements arriving from here on are LATE (post-eval) and must be
       // queued; see settleInVm in registerPromiseFunction.
       this.directSettleAllowed = false;
@@ -907,6 +1002,24 @@ export class QuickJSRuntime implements IJSRuntime {
 
   /** Install the promise-reaction tagging patch; see REACTION_TAGGING_SCRIPT. */
   private setupReactionTagging(): void {
+    // Host refcount endpoints must exist before the script captures them.
+    const retainFn = this.ctx.newFunction(RETAIN_GENERATION_FN, (genHandle) => {
+      const gen: unknown = this.ctx.dump(genHandle) as unknown;
+      if (typeof gen !== "number") return;
+      const entry = this.generationContexts.get(gen);
+      if (entry) entry.refs += 1;
+    });
+    this.ctx.setProp(this.ctx.global, RETAIN_GENERATION_FN, retainFn);
+    retainFn.dispose();
+    const releaseFn = this.ctx.newFunction(RELEASE_GENERATION_FN, (genHandle) => {
+      const gen: unknown = this.ctx.dump(genHandle) as unknown;
+      if (typeof gen !== "number") return;
+      const entry = this.generationContexts.get(gen);
+      if (entry && entry.refs > 0) entry.refs -= 1;
+    });
+    this.ctx.setProp(this.ctx.global, RELEASE_GENERATION_FN, releaseFn);
+    releaseFn.dispose();
+
     const result = this.ctx.evalCode(REACTION_TAGGING_SCRIPT);
     if (result.error) {
       const errObj: unknown = this.ctx.dump(result.error) as unknown;
@@ -929,15 +1042,23 @@ export class QuickJSRuntime implements IJSRuntime {
     }
   }
 
+  /** Reset the guest owner global at a drain-batch boundary: the deferred
+   * one-hop restore inside REACTION_TAGGING_SCRIPT can leave a stale owner
+   * when tagged callbacks from different owners interleave in one batch. */
+  private clearReactionOwner(): void {
+    if (this.disposed) return;
+    this.ctx.setProp(this.ctx.global, REACTION_OWNER_GLOBAL, this.ctx.undefined);
+  }
+
   /** Attribution sinks for the code executing RIGHT NOW: the registering
    * eval's context when inside a tagged reaction, else the current drain
    * context (the runtime's mutable fields, possibly swapped by settleInVm). */
   private currentAttribution(): AttributionContext {
     const owner = this.readReactionOwner();
     if (owner !== undefined) {
-      const context = this.generationContexts.get(owner);
-      if (context) {
-        return context;
+      const entry = this.generationContexts.get(owner);
+      if (entry) {
+        return entry.context;
       }
     }
     return {
@@ -945,6 +1066,30 @@ export class QuickJSRuntime implements IJSRuntime {
       consoleOutput: this.consoleOutput,
       eventHandler: this.eventHandler,
     };
+  }
+
+  /** Retention policy for attribution contexts: generations with outstanding
+   * tagged reactions (refs > 0) are retained so a reaction can settle any
+   * number of evals later; idle entries beyond a soft cap are evicted
+   * oldest-first. A hard cap bounds memory against pathological
+   * never-settling registrations (evicted reactions fall back to the drain
+   * context). The active generation is never evicted. */
+  private pruneGenerationContexts(): void {
+    const evict = (spare: number, includeRetained: boolean) => {
+      for (const [gen, entry] of this.generationContexts) {
+        if (spare <= 0) break;
+        if (gen === this.activeEvalGeneration) continue;
+        if (!includeRetained && entry.refs > 0) continue;
+        this.generationContexts.delete(gen);
+        spare -= 1;
+      }
+    };
+    let idle = 0;
+    for (const [gen, entry] of this.generationContexts) {
+      if (entry.refs === 0 && gen !== this.activeEvalGeneration) idle += 1;
+    }
+    evict(idle - MAX_IDLE_GENERATION_CONTEXTS, false);
+    evict(this.generationContexts.size - MAX_GENERATION_CONTEXTS, true);
   }
 
   /**

--- a/src/node/services/ptc/quickjsRuntime.ts
+++ b/src/node/services/ptc/quickjsRuntime.ts
@@ -43,6 +43,13 @@ export class QuickJSRuntime implements IJSRuntime {
    * routed through the pending-job gate instead of touching the VM directly. */
   private evalGeneration = 0;
   private activeEvalGeneration: number | null = null;
+  /** Late settlements handed to the pending-job gate but not yet run. eval()
+   * drains this at start: the gate serializes on the scope lock, so a
+   * settlement queued between calls can lose the lock race to the next
+   * code_execution call — without the drain, that eval could never consume
+   * the guest-visible promise (the tracked host promise resolves at gate
+   * hand-off, so the resolve loop has nothing left to wait on). */
+  private readonly queuedLateSettlements: Array<() => void> = [];
   /** Current registration per registerObject name; guest methods dispatch
    * through this at call time so re-registration retargets saved references. */
   private readonly registeredObjects = new Map<
@@ -197,11 +204,6 @@ export class QuickJSRuntime implements IJSRuntime {
       const toolCalls = this.toolCalls;
       const consoleOutput = this.consoleOutput;
       const eventHandler = this.eventHandler;
-      // Generation of the eval this capability originated from: settlement
-      // may touch the VM directly only while that same eval is still running
-      // (its resolve loop coordinates); otherwise the VM-facing settlement
-      // must be routed through the pending-job gate.
-      const originGeneration = this.activeEvalGeneration;
 
       eventHandler?.({
         type: "tool-call-start",
@@ -212,11 +214,14 @@ export class QuickJSRuntime implements IJSRuntime {
       });
 
       // VM-facing settlement: marshal + resolve/reject + drain continuations.
-      // Runs directly when the ORIGINATING eval is still active (routing
-      // through the gate would deadlock: the gate serializes on the mount
-      // lock held by that very call, whose resolve loop awaits this
-      // settlement). Any later settlement goes through the gate so it cannot
-      // re-enter the shared QuickJS context while another eval is running.
+      // Runs directly while ANY eval is active: that eval's resolve loop
+      // coordinates VM access and may itself be awaiting this settlement
+      // (e.g. a later call returning a promise stored by a prior call), so
+      // routing through the gate would deadlock — the gate serializes on the
+      // mount lock held by that very eval. Settlements between evals go
+      // through the gate so they cannot re-enter the shared QuickJS context
+      // unserialized; they are queued so the next eval can drain them if its
+      // call wins the mount-lock race against the gate.
       const settleInVm = (run: () => void) => {
         const guarded = () => {
           if (this.disposed) return;
@@ -240,10 +245,14 @@ export class QuickJSRuntime implements IJSRuntime {
             this.eventHandler = prevEventHandler;
           }
         };
-        if (this.activeEvalGeneration === originGeneration && originGeneration !== null) {
+        if (this.activeEvalGeneration !== null) {
+          // Attribution stays bound to the ORIGINATING eval either way: for a
+          // different active generation, guarded() swaps in the captured
+          // per-eval state for the duration of the drain.
           guarded();
         } else if (this.pendingJobGate) {
-          this.pendingJobGate(guarded);
+          this.queuedLateSettlements.push(guarded);
+          this.pendingJobGate(() => this.drainQueuedLateSettlements());
         } else {
           guarded();
         }
@@ -479,6 +488,15 @@ export class QuickJSRuntime implements IJSRuntime {
       this.abortController?.abort();
     }, timeoutMs);
 
+    // Land late settlements whose gate callback lost the mount-lock race to
+    // this call (the lock is already held by our code_execution invocation,
+    // so the gate cannot run until we return). Must happen before guest code
+    // runs so a promise stored by a prior eval is consumable here; the gate's
+    // eventual drain then finds an empty queue and no-ops. Placed after the
+    // interrupt handler + timer setup so the drain runs under THIS eval's
+    // deadline, not a stale one.
+    this.drainQueuedLateSettlements();
+
     // Wrap code in function to allow return statements.
     // With asyncify, async host functions appear synchronous to QuickJS,
     // so we don't need an async IIFE. Using evalCodeAsync handles the suspension.
@@ -559,6 +577,9 @@ export class QuickJSRuntime implements IJSRuntime {
     if (!this.disposed) {
       this.ctx.dispose();
       this.disposed = true;
+      // Queued late settlements would no-op anyway (guarded checks disposed);
+      // drop them so their closures are not retained.
+      this.queuedLateSettlements.length = 0;
     }
   }
 
@@ -571,6 +592,17 @@ export class QuickJSRuntime implements IJSRuntime {
   private assertNotDisposed(method: string): void {
     if (this.disposed) {
       throw new Error(`Cannot call ${method} on disposed QuickJSRuntime`);
+    }
+  }
+
+  /** Run queued late settlements in arrival order. Called from eval() start
+   * (under the caller's mount lock) and from the pending-job gate (under the
+   * gate's own lock acquisition) — whichever wins the race; the loser sees an
+   * empty queue. Each entry is a guarded() that no-ops after dispose. */
+  private drainQueuedLateSettlements(): void {
+    while (this.queuedLateSettlements.length > 0) {
+      const run = this.queuedLateSettlements.shift();
+      run?.();
     }
   }
 

--- a/src/node/services/ptc/runtime.ts
+++ b/src/node/services/ptc/runtime.ts
@@ -42,6 +42,25 @@ export interface IJSRuntime extends Disposable {
   registerObject(name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>): void;
 
   /**
+   * Register a host function that returns a real Promise INTO the guest
+   * (async capability bridge). Unlike registerFunction (asyncified: guest
+   * blocks until the host settles), the guest receives the Promise
+   * immediately and may await it, chain it, or ignore it (fire-and-forget).
+   * eval() waits for in-flight capability promises the returned value depends
+   * on, bounded by the same deadline/interrupt semantics.
+   */
+  registerPromiseFunction(name: string, fn: (...args: unknown[]) => Promise<unknown>): void;
+
+  /**
+   * Register a synchronous host function (no asyncify, no suspension).
+   * Required for bridges that must be callable from guest continuations
+   * resumed via executePendingJobs (e.g. code after `await capability()`),
+   * where asyncified functions cannot suspend. Keep these fast and pure-ish:
+   * they block the guest.
+   */
+  registerSyncFunction(name: string, fn: (...args: unknown[]) => unknown): void;
+
+  /**
    * Set memory/CPU limits for the sandbox.
    * Must be called before eval() to take effect.
    */

--- a/src/node/services/ptc/runtime.ts
+++ b/src/node/services/ptc/runtime.ts
@@ -61,6 +61,16 @@ export interface IJSRuntime extends Disposable {
   registerSyncFunction(name: string, fn: (...args: unknown[]) => unknown): void;
 
   /**
+   * Route late guest-continuation execution through a host-provided gate.
+   * When a fire-and-forget capability (registerPromiseFunction) settles after
+   * its originating eval() returned, the runtime must run pending guest jobs —
+   * but on a shared/persistent runtime that must not interleave with a later
+   * eval. The gate lets the owner (e.g. SandboxMount) serialize the run under
+   * its exclusive lock. Without a gate, jobs run immediately on settlement.
+   */
+  setPendingJobGate(gate: (run: () => void) => void): void;
+
+  /**
    * Set memory/CPU limits for the sandbox.
    * Must be called before eval() to take effect.
    */

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -25,6 +25,8 @@ function createMockRuntime(overrides: Partial<IJSRuntime> = {}): IJSRuntime {
     registerObject: mock(
       (_name: string, _obj: Record<string, () => Promise<unknown>>) => undefined
     ),
+    registerPromiseFunction: mock((_name: string, _fn: () => Promise<unknown>) => undefined),
+    registerSyncFunction: mock((_name: string, _fn: () => unknown) => undefined),
     setLimits: mock((_limits: RuntimeLimits) => undefined),
     onEvent: mock((_handler: (event: PTCEvent) => void) => undefined),
     abort: mock(() => undefined),

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -27,6 +27,7 @@ function createMockRuntime(overrides: Partial<IJSRuntime> = {}): IJSRuntime {
     ),
     registerPromiseFunction: mock((_name: string, _fn: () => Promise<unknown>) => undefined),
     registerSyncFunction: mock((_name: string, _fn: () => unknown) => undefined),
+    setPendingJobGate: mock((_gate: (run: () => void) => void) => undefined),
     setLimits: mock((_limits: RuntimeLimits) => undefined),
     onEvent: mock((_handler: (event: PTCEvent) => void) => undefined),
     abort: mock(() => undefined),

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -130,6 +130,50 @@ describe("ToolBridge", () => {
       expect(typeof obj.file_read).toBe("function");
     });
 
+    it("enforces capability grants: denied tools are excluded, stubbed, and never leak", async () => {
+      const executed = mock(() => ({ result: "ok" }));
+      const tools: Record<string, Tool> = {
+        file_read: createMockTool("file_read", z.object({}), executed),
+        bash: createMockTool("bash", z.object({}), executed),
+      };
+
+      const bridge = new ToolBridge(tools, {
+        version: 1,
+        bridgeTools: { allow: ["file_read"] },
+        vars: false,
+        hostEvents: false,
+      });
+
+      // Denied tool is not advertised as bridgeable...
+      expect(bridge.getBridgeableToolNames()).toEqual(["file_read"]);
+      // ...and must not leak into the model-visible non-bridgeable set either.
+      expect(Object.keys(bridge.getNonBridgeableTools())).toEqual([]);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(createMockRuntime({ registerObject: mockRegisterObject }));
+
+      // Granted tool executes.
+      const fileRead = registeredMux.file_read as (...args: unknown[]) => Promise<unknown>;
+      await fileRead({});
+      expect(executed).toHaveBeenCalledTimes(1);
+
+      // Denied tool is stubbed with a clear capability error, not a crash.
+      const bash = registeredMux.bash as (...args: unknown[]) => Promise<unknown>;
+      try {
+        await bash({});
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        expect(String(e)).toContain("Capability denied: mux.bash is not granted");
+      }
+      expect(executed).toHaveBeenCalledTimes(1); // bash never ran
+    });
+
     it("validates arguments before executing tool", async () => {
       const mockExecute = mock(() => ({ result: "ok" }));
 

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -8,6 +8,11 @@
 import type { Tool } from "ai";
 import type { z } from "zod";
 import type { IJSRuntime } from "./runtime";
+import {
+  FULL_GRANTS,
+  isBridgeToolGranted,
+  type CapabilityGrants,
+} from "@/common/types/capabilityGrants";
 
 /** Tools excluded from sandbox - UI-specific or would cause recursion */
 const EXCLUDED_TOOLS = new Set([
@@ -26,20 +31,28 @@ const EXCLUDED_TOOLS = new Set([
 export class ToolBridge {
   private readonly bridgeableTools: Map<string, Tool>;
   private readonly nonBridgeableTools: Map<string, Tool>;
+  /** Bridgeable tools denied by capability grants: stubbed with a clear error
+   * in the sandbox and exposed in NEITHER getter (a denied tool must not leak
+   * into the model-visible set via getNonBridgeableTools in exclusive mode). */
+  private readonly deniedToolNames = new Set<string>();
+  private readonly grants: CapabilityGrants;
 
-  constructor(tools: Record<string, Tool>) {
+  constructor(tools: Record<string, Tool>, grants?: CapabilityGrants) {
     this.bridgeableTools = new Map();
     this.nonBridgeableTools = new Map();
+    this.grants = grants ?? FULL_GRANTS;
 
     for (const [name, tool] of Object.entries(tools)) {
       // code_execution is the tool that uses the bridge, not a candidate for bridging
       if (name === "code_execution") continue;
 
       const isBridgeable = !EXCLUDED_TOOLS.has(name) && this.hasExecute(tool);
-      if (isBridgeable) {
+      if (!isBridgeable) {
+        this.nonBridgeableTools.set(name, tool);
+      } else if (isBridgeToolGranted(this.grants, name)) {
         this.bridgeableTools.set(name, tool);
       } else {
-        this.nonBridgeableTools.set(name, tool);
+        this.deniedToolNames.add(name);
       }
     }
   }
@@ -79,12 +92,25 @@ export class ToolBridge {
   register(runtime: IJSRuntime): void {
     const muxObj: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
 
+    // Grant-denied tools get an explicit stub: the guest sees a clear
+    // capability error instead of a confusing "mux.x is not a function".
+    for (const name of this.deniedToolNames) {
+      muxObj[name] = () =>
+        Promise.reject(new Error(`Capability denied: mux.${name} is not granted for this sandbox`));
+    }
+
     for (const [name, tool] of this.bridgeableTools) {
       // Capture tool for closure
       const boundTool = tool;
       const toolName = name;
 
       muxObj[name] = async (args: unknown) => {
+        // Defense in depth: re-check the grant at call time so a stale or
+        // mutated bridge can never invoke a non-granted tool.
+        if (!isBridgeToolGranted(this.grants, toolName)) {
+          throw new Error(`Capability denied: mux.${toolName} is not granted for this sandbox`);
+        }
+
         // Get the runtime's abort signal - this is aborted on timeout or manual abort
         const abortSignal = runtime.getAbortSignal();
 

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -257,6 +257,43 @@ describe("SandboxHostService", () => {
     await host.disposeScope("ws-race");
   });
 
+  test("withPersistentMount holds the lease: concurrent disposal waits for fn to finish", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const order: string[] = [];
+    let releaseFn: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseFn = resolve;
+    });
+
+    const run = host.withPersistentMount(
+      {
+        lifetime: "persistent",
+        runtimeFactory,
+        scopeKey: "ws-lease",
+        sessionDir: tmp.path,
+      },
+      async (mount) => {
+        order.push("fn-start");
+        await gate;
+        // The mount must still be live: disposeScope started while fn held
+        // the lease and must be queued behind it, not race it.
+        expect(mount.isDisposed).toBe(false);
+        const result = await mount.runtime.eval("return 7;");
+        order.push("fn-end");
+        return result;
+      }
+    );
+    // Give fn time to enter the lease, then attempt disposal concurrently.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const disposal = host.disposeScope("ws-lease").then(() => order.push("disposed"));
+    releaseFn?.();
+    const result = await run;
+    await disposal;
+    expect(result.success).toBe(true);
+    expect(order).toEqual(["fn-start", "fn-end", "disposed"]);
+  });
+
   test("exclusive() serializes concurrent runs on a shared mount", async () => {
     using tmp = new DisposableTempDir("sandbox-host-test");
     const host = new SandboxHostService();

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ToolBridge } from "@/node/services/ptc/toolBridge";
-import { LEAST_PRIVILEGE_GRANTS } from "@/common/types/capabilityGrants";
+import { FULL_GRANTS, LEAST_PRIVILEGE_GRANTS } from "@/common/types/capabilityGrants";
 import { DurableEventJournal } from "@/node/utils/journal/durableEventJournal";
 import { SandboxHostService } from "./sandboxHostService";
 
@@ -342,6 +342,50 @@ describe("SandboxHostService", () => {
     const drainProbe = await narrowed.runtime.eval("return typeof globalThis.drainHostEvents;");
     expect(drainProbe.result).toBe("undefined");
     await host.disposeScope("ws-grant-change");
+  });
+
+  test("bridge narrowing rebuilds the mount, revoking guest-saved bridge references", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const tools = {
+      bash: tool({
+        description: "run",
+        inputSchema: z.object({}),
+        execute: () => Promise.resolve({ output: "ran" }),
+      }),
+    };
+
+    const broadMount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-saved-ref",
+      sessionDir: tmp.path,
+      bridgeKey: "bash",
+    });
+    new ToolBridge(tools, FULL_GRANTS).register(broadMount.runtime);
+    // Guest saves a bridge reference in a global — re-registering `mux` can
+    // never revoke this closure; only destroying the runtime can.
+    const saved = await broadMount.runtime.eval(
+      "globalThis.savedBash = mux.bash; vars.keep = 1; return typeof savedBash;"
+    );
+    expect(saved.result).toBe("function");
+
+    // Policy narrowed: the effective bridge no longer includes bash.
+    const narrowedMount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-saved-ref",
+      sessionDir: tmp.path,
+      bridgeKey: "",
+    });
+    expect(narrowedMount).not.toBe(broadMount);
+    expect(broadMount.isDisposed).toBe(true);
+    // Saved closure is gone with the old runtime; vars survived the rebuild.
+    const probe = await narrowedMount.runtime.eval(
+      "return { saved: typeof globalThis.savedBash, kept: vars.keep };"
+    );
+    expect(probe.result).toEqual({ saved: "undefined", kept: 1 });
+    await host.disposeScope("ws-saved-ref");
   });
 
   test("re-registering a narrower bridge on a reused runtime revokes previously exposed tools", async () => {

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -180,7 +180,12 @@ describe("SandboxHostService", () => {
     expect(drainProbe.result).toBe("undefined");
     // Host-side APIs refuse too (clear errors, not crashes).
     expect(() => mount.postHostEvent({})).toThrow(/hostEvents grant/);
-    await expect(mount.snapshotVars()).rejects.toThrow(/vars grant/);
+    try {
+      await mount.snapshotVars();
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("vars grant");
+    }
 
     // disposeScope must not fail even though snapshotting is not granted.
     await host.disposeScope("ws-denied");

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -5,8 +5,11 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
+import { tool } from "ai";
+import { z } from "zod";
 import { DisposableTempDir } from "@/node/services/tempDir";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
+import { ToolBridge } from "@/node/services/ptc/toolBridge";
 import { LEAST_PRIVILEGE_GRANTS } from "@/common/types/capabilityGrants";
 import { DurableEventJournal } from "@/node/utils/journal/durableEventJournal";
 import { SandboxHostService } from "./sandboxHostService";
@@ -182,6 +185,50 @@ describe("SandboxHostService", () => {
     // disposeScope must not fail even though snapshotting is not granted.
     await host.disposeScope("ws-denied");
     expect(mount.isDisposed).toBe(true);
+  });
+
+  test("denied bridge capability produces a clear catchable guest error, not a crash", async () => {
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({ lifetime: "ephemeral", runtimeFactory });
+
+    const tools = {
+      file_read: tool({
+        description: "read",
+        inputSchema: z.object({}),
+        execute: () => Promise.resolve({ content: "granted!" }),
+      }),
+      bash: tool({
+        description: "run",
+        inputSchema: z.object({}),
+        execute: () => Promise.resolve({ output: "should never run" }),
+      }),
+    };
+    const bridge = new ToolBridge(tools, {
+      version: 1,
+      bridgeTools: { allow: ["file_read"] },
+      vars: false,
+      hostEvents: false,
+    });
+    bridge.register(mount.runtime);
+
+    const result = await mount.runtime.eval(`
+      const granted = mux.file_read({});
+      let denied;
+      try {
+        mux.bash({});
+        denied = "no error";
+      } catch (e) {
+        denied = e.message;
+      }
+      return { granted, denied, sandboxStillWorks: 1 + 1 };
+    `);
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      granted: { content: "granted!" },
+      denied: "Capability denied: mux.bash is not granted for this sandbox",
+      sandboxStillWorks: 2,
+    });
+    mount.release();
   });
 
   test("corrupt snapshot blob self-heals to empty vars", async () => {

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -236,6 +236,54 @@ describe("SandboxHostService", () => {
     mount.release();
   });
 
+  test("concurrent first acquisitions share one mount (no double runtime creation)", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const [a, b] = await Promise.all([
+      host.acquireMount({
+        lifetime: "persistent",
+        runtimeFactory,
+        scopeKey: "ws-race",
+        sessionDir: tmp.path,
+      }),
+      host.acquireMount({
+        lifetime: "persistent",
+        runtimeFactory,
+        scopeKey: "ws-race",
+        sessionDir: tmp.path,
+      }),
+    ]);
+    expect(b).toBe(a);
+    await host.disposeScope("ws-race");
+  });
+
+  test("exclusive() serializes concurrent runs on a shared mount", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-serial",
+      sessionDir: tmp.path,
+    });
+    const order: string[] = [];
+    await Promise.all([
+      mount.exclusive(async () => {
+        order.push("a-start");
+        // Yield long enough that an unserialized implementation interleaves b.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        order.push("a-end");
+      }),
+      mount.exclusive(async () => {
+        order.push("b-start");
+        await Promise.resolve();
+        order.push("b-end");
+      }),
+    ]);
+    expect(order).toEqual(["a-start", "a-end", "b-start", "b-end"]);
+    await host.disposeScope("ws-serial");
+  });
+
   test("discardScope: context reset discards vars instead of restoring the last snapshot", async () => {
     using tmp = new DisposableTempDir("sandbox-host-test");
     const host = new SandboxHostService();

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -236,6 +236,116 @@ describe("SandboxHostService", () => {
     mount.release();
   });
 
+  test("discardScope: context reset discards vars instead of restoring the last snapshot", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-reset",
+      sessionDir: tmp.path,
+    });
+    const write = await mount.runtime.eval("vars.secret = 'pre-reset'; return vars.secret;");
+    expect(write.success).toBe(true);
+    await mount.persistVars();
+
+    await host.discardScope("ws-reset", tmp.path);
+    expect(mount.isDisposed).toBe(true);
+
+    // The next mount must start fresh, NOT restore pre-reset state.
+    const fresh = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-reset",
+      sessionDir: tmp.path,
+    });
+    expect(fresh).not.toBe(mount);
+    const probe = await fresh.runtime.eval("return Object.keys(vars).length;");
+    expect(probe.success).toBe(true);
+    expect(probe.result).toBe(0);
+    await host.disposeScope("ws-reset");
+  });
+
+  test("reacquiring with changed grants rebuilds the mount under the new grants", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const full = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-grant-change",
+      sessionDir: tmp.path,
+    });
+    const write = await full.runtime.eval("vars.x = 1; return vars.x;");
+    expect(write.success).toBe(true);
+
+    // Same scope, narrowed grants: the full-grants mount must not be reused.
+    const narrowed = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-grant-change",
+      sessionDir: tmp.path,
+      grants: LEAST_PRIVILEGE_GRANTS,
+    });
+    expect(narrowed).not.toBe(full);
+    expect(full.isDisposed).toBe(true);
+    // The rebuilt mount enforces the new boundary: no vars, no drain bridge.
+    const varsProbe = await narrowed.runtime.eval("return typeof globalThis.vars;");
+    expect(varsProbe.result).toBe("undefined");
+    const drainProbe = await narrowed.runtime.eval("return typeof globalThis.drainHostEvents;");
+    expect(drainProbe.result).toBe("undefined");
+    await host.disposeScope("ws-grant-change");
+  });
+
+  test("re-registering a narrower bridge on a reused runtime revokes previously exposed tools", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-rebridge",
+      sessionDir: tmp.path,
+    });
+    const tools = {
+      bash: tool({
+        description: "run",
+        inputSchema: z.object({}),
+        execute: () => Promise.resolve({ output: "ran" }),
+      }),
+    };
+
+    const broad = new ToolBridge(tools, {
+      version: 1,
+      bridgeTools: { allow: "all" },
+      vars: true,
+      hostEvents: true,
+    });
+    broad.register(mount.runtime);
+    const allowed = await mount.runtime.eval("return mux.bash({});");
+    expect(allowed.success).toBe(true);
+    expect(allowed.result).toEqual({ output: "ran" });
+
+    // Next request narrowed the policy: code_execution re-registers its fresh
+    // bridge on the reused runtime, which must fully replace the old one.
+    const narrow = new ToolBridge(tools, {
+      version: 1,
+      bridgeTools: { allow: [] },
+      vars: true,
+      hostEvents: true,
+    });
+    narrow.register(mount.runtime);
+    const denied = await mount.runtime.eval(`
+      try {
+        mux.bash({});
+        return "no error";
+      } catch (e) {
+        return e.message;
+      }
+    `);
+    expect(denied.success).toBe(true);
+    expect(denied.result).toBe("Capability denied: mux.bash is not granted for this sandbox");
+    await host.disposeScope("ws-rebridge");
+  });
+
   test("corrupt snapshot blob self-heals to empty vars", async () => {
     using tmp = new DisposableTempDir("sandbox-host-test");
     const host1 = new SandboxHostService();

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -284,6 +284,28 @@ describe("SandboxHostService", () => {
     await host.disposeScope("ws-serial");
   });
 
+  test("dropScope: workspace removal disposes the mount without writing to disk", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-drop",
+      sessionDir: tmp.path,
+    });
+    const write = await mount.runtime.eval("vars.x = 1; return vars.x;");
+    expect(write.success).toBe(true);
+
+    // Record disk state, then drop: the mount must be disposed and NO new
+    // files may appear (the caller is deleting the session directory).
+    const before = readdirSync(tmp.path, { recursive: true }).length;
+    await host.dropScope("ws-drop");
+    expect(mount.isDisposed).toBe(true);
+    expect(host.hasScope("ws-drop")).toBe(false);
+    const after = readdirSync(tmp.path, { recursive: true }).length;
+    expect(after).toBe(before);
+  });
+
   test("discardScope: context reset discards vars instead of restoring the last snapshot", async () => {
     using tmp = new DisposableTempDir("sandbox-host-test");
     const host = new SandboxHostService();

--- a/src/node/services/sandbox/sandboxHostService.test.ts
+++ b/src/node/services/sandbox/sandboxHostService.test.ts
@@ -1,0 +1,221 @@
+/**
+ * QuickJS-heavy suite: keep out of broad Bun filters (runs isolated in CI,
+ * see .github/workflows: isolated_unit_tests).
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
+import { LEAST_PRIVILEGE_GRANTS } from "@/common/types/capabilityGrants";
+import { DurableEventJournal } from "@/node/utils/journal/durableEventJournal";
+import { SandboxHostService } from "./sandboxHostService";
+
+const runtimeFactory = new QuickJSRuntimeFactory();
+
+describe("SandboxHostService", () => {
+  test("ephemeral mounts are fresh per acquire and dispose on release", async () => {
+    const host = new SandboxHostService();
+    const first = await host.acquireMount({ lifetime: "ephemeral", runtimeFactory });
+    const result = await first.runtime.eval("return 1 + 1;");
+    expect(result.success).toBe(true);
+    expect(result.result).toBe(2);
+    first.release();
+    expect(first.isDisposed).toBe(true);
+
+    const second = await host.acquireMount({ lifetime: "ephemeral", runtimeFactory });
+    expect(second).not.toBe(first);
+    second.release();
+  });
+
+  test("persistent mount shares vars across separate evals and acquires", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-persist",
+      sessionDir: tmp.path,
+    });
+
+    const write = await mount.runtime.eval("vars.counter = 41; return vars.counter;");
+    expect(write.success).toBe(true);
+    expect(write.result).toBe(41);
+
+    // Re-acquire: same scope returns the same live mount.
+    const again = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-persist",
+      sessionDir: tmp.path,
+    });
+    expect(again).toBe(mount);
+
+    const read = await again.runtime.eval("vars.counter += 1; return vars.counter;");
+    expect(read.success).toBe(true);
+    expect(read.result).toBe(42);
+
+    mount.release(); // no-op for persistent mounts
+    expect(mount.isDisposed).toBe(false);
+    await host.disposeScope("ws-persist");
+    expect(mount.isDisposed).toBe(true);
+  });
+
+  test("vars snapshot/restore survives a simulated restart", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+
+    // "Process 1": write vars, snapshot via journal kit, dispose.
+    const host1 = new SandboxHostService();
+    const mount1 = await host1.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-restart",
+      sessionDir: tmp.path,
+    });
+    const write = await mount1.runtime.eval(
+      'vars.searchResults = { hits: [1, 2, 3], query: "foo" }; return true;'
+    );
+    expect(write.success).toBe(true);
+    await host1.disposeScope("ws-restart"); // snapshots before disposing
+
+    // The snapshot is a durable event referencing a blob.
+    const journal = new DurableEventJournal(tmp.path);
+    const events = await journal.read();
+    const snapshot = events.find((e) => e.kind === "sandbox-vars-snapshot");
+    expect(snapshot).toBeDefined();
+
+    // "Process 2": fresh service (simulated restart) restores latest snapshot.
+    const host2 = new SandboxHostService();
+    const mount2 = await host2.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-restart",
+      sessionDir: tmp.path,
+    });
+    expect(mount2).not.toBe(mount1);
+    const read = await mount2.runtime.eval("return vars.searchResults;");
+    expect(read.success).toBe(true);
+    expect(read.result).toEqual({ hits: [1, 2, 3], query: "foo" });
+    await host2.disposeScope("ws-restart");
+  });
+
+  test("host→guest events: queue + drain via drainHostEvents()", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-events",
+      sessionDir: tmp.path,
+    });
+
+    mount.postHostEvent({ type: "task-complete", taskId: "t1" });
+    mount.postHostEvent({ type: "task-complete", taskId: "t2" });
+
+    const drained = await mount.runtime.eval("return drainHostEvents();");
+    expect(drained.success).toBe(true);
+    expect(drained.result).toEqual([
+      { type: "task-complete", taskId: "t1" },
+      { type: "task-complete", taskId: "t2" },
+    ]);
+
+    // Queue is empty after draining.
+    const empty = await mount.runtime.eval("return drainHostEvents();");
+    expect(empty.result).toEqual([]);
+    await host.disposeScope("ws-events");
+  });
+
+  test("async capability + host event: promise resolves in-guest and completion is delivered", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-async",
+      sessionDir: tmp.path,
+    });
+
+    // Demo capability: resolves asynchronously AND posts a host event on
+    // completion (the mux.task({background:true}) delivery pattern).
+    mount.runtime.registerPromiseFunction("startTask", async (name) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mount.postHostEvent({ type: "task-started", name });
+      return { taskId: "task-123" };
+    });
+
+    const result = await mount.runtime.eval(`
+      return (async () => {
+        const handle = await startTask("demo");
+        const events = drainHostEvents();
+        return { handle, events };
+      })();
+    `);
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      handle: { taskId: "task-123" },
+      events: [{ type: "task-started", name: "demo" }],
+    });
+    await host.disposeScope("ws-async");
+  });
+
+  test("least-privilege grants disable vars and host events on the mount", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host = new SandboxHostService();
+    const mount = await host.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-denied",
+      sessionDir: tmp.path,
+      grants: LEAST_PRIVILEGE_GRANTS,
+    });
+
+    // vars namespace was never initialized...
+    const varsProbe = await mount.runtime.eval("return typeof globalThis.vars;");
+    expect(varsProbe.result).toBe("undefined");
+    // ...and the drain bridge is not exposed.
+    const drainProbe = await mount.runtime.eval("return typeof globalThis.drainHostEvents;");
+    expect(drainProbe.result).toBe("undefined");
+    // Host-side APIs refuse too (clear errors, not crashes).
+    expect(() => mount.postHostEvent({})).toThrow(/hostEvents grant/);
+    await expect(mount.snapshotVars()).rejects.toThrow(/vars grant/);
+
+    // disposeScope must not fail even though snapshotting is not granted.
+    await host.disposeScope("ws-denied");
+    expect(mount.isDisposed).toBe(true);
+  });
+
+  test("corrupt snapshot blob self-heals to empty vars", async () => {
+    using tmp = new DisposableTempDir("sandbox-host-test");
+    const host1 = new SandboxHostService();
+    const mount1 = await host1.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-heal",
+      sessionDir: tmp.path,
+    });
+    await mount1.runtime.eval("vars.x = 1; return true;");
+    await host1.disposeScope("ws-heal");
+
+    // Corrupt every blob under the session dir.
+    const corruptDir = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) corruptDir(full);
+        else writeFileSync(full, "corrupted!");
+      }
+    };
+    corruptDir(join(tmp.path, "blobs"));
+
+    const host2 = new SandboxHostService();
+    const mount2 = await host2.acquireMount({
+      lifetime: "persistent",
+      runtimeFactory,
+      scopeKey: "ws-heal",
+      sessionDir: tmp.path,
+    });
+    const read = await mount2.runtime.eval("return vars;");
+    expect(read.success).toBe(true);
+    expect(read.result).toEqual({});
+    await host2.disposeScope("ws-heal");
+  });
+});

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -45,6 +45,15 @@ export interface AcquireMountOptions {
   sessionDir?: string;
   /** Capability grants for this mount. Defaults to session-scope grants. */
   grants?: CapabilityGrants;
+  /**
+   * Identity of the effective bridge configuration (e.g. sorted bridgeable
+   * tool names). Persistent guests can save bridge function references in
+   * globals (`globalThis.saved = mux.bash`) that survive re-registration, so
+   * when the effective bridge NARROWS the mount must be rebuilt — destroying
+   * the runtime is the only reliable way to revoke saved closures. Vars
+   * survive via snapshot/restore.
+   */
+  bridgeKey?: string;
 }
 
 export class SandboxMount {
@@ -60,8 +69,22 @@ export class SandboxMount {
     private readonly persistSnapshot?: (varsJson: string) => Promise<void>,
     /** Persistent mounts share the host's per-scope mutex so exclusive() also
      * serializes against scope disposal; ephemeral mounts get their own. */
-    private readonly mutex: AsyncMutex = new AsyncMutex()
-  ) {}
+    private readonly mutex: AsyncMutex = new AsyncMutex(),
+    /** Effective bridge configuration identity; see AcquireMountOptions. */
+    public readonly bridgeKey?: string
+  ) {
+    // Late capability settlements (fire-and-forget guest code) must not
+    // re-enter the shared runtime while a later eval holds it: route their
+    // pending-job execution through the same exclusive lock.
+    runtime.setPendingJobGate((run) => {
+      this.exclusive(() => {
+        run();
+        return Promise.resolve();
+      }).catch((error: unknown) => {
+        log.warn("SandboxMount: gated pending-job run failed", { error });
+      });
+    });
+  }
 
   /**
    * Run `fn` with exclusive access to this mount's runtime. Concurrent
@@ -197,12 +220,17 @@ export class SandboxHostService {
 
     const existing = this.persistentMounts.get(scopeKey);
     if (existing && !existing.isDisposed) {
-      if (grantsKey(existing.grants) === grantsKey(grants)) {
+      if (
+        grantsKey(existing.grants) === grantsKey(grants) &&
+        existing.bridgeKey === options.bridgeKey
+      ) {
         return existing;
       }
-      // Effective grants changed between requests (e.g. policy narrowed): a
-      // mount must never outlive its capability boundary. Snapshot under the
-      // OLD grants, dispose, and rebuild below under the new grants.
+      // Effective grants OR bridge configuration changed between requests
+      // (e.g. policy narrowed): a mount must never outlive its capability
+      // boundary, and rebuilding the runtime is the only way to revoke bridge
+      // function references the guest saved in globals. Snapshot under the
+      // OLD grants, dispose, and rebuild below.
       await this.disposeScopeLocked(scopeKey);
     }
 
@@ -221,7 +249,8 @@ export class SandboxHostService {
           data: { scopeKey, blobHash: ref, size },
         });
       },
-      lock
+      lock,
+      options.bridgeKey
     );
 
     if (grants.vars) {

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -77,9 +77,24 @@ export class SandboxMount {
     // re-enter the shared runtime while a later eval holds it: route their
     // pending-job execution through the same exclusive lock.
     runtime.setPendingJobGate((run) => {
-      this.exclusive(() => {
+      this.exclusive(async () => {
         run();
-        return Promise.resolve();
+        // The continuation may have mutated vars AFTER the originating call's
+        // snapshot: persist so a restart cannot resurrect older state (memory
+        // and disk must agree — mirrors code_execution's post-eval path,
+        // including dispose-on-failure so an unsnapshottable state cannot
+        // linger).
+        if (!this.disposed && this.lifetime === "persistent" && this.grants.vars) {
+          try {
+            await this.persistVars();
+          } catch (error) {
+            log.warn(
+              "SandboxMount: vars snapshot after gated continuation failed; disposing mount",
+              { error }
+            );
+            this.dispose();
+          }
+        }
       }).catch((error: unknown) => {
         log.warn("SandboxMount: gated pending-job run failed", { error });
       });

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -1,0 +1,281 @@
+/**
+ * Sandbox Host Service (substrate 3 of the shared agent foundation).
+ *
+ * One home for QuickJS guest hosting with two mount lifetimes:
+ * - `ephemeral`: per-call, behaviorally identical to the pre-service
+ *   code_execution flow (create → eval → dispose).
+ * - `persistent`: per-workspace-session; the runtime survives across
+ *   code_execution calls and turns, is disposed on workspace archive/reset,
+ *   and exposes a guest-visible `vars` namespace whose JSON-serializable
+ *   contents the host snapshots via the journal kit (contract: data only —
+ *   functions/closures are not captured).
+ *
+ * Persistent mounts also get:
+ * - an async capability bridge (runtime.registerPromiseFunction) — used by
+ *   Track 2 for `mux.task({background:true})`-style handles;
+ * - host→guest event delivery: a queue drained from the guest via the global
+ *   `drainHostEvents()` (queue + drain model, no interrupts).
+ *
+ * WorkflowRunner intentionally keeps constructing runtimes through
+ * IJSRuntimeFactory directly: its replay-safety must not regress, and it
+ * already consumes the same abstract interface (migration note per handoff).
+ */
+
+import assert from "node:assert";
+import type { IJSRuntime, IJSRuntimeFactory } from "@/node/services/ptc/runtime";
+import { resolveCapabilityGrants, type CapabilityGrants } from "@/common/types/capabilityGrants";
+import { DurableEventJournal } from "@/node/utils/journal/durableEventJournal";
+import { log } from "@/node/services/log";
+
+export type SandboxMountLifetime = "ephemeral" | "persistent";
+
+export interface AcquireMountOptions {
+  lifetime: SandboxMountLifetime;
+  /**
+   * Factory for creating the guest runtime. Caller-provided (rather than a
+   * service default) so this module never statically pulls the QuickJS WASM
+   * stack — toolAssembly lazy-loads PTC deliberately, and archive/reset
+   * disposal must be importable from startup paths.
+   */
+  runtimeFactory: IJSRuntimeFactory;
+  /** Stable scope identity (workspaceId). Required for persistent mounts. */
+  scopeKey?: string;
+  /** Session dir for vars snapshots (journal + blobs). Required for persistent mounts. */
+  sessionDir?: string;
+  /** Capability grants for this mount. Defaults to session-scope grants. */
+  grants?: CapabilityGrants;
+}
+
+export class SandboxMount {
+  /** Set by code_execution after registering the mux.* tool bridge, so a
+   * reused persistent runtime is not re-registered on every call. */
+  public bridgeRegistered = false;
+
+  private readonly hostEventQueue: unknown[] = [];
+  private disposed = false;
+
+  constructor(
+    public readonly runtime: IJSRuntime,
+    public readonly lifetime: SandboxMountLifetime,
+    public readonly grants: CapabilityGrants,
+    public readonly scopeKey?: string,
+    /** Bound by the host service; persists a vars snapshot via the journal kit. */
+    private readonly persistSnapshot?: (varsJson: string) => Promise<void>
+  ) {}
+
+  /** Queue a host event for the guest. Guest drains via drainHostEvents(). */
+  postHostEvent(event: unknown): void {
+    this.assertNotDisposed("postHostEvent");
+    assert(this.grants.hostEvents, "postHostEvent requires the hostEvents grant");
+    this.hostEventQueue.push(event);
+  }
+
+  /** Drain the queued host events (called from the guest bridge function). */
+  drainHostEvents(): unknown[] {
+    const events = this.hostEventQueue.splice(0, this.hostEventQueue.length);
+    return events;
+  }
+
+  /**
+   * Snapshot the guest `vars` namespace as JSON text. Crashes fast (eval
+   * error) if vars contains non-serializable values like cycles — the
+   * contract is data only.
+   */
+  async snapshotVars(): Promise<string> {
+    this.assertNotDisposed("snapshotVars");
+    assert(this.grants.vars, "snapshotVars requires the vars grant");
+    const result = await this.runtime.eval("return JSON.stringify(globalThis.vars ?? {});");
+    assert(result.success, `snapshotVars failed: ${result.error}`);
+    assert(typeof result.result === "string", "snapshotVars: expected JSON string result");
+    return result.result;
+  }
+
+  /** Replace the guest `vars` namespace from JSON text (snapshot restore). */
+  async restoreVars(varsJson: string): Promise<void> {
+    this.assertNotDisposed("restoreVars");
+    assert(this.grants.vars, "restoreVars requires the vars grant");
+    // Parse host-side first: crash-fast on corrupted snapshots instead of
+    // injecting garbage into the guest.
+    JSON.parse(varsJson);
+    const literal = JSON.stringify(varsJson);
+    const result = await this.runtime.eval(
+      `globalThis.vars = JSON.parse(${literal}); return true;`
+    );
+    assert(result.success, `restoreVars failed: ${result.error}`);
+  }
+
+  /** Snapshot vars and persist through the journal kit (persistent mounts). */
+  async persistVars(): Promise<void> {
+    this.assertNotDisposed("persistVars");
+    assert(
+      this.persistSnapshot,
+      "persistVars is only available on persistent mounts with a session dir"
+    );
+    const varsJson = await this.snapshotVars();
+    await this.persistSnapshot(varsJson);
+  }
+
+  /** Per-call release: disposes ephemeral mounts, keeps persistent ones alive. */
+  release(): void {
+    if (this.lifetime === "ephemeral") {
+      this.dispose();
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.runtime.dispose();
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  private assertNotDisposed(method: string): void {
+    assert(!this.disposed, `SandboxMount.${method} called after dispose`);
+  }
+}
+
+export class SandboxHostService {
+  private readonly persistentMounts = new Map<string, SandboxMount>();
+  private readonly journals = new Map<string, DurableEventJournal>();
+
+  /**
+   * Acquire a mount. Ephemeral mounts are always fresh; persistent mounts are
+   * reused per scopeKey and restored from the latest vars snapshot when
+   * (re)created — this is the crash/restart recovery path.
+   */
+  async acquireMount(options: AcquireMountOptions): Promise<SandboxMount> {
+    const grants = options.grants ?? resolveCapabilityGrants({ scope: "session" });
+
+    if (options.lifetime === "ephemeral") {
+      const runtime = await options.runtimeFactory.create();
+      return new SandboxMount(runtime, "ephemeral", grants);
+    }
+
+    const scopeKey = options.scopeKey;
+    const sessionDir = options.sessionDir;
+    assert(scopeKey, "persistent mounts require a scopeKey");
+    assert(sessionDir, "persistent mounts require a sessionDir");
+
+    const existing = this.persistentMounts.get(scopeKey);
+    if (existing && !existing.isDisposed) {
+      return existing;
+    }
+
+    const journal = this.journalFor(scopeKey, sessionDir);
+    const runtime = await options.runtimeFactory.create();
+    const mount = new SandboxMount(runtime, "persistent", grants, scopeKey, async (varsJson) => {
+      const { ref, size } = await journal.blobs.put(varsJson);
+      await journal.append({
+        workspaceId: scopeKey,
+        kind: "sandbox-vars-snapshot",
+        data: { scopeKey, blobHash: ref, size },
+      });
+    });
+
+    if (grants.vars) {
+      await this.initializeVars(mount, journal, scopeKey);
+    }
+    if (grants.hostEvents) {
+      // Queue + drain: the guest polls for host events (task completions,
+      // lifecycle notifications). Must be a SYNC bridge function: guests call
+      // it from continuations after awaiting capability promises, where
+      // asyncified functions cannot suspend.
+      runtime.registerSyncFunction("drainHostEvents", () => mount.drainHostEvents());
+    }
+
+    this.persistentMounts.set(scopeKey, mount);
+    return mount;
+  }
+
+  /** Persist the current vars snapshot for a live persistent scope. */
+  async snapshotScope(scopeKey: string): Promise<void> {
+    const mount = this.persistentMounts.get(scopeKey);
+    if (!mount || mount.isDisposed) return;
+    await mount.persistVars();
+  }
+
+  /**
+   * Dispose a scope's persistent mount (workspace archive/reset). Snapshots
+   * best-effort first so state survives un-archive and restarts.
+   */
+  async disposeScope(scopeKey: string): Promise<void> {
+    const mount = this.persistentMounts.get(scopeKey);
+    this.persistentMounts.delete(scopeKey);
+    this.journals.delete(scopeKey);
+    if (!mount || mount.isDisposed) return;
+    try {
+      await mount.persistVars();
+    } catch (error) {
+      // Never let a snapshot failure block archive/reset.
+      log.warn(`SandboxHostService: vars snapshot failed for scope ${scopeKey}`, { error });
+    }
+    mount.dispose();
+  }
+
+  /** True when a live persistent mount exists for the scope. */
+  hasScope(scopeKey: string): boolean {
+    const mount = this.persistentMounts.get(scopeKey);
+    return mount !== undefined && !mount.isDisposed;
+  }
+
+  disposeAll(): void {
+    for (const mount of this.persistentMounts.values()) {
+      mount.dispose();
+    }
+    this.persistentMounts.clear();
+    this.journals.clear();
+  }
+
+  private journalFor(scopeKey: string, sessionDir: string): DurableEventJournal {
+    let journal = this.journals.get(scopeKey);
+    if (!journal) {
+      journal = new DurableEventJournal(sessionDir);
+      this.journals.set(scopeKey, journal);
+    }
+    return journal;
+  }
+
+  /** Set up `vars` and restore the latest snapshot if one exists (self-heal:
+   * a missing/corrupt snapshot starts empty instead of failing the mount). */
+  private async initializeVars(
+    mount: SandboxMount,
+    journal: DurableEventJournal,
+    scopeKey: string
+  ): Promise<void> {
+    const init = await mount.runtime.eval("globalThis.vars = {}; return true;");
+    assert(init.success, `vars init failed: ${init.error}`);
+
+    const events = await journal.read();
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (event.kind !== "sandbox-vars-snapshot" || event.data.scopeKey !== scopeKey) {
+        continue;
+      }
+      const varsJson = await journal.blobs.getText(event.data.blobHash);
+      if (varsJson === null) {
+        log.warn(
+          `SandboxHostService: latest vars snapshot blob missing/corrupt for ${scopeKey}; starting empty`
+        );
+        return;
+      }
+      try {
+        await mount.restoreVars(varsJson);
+      } catch (error) {
+        log.warn(`SandboxHostService: vars restore failed for ${scopeKey}; starting empty`, {
+          error,
+        });
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Process-wide host singleton (mirrors eventSpine). Production consumers:
+ * code_execution persistent mounts (opt-in) and workspace archive/reset
+ * disposal. Tests construct their own instances.
+ */
+export const sandboxHostService = new SandboxHostService();

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -25,6 +25,7 @@ import assert from "node:assert";
 import type { IJSRuntime, IJSRuntimeFactory } from "@/node/services/ptc/runtime";
 import { resolveCapabilityGrants, type CapabilityGrants } from "@/common/types/capabilityGrants";
 import { DurableEventJournal } from "@/node/utils/journal/durableEventJournal";
+import { AsyncMutex } from "@/node/utils/concurrency/asyncMutex";
 import { log } from "@/node/services/log";
 
 export type SandboxMountLifetime = "ephemeral" | "persistent";
@@ -56,8 +57,22 @@ export class SandboxMount {
     public readonly grants: CapabilityGrants,
     public readonly scopeKey?: string,
     /** Bound by the host service; persists a vars snapshot via the journal kit. */
-    private readonly persistSnapshot?: (varsJson: string) => Promise<void>
+    private readonly persistSnapshot?: (varsJson: string) => Promise<void>,
+    /** Persistent mounts share the host's per-scope mutex so exclusive() also
+     * serializes against scope disposal; ephemeral mounts get their own. */
+    private readonly mutex: AsyncMutex = new AsyncMutex()
   ) {}
+
+  /**
+   * Run `fn` with exclusive access to this mount's runtime. Concurrent
+   * code_execution calls can share one persistent mount, but eval() mutates
+   * runtime-wide state (abort controller, tool-call attribution, handlers),
+   * so evaluation + vars persistence must be serialized per runtime.
+   */
+  async exclusive<T>(fn: () => Promise<T>): Promise<T> {
+    await using _lock = await this.mutex.acquire();
+    return await fn();
+  }
 
   /** Queue a host event for the guest. Guest drains via drainHostEvents(). */
   postHostEvent(event: unknown): void {
@@ -143,6 +158,18 @@ function grantsKey(grants: CapabilityGrants): string {
 export class SandboxHostService {
   private readonly persistentMounts = new Map<string, SandboxMount>();
   private readonly journals = new Map<string, DurableEventJournal>();
+  /** Per-scope mutex serializing acquisition, exclusive runs, and disposal.
+   * Kept for the process lifetime (bounded by workspace count). */
+  private readonly scopeLocks = new Map<string, AsyncMutex>();
+
+  private lockFor(scopeKey: string): AsyncMutex {
+    let lock = this.scopeLocks.get(scopeKey);
+    if (!lock) {
+      lock = new AsyncMutex();
+      this.scopeLocks.set(scopeKey, lock);
+    }
+    return lock;
+  }
 
   /**
    * Acquire a mount. Ephemeral mounts are always fresh; persistent mounts are
@@ -162,6 +189,12 @@ export class SandboxHostService {
     assert(scopeKey, "persistent mounts require a scopeKey");
     assert(sessionDir, "persistent mounts require a sessionDir");
 
+    // Serialize per scope: concurrent first acquisitions must not both create
+    // runtimes (the map is only populated after several awaits), and
+    // acquisition must not interleave with disposal or an exclusive run.
+    const lock = this.lockFor(scopeKey);
+    await using _guard = await lock.acquire();
+
     const existing = this.persistentMounts.get(scopeKey);
     if (existing && !existing.isDisposed) {
       if (grantsKey(existing.grants) === grantsKey(grants)) {
@@ -170,19 +203,26 @@ export class SandboxHostService {
       // Effective grants changed between requests (e.g. policy narrowed): a
       // mount must never outlive its capability boundary. Snapshot under the
       // OLD grants, dispose, and rebuild below under the new grants.
-      await this.disposeScope(scopeKey);
+      await this.disposeScopeLocked(scopeKey);
     }
 
     const journal = this.journalFor(scopeKey, sessionDir);
     const runtime = await options.runtimeFactory.create();
-    const mount = new SandboxMount(runtime, "persistent", grants, scopeKey, async (varsJson) => {
-      const { ref, size } = await journal.blobs.put(varsJson);
-      await journal.append({
-        workspaceId: scopeKey,
-        kind: "sandbox-vars-snapshot",
-        data: { scopeKey, blobHash: ref, size },
-      });
-    });
+    const mount = new SandboxMount(
+      runtime,
+      "persistent",
+      grants,
+      scopeKey,
+      async (varsJson) => {
+        const { ref, size } = await journal.blobs.put(varsJson);
+        await journal.append({
+          workspaceId: scopeKey,
+          kind: "sandbox-vars-snapshot",
+          data: { scopeKey, blobHash: ref, size },
+        });
+      },
+      lock
+    );
 
     if (grants.vars) {
       await this.initializeVars(mount, journal, scopeKey);
@@ -201,6 +241,7 @@ export class SandboxHostService {
 
   /** Persist the current vars snapshot for a live persistent scope. */
   async snapshotScope(scopeKey: string): Promise<void> {
+    await using _guard = await this.lockFor(scopeKey).acquire();
     const mount = this.persistentMounts.get(scopeKey);
     if (!mount || mount.isDisposed) return;
     await mount.persistVars();
@@ -211,6 +252,14 @@ export class SandboxHostService {
    * best-effort first so state survives un-archive and restarts.
    */
   async disposeScope(scopeKey: string): Promise<void> {
+    // The scope lock also backs mount.exclusive(), so disposal waits for any
+    // in-flight evaluation instead of pulling the runtime out from under it.
+    await using _guard = await this.lockFor(scopeKey).acquire();
+    await this.disposeScopeLocked(scopeKey);
+  }
+
+  /** Dispose logic without taking the scope lock: caller must hold it. */
+  private async disposeScopeLocked(scopeKey: string): Promise<void> {
     const mount = this.persistentMounts.get(scopeKey);
     this.persistentMounts.delete(scopeKey);
     this.journals.delete(scopeKey);
@@ -233,6 +282,7 @@ export class SandboxHostService {
    * pre-reset state. Rotation-by-append keeps the journal append-only.
    */
   async discardScope(scopeKey: string, sessionDir: string): Promise<void> {
+    await using _guard = await this.lockFor(scopeKey).acquire();
     const mount = this.persistentMounts.get(scopeKey);
     this.persistentMounts.delete(scopeKey);
     const journal = this.journals.get(scopeKey) ?? new DurableEventJournal(sessionDir);

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -47,10 +47,6 @@ export interface AcquireMountOptions {
 }
 
 export class SandboxMount {
-  /** Set by code_execution after registering the mux.* tool bridge, so a
-   * reused persistent runtime is not re-registered on every call. */
-  public bridgeRegistered = false;
-
   private readonly hostEventQueue: unknown[] = [];
   private disposed = false;
 
@@ -137,6 +133,13 @@ export class SandboxMount {
   }
 }
 
+/** Stable identity for a grant set, used to detect grant changes on reuse. */
+function grantsKey(grants: CapabilityGrants): string {
+  const allow = grants.bridgeTools.allow;
+  const tools = allow === "all" ? "all" : [...allow].sort().join(",");
+  return `${grants.version}|${tools}|${grants.vars}|${grants.hostEvents}`;
+}
+
 export class SandboxHostService {
   private readonly persistentMounts = new Map<string, SandboxMount>();
   private readonly journals = new Map<string, DurableEventJournal>();
@@ -161,7 +164,13 @@ export class SandboxHostService {
 
     const existing = this.persistentMounts.get(scopeKey);
     if (existing && !existing.isDisposed) {
-      return existing;
+      if (grantsKey(existing.grants) === grantsKey(grants)) {
+        return existing;
+      }
+      // Effective grants changed between requests (e.g. policy narrowed): a
+      // mount must never outlive its capability boundary. Snapshot under the
+      // OLD grants, dispose, and rebuild below under the new grants.
+      await this.disposeScope(scopeKey);
     }
 
     const journal = this.journalFor(scopeKey, sessionDir);
@@ -206,13 +215,50 @@ export class SandboxHostService {
     this.persistentMounts.delete(scopeKey);
     this.journals.delete(scopeKey);
     if (!mount || mount.isDisposed) return;
-    try {
-      await mount.persistVars();
-    } catch (error) {
-      // Never let a snapshot failure block archive/reset.
-      log.warn(`SandboxHostService: vars snapshot failed for scope ${scopeKey}`, { error });
+    if (mount.grants.vars) {
+      try {
+        await mount.persistVars();
+      } catch (error) {
+        // Never let a snapshot failure block archive/reset.
+        log.warn(`SandboxHostService: vars snapshot failed for scope ${scopeKey}`, { error });
+      }
     }
     mount.dispose();
+  }
+
+  /**
+   * Discard a scope's sandbox state (context reset): dispose the mount
+   * WITHOUT snapshotting current vars, and supersede any earlier snapshot
+   * with an empty one so the next mount starts fresh instead of restoring
+   * pre-reset state. Rotation-by-append keeps the journal append-only.
+   */
+  async discardScope(scopeKey: string, sessionDir: string): Promise<void> {
+    const mount = this.persistentMounts.get(scopeKey);
+    this.persistentMounts.delete(scopeKey);
+    const journal = this.journals.get(scopeKey) ?? new DurableEventJournal(sessionDir);
+    this.journals.delete(scopeKey);
+    if (mount && !mount.isDisposed) {
+      mount.dispose();
+    }
+    try {
+      // Only write the empty snapshot when there is prior state to supersede;
+      // otherwise a reset in a sandbox-less workspace would create journal
+      // files for nothing.
+      const events = await journal.read();
+      const hasSnapshot = events.some(
+        (event) => event.kind === "sandbox-vars-snapshot" && event.data.scopeKey === scopeKey
+      );
+      if (!hasSnapshot) return;
+      const { ref, size } = await journal.blobs.put("{}");
+      await journal.append({
+        workspaceId: scopeKey,
+        kind: "sandbox-vars-snapshot",
+        data: { scopeKey, blobHash: ref, size },
+      });
+    } catch (error) {
+      // Never let discard bookkeeping block a context reset.
+      log.warn(`SandboxHostService: vars discard failed for scope ${scopeKey}`, { error });
+    }
   }
 
   /** True when a live persistent mount exists for the scope. */

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -85,7 +85,7 @@ export class SandboxMount {
     this.assertNotDisposed("snapshotVars");
     assert(this.grants.vars, "snapshotVars requires the vars grant");
     const result = await this.runtime.eval("return JSON.stringify(globalThis.vars ?? {});");
-    assert(result.success, `snapshotVars failed: ${result.error}`);
+    assert(result.success, `snapshotVars failed: ${result.error ?? "unknown error"}`);
     assert(typeof result.result === "string", "snapshotVars: expected JSON string result");
     return result.result;
   }
@@ -101,7 +101,7 @@ export class SandboxMount {
     const result = await this.runtime.eval(
       `globalThis.vars = JSON.parse(${literal}); return true;`
     );
-    assert(result.success, `restoreVars failed: ${result.error}`);
+    assert(result.success, `restoreVars failed: ${result.error ?? "unknown error"}`);
   }
 
   /** Snapshot vars and persist through the journal kit (persistent mounts). */
@@ -246,7 +246,7 @@ export class SandboxHostService {
     scopeKey: string
   ): Promise<void> {
     const init = await mount.runtime.eval("globalThis.vars = {}; return true;");
-    assert(init.success, `vars init failed: ${init.error}`);
+    assert(init.success, `vars init failed: ${init.error ?? "unknown error"}`);
 
     const events = await journal.read();
     for (let i = events.length - 1; i >= 0; i--) {

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -305,6 +305,25 @@ export class SandboxHostService {
   }
 
   /**
+   * Drop a scope entirely (workspace removal): dispose the runtime and forget
+   * journals WITHOUT any disk writes. The caller is deleting the session
+   * directory — a snapshot here would recreate it, and an in-flight exclusive
+   * run must finish first (the lock serializes) so it cannot persist into the
+   * deleted directory afterwards.
+   */
+  async dropScope(scopeKey: string): Promise<void> {
+    await using _guard = await this.lockFor(scopeKey).acquire();
+    const mount = this.persistentMounts.get(scopeKey);
+    this.persistentMounts.delete(scopeKey);
+    this.journals.delete(scopeKey);
+    // The scope lock stays in the map (see scopeLocks doc): deleting it while
+    // waiters hold references could let two locks govern the same scope.
+    if (mount && !mount.isDisposed) {
+      mount.dispose();
+    }
+  }
+
+  /**
    * Discard a scope's sandbox state (context reset): dispose the mount
    * WITHOUT snapshotting current vars, and supersede any earlier snapshot
    * with an empty one so the next mount starts fresh instead of restoring

--- a/src/node/services/sandbox/sandboxHostService.ts
+++ b/src/node/services/sandbox/sandboxHostService.ts
@@ -208,15 +208,49 @@ export class SandboxHostService {
     }
 
     const scopeKey = options.scopeKey;
-    const sessionDir = options.sessionDir;
     assert(scopeKey, "persistent mounts require a scopeKey");
-    assert(sessionDir, "persistent mounts require a sessionDir");
 
     // Serialize per scope: concurrent first acquisitions must not both create
     // runtimes (the map is only populated after several awaits), and
     // acquisition must not interleave with disposal or an exclusive run.
     const lock = this.lockFor(scopeKey);
     await using _guard = await lock.acquire();
+    return await this.acquirePersistentMountLocked(options, grants);
+  }
+
+  /**
+   * Run `fn` with a persistent mount while HOLDING the scope lock from
+   * acquisition through execution. acquireMount + a later mount.exclusive()
+   * leaves an unprotected gap where a concurrent grants/bridge change or
+   * scope disposal can dispose the returned mount; this API closes that gap —
+   * code_execution's register→eval→persist sequence runs entirely under one
+   * lease. `fn` must NOT call mount.exclusive() (same non-reentrant lock).
+   */
+  async withPersistentMount<T>(
+    options: AcquireMountOptions,
+    fn: (mount: SandboxMount) => Promise<T>
+  ): Promise<T> {
+    assert(options.lifetime === "persistent", "withPersistentMount requires lifetime=persistent");
+    const scopeKey = options.scopeKey;
+    assert(scopeKey, "persistent mounts require a scopeKey");
+    const grants = options.grants ?? resolveCapabilityGrants({ scope: "session" });
+
+    const lock = this.lockFor(scopeKey);
+    await using _guard = await lock.acquire();
+    const mount = await this.acquirePersistentMountLocked(options, grants);
+    return await fn(mount);
+  }
+
+  /** Get-or-create the persistent mount for a scope. Caller must hold the scope lock. */
+  private async acquirePersistentMountLocked(
+    options: AcquireMountOptions,
+    grants: CapabilityGrants
+  ): Promise<SandboxMount> {
+    const scopeKey = options.scopeKey;
+    const sessionDir = options.sessionDir;
+    assert(scopeKey, "persistent mounts require a scopeKey");
+    assert(sessionDir, "persistent mounts require a sessionDir");
+    const lock = this.lockFor(scopeKey);
 
     const existing = this.persistentMounts.get(scopeKey);
     if (existing && !existing.isDisposed) {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import * as path from "path";
 import { PlatformPaths } from "@/common/utils/paths";
+import { eventSpine } from "@/node/services/events/eventSpine";
 import {
   streamText,
   stepCountIs,
@@ -2345,6 +2346,10 @@ export class StreamManager extends EventEmitter {
         ? { acpPromptId: streamInfo.initialMetadata.acpPromptId }
         : {}),
     } as StreamStartEvent);
+    eventSpine.emit("stream.start", {
+      workspaceId: workspaceId as string,
+      messageId: streamInfo.messageId,
+    });
   }
 
   private emitStreamAbort(
@@ -3554,6 +3559,10 @@ export class StreamManager extends EventEmitter {
             // before updateHistory completes, compaction can clear the file and then
             // updateHistory writes stale data back.
             this.emit("stream-end", streamEndEvent);
+            eventSpine.emit("stream.end", {
+              workspaceId: workspaceId as string,
+              messageId: streamInfo.messageId,
+            });
           }
           break;
         } catch (error) {

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2346,10 +2346,16 @@ export class StreamManager extends EventEmitter {
         ? { acpPromptId: streamInfo.initialMetadata.acpPromptId }
         : {}),
     } as StreamStartEvent);
-    eventSpine.emit("stream.start", {
-      workspaceId: workspaceId as string,
-      messageId: streamInfo.messageId,
-    });
+    // Lifecycle spine event: skipped on replay — a reconnecting subscriber
+    // re-observes an already-running stream, and observers must see exactly
+    // one start per stream (paired with the guaranteed end in
+    // processStreamWithCleanup's finally).
+    if (!options?.replay) {
+      eventSpine.emit("stream.start", {
+        workspaceId: workspaceId as string,
+        messageId: streamInfo.messageId,
+      });
+    }
   }
 
   private emitStreamAbort(
@@ -3559,10 +3565,6 @@ export class StreamManager extends EventEmitter {
             // before updateHistory completes, compaction can clear the file and then
             // updateHistory writes stale data back.
             this.emit("stream-end", streamEndEvent);
-            eventSpine.emit("stream.end", {
-              workspaceId: workspaceId as string,
-              messageId: streamInfo.messageId,
-            });
           }
           break;
         } catch (error) {
@@ -3613,6 +3615,15 @@ export class StreamManager extends EventEmitter {
       }
 
       this.workspaceStreams.delete(workspaceId);
+
+      // Lifecycle spine event: emitted from the guaranteed-cleanup path so
+      // EVERY terminal outcome (completion, abort/Escape, provider failure)
+      // closes the stream.start emitted at the top of this method — observers
+      // tracking active streams must never retain stale entries.
+      eventSpine.emit("stream.end", {
+        workspaceId: workspaceId as string,
+        messageId: streamInfo.messageId,
+      });
     }
   }
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -26,6 +26,7 @@ import {
 import { BACKGROUND_WORK_WAKE_OPENINGS } from "@/common/utils/machineTurnPrompts";
 import { WORKSPACE_TURN_TASK_TAGS } from "@/constants/workspaceTags";
 import { log } from "@/node/services/log";
+import { eventSpine } from "@/node/services/events/eventSpine";
 import {
   discoverAgentDefinitions,
   getSkipScopesAboveForKnownScope,
@@ -7477,6 +7478,7 @@ export class TaskService {
           },
           { allowMissing: true }
         );
+        eventSpine.emit("task.reported", { workspaceId: taskId, taskId });
         await this.maybeStartPatchGenerationForReportedTask(taskId);
         await this.emitWorkspaceMetadata(taskId);
         await this.maybeStartQueuedTasks();
@@ -12164,6 +12166,7 @@ export class TaskService {
       },
       { allowMissing: true }
     );
+    eventSpine.emit("task.reported", { workspaceId: childWorkspaceId, taskId: childWorkspaceId });
 
     await this.emitWorkspaceMetadata(childWorkspaceId);
 

--- a/src/node/services/toolAssembly.test.ts
+++ b/src/node/services/toolAssembly.test.ts
@@ -32,4 +32,36 @@ describe("applyToolPolicyAndExperiments", () => {
     expect(names).toContain("mcp_prompt_get");
     expect(result.mcp_prompt_get.description).toContain("mcp__s__p");
   });
+
+  test("grant-denied tools are hidden from the model but stubbed in the sandbox", async () => {
+    const result = await applyToolPolicyAndExperiments({
+      allTools: {
+        bash: executableTool("Run a command"),
+        file_read: executableTool("Read a file"),
+      },
+      effectiveToolPolicy: undefined,
+      experiments: { programmaticToolCalling: true },
+      emitNestedToolEvent: () => undefined,
+      capabilityGrants: {
+        version: 1,
+        bridgeTools: { allow: ["file_read"] },
+        vars: false,
+        hostEvents: false,
+      },
+    });
+
+    // Grants are a ceiling on the model-visible set...
+    expect(Object.keys(result)).not.toContain("bash");
+    expect(Object.keys(result)).toContain("code_execution");
+
+    // ...but the guest must still get the documented catchable stub error —
+    // the bridge is built from the pre-grant set so denied tools are known,
+    // not "mux.bash is not a function".
+    const evalResult = (await result.code_execution.execute!(
+      { code: "try { mux.bash({}); return 'no error'; } catch (e) { return e.message; }" },
+      { toolCallId: "test-call-id", messages: [], context: undefined }
+    )) as { success: boolean; result?: unknown };
+    expect(evalResult.success).toBe(true);
+    expect(evalResult.result).toBe("Capability denied: mux.bash is not granted for this sandbox");
+  });
 });

--- a/src/node/services/toolAssembly.test.ts
+++ b/src/node/services/toolAssembly.test.ts
@@ -72,7 +72,7 @@ describe("reconcileHookReplacedCodeExecution", () => {
     // Middleware wrapped by spreading the pre-hook tool: same description,
     // new execute.
     const wrappedExecute = () => Promise.resolve({ success: true, audited: true });
-    const hookReplacement = { ...preHook, execute: wrappedExecute } as Tool;
+    const hookReplacement: Tool = { ...preHook, execute: wrappedExecute };
     const rebuilt = executableTool("defs: function file_read");
 
     const result = reconcileHookReplacedCodeExecution(preHook, hookReplacement, rebuilt);

--- a/src/node/services/toolAssembly.test.ts
+++ b/src/node/services/toolAssembly.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { z } from "zod";
 import type { Tool } from "ai";
 
-import { applyToolPolicyAndExperiments } from "./toolAssembly";
+import { applyToolPolicyAndExperiments, reconcileHookReplacedCodeExecution } from "./toolAssembly";
 
 function executableTool(description: string): Tool {
   return {
@@ -63,5 +63,34 @@ describe("applyToolPolicyAndExperiments", () => {
     )) as { success: boolean; result?: unknown };
     expect(evalResult.success).toBe(true);
     expect(evalResult.result).toBe("Capability denied: mux.bash is not granted for this sandbox");
+  });
+});
+
+describe("reconcileHookReplacedCodeExecution", () => {
+  test("spread-style wrapper gets the rebuilt description but keeps its execute", () => {
+    const preHook = executableTool("defs: function bash; function file_read");
+    // Middleware wrapped by spreading the pre-hook tool: same description,
+    // new execute.
+    const wrappedExecute = () => Promise.resolve({ success: true, audited: true });
+    const hookReplacement = { ...preHook, execute: wrappedExecute } as Tool;
+    const rebuilt = executableTool("defs: function file_read");
+
+    const result = reconcileHookReplacedCodeExecution(preHook, hookReplacement, rebuilt);
+
+    // Model-facing metadata follows the rebuilt toolset (bash removed)...
+    expect(result.description).toBe("defs: function file_read");
+    // ...while the middleware's execution wrapper is preserved.
+    expect(result.execute).toBe(wrappedExecute);
+  });
+
+  test("middleware-authored description is preserved", () => {
+    const preHook = executableTool("defs: function bash; function file_read");
+    const hookReplacement = executableTool("audited code execution");
+    const rebuilt = executableTool("defs: function file_read");
+
+    const result = reconcileHookReplacedCodeExecution(preHook, hookReplacement, rebuilt);
+
+    // Middleware took ownership of the model-facing contract; return it as-is.
+    expect(result).toBe(hookReplacement);
   });
 });

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -166,6 +166,10 @@ export async function applyToolPolicyAndExperiments(
       // Persistent mount opt-in: reuse one per-workspace guest across calls.
       // Grants must flow through: the mount enforces vars/hostEvents exposure,
       // so omitting them here would silently widen to full session grants.
+      // bridgeKey identifies the effective bridgeable toolset so the mount is
+      // rebuilt (revoking guest-saved bridge references) when policy changes
+      // what the sandbox may reach.
+      const bridgeKey = toolBridge.getBridgeableToolNames().sort().join(",");
       const mountProvider =
         sandbox && persistentSandboxMountsEnabled()
           ? () =>
@@ -175,6 +179,7 @@ export async function applyToolPolicyAndExperiments(
                 scopeKey: sandbox.workspaceId,
                 sessionDir: sandbox.sessionDir,
                 grants: opts.capabilityGrants,
+                bridgeKey,
               })
           : undefined;
 

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -21,7 +21,8 @@ import type {
 } from "@/node/services/tools/code_execution";
 import type { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import type { ToolBridge } from "@/node/services/ptc/toolBridge";
-import { sandboxHostService } from "@/node/services/sandbox/sandboxHostService";
+import type { PTCExecutionResult } from "@/node/services/ptc/types";
+import { sandboxHostService, type SandboxMount } from "@/node/services/sandbox/sandboxHostService";
 import { log } from "./log";
 import type { MCPWorkspaceStats } from "@/node/services/mcpServerManager";
 import type { TelemetryService } from "@/node/services/telemetryService";
@@ -168,26 +169,30 @@ export async function applyToolPolicyAndExperiments(
       // so omitting them here would silently widen to full session grants.
       // bridgeKey identifies the effective bridgeable toolset so the mount is
       // rebuilt (revoking guest-saved bridge references) when policy changes
-      // what the sandbox may reach.
+      // what the sandbox may reach. The lease runner (withPersistentMount)
+      // holds the scope lock from acquisition through execution.
       const bridgeKey = toolBridge.getBridgeableToolNames().sort().join(",");
-      const mountProvider =
+      const withMount =
         sandbox && persistentSandboxMountsEnabled()
-          ? () =>
-              sandboxHostService.acquireMount({
-                lifetime: "persistent",
-                runtimeFactory,
-                scopeKey: sandbox.workspaceId,
-                sessionDir: sandbox.sessionDir,
-                grants: opts.capabilityGrants,
-                bridgeKey,
-              })
+          ? (fn: (mount: SandboxMount) => Promise<PTCExecutionResult>) =>
+              sandboxHostService.withPersistentMount(
+                {
+                  lifetime: "persistent",
+                  runtimeFactory,
+                  scopeKey: sandbox.workspaceId,
+                  sessionDir: sandbox.sessionDir,
+                  grants: opts.capabilityGrants,
+                  bridgeKey,
+                },
+                fn
+              )
           : undefined;
 
       const codeExecutionTool = await ptc.createCodeExecutionTool(
         runtimeFactory,
         toolBridge,
         emitNestedToolEvent,
-        mountProvider
+        withMount
       );
 
       if (experiments?.programmaticToolCallingExclusive) {

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -156,6 +156,8 @@ export async function applyToolPolicyAndExperiments(
       const runtimeFactory = ptc.runtimeFactory;
 
       // Persistent mount opt-in: reuse one per-workspace guest across calls.
+      // Grants must flow through: the mount enforces vars/hostEvents exposure,
+      // so omitting them here would silently widen to full session grants.
       const mountProvider =
         sandbox && persistentSandboxMountsEnabled()
           ? () =>
@@ -164,6 +166,7 @@ export async function applyToolPolicyAndExperiments(
                 runtimeFactory,
                 scopeKey: sandbox.workspaceId,
                 sessionDir: sandbox.sessionDir,
+                grants: opts.capabilityGrants,
               })
           : undefined;
 

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -140,6 +140,14 @@ export async function applyToolPolicyAndExperiments(
   // ToolBridge so the mux.* API only exposes policy-allowed tools.
   const policyFilteredTools = applyToolPolicy(grantFilteredTools, effectiveToolPolicy);
 
+  // The bridge is built from the PRE-grant policy-filtered set: ToolBridge
+  // must see grant-denied tools so it can stub them with a catchable
+  // "Capability denied" guest error (not a confusing "mux.x is not a
+  // function"). Model-visible sets below still use the grant-filtered tools.
+  const policyFilteredPreGrant = opts.capabilityGrants
+    ? applyToolPolicy(allToolsWithExtra, effectiveToolPolicy)
+    : policyFilteredTools;
+
   // Handle PTC experiments — add or replace tools with code_execution
   let toolsForModel = policyFilteredTools;
   if (experiments?.programmaticToolCalling || experiments?.programmaticToolCallingExclusive) {
@@ -147,9 +155,9 @@ export async function applyToolPolicyAndExperiments(
       // Lazy-load PTC modules only when experiments are enabled
       const ptc = await getPTCModules();
 
-      // ToolBridge uses policy-filtered tools — sandbox only exposes allowed
-      // tools; grants are re-enforced at the bridge boundary.
-      const toolBridge = new ptc.ToolBridge(policyFilteredTools, opts.capabilityGrants);
+      // ToolBridge uses the pre-grant policy-filtered tools — the bridge
+      // enforces grants itself (denied tools become explicit error stubs).
+      const toolBridge = new ptc.ToolBridge(policyFilteredPreGrant, opts.capabilityGrants);
 
       // Singleton runtime factory (WASM module is expensive to load)
       ptc.runtimeFactory ??= new ptc.QuickJSRuntimeFactory();
@@ -180,8 +188,12 @@ export async function applyToolPolicyAndExperiments(
       if (experiments?.programmaticToolCallingExclusive) {
         // Exclusive mode: code_execution is mandatory — it's the only way to use bridged
         // tools. The experiment flag is the opt-in; policy cannot disable it here since
-        // that would leave no way to access tools. nonBridgeable is already policy-filtered.
-        const nonBridgeable = toolBridge.getNonBridgeableTools();
+        // that would leave no way to access tools. nonBridgeable is policy-filtered but
+        // comes from the PRE-grant bridge input, so re-apply the grants ceiling here to
+        // keep grant-denied non-bridgeable tools out of the model-visible set.
+        const nonBridgeable = opts.capabilityGrants
+          ? applyCapabilityGrants(toolBridge.getNonBridgeableTools(), opts.capabilityGrants)
+          : toolBridge.getNonBridgeableTools();
         // Keep mcp_prompt_get direct because sandbox declarations omit its
         // multiline prompt catalog.
         const promptGet = policyFilteredTools.mcp_prompt_get;

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -18,6 +18,7 @@ import type { CapabilityGrants } from "@/common/types/capabilityGrants";
 import type {
   PTCEventWithParent,
   createCodeExecutionTool as CreateCodeExecutionToolFn,
+  retargetCodeExecutionTool as RetargetCodeExecutionToolFn,
 } from "@/node/services/tools/code_execution";
 import type { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import type { ToolBridge } from "@/node/services/ptc/toolBridge";
@@ -40,6 +41,7 @@ import { getRuntimeTypeForTelemetry, roundToBase2 } from "@/common/telemetry/uti
 // Dynamic imports are justified: PTC pulls in ~10MB of dependencies that would slow startup.
 interface PTCModules {
   createCodeExecutionTool: typeof CreateCodeExecutionToolFn;
+  retargetCodeExecutionTool: typeof RetargetCodeExecutionToolFn;
   QuickJSRuntimeFactory: typeof QuickJSRuntimeFactory;
   ToolBridge: typeof ToolBridge;
   runtimeFactory: QuickJSRuntimeFactory | null;
@@ -60,11 +62,22 @@ async function getPTCModules(): Promise<PTCModules> {
 
   ptcModules = {
     createCodeExecutionTool: codeExecution.createCodeExecutionTool,
+    retargetCodeExecutionTool: codeExecution.retargetCodeExecutionTool,
     QuickJSRuntimeFactory: quickjs.QuickJSRuntimeFactory,
     ToolBridge: toolBridge.ToolBridge,
     runtimeFactory: null,
   };
   return ptcModules;
+}
+
+/**
+ * Lazy-loading wrapper around code_execution's retargetCodeExecutionTool for
+ * callers (aiService) that must not statically import the PTC modules.
+ * Returns false when either tool was not created by createCodeExecutionTool.
+ */
+export async function retargetCodeExecution(target: Tool, donor: Tool): Promise<boolean> {
+  const ptc = await getPTCModules();
+  return ptc.retargetCodeExecutionTool(target, donor);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -80,6 +80,33 @@ export async function retargetCodeExecution(target: Tool, donor: Tool): Promise<
   return ptc.retargetCodeExecutionTool(target, donor);
 }
 
+/**
+ * Reinstate a request.assemble middleware's code_execution replacement over a
+ * rebuilt instance while reconciling stale model-facing metadata. A wrapper
+ * built by spreading the pre-hook tool (`{ ...tool, execute: wrapped }`)
+ * inherits its description, whose embedded TypeScript definitions still
+ * advertise tools the rebuild removed/replaced — execution fails closed, but
+ * the model keeps being instructed those tools exist. When the wrapper
+ * inherited the pre-hook description verbatim, swap in the rebuilt
+ * description; middleware that authored its own description keeps it (it took
+ * ownership of the model-facing contract).
+ */
+export function reconcileHookReplacedCodeExecution(
+  preHook: Tool,
+  hookReplacement: Tool,
+  rebuilt: Tool
+): Tool {
+  if (
+    hookReplacement.description !== undefined &&
+    hookReplacement.description === preHook.description &&
+    rebuilt.description !== undefined &&
+    rebuilt.description !== hookReplacement.description
+  ) {
+    return { ...hookReplacement, description: rebuilt.description };
+  }
+  return hookReplacement;
+}
+
 // ---------------------------------------------------------------------------
 // Tool Policy + PTC Application
 // ---------------------------------------------------------------------------

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -19,6 +19,7 @@ import type {
 } from "@/node/services/tools/code_execution";
 import type { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import type { ToolBridge } from "@/node/services/ptc/toolBridge";
+import { sandboxHostService } from "@/node/services/sandbox/sandboxHostService";
 import { log } from "./log";
 import type { MCPWorkspaceStats } from "@/node/services/mcpServerManager";
 import type { TelemetryService } from "@/node/services/telemetryService";
@@ -82,6 +83,19 @@ export interface ApplyToolPolicyAndExperimentsOptions {
   };
   /** Callback to forward nested PTC tool events to the stream. */
   emitNestedToolEvent: (event: PTCEventWithParent) => void;
+  /**
+   * Sandbox host context for code_execution. When set AND persistent mounts
+   * are enabled (MUX_SANDBOX_PERSISTENT_MOUNTS=1), code_execution reuses a
+   * per-workspace persistent mount (shared `vars`, snapshot/restore) instead
+   * of an ephemeral per-call runtime. Foundation-level opt-in only; the
+   * persistent-kernel UX belongs to the RLM track.
+   */
+  sandbox?: { workspaceId: string; sessionDir: string };
+}
+
+/** Env opt-in for persistent code_execution mounts (dogfooding/Track 2). */
+export function persistentSandboxMountsEnabled(): boolean {
+  return process.env.MUX_SANDBOX_PERSISTENT_MOUNTS === "1";
 }
 
 /**
@@ -99,7 +113,8 @@ export interface ApplyToolPolicyAndExperimentsOptions {
 export async function applyToolPolicyAndExperiments(
   opts: ApplyToolPolicyAndExperimentsOptions
 ): Promise<Record<string, Tool>> {
-  const { allTools, extraTools, effectiveToolPolicy, experiments, emitNestedToolEvent } = opts;
+  const { allTools, extraTools, effectiveToolPolicy, experiments, emitNestedToolEvent, sandbox } =
+    opts;
 
   // Merge in extra tools (e.g., CLI-specific tools like set_exit_code).
   // These bypass policy filtering since they're injected by the runtime, not user config.
@@ -122,11 +137,25 @@ export async function applyToolPolicyAndExperiments(
 
       // Singleton runtime factory (WASM module is expensive to load)
       ptc.runtimeFactory ??= new ptc.QuickJSRuntimeFactory();
+      const runtimeFactory = ptc.runtimeFactory;
+
+      // Persistent mount opt-in: reuse one per-workspace guest across calls.
+      const mountProvider =
+        sandbox && persistentSandboxMountsEnabled()
+          ? () =>
+              sandboxHostService.acquireMount({
+                lifetime: "persistent",
+                runtimeFactory,
+                scopeKey: sandbox.workspaceId,
+                sessionDir: sandbox.sessionDir,
+              })
+          : undefined;
 
       const codeExecutionTool = await ptc.createCodeExecutionTool(
-        ptc.runtimeFactory,
+        runtimeFactory,
         toolBridge,
-        emitNestedToolEvent
+        emitNestedToolEvent,
+        mountProvider
       );
 
       if (experiments?.programmaticToolCallingExclusive) {

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -12,6 +12,8 @@
 import type { Tool } from "ai";
 
 import { applyToolPolicy, type ToolPolicy } from "@/common/utils/tools/toolPolicy";
+import { applyCapabilityGrants } from "@/common/utils/tools/capabilityGrants";
+import type { CapabilityGrants } from "@/common/types/capabilityGrants";
 // PTC types only — modules lazy-loaded to avoid loading typescript/prettier at startup
 import type {
   PTCEventWithParent,
@@ -91,6 +93,13 @@ export interface ApplyToolPolicyAndExperimentsOptions {
    * persistent-kernel UX belongs to the RLM track.
    */
   sandbox?: { workspaceId: string; sessionDir: string };
+  /**
+   * Capability grants for this assembly (registry-with-filters posture).
+   * Omitted = session-scope full grants (identical to pre-grants behavior).
+   * Enforced here (tool visibility) and at the sandbox bridge boundary
+   * (ToolBridge stubs/denies non-granted mux.* calls).
+   */
+  capabilityGrants?: CapabilityGrants;
 }
 
 /** Env opt-in for persistent code_execution mounts (dogfooding/Track 2). */
@@ -120,10 +129,16 @@ export async function applyToolPolicyAndExperiments(
   // These bypass policy filtering since they're injected by the runtime, not user config.
   const allToolsWithExtra = extraTools ? { ...allTools, ...extraTools } : allTools;
 
+  // Capability grants are a ceiling applied before policy: policy can narrow
+  // further but can never re-add a non-granted tool.
+  const grantFilteredTools = opts.capabilityGrants
+    ? applyCapabilityGrants(allToolsWithExtra, opts.capabilityGrants)
+    : allToolsWithExtra;
+
   // Apply tool policy FIRST — this must happen before PTC to ensure the sandbox
   // respects allow/deny filters. The policy-filtered tools are passed to
   // ToolBridge so the mux.* API only exposes policy-allowed tools.
-  const policyFilteredTools = applyToolPolicy(allToolsWithExtra, effectiveToolPolicy);
+  const policyFilteredTools = applyToolPolicy(grantFilteredTools, effectiveToolPolicy);
 
   // Handle PTC experiments — add or replace tools with code_execution
   let toolsForModel = policyFilteredTools;
@@ -132,8 +147,9 @@ export async function applyToolPolicyAndExperiments(
       // Lazy-load PTC modules only when experiments are enabled
       const ptc = await getPTCModules();
 
-      // ToolBridge uses policy-filtered tools — sandbox only exposes allowed tools
-      const toolBridge = new ptc.ToolBridge(policyFilteredTools);
+      // ToolBridge uses policy-filtered tools — sandbox only exposes allowed
+      // tools; grants are re-enforced at the bridge boundary.
+      const toolBridge = new ptc.ToolBridge(policyFilteredTools, opts.capabilityGrants);
 
       // Singleton runtime factory (WASM module is expensive to load)
       ptc.runtimeFactory ??= new ptc.QuickJSRuntimeFactory();

--- a/src/node/services/toolAssembly.ts
+++ b/src/node/services/toolAssembly.ts
@@ -167,10 +167,14 @@ export async function applyToolPolicyAndExperiments(
       // Persistent mount opt-in: reuse one per-workspace guest across calls.
       // Grants must flow through: the mount enforces vars/hostEvents exposure,
       // so omitting them here would silently widen to full session grants.
-      // bridgeKey identifies the effective bridgeable toolset so the mount is
-      // rebuilt (revoking guest-saved bridge references) when policy changes
-      // what the sandbox may reach. The lease runner (withPersistentMount)
-      // holds the scope lock from acquisition through execution.
+      // bridgeKey identifies the effective bridgeable tool NAMES so the mount
+      // is rebuilt when policy changes what the sandbox may reach. Names-only
+      // is sufficient for same-name replacements: guest method references
+      // dispatch through the runtime's current registration (see
+      // QuickJSRuntime.registerObject), so re-registering the fresh bridge
+      // retargets even guest-saved references to the newest implementation.
+      // The lease runner (withPersistentMount) holds the scope lock from
+      // acquisition through execution.
       const bridgeKey = toolBridge.getBridgeableToolNames().sort().join(",");
       const withMount =
         sandbox && persistentSandboxMountsEnabled()

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, mock } from "bun:test";
-import { createCodeExecutionTool, clearTypeCaches } from "./code_execution";
+import { createCodeExecutionTool, clearTypeCaches, type MountRunner } from "./code_execution";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ToolBridge } from "@/node/services/ptc/toolBridge";
 import type { Tool, ToolExecutionOptions } from "ai";
@@ -551,13 +551,16 @@ describe("createCodeExecutionTool", () => {
     it("persistent mount shares vars across two separate code_execution calls and a simulated restart", async () => {
       using tmp = new DisposableTempDir("code-exec-persistent");
       const host = new SandboxHostService();
-      const mountProvider = () =>
-        host.acquireMount({
-          lifetime: "persistent",
-          runtimeFactory,
-          scopeKey: "ws-code-exec",
-          sessionDir: tmp.path,
-        });
+      const mountProvider: MountRunner = (fn) =>
+        host.withPersistentMount(
+          {
+            lifetime: "persistent",
+            runtimeFactory,
+            scopeKey: "ws-code-exec",
+            sessionDir: tmp.path,
+          },
+          fn
+        );
       const tool = await createCodeExecutionTool(
         runtimeFactory,
         new ToolBridge({}),
@@ -587,13 +590,16 @@ describe("createCodeExecutionTool", () => {
         runtimeFactory,
         new ToolBridge({}),
         undefined,
-        () =>
-          host2.acquireMount({
-            lifetime: "persistent",
-            runtimeFactory,
-            scopeKey: "ws-code-exec",
-            sessionDir: tmp.path,
-          })
+        (fn) =>
+          host2.withPersistentMount(
+            {
+              lifetime: "persistent",
+              runtimeFactory,
+              scopeKey: "ws-code-exec",
+              sessionDir: tmp.path,
+            },
+            fn
+          )
       );
       const third = (await tool2.execute!(
         { code: "return vars.total;" },
@@ -607,13 +613,16 @@ describe("createCodeExecutionTool", () => {
     it("persists vars mutated before a failed eval so memory and disk agree", async () => {
       using tmp = new DisposableTempDir("code-exec-persistent");
       const host = new SandboxHostService();
-      const mountProvider = () =>
-        host.acquireMount({
-          lifetime: "persistent",
-          runtimeFactory,
-          scopeKey: "ws-failed-eval",
-          sessionDir: tmp.path,
-        });
+      const mountProvider: MountRunner = (fn) =>
+        host.withPersistentMount(
+          {
+            lifetime: "persistent",
+            runtimeFactory,
+            scopeKey: "ws-failed-eval",
+            sessionDir: tmp.path,
+          },
+          fn
+        );
       const tool = await createCodeExecutionTool(
         runtimeFactory,
         new ToolBridge({}),
@@ -642,13 +651,16 @@ describe("createCodeExecutionTool", () => {
         runtimeFactory,
         new ToolBridge({}),
         undefined,
-        () =>
-          host2.acquireMount({
-            lifetime: "persistent",
-            runtimeFactory,
-            scopeKey: "ws-failed-eval",
-            sessionDir: tmp.path,
-          })
+        (fn) =>
+          host2.withPersistentMount(
+            {
+              lifetime: "persistent",
+              runtimeFactory,
+              scopeKey: "ws-failed-eval",
+              sessionDir: tmp.path,
+            },
+            fn
+          )
       );
       const after = (await tool2.execute!(
         { code: "return vars.state;" },
@@ -662,13 +674,16 @@ describe("createCodeExecutionTool", () => {
     it("recovers from unsnapshottable vars by rebuilding the mount from the last durable snapshot", async () => {
       using tmp = new DisposableTempDir("code-exec-persistent");
       const host = new SandboxHostService();
-      const mountProvider = () =>
-        host.acquireMount({
-          lifetime: "persistent",
-          runtimeFactory,
-          scopeKey: "ws-cyclic-vars",
-          sessionDir: tmp.path,
-        });
+      const mountProvider: MountRunner = (fn) =>
+        host.withPersistentMount(
+          {
+            lifetime: "persistent",
+            runtimeFactory,
+            scopeKey: "ws-cyclic-vars",
+            sessionDir: tmp.path,
+          },
+          fn
+        );
       const tool = await createCodeExecutionTool(
         runtimeFactory,
         new ToolBridge({}),

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -604,6 +604,61 @@ describe("createCodeExecutionTool", () => {
       await host2.disposeScope("ws-code-exec");
     });
 
+    it("persists vars mutated before a failed eval so memory and disk agree", async () => {
+      using tmp = new DisposableTempDir("code-exec-persistent");
+      const host = new SandboxHostService();
+      const mountProvider = () =>
+        host.acquireMount({
+          lifetime: "persistent",
+          runtimeFactory,
+          scopeKey: "ws-failed-eval",
+          sessionDir: tmp.path,
+        });
+      const tool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({}),
+        undefined,
+        mountProvider
+      );
+
+      const seed = (await tool.execute!(
+        { code: "vars.state = 'initial'; return vars.state;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(seed.success).toBe(true);
+
+      // Guest mutates vars, THEN throws: the live guest keeps the mutation,
+      // so the snapshot must too — a restart must not resurrect 'initial'.
+      const failed = (await tool.execute!(
+        { code: "vars.state = 'mutated-before-throw'; throw new Error('boom');" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(failed.success).toBe(false);
+
+      // Simulated restart: fresh host restores the latest snapshot.
+      await host.disposeScope("ws-failed-eval");
+      const host2 = new SandboxHostService();
+      const tool2 = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({}),
+        undefined,
+        () =>
+          host2.acquireMount({
+            lifetime: "persistent",
+            runtimeFactory,
+            scopeKey: "ws-failed-eval",
+            sessionDir: tmp.path,
+          })
+      );
+      const after = (await tool2.execute!(
+        { code: "return vars.state;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(after.success).toBe(true);
+      expect(after.result).toBe("mutated-before-throw");
+      await host2.disposeScope("ws-failed-eval");
+    });
+
     it("clearTypeCaches forces regeneration", async () => {
       const mockTools: Record<string, Tool> = {
         file_read: createMockTool("file_read", z.object({ filePath: z.string() }), () => ({

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -3,7 +3,12 @@
  */
 
 import { describe, it, expect, mock } from "bun:test";
-import { createCodeExecutionTool, clearTypeCaches, type MountRunner } from "./code_execution";
+import {
+  createCodeExecutionTool,
+  retargetCodeExecutionTool,
+  clearTypeCaches,
+  type MountRunner,
+} from "./code_execution";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ToolBridge } from "@/node/services/ptc/toolBridge";
 import type { Tool, ToolExecutionOptions } from "ai";
@@ -418,6 +423,65 @@ describe("createCodeExecutionTool", () => {
       expect(result.toolCalls).toHaveLength(2);
       expect(result.toolCalls[0].result).toEqual({ count: 1 });
       expect(result.toolCalls[1].error).toContain("Second call failed");
+    });
+  });
+
+  describe("retargetCodeExecutionTool", () => {
+    it("retargets a captured execute reference onto the donor's bridge", async () => {
+      // The request.assemble wrapper scenario: middleware captured the
+      // pre-hook instance's execute, while a later rebuild removed `bash`
+      // from the bridgeable set. After retargeting, the captured reference
+      // must dispatch through the donor's bridge — bash is gone, file_read
+      // still works.
+      const bashExecute = mock(() => mockResults.bash);
+      const preHookTool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({
+          bash: createMockTool("bash", z.object({ script: z.string() }), bashExecute),
+          file_read: createMockTool("file_read", z.object({ filePath: z.string() })),
+        })
+      );
+      const donorTool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({
+          file_read: createMockTool("file_read", z.object({ filePath: z.string() })),
+        })
+      );
+
+      // Wrapper-style capture BEFORE the retarget.
+      const capturedExecute = preHookTool.execute!.bind(preHookTool);
+
+      expect(retargetCodeExecutionTool(preHookTool, donorTool)).toBe(true);
+
+      const bashResult = (await capturedExecute(
+        { code: 'return mux.bash({ script: "echo hi" })' },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(bashResult.success).toBe(false);
+      expect(bashExecute).not.toHaveBeenCalled();
+
+      const readResult = (await capturedExecute(
+        { code: 'return mux.file_read({ filePath: "a.txt" })' },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(readResult.success).toBe(true);
+      expect(readResult.result).toMatchObject({ content: "mock file content" });
+    });
+
+    it("returns false when either tool was not created by the factory", async () => {
+      const realTool = await createCodeExecutionTool(runtimeFactory, new ToolBridge({}));
+      const foreignTool = createMockTool("bash", z.object({ script: z.string() }));
+
+      expect(retargetCodeExecutionTool(foreignTool, realTool)).toBe(false);
+      expect(retargetCodeExecutionTool(realTool, foreignTool)).toBe(false);
+
+      // The real tool stays functional after rejected retargets.
+      const result = (await realTool.execute!(
+        { code: "return 7" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(result.success).toBe(true);
+      expect(result.result).toBe(7);
     });
   });
 

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -659,6 +659,49 @@ describe("createCodeExecutionTool", () => {
       await host2.disposeScope("ws-failed-eval");
     });
 
+    it("recovers from unsnapshottable vars by rebuilding the mount from the last durable snapshot", async () => {
+      using tmp = new DisposableTempDir("code-exec-persistent");
+      const host = new SandboxHostService();
+      const mountProvider = () =>
+        host.acquireMount({
+          lifetime: "persistent",
+          runtimeFactory,
+          scopeKey: "ws-cyclic-vars",
+          sessionDir: tmp.path,
+        });
+      const tool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({}),
+        undefined,
+        mountProvider
+      );
+
+      const seed = (await tool.execute!(
+        { code: "vars.state = 'durable'; return vars.state;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(seed.success).toBe(true);
+
+      // Guest makes vars cyclic (unsnapshottable) and throws: the snapshot
+      // fails, so the live mount must be disposed rather than kept with state
+      // that disk can never reflect.
+      const poisoned = (await tool.execute!(
+        { code: "vars.self = vars; throw new Error('boom');" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(poisoned.success).toBe(false);
+
+      // Next call rebuilds the mount from the last durable snapshot: the
+      // cyclic mutation is gone, the seeded value is restored.
+      const recovered = (await tool.execute!(
+        { code: "return { state: vars.state, self: typeof vars.self };" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(recovered.success).toBe(true);
+      expect(recovered.result).toEqual({ state: "durable", self: "undefined" });
+      await host.disposeScope("ws-cyclic-vars");
+    });
+
     it("clearTypeCaches forces regeneration", async () => {
       const mockTools: Record<string, Tool> = {
         file_read: createMockTool("file_read", z.object({ filePath: z.string() }), () => ({

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -9,6 +9,8 @@ import { ToolBridge } from "@/node/services/ptc/toolBridge";
 import type { Tool, ToolExecutionOptions } from "ai";
 import type { PTCEvent, PTCExecutionResult } from "@/node/services/ptc/types";
 import { z } from "zod";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { SandboxHostService } from "@/node/services/sandbox/sandboxHostService";
 
 const mockToolCallOptions: ToolExecutionOptions<unknown> = {
   toolCallId: "test-call-id",
@@ -544,6 +546,62 @@ describe("createCodeExecutionTool", () => {
       expect(desc1).not.toBe(desc2);
       expect(desc1).not.toContain("function bash");
       expect(desc2).toContain("function bash");
+    });
+
+    it("persistent mount shares vars across two separate code_execution calls and a simulated restart", async () => {
+      using tmp = new DisposableTempDir("code-exec-persistent");
+      const host = new SandboxHostService();
+      const mountProvider = () =>
+        host.acquireMount({
+          lifetime: "persistent",
+          runtimeFactory,
+          scopeKey: "ws-code-exec",
+          sessionDir: tmp.path,
+        });
+      const tool = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({}),
+        undefined,
+        mountProvider
+      );
+
+      // Call 1 writes vars; call 2 (a separate tool call) reads them.
+      const first = (await tool.execute!(
+        { code: "vars.total = 40; return vars.total;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(first.success).toBe(true);
+      expect(first.result).toBe(40);
+
+      const second = (await tool.execute!(
+        { code: "vars.total += 2; return vars.total;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(second.success).toBe(true);
+      expect(second.result).toBe(42);
+
+      // Simulated restart: fresh host restores the per-call snapshot.
+      await host.disposeScope("ws-code-exec");
+      const host2 = new SandboxHostService();
+      const tool2 = await createCodeExecutionTool(
+        runtimeFactory,
+        new ToolBridge({}),
+        undefined,
+        () =>
+          host2.acquireMount({
+            lifetime: "persistent",
+            runtimeFactory,
+            scopeKey: "ws-code-exec",
+            sessionDir: tmp.path,
+          })
+      );
+      const third = (await tool2.execute!(
+        { code: "return vars.total;" },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+      expect(third.success).toBe(true);
+      expect(third.result).toBe(42);
+      await host2.disposeScope("ws-code-exec");
     });
 
     it("clearTypeCaches forces regeneration", async () => {

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -146,14 +146,12 @@ ${muxTypes}
         }
 
         // Register tools - they'll use runtime.getAbortSignal() for cancellation.
-        // Persistent mounts register once; re-registering on a reused runtime
-        // would rebuild the mux.* object every call for no benefit.
-        if (!mount?.bridgeRegistered) {
-          toolBridge.register(runtime);
-          if (mount) {
-            mount.bridgeRegistered = true;
-          }
-        }
+        // Always re-register, even on reused persistent mounts: each request
+        // builds a fresh ToolBridge from the CURRENT policy + grants, and a
+        // stale bridge would keep exposing tools after permissions narrowed.
+        // Registration just overwrites the guest's `mux` global, so this is
+        // cheap and idempotent.
+        toolBridge.register(runtime);
 
         // Handle abort signal - interrupt sandbox and cancel nested tools
         if (abortSignal) {

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -128,54 +128,66 @@ ${muxTypes}
       const mount = mountProvider ? await mountProvider() : null;
       const runtime = mount ? mount.runtime : await runtimeFactory.create();
 
-      const onAbort = () => runtime.abort();
-      try {
-        // Set resource limits (clamp timeout to max)
-        const timeoutSecs = Math.min(timeout_secs ?? DEFAULT_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
-        runtime.setLimits({
-          memoryBytes: DEFAULT_MEMORY_BYTES,
-          timeoutMs: timeoutSecs * 1000,
-        });
-
-        // Subscribe to events for UI streaming
-        // Wrap callback to include parentToolCallId from AI SDK context
-        if (emitNestedEvent) {
-          runtime.onEvent((event: PTCEvent) => {
-            emitNestedEvent({ ...event, parentToolCallId: toolCallId });
+      const runWithRuntime = async (): Promise<PTCExecutionResult> => {
+        const onAbort = () => runtime.abort();
+        try {
+          // Set resource limits (clamp timeout to max)
+          const timeoutSecs = Math.min(timeout_secs ?? DEFAULT_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
+          runtime.setLimits({
+            memoryBytes: DEFAULT_MEMORY_BYTES,
+            timeoutMs: timeoutSecs * 1000,
           });
-        }
 
-        // Register tools - they'll use runtime.getAbortSignal() for cancellation.
-        // Always re-register, even on reused persistent mounts: each request
-        // builds a fresh ToolBridge from the CURRENT policy + grants, and a
-        // stale bridge would keep exposing tools after permissions narrowed.
-        // Registration just overwrites the guest's `mux` global, so this is
-        // cheap and idempotent.
-        toolBridge.register(runtime);
-
-        // Handle abort signal - interrupt sandbox and cancel nested tools
-        if (abortSignal) {
-          // If already aborted, abort runtime immediately
-          if (abortSignal.aborted) {
-            runtime.abort();
-          } else {
-            abortSignal.addEventListener("abort", onAbort, { once: true });
+          // Subscribe to events for UI streaming
+          // Wrap callback to include parentToolCallId from AI SDK context
+          if (emitNestedEvent) {
+            runtime.onEvent((event: PTCEvent) => {
+              emitNestedEvent({ ...event, parentToolCallId: toolCallId });
+            });
           }
-        }
 
-        // Execute the code
-        const result = await runtime.eval(code);
+          // Register tools - they'll use runtime.getAbortSignal() for cancellation.
+          // Always re-register, even on reused persistent mounts: each request
+          // builds a fresh ToolBridge from the CURRENT policy + grants, and a
+          // stale bridge would keep exposing tools after permissions narrowed.
+          // Registration just overwrites the guest's `mux` global, so this is
+          // cheap and idempotent.
+          toolBridge.register(runtime);
 
-        // Persist the shared vars namespace after each call on persistent
-        // mounts so state survives crashes/restarts (turn-boundary snapshots
-        // are the Track 2 refinement; per-call is the safe foundation).
-        if (mount?.lifetime === "persistent" && mount.grants.vars && result.success) {
-          await mount.persistVars();
+          // Handle abort signal - interrupt sandbox and cancel nested tools
+          if (abortSignal) {
+            // If already aborted, abort runtime immediately
+            if (abortSignal.aborted) {
+              runtime.abort();
+            } else {
+              abortSignal.addEventListener("abort", onAbort, { once: true });
+            }
+          }
+
+          // Execute the code
+          const result = await runtime.eval(code);
+
+          // Persist the shared vars namespace after each call on persistent
+          // mounts so state survives crashes/restarts (turn-boundary snapshots
+          // are the Track 2 refinement; per-call is the safe foundation).
+          if (mount?.lifetime === "persistent" && mount.grants.vars && result.success) {
+            await mount.persistVars();
+          }
+          return result;
+        } finally {
+          // A late abort of THIS call's signal must not poison a reused runtime.
+          abortSignal?.removeEventListener("abort", onAbort);
         }
-        return result;
+      };
+
+      try {
+        // Persistent mounts can be handed to concurrent code_execution calls
+        // for the same workspace, but eval() mutates runtime-wide state
+        // (abort controller, tool-call attribution, event handler), so the
+        // register→eval→persist sequence runs under the mount's exclusive
+        // lock. Ephemeral runtimes are per-call and need no serialization.
+        return mount ? await mount.exclusive(runWithRuntime) : await runWithRuntime();
       } finally {
-        // A late abort of THIS call's signal must not poison a reused runtime.
-        abortSignal?.removeEventListener("abort", onAbort);
         if (mount) {
           mount.release(); // dispose ephemeral mounts; keep persistent alive
         } else {

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -54,6 +54,39 @@ export type MountRunner = (
   fn: (mount: SandboxMount) => Promise<PTCExecutionResult>
 ) => Promise<PTCExecutionResult>;
 
+/**
+ * Late-bound dispatch state for a created code_execution instance. execute()
+ * reads bridge + mount runner from here at CALL time (not closure-capture
+ * time) so retargetCodeExecutionTool can swing an already-created instance —
+ * and any middleware wrapper delegating to it, even through a captured
+ * `execute` function reference — onto a fresh bridge/mount.
+ */
+interface RetargetableState {
+  toolBridge: ToolBridge;
+  withMount: MountRunner | undefined;
+}
+
+const retargetableStates = new WeakMap<object, RetargetableState>();
+
+/**
+ * Point `target` (an instance returned by createCodeExecutionTool) at the
+ * bridge + mount runner of `donor` (another such instance). Used when a
+ * request.assemble hook wrapped/replaced code_execution while also editing
+ * other bridgeable tools: the wrapper delegates to the PRE-hook instance,
+ * which must dispatch through the rebuilt post-hook bridge instead of the
+ * stale one. Returns false when either tool was not created by this factory.
+ */
+export function retargetCodeExecutionTool(target: Tool, donor: Tool): boolean {
+  const targetState = retargetableStates.get(target);
+  const donorState = retargetableStates.get(donor);
+  if (targetState === undefined || donorState === undefined) {
+    return false;
+  }
+  targetState.toolBridge = donorState.toolBridge;
+  targetState.withMount = donorState.withMount;
+  return true;
+}
+
 export async function createCodeExecutionTool(
   runtimeFactory: IJSRuntimeFactory,
   toolBridge: ToolBridge,
@@ -61,11 +94,12 @@ export async function createCodeExecutionTool(
   withMount?: MountRunner
 ): Promise<Tool> {
   const bridgeableTools = toolBridge.getBridgeableTools();
+  const state: RetargetableState = { toolBridge, withMount };
 
   // Generate mux types for type validation and documentation (cached by tool set hash)
   const muxTypes = await getCachedMuxTypes(bridgeableTools);
 
-  return tool({
+  const codeExecutionTool = tool({
     description: `Execute sandboxed JavaScript to batch tools and transform outputs.
 
 **When to use:** Prefer this tool when making 2+ tool calls, especially when later calls depend on earlier results. Reduces round-trip latency.
@@ -107,6 +141,11 @@ ${muxTypes}
       { abortSignal, toolCallId }
     ): Promise<PTCExecutionResult> => {
       const execStartTime = Date.now();
+
+      // Late-bound dispatch: snapshot the CURRENT bridge + mount runner as a
+      // pair so a retarget (see retargetCodeExecutionTool) lands atomically —
+      // the whole call uses either the old pair or the new pair, never a mix.
+      const { toolBridge: activeBridge, withMount: activeMount } = state;
 
       // Static analysis before execution - catch syntax errors and sandbox-forbidden patterns.
       // TypeScript typing issues are intentionally non-blocking for one-off runtime scripts.
@@ -157,7 +196,7 @@ ${muxTypes}
           // stale bridge would keep exposing tools after permissions narrowed.
           // Registration just overwrites the guest's `mux` global, so this is
           // cheap and idempotent.
-          toolBridge.register(runtime);
+          activeBridge.register(runtime);
 
           // Handle abort signal - interrupt sandbox and cancel nested tools
           if (abortSignal) {
@@ -207,8 +246,8 @@ ${muxTypes}
       // holds the scope lock from acquisition through the whole
       // register→eval→persist sequence, so concurrent calls, grant changes,
       // and scope disposal are all serialized against this execution.
-      if (withMount) {
-        return await withMount((mount) => runWithRuntime(mount, mount.runtime));
+      if (activeMount) {
+        return await activeMount((mount) => runWithRuntime(mount, mount.runtime));
       }
       // Classic ephemeral flow: per-call runtime, no serialization needed.
       const runtime = await runtimeFactory.create();
@@ -219,4 +258,6 @@ ${muxTypes}
       }
     },
   });
+  retargetableStates.set(codeExecutionTool, state);
+  return codeExecutionTool;
 }

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -15,6 +15,7 @@ import type { PTCEvent, PTCExecutionResult } from "@/node/services/ptc/types";
 import type { SandboxMount } from "@/node/services/sandbox/sandboxHostService";
 
 import { analyzeCode } from "@/node/services/ptc/staticAnalysis";
+import { log } from "@/node/services/log";
 import { getCachedMuxTypes, clearTypeCache } from "@/node/services/ptc/typeGenerator";
 
 // Default limits
@@ -170,8 +171,21 @@ ${muxTypes}
           // Persist the shared vars namespace after each call on persistent
           // mounts so state survives crashes/restarts (turn-boundary snapshots
           // are the Track 2 refinement; per-call is the safe foundation).
-          if (mount?.lifetime === "persistent" && mount.grants.vars && result.success) {
-            await mount.persistVars();
+          if (mount?.lifetime === "persistent" && mount.grants.vars) {
+            if (result.success) {
+              await mount.persistVars();
+            } else {
+              // Failed/timed-out/aborted evals may still have mutated vars
+              // before failing, and the live guest keeps those mutations —
+              // persist best-effort so a restart cannot resurrect older state
+              // (memory and disk must agree). Never mask the eval result with
+              // a snapshot error.
+              try {
+                await mount.persistVars();
+              } catch (persistError) {
+                log.warn("code_execution: post-failure vars snapshot failed", { persistError });
+              }
+            }
           }
           return result;
         } finally {

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -171,20 +171,23 @@ ${muxTypes}
           // Persist the shared vars namespace after each call on persistent
           // mounts so state survives crashes/restarts (turn-boundary snapshots
           // are the Track 2 refinement; per-call is the safe foundation).
+          // Failed/timed-out/aborted evals may still have mutated vars before
+          // failing and the live guest keeps those mutations, so persist after
+          // failures too — memory and disk must agree.
           if (mount?.lifetime === "persistent" && mount.grants.vars) {
-            if (result.success) {
+            try {
               await mount.persistVars();
-            } else {
-              // Failed/timed-out/aborted evals may still have mutated vars
-              // before failing, and the live guest keeps those mutations —
-              // persist best-effort so a restart cannot resurrect older state
-              // (memory and disk must agree). Never mask the eval result with
-              // a snapshot error.
-              try {
-                await mount.persistVars();
-              } catch (persistError) {
-                log.warn("code_execution: post-failure vars snapshot failed", { persistError });
-              }
+            } catch (persistError) {
+              // Vars became unsnapshottable (e.g. guest created a cycle then
+              // threw). Leaving the live mount would make memory and disk
+              // permanently disagree; dispose it so the next acquire rebuilds
+              // from the last durable snapshot. Never mask the eval result
+              // with a snapshot error.
+              log.warn(
+                "code_execution: vars snapshot failed; disposing mount so the next call restores the last durable snapshot",
+                { persistError }
+              );
+              mount.dispose();
             }
           }
           return result;

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -148,7 +148,7 @@ ${muxTypes}
         // Register tools - they'll use runtime.getAbortSignal() for cancellation.
         // Persistent mounts register once; re-registering on a reused runtime
         // would rebuild the mux.* object every call for no benefit.
-        if (!mount || !mount.bridgeRegistered) {
+        if (!mount?.bridgeRegistered) {
           toolBridge.register(runtime);
           if (mount) {
             mount.bridgeRegistered = true;
@@ -171,7 +171,7 @@ ${muxTypes}
         // Persist the shared vars namespace after each call on persistent
         // mounts so state survives crashes/restarts (turn-boundary snapshots
         // are the Track 2 refinement; per-call is the safe foundation).
-        if (mount && mount.lifetime === "persistent" && mount.grants.vars && result.success) {
+        if (mount?.lifetime === "persistent" && mount.grants.vars && result.success) {
           await mount.persistVars();
         }
         return result;

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -12,6 +12,7 @@ import type { Tool } from "ai";
 import type { ToolBridge } from "@/node/services/ptc/toolBridge";
 import type { IJSRuntimeFactory } from "@/node/services/ptc/runtime";
 import type { PTCEvent, PTCExecutionResult } from "@/node/services/ptc/types";
+import type { SandboxMount } from "@/node/services/sandbox/sandboxHostService";
 
 import { analyzeCode } from "@/node/services/ptc/staticAnalysis";
 import { getCachedMuxTypes, clearTypeCache } from "@/node/services/ptc/typeGenerator";
@@ -40,11 +41,16 @@ export type PTCEventWithParent = PTCEvent & { parentToolCallId: string };
  * @param runtimeFactory Factory for creating QuickJS runtime instances
  * @param toolBridge Bridge containing tools to expose in sandbox
  * @param emitNestedEvent Callback for streaming nested tool events (includes parentToolCallId)
+ * @param mountProvider Optional SandboxHostService mount source. When absent,
+ *   behavior is the classic ephemeral per-call flow (create → eval → dispose).
+ *   A persistent mount survives across calls: `vars` is shared, the tool
+ *   bridge is registered once, and the runtime is not disposed here.
  */
 export async function createCodeExecutionTool(
   runtimeFactory: IJSRuntimeFactory,
   toolBridge: ToolBridge,
-  emitNestedEvent?: (event: PTCEventWithParent) => void
+  emitNestedEvent?: (event: PTCEventWithParent) => void,
+  mountProvider?: () => Promise<SandboxMount>
 ): Promise<Tool> {
   const bridgeableTools = toolBridge.getBridgeableTools();
 
@@ -116,9 +122,13 @@ ${muxTypes}
         };
       }
 
-      // Create runtime with resource limits
-      const runtime = await runtimeFactory.create();
+      // Acquire the runtime: a SandboxHostService mount when provided
+      // (persistent mounts are reused across calls), otherwise the classic
+      // ephemeral per-call runtime.
+      const mount = mountProvider ? await mountProvider() : null;
+      const runtime = mount ? mount.runtime : await runtimeFactory.create();
 
+      const onAbort = () => runtime.abort();
       try {
         // Set resource limits (clamp timeout to max)
         const timeoutSecs = Math.min(timeout_secs ?? DEFAULT_TIMEOUT_SECS, MAX_TIMEOUT_SECS);
@@ -135,8 +145,15 @@ ${muxTypes}
           });
         }
 
-        // Register tools - they'll use runtime.getAbortSignal() for cancellation
-        toolBridge.register(runtime);
+        // Register tools - they'll use runtime.getAbortSignal() for cancellation.
+        // Persistent mounts register once; re-registering on a reused runtime
+        // would rebuild the mux.* object every call for no benefit.
+        if (!mount || !mount.bridgeRegistered) {
+          toolBridge.register(runtime);
+          if (mount) {
+            mount.bridgeRegistered = true;
+          }
+        }
 
         // Handle abort signal - interrupt sandbox and cancel nested tools
         if (abortSignal) {
@@ -144,15 +161,29 @@ ${muxTypes}
           if (abortSignal.aborted) {
             runtime.abort();
           } else {
-            abortSignal.addEventListener("abort", () => runtime.abort(), { once: true });
+            abortSignal.addEventListener("abort", onAbort, { once: true });
           }
         }
 
         // Execute the code
-        return await runtime.eval(code);
+        const result = await runtime.eval(code);
+
+        // Persist the shared vars namespace after each call on persistent
+        // mounts so state survives crashes/restarts (turn-boundary snapshots
+        // are the Track 2 refinement; per-call is the safe foundation).
+        if (mount && mount.lifetime === "persistent" && mount.grants.vars && result.success) {
+          await mount.persistVars();
+        }
+        return result;
       } finally {
-        // Clean up runtime resources
-        runtime.dispose();
+        // A late abort of THIS call's signal must not poison a reused runtime.
+        abortSignal?.removeEventListener("abort", onAbort);
+        if (mount) {
+          mount.release(); // dispose ephemeral mounts; keep persistent alive
+        } else {
+          // Clean up runtime resources
+          runtime.dispose();
+        }
       }
     },
   });

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -10,7 +10,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { Tool } from "ai";
 import type { ToolBridge } from "@/node/services/ptc/toolBridge";
-import type { IJSRuntimeFactory } from "@/node/services/ptc/runtime";
+import type { IJSRuntime, IJSRuntimeFactory } from "@/node/services/ptc/runtime";
 import type { PTCEvent, PTCExecutionResult } from "@/node/services/ptc/types";
 import type { SandboxMount } from "@/node/services/sandbox/sandboxHostService";
 
@@ -42,16 +42,23 @@ export type PTCEventWithParent = PTCEvent & { parentToolCallId: string };
  * @param runtimeFactory Factory for creating QuickJS runtime instances
  * @param toolBridge Bridge containing tools to expose in sandbox
  * @param emitNestedEvent Callback for streaming nested tool events (includes parentToolCallId)
- * @param mountProvider Optional SandboxHostService mount source. When absent,
+ * @param withMount Optional SandboxHostService lease runner
+ *   (withPersistentMount bound to this workspace's scope). When absent,
  *   behavior is the classic ephemeral per-call flow (create → eval → dispose).
- *   A persistent mount survives across calls: `vars` is shared, the tool
- *   bridge is registered once, and the runtime is not disposed here.
+ *   The runner holds the scope lock from mount acquisition through fn's
+ *   completion, so the register→eval→persist sequence cannot race concurrent
+ *   grant changes or scope disposal; the persistent runtime is not disposed
+ *   here.
  */
+export type MountRunner = (
+  fn: (mount: SandboxMount) => Promise<PTCExecutionResult>
+) => Promise<PTCExecutionResult>;
+
 export async function createCodeExecutionTool(
   runtimeFactory: IJSRuntimeFactory,
   toolBridge: ToolBridge,
   emitNestedEvent?: (event: PTCEventWithParent) => void,
-  mountProvider?: () => Promise<SandboxMount>
+  withMount?: MountRunner
 ): Promise<Tool> {
   const bridgeableTools = toolBridge.getBridgeableTools();
 
@@ -123,13 +130,10 @@ ${muxTypes}
         };
       }
 
-      // Acquire the runtime: a SandboxHostService mount when provided
-      // (persistent mounts are reused across calls), otherwise the classic
-      // ephemeral per-call runtime.
-      const mount = mountProvider ? await mountProvider() : null;
-      const runtime = mount ? mount.runtime : await runtimeFactory.create();
-
-      const runWithRuntime = async (): Promise<PTCExecutionResult> => {
+      const runWithRuntime = async (
+        mount: SandboxMount | null,
+        runtime: IJSRuntime
+      ): Promise<PTCExecutionResult> => {
         const onAbort = () => runtime.abort();
         try {
           // Set resource limits (clamp timeout to max)
@@ -197,20 +201,21 @@ ${muxTypes}
         }
       };
 
+      // Persistent mounts can be handed to concurrent code_execution calls
+      // for the same workspace, but eval() mutates runtime-wide state (abort
+      // controller, tool-call attribution, event handler). The lease runner
+      // holds the scope lock from acquisition through the whole
+      // register→eval→persist sequence, so concurrent calls, grant changes,
+      // and scope disposal are all serialized against this execution.
+      if (withMount) {
+        return await withMount((mount) => runWithRuntime(mount, mount.runtime));
+      }
+      // Classic ephemeral flow: per-call runtime, no serialization needed.
+      const runtime = await runtimeFactory.create();
       try {
-        // Persistent mounts can be handed to concurrent code_execution calls
-        // for the same workspace, but eval() mutates runtime-wide state
-        // (abort controller, tool-call attribution, event handler), so the
-        // register→eval→persist sequence runs under the mount's exclusive
-        // lock. Ephemeral runtimes are per-call and need no serialization.
-        return mount ? await mount.exclusive(runWithRuntime) : await runWithRuntime();
+        return await runWithRuntime(null, runtime);
       } finally {
-        if (mount) {
-          mount.release(); // dispose ephemeral mounts; keep persistent alive
-        } else {
-          // Clean up runtime resources
-          runtime.dispose();
-        }
+        runtime.dispose();
       }
     },
   });

--- a/src/node/services/tools/withHooks.ts
+++ b/src/node/services/tools/withHooks.ts
@@ -1,6 +1,12 @@
 /**
  * Higher-order function that wraps a tool with hook support.
  *
+ * Tool execution runs through the event spine's `tool.execute` waterfall
+ * (see src/node/services/events/eventSpine.ts). The shell hook protocol lives
+ * in `shellToolHookMiddleware`, registered as the built-in middleware on that
+ * point, so future consumers (plugin hooks, turn-envelope emission) compose
+ * around the same pipeline.
+ *
  * Hook priority (new → legacy):
  * - Pre-execution: tool_pre → tool_hook (if no tool_pre)
  * - Post-execution: tool_post → tool_hook (only if tool_hook was used for pre)
@@ -12,6 +18,7 @@
  * Legacy model (tool_hook): single hook with marker protocol (echo $MUX_EXEC)
  */
 
+import assert from "node:assert";
 import type { Tool } from "ai";
 import { cloneToolPreservingDescriptors } from "@/common/utils/tools/cloneToolPreservingDescriptors";
 import type { Runtime } from "@/node/runtime/Runtime";
@@ -24,6 +31,11 @@ import {
   runPreHook,
   runPostHook,
 } from "@/node/services/hooks";
+import {
+  eventSpine,
+  type ToolExecuteContext,
+  type WaterfallNext,
+} from "@/node/services/events/eventSpine";
 import { log } from "@/node/services/log";
 
 export interface HookConfig {
@@ -82,17 +94,7 @@ export function withHooks<TParameters, TResult>(
   const wrappedToolRecord = wrappedTool as any as Record<string, unknown>;
 
   wrappedToolRecord.execute = async (args: TParameters, options: unknown) => {
-    // Find hooks (checked per call - hooks can be added/removed dynamically)
-    const [preHookPath, postHookPath, legacyHookPath] = await Promise.all([
-      getPreHookPath(config.runtime, config.cwd),
-      getPostHookPath(config.runtime, config.cwd),
-      getHookPath(config.runtime, config.cwd),
-    ]);
-
-    // No hooks at all - execute tool directly
-    if (!preHookPath && !postHookPath && !legacyHookPath) {
-      return executeFn.call(tool, args, options) as TResult;
-    }
+    ensureShellToolHookMiddleware();
 
     // Extract abort signal from tool options (if present)
     const abortSignal =
@@ -100,193 +102,215 @@ export function withHooks<TParameters, TResult>(
         ? (options as { abortSignal?: AbortSignal }).abortSignal
         : undefined;
 
-    const toolInput = JSON.stringify(args);
-    const hookContext = {
-      tool: toolName,
-      toolInput,
-      toolInputValue: args,
-      workspaceId: config.workspaceId,
-      projectDir: config.cwd,
-      runtimeTempDir: config.runtimeTempDir,
-      env: config.env,
+    const ctx: ToolExecuteContext = {
+      toolName,
+      args,
+      host: {
+        runtime: config.runtime,
+        runtimeTempDir: config.runtimeTempDir,
+        cwd: config.cwd,
+        workspaceId: config.workspaceId,
+        env: config.env,
+      },
       abortSignal,
+      executed: false,
     };
 
-    // Use new model (tool_pre/tool_post) if tool_pre exists
-    if (preHookPath) {
-      return executeWithNewHooks(
-        config.runtime,
-        preHookPath,
-        postHookPath,
-        hookContext,
-        toolName,
-        () => executeFn.call(tool, args, options) as TResult
-      );
-    }
+    await eventSpine.run("tool.execute", ctx, async (c) => {
+      assert(!c.blocked, `tool.execute terminal reached with blocked context (${toolName})`);
+      // Middleware may have rewritten args; execute with the current ones.
+      c.result = await (executeFn.call(tool, c.args as TParameters, options) as
+        | TResult
+        | Promise<TResult>);
+      c.executed = true;
+    });
 
-    // Fall back to legacy model (tool_hook) if it exists
-    if (legacyHookPath) {
-      return executeWithLegacyHook(
-        config.runtime,
-        legacyHookPath,
-        hookContext,
-        toolName,
-        () => executeFn.call(tool, args, options) as TResult
-      );
+    if (ctx.blocked) {
+      return ctx.blocked.result as TResult;
     }
-
-    // Only post hook exists (no pre) - execute tool then run post
-    const result = (await executeFn.call(tool, args, options)) as TResult;
-    if (postHookPath) {
-      const postStart = Date.now();
-      const postResult = await runPostHook(config.runtime, postHookPath, hookContext, result);
-      const hookDurationMs = Date.now() - postStart;
-      if (postResult.output) {
-        return appendHookOutput(
-          result,
-          truncateHookOutput(postResult.output),
-          hookDurationMs,
-          postHookPath
-        ) as TResult;
-      }
-    }
-    return result;
+    assert(
+      ctx.executed,
+      `tool.execute middleware for ${toolName} neither executed nor blocked the tool`
+    );
+    return ctx.result as TResult;
   };
 
   return wrappedTool;
 }
 
-/** Execute tool with new pre/post hook model */
-async function executeWithNewHooks<TResult>(
-  runtime: Runtime,
-  preHookPath: string,
-  postHookPath: string | null,
-  context: {
-    tool: string;
-    toolInput: string;
-    workspaceId: string;
-    projectDir: string;
-    runtimeTempDir?: string;
-    env?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  },
-  toolName: string,
-  executeTool: () => TResult | Promise<TResult>
-): Promise<TResult> {
-  log.debug("[withHooks] Running tool with pre/post hooks", {
-    toolName,
-    preHookPath,
-    postHookPath,
-  });
+// ---------------------------------------------------------------------------
+// Shell tool hook middleware (built-in `tool.execute` consumer)
+// ---------------------------------------------------------------------------
 
-  const hookStart = Date.now();
+let shellToolHookMiddlewareRegistered = false;
 
-  // Run pre-hook
-  const preResult = await runPreHook(runtime, preHookPath, context);
+/**
+ * Idempotently register the shell hook middleware on the spine. Invoked from
+ * withHooks() so every entry point that wraps tools (desktop, CLI, tests) gets
+ * identical hook behavior without a separate bootstrap step.
+ */
+function ensureShellToolHookMiddleware(): void {
+  if (shellToolHookMiddlewareRegistered) return;
+  shellToolHookMiddlewareRegistered = true;
+  eventSpine.use("tool.execute", shellToolHookMiddleware);
+}
 
-  // Pre-hook blocked tool
-  if (!preResult.allowed) {
-    const output = truncateHookOutput(
-      preResult.output || `Tool blocked by pre-hook (exit ${preResult.exitCode})`
-    );
-    log.debug("[withHooks] Pre-hook blocked tool", { toolName, output });
-    const errorResult: { error: string } = { error: output };
-    return errorResult as TResult;
+/**
+ * The `.mux/tool_pre` / `.mux/tool_post` / legacy `.mux/tool_hook` protocol as
+ * around-style middleware. Behavior is identical to the pre-spine withHooks
+ * implementation; the legacy protocol inherently wraps execution, which is why
+ * the pipeline is around-style.
+ */
+async function shellToolHookMiddleware(
+  ctx: ToolExecuteContext,
+  next: WaterfallNext
+): Promise<void> {
+  const { runtime, cwd } = ctx.host;
+
+  // Find hooks (checked per call - hooks can be added/removed dynamically)
+  const [preHookPath, postHookPath, legacyHookPath] = await Promise.all([
+    getPreHookPath(runtime, cwd),
+    getPostHookPath(runtime, cwd),
+    getHookPath(runtime, cwd),
+  ]);
+
+  // No hooks at all - continue the pipeline directly
+  if (!preHookPath && !postHookPath && !legacyHookPath) {
+    return next();
   }
 
-  // Execute tool
-  const result = await executeTool();
+  const toolName = ctx.toolName;
+  const hookContext = {
+    tool: toolName,
+    toolInput: JSON.stringify(ctx.args),
+    toolInputValue: ctx.args,
+    workspaceId: ctx.host.workspaceId,
+    projectDir: cwd,
+    runtimeTempDir: ctx.host.runtimeTempDir,
+    env: ctx.host.env,
+    abortSignal: ctx.abortSignal,
+  };
 
-  // Run post-hook if exists
-  if (postHookPath) {
-    const postResult = await runPostHook(runtime, postHookPath, context, result);
+  // Use new model (tool_pre/tool_post) if tool_pre exists
+  if (preHookPath) {
+    log.debug("[withHooks] Running tool with pre/post hooks", {
+      toolName,
+      preHookPath,
+      postHookPath,
+    });
+
+    const hookStart = Date.now();
+    const preResult = await runPreHook(runtime, preHookPath, hookContext);
+
+    // Pre-hook blocked tool
+    if (!preResult.allowed) {
+      const output = truncateHookOutput(
+        preResult.output || `Tool blocked by pre-hook (exit ${preResult.exitCode})`
+      );
+      log.debug("[withHooks] Pre-hook blocked tool", { toolName, output });
+      ctx.blocked = { result: { error: output } };
+      return;
+    }
+
+    // Execute tool (rest of pipeline)
+    await next();
+
+    // Run post-hook if exists
+    if (postHookPath) {
+      const postResult = await runPostHook(runtime, postHookPath, hookContext, ctx.result);
+      const hookDurationMs = Date.now() - hookStart;
+      let hookOutput = postResult.output;
+
+      if (!postResult.success && !hookOutput) {
+        hookOutput = `Post-hook failed (exit code ${postResult.exitCode})`;
+      }
+
+      if (hookOutput) {
+        hookOutput = truncateHookOutput(hookOutput);
+        log.debug("[withHooks] Post-hook produced output", {
+          toolName,
+          success: postResult.success,
+          output: hookOutput,
+        });
+        ctx.result = appendHookOutput(ctx.result, hookOutput, hookDurationMs, postHookPath);
+      }
+    }
+    return;
+  }
+
+  // Fall back to legacy model (tool_hook) if it exists
+  if (legacyHookPath) {
+    log.debug("[withHooks] Running tool with legacy hook", { toolName, hookPath: legacyHookPath });
+
+    const hookStart = Date.now();
+    const { result, hook } = await runWithHook<unknown>(
+      runtime,
+      legacyHookPath,
+      hookContext,
+      async () => {
+        await next();
+        return ctx.result;
+      },
+      {
+        slowThresholdMs: 10000,
+        onSlowHook: (phase, elapsedMs) => {
+          const seconds = (elapsedMs / 1000).toFixed(1);
+          log.warn(`[withHooks] Slow ${phase}-hook for ${toolName}: ${seconds}s`);
+          console.warn(`⚠️  Slow tool hook (${phase}): ${toolName} took ${seconds}s`);
+        },
+      }
+    );
     const hookDurationMs = Date.now() - hookStart;
-    let hookOutput = postResult.output;
 
-    if (!postResult.success && !hookOutput) {
-      hookOutput = `Post-hook failed (exit code ${postResult.exitCode})`;
+    // Hook blocked tool execution (exited before $MUX_EXEC)
+    if (!hook.toolExecuted) {
+      const blockOutput = truncateHookOutput(
+        [hook.stdoutBeforeExec, hook.stderr].filter(Boolean).join("\n").trim()
+      );
+      log.debug("[withHooks] Hook blocked tool execution", { toolName, output: blockOutput });
+      ctx.blocked = {
+        result: { error: blockOutput || "Tool blocked by hook (exited before $MUX_EXEC)" },
+      };
+      return;
+    }
+
+    // Combine stdout and stderr for hook output
+    let hookOutput = [hook.stdout, hook.stderr].filter(Boolean).join("\n").trim();
+
+    if (!hook.success && !hookOutput) {
+      hookOutput = `Tool hook failed (exit code ${hook.exitCode})`;
     }
 
     if (hookOutput) {
       hookOutput = truncateHookOutput(hookOutput);
-      log.debug("[withHooks] Post-hook produced output", {
+      log.debug("[withHooks] Hook produced output", {
         toolName,
-        success: postResult.success,
+        success: hook.success,
         output: hookOutput,
       });
-      return appendHookOutput(result, hookOutput, hookDurationMs, postHookPath) as TResult;
+      ctx.result = appendHookOutput(result, hookOutput, hookDurationMs, legacyHookPath);
+      return;
     }
+
+    // Note: result could be TResult or AsyncIterable<TResult>
+    ctx.result = result;
+    return;
   }
 
-  return result;
-}
-
-/** Execute tool with legacy tool_hook model */
-async function executeWithLegacyHook<TResult>(
-  runtime: Runtime,
-  hookPath: string,
-  context: {
-    tool: string;
-    toolInput: string;
-    workspaceId: string;
-    projectDir: string;
-    runtimeTempDir?: string;
-    env?: Record<string, string>;
-    abortSignal?: AbortSignal;
-  },
-  toolName: string,
-  executeTool: () => TResult | Promise<TResult>
-): Promise<TResult> {
-  log.debug("[withHooks] Running tool with legacy hook", { toolName, hookPath });
-
-  const hookStart = Date.now();
-  const { result, hook } = await runWithHook<TResult>(
-    runtime,
-    hookPath,
-    context,
-    () => Promise.resolve(executeTool()),
-    {
-      slowThresholdMs: 10000,
-      onSlowHook: (phase, elapsedMs) => {
-        const seconds = (elapsedMs / 1000).toFixed(1);
-        log.warn(`[withHooks] Slow ${phase}-hook for ${toolName}: ${seconds}s`);
-        console.warn(`⚠️  Slow tool hook (${phase}): ${toolName} took ${seconds}s`);
-      },
-    }
-  );
-  const hookDurationMs = Date.now() - hookStart;
-
-  // Hook blocked tool execution (exited before $MUX_EXEC)
-  if (!hook.toolExecuted) {
-    const blockOutput = truncateHookOutput(
-      [hook.stdoutBeforeExec, hook.stderr].filter(Boolean).join("\n").trim()
+  // Only post hook exists (no pre) - execute tool then run post
+  assert(postHookPath, "shellToolHookMiddleware: expected tool_post path in post-only branch");
+  await next();
+  const postStart = Date.now();
+  const postResult = await runPostHook(runtime, postHookPath, hookContext, ctx.result);
+  const hookDurationMs = Date.now() - postStart;
+  if (postResult.output) {
+    ctx.result = appendHookOutput(
+      ctx.result,
+      truncateHookOutput(postResult.output),
+      hookDurationMs,
+      postHookPath
     );
-    log.debug("[withHooks] Hook blocked tool execution", { toolName, output: blockOutput });
-    const errorResult: { error: string } = {
-      error: blockOutput || "Tool blocked by hook (exited before $MUX_EXEC)",
-    };
-    return errorResult as TResult;
   }
-
-  // Combine stdout and stderr for hook output
-  let hookOutput = [hook.stdout, hook.stderr].filter(Boolean).join("\n").trim();
-
-  if (!hook.success && !hookOutput) {
-    hookOutput = `Tool hook failed (exit code ${hook.exitCode})`;
-  }
-
-  if (hookOutput) {
-    hookOutput = truncateHookOutput(hookOutput);
-    log.debug("[withHooks] Hook produced output", {
-      toolName,
-      success: hook.success,
-      output: hookOutput,
-    });
-    return appendHookOutput(result, hookOutput, hookDurationMs, hookPath) as TResult;
-  }
-
-  // Note: result could be TResult or AsyncIterable<TResult>
-  return result as TResult;
 }
 
 /** Check if a value is an AsyncIterable (streaming result) */

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -3228,6 +3228,7 @@ describe("WorkflowRunner", () => {
             registerObject: noop,
             registerPromiseFunction: noop,
             registerSyncFunction: noop,
+            setPendingJobGate: noop,
             onEvent: noop,
             abort: noop,
             getAbortSignal() {

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -3226,6 +3226,8 @@ describe("WorkflowRunner", () => {
             },
             registerFunction: noop,
             registerObject: noop,
+            registerPromiseFunction: noop,
+            registerSyncFunction: noop,
             onEvent: noop,
             abort: noop,
             getAbortSignal() {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -22,6 +22,7 @@ import { Ok, Err } from "@/common/types/result";
 import { askUserQuestionManager } from "@/node/services/askUserQuestionManager";
 import { delegatedToolCallManager } from "@/node/services/delegatedToolCallManager";
 import { log } from "@/node/services/log";
+import { eventSpine } from "@/node/services/events/eventSpine";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
 import { AgentSession, type StreamErrorRecoveryOutcome } from "@/node/services/agentSession";
 import type { HistoryService } from "@/node/services/historyService";
@@ -4337,6 +4338,7 @@ export class WorkspaceService extends EventEmitter {
         session.emitMetadata(this.enrichFrontendMetadata(completeMetadata));
       }
 
+      eventSpine.emit("workspace.created", { workspaceId });
       return Ok({ metadata: this.enrichFrontendMetadata(completeMetadata) });
     } catch (error) {
       initLogger.logComplete(-1);
@@ -6986,6 +6988,7 @@ export class WorkspaceService extends EventEmitter {
       // before the workspace's memory dies with it. Fire-and-forget; never blocks archive.
       this.memoryConsolidationService?.triggerInBackground(workspaceId, "archive");
 
+      eventSpine.emit("workspace.archived", { workspaceId });
       return Ok({ kind: "archived" as const });
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -9833,9 +9833,10 @@ export class WorkspaceService extends EventEmitter {
       this.sessions.get(workspaceId)?.clearFileState();
 
       // Persistent sandbox mounts are scoped to the workspace session; a
-      // context reset ends that session, so the mount is disposed (vars are
-      // snapshotted best-effort inside disposeScope).
-      await sandboxHostService.disposeScope(workspaceId);
+      // context reset ends that session, so sandbox state is DISCARDED (not
+      // snapshotted) — vars must not survive a reset the way they survive
+      // archive/un-archive.
+      await sandboxHostService.discardScope(workspaceId, this.config.getSessionDir(workspaceId));
 
       return Ok("reset");
     } finally {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -23,6 +23,7 @@ import { askUserQuestionManager } from "@/node/services/askUserQuestionManager";
 import { delegatedToolCallManager } from "@/node/services/delegatedToolCallManager";
 import { log } from "@/node/services/log";
 import { eventSpine } from "@/node/services/events/eventSpine";
+import { sandboxHostService } from "@/node/services/sandbox/sandboxHostService";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
 import { AgentSession, type StreamErrorRecoveryOutcome } from "@/node/services/agentSession";
 import type { HistoryService } from "@/node/services/historyService";
@@ -6988,6 +6989,10 @@ export class WorkspaceService extends EventEmitter {
       // before the workspace's memory dies with it. Fire-and-forget; never blocks archive.
       this.memoryConsolidationService?.triggerInBackground(workspaceId, "archive");
 
+      // Dispose the workspace's persistent sandbox mount (snapshot-then-dispose
+      // inside disposeScope keeps vars recoverable on un-archive).
+      await sandboxHostService.disposeScope(workspaceId);
+
       eventSpine.emit("workspace.archived", { workspaceId });
       return Ok({ kind: "archived" as const });
     } catch (error) {
@@ -9826,6 +9831,11 @@ export class WorkspaceService extends EventEmitter {
         log.error("Failed to require goal acknowledgment after context reset:", error);
       }
       this.sessions.get(workspaceId)?.clearFileState();
+
+      // Persistent sandbox mounts are scoped to the workspace session; a
+      // context reset ends that session, so the mount is disposed (vars are
+      // snapshotted best-effort inside disposeScope).
+      await sandboxHostService.disposeScope(workspaceId);
 
       return Ok("reset");
     } finally {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5209,6 +5209,13 @@ export class WorkspaceService extends EventEmitter {
       // the resulting stream-abort event would otherwise be recorded on the timeline after the
       // delete, recreating the session directory for a workspace the user removed.
       this.disposeSession(workspaceId);
+
+      // Drop any persistent sandbox mount BEFORE deleting the session
+      // directory: dropScope disposes the runtime without disk writes and
+      // waits for in-flight evaluation, so a late vars snapshot cannot
+      // recreate the directory (and the QuickJS runtime is not leaked in the
+      // process-wide singleton).
+      await sandboxHostService.dropScope(workspaceId);
       try {
         await this.timelineRecorder.closeWorkspace(workspaceId);
         timelineClosed = true;

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -4040,6 +4040,7 @@ export class WorkspaceService extends EventEmitter {
 
       const enrichedMetadata = this.enrichFrontendMetadata(completeMetadata);
       this.getOrCreateSession(workspaceId).emitMetadata(enrichedMetadata);
+      eventSpine.emit("workspace.created", { workspaceId });
       return Ok({ metadata: enrichedMetadata });
     } catch (error) {
       await this.config.removeWorkspace(workspaceId).catch(() => undefined);
@@ -4731,6 +4732,7 @@ export class WorkspaceService extends EventEmitter {
         session.emitMetadata(this.enrichFrontendMetadata(completeMetadata));
       }
 
+      eventSpine.emit("workspace.created", { workspaceId });
       return Ok(enrichedMetadata);
     } catch (error) {
       initLogger?.logComplete(-1);
@@ -8252,6 +8254,7 @@ export class WorkspaceService extends EventEmitter {
       const enrichedMetadata = this.enrichFrontendMetadata(metadata);
       session.emitMetadata(enrichedMetadata);
 
+      eventSpine.emit("workspace.created", { workspaceId: newWorkspaceId });
       return Ok({ metadata: enrichedMetadata, projectPath: foundProjectPath });
     } catch (error) {
       const message = getErrorMessage(error);

--- a/src/node/utils/journal/blobStore.test.ts
+++ b/src/node/utils/journal/blobStore.test.ts
@@ -44,7 +44,12 @@ describe("BlobStore", () => {
   test("rejects malformed refs (crash-fast on programmer error)", async () => {
     using tmp = new DisposableTempDir("blobstore-test");
     const store = new BlobStore(tmp.path);
-    await expect(store.get("md5:abc" as never)).rejects.toThrow(/Invalid blob ref/);
+    try {
+      await store.get("md5:abc" as never);
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("Invalid blob ref");
+    }
   });
 
   test("roundtrips binary content", async () => {

--- a/src/node/utils/journal/blobStore.test.ts
+++ b/src/node/utils/journal/blobStore.test.ts
@@ -41,6 +41,22 @@ describe("BlobStore", () => {
     expect(await store.get(ref)).toBeNull();
   });
 
+  test("put repairs a corrupted existing blob instead of trusting the path", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    const { ref } = await store.put("legit content");
+    const hash = ref.slice("sha256:".length);
+    const blobPath = path.join(tmp.path, hash.slice(0, 2), hash);
+    await fs.writeFile(blobPath, "tampered");
+    expect(await store.get(ref)).toBeNull();
+
+    // Re-putting the original content must rewrite the corrupt file so the
+    // blob becomes readable again (otherwise the ref is poisoned forever).
+    const again = await store.put("legit content");
+    expect(again.ref).toBe(ref);
+    expect(await store.getText(ref)).toBe("legit content");
+  });
+
   test("rejects malformed refs (crash-fast on programmer error)", async () => {
     using tmp = new DisposableTempDir("blobstore-test");
     const store = new BlobStore(tmp.path);

--- a/src/node/utils/journal/blobStore.test.ts
+++ b/src/node/utils/journal/blobStore.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { BlobStore } from "./blobStore";
+
+describe("BlobStore", () => {
+  test("roundtrips text content by hash", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    const { ref, size } = await store.put("hello blob world");
+    expect(ref).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(size).toBe("hello blob world".length);
+    expect(await store.getText(ref)).toBe("hello blob world");
+    expect(await store.has(ref)).toBe(true);
+  });
+
+  test("stores identical content once (same ref, one file)", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    const first = await store.put("same content");
+    const second = await store.put("same content");
+    expect(second.ref).toBe(first.ref);
+
+    const fanoutDir = path.join(tmp.path, first.ref.slice("sha256:".length, "sha256:".length + 2));
+    const files = await fs.readdir(fanoutDir);
+    expect(files).toHaveLength(1);
+  });
+
+  test("returns null for missing blobs and corrupted blobs (hash mismatch)", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    const missingRef = `sha256:${"0".repeat(64)}` as const;
+    expect(await store.get(missingRef)).toBeNull();
+
+    const { ref } = await store.put("legit content");
+    // Corrupt the blob on disk; get() must detect the mismatch and self-heal to null.
+    const hash = ref.slice("sha256:".length);
+    const blobPath = path.join(tmp.path, hash.slice(0, 2), hash);
+    await fs.writeFile(blobPath, "tampered");
+    expect(await store.get(ref)).toBeNull();
+  });
+
+  test("rejects malformed refs (crash-fast on programmer error)", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    await expect(store.get("md5:abc" as never)).rejects.toThrow(/Invalid blob ref/);
+  });
+
+  test("roundtrips binary content", async () => {
+    using tmp = new DisposableTempDir("blobstore-test");
+    const store = new BlobStore(tmp.path);
+    const bytes = new Uint8Array([0, 255, 1, 254, 2, 253]);
+    const { ref } = await store.put(bytes);
+    const back = await store.get(ref);
+    expect(back).not.toBeNull();
+    expect(new Uint8Array(back!)).toEqual(bytes);
+  });
+});

--- a/src/node/utils/journal/blobStore.ts
+++ b/src/node/utils/journal/blobStore.ts
@@ -34,15 +34,21 @@ export class BlobStore {
     const blobPath = this.pathFor(ref);
 
     try {
-      await fs.access(blobPath);
-      return { ref, size: buffer.byteLength }; // store-once: already present
+      // Store-once, but verify: an existing path whose bytes no longer match
+      // the addressed content (torn write, disk corruption) must be replaced,
+      // otherwise get() rejects it forever and no future put() could repair it.
+      const existing = await fs.readFile(blobPath);
+      if (existing.equals(buffer)) {
+        return { ref, size: buffer.byteLength };
+      }
+      log.warn(`BlobStore: existing blob ${ref} is corrupted; rewriting`);
     } catch {
-      // Not present yet - write below.
+      // Not present (or unreadable) yet - write below.
     }
 
     await fs.mkdir(path.dirname(blobPath), { recursive: true });
     // Atomic install: write to a unique temp file, then rename. Rename over an
-    // existing blob is fine because content-addressed files are byte-identical.
+    // existing (possibly corrupt) blob both installs and self-heals.
     const tempPath = `${blobPath}.tmp-${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
     await fs.writeFile(tempPath, buffer);
     await fs.rename(tempPath, blobPath);

--- a/src/node/utils/journal/blobStore.ts
+++ b/src/node/utils/journal/blobStore.ts
@@ -1,0 +1,100 @@
+/**
+ * Content-addressed blob store (journal kit companion).
+ *
+ * Blobs are stored once by sha256 under `<dir>/<hash[0:2]>/<hash>` and
+ * referenced from journal rows as `sha256:<hex>` (BlobRef). Consumers:
+ * turn-envelope system-prompt text (Track 1), offloaded result values and
+ * sandbox vars snapshots (Track 2 / sandbox host).
+ *
+ * Writes are atomic (temp file + rename); content addressing makes concurrent
+ * writers of the same content converge on identical bytes. Reads verify the
+ * hash (cheap second-algorithm validation) and self-heal by returning null on
+ * corruption instead of propagating bad bytes.
+ */
+
+import assert from "node:assert";
+import crypto from "node:crypto";
+import * as fs from "fs/promises";
+import * as path from "path";
+import type { BlobRef } from "@/common/types/durableEvent";
+import { BlobRefSchema } from "@/common/types/durableEvent";
+import { log } from "@/node/services/log";
+
+export class BlobStore {
+  constructor(private readonly dir: string) {
+    assert(dir.length > 0, "BlobStore requires a directory");
+  }
+
+  /** Store content once by hash. Returns the BlobRef and size in bytes. */
+  async put(content: string | Uint8Array): Promise<{ ref: BlobRef; size: number }> {
+    const buffer =
+      typeof content === "string" ? Buffer.from(content, "utf-8") : Buffer.from(content);
+    const hash = crypto.createHash("sha256").update(buffer).digest("hex");
+    const ref: BlobRef = `sha256:${hash}`;
+    const blobPath = this.pathFor(ref);
+
+    try {
+      await fs.access(blobPath);
+      return { ref, size: buffer.byteLength }; // store-once: already present
+    } catch {
+      // Not present yet - write below.
+    }
+
+    await fs.mkdir(path.dirname(blobPath), { recursive: true });
+    // Atomic install: write to a unique temp file, then rename. Rename over an
+    // existing blob is fine because content-addressed files are byte-identical.
+    const tempPath = `${blobPath}.tmp-${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
+    await fs.writeFile(tempPath, buffer);
+    await fs.rename(tempPath, blobPath);
+    return { ref, size: buffer.byteLength };
+  }
+
+  /**
+   * Read a blob. Returns null when missing or corrupted (hash mismatch) —
+   * load paths self-heal rather than crash on damaged session data.
+   */
+  async get(ref: BlobRef): Promise<Buffer | null> {
+    this.assertValidRef(ref);
+    let buffer: Buffer;
+    try {
+      buffer = await fs.readFile(this.pathFor(ref));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      throw error;
+    }
+    const hash = crypto.createHash("sha256").update(buffer).digest("hex");
+    if (`sha256:${hash}` !== ref) {
+      log.warn(`BlobStore: hash mismatch for ${ref} (corrupted blob); treating as missing`);
+      return null;
+    }
+    return buffer;
+  }
+
+  /** Read a blob as UTF-8 text; null when missing or corrupted. */
+  async getText(ref: BlobRef): Promise<string | null> {
+    const buffer = await this.get(ref);
+    return buffer === null ? null : buffer.toString("utf-8");
+  }
+
+  async has(ref: BlobRef): Promise<boolean> {
+    this.assertValidRef(ref);
+    try {
+      await fs.access(this.pathFor(ref));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private pathFor(ref: BlobRef): string {
+    const hash = ref.slice("sha256:".length);
+    // Two-level fan-out keeps directories small as blobs accumulate.
+    return path.join(this.dir, hash.slice(0, 2), hash);
+  }
+
+  private assertValidRef(ref: string): void {
+    assert(BlobRefSchema.safeParse(ref).success, `Invalid blob ref: ${ref}`);
+  }
+}

--- a/src/node/utils/journal/durableEventJournal.test.ts
+++ b/src/node/utils/journal/durableEventJournal.test.ts
@@ -77,8 +77,8 @@ describe("DurableEventJournal", () => {
     using tmp = new DisposableTempDir("durable-journal-test");
     const journal = new DurableEventJournal(tmp.path);
     // hook-context requires exactly one of text/blobHash.
-    await expect(
-      journal.append({
+    try {
+      await journal.append({
         workspaceId: "ws-1",
         kind: "hook-context",
         data: {
@@ -87,7 +87,10 @@ describe("DurableEventJournal", () => {
           text: "both",
           blobHash: `sha256:${"0".repeat(64)}`,
         },
-      })
-    ).rejects.toThrow(/failed schema validation/);
+      });
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("failed schema validation");
+    }
   });
 });

--- a/src/node/utils/journal/durableEventJournal.test.ts
+++ b/src/node/utils/journal/durableEventJournal.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { DurableEventJournal } from "./durableEventJournal";
+
+describe("DurableEventJournal", () => {
+  test("appends drafts for every schema kind and reads them back in order", async () => {
+    using tmp = new DisposableTempDir("durable-journal-test");
+    const journal = new DurableEventJournal(tmp.path);
+
+    // Content-address a system prompt, then reference it from a turn envelope.
+    const { ref: promptRef } = await journal.blobs.put("You are a helpful agent.");
+    const envelope = await journal.append({
+      workspaceId: "ws-1",
+      kind: "turn-envelope",
+      data: {
+        systemPromptHash: promptRef,
+        toolsetManifest: [
+          { name: "bash", schemaHash: "abc" },
+          { name: "file_read", schemaHash: "def" },
+        ],
+        modelString: "anthropic:claude-test",
+        providerOptionsHash: "opts-hash",
+        thinkingLevel: "medium",
+      },
+    });
+    expect(envelope.seq).toBe(0);
+    expect(envelope.v).toBe(1);
+
+    const { ref: valueRef, size } = await journal.blobs.put("x".repeat(1024));
+    await journal.append({
+      workspaceId: "ws-1",
+      kind: "result-handle",
+      data: { handle: "vars.searchResults", preview: "xxxx…", blobHash: valueRef, size },
+    });
+
+    await journal.append({
+      workspaceId: "ws-1",
+      kind: "refinement",
+      id: "refinement-1",
+      data: { kind: "skill-edit", action: { file: "SKILL.md" }, inverse: { revert: true } },
+    });
+
+    await journal.append({
+      workspaceId: "ws-1",
+      kind: "hook-context",
+      data: { hookId: "plugin:demo", placement: "system-prompt", text: "extra context" },
+    });
+
+    await journal.append({
+      workspaceId: "ws-1",
+      kind: "sandbox-vars-snapshot",
+      data: { scopeKey: "ws-1", blobHash: valueRef, size },
+    });
+
+    const events = await journal.read();
+    expect(events.map((e) => e.kind)).toEqual([
+      "turn-envelope",
+      "result-handle",
+      "refinement",
+      "hook-context",
+      "sandbox-vars-snapshot",
+    ]);
+    expect(events.map((e) => e.seq)).toEqual([0, 1, 2, 3, 4]);
+    // Caller-supplied stable id is preserved.
+    expect(events[2].id).toBe("refinement-1");
+    // Blob referenced from the envelope resolves back to the original text.
+    const first = events[0];
+    expect(first.kind).toBe("turn-envelope");
+    if (first.kind === "turn-envelope") {
+      expect(await journal.blobs.getText(first.data.systemPromptHash)).toBe(
+        "You are a helpful agent."
+      );
+    }
+  });
+
+  test("rejects drafts violating kind-specific invariants", async () => {
+    using tmp = new DisposableTempDir("durable-journal-test");
+    const journal = new DurableEventJournal(tmp.path);
+    // hook-context requires exactly one of text/blobHash.
+    await expect(
+      journal.append({
+        workspaceId: "ws-1",
+        kind: "hook-context",
+        data: {
+          hookId: "plugin:demo",
+          placement: "system-prompt",
+          text: "both",
+          blobHash: `sha256:${"0".repeat(64)}`,
+        },
+      })
+    ).rejects.toThrow(/failed schema validation/);
+  });
+});

--- a/src/node/utils/journal/durableEventJournal.ts
+++ b/src/node/utils/journal/durableEventJournal.ts
@@ -1,0 +1,61 @@
+/**
+ * DurableEventJournal: the concrete per-session journal for the shared
+ * durable-event schema (src/common/types/durableEvent.ts), pairing the generic
+ * Journal with a content-addressed BlobStore.
+ *
+ * Layout inside a session dir:
+ * - `durable-events.jsonl` — one DurableEvent per line
+ * - `blobs/<hash[0:2]>/<hash>` — content-addressed payloads
+ *
+ * This is the durable leg of the event spine's three-way split. New consumers
+ * (turn envelopes, refinement journal, result handles) append here; the
+ * HistoryService/chat.jsonl family intentionally stays as-is.
+ */
+
+import crypto from "node:crypto";
+import * as path from "path";
+import {
+  DurableEventSchema,
+  DURABLE_EVENT_VERSION,
+  type DurableEvent,
+  type DurableEventDraft,
+} from "@/common/types/durableEvent";
+import { Journal } from "./journal";
+import { BlobStore } from "./blobStore";
+
+export const DURABLE_EVENTS_FILE_NAME = "durable-events.jsonl";
+export const BLOBS_DIR_NAME = "blobs";
+
+export class DurableEventJournal {
+  private readonly journal: Journal<DurableEvent>;
+  /** Blob store for content-addressed payloads referenced from rows. */
+  public readonly blobs: BlobStore;
+
+  constructor(sessionDir: string) {
+    this.journal = new Journal<DurableEvent>({
+      filePath: path.join(sessionDir, DURABLE_EVENTS_FILE_NAME),
+      schema: DurableEventSchema,
+      getSeq: (row) => row.seq,
+      getId: (row) => row.id,
+    });
+    this.blobs = new BlobStore(path.join(sessionDir, BLOBS_DIR_NAME));
+  }
+
+  /** Append a draft; the journal assigns v/seq/ts (and id unless provided). */
+  async append(draft: DurableEventDraft): Promise<DurableEvent> {
+    return this.journal.append((seq) => {
+      return {
+        ...draft,
+        v: DURABLE_EVENT_VERSION,
+        seq,
+        id: draft.id ?? crypto.randomUUID(),
+        ts: Date.now(),
+      } as DurableEvent;
+    });
+  }
+
+  /** Read all events (self-healed: malformed/duplicate rows dropped, seq order). */
+  async read(): Promise<DurableEvent[]> {
+    return this.journal.read();
+  }
+}

--- a/src/node/utils/journal/durableEventJournal.ts
+++ b/src/node/utils/journal/durableEventJournal.ts
@@ -44,13 +44,16 @@ export class DurableEventJournal {
   /** Append a draft; the journal assigns v/seq/ts (and id unless provided). */
   async append(draft: DurableEventDraft): Promise<DurableEvent> {
     return this.journal.append((seq) => {
-      return {
+      const row = {
         ...draft,
         v: DURABLE_EVENT_VERSION,
         seq,
         id: draft.id ?? crypto.randomUUID(),
         ts: Date.now(),
-      } as DurableEvent;
+      };
+      // The spread of a distributive draft union does not re-narrow to the
+      // discriminated union; the journal schema-validates the row on append.
+      return row as DurableEvent;
     });
   }
 

--- a/src/node/utils/journal/journal.test.ts
+++ b/src/node/utils/journal/journal.test.ts
@@ -87,9 +87,12 @@ describe("Journal", () => {
   test("append rejects rows that fail schema validation", async () => {
     using tmp = new DisposableTempDir("journal-test");
     const journal = makeJournal(tmp.path);
-    await expect(journal.append((seq) => ({ seq, id: "", value: "empty id" }))).rejects.toThrow(
-      /failed schema validation/
-    );
+    try {
+      await journal.append((seq) => ({ seq, id: "", value: "empty id" }));
+      expect.unreachable("Should have thrown");
+    } catch (e) {
+      expect(String(e)).toContain("failed schema validation");
+    }
     // The failed append must not poison subsequent appends.
     const ok = await journal.append((seq) => ({ seq, id: "a", value: "fine" }));
     expect(ok.seq).toBe(0);

--- a/src/node/utils/journal/journal.test.ts
+++ b/src/node/utils/journal/journal.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { z } from "zod";
+import { DisposableTempDir } from "@/node/services/tempDir";
+import { Journal } from "./journal";
+
+const RowSchema = z.object({
+  seq: z.number().int().nonnegative(),
+  id: z.string().min(1),
+  value: z.string(),
+});
+type Row = z.infer<typeof RowSchema>;
+
+function makeJournal(dir: string): Journal<Row> {
+  return new Journal<Row>({
+    filePath: path.join(dir, "test.jsonl"),
+    schema: RowSchema,
+    getSeq: (row) => row.seq,
+    getId: (row) => row.id,
+  });
+}
+
+describe("Journal", () => {
+  test("appends rows with monotonic sequence and reads them back", async () => {
+    using tmp = new DisposableTempDir("journal-test");
+    const journal = makeJournal(tmp.path);
+
+    const a = await journal.append((seq) => ({ seq, id: "a", value: "first" }));
+    const b = await journal.append((seq) => ({ seq, id: "b", value: "second" }));
+    expect(a.seq).toBe(0);
+    expect(b.seq).toBe(1);
+
+    const rows = await journal.read();
+    expect(rows.map((r) => r.value)).toEqual(["first", "second"]);
+  });
+
+  test("resumes the sequence counter from existing rows (fresh instance)", async () => {
+    using tmp = new DisposableTempDir("journal-test");
+    await makeJournal(tmp.path).append((seq) => ({ seq, id: "a", value: "x" }));
+    const reopened = makeJournal(tmp.path);
+    const next = await reopened.append((seq) => ({ seq, id: "b", value: "y" }));
+    expect(next.seq).toBe(1);
+  });
+
+  test("self-heals: corrupted lines never brick the journal", async () => {
+    using tmp = new DisposableTempDir("journal-test");
+    const filePath = path.join(tmp.path, "test.jsonl");
+    const journal = makeJournal(tmp.path);
+    await journal.append((seq) => ({ seq, id: "a", value: "good-1" }));
+    await journal.append((seq) => ({ seq, id: "b", value: "good-2" }));
+
+    // Inject: malformed JSON, schema-invalid row, duplicate id, torn tail.
+    await fs.appendFile(filePath, "{not json at all\n");
+    await fs.appendFile(filePath, `${JSON.stringify({ seq: "NaN", id: 5 })}\n`);
+    await fs.appendFile(filePath, `${JSON.stringify({ seq: 0, id: "a", value: "dupe" })}\n`);
+    await fs.appendFile(filePath, '{"seq":99,"id":"torn","va'); // no newline - torn write
+
+    const reopened = makeJournal(tmp.path);
+    const rows = await reopened.read();
+    expect(rows.map((r) => r.value)).toEqual(["good-1", "good-2"]); // first id wins, garbage dropped
+
+    // Appending after a torn tail heals the file (new row lands on a fresh line).
+    const next = await reopened.append((seq) => ({ seq, id: "c", value: "good-3" }));
+    expect(next.seq).toBe(2);
+    const healed = await reopened.read();
+    expect(healed.map((r) => r.value)).toEqual(["good-1", "good-2", "good-3"]);
+  });
+
+  test("read sorts by seq and returns [] for a missing file", async () => {
+    using tmp = new DisposableTempDir("journal-test");
+    const filePath = path.join(tmp.path, "test.jsonl");
+    expect(await makeJournal(tmp.path).read()).toEqual([]);
+
+    // Out-of-order rows on disk (e.g. merged files) come back seq-sorted.
+    await fs.mkdir(tmp.path, { recursive: true });
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify({ seq: 2, id: "c", value: "third" })}\n` +
+        `${JSON.stringify({ seq: 0, id: "a", value: "first" })}\n` +
+        `${JSON.stringify({ seq: 1, id: "b", value: "second" })}\n`
+    );
+    const rows = await makeJournal(tmp.path).read();
+    expect(rows.map((r) => r.value)).toEqual(["first", "second", "third"]);
+  });
+
+  test("append rejects rows that fail schema validation", async () => {
+    using tmp = new DisposableTempDir("journal-test");
+    const journal = makeJournal(tmp.path);
+    await expect(journal.append((seq) => ({ seq, id: "", value: "empty id" }))).rejects.toThrow(
+      /failed schema validation/
+    );
+    // The failed append must not poison subsequent appends.
+    const ok = await journal.append((seq) => ({ seq, id: "a", value: "fine" }));
+    expect(ok.seq).toBe(0);
+  });
+});

--- a/src/node/utils/journal/journal.ts
+++ b/src/node/utils/journal/journal.ts
@@ -1,0 +1,171 @@
+/**
+ * Journal kit: append-only JSONL journal with monotonic sequence assignment,
+ * stable-ID dedupe, and self-healing reads (substrate 2 of the shared agent
+ * foundation).
+ *
+ * Doctrine (matches HistoryService/TimelineService): one malformed or
+ * duplicated line must never brick the log. Appends are single-write JSONL
+ * lines; torn tails from crashes are healed by prepending a separator on the
+ * next append and by skipping unparseable lines on read.
+ *
+ * Single-writer expectation: one Journal instance owns a file at a time.
+ * Appends are serialized through an internal promise queue so sequence
+ * assignment is race-free within the instance.
+ */
+
+import assert from "node:assert";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { log } from "@/node/services/log";
+
+/** Minimal schema contract (zod-compatible) so the kit stays dependency-light. */
+export interface JournalRowSchema<T> {
+  safeParse(value: unknown): { success: true; data: T } | { success: false; error?: unknown };
+}
+
+export interface JournalOptions<T> {
+  filePath: string;
+  schema: JournalRowSchema<T>;
+  /** Extract the monotonic sequence from a row. */
+  getSeq: (row: T) => number;
+  /** Extract the stable unique id from a row (dedupe key on read). */
+  getId: (row: T) => string;
+}
+
+export class Journal<T> {
+  private readonly filePath: string;
+  private readonly schema: JournalRowSchema<T>;
+  private readonly getSeq: (row: T) => number;
+  private readonly getId: (row: T) => string;
+  /** Next sequence to assign; null until the file has been scanned once. */
+  private nextSeq: number | null = null;
+  /** Serializes appends so seq assignment and tail-healing are race-free. */
+  private writeQueue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: JournalOptions<T>) {
+    assert(options.filePath.length > 0, "Journal requires a file path");
+    this.filePath = options.filePath;
+    this.schema = options.schema;
+    this.getSeq = options.getSeq;
+    this.getId = options.getId;
+  }
+
+  /**
+   * Append one row built from the next monotonic sequence number. The build
+   * result is validated against the schema before hitting disk (crash-fast on
+   * programmer error rather than persisting garbage).
+   */
+  async append(build: (seq: number) => T): Promise<T> {
+    const task = this.writeQueue.then(async () => {
+      const seq = await this.ensureNextSeq();
+      const row = build(seq);
+      assert(
+        this.getSeq(row) === seq,
+        `Journal append: row seq ${this.getSeq(row)} must equal assigned seq ${seq}`
+      );
+      const parsed = this.schema.safeParse(row);
+      assert(
+        parsed.success,
+        `Journal append: row failed schema validation: ${JSON.stringify(row)}`
+      );
+
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true });
+      // Heal a torn tail (crash mid-append): start on a fresh line so this row
+      // stays parseable even if the previous write was truncated.
+      const separator = (await this.hasUnterminatedTail()) ? "\n" : "";
+      const line = JSON.stringify(row);
+      assert(!line.includes("\n"), "Journal rows must serialize to a single line");
+      await fs.appendFile(this.filePath, `${separator}${line}\n`, "utf-8");
+      this.nextSeq = seq + 1;
+      return row;
+    });
+    // Keep the queue alive even if this append fails.
+    this.writeQueue = task.catch(() => undefined);
+    return task;
+  }
+
+  /**
+   * Read all rows, self-healing as we go:
+   * - unparseable / schema-invalid lines are skipped (warn-logged),
+   * - duplicate ids are dropped (first occurrence wins),
+   * - rows are stable-sorted by seq (ties keep file order).
+   */
+  async read(): Promise<T[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw error;
+    }
+
+    const rows: T[] = [];
+    const seenIds = new Set<string>();
+    const lines = raw.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+      let value: unknown;
+      try {
+        value = JSON.parse(line);
+      } catch {
+        log.warn(`Journal: skipping malformed JSON at line ${i + 1} in ${this.filePath}`);
+        continue;
+      }
+      const parsed = this.schema.safeParse(value);
+      if (!parsed.success) {
+        log.warn(`Journal: skipping schema-invalid row at line ${i + 1} in ${this.filePath}`);
+        continue;
+      }
+      const id = this.getId(parsed.data);
+      if (seenIds.has(id)) {
+        log.warn(`Journal: dropping duplicate row id '${id}' at line ${i + 1} in ${this.filePath}`);
+        continue;
+      }
+      seenIds.add(id);
+      rows.push(parsed.data);
+    }
+
+    // Stable sort by seq; JS Array.prototype.sort is stable, so file order is
+    // preserved for equal sequence numbers.
+    rows.sort((a, b) => this.getSeq(a) - this.getSeq(b));
+    return rows;
+  }
+
+  /** Scan once to initialize the monotonic counter (max valid seq + 1). */
+  private async ensureNextSeq(): Promise<number> {
+    if (this.nextSeq !== null) {
+      return this.nextSeq;
+    }
+    const rows = await this.read();
+    const maxSeq = rows.reduce((max, row) => Math.max(max, this.getSeq(row)), -1);
+    this.nextSeq = maxSeq + 1;
+    return this.nextSeq;
+  }
+
+  /** True when the file exists, is non-empty, and does not end with "\n". */
+  private async hasUnterminatedTail(): Promise<boolean> {
+    let handle: fs.FileHandle;
+    try {
+      handle = await fs.open(this.filePath, "r");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+    try {
+      const { size } = await handle.stat();
+      if (size === 0) {
+        return false;
+      }
+      const buffer = Buffer.alloc(1);
+      await handle.read(buffer, 0, 1, size - 1);
+      return buffer.toString("utf-8") !== "\n";
+    } finally {
+      await handle.close();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the **shared agent-foundation layer**: four substrates that both upcoming experiment tracks (Track 1: dsh-style plugin architecture; Track 2: prime-agent RLM / persistent kernel) build on — a typed event spine, a journal kit with a content-addressed blob store, a Sandbox Host Service with persistent mounts and an async capability bridge, and capability grants enforced at both the sandbox bridge and tool assembly.

## Background

Both experiment tracks need the same underlying mechanics: a hookable event pipeline around tool execution, durable append-only event logging that can replay byte-for-byte, a QuickJS sandbox whose state can outlive a single `code_execution` call (and a process restart), and a policy vocabulary that limits what a sandbox may reach. Implementing these once as a shared foundation keeps the two tracks decoupled from each other while giving them a common, tested substrate.

## Implementation

**Substrate 1 — Typed event spine** (`src/node/services/events/eventSpine.ts`)
- dsh-inspired three-way split: read-only **observer events** (workspace/session/stream/task lifecycle), mutating **waterfall hooks** (`tool.execute`, `request.assemble`, `compaction.prepare`), and **durable events** (persisted via the journal kit, not the spine itself).
- The `tool.execute` waterfall is an around-style middleware pipeline (`(ctx, next)`) with `useBefore`/`useAfter` sugar. Legacy `.mux/tool_hook` shell hooks inherently *wrap* execution, so they port cleanly onto the same primitive as the new `tool_pre`/`tool_post` hooks: `withHooks.ts` is now a built-in spine middleware. All 47 existing hook tests pass unmodified.
- Observer events are emitted from `WorkspaceService`, `TaskService`, `StreamManager`, and `AgentSession`; throwing observers are logged and swallowed so they can never break the emitting hot path.

**Substrate 2 — Journal kit + blob store** (`src/node/utils/journal/`)
- `Journal<T>`: append-only JSONL with monotonic `seq`, stable-ID dedupe, torn-tail newline repair, and malformed-line filtering (self-healing loads, per the crash-resilience doctrine).
- `BlobStore`: content-addressed sha256 store (`blobs/<hh>/<hash>`), atomic temp-file+rename writes, hash-verified reads that self-heal corrupt blobs.
- `DurableEventJournal` binds both to `durable-events.jsonl`; the record schema (`src/common/types/durableEvent.ts`) is a discriminated union over `kind` (`turn-envelope`, `refinement`, `result-handle`, `hook-context`, `sandbox-vars-snapshot`) with large payloads referenced by `BlobRef`. `chat.jsonl`/HistoryService is untouched.

**Substrate 3 — Sandbox Host Service** (`src/node/services/sandbox/sandboxHostService.ts`)
- `SandboxMount` with `ephemeral` (per-call) and `persistent` (per-workspace-session) lifetimes; persistent mounts share a `vars` namespace across evals/acquires, snapshot it to the durable journal on dispose, and restore it after restart.
- Host→guest event queue drained in-guest via `drainHostEvents()`.
- QuickJS runtime gains `registerPromiseFunction` (asyncified) and `registerSyncFunction` (plain sync). The split matters: quickjs-emscripten Asyncify can only suspend inside the initial `evalCodeAsync` stack, so bridges callable from post-`await` guest continuations must be sync-registered.
- Persistent mounts for `code_execution` are opt-in via `MUX_SANDBOX_PERSISTENT_MOUNTS=1` (full persistent-kernel UX is owned by Track 2).

**Substrate 4 — Capability grants** (`src/common/types/capabilityGrants.ts`, `src/common/utils/tools/capabilityGrants.ts`)
- `CapabilityGrants` (`bridgeTools` allow-list/`all`, `vars`, `hostEvents`) with `FULL_GRANTS` (session scope) and `LEAST_PRIVILEGE_GRANTS` (project scope).
- Enforced at two points with one vocabulary: the sandbox bridge (`ToolBridge` — denied tools excluded from both bridgeable and non-bridgeable sets, stubbed with a clear `Capability denied` guest error, re-checked at call time) and tool assembly (`applyCapabilityGrants` as a ceiling filter ahead of tool policy).

## Validation

- `make static-check` green (typecheck, lint, format, docs links).
- New suites: `eventSpine.test.ts`, `journal.test.ts`, `blobStore.test.ts`, `durableEventJournal.test.ts`, `sandboxHostService.test.ts` (registered in `isolated_unit_tests` — QuickJS-heavy), `capabilityGrants.test.ts`; extended `toolBridge.test.ts`, `quickjsRuntime.test.ts`. Existing touched suites (`withHooks`, `code_execution`, `WorkflowRunner`, `streamManager`, `agentSession`) pass.
- Dogfood gates run against a real workspace: legacy + new shell hooks executing through the spine; persistent `vars` shared across separate `code_execution` calls, snapshotted, and restored across a simulated restart; denied bridge capabilities produce catchable in-guest errors without crashing the sandbox.

## Risks

- **Tool execution path** (`withHooks` → spine middleware): highest-traffic surface touched. Mitigated by keeping all 47 existing hook tests unmodified and green, plus an empty-pipeline fast path (`hasMiddleware`) so workspaces without hooks skip context construction.
- **ToolBridge constructor signature** gained an optional `grants` param defaulting to `FULL_GRANTS` — existing callers are behaviorally unchanged.
- **New observer emissions** in stream/workspace/task hot paths are wrapped so listener errors cannot propagate.
- Journal/blob/sandbox services are new code, not yet wired into critical flows beyond opt-in paths; regression blast radius there is low.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$77.49`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=77.49 -->
