### PR TITLE
🤖 fix: preserve legacy MCP OAuth binding fields for downgrade compatibility

### DIFF
--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -11,7 +11,20 @@ import {
   probeServerForBearerChallenge,
   resolveOAuthScope,
 } from "./mcpOauthService";
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
 import type { MCPOAuthClientInformation, MCPOAuthTokens } from "@/common/types/mcpOauth";
+
+interface StoredCredentialsSnapshot {
+  serverUrl: string;
+  updatedAtMs: number;
+  clientInformation?: MCPOAuthClientInformation;
+  tokens?: MCPOAuthTokens;
+}
+
+interface StoreSnapshot {
+  version: 2;
+  entries: Record<string, StoredCredentialsSnapshot>;
+}
 
 function getStoreFilePath(muxHome: string): string {
   return path.join(muxHome, "mcp-oauth.json");
@@ -26,6 +39,17 @@ describe("McpOauthService store", () => {
 
   const serverName = "test-server";
   const serverUrl = "https://example.com";
+  const authorizationServerUrl = "https://auth.example.com/";
+  const tokenEndpoint = "https://auth.example.com/token";
+  const discoveryState: OAuthDiscoveryState = {
+    authorizationServerUrl,
+    authorizationServerMetadata: {
+      issuer: authorizationServerUrl,
+      authorization_endpoint: "https://auth.example.com/authorize",
+      token_endpoint: tokenEndpoint,
+      response_types_supported: ["code"],
+    },
+  };
 
   beforeEach(async () => {
     muxHome = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-oauth-home-"));
@@ -48,9 +72,30 @@ describe("McpOauthService store", () => {
     await fs.rm(projectPath, { recursive: true, force: true });
   });
 
-  async function readStoreFile(): Promise<unknown> {
+  async function readStoreFile(): Promise<StoreSnapshot> {
     const raw = await fs.readFile(getStoreFilePath(muxHome), "utf-8");
-    return JSON.parse(raw) as unknown;
+    return JSON.parse(raw) as StoreSnapshot;
+  }
+
+  async function seedStoredCredentials(input: {
+    clientInformation: MCPOAuthClientInformation;
+    tokens: MCPOAuthTokens;
+  }): Promise<void> {
+    await fs.writeFile(
+      getStoreFilePath(muxHome),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          "https://example.com/": {
+            serverUrl,
+            updatedAtMs: Date.now(),
+            clientInformation: input.clientInformation,
+            tokens: input.tokens,
+          },
+        },
+      }),
+      "utf-8"
+    );
   }
 
   test("reading corrupt JSON store self-heals to empty", async () => {
@@ -254,6 +299,138 @@ describe("McpOauthService store", () => {
     expect(clientInformation?.authorization_server).toBe("https://auth.example.com/");
     expect(clientInformation?.token_endpoint).toBe("https://auth.example.com/token");
   });
+
+  test("saveTokens stamps the legacy binding from discovery state", async () => {
+    await seedStoredCredentials({
+      clientInformation: { client_id: "client-id", issuer: authorizationServerUrl },
+      tokens: {
+        access_token: "access-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        issuer: authorizationServerUrl,
+      },
+    });
+
+    const provider = await service.getAuthProviderForServer({ serverUrl });
+    expect(provider).toBeDefined();
+
+    await provider!.saveDiscoveryState?.(discoveryState);
+    await provider!.saveTokens({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      refresh_token: "new-refresh-token",
+      issuer: authorizationServerUrl,
+    });
+
+    const stored = (await readStoreFile()).entries["https://example.com/"];
+    expect(stored.tokens).toEqual({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      refresh_token: "new-refresh-token",
+      issuer: authorizationServerUrl,
+      authorization_server: authorizationServerUrl,
+      token_endpoint: tokenEndpoint,
+    });
+  });
+
+  test("saveTokens preserves the legacy binding without discovery state", async () => {
+    await seedStoredCredentials({
+      clientInformation: { client_id: "client-id" },
+      tokens: {
+        access_token: "access-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        authorization_server: authorizationServerUrl,
+        token_endpoint: tokenEndpoint,
+      },
+    });
+
+    const provider = await service.getAuthProviderForServer({ serverUrl });
+    expect(provider).toBeDefined();
+
+    await provider!.saveTokens({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      refresh_token: "new-refresh-token",
+      issuer: authorizationServerUrl,
+    });
+
+    const stored = (await readStoreFile()).entries["https://example.com/"];
+    expect(stored.tokens).toEqual({
+      access_token: "new-access-token",
+      token_type: "Bearer",
+      refresh_token: "new-refresh-token",
+      issuer: authorizationServerUrl,
+      authorization_server: authorizationServerUrl,
+      token_endpoint: tokenEndpoint,
+    });
+  });
+
+  test("saveClientInformation stamps the legacy binding from discovery state", async () => {
+    await seedStoredCredentials({
+      clientInformation: { client_id: "client-id", issuer: authorizationServerUrl },
+      tokens: {
+        access_token: "access-token",
+        token_type: "Bearer",
+        refresh_token: "refresh-token",
+        issuer: authorizationServerUrl,
+      },
+    });
+
+    const provider = await service.getAuthProviderForServer({ serverUrl });
+    expect(provider).toBeDefined();
+
+    await provider!.saveDiscoveryState?.(discoveryState);
+    await provider!.saveClientInformation?.({ client_id: "new-client-id" });
+
+    const stored = (await readStoreFile()).entries["https://example.com/"];
+    expect(stored.clientInformation).toEqual({
+      client_id: "new-client-id",
+      authorization_server: authorizationServerUrl,
+      token_endpoint: tokenEndpoint,
+    });
+  });
+
+  test.each([true, false])(
+    "partial discovery preserves only an existing complete binding (existing: %s)",
+    async (hasExistingBinding) => {
+      const existingBinding = hasExistingBinding
+        ? {
+            authorization_server: authorizationServerUrl,
+            token_endpoint: tokenEndpoint,
+          }
+        : {};
+      await seedStoredCredentials({
+        clientInformation: { client_id: "client-id" },
+        tokens: {
+          access_token: "access-token",
+          token_type: "Bearer",
+          refresh_token: "refresh-token",
+          ...existingBinding,
+        },
+      });
+
+      const provider = await service.getAuthProviderForServer({ serverUrl });
+      expect(provider).toBeDefined();
+
+      await provider!.saveDiscoveryState?.({ authorizationServerUrl });
+      await provider!.saveTokens({
+        access_token: "new-access-token",
+        token_type: "Bearer",
+        refresh_token: "new-refresh-token",
+        issuer: authorizationServerUrl,
+      });
+
+      const stored = (await readStoreFile()).entries["https://example.com/"];
+      expect(stored.tokens).toEqual({
+        access_token: "new-access-token",
+        token_type: "Bearer",
+        refresh_token: "new-refresh-token",
+        issuer: authorizationServerUrl,
+        ...existingBinding,
+      });
+    }
+  );
 
   test.each([
     // Corrupted: not a parseable URL.

--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -12,18 +12,15 @@ import {
   resolveOAuthScope,
 } from "./mcpOauthService";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/client";
-import type { MCPOAuthClientInformation, MCPOAuthTokens } from "@/common/types/mcpOauth";
-
-interface StoredCredentialsSnapshot {
-  serverUrl: string;
-  updatedAtMs: number;
-  clientInformation?: MCPOAuthClientInformation;
-  tokens?: MCPOAuthTokens;
-}
+import type {
+  MCPOAuthClientInformation,
+  MCPOAuthStoredCredentials,
+  MCPOAuthTokens,
+} from "@/common/types/mcpOauth";
 
 interface StoreSnapshot {
   version: 2;
-  entries: Record<string, StoredCredentialsSnapshot>;
+  entries: Record<string, MCPOAuthStoredCredentials>;
 }
 
 function getStoreFilePath(muxHome: string): string {

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -345,7 +345,10 @@ async function fetchProtectedResourceScopes(url: URL): Promise<string[]> {
  * we keep round-tripping them so downgrading Mux does not break token
  * refresh after an app restart.
  */
-function parseAuthorizationServerBinding(value: Record<string, unknown>): {
+function parseAuthorizationServerBinding(value: {
+  authorization_server?: unknown;
+  token_endpoint?: unknown;
+}): {
   authorization_server?: string;
   token_endpoint?: string;
 } {
@@ -1570,9 +1573,7 @@ export class McpOauthService {
       // Do not carry a legacy binding across defensive server URL replacement.
       const legacyBinding =
         input.legacyBinding ??
-        (serverMatches && creds.tokens
-          ? parseAuthorizationServerBinding({ ...creds.tokens })
-          : undefined);
+        (serverMatches && creds.tokens ? parseAuthorizationServerBinding(creds.tokens) : undefined);
 
       // Defensive: Never keep tokens bound to a different URL.
       if (!serverMatches) {
@@ -1603,7 +1604,7 @@ export class McpOauthService {
       const legacyBinding =
         input.legacyBinding ??
         (serverMatches && creds.clientInformation
-          ? parseAuthorizationServerBinding({ ...creds.clientInformation })
+          ? parseAuthorizationServerBinding(creds.clientInformation)
           : undefined);
 
       // Defensive: Never keep client info bound to a different URL.

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -3,7 +3,11 @@ import * as http from "http";
 import * as path from "path";
 import * as fsPromises from "fs/promises";
 import writeFileAtomic from "write-file-atomic";
-import { auth, type OAuthClientProvider } from "@modelcontextprotocol/client";
+import {
+  auth,
+  type OAuthClientProvider,
+  type OAuthDiscoveryState,
+} from "@modelcontextprotocol/client";
 import type { Config } from "@/node/config";
 import type { MCPConfigService } from "@/node/services/mcpConfigService";
 import type { WindowService } from "@/node/services/windowService";
@@ -102,6 +106,7 @@ interface OAuthFlowBase {
 
   /** PKCE verifier for this flow (set by the MCP SDK auth()). */
   codeVerifier: string | null;
+  discoveryState: OAuthDiscoveryState | undefined;
 
   timeout: ReturnType<typeof setTimeout>;
   cleanupTimeout: ReturnType<typeof setTimeout> | null;
@@ -367,6 +372,26 @@ function parseAuthorizationServerBinding(value: Record<string, unknown>): {
   }
 
   return { authorization_server: authorizationServer, token_endpoint: tokenEndpoint };
+}
+
+interface AuthorizationServerBinding {
+  authorization_server: string;
+  token_endpoint: string;
+}
+
+// Discovery is where both legacy binding fields are available for downgrade-compatible saves (#3823).
+function deriveAuthorizationServerBinding(
+  state: OAuthDiscoveryState | undefined
+): AuthorizationServerBinding | undefined {
+  const tokenEndpoint = state?.authorizationServerMetadata?.token_endpoint;
+  if (!state?.authorizationServerUrl || !tokenEndpoint) {
+    return undefined;
+  }
+
+  return {
+    authorization_server: state.authorizationServerUrl,
+    token_endpoint: tokenEndpoint,
+  };
 }
 
 /**
@@ -839,6 +864,7 @@ export class McpOauthService {
       scope: await resolveOAuthScope(challenge),
       resourceMetadataUrl: challenge?.resourceMetadataUrl,
       codeVerifier: null,
+      discoveryState: undefined,
       server: serverListener,
       timeout: setTimeout(() => {
         void this.finishDesktopFlow(flowId, Err("Timed out waiting for OAuth callback"));
@@ -983,6 +1009,7 @@ export class McpOauthService {
       scope: await resolveOAuthScope(challenge),
       resourceMetadataUrl: challenge?.resourceMetadataUrl,
       codeVerifier: null,
+      discoveryState: undefined,
       timeout: setTimeout(() => {
         void this.finishServerFlow(flowId, Err("Timed out waiting for OAuth callback"));
       }, DEFAULT_SERVER_TIMEOUT_MS),
@@ -1145,7 +1172,12 @@ export class McpOauthService {
           serverUrl: flow.serverUrlForStoreKey,
           // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
           tokens: tokens as unknown as MCPOAuthTokens,
+          legacyBinding: deriveAuthorizationServerBinding(flow.discoveryState),
         });
+      },
+      saveDiscoveryState: (state) => {
+        // Cache only for downgrade-compatible writes; read-back would change SDK discovery behavior.
+        flow.discoveryState = state;
       },
       redirectToAuthorization: (authorizationUrl) => {
         flow.authorizeUrl = authorizationUrl.toString();
@@ -1199,6 +1231,7 @@ export class McpOauthService {
         await this.saveClientInformation({
           serverUrl: flow.serverUrlForStoreKey,
           clientInformation: next,
+          legacyBinding: deriveAuthorizationServerBinding(flow.discoveryState),
         });
       },
       state: () => Promise.resolve(flow.flowId),
@@ -1209,6 +1242,8 @@ export class McpOauthService {
     serverUrl: string;
     serverName?: string;
   }): OAuthClientProvider {
+    let discoveryState: OAuthDiscoveryState | undefined;
+
     return {
       tokens: async () => {
         const creds = await this.getValidStoredCredentials({ serverUrl: input.serverUrl });
@@ -1220,7 +1255,12 @@ export class McpOauthService {
           serverUrl: input.serverUrl,
           // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
           tokens: tokens as unknown as MCPOAuthTokens,
+          legacyBinding: deriveAuthorizationServerBinding(discoveryState),
         });
+      },
+      saveDiscoveryState: (state) => {
+        // Cache only for downgrade-compatible writes; read-back would change SDK discovery behavior.
+        discoveryState = state;
       },
       redirectToAuthorization: async () => {
         // Avoid any user-visible side effects during background tool calls.
@@ -1267,6 +1307,7 @@ export class McpOauthService {
           serverUrl: input.serverUrl,
           // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
           clientInformation: clientInformation as unknown as MCPOAuthClientInformation,
+          legacyBinding: deriveAuthorizationServerBinding(discoveryState),
         });
       },
     };
@@ -1514,21 +1555,32 @@ export class McpOauthService {
     });
   }
 
-  private async saveTokens(input: { serverUrl: string; tokens: MCPOAuthTokens }): Promise<void> {
+  private async saveTokens(input: {
+    serverUrl: string;
+    tokens: MCPOAuthTokens;
+    legacyBinding?: AuthorizationServerBinding;
+  }): Promise<void> {
     await this.storeLock.withLock(this.storeFilePath, async () => {
       const store = await this.ensureStoreLoadedLocked();
       const creds = (store.entries[input.serverUrl] ??= {
         serverUrl: input.serverUrl,
         updatedAtMs: Date.now(),
       });
+      const serverMatches = normalizeServerUrlForComparison(creds.serverUrl) === input.serverUrl;
+      // Do not carry a legacy binding across defensive server URL replacement.
+      const legacyBinding =
+        input.legacyBinding ??
+        (serverMatches && creds.tokens
+          ? parseAuthorizationServerBinding({ ...creds.tokens })
+          : undefined);
 
       // Defensive: Never keep tokens bound to a different URL.
-      if (normalizeServerUrlForComparison(creds.serverUrl) !== input.serverUrl) {
+      if (!serverMatches) {
         creds.clientInformation = undefined;
       }
 
       creds.serverUrl = input.serverUrl;
-      creds.tokens = input.tokens;
+      creds.tokens = { ...input.tokens, ...legacyBinding };
       creds.updatedAtMs = Date.now();
 
       await this.persistStoreLocked(store);
@@ -1538,6 +1590,7 @@ export class McpOauthService {
   private async saveClientInformation(input: {
     serverUrl: string;
     clientInformation: MCPOAuthClientInformation;
+    legacyBinding?: AuthorizationServerBinding;
   }): Promise<void> {
     await this.storeLock.withLock(this.storeFilePath, async () => {
       const store = await this.ensureStoreLoadedLocked();
@@ -1545,9 +1598,16 @@ export class McpOauthService {
         serverUrl: input.serverUrl,
         updatedAtMs: Date.now(),
       });
+      const serverMatches = normalizeServerUrlForComparison(creds.serverUrl) === input.serverUrl;
+      // Do not carry a legacy binding across defensive server URL replacement.
+      const legacyBinding =
+        input.legacyBinding ??
+        (serverMatches && creds.clientInformation
+          ? parseAuthorizationServerBinding({ ...creds.clientInformation })
+          : undefined);
 
       // Defensive: Never keep client info bound to a different URL.
-      if (normalizeServerUrlForComparison(creds.serverUrl) !== input.serverUrl) {
+      if (!serverMatches) {
         creds.tokens = undefined;
       }
 
@@ -1560,7 +1620,7 @@ export class McpOauthService {
       }
 
       creds.serverUrl = input.serverUrl;
-      creds.clientInformation = input.clientInformation;
+      creds.clientInformation = { ...input.clientInformation, ...legacyBinding };
       creds.updatedAtMs = Date.now();
 
       await this.persistStoreLocked(store);


### PR DESCRIPTION
Fixes #3823

## Summary

Newly issued or refreshed MCP OAuth credentials now carry the legacy `@ai-sdk/mcp` `authorization_server`/`token_endpoint` binding pair alongside the SDK v2 `issuer` stamp, so downgrading Mux to an `@ai-sdk/mcp`-based version no longer forces an interactive re-login per MCP server.

## Background

PR #3822 migrated the MCP client to the official `@modelcontextprotocol` SDK v2. Its `saveTokens()`/`saveClientInformation()` persist the SDK-supplied objects wholesale, and SDK v2 objects carry only the v2 `issuer` stamp, never the legacy binding pair that `@ai-sdk/mcp`'s `auth()` requires before it will use a stored `refresh_token`. Worse than the issue states: a background token refresh on a pre-v2 credential replaced `creds.tokens` wholesale and wiped an existing binding pair from disk. Codex flagged this as a P1 on #3822 (deferred there because downgrade compatibility was out of scope for the migration): https://github.com/coder/mux/pull/3822#discussion_r3743928013

## Implementation

- Both OAuth providers (interactive flow + background refresh) now implement the SDK's `saveDiscoveryState` hook, caching the discovery result in memory (on the flow object / in the provider closure). Only the write hook is implemented; the `discoveryState()` read-back is intentionally omitted so SDK discovery behavior is unchanged.
- `saveTokens()`/`saveClientInformation()` accept an optional legacy binding derived from that discovery state (`authorizationServerUrl` + `authorizationServerMetadata.token_endpoint`, atomic pair or nothing) and stamp it onto the persisted object without touching the v2 `issuer`.
- When no fresh binding is available (e.g. metadata discovery failed), a pre-existing complete pair on the old entry is preserved instead of being wiped. Preservation is skipped when the defensive server-URL-mismatch branch fires, since old bindings for a different server must not leak onto new credentials.

## Validation

- New behavioral store tests drive the real service through the public provider seam and assert the persisted `mcp-oauth.json`: fresh stamping from discovery state, refresh preserving an existing pair (fails on main, the refresh-wipe regression), `saveClientInformation` stamping, and partial discovery never producing a half-pair.
- Dogfood UAT recorded as not applicable: persistence-layer fix with no UI surface (explicit opt-out); the credential-store unit tests are the acceptance evidence.

## Risks

Low. Scope is limited to the two credential-save paths in `mcpOauthService.ts`; the stamped fields are already round-tripped by the store parser and ignored by SDK v2. Worst case regression is a malformed binding pair on saved credentials, which the existing self-healing read path (`parseAuthorizationServerBinding`) drops as a pair.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
