### PR TITLE
🤖 fix: align Docker server MUX_ROOT persistence contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN mkdir -p /root/.mux
 
 # Default environment variables
 ENV NODE_ENV=production
-ENV MUX_HOME=/root/.mux
+ENV MUX_ROOT=/root/.mux
 
 # Expose server port
 EXPOSE 3000

--- a/src/common/constants/paths.test.ts
+++ b/src/common/constants/paths.test.ts
@@ -7,10 +7,10 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import { tmpdir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
-import { afterEach, describe, expect, test } from "bun:test";
-import { cleanupObsoleteMuxBinArtifacts } from "./paths";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanupObsoleteMuxBinArtifacts, getMuxHome } from "./paths";
 
 const tempDirs: string[] = [];
 
@@ -24,6 +24,58 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+const ENV_KEYS = ["MUX_ROOT", "MUX_HOME", "NODE_ENV"] as const;
+type EnvKey = (typeof ENV_KEYS)[number];
+
+describe("getMuxHome", () => {
+  let originalEnv: Record<EnvKey, string | undefined>;
+
+  beforeEach(() => {
+    originalEnv = {
+      MUX_ROOT: process.env.MUX_ROOT,
+      MUX_HOME: process.env.MUX_HOME,
+      NODE_ENV: process.env.NODE_ENV,
+    };
+
+    for (const key of ENV_KEYS) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  test("uses MUX_ROOT exactly when set", () => {
+    process.env.MUX_ROOT = "/custom/mux-root";
+    process.env.MUX_HOME = "/ignored/mux-home";
+    process.env.NODE_ENV = "production";
+
+    expect(getMuxHome()).toBe("/custom/mux-root");
+  });
+
+  test("ignores MUX_HOME and uses the homedir default", () => {
+    process.env.MUX_HOME = "/ignored/mux-home";
+    process.env.NODE_ENV = "production";
+
+    expect(getMuxHome()).toBe(join(homedir(), ".mux"));
+  });
+
+  test("uses the development suffix without MUX_ROOT", () => {
+    process.env.MUX_HOME = "/ignored/mux-home";
+    process.env.NODE_ENV = "development";
+
+    expect(getMuxHome()).toBe(join(homedir(), ".mux-dev"));
+  });
 });
 
 describe("cleanupObsoleteMuxBinArtifacts", () => {


### PR DESCRIPTION
Fixes #3802

## Summary

The Docker server image declared `ENV MUX_HOME=/root/.mux`, but the application resolver `getMuxHome()` (`src/common/constants/paths.ts`) only honors `MUX_ROOT`, so `MUX_HOME` was dead configuration. This PR makes `MUX_ROOT=/root/.mux` the explicit image contract and adds behavioral tests pinning the resolver's precedence.

## Background

The image worked only because `os.homedir()` happens to resolve to `/root` in the root container, so state landed in the mounted volume (`mux-data:/root/.mux`) by coincidence. Under `docker run --user ...`, the implicit homedir fallback can resolve elsewhere, silently bypassing the mounted volume or failing on writes.

Per the issue's contract: `MUX_HOME` is intentionally NOT added as an application alias (no dual-variable precedence), directory creation and the volume location are unchanged so existing volumes stay compatible, and non-root execution remains an explicit operator concern (no chown/migration logic).

## Validation

- New tests in `src/common/constants/paths.test.ts`: `MUX_ROOT` is returned exactly; `MUX_HOME` alone does not alter resolution; `-dev` suffix branch covered; mutated env vars restored. Red-green verified: removing the `MUX_ROOT` branch from `getMuxHome()` fails exactly the precedence test.
- `make static-check-full` green locally.
- Local image build + smoke: `docker inspect` shows `MUX_ROOT=/root/.mux` and no `MUX_HOME`; container `/health` returns OK; server state (`sessions/`, `logs/`, `server.lock`) is written under `/root/.mux`.
- Remote dogfood UAT was unavailable for this Docker-image scenario (no agent-enabled template provisions coder/mux); the local image smoke above stands in as the scenario evidence.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
