### PR TITLE
🤖 fix: prevent Copilot Sonnet 4.5 tool-stream hasFinished crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@ai-sdk/deepseek": "^3.0.7",
         "@ai-sdk/google": "^4.0.11",
         "@ai-sdk/moonshotai": "^3.0.15",
-        "@ai-sdk/openai": "^4.0.11",
+        "@ai-sdk/openai": "^4.0.43",
         "@ai-sdk/openai-compatible": "^3.0.7",
         "@ai-sdk/xai": "^4.0.37",
         "@aws-sdk/credential-providers": "^3.940.0",
@@ -233,7 +233,7 @@
 
     "@ai-sdk/moonshotai": ["@ai-sdk/moonshotai@3.0.15", "", { "dependencies": { "@ai-sdk/openai-compatible": "3.0.12", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-R4+UEk1f1+lare2dQ1xK1vOJLXFmKo2wZ/d1wXTCZGOsls2I4KXEgl6oq1rB2PRT6NkvA5DK52fMA9DaeQZoYQ=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2PLnVPBsdJusgquPVYgPWd3ox4lbUFkp7DVUSmM0lQ4VISQoNxdgo6TvFAHgwQn9wJ/ckVYVRLU7+BvHc7T8ww=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@4.0.43", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-O5t21AmcBwsEg/l8ro91CHzdBjEkxtJRFh6DH9KDjRrWDeTMuqJt7XkaFHIqL8H0nvjFv8H7kck+JwirUWPS2g=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@3.0.7", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.7" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-y8RVpm8BZKNHDxlbNVt/GYmoBBqLx10m4d7bOzOnRD8V2aP3Cr6/g/bfubR4EkbW1ySrnPr62svZIeND2fdp3Q=="],
 
@@ -3799,6 +3799,10 @@
 
     "@ai-sdk/moonshotai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ=="],
 
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
+
     "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
     "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
@@ -4396,6 +4400,8 @@
     "zip-stream/archiver-utils": ["archiver-utils@3.0.4", "", { "dependencies": { "glob": "^7.2.3", "graceful-fs": "^4.2.0", "lazystream": "^1.0.0", "lodash.defaults": "^4.2.0", "lodash.difference": "^4.5.0", "lodash.flatten": "^4.4.0", "lodash.isplainobject": "^4.0.6", "lodash.union": "^4.6.0", "normalize-path": "^3.0.0", "readable-stream": "^3.6.0" } }, "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw=="],
 
     "zip-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@ai-sdk/xai/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-rVo9s20dUxtwH6Q6jXJ8B3eS83Nfm1GWQt9p9DQiSx0="; # mux-offline-cache-hash
+            outputHash = "sha256-Kv+ca+RZAcLiZj/Acf0Ugy2oRX07NJ6Ap5F0Sp/p9/A="; # mux-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ai-sdk/deepseek": "^3.0.7",
     "@ai-sdk/google": "^4.0.11",
     "@ai-sdk/moonshotai": "^3.0.15",
-    "@ai-sdk/openai": "^4.0.11",
+    "@ai-sdk/openai": "^4.0.43",
     "@ai-sdk/openai-compatible": "^3.0.7",
     "@ai-sdk/xai": "^4.0.37",
     "@aws-sdk/credential-providers": "^3.940.0",

--- a/src/node/services/providerModelFactory.test.ts
+++ b/src/node/services/providerModelFactory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, spyOn } from "bun:test";
-import { generateText, type Tool } from "ai";
+import { generateText, jsonSchema, streamText, tool, type Tool } from "ai";
 import { xai } from "@ai-sdk/xai";
 import { writeFile } from "node:fs/promises";
 import * as fs from "fs";
