### PR TITLE
🤖 fix: stop EPIPE error dialog loop when stdout/stderr pipe dies

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -2,6 +2,14 @@
 // Must be set before any filesystem operations occur.
 process.umask(0o077);
 
+import { installEpipeGuard, isEpipeError } from "./utils/epipeGuard";
+
+// When the launching terminal exits (packaged Linux/AppImage), stdout/stderr
+// become dead pipes and every console write raises EPIPE. Swallow those before
+// anything logs so they can never crash the app or loop the error dialog (#3082).
+installEpipeGuard(process.stdout);
+installEpipeGuard(process.stderr);
+
 // Enable source map support for better error stack traces in production
 import "source-map-support/register";
 import * as fs from "node:fs";
@@ -169,8 +177,9 @@ process.on("uncaughtException", (error: unknown) => {
 
   console.error("Stack:", stack);
 
-  // Show error dialog in production
-  if (app.isPackaged) {
+  // Show error dialog in production. EPIPE never warrants a modal: it means a
+  // pipe reader went away (defense-in-depth for streams the guard above misses).
+  if (app.isPackaged && !isEpipeError(error)) {
     dialog.showErrorBox(
       "Application Error",
       `An unexpected error occurred:\n\n${message}\n\nStack trace:\n${stack ?? "No stack trace available"}`
@@ -182,7 +191,7 @@ process.on("unhandledRejection", (reason, promise) => {
   console.error("Unhandled Rejection at:", promise);
   console.error("Reason:", reason);
 
-  if (app.isPackaged) {
+  if (app.isPackaged && !isEpipeError(reason)) {
     const message = getErrorMessage(reason);
     const stack = reason instanceof Error ? reason.stack : undefined;
     dialog.showErrorBox(

--- a/src/desktop/utils/epipeGuard.test.ts
+++ b/src/desktop/utils/epipeGuard.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { installEpipeGuard, isEpipeError } from "./epipeGuard";
+
+function errnoError(code: string): Error {
+  const error: NodeJS.ErrnoException = new Error(`write ${code}`);
+  error.code = code;
+  return error;
+}
+
+describe("isEpipeError", () => {
+  test("matches errors with code EPIPE", () => {
+    expect(isEpipeError(errnoError("EPIPE"))).toBe(true);
+  });
+
+  test("rejects other errno codes", () => {
+    expect(isEpipeError(errnoError("ECONNRESET"))).toBe(false);
+    expect(isEpipeError(errnoError("EIO"))).toBe(false);
+  });
+
+  test("rejects errors without a code and non-error values", () => {
+    expect(isEpipeError(new Error("write EPIPE"))).toBe(false);
+    expect(isEpipeError("EPIPE")).toBe(false);
+    expect(isEpipeError(null)).toBe(false);
+    expect(isEpipeError(undefined)).toBe(false);
+  });
+});
+
+describe("installEpipeGuard", () => {
+  test("swallows EPIPE errors emitted on the stream", () => {
+    const stream = new EventEmitter();
+    installEpipeGuard(stream);
+    expect(() => stream.emit("error", errnoError("EPIPE"))).not.toThrow();
+  });
+
+  test("rethrows non-EPIPE errors so they still surface", () => {
+    const stream = new EventEmitter();
+    installEpipeGuard(stream);
+    expect(() => stream.emit("error", errnoError("ENOSPC"))).toThrow("write ENOSPC");
+  });
+
+  test("tolerates a missing stream", () => {
+    expect(() => installEpipeGuard(undefined)).not.toThrow();
+  });
+});

--- a/src/desktop/utils/epipeGuard.ts
+++ b/src/desktop/utils/epipeGuard.ts
@@ -1,0 +1,28 @@
+/**
+ * EPIPE guard for process.stdout/stderr (issue #3082).
+ *
+ * In packaged Linux builds (AppImage), when the launching terminal exits the
+ * read end of the stdout/stderr pipes goes away and every console write emits
+ * an async "error" event with code EPIPE on the stream. Without an error
+ * listener Node promotes that to an uncaughtException, which pops Electron's
+ * "Application Error" modal; the handler then logs to the same dead pipe, so
+ * dismissing one dialog immediately spawns the next, forever.
+ */
+
+/** True for EPIPE stream errors (the pipe reader is gone; nothing actionable). */
+export function isEpipeError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EPIPE";
+}
+
+/**
+ * Swallow EPIPE write errors on the given stdio stream. Non-EPIPE errors are
+ * rethrown so genuinely unexpected stream failures still surface as
+ * uncaughtException.
+ */
+export function installEpipeGuard(stream: NodeJS.EventEmitter | undefined): void {
+  stream?.on("error", (error: unknown) => {
+    if (!isEpipeError(error)) {
+      throw error;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

Prevents the endless "Application Error: write EPIPE" modal loop in packaged Linux builds by swallowing EPIPE errors on `process.stdout`/`process.stderr` and excluding EPIPE from the crash-dialog paths.

Fixes #3082

## Background

When the terminal that launched the AppImage exits (or the pipe reader otherwise goes away), every console write emits an async `error` event with code `EPIPE` on the stdio stream. With no `error` listener attached, Node promotes it to an `uncaughtException`, whose handler shows Electron's "Application Error" modal and logs to the same dead pipe — so dismissing one dialog immediately triggers the next, forever, making the app unusable.

The existing `log.ts` EPIPE protection only catches synchronous write failures; the async stream `error` events were unguarded.

## Implementation

- `src/desktop/utils/epipeGuard.ts`: `isEpipeError` classifier plus `installEpipeGuard`, which attaches an `error` listener that swallows EPIPE and rethrows anything else (so genuinely unexpected stream failures still surface).
- `src/desktop/main.ts`: installs the guard on stdout/stderr at the very top, before anything logs; additionally filters EPIPE out of the `uncaughtException`/`unhandledRejection` dialog paths as defense-in-depth for EPIPEs surfacing from other fds.

## Validation

- Empirically confirmed on Linux that writes to a dead pipe emit `EPIPE` on every subsequent write (never `ERR_STREAM_DESTROYED`), so the EPIPE-only classifier fully covers the loop.
- Unit tests cover the classifier and the swallow-vs-rethrow branching of the stream guard.

## Risks

Low. EPIPE on stdio means the reader is gone and nothing is actionable; all other error codes keep the existing crash-dialog behavior.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
