### PR TITLE
🤖 fix: self-heal corrupt analytics rows that wallpaper the dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@duckdb/node-api": "^1.4.4-r.1",
+        "@duckdb/node-api": "^1.5.5-r.4",
         "@homebridge/ciao": "^1.3.4",
         "@jitl/quickjs-wasmfile-release-asyncify": "^0.31.0",
         "@lydell/node-pty": "1.1.0",
@@ -561,19 +561,25 @@
 
     "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
-    "@duckdb/node-api": ["@duckdb/node-api@1.4.4-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.4.4-r.1" } }, "sha512-oqaH9DXTJNwyLkd2FgJwmSnWVqjB5irbESeTeNVMBnM03iRaNY545BhfBDumu1TnOV2koIdG1mNsmjgq/ZTIkA=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.5-r.4", "", { "dependencies": { "@duckdb/node-bindings": "1.5.5-r.4" } }, "sha512-8v0CZNo7aM6GQCNUHERGTrZWIfss8xKzZPF3ACNhPdMMrt7UjkNI5nRQ9FTFO7Yx8ghxYxVpdotmBBMQ5vXUOA=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.4.4-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.4.4-r.1", "@duckdb/node-bindings-darwin-x64": "1.4.4-r.1", "@duckdb/node-bindings-linux-arm64": "1.4.4-r.1", "@duckdb/node-bindings-linux-x64": "1.4.4-r.1", "@duckdb/node-bindings-win32-x64": "1.4.4-r.1" } }, "sha512-NFm0AMrK3kiVLQhgnGUEjX5c8Elm93dYePZ9BUCvvd0AVVTKEBeRhBp9afziuzP3Sl5+7XQ1TyaBLsZJKKBDBQ=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.5-r.4", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.5-r.4", "@duckdb/node-bindings-darwin-x64": "1.5.5-r.4", "@duckdb/node-bindings-linux-arm64": "1.5.5-r.4", "@duckdb/node-bindings-linux-arm64-musl": "1.5.5-r.4", "@duckdb/node-bindings-linux-x64": "1.5.5-r.4", "@duckdb/node-bindings-linux-x64-musl": "1.5.5-r.4", "@duckdb/node-bindings-win32-arm64": "1.5.5-r.4", "@duckdb/node-bindings-win32-x64": "1.5.5-r.4" } }, "sha512-n+4hEfjp4vny3BuWn5p1Gh5CzHaPRxoI8TzTytxL1GMlIKKrXcg/o6sSAjrsROUXGAM4WQCiWPLKnPsjJJSggg=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.4.4-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/NtbkCgCAOJDxw41XvSGV/mxQAlsx+2xUvhIVUj6fxoOfTG4jTttRhuphwE3EXNoWzJOjZxCZ5LwhC/qb6ZwLg=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.5-r.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4OdO3pkoJzAZDnZ2iyehi67XL4+WqHPCGYWbyAsYyhGJS+WscGrAnFhMhHudMM2XF8pIEM2tuOKMmwWnTNN2wQ=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.4.4-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-lzFRDrZwc1EoV513vmKufasiAQ2WlhEb0O6guRBarbvOKKVhRb8tQ5H7LPVTrIewjTI3XDgHrnK+vfh9L+xQcA=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.5-r.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-WHg3E+TupdujG31LGujMMcmtPIdW6rqRHeihlKgJR8EMetHycoYkwYxRud0niitJvS+uV0du/6pdemzs3HG9GQ=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.4.4-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-wq92/EcTiOTRW1RSDOwjeLyMMXWwNVNwU21TQdfu3sgS86+Ih3raaK68leDgY5cWgf72We3J2W7HYz8GwxcMYw=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.5-r.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-VIeHMpYAKpGiWZ4QYsOhODAHDEcXcn089aKty0MFsMEKaEfRJWixKwnwXy/ba2/wwFmnPiSFhKNqygj2BrQbqw=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.4.4-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fjYNc+t4/T7mhzZ57oJoIQaWvbYVvxhidcNNansQFiWnd6/JMLCULd4qnt8XI3Tt2BrZsraH690KSBIS3QPt0w=="],
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.5-r.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Tswnf+/XWpOcFJNUUu1fkFIX/su4tMcnNz0ZV0Nru3/CkJKIMwBh+VL4SM9YV4zPK90GC4Lm8gzafjc1qDmfyQ=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.4.4-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+J+MUYGvYWfX0balWToDIy3CBYg7hHI0KQUQ39+SniinXlMF8+puRW6ebyQ+AXrcrKkwuj4wzJuEBD0AdhHGtw=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.5-r.4", "", { "os": "linux", "cpu": "x64" }, "sha512-EY+CL/4h8MQZd9MxTBq+98m3U9osmvHBwhE9b5fMWQGt2I6p1j8fvX0SXiwy9KBfQIbjVUOf5XvGdXncI54KSg=="],
+
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.5-r.4", "", { "os": "linux", "cpu": "x64" }, "sha512-h0ixrgGHtHh+C/Fu1eAL9hX4iCf8yuyJN6Y24Gh8axXXP8UuSh0rQRAQUQTYarQ8pm2qSG/67ZYjyYYydD+J/w=="],
+
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.5-r.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-uorAnySIMwWkRDuUhM1yTDxWIislnX8mndhFIw6r4VKhVW61HEOOMX5oAgkSQFII4RNWpC5PCcUAEhSATgNvVQ=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.5-r.4", "", { "os": "win32", "cpu": "x64" }, "sha512-X9XGcWQ10P3mvUIaMXXk2bi94Cow7b/ziTPMKxJ0U8U3wQPxsLzEUP7D7C/KrBWINl5am2k+5SkDVyA/THUgPg=="],
 
     "@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-Ci2q4ZCIymKhf4rinh6VKdzaGVBCRBsMUgjQOXTqotM="; # xum-offline-cache-hash
+            outputHash = "sha256-ri3Q1gY4ifnjT9FMg3wNqoIT5OJbfQRKAWw5Zt8DH9k="; # xum-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@duckdb/node-api": "^1.4.4-r.1",
+    "@duckdb/node-api": "^1.5.5-r.4",
     "@homebridge/ciao": "^1.3.4",
     "@jitl/quickjs-wasmfile-release-asyncify": "^0.31.0",
     "@lydell/node-pty": "1.1.0",

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -152,12 +152,23 @@ async function handleInit(data: InitData): Promise<void> {
   await sweepCorruptRows("init");
 }
 
