### PR TITLE
🤖 fix: preserve sub-agent report Markdown

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2806,13 +2806,23 @@ describe("TaskService", () => {
           turnId: "turn",
         },
       },
-      // StreamManager stores provider text deltas as adjacent parts; report assembly must
-      // concatenate them exactly instead of turning token boundaries into Markdown newlines.
       parts: [
+        // StreamManager stores provider text deltas as adjacent parts; concatenate them exactly.
         { type: "text", text: "## Verified" },
         { type: "text", text: " root" },
         { type: "text", text: " cause\n\n" },
         { type: "text", text: "- Fixed" },
+        // Non-text parts separate rendered text runs and must remain a report block boundary.
+        {
+          type: "dynamic-tool",
+          toolCallId: "call-1",
+          toolName: "bash",
+          input: { script: "true" },
+          state: "output-available",
+          output: { success: true },
+        },
+        { type: "text", text: "Follow-up" },
+        { type: "text", text: " complete." },
       ],
     });
 
@@ -2821,8 +2831,8 @@ describe("TaskService", () => {
       status: "completed",
       workspaceId: "childworkspace",
       messageId: "msg_1",
-      reportMarkdown: "## Verified root cause\n\n- Fixed",
-      finalMessageRef: { messageId: "msg_1", agentId: "exec", textCharCount: 31 },
+      reportMarkdown: "## Verified root cause\n\n- Fixed\n\nFollow-up complete.",
+      finalMessageRef: { messageId: "msg_1", agentId: "exec", textCharCount: 50 },
     });
     const childConfig = findWorkspaceInConfig(config, "childworkspace");
     expect(childConfig?.parentWorkspaceId).toBeUndefined();

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -2806,7 +2806,14 @@ describe("TaskService", () => {
           turnId: "turn",
         },
       },
-      parts: [{ type: "text", text: "Done" }],
+      // StreamManager stores provider text deltas as adjacent parts; report assembly must
+      // concatenate them exactly instead of turning token boundaries into Markdown newlines.
+      parts: [
+        { type: "text", text: "## Verified" },
+        { type: "text", text: " root" },
+        { type: "text", text: " cause\n\n" },
+        { type: "text", text: "- Fixed" },
+      ],
     });
 
     const snapshot = await taskService.getWorkspaceTurnSnapshot(parentId, "wst_handle");
@@ -2814,8 +2821,8 @@ describe("TaskService", () => {
       status: "completed",
       workspaceId: "childworkspace",
       messageId: "msg_1",
-      reportMarkdown: "Done",
-      finalMessageRef: { messageId: "msg_1", agentId: "exec", textCharCount: 4 },
+      reportMarkdown: "## Verified root cause\n\n- Fixed",
+      finalMessageRef: { messageId: "msg_1", agentId: "exec", textCharCount: 31 },
     });
     const childConfig = findWorkspaceInConfig(config, "childworkspace");
     expect(childConfig?.parentWorkspaceId).toBeUndefined();

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10159,16 +10159,30 @@ export class TaskService {
   }
 
   private buildWorkspaceTurnReportMarkdown(event: StreamEndEvent): string {
-    // Text parts are provider stream deltas, so inserting separators here turns token boundaries
-    // into arbitrary Markdown line breaks and can split headings, links, and code spans.
-    const text = event.parts
-      .filter(
-        (part): part is Extract<(typeof event.parts)[number], { type: "text" }> =>
-          part.type === "text"
-      )
-      .map((part) => part.text)
-      .join("")
-      .trim();
+    const textRuns: string[] = [];
+    let currentTextRun: string[] = [];
+    const flushTextRun = () => {
+      const text = currentTextRun.join("");
+      if (text.length > 0) {
+        textRuns.push(text);
+      }
+      currentTextRun = [];
+    };
+
+    for (const part of event.parts) {
+      if (part.type === "text") {
+        // Adjacent text parts are provider stream deltas; concatenate them exactly so token
+        // boundaries do not become arbitrary Markdown line breaks.
+        currentTextRun.push(part.text);
+      } else {
+        // A tool or reasoning part separates rendered text blocks. Preserve that boundary when
+        // projecting the turn into one report body instead of running the blocks together.
+        flushTextRun();
+      }
+    }
+    flushTextRun();
+
+    const text = textRuns.join("\n\n").trim();
     return text.length > 0 ? text : "Workspace turn completed without final text output.";
   }
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10159,13 +10159,15 @@ export class TaskService {
   }
 
   private buildWorkspaceTurnReportMarkdown(event: StreamEndEvent): string {
+    // Text parts are provider stream deltas, so inserting separators here turns token boundaries
+    // into arbitrary Markdown line breaks and can split headings, links, and code spans.
     const text = event.parts
       .filter(
         (part): part is Extract<(typeof event.parts)[number], { type: "text" }> =>
           part.type === "text"
       )
       .map((part) => part.text)
-      .join("\n")
+      .join("")
       .trim();
     return text.length > 0 ? text : "Workspace turn completed without final text output.";
   }


### PR DESCRIPTION
## Summary

Preserve sub-agent workspace-turn Markdown by concatenating adjacent streamed text deltas exactly while retaining a blank-line separator between distinct text runs split by tools or reasoning.

## Background

Workspace turns persist provider text deltas as adjacent message parts. Their terminal report builder joined every text part with `\n`, so provider token/chunk boundaries became arbitrary Markdown line breaks. This could split nearly every word, heading, link, or code span in a sub-agent report.

## Implementation

- concatenate adjacent workspace-turn text deltas without a separator
- preserve only newlines that the model actually emitted within each text run
- retain a blank-line boundary when a tool or reasoning part separates distinct rendered text runs
- cover both adjacent deltas and nonadjacent runs in regression tests

## Validation

- `bun test src/node/services/taskService.test.ts`
- `bun test src/node/services/tools/task.test.ts src/node/services/tools/task_await.test.ts`
- `make static-check`

## Risks

Low. The change is limited to terminal workspace-turn report assembly and aligns it with the renderer's existing adjacent-text-part grouping while preserving separate rendered blocks.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$19.56`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=19.56 -->
