### PR TITLE
🤖 fix: settle workspace-turn queue-cut supersedes as interrupted, not error

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4859,6 +4859,20 @@ describe("TaskService", () => {
     expect(snapshot?.deferredMessageIds).toBeUndefined();
   });
 
+  test("repeat interrupt of an already-interrupted workspace turn is a no-op", async () => {
+    // A queue-cut supersede settles the handle interrupted while the target
+    // workspace keeps streaming under the new input. A stale task_stop for the
+    // settled handle must not stop that unrelated stream.
+    const { parentId, taskService, aiMocks } = await startWorkspaceTurnForTest();
+    const first = await taskService.interruptWorkspaceTurn(parentId, "wst_handle");
+    expect(first.success).toBe(true);
+    aiMocks.stopStream.mockClear();
+
+    const repeat = await taskService.interruptWorkspaceTurn(parentId, "wst_handle");
+    expect(repeat).toEqual(Ok({ workspaceId: "childworkspace" }));
+    expect(aiMocks.stopStream).not.toHaveBeenCalled();
+  });
+
   test("workspace-turn stale recovery skips deferred pre-handoff stream-end history", async () => {
     const { config, parentId, projectPath, taskService, historyService } =
       await startWorkspaceTurnForTest();

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -5587,6 +5587,61 @@ describe("TaskService", () => {
     });
   });
 
