### PR TITLE
🤖 fix: share gitconfig with non-root Docker container users

### DIFF
--- a/src/node/runtime/DockerRuntime.test.ts
+++ b/src/node/runtime/DockerRuntime.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
-import { DockerRuntime, getContainerName } from "./DockerRuntime";
-import type { InitLogger } from "./Runtime";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { DockerRuntime, getContainerName, type DockerRuntimeConfig } from "./DockerRuntime";
+import type { ExecOptions, ExecStream, InitLogger, WorkspaceInitParams } from "./Runtime";
 
 const noopInitLogger: InitLogger = {
   logStep: () => {
@@ -17,12 +20,98 @@ const noopInitLogger: InitLogger = {
   },
 };
 
-/**
- * DockerRuntime constructor tests (run with bun test)
- *
- * Note: Docker workspace operation tests require Docker
- * and should be in tests/runtime/runtime.test.ts
- */
+interface ContainerUserFixture {
+  uid: string;
+  gid: string;
+  home: string;
+}
+
+interface ExecCall {
+  command: string;
+  options: ExecOptions;
+  stdinChunks: Uint8Array[];
+}
+
+function createTextStream(text = ""): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(text);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (encoded.byteLength > 0) {
+        controller.enqueue(encoded);
+      }
+      controller.close();
+    },
+  });
+}
+
+class CredentialTestDockerRuntime extends DockerRuntime {
+  readonly log: string[] = [];
+  readonly execCalls: ExecCall[] = [];
+
+  constructor(
+    config: DockerRuntimeConfig,
+    private readonly userFixture: ContainerUserFixture
+  ) {
+    super(config);
+  }
+
+  protected override checkExistingContainer(
+    _containerName: string,
+    _workspacePath: string,
+    _branchName: string
+  ): Promise<{ action: "skip" }> {
+    this.log.push("checkExistingContainer");
+    return Promise.resolve({ action: "skip" });
+  }
+
+  protected override detectContainerUser(
+    _containerName: string,
+    _abortSignal?: AbortSignal
+  ): Promise<ContainerUserFixture> {
+    this.log.push("detectContainerUser");
+    return Promise.resolve(this.userFixture);
+  }
+
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    const call: ExecCall = { command, options, stdinChunks: [] };
+    this.log.push(`exec:${command}`);
+    this.execCalls.push(call);
+
+    return Promise.resolve({
+      stdout: createTextStream(),
+      stderr: createTextStream(),
+      stdin: new WritableStream<Uint8Array>({
+        write(chunk) {
+          call.stdinChunks.push(chunk.slice());
+        },
+      }),
+      exitCode: Promise.resolve(0),
+      duration: Promise.resolve(0),
+    });
+  }
+}
+
+function buildPostCreateSetupParams(
+  overrides: Partial<WorkspaceInitParams> = {}
+): WorkspaceInitParams {
+  return {
+    projectPath: "/tmp/project",
+    branchName: "feature",
+    trunkBranch: "main",
+    workspacePath: "/src",
+    initLogger: noopInitLogger,
+    ...overrides,
+  };
+}
+
+function getGitconfigWriteCall(runtime: CredentialTestDockerRuntime): ExecCall | undefined {
+  return runtime.execCalls.find((call) => call.command.includes(".gitconfig"));
+}
+
+function getGhSetupCall(runtime: CredentialTestDockerRuntime): ExecCall | undefined {
+  return runtime.execCalls.find((call) => call.command.includes("gh auth setup-git"));
+}
+
 describe("DockerRuntime constructor", () => {
   it("should accept image name", () => {
     expect(() => {
@@ -54,6 +143,117 @@ describe("DockerRuntime constructor", () => {
     });
     expect(runtime.getImage()).toBe("ubuntu:22.04");
     // Runtime should be ready for exec operations without calling createWorkspace
+  });
+});
+
+describe("DockerRuntime.postCreateSetup credentials", () => {
+  let originalHome: string | undefined;
+  let originalGhToken: string | undefined;
+  let tempHome: string;
+  let hostGitconfigContents: Buffer;
+
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    originalGhToken = process.env.GH_TOKEN;
+    delete process.env.GH_TOKEN;
+
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "mux-docker-credentials-"));
+    hostGitconfigContents = Buffer.from("[user]\n\tname = Mux Test\n");
+    await fs.writeFile(path.join(tempHome, ".gitconfig"), hostGitconfigContents);
+    process.env.HOME = tempHome;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalGhToken === undefined) {
+      delete process.env.GH_TOKEN;
+    } else {
+      process.env.GH_TOKEN = originalGhToken;
+    }
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it("detects and caches a non-root user before writing gitconfig to its home", async () => {
+    const runtime = new CredentialTestDockerRuntime(
+      { image: "codercom/enterprise-base", containerName: "mux-test", shareCredentials: true },
+      { uid: "1000", gid: "1000", home: "/home/coder" }
+    );
+
+    await runtime.postCreateSetup(buildPostCreateSetupParams());
+
+    const writeCall = getGitconfigWriteCall(runtime);
+    expect(writeCall).toBeDefined();
+    expect(runtime.log.indexOf("detectContainerUser")).toBeLessThan(
+      runtime.log.findIndex((entry) => entry.includes(".gitconfig"))
+    );
+    expect(writeCall?.command).toContain("$HOME/.gitconfig");
+    expect(writeCall?.command).not.toContain("/root/.gitconfig");
+    expect(runtime.log.some((entry) => entry.includes("docker cp"))).toBe(false);
+    expect([...Buffer.concat(writeCall?.stdinChunks ?? [])]).toEqual([...hostGitconfigContents]);
+    expect(await runtime.resolvePath("~")).toBe("/home/coder");
+  });
+
+  it("preserves root container home behavior", async () => {
+    const runtime = new CredentialTestDockerRuntime(
+      { image: "ubuntu:22.04", containerName: "mux-test", shareCredentials: true },
+      { uid: "0", gid: "0", home: "/root" }
+    );
+
+    await runtime.postCreateSetup(buildPostCreateSetupParams());
+
+    const writeCall = getGitconfigWriteCall(runtime);
+    expect(writeCall?.command).toContain("$HOME/.gitconfig");
+    expect([...Buffer.concat(writeCall?.stdinChunks ?? [])]).toEqual([...hostGitconfigContents]);
+    expect(await runtime.resolvePath("~")).toBe("/root");
+  });
+
+  it("runs gh credential setup after user detection when a token is provided", async () => {
+    const runtime = new CredentialTestDockerRuntime(
+      { image: "ubuntu:22.04", containerName: "mux-test", shareCredentials: true },
+      { uid: "1000", gid: "1000", home: "/home/coder" }
+    );
+
+    await runtime.postCreateSetup(buildPostCreateSetupParams({ env: { GH_TOKEN: "test-token" } }));
+
+    const ghCall = getGhSetupCall(runtime);
+    expect(ghCall).toBeDefined();
+    expect(runtime.log.indexOf("detectContainerUser")).toBeLessThan(
+      runtime.log.findIndex((entry) => entry.includes("gh auth setup-git"))
+    );
+    expect(ghCall?.options.env).toEqual({ GH_TOKEN: "test-token" });
+  });
+
+  it("does not run gh credential setup without a token", async () => {
+    const runtime = new CredentialTestDockerRuntime(
+      { image: "ubuntu:22.04", containerName: "mux-test", shareCredentials: true },
+      { uid: "1000", gid: "1000", home: "/home/coder" }
+    );
+
+    await runtime.postCreateSetup(buildPostCreateSetupParams());
+
+    expect(getGhSetupCall(runtime)).toBeUndefined();
+  });
+
+  it("skips credential commands when credential sharing is disabled or absent", async () => {
+    for (const shareCredentials of [false, undefined]) {
+      const runtime = new CredentialTestDockerRuntime(
+        {
+          image: "ubuntu:22.04",
+          containerName: "mux-test",
+          ...(shareCredentials === undefined ? {} : { shareCredentials }),
+        },
+        { uid: "1000", gid: "1000", home: "/home/coder" }
+      );
+
+      await runtime.postCreateSetup(buildPostCreateSetupParams());
+
+      expect(getGitconfigWriteCall(runtime)).toBeUndefined();
+      expect(getGhSetupCall(runtime)).toBeUndefined();
+    }
   });
 });
 