-/** Delete corruption-class rows and log when anything was actually removed. */
+/**
+ * Delete corruption-class rows and log when anything was actually removed.
+ * Best-effort: a failed sweep must never reject init (which would cache a
+ * worker error and disable analytics until restart) or fail an
+ * otherwise-successful ingest, so errors are logged and swallowed.
+ */
 async function sweepCorruptRows(context: string): Promise<void> {
-  const deleted = await deleteCorruptAnalyticsRows(getConn());
-  if (deleted > 0) {
+  try {
+    const deleted = await deleteCorruptAnalyticsRows(getConn());
+    if (deleted > 0) {
+      process.stderr.write(
+        `[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})\n`
+      );
+    }
+  } catch (error) {
     process.stderr.write(
-      `[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})\n`
+      `[analytics-worker] Corrupt-row sweep failed (${context}): ${getErrorMessage(error)}\n`
     );
   }
 }

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -6,6 +6,7 @@ import { decideSyncPlan, type SyncAction } from "./backfillDecision";
 import { shouldCheckpointAfterSync } from "./checkpointDecision";
 import {
   clearWorkspaceAnalyticsState,
+  deleteCorruptAnalyticsRows,
   getCurrentPricingFingerprint,
   ingestWorkspace,
   readStoredPricingFingerprint,
@@ -147,6 +148,18 @@ async function handleInit(data: InitData): Promise<void> {
   for (const migrationSql of DELEGATION_ROLLUPS_COLUMN_MIGRATIONS_SQL) {
     await activeConn.run(migrationSql);
   }
+
+  await sweepCorruptRows("init");
+}
+
+/** Delete corruption-class rows and log when anything was actually removed. */
+async function sweepCorruptRows(context: string): Promise<void> {
+  const deleted = await deleteCorruptAnalyticsRows(getConn());
+  if (deleted > 0) {
+    process.stderr.write(
+      `[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})\n`
+    );
+  }
 }
 
 async function handleIngest(data: IngestData): Promise<void> {
@@ -154,6 +167,7 @@ async function handleIngest(data: IngestData): Promise<void> {
   assert(data.sessionDir.trim().length > 0, "ingest requires sessionDir");
 
   await ingestWorkspace(getConn(), data.workspaceId, data.sessionDir, data.meta ?? {});
+  await sweepCorruptRows("ingest");
 }
 
 async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesIngested: number }> {
@@ -169,6 +183,7 @@ async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesInges
   // A completed rebuild priced everything with the current tables; refresh the
   // fingerprint so the next sync check does not schedule a redundant rebuild.
   await storePricingFingerprint(getConn());
+  await sweepCorruptRows("rebuildAll");
   return result;
 }
 
@@ -390,6 +405,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     if (pricingFingerprintChanged) {
       await storePricingFingerprint(getConn());
     }
+    await sweepCorruptRows("syncCheck full_rebuild");
     await checkpointIfNeeded(plan.action, workspacesIngested, 0);
 
     const elapsedMs = Math.round(performance.now() - syncStartMs);
@@ -448,6 +464,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     }
   }
 
+  await sweepCorruptRows("syncCheck incremental");
   await checkpointIfNeeded(plan.action, workspacesIngested, workspacesPurged);
 
   const elapsedMs = Math.round(performance.now() - syncStartMs);

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -154,33 +154,18 @@ async function handleInit(data: InitData): Promise<void> {
 }
 
 /**
- * Workspaces whose most recent ingest failed before their watermark write.
- * Missing-watermark evidence must skip them in EVERY sweep (not just the one
- * after the failing pass) until a successful ingest writes their watermark;
- * otherwise routine activity elsewhere (e.g. handleIngest for another
- * workspace) re-deletes the failing workspace's real rows. Worker-lifetime
- * only: after a restart the init sweep intentionally deletes orphans, and the
- * first syncCheck re-ingests them from disk.
- */
-const failedIngestExemptions = new Set<string>();
-
-/** A rebuild re-evaluates every workspace on disk, so its failure set replaces the accumulated one. */
-function replaceFailedIngestExemptions(failedWorkspaceIds: ReadonlySet<string>): void {
-  failedIngestExemptions.clear();
-  for (const workspaceId of failedWorkspaceIds) {
-    failedIngestExemptions.add(workspaceId);
-  }
-}
-
-/**
  * Delete corruption-class rows and log when anything was actually removed.
  * Best-effort: a failed sweep must never reject init (which would cache a
- * worker error and disable analytics until restart) or fail an
- * otherwise-successful ingest, so errors are logged and swallowed.
+ * worker error and disable analytics until restart), so errors are logged
+ * and swallowed. Runs only at init and after rebuilds: missing-watermark
+ * evidence is unsafe after ordinary ingests (see deleteCorruptAnalyticsRows).
  */
