### PR TITLE
🤖 fix: map Copilot Responses function-call SSE events

### DIFF
--- a/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
@@ -751,4 +751,499 @@ describe("CopilotResponsesLanguageModel", () => {
     expect(parts.map((part) => part.type)).toEqual(["stream-start", "response-metadata", "error"]);
     expect(parts[2].type).toBe("error");
   });
+
+  it("maps function-call SSE events to tool stream parts", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_tool", created_at: 1_710_000_050, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_1",
+                  call_id: "call_1",
+                  name: "get_weather",
+                },
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "fc_1",
+                delta: '{"city":',
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "fc_1",
+                delta: '"Berlin"}',
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                type: "response.function_call_arguments.done",
+                output_index: 0,
+                item_id: "fc_1",
+                arguments: '{"city":"Berlin"}',
+              },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_1",
+                  call_id: "call_1",
+                  name: "get_weather",
+                  arguments: '{"city":"Berlin"}',
+                },
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 5, output_tokens: 9, total_tokens: 14 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "weather?" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    // The done events (arguments.done + output_item.done) must finalize once:
+    // exactly one tool-input-end and one tool-call.
+    expect(parts.map((part) => part.type)).toEqual([
+      "stream-start",
+      "response-metadata",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-delta",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+    expect(parts[2]).toEqual({ type: "tool-input-start", id: "call_1", toolName: "get_weather" });
+    expect(parts[3]).toEqual({ type: "tool-input-delta", id: "call_1", delta: '{"city":' });
+    expect(parts[4]).toEqual({ type: "tool-input-delta", id: "call_1", delta: '"Berlin"}' });
+    expect(parts[5]).toEqual({ type: "tool-input-end", id: "call_1" });
+    expect(parts[6]).toEqual({
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "get_weather",
+      input: '{"city":"Berlin"}',
+    });
+    expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: "tool-calls" });
+  });
+
+  it("interleaves text and tool-call parts from a mixed stream", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_mixed", created_at: 1_710_000_060, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { type: "message", id: "msg_1" },
+              },
+            },
+            {
+              event: "response.output_text.delta",
+              data: {
+                type: "response.output_text.delta",
+                output_index: 0,
+                content_index: 0,
+                item_id: "msg_1",
+                delta: "Checking the weather.",
+              },
+            },
+            {
+              event: "response.output_text.done",
+              data: {
+                type: "response.output_text.done",
+                output_index: 0,
+                content_index: 0,
+                item_id: "msg_1",
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 1,
+                item: {
+                  type: "function_call",
+                  id: "fc_2",
+                  call_id: "call_2",
+                  name: "get_weather",
+                },
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 1,
+                item_id: "fc_2",
+                delta: '{"city":"Paris"}',
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                type: "response.function_call_arguments.done",
+                output_index: 1,
+                item_id: "fc_2",
+                arguments: '{"city":"Paris"}',
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 4, output_tokens: 6, total_tokens: 10 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "weather?" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "stream-start",
+      "response-metadata",
+      "text-start",
+      "text-delta",
+      "text-end",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+    expect(parts[3]).toEqual({
+      type: "text-delta",
+      id: "text-0-0",
+      delta: "Checking the weather.",
+    });
+    expect(parts[8]).toEqual({
+      type: "tool-call",
+      toolCallId: "call_2",
+      toolName: "get_weather",
+      input: '{"city":"Paris"}',
+    });
+    expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: "tool-calls" });
+  });
+
+  it("routes interleaved argument deltas to the correct tool call", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_multi", created_at: 1_710_000_070, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "lookup_user" },
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 1,
+                item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "lookup_org" },
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "fc_a",
+                delta: '{"id":',
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 1,
+                item_id: "fc_b",
+                delta: '{"org":',
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "fc_a",
+                delta: "7}",
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 1,
+                item_id: "fc_b",
+                delta: '"acme"}',
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                type: "response.function_call_arguments.done",
+                output_index: 0,
+                item_id: "fc_a",
+                arguments: '{"id":7}',
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                type: "response.function_call_arguments.done",
+                output_index: 1,
+                item_id: "fc_b",
+                arguments: '{"org":"acme"}',
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 3, output_tokens: 8, total_tokens: 11 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "who?" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    const deltas = parts.filter(
+      (part): part is Extract<LanguageModelV2StreamPart, { type: "tool-input-delta" }> =>
+        part.type === "tool-input-delta"
+    );
+    expect(deltas.map((part) => ({ id: part.id, delta: part.delta }))).toEqual([
+      { id: "call_a", delta: '{"id":' },
+      { id: "call_b", delta: '{"org":' },
+      { id: "call_a", delta: "7}" },
+      { id: "call_b", delta: '"acme"}' },
+    ]);
+
+    const toolCalls = parts.filter(
+      (part): part is Extract<LanguageModelV2StreamPart, { type: "tool-call" }> =>
+        part.type === "tool-call"
+    );
+    expect(toolCalls).toEqual([
+      { type: "tool-call", toolCallId: "call_a", toolName: "lookup_user", input: '{"id":7}' },
+      { type: "tool-call", toolCallId: "call_b", toolName: "lookup_org", input: '{"org":"acme"}' },
+    ]);
+    expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: "tool-calls" });
+  });
+
+  it("falls back to accumulated argument deltas when the done event omits arguments", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_acc", created_at: 1_710_000_080, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.output_item.added",
+              data: {
+                type: "response.output_item.added",
+                output_index: 0,
+                item: { type: "function_call", id: "fc_3", call_id: "call_3", name: "run_query" },
+              },
+            },
+            {
+              event: "response.function_call_arguments.delta",
+              data: {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "fc_3",
+                delta: '{"q":"a"}',
+              },
+            },
+            {
+              event: "response.function_call_arguments.done",
+              data: {
+                type: "response.function_call_arguments.done",
+                output_index: 0,
+                item_id: "fc_3",
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 2, output_tokens: 3, total_tokens: 5 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "query" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "stream-start",
+      "response-metadata",
+      "tool-input-start",
+      "tool-input-delta",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+    expect(parts[5]).toEqual({
+      type: "tool-call",
+      toolCallId: "call_3",
+      toolName: "run_query",
+      input: '{"q":"a"}',
+    });
+  });
+
+  it("keeps the non-tool finish mapping when no function call was seen", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_plain", created_at: 1_710_000_090, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "plain" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts.at(-1)).toMatchObject({ type: "finish", finishReason: "other" });
+  });
+
+  it("returns tool-call content for function_call output items in doGenerate", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createJsonResponse({
+            id: "resp_gen",
+            created_at: 1_710_000_100,
+            model: "copilot-test",
+            output: [
+              {
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "Looking that up." }],
+              },
+              {
+                type: "function_call",
+                id: "fc_gen",
+                call_id: "call_gen",
+                name: "get_weather",
+                arguments: '{"city":"Oslo"}',
+              },
+            ],
+            usage: { input_tokens: 6, output_tokens: 4, total_tokens: 10 },
+          })
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doGenerate({
+      prompt: [{ role: "user", content: [{ type: "text", text: "weather?" }] }],
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: "Looking that up." },
+      {
+        type: "tool-call",
+        toolCallId: "call_gen",
+        toolName: "get_weather",
+        input: '{"city":"Oslo"}',
+      },
+    ]);
+    expect(result.finishReason).toBe("tool-calls");
+  });
 });

