### PR TITLE
🤖 fix: don't re-fire browser notifications when replaying notify results

### DIFF
--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -141,6 +141,7 @@ function endToolCall(
     result: unknown;
     timestamp?: number;
     parentToolCallId?: string;
+    replay?: boolean;
   }
 ): void {
   aggregator.handleToolCallEnd({
@@ -152,6 +153,7 @@ function endToolCall(
     result: options.result,
     timestamp: options.timestamp ?? Date.now(),
     parentToolCallId: options.parentToolCallId,
+    replay: options.replay,
   });
 }
 
@@ -4299,5 +4301,128 @@ describe("review_pane_update -> assistedReviewHunks", () => {
     const pins = aggregator.getAssistedReviewHunks();
     expect(pins).toHaveLength(1);
     expect(pins[0].path).toBe("src/bar.ts");
+  });
+});
+
+/**
+ * Tests for notify tool results -> Web Notifications routing.
+ *
+ * The notify tool persists its routing metadata (`notifiedVia: "browser"`) in
+ * history, so the aggregator must fire Web Notifications only for live tool
+ * results. History hydration and reconnect replay re-process the same outputs
+ * on every workspace switch/reload and must stay silent (#2547).
+ */
+class FakeNotification {
+  static permission = "granted";
+  static created: Array<{ title: string; body?: string }> = [];
+  onclick: (() => void) | null = null;
+
+  constructor(title: string, options?: { body?: string }) {
+    FakeNotification.created.push({ title, body: options?.body });
+  }
+
+  static requestPermission(): Promise<string> {
+    return Promise.resolve("granted");
+  }
+}
+
+function withFakeNotificationWindow<T>(fn: () => T): T {
+  const globalWithWindow = globalThis as unknown as { window?: unknown };
+  const previousWindow = globalWithWindow.window;
+  FakeNotification.created = [];
+  globalWithWindow.window = { Notification: FakeNotification, focus: () => undefined };
+  try {
+    return fn();
+  } finally {
+    if (previousWindow === undefined) {
+      delete globalWithWindow.window;
+    } else {
+      globalWithWindow.window = previousWindow;
+    }
+  }
+}
+
+function browserNotifyOutput(title: string, message?: string) {
+  return {
+    success: true,
+    title,
+    message,
+    ui_only: { notify: { notifiedVia: "browser", workspaceId: TEST_WORKSPACE_ID } },
+  };
+}
+
+function runNotifyTool(
+  aggregator: StreamingMessageAggregator,
+  options: { messageId?: string; toolCallId?: string; replay?: boolean } = {}
+): void {
+  const messageId = options.messageId ?? "msg-1";
+  const toolCallId = options.toolCallId ?? "tc-notify";
+  startToolCall(aggregator, {
+    messageId,
+    toolCallId,
+    toolName: "notify",
+    args: { title: "Task done" },
+  });
+  endToolCall(aggregator, {
+    messageId,
+    toolCallId,
+    toolName: "notify",
+    result: browserNotifyOutput("Task done", "All checks passed"),
+    replay: options.replay,
+  });
+}
+
+describe("notify tool -> browser notifications", () => {
+  test("live notify results fire a browser notification", () => {
+    withFakeNotificationWindow(() => {
+      const aggregator = createTestAggregator();
+      startTestStream(aggregator, { messageId: "msg-1" });
+
+      runNotifyTool(aggregator);
+
+      expect(FakeNotification.created).toEqual([{ title: "Task done", body: "All checks passed" }]);
+    });
+  });
+
+  test("replayed tool-call-end does not re-fire the notification", () => {
+    // Reconnect replay re-emits tool-call-end (replay: true) for already-completed
+    // calls of an active stream; the user was already notified when it ran live.
+    withFakeNotificationWindow(() => {
+      const aggregator = createTestAggregator();
+      startTestStream(aggregator, { messageId: "msg-1" });
+
+      runNotifyTool(aggregator, { replay: true });
+
+      expect(FakeNotification.created).toEqual([]);
+    });
+  });
+
+  test("history hydration does not re-fire notifications; later live ones still do", () => {
+    // Workspace switches and reloads hydrate the full transcript through
+    // loadHistoricalMessages; historical notify results must stay silent.
+    withFakeNotificationWindow(() => {
+      const aggregator = createTestAggregator();
+      const message = createMuxMessage("msg-1", "assistant", "", {
+        historySequence: 1,
+        timestamp: Date.now(),
+        muxMetadata: { type: "normal", requestedModel: TEST_MODEL },
+      });
+      message.parts.push({
+        type: "dynamic-tool",
+        toolCallId: "tc-notify",
+        toolName: "notify",
+        state: "output-available",
+        input: { title: "Task done" },
+        output: browserNotifyOutput("Task done", "All checks passed"),
+      });
+
+      aggregator.loadHistoricalMessages([message]);
+      expect(FakeNotification.created).toEqual([]);
+
+      // A genuinely new notify after hydration still notifies.
+      startTestStream(aggregator, { messageId: "msg-2", historySequence: 2 });
+      runNotifyTool(aggregator, { messageId: "msg-2", toolCallId: "tc-notify-2" });
+      expect(FakeNotification.created).toEqual([{ title: "Task done", body: "All checks passed" }]);
+    });
   });
 });

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -1240,9 +1240,10 @@ export class StreamingMessageAggregator {
           let assistantUpdatedTodos = false;
           for (const part of message.parts) {
             if (isDynamicToolPart(part) && part.state === "output-available") {
-              // Replay deliberately omits the timestamp so historical
-              // assisted-review pins don't all light up as "new" on initial
-              // load; only live updates get a fresh addedAt.
+              // Replay deliberately omits the live context so historical
+              // events don't re-fire user-visible side effects: assisted-review
+              // pins don't light up as "new" and notify results don't re-send
+              // browser notifications on every hydration.
               this.processToolResult(part.toolName, part.input, part.output);
               if (
                 part.toolName === "todo_write" &&
@@ -2583,7 +2584,10 @@ export class StreamingMessageAggregator {
     toolName: string,
     input: unknown,
     output: unknown,
-    messageContext?: { timestamp?: number }
+    // Present only for live (non-replay) tool results. History hydration and reconnect
+    // replay omit it so user-visible side effects (browser notifications, assisted-review
+    // "new" badges) never re-fire for events the user already saw.
+    liveContext?: { timestamp: number }
   ): void {
     // Update TODO state if this was a successful todo_write.
     // We still reconstruct from history so interrupted/incomplete plans survive reloads;
@@ -2640,14 +2644,14 @@ export class StreamingMessageAggregator {
             // Carry forward addedAt for `add` ops only so a refined
             // comment doesn't reset the "new" badge.
             candidate.addedAt = previous.addedAt;
-          } else if (messageContext?.timestamp !== undefined) {
+          } else if (liveContext !== undefined) {
             // `replace` op (or first time we've seen this key under any op):
             // stamp with the current message's timestamp. `replace` is an
             // explicit republish, so reuse of an old key should still
             // re-arm the "new" badge. Replay deliberately omits the
             // timestamp so historical pins don't all light up as "new"
             // on initial load.
-            candidate.addedAt = messageContext.timestamp;
+            candidate.addedAt = liveContext.timestamp;
           }
           next.push(candidate);
         }
@@ -2683,8 +2687,11 @@ export class StreamingMessageAggregator {
       }
     }
 
-    // Handle browser notifications when Electron wasn't available
-    if (toolName === "notify") {
+    // Handle browser notifications when Electron wasn't available.
+    // Live results only: notify outputs are persisted in history with their routing
+    // metadata, so history hydration and reconnect replay would otherwise re-fire
+    // OS notifications for past events on every workspace switch or reload (#2547).
+    if (toolName === "notify" && liveContext !== undefined) {
       const result = parseNotifySuccessResult(output);
       if (result) {
         const uiOnlyNotify = getToolOutputUiOnly(output)?.notify;
@@ -2782,11 +2789,15 @@ export class StreamingMessageAggregator {
 
         // Process tool result to update derived state (todos, agentStatus, etc.)
         // Live updates stamp a fresh `Date.now()` so the Assisted-review "new"
-        // badge can highlight just-introduced pins (the replay path
-        // intentionally omits this so historical pins don't flash on load).
-        this.processToolResult(data.toolName, toolPart.input, data.result, {
-          timestamp: Date.now(),
-        });
+        // badge can highlight just-introduced pins. Reconnect replay re-emits
+        // tool-call-end for already-completed calls, so treat those like the
+        // history-hydration path: no fresh timestamp and no notification re-fire.
+        this.processToolResult(
+          data.toolName,
+          toolPart.input,
+          data.result,
+          data.replay === true ? undefined : { timestamp: Date.now() }
+        );
 
         // Tool output is now stable - invalidate all caches.
         this.markMessageDirty(data.messageId);


### PR DESCRIPTION
## Summary

In browser mode, Mux re-fires OS notifications for past `notify` tool calls every time the user switches workspaces or reloads the app. This gates the notification side effect so only live tool results notify; history hydration and reconnect replay stay silent.

Fixes #2547

## Background

In browser mode the `notify` tool always returns `notifiedVia: "browser"` (Electron is unavailable server-side), delegating delivery to the frontend. That routing metadata is persisted in chat history. `StreamingMessageAggregator.processToolResult` fired the Web Notification unconditionally, and it runs on two replay paths in addition to live tool-call-end events:

- `loadHistoricalMessages` re-processes every historical tool result to rebuild derived state. Since only the active workspace holds the `onChat` subscription, every workspace switch and reload triggers full history hydration, re-firing every historical browser notification. This is exactly the reported repro (re-notify on chat switch, re-notify on reload).
- Reconnect replay (`replayStream`) re-emits `tool-call-end` with `replay: true` for already-completed calls of an active stream, which flowed into the same handler with a fresh live timestamp.

The response-complete producer (App.tsx) is not affected: `stream-end` is never replayed for completed streams, and the background-activity completion path requires observing a live streaming true→false transition.

## Implementation

`processToolResult` now takes an explicit `liveContext` parameter (renamed from `messageContext`) that is present only for live, non-replay tool results:

- The `notify` → browser-notification side effect requires `liveContext`.
- `handleToolCallEnd` omits `liveContext` when the event carries `replay: true`, so reconnect replay behaves like history hydration. As a side benefit this also stops replayed `review_pane_update` results from re-arming the assisted-review "new" badge with a fresh timestamp, matching the documented intent of that badge.

## Validation

- Red-green on both guards independently: removing the `liveContext` gate fails the hydration and replay tests; reverting the `handleToolCallEnd` replay check fails exactly the replayed tool-call-end test.
- New behavioral tests: live notify results fire once; replayed `tool-call-end` and history hydration stay silent; a genuinely new notify after hydration still fires.

## Risks

Low severity, scoped to notification delivery. The behavioral change is that notify results reconstructed from history or reconnect replay no longer notify; a notify that completes while the workspace is live-subscribed still does. Notifications for workspaces without an active `onChat` subscription were already not delivered through this path (activity-snapshot-driven response-complete notifications are unchanged).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
