### PR TITLE
🤖 fix: use platform esbuild binary so poisoned macOS inode can't kill builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ ifeq (,$(filter -j%,$(MAKEFLAGS)))
 MAKEFLAGS += -j
 endif
 
+# Issue #3831: macOS may SIGKILL the copied esbuild inode while the platform binary still execs.
+# ESBUILD_BINARY_PATH is not used because only esbuild's JS API honors it, not the Go CLI.
+ESBUILD_BIN = $(firstword $(wildcard node_modules/@esbuild/*/bin/esbuild) node_modules/esbuild/bin/esbuild)
+
 # Common esbuild flags for CLI API bundle (ESM format for trpc-cli)
 ESBUILD_CLI_FLAGS := --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:jsonc-parser --external:@trpc/server --external:ssh2 --external:cpu-features --banner:js="import{createRequire}from'module';globalThis.require=createRequire(import.meta.url);"
 
@@ -163,7 +167,7 @@ dev: node_modules/.installed build-main build-preload ## Start development serve
 	@bun x concurrently -k \
 		"bun x nodemon --watch src/node/workflowRuntime --ext js --exec 'bun scripts/gen_workflow_runtime_sources.ts'" \
 		"bun x concurrently \"$(TSGO) -w -p tsconfig.main.json\" \"bun x tsc-alias -w -p tsconfig.main.json\"" \
-		'bun x esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
+		'$(ESBUILD_BIN) src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
 		"vite"
 endif
 
@@ -190,7 +194,7 @@ dev-server: node_modules/.installed build-main ## Start server mode with hot rel
 	@# Keep tsgo -> tsc-alias sequential to avoid transient unresolved @/ imports in dist during restarts.
 	@bun x concurrently -k \
 		"bun x nodemon --watch src --watch tsconfig.main.json --watch tsconfig.json --ext ts,tsx,json,js --ignore dist --ignore node_modules --exec 'node scripts/build-main-watch.js'" \
-		'bun x esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
+		'$(ESBUILD_BIN) src/cli/api.ts $(ESBUILD_CLI_FLAGS) --watch' \
 		"bun x nodemon --watch dist/.main-build-complete --delay 300ms --exec 'NODE_ENV=development node dist/cli/index.js server --no-auth --host $(or $(BACKEND_HOST),127.0.0.1) --port $(or $(BACKEND_PORT),3000)'" \
 		"MUX_VITE_HOST=$(or $(VITE_HOST),127.0.0.1) MUX_VITE_PORT=$(or $(VITE_PORT),5173) MUX_VITE_ALLOWED_HOSTS=$(VITE_ALLOWED_HOSTS) MUX_BACKEND_PORT=$(or $(BACKEND_PORT),3000) vite"
 endif
@@ -236,7 +240,7 @@ dist/cli/index.js: src/cli/index.ts src/desktop/main.ts src/cli/server.ts src/ve
 # Build API CLI as ESM bundle (trpc-cli requires ESM with top-level await)
 dist/cli/api.mjs: src/cli/api.ts src/cli/proxifyOrpc.ts $(TS_SOURCES)
 	@echo "Building API CLI (ESM)..."
-	@bun x esbuild src/cli/api.ts $(ESBUILD_CLI_FLAGS)
+	@$(ESBUILD_BIN) src/cli/api.ts $(ESBUILD_CLI_FLAGS)
 
 build-preload: node_modules/.installed dist/preload.js ## Build preload script
 
@@ -290,7 +294,7 @@ dist/runtime/server-bundle.js: build-main $(TS_SOURCES)
 	@echo "Bundling server runtime for Docker..."
 	@test -f dist/cli/server.js
 	@mkdir -p dist/runtime
-	@bun x esbuild dist/cli/server.js $(ESBUILD_SERVER_FLAGS)
+	@$(ESBUILD_BIN) dist/cli/server.js $(ESBUILD_SERVER_FLAGS)
 
 # Bundle tokenizer worker next to server-bundle.js so workerPool resolves it at runtime.
 # Depend on build-main explicitly because tokenizer worker JS is emitted under dist/node/ as a side effect.
@@ -298,7 +302,7 @@ dist/runtime/tokenizer.worker.js: build-main
 	@echo "Bundling tokenizer worker for Docker..."
 	@test -f dist/node/utils/main/tokenizer.worker.js
 	@mkdir -p dist/runtime
-	@bun x esbuild dist/node/utils/main/tokenizer.worker.js $(ESBUILD_TOKENIZER_WORKER_FLAGS)
+	@$(ESBUILD_BIN) dist/node/utils/main/tokenizer.worker.js $(ESBUILD_TOKENIZER_WORKER_FLAGS)
 
 # Docker runtime keeps static assets under dist/static/ for compatibility with existing image layout.
 dist/static/.copied: static/splash.html

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,9 @@ dist/cli/index.js: src/cli/index.ts src/desktop/main.ts src/cli/server.ts src/ve
 	@touch dist/.main-build-complete
 
 # Build API CLI as ESM bundle (trpc-cli requires ESM with top-level await)
-dist/cli/api.mjs: src/cli/api.ts src/cli/proxifyOrpc.ts $(TS_SOURCES)
+# node_modules/.installed is required here: unlike `bun x`, $(ESBUILD_BIN) cannot
+# self-bootstrap, and parallel make would otherwise race this recipe against bun install.
+dist/cli/api.mjs: src/cli/api.ts src/cli/proxifyOrpc.ts $(TS_SOURCES) node_modules/.installed
 	@echo "Building API CLI (ESM)..."
 	@$(ESBUILD_BIN) src/cli/api.ts $(ESBUILD_CLI_FLAGS)
 


### PR DESCRIPTION
## Summary

Resolve the esbuild binary in the Makefile to the platform package (`node_modules/@esbuild/<platform>/bin/esbuild`) instead of going through the copied binary at `node_modules/esbuild/bin/esbuild`, so a macOS signature-cache-poisoned inode can no longer kill dev mode and production builds with an opaque `Killed: 9`.

Fixes #3831

## Background

On macOS, the kernel can SIGKILL `node_modules/esbuild/bin/esbuild` on every exec once that inode's signature-cache entry is poisoned, while the byte-identical platform-package binary execs fine. Every esbuild call site in the Makefile ran through the copied binary via `bun x esbuild` / `npx esbuild`, so one poisoned inode broke `make dev`, `make dev-server`, and all esbuild-dependent build targets.

### Why not `ESBUILD_BINARY_PATH` (the issue's option 1)

`ESBUILD_BINARY_PATH` is honored only by esbuild's JS API (`lib/main.js`); the compiled Go CLI binary ignores it entirely (verified empirically: `ESBUILD_BINARY_PATH=/nonexistent bun x esbuild --version` exits 0). All Makefile call sites are CLI invocations, so a Makefile export would be dead configuration, the same class of bug #3802 just removed.

## Implementation

- New `ESBUILD_BIN = $(firstword $(wildcard node_modules/@esbuild/*/bin/esbuild) node_modules/esbuild/bin/esbuild)`. Recursive `=` (not `:=`) so the glob resolves at recipe time, after the `node_modules/.installed` prerequisite has run; falls back to the copied shim if the glob is empty. Package managers install exactly one host-matching platform package, so the wildcard is unambiguous.
- All 5 Unix call sites (`dev`, `dev-server`, `dist/cli/api.mjs`, `dist/runtime/server-bundle.js`, `dist/runtime/tokenizer.worker.js`) now invoke `$(ESBUILD_BIN)` directly.
- Windows branches (`npx esbuild` under `ifeq ($(OS),Windows_NT)`) are deliberately unchanged: the Windows platform package has a different layout (`esbuild.exe`, no `bin/`), and the macOS inode issue does not apply there.
- The issue's option 3 (self-healing preflight in `node_modules/.installed`) was skipped: with every Makefile call site bypassing the copied binary, it would add install-flow complexity with no remaining Makefile consumer.

## Validation

- `make -n dist/cli/api.mjs` shows the resolved command is `node_modules/@esbuild/linux-x64/bin/esbuild ...` (platform package, not `bun x esbuild`).
- `make dist/cli/api.mjs dist/runtime/server-bundle.js dist/runtime/tokenizer.worker.js` all build successfully on Linux via the resolved binary.
- `make static-check-full` green.
- Verification limit: the macOS kernel SIGKILL behavior itself cannot be reproduced on Linux; what is verified here is that every Unix call site resolves to and builds with the platform-package binary, which the issue confirms execs fine on affected machines.

## Risks

Low. Makefile-only; no runtime code changes. Worst case for an exotic platform without an `@esbuild/*/bin/esbuild` layout is the previous behavior (fallback to the copied shim path). Windows dev targets are byte-identical to main.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