--- a/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.test.ts
@@ -1169,6 +1169,67 @@ describe("CopilotResponsesLanguageModel", () => {
     });
   });
 
+  it("emits a full tool lifecycle for a done-only function_call stream", async () => {
+    restoreFetchers.push(
+      mockFetch(() =>
+        Promise.resolve(
+          createSseResponse([
+            {
+              event: "response.created",
+              data: {
+                type: "response.created",
+                response: { id: "resp_done", created_at: 1_710_000_085, model: "copilot-test" },
+              },
+            },
+            {
+              event: "response.output_item.done",
+              data: {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: {
+                  type: "function_call",
+                  id: "fc_4",
+                  call_id: "call_4",
+                  name: "get_time",
+                  arguments: '{"tz":"UTC"}',
+                },
+              },
+            },
+            {
+              event: "response.completed",
+              data: {
+                type: "response.completed",
+                response: { usage: { input_tokens: 2, output_tokens: 2, total_tokens: 4 } },
+              },
+            },
+          ])
+        )
+      )
+    );
+
+    const model = createModel();
+    const result = await model.doStream({
+      prompt: [{ role: "user", content: [{ type: "text", text: "time?" }] }],
+    });
+    const parts = await collectStreamParts(result.stream);
+
+    expect(parts.map((part) => part.type)).toEqual([
+      "stream-start",
+      "response-metadata",
+      "tool-input-start",
+      "tool-input-end",
+      "tool-call",
+      "finish",
+    ]);
+    expect(parts[2]).toEqual({ type: "tool-input-start", id: "call_4", toolName: "get_time" });
+    expect(parts[4]).toEqual({
+      type: "tool-call",
+      toolCallId: "call_4",
+      toolName: "get_time",
+      input: '{"tz":"UTC"}',
+    });
+  });
+
   it("keeps the non-tool finish mapping when no function call was seen", async () => {
     restoreFetchers.push(
       mockFetch(() =>

--- a/src/node/services/copilot/copilotResponsesLanguageModel.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.ts
@@ -455,10 +455,21 @@ function mapStreamEvent(event: string, data: JsonRecord, state: StreamState) {
       if (getString(item?.type) !== "function_call") {
         return [];
       }
+      const known = resolveToolCall(data, state);
       // Register on the fly so a done-only stream (no prior added event) still
-      // yields a terminal tool-call part.
-      const call = resolveToolCall(data, state) ?? registerToolCall(data, item, state);
-      return call ? finalizeToolCall(call, getString(item?.arguments), state) : [];
+      // yields a terminal tool-call part, with a matching tool-input-start so
+      // consumers see a complete input lifecycle.
+      const call = known ?? registerToolCall(data, item, state);
+      if (!call) {
+        return [];
+      }
+      const parts = finalizeToolCall(call, getString(item?.arguments), state);
+      return known
+        ? parts
+        : ([
+            { type: "tool-input-start", id: call.toolCallId, toolName: call.toolName },
+            ...parts,
+          ] satisfies LanguageModelV2StreamPart[]);
     }
     case "response.completed":
     case "response.incomplete":

--- a/src/node/services/copilot/copilotResponsesLanguageModel.ts
+++ b/src/node/services/copilot/copilotResponsesLanguageModel.ts
@@ -39,9 +39,14 @@ export class CopilotResponsesLanguageModel implements LanguageModelV2 {
     const response = await this.post(body, options);
     const responseBody = (await response.json()) as JsonRecord;
 
+    const content = extractContent(responseBody);
+
     return {
-      content: extractTextContent(responseBody),
-      finishReason: mapFinishReason(getRawFinishReason(responseBody)),
+      content,
+      finishReason: mapFinishReason(
+        getRawFinishReason(responseBody),
+        content.some((part) => part.type === "tool-call")
+      ),
       usage: mapUsage(responseBody.usage),
       warnings: [],
       request: { body },
@@ -274,12 +279,31 @@ function getReasoningOption(providerOptions: LanguageModelV2CallOptions["provide
   return typeof reasoningEffort === "string" ? { effort: reasoningEffort } : undefined;
 }
 
+interface OngoingToolCall {
+  toolCallId: string;
+  toolName: string;
+  argumentsText: string;
+  finalized: boolean;
+}
+
+interface StreamState {
+  textAliases: Map<string, string>;
+  toolCallsByIndex: Map<number, OngoingToolCall>;
+  toolCallsByItemId: Map<string, OngoingToolCall>;
+  sawFunctionCall: boolean;
+}
+
 async function consumeSseStream(
   source: ReadableStream<Uint8Array>,
   includeRawChunks: boolean,
   controller: ReadableStreamDefaultController<LanguageModelV2StreamPart>
 ) {
-  const aliasRegistry = new Map<string, string>();
+  const state: StreamState = {
+    textAliases: new Map(),
+    toolCallsByIndex: new Map(),
+    toolCallsByItemId: new Map(),
+    sawFunctionCall: false,
+  };
   const reader = source.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -296,14 +320,14 @@ async function consumeSseStream(
         const frame = buffer.slice(0, boundary);
         buffer = buffer.slice(boundary + 2);
         sawTerminalEvent =
-          processFrame(frame, aliasRegistry, includeRawChunks, controller) || sawTerminalEvent;
+          processFrame(frame, state, includeRawChunks, controller) || sawTerminalEvent;
         boundary = buffer.indexOf("\n\n");
       }
 
       if (done) {
         if (buffer.trim().length > 0) {
           sawTerminalEvent =
-            processFrame(buffer, aliasRegistry, includeRawChunks, controller) || sawTerminalEvent;
+            processFrame(buffer, state, includeRawChunks, controller) || sawTerminalEvent;
         }
         if (!sawTerminalEvent) {
           controller.enqueue({ type: "error", error: createStreamTruncatedError() });
@@ -321,7 +345,7 @@ async function consumeSseStream(
 
 function processFrame(
   frame: string,
-  aliasRegistry: Map<string, string>,
+  state: StreamState,
   includeRawChunks: boolean,
   controller: ReadableStreamDefaultController<LanguageModelV2StreamPart>
 ): boolean {
@@ -335,7 +359,7 @@ function processFrame(
   }
 
   let sawTerminalEvent = false;
-  for (const part of mapStreamEvent(parsed.event, parsed.data, aliasRegistry)) {
+  for (const part of mapStreamEvent(parsed.event, parsed.data, state)) {
     sawTerminalEvent = part.type === "finish" || part.type === "error" || sawTerminalEvent;
     controller.enqueue(part);
   }
@@ -371,7 +395,7 @@ function parseSseFrame(frame: string) {
   return { event, data: JSON.parse(rawData) as JsonRecord };
 }
 
-function mapStreamEvent(event: string, data: JsonRecord, aliasRegistry: Map<string, string>) {
+function mapStreamEvent(event: string, data: JsonRecord, state: StreamState) {
   const type = getString(data.type) ?? event;
   switch (type) {
     case "response.created":
@@ -385,22 +409,56 @@ function mapStreamEvent(event: string, data: JsonRecord, aliasRegistry: Map<stri
       ] satisfies LanguageModelV2StreamPart[];
     case "response.output_item.added": {
       const item = data.item as JsonRecord | undefined;
-      if (getString(item?.type) !== "message") {
+      const itemType = getString(item?.type);
+      if (itemType === "function_call") {
+        const call = registerToolCall(data, item, state);
+        return call
+          ? ([
+              { type: "tool-input-start", id: call.toolCallId, toolName: call.toolName },
+            ] satisfies LanguageModelV2StreamPart[])
+          : [];
+      }
+      if (itemType !== "message") {
         return [];
       }
-      const id = resolveStableTextId(data, aliasRegistry, getString(item?.id));
+      const id = resolveStableTextId(data, state.textAliases, getString(item?.id));
       return id ? ([{ type: "text-start", id }] satisfies LanguageModelV2StreamPart[]) : [];
     }
     case "response.output_text.delta": {
-      const id = resolveStableTextId(data, aliasRegistry, getString(data.item_id));
+      const id = resolveStableTextId(data, state.textAliases, getString(data.item_id));
       const delta = getString(data.delta);
       return id && delta !== undefined
         ? ([{ type: "text-delta", id, delta }] satisfies LanguageModelV2StreamPart[])
         : [];
     }
     case "response.output_text.done": {
-      const id = resolveStableTextId(data, aliasRegistry, getString(data.item_id));
+      const id = resolveStableTextId(data, state.textAliases, getString(data.item_id));
       return id ? ([{ type: "text-end", id }] satisfies LanguageModelV2StreamPart[]) : [];
+    }
+    case "response.function_call_arguments.delta": {
+      const call = resolveToolCall(data, state);
+      const delta = getString(data.delta);
+      if (!call || call.finalized || delta === undefined) {
+        return [];
+      }
+      call.argumentsText += delta;
+      return [
+        { type: "tool-input-delta", id: call.toolCallId, delta },
+      ] satisfies LanguageModelV2StreamPart[];
+    }
+    case "response.function_call_arguments.done": {
+      const call = resolveToolCall(data, state);
+      return call ? finalizeToolCall(call, getString(data.arguments), state) : [];
+    }
+    case "response.output_item.done": {
+      const item = data.item as JsonRecord | undefined;
+      if (getString(item?.type) !== "function_call") {
+        return [];
+      }
+      // Register on the fly so a done-only stream (no prior added event) still
+      // yields a terminal tool-call part.
+      const call = resolveToolCall(data, state) ?? registerToolCall(data, item, state);
+      return call ? finalizeToolCall(call, getString(item?.arguments), state) : [];
     }
     case "response.completed":
     case "response.incomplete":
@@ -408,7 +466,7 @@ function mapStreamEvent(event: string, data: JsonRecord, aliasRegistry: Map<stri
         {
           type: "finish",
           usage: mapUsage((data.response as JsonRecord | undefined)?.usage),
-          finishReason: mapFinishReason(getRawFinishReason(data.response)),
+          finishReason: mapFinishReason(getRawFinishReason(data.response), state.sawFunctionCall),
         },
       ] satisfies LanguageModelV2StreamPart[];
     case "response.failed":
@@ -437,6 +495,60 @@ function createResponseFailedError(data: JsonRecord) {
   );
 }
 
+function registerToolCall(data: JsonRecord, item: JsonRecord | undefined, state: StreamState) {
+  const toolCallId = getString(item?.call_id);
+  const toolName = getString(item?.name);
+  if (toolCallId === undefined || toolName === undefined) {
+    return undefined;
+  }
+
+  const call: OngoingToolCall = { toolCallId, toolName, argumentsText: "", finalized: false };
+  const outputIndex = getNumber(data.output_index);
+  if (outputIndex !== undefined) {
+    state.toolCallsByIndex.set(outputIndex, call);
+  }
+  const itemId = getString(item?.id);
+  if (itemId !== undefined) {
+    state.toolCallsByItemId.set(itemId, call);
+  }
+  return call;
+}
+
+function resolveToolCall(data: JsonRecord, state: StreamState) {
+  const outputIndex = getNumber(data.output_index);
+  if (outputIndex !== undefined) {
+    const call = state.toolCallsByIndex.get(outputIndex);
+    if (call) {
+      return call;
+    }
+  }
+
+  const itemId = getString(data.item_id) ?? getString((data.item as JsonRecord | undefined)?.id);
+  return itemId !== undefined ? state.toolCallsByItemId.get(itemId) : undefined;
+}
+
+function finalizeToolCall(
+  call: OngoingToolCall,
+  completeArguments: string | undefined,
+  state: StreamState
+): LanguageModelV2StreamPart[] {
+  if (call.finalized) {
+    return [];
+  }
+  call.finalized = true;
+  state.sawFunctionCall = true;
+
+  return [
+    { type: "tool-input-end", id: call.toolCallId },
+    {
+      type: "tool-call",
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      input: completeArguments ?? call.argumentsText,
+    },
+  ];
+}
+
 function resolveStableTextId(
   data: JsonRecord,
   aliasRegistry: Map<string, string>,
@@ -458,17 +570,33 @@ function resolveStableTextId(
   return undefined;
 }
 
-function extractTextContent(responseBody: JsonRecord): LanguageModelV2Content[] {
+function extractContent(responseBody: JsonRecord): LanguageModelV2Content[] {
   const output = Array.isArray(responseBody.output) ? responseBody.output : [];
   const content: LanguageModelV2Content[] = [];
 
   for (const item of output) {
-    const message = item as JsonRecord;
-    if (getString(message.type) !== "message" || !Array.isArray(message.content)) {
+    const outputItem = item as JsonRecord;
+    const itemType = getString(outputItem.type);
+
+    if (itemType === "function_call") {
+      const toolCallId = getString(outputItem.call_id);
+      const toolName = getString(outputItem.name);
+      if (toolCallId !== undefined && toolName !== undefined) {
+        content.push({
+          type: "tool-call",
+          toolCallId,
+          toolName,
+          input: getString(outputItem.arguments) ?? "{}",
+        });
+      }
       continue;
     }
 
-    for (const part of message.content) {
+    if (itemType !== "message" || !Array.isArray(outputItem.content)) {
+      continue;
+    }
+
+    for (const part of outputItem.content) {
       const textPart = part as JsonRecord;
       if (getString(textPart.type) === "output_text" && typeof textPart.text === "string") {
         content.push({ type: "text", text: textPart.text });
@@ -504,7 +632,12 @@ function getRawFinishReason(value: unknown) {
   );
 }
 
-function mapFinishReason(reason: unknown): LanguageModelV2FinishReason {
+function mapFinishReason(reason: unknown, hasFunctionCall: boolean): LanguageModelV2FinishReason {
+  // The Responses API reports completion via status, not finish_reason, so a
+  // tool-calling turn typically ends with no raw reason at all.
+  if (reason === undefined && hasFunctionCall) {
+    return "tool-calls";
+  }
   switch (reason) {
     case "stop":
       return "stop";


### PR DESCRIPTION
## Summary

`CopilotResponsesLanguageModel` sent function tools in outbound Responses requests but silently dropped every function-call event from the response stream, so Copilot Responses models could never actually invoke tools. This maps the standard OpenAI Responses function-call SSE events to AI SDK tool stream parts and fixes the non-streaming path too.

Fixes #3771

## Background

`mapStreamEvent()` handled only message/text and terminal events: `response.output_item.added` returned no parts unless the item was a `message`, and there were no cases for `response.function_call_arguments.delta`/`.done` or `response.output_item.done`. `doGenerate`'s content extraction likewise ignored `function_call` output items. Related routing work (#3769) is intentionally out of scope.

## Implementation

Mirrors `@ai-sdk/openai`'s Responses mapping:

- `output_item.added` with `item.type === "function_call"` registers the call (keyed by `output_index`, with `item_id` fallback) and emits `tool-input-start`.
- `function_call_arguments.delta` emits `tool-input-delta` and accumulates the delta.
- `function_call_arguments.done` and `output_item.done` both finalize: whichever arrives first emits `tool-input-end` + the terminal `tool-call` part (input prefers the event's complete arguments string, falling back to accumulated deltas); the other is a no-op. A done-only stream still registers on the fly.
- `response.completed` with no raw finish reason after a function call maps to `tool-calls` (the Responses API reports completion via status, not `finish_reason`); text-only behavior is unchanged.
- `doGenerate` now returns `tool-call` content for `function_call` output items in output order, with the same finish-reason rule.

## Validation

- New behavioral tests with synthetic SSE fixtures: single tool call with dedupe across both done events, tool call interleaved with text, two tool calls with interleaved argument deltas, accumulated-delta fallback when `done` omits `arguments`, `doGenerate` tool-call content, and a no-tool finish-reason regression guard.
- No live Copilot calls (no credentials available); synthetic-SSE unit tests are the acceptance evidence per the issue's documented UAT opt-out.
- `make static-check-full` green locally.

## Risks

Low and contained to the Copilot Responses adapter. The main behavior change is the finish-reason mapping when a function call was seen; text-only streams keep the existing mapping (guarded by a regression test).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
