### PR TITLE
🤖 fix: route Copilot gpt-5.4 models through the Responses API

### DIFF
--- a/src/common/utils/copilot/modelRouting.test.ts
+++ b/src/common/utils/copilot/modelRouting.test.ts
@@ -27,8 +27,16 @@ describe("isCopilotRoutableModel", () => {
 });
 
 describe("selectCopilotApiMode", () => {
+  it("routes catalog-declared Responses-only models by exact id", () => {
+    expect(selectCopilotApiMode("gpt-5.4-mini")).toBe("responses");
+    expect(selectCopilotApiMode("gpt-5.4")).toBe("responses");
+  });
+
+  it("strips provider prefixes before selecting the API mode", () => {
+    expect(selectCopilotApiMode("github-copilot:gpt-5.4-mini")).toBe("responses");
+  });
+
   it("routes Codex-family models to Responses", () => {
-    // opencode routes a wider GPT-5 set through Responses, but Mux scopes that path to Codex first.
     expect(selectCopilotApiMode("gpt-5.3-codex")).toBe("responses");
     expect(selectCopilotApiMode("gpt-5.1-codex-mini")).toBe("responses");
   });
@@ -36,6 +44,7 @@ describe("selectCopilotApiMode", () => {
   it("routes GPT-5 and other Copilot families to chat completions", () => {
     expect(selectCopilotApiMode("gpt-5.5")).toBe("chatCompletions");
     expect(selectCopilotApiMode("gpt-5.5-pro")).toBe("chatCompletions");
+    expect(selectCopilotApiMode("gpt-5-mini")).toBe("chatCompletions");
     expect(selectCopilotApiMode("claude-opus-4-6")).toBe("chatCompletions");
     expect(selectCopilotApiMode("claude-sonnet-4-6")).toBe("chatCompletions");
     expect(selectCopilotApiMode("gemini-3.1-pro-preview")).toBe("chatCompletions");
@@ -48,6 +57,8 @@ describe("selectCopilotApiMode", () => {
   });
 
   it("keeps lookalike model ids on chat completions too", () => {
+    expect(selectCopilotApiMode("gpt-5.4-mini-preview")).toBe("chatCompletions");
+    expect(selectCopilotApiMode("gpt-5.40")).toBe("chatCompletions");
     expect(selectCopilotApiMode("claude")).toBe("chatCompletions");
     expect(selectCopilotApiMode("gemini-30-experimental")).toBe("chatCompletions");
     expect(selectCopilotApiMode("grok-codec-preview")).toBe("chatCompletions");

--- a/src/common/utils/copilot/modelRouting.ts
+++ b/src/common/utils/copilot/modelRouting.ts
@@ -7,10 +7,18 @@ export function isCopilotRoutableModel(_modelId: string): boolean {
   return true;
 }
 
+// Copilot's catalog marks these models as Responses-only, and chat completions rejects them
+// with unsupported_api_for_model. Use explicit membership because routing has no catalog credentials.
+const COPILOT_RESPONSES_ONLY_MODELS = new Set(["gpt-5.4", "gpt-5.4-mini"]);
+
 export function selectCopilotApiMode(modelId: string): CopilotApiMode {
+  const unprefixedId = modelId.includes(":") ? modelId.slice(modelId.indexOf(":") + 1) : modelId;
+
   // Copilot Codex-family models are proven to work through the custom Responses path.
   // Keep the broader Copilot catalog on chat completions until the upstream parser is reliable.
-  return modelId.includes("-codex") ? "responses" : "chatCompletions";
+  return COPILOT_RESPONSES_ONLY_MODELS.has(unprefixedId) || unprefixedId.includes("-codex")
+    ? "responses"
+    : "chatCompletions";
 }
 
 export function normalizeCopilotModelId(id: string): string {


### PR DESCRIPTION
## Summary

Route GitHub Copilot's `gpt-5.4` and `gpt-5.4-mini` through the Responses API. Copilot's catalog declares these models Responses-only, and posting them to `/chat/completions` fails with HTTP 400 `unsupported_api_for_model`, making them unusable through mux.

Fixes #3769

## Background

`selectCopilotApiMode()` routed only `-codex` model IDs through the Responses path; everything else went to `/chat/completions`. Copilot rejects the `gpt-5.4` family there (`model "gpt-5.4-mini" is not accessible via the /chat/completions endpoint`). The same constraint is independently documented across the ecosystem (LiteLLM #23332, Cherry Studio #13637, LobeHub #13201). A blanket `gpt-5*` rule would be wrong: Copilot's `gpt-5-mini` is chat-completions-only, so membership is explicit.

## Implementation

- `modelRouting.ts`: a static `COPILOT_RESPONSES_ONLY_MODELS` set (`gpt-5.4`, `gpt-5.4-mini`) checked ahead of the existing `-codex` heuristic, after stripping any `provider:` prefix. All other models keep their current routing.
- Why not drive this from the Copilot `/models` catalog's `supported_endpoints`: mux persists only a flat list of model ID strings, fetched once during OAuth login. Persisting capability data would change the store shape (rippling through the config schema and its consumers) and would still leave already-logged-in users without capability data until re-login. The static set fixes everyone immediately; catalog-driven routing can follow if Copilot keeps adding Responses-only models.
- Dependency note: tool-call streaming on the Responses path requires #3880; without it, routed models still stream text correctly. This PR is routing-only and does not touch `copilotResponsesLanguageModel.ts`.

## Validation

- No Copilot credentials are available in this environment, so live verification was not possible; unit tests are the acceptance evidence. The Chat Completions rejection is proven by the issue's evidence; Responses-side acceptance follows the documented catalog constraint (VS Code routes these models via Responses, and the third-party clients above fixed the same bug the same way).
- New unit tests cover: exact-ID Responses routing, provider-prefix stripping, unchanged `-codex` routing, unchanged chat-completions defaults (`gpt-5.5`, `gpt-5-mini`, claude/gemini/grok families), and lookalike IDs (`gpt-5.4-mini-preview`, `gpt-5.40`) staying on chat completions.
- `make static-check-full` green locally.

## Risks

Low. Routing changes for exactly two model IDs; all other models hit the same code paths as before. Worst case for the two IDs is trading one failure mode for another, and until #3880 lands, tool calls on these models will not stream (text works).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