-async function sweepCorruptRows(context: string): Promise<void> {
+async function sweepCorruptRows(
+  context: string,
+  preserveWorkspaceIds?: ReadonlySet<string>
+): Promise<void> {
   try {
-    const deleted = await deleteCorruptAnalyticsRows(getConn(), failedIngestExemptions);
+    const deleted = await deleteCorruptAnalyticsRows(getConn(), preserveWorkspaceIds);
     if (deleted > 0) {
       log.info(`[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})`);
     }
@@ -193,14 +178,7 @@ async function handleIngest(data: IngestData): Promise<void> {
   assert(data.workspaceId.trim().length > 0, "ingest requires workspaceId");
   assert(data.sessionDir.trim().length > 0, "ingest requires sessionDir");
 
-  try {
-    await ingestWorkspace(getConn(), data.workspaceId, data.sessionDir, data.meta ?? {});
-    failedIngestExemptions.delete(data.workspaceId);
-  } catch (error) {
-    failedIngestExemptions.add(data.workspaceId);
-    throw error;
-  }
-  await sweepCorruptRows("ingest");
+  await ingestWorkspace(getConn(), data.workspaceId, data.sessionDir, data.meta ?? {});
 }
 
 async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesIngested: number }> {
@@ -213,18 +191,16 @@ async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesInges
   }
 
   const result = await rebuildAll(getConn(), data.sessionsDir, data.workspaceMetaById ?? {});
+  await sweepCorruptRows("rebuildAll", result.failedWorkspaceIds);
   // A completed rebuild priced everything with the current tables; refresh the
   // fingerprint so the next sync check does not schedule a redundant rebuild.
   await storePricingFingerprint(getConn());
-  replaceFailedIngestExemptions(result.failedWorkspaceIds);
-  await sweepCorruptRows("rebuildAll");
   return { workspacesIngested: result.workspacesIngested };
 }
 
 async function handleClearWorkspace(data: ClearWorkspaceData): Promise<void> {
   assert(data.workspaceId.trim().length > 0, "clearWorkspace requires workspaceId");
   await clearWorkspaceAnalyticsState(getConn(), data.workspaceId);
-  failedIngestExemptions.delete(data.workspaceId);
 }
 
 async function handleQuery(data: QueryData): Promise<unknown> {
@@ -437,11 +413,10 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
       data.sessionsDir,
       data.workspaceMetaById
     );
+    await sweepCorruptRows("syncCheck full_rebuild", failedWorkspaceIds);
     if (pricingFingerprintChanged) {
       await storePricingFingerprint(getConn());
     }
-    replaceFailedIngestExemptions(failedWorkspaceIds);
-    await sweepCorruptRows("syncCheck full_rebuild");
     await checkpointIfNeeded(plan.action, workspacesIngested, 0);
 
     const elapsedMs = Math.round(performance.now() - syncStartMs);
@@ -480,10 +455,8 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
 
     try {
       await ingestWorkspace(getConn(), workspaceId, discoveredWorkspace.sessionDir, workspaceMeta);
-      failedIngestExemptions.delete(workspaceId);
       workspacesIngested += 1;
     } catch (error) {
-      failedIngestExemptions.add(workspaceId);
       process.stderr.write(
         `[analytics-worker] Failed to ingest workspace during sync check (${workspaceId}): ${getErrorMessage(error)}\n`
       );
@@ -494,7 +467,6 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   for (const workspaceId of plan.workspaceIdsToPurge) {
     try {
       await clearWorkspaceAnalyticsState(getConn(), workspaceId);
-      failedIngestExemptions.delete(workspaceId);
       workspacesPurged += 1;
     } catch (error) {
       process.stderr.write(
@@ -503,7 +475,6 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     }
   }
 
-  await sweepCorruptRows("syncCheck incremental");
   await checkpointIfNeeded(plan.action, workspacesIngested, workspacesPurged);
 
   const elapsedMs = Math.round(performance.now() - syncStartMs);

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -154,17 +154,33 @@ async function handleInit(data: InitData): Promise<void> {
 }
 
 /**
+ * Workspaces whose most recent ingest failed before their watermark write.
+ * Missing-watermark evidence must skip them in EVERY sweep (not just the one
+ * after the failing pass) until a successful ingest writes their watermark;
+ * otherwise routine activity elsewhere (e.g. handleIngest for another
+ * workspace) re-deletes the failing workspace's real rows. Worker-lifetime
+ * only: after a restart the init sweep intentionally deletes orphans, and the
+ * first syncCheck re-ingests them from disk.
+ */
+const failedIngestExemptions = new Set<string>();
+
+/** A rebuild re-evaluates every workspace on disk, so its failure set replaces the accumulated one. */
+function replaceFailedIngestExemptions(failedWorkspaceIds: ReadonlySet<string>): void {
+  failedIngestExemptions.clear();
+  for (const workspaceId of failedWorkspaceIds) {
+    failedIngestExemptions.add(workspaceId);
+  }
+}
+
+/**
  * Delete corruption-class rows and log when anything was actually removed.
  * Best-effort: a failed sweep must never reject init (which would cache a
  * worker error and disable analytics until restart) or fail an
  * otherwise-successful ingest, so errors are logged and swallowed.
  */
-async function sweepCorruptRows(
-  context: string,
-  preserveWorkspaceIds?: ReadonlySet<string>
-): Promise<void> {
+async function sweepCorruptRows(context: string): Promise<void> {
   try {
-    const deleted = await deleteCorruptAnalyticsRows(getConn(), preserveWorkspaceIds);
+    const deleted = await deleteCorruptAnalyticsRows(getConn(), failedIngestExemptions);
     if (deleted > 0) {
       log.info(`[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})`);
     }
@@ -177,7 +193,13 @@ async function handleIngest(data: IngestData): Promise<void> {
   assert(data.workspaceId.trim().length > 0, "ingest requires workspaceId");
   assert(data.sessionDir.trim().length > 0, "ingest requires sessionDir");
 
-  await ingestWorkspace(getConn(), data.workspaceId, data.sessionDir, data.meta ?? {});
+  try {
+    await ingestWorkspace(getConn(), data.workspaceId, data.sessionDir, data.meta ?? {});
+    failedIngestExemptions.delete(data.workspaceId);
+  } catch (error) {
+    failedIngestExemptions.add(data.workspaceId);
+    throw error;
+  }
   await sweepCorruptRows("ingest");
 }
 
@@ -194,13 +216,15 @@ async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesInges
   // A completed rebuild priced everything with the current tables; refresh the
   // fingerprint so the next sync check does not schedule a redundant rebuild.
   await storePricingFingerprint(getConn());
-  await sweepCorruptRows("rebuildAll", result.failedWorkspaceIds);
+  replaceFailedIngestExemptions(result.failedWorkspaceIds);
+  await sweepCorruptRows("rebuildAll");
   return { workspacesIngested: result.workspacesIngested };
 }
 
 async function handleClearWorkspace(data: ClearWorkspaceData): Promise<void> {
   assert(data.workspaceId.trim().length > 0, "clearWorkspace requires workspaceId");
   await clearWorkspaceAnalyticsState(getConn(), data.workspaceId);
+  failedIngestExemptions.delete(data.workspaceId);
 }
 
 async function handleQuery(data: QueryData): Promise<unknown> {
@@ -416,7 +440,8 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     if (pricingFingerprintChanged) {
       await storePricingFingerprint(getConn());
     }
-    await sweepCorruptRows("syncCheck full_rebuild", failedWorkspaceIds);
+    replaceFailedIngestExemptions(failedWorkspaceIds);
+    await sweepCorruptRows("syncCheck full_rebuild");
     await checkpointIfNeeded(plan.action, workspacesIngested, 0);
 
     const elapsedMs = Math.round(performance.now() - syncStartMs);
@@ -432,7 +457,6 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   }
 
   let workspacesIngested = 0;
-  const failedIngestWorkspaceIds = new Set<string>();
   for (const workspaceId of plan.workspaceIdsToIngest) {
     const discoveredWorkspace = discoveredWorkspacesById.get(workspaceId);
     assert(
@@ -456,9 +480,10 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
 
     try {
       await ingestWorkspace(getConn(), workspaceId, discoveredWorkspace.sessionDir, workspaceMeta);
+      failedIngestExemptions.delete(workspaceId);
       workspacesIngested += 1;
     } catch (error) {
-      failedIngestWorkspaceIds.add(workspaceId);
+      failedIngestExemptions.add(workspaceId);
       process.stderr.write(
         `[analytics-worker] Failed to ingest workspace during sync check (${workspaceId}): ${getErrorMessage(error)}\n`
       );
@@ -469,6 +494,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   for (const workspaceId of plan.workspaceIdsToPurge) {
     try {
       await clearWorkspaceAnalyticsState(getConn(), workspaceId);
+      failedIngestExemptions.delete(workspaceId);
       workspacesPurged += 1;
     } catch (error) {
       process.stderr.write(
@@ -477,7 +503,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     }
   }
 
-  await sweepCorruptRows("syncCheck incremental", failedIngestWorkspaceIds);
+  await sweepCorruptRows("syncCheck incremental");
   await checkpointIfNeeded(plan.action, workspacesIngested, workspacesPurged);
 
   const elapsedMs = Math.round(performance.now() - syncStartMs);

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { parentPort } from "node:worker_threads";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { getErrorMessage } from "@/common/utils/errors";
+import { log } from "@/node/services/log";
 import { decideSyncPlan, type SyncAction } from "./backfillDecision";
 import { shouldCheckpointAfterSync } from "./checkpointDecision";
 import {
@@ -158,18 +159,17 @@ async function handleInit(data: InitData): Promise<void> {
  * worker error and disable analytics until restart) or fail an
  * otherwise-successful ingest, so errors are logged and swallowed.
  */
-async function sweepCorruptRows(context: string): Promise<void> {
+async function sweepCorruptRows(
+  context: string,
+  preserveWorkspaceIds?: ReadonlySet<string>
+): Promise<void> {
   try {
-    const deleted = await deleteCorruptAnalyticsRows(getConn());
+    const deleted = await deleteCorruptAnalyticsRows(getConn(), preserveWorkspaceIds);
     if (deleted > 0) {
-      process.stderr.write(
-        `[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})\n`
-      );
+      log.info(`[analytics-worker] Deleted ${deleted} corrupt analytics row(s) (${context})`);
     }
   } catch (error) {
-    process.stderr.write(
-      `[analytics-worker] Corrupt-row sweep failed (${context}): ${getErrorMessage(error)}\n`
-    );
+    log.warn(`[analytics-worker] Corrupt-row sweep failed (${context}): ${getErrorMessage(error)}`);
   }
 }
 
@@ -194,8 +194,8 @@ async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesInges
   // A completed rebuild priced everything with the current tables; refresh the
   // fingerprint so the next sync check does not schedule a redundant rebuild.
   await storePricingFingerprint(getConn());
-  await sweepCorruptRows("rebuildAll");
-  return result;
+  await sweepCorruptRows("rebuildAll", result.failedWorkspaceIds);
+  return { workspacesIngested: result.workspacesIngested };
 }
 
 async function handleClearWorkspace(data: ClearWorkspaceData): Promise<void> {
@@ -408,7 +408,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   }
 
   if (plan.action === "full_rebuild") {
-    const { workspacesIngested } = await rebuildAll(
+    const { workspacesIngested, failedWorkspaceIds } = await rebuildAll(
       getConn(),
       data.sessionsDir,
       data.workspaceMetaById
@@ -416,7 +416,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     if (pricingFingerprintChanged) {
       await storePricingFingerprint(getConn());
     }
-    await sweepCorruptRows("syncCheck full_rebuild");
+    await sweepCorruptRows("syncCheck full_rebuild", failedWorkspaceIds);
     await checkpointIfNeeded(plan.action, workspacesIngested, 0);
 
     const elapsedMs = Math.round(performance.now() - syncStartMs);
@@ -432,6 +432,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   }
 
   let workspacesIngested = 0;
+  const failedIngestWorkspaceIds = new Set<string>();
   for (const workspaceId of plan.workspaceIdsToIngest) {
     const discoveredWorkspace = discoveredWorkspacesById.get(workspaceId);
     assert(
@@ -457,6 +458,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
       await ingestWorkspace(getConn(), workspaceId, discoveredWorkspace.sessionDir, workspaceMeta);
       workspacesIngested += 1;
     } catch (error) {
+      failedIngestWorkspaceIds.add(workspaceId);
       process.stderr.write(
         `[analytics-worker] Failed to ingest workspace during sync check (${workspaceId}): ${getErrorMessage(error)}\n`
       );
@@ -475,7 +477,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     }
   }
 
-  await sweepCorruptRows("syncCheck incremental");
+  await sweepCorruptRows("syncCheck incremental", failedIngestWorkspaceIds);
   await checkpointIfNeeded(plan.action, workspacesIngested, workspacesPurged);
 
   const elapsedMs = Math.round(performance.now() - syncStartMs);

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -1645,9 +1645,17 @@ describe("deleteCorruptAnalyticsRows", () => {
       "anthropic:claude-haiku-4-5",
       1.0,
     ]);
+    // Migrated legacy IDs are `${projectBasename}-${workspaceBasename}` with
+    // no length limit (up to 2x NAME_MAX + 1 = 511 chars) and must survive.
+    const legacyId = `${"p".repeat(255)}-${"w".repeat(255)}`;
+    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+      legacyId,
+      "anthropic:claude-haiku-4-5",
+      2.0,
+    ]);
     // Phantom corruption row: varchar columns hold cross-row concatenations.
     await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
-      "x".repeat(500),
+      "x".repeat(2000),
       "anthropic:claude-haiku-4-5".repeat(100),
       0.05,
     ]);
@@ -1659,13 +1667,16 @@ describe("deleteCorruptAnalyticsRows", () => {
     await conn.run(
       `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
        VALUES (?, ?, ?)`,
-      ["p".repeat(500), "child-corrupt", "openai:gpt-5.6-sol"]
+      ["p".repeat(2000), "child-corrupt", "openai:gpt-5.6-sol"]
     );
 
     expect(await deleteCorruptAnalyticsRows(conn)).toBe(2);
 
-    const eventRows = await queryRows(conn, "SELECT workspace_id FROM events");
-    expect(eventRows).toEqual([{ workspace_id: "ws-healthy" }]);
+    const eventRows = await queryRows(
+      conn,
+      "SELECT workspace_id FROM events ORDER BY LENGTH(workspace_id)"
+    );
+    expect(eventRows).toEqual([{ workspace_id: "ws-healthy" }, { workspace_id: legacyId }]);
     const rollupRows = await queryRows(conn, "SELECT parent_workspace_id FROM delegation_rollups");
     expect(rollupRows).toEqual([{ parent_workspace_id: "parent-healthy" }]);
 

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -9,6 +9,7 @@ import {
   appendEvents,
   CHAT_FILE_NAME,
   clearWorkspaceAnalyticsState,
+  deleteCorruptAnalyticsRows,
   getCurrentPricingFingerprint,
   ingestWorkspace,
   parseWorkspaceFromDisk,
@@ -1632,5 +1633,43 @@ describe("pricing fingerprint", () => {
     // Idempotent upsert: storing again keeps a single row with the same value.
     await storePricingFingerprint(conn);
     expect(await readStoredPricingFingerprint(conn)).toBe(getCurrentPricingFingerprint());
+  });
+});
+
+describe("deleteCorruptAnalyticsRows", () => {
+  test("deletes rows with impossible string lengths while keeping healthy rows", async () => {
+    const conn = await createTestConn();
+
+    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+      "ws-healthy",
+      "anthropic:claude-haiku-4-5",
+      1.0,
+    ]);
+    // Phantom corruption row: varchar columns hold cross-row concatenations.
+    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+      "x".repeat(500),
+      "anthropic:claude-haiku-4-5".repeat(100),
+      0.05,
+    ]);
+    await conn.run(
+      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
+       VALUES (?, ?, ?)`,
+      ["parent-healthy", "child-healthy", "openai:gpt-5.6-sol"]
+    );
+    await conn.run(
+      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
+       VALUES (?, ?, ?)`,
+      ["p".repeat(500), "child-corrupt", "openai:gpt-5.6-sol"]
+    );
+
+    expect(await deleteCorruptAnalyticsRows(conn)).toBe(2);
+
+    const eventRows = await queryRows(conn, "SELECT workspace_id FROM events");
+    expect(eventRows).toEqual([{ workspace_id: "ws-healthy" }]);
+    const rollupRows = await queryRows(conn, "SELECT parent_workspace_id FROM delegation_rollups");
+    expect(rollupRows).toEqual([{ parent_workspace_id: "parent-healthy" }]);
+
+    // Idempotent: nothing left to delete.
+    expect(await deleteCorruptAnalyticsRows(conn)).toBe(0);
   });
 });

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -1653,6 +1653,14 @@ describe("deleteCorruptAnalyticsRows", () => {
       "anthropic:claude-haiku-4-5",
       2.0,
     ]);
+    // Custom-provider model IDs have no schema max length; an extremely long
+    // model on an otherwise-healthy row must never be deletion evidence.
+    const longModel = `custom:${"m".repeat(2000)}`;
+    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+      "ws-long-model",
+      longModel,
+      3.0,
+    ]);
     // Phantom corruption row: varchar columns hold cross-row concatenations.
     await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
       "x".repeat(2000),
@@ -1676,7 +1684,11 @@ describe("deleteCorruptAnalyticsRows", () => {
       conn,
       "SELECT workspace_id FROM events ORDER BY LENGTH(workspace_id)"
     );
-    expect(eventRows).toEqual([{ workspace_id: "ws-healthy" }, { workspace_id: legacyId }]);
+    expect(eventRows).toEqual([
+      { workspace_id: "ws-healthy" },
+      { workspace_id: "ws-long-model" },
+      { workspace_id: legacyId },
+    ]);
     const rollupRows = await queryRows(conn, "SELECT parent_workspace_id FROM delegation_rollups");
     expect(rollupRows).toEqual([{ parent_workspace_id: "parent-healthy" }]);
 

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -1637,48 +1637,61 @@ describe("pricing fingerprint", () => {
 });
 
 describe("deleteCorruptAnalyticsRows", () => {
-  test("deletes rows with impossible string lengths while keeping healthy rows", async () => {
+  async function seedWatermark(conn: DuckDBConnection, workspaceId: string): Promise<void> {
+    await conn.run(
+      "INSERT INTO ingest_watermarks (workspace_id, last_sequence, last_modified) VALUES (?, ?, ?)",
+      [workspaceId, 1, 1]
+    );
+  }
+
+  test("deletes corrupt rows while keeping healthy rows", async () => {
     const conn = await createTestConn();
 
-    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
-      "ws-healthy",
-      "anthropic:claude-haiku-4-5",
-      1.0,
-    ]);
     // Migrated legacy IDs are `${projectBasename}-${workspaceBasename}` with
     // no length limit (up to 2x NAME_MAX + 1 = 511 chars) and must survive.
     const legacyId = `${"p".repeat(255)}-${"w".repeat(255)}`;
-    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
-      legacyId,
-      "anthropic:claude-haiku-4-5",
-      2.0,
-    ]);
     // Custom-provider model IDs have no schema max length; an extremely long
     // model on an otherwise-healthy row must never be deletion evidence.
     const longModel = `custom:${"m".repeat(2000)}`;
-    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
-      "ws-long-model",
-      longModel,
-      3.0,
-    ]);
-    // Phantom corruption row: varchar columns hold cross-row concatenations.
-    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
-      "x".repeat(2000),
-      "anthropic:claude-haiku-4-5".repeat(100),
-      0.05,
-    ]);
-    await conn.run(
-      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
-       VALUES (?, ?, ?)`,
-      ["parent-healthy", "child-healthy", "openai:gpt-5.6-sol"]
-    );
-    await conn.run(
-      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
-       VALUES (?, ?, ?)`,
-      ["p".repeat(2000), "child-corrupt", "openai:gpt-5.6-sol"]
-    );
 
-    expect(await deleteCorruptAnalyticsRows(conn)).toBe(2);
+    for (const workspaceId of ["ws-healthy", legacyId, "ws-long-model", "parent-healthy"]) {
+      await seedWatermark(conn, workspaceId);
+    }
+
+    for (const [workspaceId, model, cost] of [
+      ["ws-healthy", "anthropic:claude-haiku-4-5", 1.0],
+      [legacyId, "anthropic:claude-haiku-4-5", 2.0],
+      ["ws-long-model", longModel, 3.0],
+      // Large-batch phantom: concatenated identifiers exceed the length caps.
+      ["x".repeat(2000), "anthropic:claude-haiku-4-5".repeat(100), 0.05],
+      // Small-batch phantom: two concatenated 10-char workspace IDs stay far
+      // under the length caps but can never match a real watermark.
+      ["aaaaabbbbbcccccddddd", "openai:gpt-5.6-solopenai:gpt-5.6-sol", 0.05],
+    ] as const) {
+      await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+        workspaceId,
+        model,
+        cost,
+      ]);
+    }
+
+    for (const [parent, child] of [
+      ["parent-healthy", "child-healthy"],
+      // A rollup may outlive its removed child workspace; only the parent
+      // must be a known workspace.
+      ["parent-healthy", "child-removed"],
+      ["p".repeat(2000), "child-corrupt"],
+      // Small-batch phantom parent: unknown to watermarks.
+      ["par-aaaaapar-bbbbb", "child-x"],
+    ] as const) {
+      await conn.run(
+        `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
+         VALUES (?, ?, ?)`,
+        [parent, child, "openai:gpt-5.6-sol"]
+      );
+    }
+
+    expect(await deleteCorruptAnalyticsRows(conn)).toBe(4);
 
     const eventRows = await queryRows(
       conn,
@@ -1689,8 +1702,14 @@ describe("deleteCorruptAnalyticsRows", () => {
       { workspace_id: "ws-long-model" },
       { workspace_id: legacyId },
     ]);
-    const rollupRows = await queryRows(conn, "SELECT parent_workspace_id FROM delegation_rollups");
-    expect(rollupRows).toEqual([{ parent_workspace_id: "parent-healthy" }]);
+    const rollupRows = await queryRows(
+      conn,
+      "SELECT child_workspace_id FROM delegation_rollups ORDER BY child_workspace_id"
+    );
+    expect(rollupRows).toEqual([
+      { child_workspace_id: "child-healthy" },
+      { child_workspace_id: "child-removed" },
+    ]);
 
     // Idempotent: nothing left to delete.
     expect(await deleteCorruptAnalyticsRows(conn)).toBe(0);

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -291,7 +291,7 @@ describe("rebuildAll", () => {
 
     const result = await rebuildAll(conn, createMissingSessionsDir());
 
-    expect(result).toEqual({ workspacesIngested: 0 });
+    expect(result).toEqual({ workspacesIngested: 0, failedWorkspaceIds: new Set() });
     expect(getSqlStatements(runMock)).toEqual([
       "BEGIN TRANSACTION",
       "DELETE FROM events",
@@ -341,7 +341,7 @@ describe("rebuildAll", () => {
 
     const result = await rebuildAll(conn, sessionsDir, {});
 
-    expect(result).toEqual({ workspacesIngested: 1 });
+    expect(result.workspacesIngested).toBe(1);
     expect(await queryEventCount(conn)).toBe(1);
   });
 });
@@ -1217,7 +1217,7 @@ describe("ingestArchivedSubagentTranscripts", () => {
 
     const result = await rebuildAll(conn, sessionsDir);
 
-    expect(result).toEqual({ workspacesIngested: 1 });
+    expect(result).toEqual({ workspacesIngested: 1, failedWorkspaceIds: new Set() });
     expect(await queryEventCount(conn)).toBe(2);
     expect(await queryEventCount(conn, parentWorkspaceId)).toBe(1);
     expect(await queryEventCount(conn, childWorkspaceId)).toBe(1);
@@ -1713,5 +1713,41 @@ describe("deleteCorruptAnalyticsRows", () => {
 
     // Idempotent: nothing left to delete.
     expect(await deleteCorruptAnalyticsRows(conn)).toBe(0);
+  });
+
+  test("exempts failed-ingest workspaces from watermark evidence but not length evidence", async () => {
+    const conn = await createTestConn();
+
+    // A poison record makes this workspace's ingest throw before its
+    // watermark write on every retry; its real partial rows must survive
+    // the post-sync sweep or the workspace's spend disappears permanently.
+    await conn.run("INSERT INTO events (workspace_id, model, total_cost_usd) VALUES (?, ?, ?)", [
+      "ws-failed-ingest",
+      "anthropic:claude-haiku-4-5",
+      1.0,
+    ]);
+    await conn.run(
+      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, model)
+       VALUES (?, ?, ?)`,
+      ["ws-failed-ingest", "child-a", "openai:gpt-5.6-sol"]
+    );
+    // Length evidence is structural corruption regardless of exemption.
+    await conn.run(
+      "INSERT INTO events (workspace_id, parent_workspace_id, model) VALUES (?, ?, ?)",
+      ["ws-failed-ingest", "x".repeat(2000), "anthropic:claude-haiku-4-5"]
+    );
+
+    expect(await deleteCorruptAnalyticsRows(conn, new Set(["ws-failed-ingest"]))).toBe(1);
+
+    const eventRows = await queryRows(conn, "SELECT workspace_id, model FROM events");
+    expect(eventRows).toEqual([
+      { workspace_id: "ws-failed-ingest", model: "anthropic:claude-haiku-4-5" },
+    ]);
+    expect(await queryRows(conn, "SELECT child_workspace_id FROM delegation_rollups")).toEqual([
+      { child_workspace_id: "child-a" },
+    ]);
+
+    // A later pass without the exemption treats the same rows as orphans.
+    expect(await deleteCorruptAnalyticsRows(conn)).toBe(2);
   });
 });

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -344,6 +344,28 @@ describe("rebuildAll", () => {
     expect(result.workspacesIngested).toBe(1);
     expect(await queryEventCount(conn)).toBe(1);
   });
+
+  test("reports metadata-stage failures so the sweep preserves already-appended rows", async () => {
+    const conn = await createTestConn();
+    const sessionsDir = await createTempSessionDir();
+
+    // Chat parses and appends fine, but the unreadable sidecar (a directory)
+    // throws in ingestHeadlessUsage before the watermark write.
+    const workspaceDir = path.join(sessionsDir, "ws-meta-fail");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await writeChatJsonl(workspaceDir, [makeUserLine(), makeAssistantLine()]);
+    await fs.mkdir(path.join(workspaceDir, "headless-usage.jsonl"));
+
+    const result = await rebuildAll(conn, sessionsDir, {});
+
+    expect(result.failedWorkspaceIds).toEqual(new Set(["ws-meta-fail"]));
+    expect(await queryEventCount(conn, "ws-meta-fail")).toBe(1);
+
+    // The post-rebuild sweep runs with exactly this failure set; the
+    // watermark-less rows must survive it.
+    expect(await deleteCorruptAnalyticsRows(conn, result.failedWorkspaceIds)).toBe(0);
+    expect(await queryEventCount(conn, "ws-meta-fail")).toBe(1);
+  });
 });
 
 describe("appendEvents", () => {

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -1772,4 +1772,19 @@ describe("deleteCorruptAnalyticsRows", () => {
     // A later pass without the exemption treats the same rows as orphans.
     expect(await deleteCorruptAnalyticsRows(conn)).toBe(2);
   });
+
+  test("keeps rollups whose legacy agent_type is arbitrarily long", async () => {
+    const conn = await createTestConn();
+    await seedWatermark(conn, "parent-legacy");
+
+    // Legacy metadata and rollup entries accept unbounded agent types, so
+    // agent_type length alone is never corruption evidence.
+    await conn.run(
+      `INSERT INTO delegation_rollups (parent_workspace_id, child_workspace_id, agent_type, model)
+       VALUES (?, ?, ?, ?)`,
+      ["parent-legacy", "child-a", "t".repeat(2000), "openai:gpt-5.6-sol"]
+    );
+
+    expect(await deleteCorruptAnalyticsRows(conn)).toBe(0);
+  });
 });

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -872,25 +872,35 @@ export async function clearWorkspaceAnalyticsState(
  * once in the wild: a 17KB "model" string spanning ~670 events, which then
  * wallpapered the Analytics dashboard as one giant legend entry). The donor
  * rows are written correctly, so deleting rows with impossible string lengths
- * loses no real data. Thresholds are generous: legitimate values are all far
- * shorter (workspace IDs are short hex; model IDs are < 100 chars).
+ * loses no real data.
+ *
+ * Thresholds sit above the longest legitimately constructible value for each
+ * column so no legal row can match:
+ * - Workspace IDs: new IDs are short hex, but migrated legacy IDs are
+ *   `${projectBasename}-${workspaceBasename}` (config.generateLegacyId) with
+ *   no explicit limit; each basename is bounded by the filesystem's NAME_MAX
+ *   (255 bytes), so 511 is the legal ceiling. Cap at 1024.
+ * - Agent IDs/types also derive from file basenames: same 1024 cap.
+ * - Model strings are `provider:modelId` config values (longest observed in a
+ *   large production DB: 41 chars); 512 is far beyond any real model ID.
+ * The observed phantom row exceeded every one of these by an order of
+ * magnitude (6,720-char workspace_id, 17,229-char model).
  */
 export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promise<number> {
   const eventsResult = await conn.run(`
     DELETE FROM events
-    WHERE LENGTH(workspace_id) > 64
-       OR LENGTH(parent_workspace_id) > 64
-       OR LENGTH(model) > 256
-       OR LENGTH(agent_id) > 64
-       OR LENGTH(thinking_level) > 64
+    WHERE LENGTH(workspace_id) > 1024
+       OR LENGTH(parent_workspace_id) > 1024
+       OR LENGTH(model) > 512
+       OR LENGTH(agent_id) > 1024
   `);
 
   const rollupsResult = await conn.run(`
     DELETE FROM delegation_rollups
-    WHERE LENGTH(parent_workspace_id) > 64
-       OR LENGTH(child_workspace_id) > 64
-       OR LENGTH(model) > 256
-       OR LENGTH(agent_type) > 64
+    WHERE LENGTH(parent_workspace_id) > 1024
+       OR LENGTH(child_workspace_id) > 1024
+       OR LENGTH(model) > 512
+       OR LENGTH(agent_type) > 1024
   `);
 
   return eventsResult.rowsChanged + rollupsResult.rowsChanged;

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -874,18 +874,25 @@ export async function clearWorkspaceAnalyticsState(
  * rows are written correctly, so deleting rows with impossible string lengths
  * loses no real data.
  *
- * Detection anchors ONLY on identifier columns with a provable legal maximum,
- * because the corruption concatenates every VARCHAR column at once and
- * workspace identifiers are present on every row:
- * - Workspace IDs: new IDs are short hex, but migrated legacy IDs are
- *   `${projectBasename}-${workspaceBasename}` (config.generateLegacyId) with
- *   no explicit limit; each basename is bounded by the filesystem's NAME_MAX
- *   (255 bytes), so 511 is the legal ceiling. Cap at 1024.
- * - Agent IDs/types also derive from file basenames: same 1024 cap.
- * Unbounded columns (model: custom-provider model IDs have no schema max, see
- * ProviderModelEntrySchema; paths; workspace names) must NOT be deletion
- * evidence on their own, or a legitimately long value would wipe real spend.
- * The observed phantom row's workspace_id was 6,720 chars.
+ * Two evidence classes, both structural (unbounded columns like model,
+ * paths, and workspace names are never deletion evidence on their own, since
+ * custom-provider model IDs etc. have no schema max length):
+ *
+ * 1. Identifier length beyond the legal construction maximum. New workspace
+ *    IDs are short hex; migrated legacy IDs are
+ *    `${projectBasename}-${workspaceBasename}` (config.generateLegacyId),
+ *    each basename bounded by the filesystem's NAME_MAX (255 bytes), so 511
+ *    is the ceiling. Agent IDs/types also derive from basenames. Cap at 1024.
+ *
+ * 2. Workspace identity unknown to ingest_watermarks. A concatenation of two
+ *    or more workspace IDs can never equal a real workspace ID, no matter how
+ *    small the corrupted batch, while every legitimate row's workspace gets a
+ *    watermark by the end of the ingest/rebuild pass that wrote it (sweeps
+ *    run after those passes complete). If a crash lands between the event
+ *    write and the watermark write, deleting the orphans is still safe: the
+ *    missing watermark makes the next syncCheck re-ingest that workspace from
+ *    disk in full. delegation_rollups joins on parent_workspace_id only;
+ *    child_workspace_id may legitimately reference a removed child workspace.
  */
 export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promise<number> {
   const eventsResult = await conn.run(`
@@ -893,6 +900,9 @@ export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promis
     WHERE LENGTH(workspace_id) > 1024
        OR LENGTH(parent_workspace_id) > 1024
        OR LENGTH(agent_id) > 1024
+       OR NOT EXISTS (
+         SELECT 1 FROM ingest_watermarks w WHERE w.workspace_id = events.workspace_id
+       )
   `);
 
   const rollupsResult = await conn.run(`
@@ -900,6 +910,10 @@ export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promis
     WHERE LENGTH(parent_workspace_id) > 1024
        OR LENGTH(child_workspace_id) > 1024
        OR LENGTH(agent_type) > 1024
+       OR NOT EXISTS (
+         SELECT 1 FROM ingest_watermarks w
+         WHERE w.workspace_id = delegation_rollups.parent_workspace_id
+       )
   `);
 
   return eventsResult.rowsChanged + rollupsResult.rowsChanged;

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -865,6 +865,37 @@ export async function clearWorkspaceAnalyticsState(
   }
 }
 
+/**
+ * Self-healing sweep for a rare native-layer corruption class: a phantom row
+ * can materialize whose every VARCHAR column is the concatenation of that
+ * column's non-null values across an entire batch of inserted rows (observed
+ * once in the wild: a 17KB "model" string spanning ~670 events, which then
+ * wallpapered the Analytics dashboard as one giant legend entry). The donor
+ * rows are written correctly, so deleting rows with impossible string lengths
+ * loses no real data. Thresholds are generous: legitimate values are all far
+ * shorter (workspace IDs are short hex; model IDs are < 100 chars).
+ */
+export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promise<number> {
+  const eventsResult = await conn.run(`
+    DELETE FROM events
+    WHERE LENGTH(workspace_id) > 64
+       OR LENGTH(parent_workspace_id) > 64
+       OR LENGTH(model) > 256
+       OR LENGTH(agent_id) > 64
+       OR LENGTH(thinking_level) > 64
+  `);
+
+  const rollupsResult = await conn.run(`
+    DELETE FROM delegation_rollups
+    WHERE LENGTH(parent_workspace_id) > 64
+       OR LENGTH(child_workspace_id) > 64
+       OR LENGTH(model) > 256
+       OR LENGTH(agent_type) > 64
+  `);
+
+  return eventsResult.rowsChanged + rollupsResult.rowsChanged;
+}
+
 function serializeHeadSignatureValue(value: string | number | null): string {
   if (value === null) {
     return "null";

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -874,24 +874,24 @@ export async function clearWorkspaceAnalyticsState(
  * rows are written correctly, so deleting rows with impossible string lengths
  * loses no real data.
  *
- * Thresholds sit above the longest legitimately constructible value for each
- * column so no legal row can match:
+ * Detection anchors ONLY on identifier columns with a provable legal maximum,
+ * because the corruption concatenates every VARCHAR column at once and
+ * workspace identifiers are present on every row:
  * - Workspace IDs: new IDs are short hex, but migrated legacy IDs are
  *   `${projectBasename}-${workspaceBasename}` (config.generateLegacyId) with
  *   no explicit limit; each basename is bounded by the filesystem's NAME_MAX
  *   (255 bytes), so 511 is the legal ceiling. Cap at 1024.
  * - Agent IDs/types also derive from file basenames: same 1024 cap.
- * - Model strings are `provider:modelId` config values (longest observed in a
- *   large production DB: 41 chars); 512 is far beyond any real model ID.
- * The observed phantom row exceeded every one of these by an order of
- * magnitude (6,720-char workspace_id, 17,229-char model).
+ * Unbounded columns (model: custom-provider model IDs have no schema max, see
+ * ProviderModelEntrySchema; paths; workspace names) must NOT be deletion
+ * evidence on their own, or a legitimately long value would wipe real spend.
+ * The observed phantom row's workspace_id was 6,720 chars.
  */
 export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promise<number> {
   const eventsResult = await conn.run(`
     DELETE FROM events
     WHERE LENGTH(workspace_id) > 1024
        OR LENGTH(parent_workspace_id) > 1024
-       OR LENGTH(model) > 512
        OR LENGTH(agent_id) > 1024
   `);
 
@@ -899,7 +899,6 @@ export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promis
     DELETE FROM delegation_rollups
     WHERE LENGTH(parent_workspace_id) > 1024
        OR LENGTH(child_workspace_id) > 1024
-       OR LENGTH(model) > 512
        OR LENGTH(agent_type) > 1024
   `);
 

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -1987,6 +1987,10 @@ export async function rebuildAll(
           );
         }
       } catch (error) {
+        // The workspace's chat rows are already appended but its watermark may
+        // not be written; report it failed so the post-rebuild sweep's
+        // missing-watermark evidence does not delete those rows.
+        failedWorkspaceIds.add(workspace.workspaceId);
         log.warn("[analytics-etl] Failed to write metadata during rebuild", {
           workspaceId: workspace.workspaceId,
           error: getErrorMessage(error),

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -884,20 +884,20 @@ const CORRUPT_IDENTIFIER_MAX_LENGTH = 1024;
  *    IDs are short hex; migrated legacy IDs are
  *    `${projectBasename}-${workspaceBasename}` (config.generateLegacyId),
  *    each basename bounded by the filesystem's NAME_MAX (255 bytes), so 511
- *    is the construction ceiling. Agent IDs/types also derive from basenames.
+ *    is the construction ceiling. Agent IDs also derive from basenames.
  *    CORRUPT_IDENTIFIER_MAX_LENGTH doubles that ceiling for headroom.
+ *    agent_type is excluded: legacy workspace metadata and rollup entries
+ *    accept unbounded agent-type strings, so length there is not evidence.
  *
  * 2. Workspace identity unknown to ingest_watermarks. A concatenation of two
  *    or more workspace IDs can never equal a real workspace ID, no matter how
- *    small the corrupted batch, while every legitimate row's workspace gets a
- *    watermark by the end of the ingest/rebuild pass that wrote it (sweeps
- *    run after those passes complete). If a crash lands between the event
- *    write and the watermark write, deleting the orphans is still safe: the
- *    missing watermark makes the next syncCheck re-ingest that workspace from
- *    disk in full. The exception is a workspace whose ingest FAILED in the
- *    current pass (a poison record makes every retry throw before the
- *    watermark write): callers pass those IDs as preserveWorkspaceIds so the
- *    sweep does not delete a failing workspace's real rows after every sync.
+ *    small the corrupted batch. This evidence is only safe at init, before
+ *    any ingest of the session (prior-session rows either have watermarks or
+ *    are orphans the first syncCheck re-ingests from disk), or right after a
+ *    rebuild that reports the workspaces whose ingest failed before their
+ *    watermark write via preserveWorkspaceIds. Running it after ordinary
+ *    ingests deletes real rows of workspaces whose ingest keeps failing on a
+ *    poison record, so callers must not sweep there.
  *    delegation_rollups joins on parent_workspace_id only;
  *    child_workspace_id may legitimately reference a removed child workspace.
  */
@@ -925,7 +925,6 @@ export async function deleteCorruptAnalyticsRows(
     DELETE FROM delegation_rollups
     WHERE LENGTH(parent_workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
        OR LENGTH(child_workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
-       OR LENGTH(agent_type) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
        OR (NOT EXISTS (
          SELECT 1 FROM ingest_watermarks w
          WHERE w.workspace_id = delegation_rollups.parent_workspace_id

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -865,6 +865,8 @@ export async function clearWorkspaceAnalyticsState(
   }
 }
 
+const CORRUPT_IDENTIFIER_MAX_LENGTH = 1024;
+
 /**
  * Self-healing sweep for a rare native-layer corruption class: a phantom row
  * can materialize whose every VARCHAR column is the concatenation of that
@@ -882,7 +884,8 @@ export async function clearWorkspaceAnalyticsState(
  *    IDs are short hex; migrated legacy IDs are
  *    `${projectBasename}-${workspaceBasename}` (config.generateLegacyId),
  *    each basename bounded by the filesystem's NAME_MAX (255 bytes), so 511
- *    is the ceiling. Agent IDs/types also derive from basenames. Cap at 1024.
+ *    is the construction ceiling. Agent IDs/types also derive from basenames.
+ *    CORRUPT_IDENTIFIER_MAX_LENGTH doubles that ceiling for headroom.
  *
  * 2. Workspace identity unknown to ingest_watermarks. A concatenation of two
  *    or more workspace IDs can never equal a real workspace ID, no matter how
@@ -891,29 +894,42 @@ export async function clearWorkspaceAnalyticsState(
  *    run after those passes complete). If a crash lands between the event
  *    write and the watermark write, deleting the orphans is still safe: the
  *    missing watermark makes the next syncCheck re-ingest that workspace from
- *    disk in full. delegation_rollups joins on parent_workspace_id only;
+ *    disk in full. The exception is a workspace whose ingest FAILED in the
+ *    current pass (a poison record makes every retry throw before the
+ *    watermark write): callers pass those IDs as preserveWorkspaceIds so the
+ *    sweep does not delete a failing workspace's real rows after every sync.
+ *    delegation_rollups joins on parent_workspace_id only;
  *    child_workspace_id may legitimately reference a removed child workspace.
  */
-export async function deleteCorruptAnalyticsRows(conn: DuckDBConnection): Promise<number> {
+export async function deleteCorruptAnalyticsRows(
+  conn: DuckDBConnection,
+  preserveWorkspaceIds: ReadonlySet<string> = new Set()
+): Promise<number> {
+  // Length evidence stays authoritative for preserved workspaces; only the
+  // watermark-membership evidence is exempted for them.
+  const preserveList = [...preserveWorkspaceIds]
+    .map((id) => `'${id.replaceAll("'", "''")}'`)
+    .join(", ");
+
   const eventsResult = await conn.run(`
     DELETE FROM events
-    WHERE LENGTH(workspace_id) > 1024
-       OR LENGTH(parent_workspace_id) > 1024
-       OR LENGTH(agent_id) > 1024
-       OR NOT EXISTS (
+    WHERE LENGTH(workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR LENGTH(parent_workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR LENGTH(agent_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR (NOT EXISTS (
          SELECT 1 FROM ingest_watermarks w WHERE w.workspace_id = events.workspace_id
-       )
+       )${preserveList ? ` AND events.workspace_id NOT IN (${preserveList})` : ""})
   `);
 
   const rollupsResult = await conn.run(`
     DELETE FROM delegation_rollups
-    WHERE LENGTH(parent_workspace_id) > 1024
-       OR LENGTH(child_workspace_id) > 1024
-       OR LENGTH(agent_type) > 1024
-       OR NOT EXISTS (
+    WHERE LENGTH(parent_workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR LENGTH(child_workspace_id) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR LENGTH(agent_type) > ${CORRUPT_IDENTIFIER_MAX_LENGTH}
+       OR (NOT EXISTS (
          SELECT 1 FROM ingest_watermarks w
          WHERE w.workspace_id = delegation_rollups.parent_workspace_id
-       )
+       )${preserveList ? ` AND delegation_rollups.parent_workspace_id NOT IN (${preserveList})` : ""})
   `);
 
   return eventsResult.rowsChanged + rollupsResult.rowsChanged;
@@ -1843,7 +1859,7 @@ export async function rebuildAll(
   conn: DuckDBConnection,
   sessionsDir: string,
   workspaceMetaById: WorkspaceMetaById = {}
-): Promise<{ workspacesIngested: number }> {
+): Promise<{ workspacesIngested: number; failedWorkspaceIds: Set<string> }> {
   assert(sessionsDir.trim().length > 0, "rebuildAll: sessionsDir is required");
   assert(
     isRecord(workspaceMetaById) && !Array.isArray(workspaceMetaById),
@@ -1868,7 +1884,7 @@ export async function rebuildAll(
     entries = await fs.readdir(sessionsDir, { withFileTypes: true });
   } catch (error) {
     if (isRecord(error) && error.code === "ENOENT") {
-      return { workspacesIngested: 0 };
+      return { workspacesIngested: 0, failedWorkspaceIds: new Set() };
     }
 
     throw error;
@@ -1999,5 +2015,5 @@ export async function rebuildAll(
     }
   }
 
-  return { workspacesIngested };
+  return { workspacesIngested, failedWorkspaceIds };
 }


### PR DESCRIPTION
## Summary

Adds a self-healing sweep that deletes a rare class of corrupt analytics rows which wallpaper the Analytics dashboard, and upgrades `@duckdb/node-api` from 1.4.4-r.1 to 1.5.5-r.4 after verifying the upgrade preserves stats and is downgrade-safe.

## Background

A production `analytics.db` contained exactly one corrupt `events` row whose every VARCHAR column was the concatenation of that column's non-null values across an entire insert batch (672 rows spanning 3 workspaces): a 17,229-char `model` string, a 6,720-char `workspace_id`, `thinking_level` of `highhigh`, `agent_id` of `execexplore`. The fragment arithmetic is exact (e.g. `project_path` = 672 x 17 bytes of `/home/coder/coder`). Since `SpendChart` creates one legend entry and bar series per distinct model, that single row rendered as a giant legend entry covering the whole dashboard.

The corruption happened below our JS layer (the write path is a bound-parameter `INSERT` per row; numerics were copied from one donor row while varchars concatenated across the batch). All 672 donor rows were also written correctly, so the phantom row is pure junk and deleting it loses no data.

## Implementation

- `deleteCorruptAnalyticsRows()` (etl.ts) deletes on two structural evidence classes:
  - Identifier length beyond the legal construction ceiling (`CORRUPT_IDENTIFIER_MAX_LENGTH`, 2x the 511-char legacy-ID maximum). Applies to workspace/parent/agent IDs; `agent_type` is excluded because legacy metadata accepts unbounded agent types. Unbounded columns like `model` are never evidence.
  - Workspace identity unknown to `ingest_watermarks` (a concatenation of two workspace IDs can never match a real one), which also catches small-batch phantoms below the length cap.
- Sweep timing is deliberately narrow: once at worker init (before any ingest of the session, healing existing DBs on next app start) and immediately after rebuild passes, which pass their own failed-workspace set so rows appended before a failed watermark write are preserved. Sweeping after ordinary ingests is unsafe (it deletes real rows of a workspace whose ingest keeps failing on a poison record) and would scan both tables on every stream-end.
- `rebuildAll` now reports `failedWorkspaceIds` (append-stage and metadata-stage failures) for the post-rebuild sweep.
- `@duckdb/node-api` 1.4.4-r.1 -> 1.5.5-r.4: the corruption mechanism lives in the native bindings, so pick up a year of upstream fixes.

## Validation

- Sweep validated against a copy of the affected production DB: exactly 1 row deleted, 58,478 healthy rows kept, total spend unchanged.
- Upgrade safety, all on copies of the production DB:
  - Stats parity: totals, by-model, by-project, by-day, rollups, and watermark aggregates are identical across 1.4.4 and 1.5.5 (the only observed diff was last-ulp FP summation noise that also varies run-to-run within a single version).
  - Downgrade: a DB written and checkpointed by 1.5.5 reopens, reads, and writes correctly under 1.4.4.
  - Crash windows: an uncheckpointed WAL written by 1.4.4 replays under 1.5.5, and vice versa.
- Behavioral tests for the sweep: deletion/retention/idempotence, failed-ingest preservation vs. length evidence (red-green verified), rebuild metadata-stage failure reporting (red-green verified), unbounded legacy `agent_type` retention. Analytics + SqlExplorer suites pass under 1.5.5; `make static-check-full` green.

## Risks

- Deletion false-positives would require identifier values 2x beyond the legal construction maximum or a workspace absent from watermarks at init/rebuild time; both are structurally impossible for rows written by the current code, and the init-time orphan case self-heals via the first syncCheck re-ingest.
- Mid-session corruption (never observed; the incident predated app start) heals at the next app start or rebuild rather than within one sync interval. This is the accepted tradeoff for never deleting a failing workspace's real rows.
- Dependency bump risk is bounded to the analytics subsystem (the only DuckDB consumer) and covered by the parity/downgrade/WAL validation above.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