--- a/src/node/runtime/DockerRuntime.test.ts
+++ b/src/node/runtime/DockerRuntime.test.ts
@@ -147,10 +147,10 @@ describe("DockerRuntime constructor", () => {
 });
 
 describe("DockerRuntime.postCreateSetup credentials", () => {
+  const hostGitconfigContents = Buffer.from("[user]\n\tname = Mux Test\n");
   let originalHome: string | undefined;
   let originalGhToken: string | undefined;
   let tempHome: string;
-  let hostGitconfigContents: Buffer;
 
   beforeEach(async () => {
     originalHome = process.env.HOME;
@@ -158,7 +158,6 @@ describe("DockerRuntime.postCreateSetup credentials", () => {
     delete process.env.GH_TOKEN;
 
     tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "mux-docker-credentials-"));
-    hostGitconfigContents = Buffer.from("[user]\n\tname = Mux Test\n");
     await fs.writeFile(path.join(tempHome, ".gitconfig"), hostGitconfigContents);
     process.env.HOME = tempHome;
   });
@@ -192,7 +191,6 @@ describe("DockerRuntime.postCreateSetup credentials", () => {
     );
     expect(writeCall?.command).toContain("$HOME/.gitconfig");
     expect(writeCall?.command).not.toContain("/root/.gitconfig");
-    expect(runtime.log.some((entry) => entry.includes("docker cp"))).toBe(false);
     expect([...Buffer.concat(writeCall?.stdinChunks ?? [])]).toEqual([...hostGitconfigContents]);
     expect(await runtime.resolvePath("~")).toBe("/home/coder");
   });

--- a/src/node/runtime/DockerRuntime.ts
+++ b/src/node/runtime/DockerRuntime.ts
@@ -35,8 +35,7 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { syncProjectViaGitBundle } from "./gitBundleSync";
 import { GIT_NO_HOOKS_ENV, gitNoHooksPrefix } from "@/node/utils/gitNoHooksEnv";
 import {
-  getHostGitconfigPath,
-  hasHostGitconfig,
+  readHostGitconfig,
   resolveGhToken,
   resolveSshAgentForwarding,
 } from "./credentialForwarding";
@@ -155,7 +154,7 @@ function runSpawnCommand(
 /**
  * Build Docker args for credential sharing.
  * Forwards SSH agent into the container.
- * Note: ~/.gitconfig is copied (not mounted) after container creation so gh can modify it.
+ * Note: ~/.gitconfig is streamed into the container after creation so gh can modify it.
  * Uses agent forwarding only (no ~/.ssh mount) to avoid passphrase/permission issues.
  */
 function buildCredentialArgs(): string[] {
@@ -261,7 +260,7 @@ export interface DockerRuntimeConfig {
    * to allow exec operations without calling createWorkspace again.
    */
   containerName?: string;
-  /** Forward SSH agent and mount ~/.gitconfig read-only into container */
+  /** Forward SSH agent and copy ~/.gitconfig into container */
   shareCredentials?: boolean;
 }
 
@@ -491,7 +490,8 @@ export class DockerRuntime extends RemoteRuntime {
             ? "Container already running (from fork), skipping init hook..."
             : "Container already running (from fork), running init hook..."
         );
-        await this.setupCredentials(containerName, env);
+        await this.ensureContainerUserInfo(containerName, abortSignal);
+        await this.setupCredentials(env, abortSignal);
         return;
       case "cleanup":
         initLogger.logStep(containerCheck.reason);
@@ -553,7 +553,7 @@ export class DockerRuntime extends RemoteRuntime {
    * Check if a container already exists and whether it's valid for reuse.
    * Returns action to take: skip setup, cleanup invalid container, or create new.
    */
-  private async checkExistingContainer(
+  protected async checkExistingContainer(
     containerName: string,
     workspacePath: string,
     branchName: string
@@ -594,7 +594,7 @@ export class DockerRuntime extends RemoteRuntime {
     return { action: "skip" };
   }
 
-  private async detectContainerUser(
+  protected async detectContainerUser(
     containerName: string,
     abortSignal?: AbortSignal
   ): Promise<ContainerUserInfo> {
@@ -609,6 +609,15 @@ export class DockerRuntime extends RemoteRuntime {
       gid: sanitizeContainerUserId(gidResult.stdout),
       home: homeResult.stdout.trim() || "/root",
     };
+  }
+
+  private async ensureContainerUserInfo(
+    containerName: string,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    if (!this.containerHome) {
+      this.storeContainerUserInfo(await this.detectContainerUser(containerName, abortSignal));
+    }
   }
 
   private storeContainerUserInfo(userInfo: ContainerUserInfo): void {
@@ -632,38 +641,50 @@ export class DockerRuntime extends RemoteRuntime {
    * Called for both new containers and reused forked containers.
    */
   private async setupCredentials(
-    containerName: string,
-    env?: Record<string, string>
+    env?: Record<string, string>,
+    abortSignal?: AbortSignal
   ): Promise<void> {
     if (!this.config.shareCredentials) return;
 
-    // Copy host gitconfig into container (not mounted, so gh can modify it).
-    // Use argv-based Docker calls so credential paths/tokens never go through a host shell.
-    if (hasHostGitconfig()) {
-      await runSpawnCommand(
-        "docker",
-        ["cp", getHostGitconfigPath(), `${containerName}:/root/.gitconfig`],
-        10000
-      );
+    if (abortSignal?.aborted) {
+      throw new RuntimeError("Operation aborted before credential setup", "exec");
+    }
+
+    // Copy rather than mount so gh can modify the file. exec runs as the container's
+    // default user, so $HOME and file ownership are correct for non-root images.
+    const gitconfigContents = await readHostGitconfig();
+    if (gitconfigContents) {
+      const stream = await this.exec('cat > "$HOME/.gitconfig"', {
+        cwd: "/",
+        timeout: 30,
+        abortSignal,
+      });
+      const writer = stream.stdin.getWriter();
+      try {
+        await writer.write(gitconfigContents);
+      } finally {
+        writer.releaseLock();
+      }
+      await stream.stdin.close();
+      const exitCode = await stream.exitCode;
+      if (exitCode !== 0) {
+        const stderr = await streamToString(stream.stderr);
+        throw new RuntimeError(`Failed to copy gitconfig: ${stderr}`, "file_io");
+      }
     }
 
     // Configure gh CLI as git credential helper if GH_TOKEN is available
     // GH_TOKEN can come from project secrets (env) or host environment (buildCredentialArgs)
     const ghToken = resolveGhToken(env);
     if (ghToken) {
-      await runSpawnCommand(
-        "docker",
-        [
-          "exec",
-          "-e",
-          `GH_TOKEN=${ghToken}`,
-          containerName,
-          "sh",
-          "-c",
-          "command -v gh >/dev/null && gh auth setup-git || true",
-        ],
-        10000
-      );
+      const stream = await this.exec("command -v gh >/dev/null && gh auth setup-git || true", {
+        cwd: "/",
+        timeout: 30,
+        env: { GH_TOKEN: ghToken },
+        abortSignal,
+      });
+      await stream.stdin.close();
+      await stream.exitCode;
     }
   }
 
@@ -732,7 +753,7 @@ export class DockerRuntime extends RemoteRuntime {
     initLogger.logStep("Container ready");
 
     // Setup credentials (gitconfig + gh auth)
-    await this.setupCredentials(containerName, env);
+    await this.setupCredentials(env, abortSignal);
 
     // 2. Sync project to container using git bundle + docker cp
     initLogger.logStep("Syncing project files to container...");
@@ -1304,9 +1325,7 @@ export class DockerRuntime extends RemoteRuntime {
     }
 
     // Detect container user info if not already set (e.g., runtime recreated for existing workspace)
-    if (!this.containerHome) {
-      this.storeContainerUserInfo(await this.detectContainerUser(this.containerName));
-    }
+    await this.ensureContainerUserInfo(this.containerName);
 
     return { ready: true };
   }

--- a/src/node/runtime/credentialForwarding.ts
+++ b/src/node/runtime/credentialForwarding.ts
@@ -29,12 +29,8 @@ export function resolveGhToken(env?: Record<string, string>): string | null {
   return env?.GH_TOKEN ?? process.env.GH_TOKEN ?? null;
 }
 
-export function getHostGitconfigPath(): string {
-  return path.join(os.homedir(), ".gitconfig");
-}
-
-export function hasHostGitconfig(): boolean {
-  return existsSync(getHostGitconfigPath());
+function getHostGitconfigPath(): string {
+  return path.join(process.env.HOME ?? os.homedir(), ".gitconfig");
 }
 
 export async function readHostGitconfig(): Promise<Buffer | null> {


### PR DESCRIPTION
Part of #3819.

## Summary

`DockerRuntime` now writes the shared host `~/.gitconfig` into the container as the container's default user, targeting that user's `$HOME`, instead of `docker cp`-ing it to a hardcoded `/root/.gitconfig`. Container user info is also detected and cached before credential setup on the container reuse/fork path, matching the fresh-provisioning path.

## Background

Two concrete bugs from #3819:

- `setupCredentials()` copied the host gitconfig to `<container>:/root/.gitconfig`. Images whose default `USER` is non-root (e.g. `coder` in codercom images, `node` in node images) read `$HOME/.gitconfig` and cannot even traverse `/root` (mode 700), so credential sharing silently did nothing for them.
- The reuse/fork branch (`case "skip"` in `postCreateSetup()`) ran credential setup while `this.containerHome` was still undefined; only fresh provisioning detected the container user first, so `~` resolution fell back to `/root` on reused containers.

This PR fixes only these concrete bugs. The broader design question about portability of credential helpers referenced *inside* the copied gitconfig (host-specific helper paths, `gh auth setup-git` reachability, etc.) intentionally remains open in #3819.

## Implementation

- `setupCredentials()` mirrors `DevcontainerRuntime.setupCredentials()`: it streams `readHostGitconfig()` into `this.exec('cat > "$HOME/.gitconfig"')`. `docker exec` runs as the image's default user, so `$HOME` resolves in-container and the file gets that user's ownership; root-user containers still end up with `/root/.gitconfig`. Failures now throw `RuntimeError` (Devcontainer parity) instead of being silently ignored.
- The `gh auth setup-git` step already ran as the default container user (it was not affected by the `/root` bug); it is converted to the same `this.exec` form for parity and testability.
- New `ensureContainerUserInfo()` helper (extracted from `ensureReady()`) detects and caches container user info; the reuse/fork path now calls it before credential setup.
- `getHostGitconfigPath()` prefers `$HOME` over `os.homedir()` (matches git's own config resolution order and keeps the new tests deterministic across platforms); `hasHostGitconfig` is dropped in favor of the existing `readHostGitconfig` and the path helper is no longer exported (DockerRuntime was the only external consumer).
- Tests drive the real `postCreateSetup()` skip path through a subclass with canned exec streams (no Docker daemon): root and non-root home fixtures, detection-before-write ordering, streamed gitconfig bytes, `GH_TOKEN` gating, and `shareCredentials` off.

## Validation

Live smoke test on a real Docker daemon against a non-root image (`FROM node:20` / `USER node`), driving the real `postCreateSetup()`:

- Pre-fix behavior reproduced: `docker cp` to `/root/.gitconfig` is unreadable by the default user (`Permission denied`, `git config --get user.name` empty).
- With this branch, both the fresh-provisioning pass and a second reuse/skip pass (new runtime instance, `containerHome` undefined) produce `/home/node/.gitconfig` owned `node:node`, `git config --get user.name` returns the shared identity as the non-root user, `resolvePath("~")` returns `/home/node` on both paths, and `/root/.gitconfig` is absent.

## Risks

Low and scoped to Docker workspaces with `shareCredentials`. Behavior changes: gitconfig write failures now fail workspace provisioning loudly instead of silently continuing without credentials, and root containers get `$HOME/.gitconfig` resolved in-container (same `/root/.gitconfig` result). The reuse-path user detection adds three cheap `docker exec` calls that fresh provisioning already performed.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