+  test("snapshot history repair does not upgrade an error settlement to a supersede", async () => {
+    // A tool-calls turn correctly settled as error (no live queue-cut evidence,
+    // e.g. a required-tool stop) must stay an error even after unrelated user
+    // messages land in child history: order is not causal queue-cut evidence.
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
+    };
+    expect(
+      (
+        await historyService.appendToHistory(
+          "childworkspace",
+          createMuxMessage("msg_required_tool_stop", "assistant", "Stopped on required tool", {
+            model: "anthropic:claude-opus-4-6",
+            agentId: "exec",
+            finishReason: "tool-calls",
+            muxMetadata,
+          })
+        )
+      ).success
+    ).toBe(true);
+    expect(
+      (
+        await historyService.appendToHistory(
+          "childworkspace",
+          createMuxMessage("msg_unrelated_later_input", "user", "Unrelated later question")
+        )
+      ).success
+    ).toBe(true);
+    await new TaskHandleStore(config).upsertWorkspaceTurn({
+      kind: "workspace_turn",
+      handleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      workspaceId: "childworkspace",
+      turnId: "turn",
+      status: "error",
+      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      updatedAt: "2026-06-19T00:00:01.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+      messageId: "msg_required_tool_stop",
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(snapshot).toMatchObject({
+      status: "error",
+      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+      messageId: "msg_required_tool_stop",
+    });
+  });
+
   test("getWorkspaceTurnSnapshot repairs a stale error handle from self-healed history", async () => {
     const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
     await config.editConfig((cfg) => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -1599,6 +1599,87 @@ describe("TaskService", () => {
     expect(JSON.stringify(parentHistory)).not.toContain("Already returned by task_await.");
   });
 
+  test("queue-cut supersede settlement is delivered to the persistent child's direct parent", async () => {
+    // The old error settlement appended a terminal failure to the direct
+    // parent; the interrupted supersede settlement must not silently vanish.
+    const config = await createTestConfig(rootDir);
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
+    const childTaskId = "child-superseded-delivery";
+    const handleId = "wst_superseded_delivery";
+    await config.editConfig((cfg) => {
+      const project = cfg.projects.get(projectPath);
+      assert(project, "test project must exist");
+      project.workspaces.push(
+        projectWorkspace(projectPath, "child", childTaskId, {
+          parentWorkspaceId: parentId,
+          agentId: "explore",
+          agentType: "explore",
+          taskStatus: "reported",
+          title: "Superseded Reviewer",
+        })
+      );
+      return cfg;
+    });
+    const { historyService, taskService } = createTaskServiceHarness(config);
+    const taskHandleStore = (taskService as unknown as { taskHandleStore: TaskHandleStore })
+      .taskHandleStore;
+    const supersededRecord: WorkspaceTurnTaskHandleRecord = {
+      kind: "workspace_turn",
+      handleId,
+      ownerWorkspaceId: parentId,
+      workspaceId: childTaskId,
+      turnId: "superseded-delivery",
+      status: "interrupted",
+      error:
+        "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report",
+      createdAt: "2026-08-11T00:00:00.000Z",
+      updatedAt: "2026-08-11T00:00:01.000Z",
+      createdWorkspace: false,
+      disposableWorkspace: false,
+      directParentResultDeliveryRequiredAt: "2026-08-11T00:00:01.000Z",
+    };
+    await taskHandleStore.upsertWorkspaceTurn(supersededRecord);
+
+    await (
+      taskService as unknown as {
+        deliverPersistentChildWorkspaceTurnResult: (
+          record: WorkspaceTurnTaskHandleRecord,
+          waiterWorkspaceIds: ReadonlySet<string>
+        ) => Promise<void>;
+      }
+    ).deliverPersistentChildWorkspaceTurnResult(supersededRecord, new Set());
+
+    const parentHistory = await historyService.getHistoryFromLatestBoundary(parentId);
+    expect(parentHistory.success).toBe(true);
+    const serialized = JSON.stringify(parentHistory);
+    expect(serialized).toContain("workspace_turn_superseded");
+    expect(serialized).toContain("superseded by new input in the target workspace");
+    expect(
+      (await taskHandleStore.getWorkspaceTurn(parentId, handleId))?.directParentResultDeliveredAt
+    ).toBeDefined();
+
+    // Explicit cancellations (no supersede reason) must stay silent.
+    const { error: _supersedeReason, ...canceledBase } = supersededRecord;
+    const canceledRecord: WorkspaceTurnTaskHandleRecord = {
+      ...canceledBase,
+      handleId: "wst_canceled_delivery",
+      turnId: "canceled-delivery",
+    };
+    await taskHandleStore.upsertWorkspaceTurn(canceledRecord);
+    await (
+      taskService as unknown as {
+        deliverPersistentChildWorkspaceTurnResult: (
+          record: WorkspaceTurnTaskHandleRecord,
+          waiterWorkspaceIds: ReadonlySet<string>
+        ) => Promise<void>;
+      }
+    ).deliverPersistentChildWorkspaceTurnResult(canceledRecord, new Set());
+    expect(
+      (await taskHandleStore.getWorkspaceTurn(parentId, "wst_canceled_delivery"))
+        ?.directParentResultDeliveredAt
+    ).toBeUndefined();
+  });
+
   test("terminal recovery skips legacy delivery records and contains per-record replay failures", async () => {
     const config = await createTestConfig(rootDir);
     const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
@@ -4649,7 +4730,10 @@ describe("TaskService", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
-  test("workspace-turn tool-calls stream-end without continuation settles interrupted", async () => {
+  test("workspace-turn tool-calls stream-end without queue-cut evidence settles error", async () => {
+    // A "tool-calls" finish without any queued/preparing/streaming successor is
+    // not a queue cut (e.g. a successful required-tool stop condition); it must
+    // keep the truncation error handling rather than claim a supersede.
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
@@ -4675,11 +4759,10 @@ describe("TaskService", () => {
 
     const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
     expect(snapshot).toMatchObject({
-      status: "interrupted",
+      status: "error",
       workspaceId: "childworkspace",
       messageId: "msg_tool_calls_terminal",
-      error:
-        "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report",
+      error: "Workspace turn ended before completion (finishReason: tool-calls)",
     });
   });
 

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -5536,6 +5536,57 @@ describe("TaskService", () => {
     });
   });
 
+  test("snapshot history repair does not downgrade a supersede settlement before the successor lands", async () => {
+    // Queue-cut supersede race: the handle settles interrupted from the
+    // tool-calls stream-end, but the superseding queued input has not appended
+    // its user message to child history yet. A task_await snapshot read in that
+    // window repairs from the SAME correlated final and must preserve the
+    // supersede classification instead of downgrading it to a truncation error.
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const supersedeReason =
+      "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report";
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
+    };
+    expect(
+      (
+        await historyService.appendToHistory(
+          "childworkspace",
+          createMuxMessage("msg_queue_cut", "assistant", "Cut mid-work", {
+            model: "anthropic:claude-opus-4-6",
+            agentId: "exec",
+            finishReason: "tool-calls",
+            muxMetadata,
+          })
+        )
+      ).success
+    ).toBe(true);
+    await new TaskHandleStore(config).upsertWorkspaceTurn({
+      kind: "workspace_turn",
+      handleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      workspaceId: "childworkspace",
+      turnId: "turn",
+      status: "interrupted",
+      error: supersedeReason,
+      createdAt: "2026-06-19T00:00:00.000Z",
+      updatedAt: "2026-06-19T00:00:01.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+      messageId: "msg_queue_cut",
+    });
+
+    const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
+    expect(snapshot).toMatchObject({
+      status: "interrupted",
+      error: supersedeReason,
+      messageId: "msg_queue_cut",
+    });
+  });
+
   test("getWorkspaceTurnSnapshot repairs a stale error handle from self-healed history", async () => {
     const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
     await config.editConfig((cfg) => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -4351,10 +4351,12 @@ describe("TaskService", () => {
     expect(preservedReport?.metadata?.muxMetadata).toEqual(previousCorrelation);
   });
 
-  test("workspace-turn tool-calls stream-end with superseding queued input settles error", async () => {
+  test("workspace-turn tool-calls stream-end with superseding queued input settles interrupted", async () => {
     // Ordinary queued input (manual message, bare /compact) also cuts the
     // stream at a tool boundary, but it supersedes the delegated turn instead
-    // of continuing it — the handle must settle now, not defer forever.
+    // of continuing it — the handle must settle now, not defer forever. The
+    // child keeps working under the new input, so the owner sees an
+    // interruption with a supersede reason, not a task failure.
     const hasPendingQueuedOrPreparingTurn = mock(
       (workspaceId: string) => workspaceId === "childworkspace"
     );
@@ -4385,9 +4387,10 @@ describe("TaskService", () => {
 
     const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
     expect(snapshot).toMatchObject({
-      status: "error",
+      status: "interrupted",
       messageId: "msg_superseded_cut",
-      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+      error:
+        "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report",
     });
   });
 
@@ -4646,7 +4649,7 @@ describe("TaskService", () => {
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
 
-  test("workspace-turn tool-calls stream-end without continuation settles error", async () => {
+  test("workspace-turn tool-calls stream-end without continuation settles interrupted", async () => {
     const { parentId, taskService } = await startWorkspaceTurnForTest();
     const internal = taskService as unknown as {
       handleStreamEnd: (event: StreamEndEvent) => Promise<void>;
@@ -4672,10 +4675,11 @@ describe("TaskService", () => {
 
     const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
     expect(snapshot).toMatchObject({
-      status: "error",
+      status: "interrupted",
       workspaceId: "childworkspace",
       messageId: "msg_tool_calls_terminal",
-      error: "Workspace turn ended before completion (finishReason: tool-calls)",
+      error:
+        "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report",
     });
   });
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8115,7 +8115,15 @@ export class TaskService {
           });
         }
         const recovered = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
-          queueCutSupersedeEvidence: sawNewerUserMessage,
+          // The persisted supersede classification stays authoritative when this
+          // repair rebuilds from the SAME correlated final that settled it: the
+          // superseding queued input may not have appended its user message to
+          // child history yet (queue-dispatch timing), and that absence must not
+          // downgrade the supersede to a truncation error. Only a different
+          // correlated final (contradictory same-turn evidence) may resettle.
+          queueCutSupersedeEvidence:
+            sawNewerUserMessage ||
+            (isSupersededWorkspaceTurnInterrupt(record) && event.messageId === record.messageId),
         });
         if (
           !options.repairFromHistory ||

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -696,6 +696,20 @@ const WORKSPACE_TURN_SUPERSEDED_BY_NEW_INPUT_ERROR =
   "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report";
 
 /**
+ * Distinguishes queue-cut supersede interrupts from explicit cancellations
+ * (user Esc, task_stop): supersedes still deliver a terminal continuation to a
+ * persistent child's direct parent, while explicit cancels stay silent because
+ * the canceller already knows the outcome.
+ */
+function isSupersededWorkspaceTurnInterrupt(
+  record: Pick<WorkspaceTurnTaskHandleRecord, "status" | "error">
+): boolean {
+  return (
+    record.status === "interrupted" && record.error === WORKSPACE_TURN_SUPERSEDED_BY_NEW_INPUT_ERROR
+  );
+}
+
+/**
  * Settled workspace-turn records eligible for self-heal correction (resettle from a
  * correlated stream-end, or read-time repair/revive): transient stream-error settlements
  * (status "error"), stale restart-recovery interrupts, and queue-cut supersedes (late
@@ -6463,7 +6477,14 @@ export class TaskService {
   private workspaceTurnRequiresDirectParentDelivery(
     record: WorkspaceTurnTaskHandleRecord
   ): boolean {
-    if (record.status !== "completed" && record.status !== "error") {
+    // Queue-cut supersedes count as terminal outcomes the direct parent must
+    // learn about (the old error settlement delivered them); explicit
+    // cancellations stay silent.
+    if (
+      record.status !== "completed" &&
+      record.status !== "error" &&
+      !isSupersededWorkspaceTurnInterrupt(record)
+    ) {
       return false;
     }
     const childEntry = findWorkspaceEntry(this.config.loadConfigOrDefault(), record.workspaceId);
@@ -6590,7 +6611,11 @@ export class TaskService {
     record: WorkspaceTurnTaskHandleRecord,
     foregroundWaiterWorkspaceIds: ReadonlySet<string>
   ): Promise<void> {
-    if (record.status !== "completed" && record.status !== "error") {
+    if (
+      record.status !== "completed" &&
+      record.status !== "error" &&
+      !isSupersededWorkspaceTurnInterrupt(record)
+    ) {
       return;
     }
 
@@ -6660,7 +6685,9 @@ export class TaskService {
             agentType,
             executionVersion: deliveryVersion,
             executionId: record.handleId,
-            errorType: "workspace_turn_error",
+            errorType: isSupersededWorkspaceTurnInterrupt(record)
+              ? "workspace_turn_superseded"
+              : "workspace_turn_error",
             errorMessage: record.error ?? "Workspace turn failed",
           });
     if (!alreadyDelivered) {
@@ -8066,6 +8093,9 @@ export class TaskService {
     // message older than that unrelated prompt still proves the turn completed, so the
     // durable-history repair scan must continue past it.
     let reviveAllowed = turnLive;
+    // A user message newer than the correlated final is durable evidence that
+    // queued input dispatched after the cut (see queueCutSupersedeEvidence).
+    let sawNewerUserMessage = false;
     for (const message of historyResult.data.toReversed()) {
       if (
         this.isDeferredWorkspaceTurnMessage(record, message.id) &&
@@ -8084,7 +8114,9 @@ export class TaskService {
             deferredMessageIds: [event.messageId],
           });
         }
-        const recovered = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event);
+        const recovered = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
+          queueCutSupersedeEvidence: sawNewerUserMessage,
+        });
         if (
           !options.repairFromHistory ||
           (recovered.status === record.status && recovered.messageId === record.messageId)
@@ -8101,6 +8133,7 @@ export class TaskService {
       if (message.role !== "user") {
         continue;
       }
+      sawNewerUserMessage = true;
       const metadata = this.getWorkspaceTurnMetadataFromValue(message.metadata?.muxMetadata);
       const correlatedPrompt =
         metadata != null &&
@@ -10141,19 +10174,23 @@ export class TaskService {
 
   private buildTerminalWorkspaceTurnRecordFromEvent(
     record: WorkspaceTurnTaskHandleRecord,
-    event: StreamEndEvent
+    event: StreamEndEvent,
+    options: { queueCutSupersedeEvidence: boolean }
   ): WorkspaceTurnTaskHandleRecord {
     const baseRecord = { ...record };
     delete baseRecord.error;
     delete baseRecord.deferredMessageIds;
-    // A "tool-calls" finish on a delegated turn is always a queue cut: some other
-    // queued input (a manual user message, /compact) dispatched at the tool
-    // boundary and superseded the turn (same-turn continuations were already
-    // deferred by the caller). The child keeps working under that new input, so
-    // this is a supersede — not a failure of the delegated work. Settle as
-    // interrupted with a human-readable reason instead of alarming the owner
-    // with an "error" and internal finishReason jargon.
-    if (event.metadata.finishReason === "tool-calls") {
+    // A "tool-calls" finish on a delegated turn backed by queue-dispatch
+    // evidence is a queue cut: some other queued input (a manual user message,
+    // /compact) dispatched at the tool boundary and superseded the turn
+    // (same-turn continuations were already deferred by the caller). The child
+    // keeps working under that new input, so this is a supersede — not a
+    // failure of the delegated work. Settle as interrupted with a
+    // human-readable reason instead of alarming the owner with an "error" and
+    // internal finishReason jargon. Without such evidence a "tool-calls"
+    // finish can come from other stop conditions (e.g. a successful
+    // required-tool result), so it falls through to the truncation branch.
+    if (event.metadata.finishReason === "tool-calls" && options.queueCutSupersedeEvidence) {
       return {
         ...baseRecord,
         status: "interrupted",
@@ -10220,13 +10257,21 @@ export class TaskService {
     }
 
     const allowDeferredMessages = !(await this.hasActiveWorkspaceTurnDeferredBlockers(record));
+    // A user message newer than the correlated final is durable evidence that
+    // queued input dispatched after the cut (see queueCutSupersedeEvidence).
+    let sawNewerUserMessage = false;
     for (const message of historyResult.data.toReversed()) {
       if (this.isDeferredWorkspaceTurnMessage(record, message.id) && !allowDeferredMessages) {
         continue;
       }
       const event = this.buildWorkspaceTurnStreamEndEventFromHistory(record, message);
       if (event != null) {
-        return this.buildTerminalWorkspaceTurnRecordFromEvent(record, event);
+        return this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
+          queueCutSupersedeEvidence: sawNewerUserMessage,
+        });
+      }
+      if (message.role === "user") {
+        sawNewerUserMessage = true;
       }
     }
     return null;
@@ -10393,6 +10438,20 @@ export class TaskService {
     );
   }
 
+  /**
+   * Whether the superseding queued input that cut this stream is still visible
+   * live: queued/preparing/auto-retrying in the child session, or already
+   * streaming as a different (uncorrelated) message. Same-turn continuations
+   * were ruled out by the caller via hasSameTurnContinuation.
+   */
+  private hasLiveQueueCutSupersedeEvidence(event: StreamEndEvent): boolean {
+    if (this.workspaceService.hasPendingQueuedOrPreparingTurn(event.workspaceId)) {
+      return true;
+    }
+    const activeStream = this.aiService.getStreamInfo(event.workspaceId);
+    return activeStream != null && activeStream.messageId !== event.messageId;
+  }
+
   private async finalizeWorkspaceTurnFromStreamEnd(event: StreamEndEvent): Promise<boolean> {
     const metadata = this.getWorkspaceTurnMetadata(event);
     if (metadata == null) {
@@ -10446,7 +10505,9 @@ export class TaskService {
       return true;
     }
 
-    const next = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event);
+    const next = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
+      queueCutSupersedeEvidence: this.hasLiveQueueCutSupersedeEvidence(event),
+    });
     await this.settleWorkspaceTurn({
       record,
       next,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8346,6 +8346,13 @@ export class TaskService {
       if (record.status === "completed" || record.status === "error") {
         return Err(`Workspace turn is already ${record.status} and cannot be interrupted.`);
       }
+      // Already-settled interrupts (explicit stop, restart recovery, queue-cut
+      // supersede) have nothing left to stop: proceeding would stopStream the
+      // target workspace's *current* stream — e.g. the manual message or
+      // /compact that superseded the delegated turn. Idempotent no-op instead.
+      if (record.status === "interrupted") {
+        return Ok({ workspaceId: record.workspaceId });
+      }
 
       workspaceId = record.workspaceId;
       shouldClearQueuedPrompt =

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8093,9 +8093,6 @@ export class TaskService {
     // message older than that unrelated prompt still proves the turn completed, so the
     // durable-history repair scan must continue past it.
     let reviveAllowed = turnLive;
-    // A user message newer than the correlated final is durable evidence that
-    // queued input dispatched after the cut (see queueCutSupersedeEvidence).
-    let sawNewerUserMessage = false;
     for (const message of historyResult.data.toReversed()) {
       if (
         this.isDeferredWorkspaceTurnMessage(record, message.id) &&
@@ -8115,15 +8112,16 @@ export class TaskService {
           });
         }
         const recovered = this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
-          // The persisted supersede classification stays authoritative when this
-          // repair rebuilds from the SAME correlated final that settled it: the
-          // superseding queued input may not have appended its user message to
-          // child history yet (queue-dispatch timing), and that absence must not
-          // downgrade the supersede to a truncation error. Only a different
+          // Repair preserves — never invents — a supersede classification.
+          // History order is not causal queue-dispatch evidence (an unrelated
+          // later user message must not upgrade an error settlement), while the
+          // persisted supersede stays authoritative when rebuilding from the
+          // SAME correlated final that settled it: the superseding queued input
+          // may not have appended its user message yet, and that absence must
+          // not downgrade the supersede to a truncation error. Only a different
           // correlated final (contradictory same-turn evidence) may resettle.
           queueCutSupersedeEvidence:
-            sawNewerUserMessage ||
-            (isSupersededWorkspaceTurnInterrupt(record) && event.messageId === record.messageId),
+            isSupersededWorkspaceTurnInterrupt(record) && event.messageId === record.messageId,
         });
         if (
           !options.repairFromHistory ||
@@ -8141,7 +8139,6 @@ export class TaskService {
       if (message.role !== "user") {
         continue;
       }
-      sawNewerUserMessage = true;
       const metadata = this.getWorkspaceTurnMetadataFromValue(message.metadata?.muxMetadata);
       const correlatedPrompt =
         metadata != null &&
@@ -10265,21 +10262,20 @@ export class TaskService {
     }
 
     const allowDeferredMessages = !(await this.hasActiveWorkspaceTurnDeferredBlockers(record));
-    // A user message newer than the correlated final is durable evidence that
-    // queued input dispatched after the cut (see queueCutSupersedeEvidence).
-    let sawNewerUserMessage = false;
     for (const message of historyResult.data.toReversed()) {
       if (this.isDeferredWorkspaceTurnMessage(record, message.id) && !allowDeferredMessages) {
         continue;
       }
       const event = this.buildWorkspaceTurnStreamEndEventFromHistory(record, message);
       if (event != null) {
+        // History order alone cannot prove a queue cut (a later unrelated user
+        // message is not causal evidence), so stale recovery conservatively
+        // settles tool-calls finals as errors. Genuine supersedes are
+        // classified live at stream-end; a crash-window misclassification here
+        // stays self-heal eligible for later correlated evidence.
         return this.buildTerminalWorkspaceTurnRecordFromEvent(record, event, {
-          queueCutSupersedeEvidence: sawNewerUserMessage,
+          queueCutSupersedeEvidence: false,
         });
-      }
-      if (message.role === "user") {
-        sawNewerUserMessage = true;
       }
     }
     return null;

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -687,11 +687,22 @@ const WORKSPACE_TURN_RECOVERABLE_STREAM_ERRORS: ReadonlySet<StreamErrorType> = n
 const WORKSPACE_TURN_STALE_RESTART_ERROR = "Workspace turn interrupted after restart";
 
 /**
+ * Reason persisted when other queued input (a manual user message, /compact)
+ * cut a delegated turn at a tool boundary and superseded it. The target
+ * workspace continues under the new input, so the owner sees an interruption
+ * with this explanation rather than a task failure.
+ */
+const WORKSPACE_TURN_SUPERSEDED_BY_NEW_INPUT_ERROR =
+  "Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report";
+
+/**
  * Settled workspace-turn records eligible for self-heal correction (resettle from a
  * correlated stream-end, or read-time repair/revive): transient stream-error settlements
- * (status "error") and stale restart-recovery interrupts. Explicit interrupts — user Esc,
- * task_terminate, cancel reasons — must stay terminal even if a late correlated stream-end
- * or same-turn retry evidence arrives, so canceled work never resurfaces as completed.
+ * (status "error"), stale restart-recovery interrupts, and queue-cut supersedes (late
+ * correlated evidence of the same turn proves it actually continued). Explicit interrupts —
+ * user Esc, task_terminate, cancel reasons — must stay terminal even if a late correlated
+ * stream-end or same-turn retry evidence arrives, so canceled work never resurfaces as
+ * completed.
  */
 function isSelfHealEligibleSettledWorkspaceTurn(
   record: Pick<WorkspaceTurnTaskHandleRecord, "status" | "error">
@@ -699,7 +710,11 @@ function isSelfHealEligibleSettledWorkspaceTurn(
   if (record.status === "error") {
     return true;
   }
-  return record.status === "interrupted" && record.error === WORKSPACE_TURN_STALE_RESTART_ERROR;
+  return (
+    record.status === "interrupted" &&
+    (record.error === WORKSPACE_TURN_STALE_RESTART_ERROR ||
+      record.error === WORKSPACE_TURN_SUPERSEDED_BY_NEW_INPUT_ERROR)
+  );
 }
 
 /**
@@ -10124,6 +10139,27 @@ export class TaskService {
     const baseRecord = { ...record };
     delete baseRecord.error;
     delete baseRecord.deferredMessageIds;
+    // A "tool-calls" finish on a delegated turn is always a queue cut: some other
+    // queued input (a manual user message, /compact) dispatched at the tool
+    // boundary and superseded the turn (same-turn continuations were already
+    // deferred by the caller). The child keeps working under that new input, so
+    // this is a supersede — not a failure of the delegated work. Settle as
+    // interrupted with a human-readable reason instead of alarming the owner
+    // with an "error" and internal finishReason jargon.
+    if (event.metadata.finishReason === "tool-calls") {
+      return {
+        ...baseRecord,
+        status: "interrupted",
+        updatedAt: getIsoNow(),
+        messageId: event.messageId,
+        error: WORKSPACE_TURN_SUPERSEDED_BY_NEW_INPUT_ERROR,
+        finalMessageRef: this.buildWorkspaceTurnFinalMessageRef(event),
+        finalMessage: {
+          messageId: event.messageId,
+          metadata: event.metadata,
+        },
+      };
+    }
     // Truncated/non-stop provider finishes are partial output, not a completed delegated turn.
     if (event.metadata.finishReason != null && event.metadata.finishReason !== "stop") {
       return {

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -105,6 +105,51 @@ describe("task_await tool", () => {
     });
   });
 
+  it("surfaces the persisted interrupt reason for interrupted workspace turns", async () => {
+    // Queue-cut supersedes settle interrupted with a persisted reason; the owner
+    // must be able to distinguish that from an explicit cancellation.
+    using tempDir = new TestTempDir("test-task-await-workspace-turn-interrupted");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+
+    const taskService = {
+      listActiveDescendantAgentTaskIds: mock(() => []),
+      listWorkspaceTurnTasks: mock(() => []),
+      isDescendantAgentTask: mock(() => Promise.resolve(false)),
+      getAgentTaskStatuses: mock(() => new Map()),
+      markWorkspaceTurnTerminalAttentionConsumed: mock(() => Promise.resolve()),
+      getWorkspaceTurnSnapshot: mock(() =>
+        Promise.resolve({
+          kind: "workspace_turn",
+          handleId: "wst_superseded",
+          ownerWorkspaceId: "parent-workspace",
+          workspaceId: "child-workspace",
+          turnId: "turn-1",
+          status: "interrupted",
+          error: "Workspace turn superseded by new input in the target workspace",
+          createdAt: "2026-06-19T00:00:00.000Z",
+          updatedAt: "2026-06-19T00:00:10.000Z",
+          createdWorkspace: true,
+          disposableWorkspace: false,
+        })
+      ),
+    } as unknown as TaskService;
+
+    const tool = createTaskAwaitTool({ ...baseConfig, taskService });
+    const result = (await Promise.resolve(
+      tool.execute!({ task_ids: ["wst_superseded"], timeout_secs: 0 }, mockToolCallOptions)
+    )) as { results: Array<Record<string, unknown>> };
+
+    expect(result.results).toEqual([
+      {
+        status: "interrupted",
+        taskId: "wst_superseded",
+        handleKind: "workspace_turn",
+        workspaceId: "child-workspace",
+        note: "Workspace turn was interrupted: Workspace turn superseded by new input in the target workspace. The full workspace is preserved.",
+      },
+    ]);
+  });
+
   it("awaits a nested child continuation through its recorded owner", async () => {
     using tempDir = new TestTempDir("test-task-await-nested-continuation-owner");
     const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "root-workspace" });

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -601,6 +601,18 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             finalMessageRef: record.finalMessageRef,
             note: COMPLETED_REPORT_REFETCH_NOTE,
           });
+          // Interrupted handles persist a human-readable reason (e.g. "superseded by
+          // new input in the target workspace") that lets the owner distinguish
+          // supersession from an explicit cancellation — surface it in the note.
+          const interruptedWorkspaceTurnResult = (record: WorkspaceTurnTaskHandleRecord) => ({
+            status: "interrupted" as const,
+            taskId,
+            ...workspaceTurnIdentityFields(record.workspaceId),
+            note:
+              record.error != null && record.error.length > 0
+                ? `Workspace turn was interrupted: ${record.error}. The full workspace is preserved.`
+                : "Workspace turn was interrupted. The full workspace is preserved.",
+          });
           if (timeoutMs === 0 || !isActiveWorkspaceTurnTaskStatus(snapshot.status)) {
             if (snapshot.status === "completed") {
               await markWorkspaceTurnTerminalAttentionConsumed(snapshot);
@@ -608,12 +620,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             }
             if (snapshot.status === "interrupted") {
               await markWorkspaceTurnTerminalAttentionConsumed(snapshot);
-              return {
-                status: "interrupted" as const,
-                taskId,
-                ...workspaceTurnIdentityFields(snapshot.workspaceId),
-                note: "Workspace turn was interrupted. The full workspace is preserved.",
-              };
+              return interruptedWorkspaceTurnResult(snapshot);
             }
             if (snapshot.status === "error") {
               await markWorkspaceTurnTerminalAttentionConsumed(snapshot);
@@ -691,12 +698,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               }
               if (latest.status === "interrupted") {
                 await markWorkspaceTurnTerminalAttentionConsumed(latest);
-                return {
-                  status: "interrupted" as const,
-                  taskId,
-                  ...workspaceTurnIdentityFields(latest.workspaceId),
-                  note: "Workspace turn was interrupted. The full workspace is preserved.",
-                };
+                return interruptedWorkspaceTurnResult(latest);
               }
               return {
                 status: latest.status,
@@ -722,12 +724,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
               }
               if (latest.status === "interrupted") {
                 await markWorkspaceTurnTerminalAttentionConsumed(latest);
-                return {
-                  status: "interrupted" as const,
-                  taskId,
-                  ...workspaceTurnIdentityFields(latest.workspaceId),
-                  note: "Workspace turn was interrupted. The full workspace is preserved.",
-                };
+                return interruptedWorkspaceTurnResult(latest);
               }
               return {
                 status: latest.status,
@@ -753,12 +750,7 @@ export const createTaskAwaitTool: ToolFactory = (config: ToolConfiguration) => {
             }
             if (latest?.status === "interrupted") {
               await markWorkspaceTurnTerminalAttentionConsumed(latest);
-              return {
-                status: "interrupted" as const,
-                taskId,
-                ...workspaceTurnIdentityFields(latest.workspaceId),
-                note: "Workspace turn was interrupted. The full workspace is preserved.",
-              };
+              return interruptedWorkspaceTurnResult(latest);
             }
             return { status: "error" as const, taskId, error: message };
           }


### PR DESCRIPTION
## Summary

Settle delegated workspace-turn queue cuts (finishReason `tool-calls`) as `interrupted` with a human-readable supersede reason instead of a red task failure that leaks internal finishReason jargon to the owner.

## Background

When a parent delegates a turn to another workspace (`task(kind=workspace)`) and someone types a manual message into that target workspace, the queued input dispatches at the next tool boundary and soft-cuts the in-flight stream with finishReason `tool-calls` (the `hasQueuedMessages("tool-end")` stop condition). Same-turn continuations (bash-monitor wakes, report wake-ups) already defer settlement (#3797, #3852) — but any *other* queued input supersedes the delegated turn, and `buildTerminalWorkspaceTurnRecordFromEvent` lumped that cut into the generic non-`stop` truncation branch:

> **1 task failed** — `Workspace turn ended before completion (finishReason: tool-calls)`

That is wrong on both axes: the delegated work did not fail (the child keeps working under the new input), and `finishReason: tool-calls` is internal streaming vocabulary that should never surface as an erroneous state to the owner. The alarming failure wake also baits the parent into re-delegating a duplicate turn.

## Implementation

- `buildTerminalWorkspaceTurnRecordFromEvent`: a `tool-calls` finish on a correlated delegated turn is by construction a queue cut whose same-turn continuations were already deferred by the caller — settle it as `interrupted` with the reason *"Workspace turn superseded by new input in the target workspace; the workspace continues under that input and this delegated turn will not report"*. The task UI renders `interrupted` with the calm tone (no danger banner, no force-expand), and terminal-attention wakes report outcome `interrupted`.
- Genuine truncation finishes (`length`, etc.) keep the existing `error` settlement.
- The new supersede interrupt stays self-heal eligible in `isSelfHealEligibleSettledWorkspaceTurn` (it previously was, via `status: "error"`), so a false supersede is still corrected by late correlated evidence of the same turn.

## Validation

Reconstructed the reported incident from live session data (`chat.jsonl`, `task-handles/wst_*.json`, terminal-attention records): a manual user message queued into the delegated child cut the stream at a tool boundary and the handle settled `error` with the finishReason message. Updated the two tests that pinned the old error behavior; `workspace-turn`/`resettle`/`self-heal`/`revive` test groups pass. The 3 remaining monolithic-run failures in `taskService.test.ts` reproduce identically on the base commit (cross-test interference; they pass in isolation).

## Risks

Low severity, scoped to delegated workspace-turn settlement. Owners now see `interrupted` instead of `error` for queue-cut supersedes; waiter promises still reject (message text changed). Truncation/error paths and same-turn continuation deferral are untouched.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$8.81`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=8.81 -->