@@ -709,6 +709,120 @@ describe("ProviderModelFactory GitHub Copilot", () => {
         expect(result.data.routeProvider).toBe("github-copilot");
         expect(result.data.effectiveModelString).toBe("github-copilot:gpt-5.5");
         expect(result.data.model.constructor.name).toMatch(/OpenAIChatLanguageModel$/);
+      } finally {
+        PROVIDER_REGISTRY.openai = originalOpenAIRegistry;
+      }
+    });
+  });
+
+  it("streams Copilot tool calls whose indexes start above zero", async () => {
+    await withTempConfig(async (config, factory) => {
+      const originalOpenAIRegistry = PROVIDER_REGISTRY.openai;
+
+      saveCopilotConfig(config, ["claude-sonnet-4.5"]);
+
+      PROVIDER_REGISTRY.openai = async () => {
+        const module = await originalOpenAIRegistry();
+        return {
+          ...module,
+          createOpenAI: (options) => {
+            const choiceChunk = (
+              delta: Record<string, unknown>,
+              finishReason: string | null = null
+            ) => ({
+              id: "chatcmpl_test",
+              object: "chat.completion.chunk",
+              created: 1,
+              model: "claude-sonnet-4.5",
+              choices: [{ index: 0, delta, finish_reason: finishReason }],
+            });
+            const chunks = [
+              choiceChunk({
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 1,
+                    id: "call_1",
+                    type: "function",
+                    function: { name: "get_weather", arguments: "" },
+                  },
+                ],
+              }),
+              choiceChunk({
+                tool_calls: [
+                  {
+                    index: 1,
+                    function: { arguments: '{"location":' },
+                  },
+                ],
+              }),
+              choiceChunk({
+                tool_calls: [
+                  {
+                    index: 1,
+                    function: { arguments: '"Paris"}' },
+                  },
+                ],
+              }),
+              choiceChunk({}, "tool_calls"),
+              {
+                id: "chatcmpl_test",
+                object: "chat.completion.chunk",
+                created: 1,
+                model: "claude-sonnet-4.5",
+                choices: [],
+                usage: {
+                  prompt_tokens: 1,
+                  completion_tokens: 1,
+                  total_tokens: 2,
+                },
+              },
+            ];
+            const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}`).join("\n\n")}\n\ndata: [DONE]\n\n`;
+            const mockFetch = Object.assign(
+              () =>
+                Promise.resolve(
+                  new Response(body, { headers: { "content-type": "text/event-stream" } })
+                ),
+              fetch
+            ) as typeof fetch;
+            return module.createOpenAI({ ...options, fetch: mockFetch });
+          },
+        };
+      };
+
+      try {
+        const result = await factory.createModel("github-copilot:claude-sonnet-4.5");
+        expect(result.success).toBe(true);
+        if (!result.success) {
+          return;
+        }
+
+        const stream = streamText({
+          model: result.data,
+          prompt: "What is the weather in Paris?",
+          tools: {
+            get_weather: tool({
+              inputSchema: jsonSchema<{ location: string }>({
+                type: "object",
+                properties: { location: { type: "string" } },
+                required: ["location"],
+                additionalProperties: false,
+              }),
+            }),
+          },
+        });
+        const parts = [];
+        for await (const part of stream.fullStream) {
+          parts.push(part);
+        }
+
+        expect(parts.filter((part) => part.type === "error")).toEqual([]);
+        const toolCallParts = parts.filter((part) => part.type === "tool-call");
+        expect(toolCallParts).toHaveLength(1);
+        expect(toolCallParts[0]?.toolName).toBe("get_weather");
+        expect(toolCallParts[0]?.input).toEqual({ location: "Paris" });
+        expect(parts.find((part) => part.type === "finish")?.finishReason).toBe("tool-calls");
       } finally {
         PROVIDER_REGISTRY.openai = originalOpenAIRegistry;
       }


### PR DESCRIPTION
## Summary

Bumps `@ai-sdk/openai` from `^4.0.11` to `^4.0.43` so Copilot chat-completions streaming uses `@ai-sdk/provider-utils@5.0.27`, which fixes the `TypeError: Cannot read properties of undefined (reading 'hasFinished')` crash on tool-call streams from `github-copilot:claude-sonnet-4.5`. Adds a regression test reproducing Copilot's sparse `tool_calls` index shape.

Fixes #3770

## Background

Copilot chat-completions models are built via `createOpenAI()` (`providerModelFactory.ts`), which resolved `@ai-sdk/provider-utils@5.0.7`. That version's `StreamingToolCallTracker` stores tracked tool calls in a plain array indexed by the SSE `tool_calls[*].index` field. Copilot's Sonnet 4.5 emits indexes that start at 1 (no index 0), creating array holes; `flush()` iterates the array and dereferences `toolCall.hasFinished` on a hole, killing the stream 100% of the time. Upstream fixed the tracker (Map/Set-based) in `provider-utils@5.0.27`.

## Implementation

- `@ai-sdk/openai` `^4.0.11` -> `^4.0.43` (the first version carrying the fix is 4.0.40; 4.0.43 is the latest 4.0.x). The lockfile diff is scoped: only `@ai-sdk/openai` and its exact-pinned `@ai-sdk/provider@4.0.7` / `@ai-sdk/provider-utils@5.0.27` resolutions change; all other `@ai-sdk/*` providers keep their existing `provider-utils@5.0.7` resolution, so the blast radius is the OpenAI/Copilot chat path only.
- Regression test in `providerModelFactory.test.ts`: injects a synthetic chat-completions SSE stream whose `tool_calls` delta uses `index: 1` with no index 0, streams through the real factory-built `github-copilot:claude-sonnet-4.5` model, and asserts no error parts, the assembled `get_weather` call, and `finishReason: "tool-calls"`.
- `flake.nix` offline-cache hash refreshed for the lockfile change.

## Validation

- Red-green: with base deps (`@ai-sdk/openai@4.0.11` / `provider-utils@5.0.7`) the new test fails with `TypeError: undefined is not an object (evaluating 'toolCall.hasFinished')` at `provider-utils` `flush()`; with the bump it passes.
- Full unit suite run on the bump: the only failures also reproduce on base with `package.json`/`bun.lock` restored to HEAD (pre-existing WorkspaceService/TaskService failures on main) or are known suite-order flakes that pass in isolation under both dependency states; no regressions attributable to this change.
- No live Copilot UAT: no Copilot credentials in this environment; the synthetic-SSE red-green regression test is the documented acceptance evidence.

## Risks

Low. The bump moves `@ai-sdk/openai` across patch releases (4.0.11 -> 4.0.43) which also affects direct OpenAI chat/responses usage, but the full provider test suite (113 tests in `providerModelFactory.test.ts`) and unit suite show no behavior drift. Other providers are unaffected by construction (per-package exact pins).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
