### PR TITLE
🤖 feat: per-project custom system prompts

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -268,6 +268,7 @@ function createProjectContextValue(
     updateSecrets: () => Promise.resolve(),
     updateDisplayName: () => resolveVoidResult(),
     updateColor: () => resolveVoidResult(),
+    updateCustomInstructions: () => resolveVoidResult(),
     assignWorkspaceToSubProject: () => resolveVoidResult(),
     hasAnyProject: false,
     resolveNewChatProjectPath: () => null,
@@ -527,6 +528,8 @@ function installProjectSidebarTestDoubles() {
     setRuntimesProjectPath: () => undefined,
     secretsProjectPath: null,
     setSecretsProjectPath: () => undefined,
+    instructionsProjectPath: null,
+    setInstructionsProjectPath: () => undefined,
   }));
   spyOn(WorkspaceContextModule, "useWorkspaceActions").mockImplementation(
     () =>
@@ -1330,6 +1333,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       updateSecrets: () => Promise.resolve(),
       updateDisplayName: () => resolveVoidResult(),
       updateColor: () => resolveVoidResult(),
+      updateCustomInstructions: () => resolveVoidResult(),
       assignWorkspaceToSubProject: () => resolveVoidResult(),
       hasAnyProject: true,
       resolveNewChatProjectPath: () => "/projects/demo-project",
@@ -1920,6 +1924,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       updateSecrets: () => Promise.resolve(),
       updateDisplayName: () => resolveVoidResult(),
       updateColor: () => resolveVoidResult(),
+      updateCustomInstructions: () => resolveVoidResult(),
       assignWorkspaceToSubProject: () => resolveVoidResult(),
       hasAnyProject: true,
       resolveNewChatProjectPath: () => "/projects/demo-project",
@@ -2345,6 +2350,7 @@ describe("ProjectSidebar project actions menu", () => {
       "Edit name",
       "Add sub-project",
       "Manage secrets",
+      "Instructions",
       "Change color",
       "Delete...",
     ]);
@@ -2373,6 +2379,13 @@ describe("ProjectSidebar project actions menu", () => {
 
     expect(settingsOpenMock).toHaveBeenCalledWith("secrets", {
       secretsProjectPath: demoProjectPath,
+    });
+
+    fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));
+    fireEvent.click(view.getByRole("button", { name: "Instructions" }));
+
+    expect(settingsOpenMock).toHaveBeenCalledWith("instructions", {
+      instructionsProjectPath: demoProjectPath,
     });
 
     fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -120,6 +120,7 @@ import {
   KeyRound,
   Palette,
   Pencil,
+  ScrollText,
   Trash,
   Plus,
 } from "lucide-react";
@@ -1426,6 +1427,19 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     [MOBILE_BREAKPOINT, collapsed, onToggleCollapsed, persistMobileSidebarScrollTop, settings]
   );
 
+  const handleOpenInstructions = useCallback(
+    (projectPath: string) => {
+      // Same mobile collapse behavior as handleOpenSecrets.
+      if (window.innerWidth <= MOBILE_BREAKPOINT && !collapsed) {
+        persistMobileSidebarScrollTop(mobileScrollTopRef.current);
+        onToggleCollapsed();
+      }
+      // Navigate to Settings → Instructions with the project pre-selected.
+      settings.open("instructions", { instructionsProjectPath: projectPath });
+    },
+    [MOBILE_BREAKPOINT, collapsed, onToggleCollapsed, persistMobileSidebarScrollTop, settings]
+  );
+
   const closeProjectContextMenu = useCallback(() => {
     projectContextMenu.close();
     setProjectMenuTargetPath(null);
@@ -1543,6 +1557,15 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     handleOpenSecrets(projectMenuTargetPath);
     closeProjectContextMenu();
   }, [closeProjectContextMenu, handleOpenSecrets, projectMenuTargetPath]);
+
+  const handleProjectMenuInstructions = useCallback(() => {
+    if (!projectMenuTargetPath) {
+      return;
+    }
+
+    handleOpenInstructions(projectMenuTargetPath);
+    closeProjectContextMenu();
+  }, [closeProjectContextMenu, handleOpenInstructions, projectMenuTargetPath]);
 
   const handleProjectMenuDelete = useCallback(
     (buttonElement?: HTMLElement) => {
@@ -3336,6 +3359,14 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
               disabled={!hasProjectMenuTarget}
               onClick={() => {
                 handleProjectMenuManageSecrets();
+              }}
+            />
+            <PositionedMenuItem
+              icon={<ScrollText className="h-4 w-4 shrink-0" strokeWidth={1.8} />}
+              label="Instructions"
+              disabled={!hasProjectMenuTarget}
+              onClick={() => {
+                handleProjectMenuInstructions();
               }}
             />
             <PositionedMenuItem

--- a/src/browser/contexts/ProjectContext.tsx
+++ b/src/browser/contexts/ProjectContext.tsx
@@ -97,6 +97,10 @@ export interface ProjectContext {
   updateSecrets: (projectPath: string, secrets: Secret[]) => Promise<void>;
   updateDisplayName: (projectPath: string, displayName: string | null) => Promise<Result<void>>;
   updateColor: (projectPath: string, color: string | null) => Promise<Result<void>>;
+  updateCustomInstructions: (
+    projectPath: string,
+    customInstructions: string | null
+  ) => Promise<Result<void>>;
 
   assignWorkspaceToSubProject: (
     projectPath: string,
@@ -550,6 +554,20 @@ export function ProjectProvider(props: { children: ReactNode }) {
     [api, refreshProjects]
   );
 
+  const updateCustomInstructions = useCallback(
+    async (projectPath: string, customInstructions: string | null): Promise<Result<void>> => {
+      if (!api) return { success: false, error: "API not connected" };
+      try {
+        await api.projects.setCustomInstructions({ projectPath, customInstructions });
+        await refreshProjects();
+        return { success: true, data: undefined };
+      } catch (error) {
+        return { success: false, error: getErrorMessage(error) };
+      }
+    },
+    [api, refreshProjects]
+  );
+
   const assignWorkspaceToSubProject = useCallback(
     async (
       projectPath: string,
@@ -602,6 +620,7 @@ export function ProjectProvider(props: { children: ReactNode }) {
       updateSecrets,
       updateDisplayName,
       updateColor,
+      updateCustomInstructions,
       assignWorkspaceToSubProject,
     }),
     [
@@ -627,6 +646,7 @@ export function ProjectProvider(props: { children: ReactNode }) {
       updateSecrets,
       updateDisplayName,
       updateColor,
+      updateCustomInstructions,
       assignWorkspaceToSubProject,
     ]
   );

--- a/src/browser/contexts/SettingsContext.tsx
+++ b/src/browser/contexts/SettingsContext.tsx
@@ -19,6 +19,8 @@ export interface OpenSettingsOptions {
   runtimesProjectPath?: string;
   /** When opening the Secrets settings, pre-select this project scope. */
   secretsProjectPath?: string;
+  /** When opening the Instructions settings, pre-select this project. */
+  instructionsProjectPath?: string;
 }
 
 interface SettingsContextValue {
@@ -46,6 +48,10 @@ interface SettingsContextValue {
   /** One-shot hint for SecretsSection to pre-select a project scope. */
   secretsProjectPath: string | null;
   setSecretsProjectPath: (path: string | null) => void;
+
+  /** One-shot hint for InstructionsSection to pre-select a project. */
+  instructionsProjectPath: string | null;
+  setInstructionsProjectPath: (path: string | null) => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
@@ -64,6 +70,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
   const [providersStartCoderLogin, setProvidersStartCoderLogin] = useState(false);
   const [runtimesProjectPath, setRuntimesProjectPath] = useState<string | null>(null);
   const [secretsProjectPath, setSecretsProjectPath] = useState<string | null>(null);
+  const [instructionsProjectPath, setInstructionsProjectPath] = useState<string | null>(null);
 
   const closeCallbacksRef = useRef(new Set<() => void>());
 
@@ -90,6 +97,11 @@ export function SettingsProvider(props: { children: ReactNode }) {
       } else {
         setSecretsProjectPath(null);
       }
+      if (nextSection === "instructions") {
+        setInstructionsProjectPath(options?.instructionsProjectPath ?? null);
+      } else {
+        setInstructionsProjectPath(null);
+      }
       router.navigateToSettings(nextSection);
     },
     [router]
@@ -111,6 +123,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
       setProvidersStartCoderLogin(false);
       setRuntimesProjectPath(null);
       setSecretsProjectPath(null);
+      setInstructionsProjectPath(null);
       for (const callback of closeCallbacksRef.current) {
         callback();
       }
@@ -123,6 +136,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
     setProvidersStartCoderLogin(false);
     setRuntimesProjectPath(null);
     setSecretsProjectPath(null);
+    setInstructionsProjectPath(null);
     router.navigateFromSettings();
   }, [router]);
 
@@ -138,6 +152,9 @@ export function SettingsProvider(props: { children: ReactNode }) {
       }
       if (section !== "secrets") {
         setSecretsProjectPath(null);
+      }
+      if (section !== "instructions") {
+        setInstructionsProjectPath(null);
       }
       router.navigateToSettings(section, options);
     },
@@ -160,6 +177,8 @@ export function SettingsProvider(props: { children: ReactNode }) {
       setRuntimesProjectPath,
       secretsProjectPath,
       setSecretsProjectPath,
+      instructionsProjectPath,
+      setInstructionsProjectPath,
     }),
     [
       isOpen,
@@ -172,6 +191,7 @@ export function SettingsProvider(props: { children: ReactNode }) {
       providersStartCoderLogin,
       runtimesProjectPath,
       secretsProjectPath,
+      instructionsProjectPath,
     ]
   );
 

--- a/src/browser/features/Settings/Sections/InstructionsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { userEvent, within } from "@storybook/test";
+import { expect, userEvent, waitFor, within } from "@storybook/test";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mocks/workspaces";
@@ -88,11 +88,12 @@ export const DirtyDraftEnablesSave: Story = {
     const textarea = await canvas.findByRole("textbox", {
       name: /Project custom instructions/i,
     });
+    // Projects load asynchronously; until one is selected the textarea is
+    // disabled and userEvent.type would silently no-op (flaked in Pixel).
+    await waitFor(() => expect(textarea).toBeEnabled());
     await userEvent.type(textarea, "Never commit directly to main.");
 
     const saveButton = await canvas.findByRole("button", { name: /^Save$/i });
-    if (saveButton.hasAttribute("disabled")) {
-      throw new Error("Save should be enabled after editing the draft");
-    }
+    await waitFor(() => expect(saveButton).toBeEnabled());
   },
 };

--- a/src/browser/features/Settings/Sections/InstructionsSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "@storybook/test";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
+import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mocks/workspaces";
+import { selectWorkspace } from "@/browser/stories/helpers/uiState";
+import { InstructionsSection } from "./InstructionsSection.js";
+import { SettingsSectionStory } from "./settingsStoryUtils.js";
+
+const PROJECT_PATH_A = "/Users/test/my-app";
+const PROJECT_PATH_B = "/Users/test/other-app";
+
+function setupInstructionsStory(customInstructions?: string) {
+  const workspaces = [
+    createWorkspace({
+      id: "ws-instructions-a",
+      name: "main",
+      projectName: "my-app",
+      projectPath: PROJECT_PATH_A,
+    }),
+    createWorkspace({
+      id: "ws-instructions-b",
+      name: "main",
+      projectName: "other-app",
+      projectPath: PROJECT_PATH_B,
+    }),
+  ];
+
+  selectWorkspace(workspaces[0]);
+
+  const projects = groupWorkspacesByProject(workspaces);
+  const projectA = projects.get(PROJECT_PATH_A);
+  if (projectA && customInstructions) {
+    projectA.customInstructions = customInstructions;
+  }
+
+  return createMockORPCClient({ workspaces, projects });
+}
+
+const meta: Meta = {
+  ...lightweightMeta,
+  title: "Settings/Sections/InstructionsSection",
+  component: InstructionsSection,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function renderInstructionsSection(setup: () => ReturnType<typeof createMockORPCClient>) {
+  return (
+    <SettingsSectionStory setup={setup}>
+      <div className="bg-background p-6">
+        <InstructionsSection />
+      </div>
+    </SettingsSectionStory>
+  );
+}
+
+export const Empty: Story = {
+  render: () => renderInstructionsSection(() => setupInstructionsStory()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText(/Custom instructions are appended to the system prompt/i);
+    await canvas.findByRole("textbox", { name: /Project custom instructions/i });
+  },
+};
+
+export const WithSavedInstructions: Story = {
+  render: () =>
+    renderInstructionsSection(() =>
+      setupInstructionsStory(
+        "Always run the full test suite before committing.\nPrefer small, reviewable changes."
+      )
+    ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByDisplayValue(/Always run the full test suite before committing/i);
+  },
+};
+
+export const DirtyDraftEnablesSave: Story = {
+  render: () => renderInstructionsSection(() => setupInstructionsStory()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const textarea = await canvas.findByRole("textbox", {
+      name: /Project custom instructions/i,
+    });
+    await userEvent.type(textarea, "Never commit directly to main.");
+
+    const saveButton = await canvas.findByRole("button", { name: /^Save$/i });
+    if (saveButton.hasAttribute("disabled")) {
+      throw new Error("Save should be enabled after editing the draft");
+    }
+  },
+};

--- a/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
@@ -26,11 +26,19 @@ function mockProjectContext(
 }
 
 function mockSettingsContext(instructionsProjectPath: string | null = null) {
+  // Stateful, stable-identity mock mirroring production: the setter really
+  // clears the hint and keeps its identity across renders. A fresh no-op
+  // setter per render re-fires the hint effect forever, masking ordering
+  // races between the hint and the default selection.
+  let hint = instructionsProjectPath;
+  const setInstructionsProjectPath = (value: string | null) => {
+    hint = value;
+  };
   spyOn(SettingsContextModule, "useSettings").mockImplementation(
     () =>
       ({
-        instructionsProjectPath,
-        setInstructionsProjectPath: () => undefined,
+        instructionsProjectPath: hint,
+        setInstructionsProjectPath,
       }) as unknown as ReturnType<typeof SettingsContextModule.useSettings>
   );
 }

--- a/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
@@ -94,6 +94,56 @@ describe("InstructionsSection", () => {
     });
   });
 
+  test("Cmd/Ctrl+Enter in the textarea saves, but only when dirty", async () => {
+    const updateCustomInstructions = mock(
+      (_projectPath: string, _customInstructions: string | null) => resolveVoidResult()
+    );
+    mockProjectContext(new Map([[PROJECT_PATH, { workspaces: [] }]]), updateCustomInstructions);
+    mockSettingsContext();
+
+    const view = render(<InstructionsSection />);
+    const textarea = view.getByRole("textbox", { name: "Project custom instructions" });
+
+    // happy-dom does not deliver React's synthetic keyDown either, so invoke
+    // the element's React onKeyDown prop directly (same workaround as
+    // typeIntoTextarea above).
+    const pressModEnter = (modifier: "metaKey" | "ctrlKey") => {
+      const reactPropsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps"));
+      if (!reactPropsKey) throw new Error("Expected textarea to expose React props");
+      const reactProps = (textarea as unknown as Record<string, unknown>)[reactPropsKey] as {
+        onKeyDown?: (event: {
+          key: string;
+          metaKey: boolean;
+          ctrlKey: boolean;
+          preventDefault: () => void;
+        }) => void;
+      };
+      if (!reactProps.onKeyDown) throw new Error("Expected textarea to expose onKeyDown handler");
+      act(() => {
+        reactProps.onKeyDown!({
+          key: "Enter",
+          metaKey: modifier === "metaKey",
+          ctrlKey: modifier === "ctrlKey",
+          preventDefault: () => undefined,
+        });
+      });
+    };
+
+    // Not dirty: the shortcut must not save.
+    pressModEnter("metaKey");
+    expect(updateCustomInstructions).not.toHaveBeenCalled();
+
+    typeIntoTextarea(textarea as HTMLTextAreaElement, "Shortcut-saved guidance.");
+    pressModEnter("ctrlKey");
+
+    await waitFor(() => {
+      expect(updateCustomInstructions).toHaveBeenCalledWith(
+        PROJECT_PATH,
+        "Shortcut-saved guidance."
+      );
+    });
+  });
+
   test("clearing saved instructions saves null so config stays minimal", async () => {
     const updateCustomInstructions = mock(
       (_projectPath: string, _customInstructions: string | null) => resolveVoidResult()

--- a/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.test.tsx
@@ -1,0 +1,138 @@
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { installDom } from "../../../../../tests/ui/dom";
+import * as ProjectContextModule from "@/browser/contexts/ProjectContext";
+import * as SettingsContextModule from "@/browser/contexts/SettingsContext";
+import type { ProjectConfig } from "@/common/types/project";
+import type { Result } from "@/common/types/result";
+import { InstructionsSection } from "./InstructionsSection";
+
+const PROJECT_PATH = "/projects/demo-project";
+
+const resolveVoidResult = (): Promise<Result<void>> =>
+  Promise.resolve({ success: true, data: undefined });
+
+function mockProjectContext(
+  userProjects: Map<string, ProjectConfig>,
+  updateCustomInstructions: ProjectContextModule.ProjectContext["updateCustomInstructions"]
+) {
+  spyOn(ProjectContextModule, "useProjectContext").mockImplementation(
+    () =>
+      ({
+        userProjects,
+        updateCustomInstructions,
+      }) as unknown as ProjectContextModule.ProjectContext
+  );
+}
+
+function mockSettingsContext(instructionsProjectPath: string | null = null) {
+  spyOn(SettingsContextModule, "useSettings").mockImplementation(
+    () =>
+      ({
+        instructionsProjectPath,
+        setInstructionsProjectPath: () => undefined,
+      }) as unknown as ReturnType<typeof SettingsContextModule.useSettings>
+  );
+}
+
+// happy-dom does not deliver React's synthetic onChange for controlled fields,
+// so invoke the element's React onChange prop directly (same workaround as
+// SshPromptDialog.test.tsx).
+function typeIntoTextarea(textarea: HTMLTextAreaElement, value: string) {
+  fireEvent.change(textarea, { target: { value } });
+  const reactPropsKey = Object.keys(textarea).find((key) => key.startsWith("__reactProps"));
+  if (!reactPropsKey) {
+    throw new Error("Expected textarea to expose React props");
+  }
+  const reactProps = (textarea as unknown as Record<string, unknown>)[reactPropsKey] as {
+    onChange?: (event: { target: { value: string } }) => void;
+  };
+  if (!reactProps.onChange) {
+    throw new Error("Expected textarea to expose onChange handler");
+  }
+  act(() => {
+    reactProps.onChange!({ target: { value } });
+  });
+}
+
+describe("InstructionsSection", () => {
+  let cleanupDom: () => void;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    cleanupDom();
+  });
+
+  test("saves the edited draft for the selected project", async () => {
+    const updateCustomInstructions = mock(
+      (_projectPath: string, _customInstructions: string | null) => resolveVoidResult()
+    );
+    mockProjectContext(new Map([[PROJECT_PATH, { workspaces: [] }]]), updateCustomInstructions);
+    mockSettingsContext();
+
+    const view = render(<InstructionsSection />);
+
+    const textarea = view.getByRole("textbox", { name: "Project custom instructions" });
+    const save = view.getByRole("button", { name: "Save" });
+    expect((save as HTMLButtonElement).disabled).toBe(true);
+
+    typeIntoTextarea(textarea as HTMLTextAreaElement, "Never commit directly to main.");
+    expect((save as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      expect(updateCustomInstructions).toHaveBeenCalledWith(
+        PROJECT_PATH,
+        "Never commit directly to main."
+      );
+    });
+  });
+
+  test("clearing saved instructions saves null so config stays minimal", async () => {
+    const updateCustomInstructions = mock(
+      (_projectPath: string, _customInstructions: string | null) => resolveVoidResult()
+    );
+    mockProjectContext(
+      new Map([
+        [PROJECT_PATH, { workspaces: [], customInstructions: "Existing project guidance." }],
+      ]),
+      updateCustomInstructions
+    );
+    mockSettingsContext();
+
+    const view = render(<InstructionsSection />);
+
+    const textarea = view.getByRole("textbox", { name: "Project custom instructions" });
+    expect((textarea as HTMLTextAreaElement).value).toBe("Existing project guidance.");
+
+    typeIntoTextarea(textarea as HTMLTextAreaElement, "   ");
+    fireEvent.click(view.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(updateCustomInstructions).toHaveBeenCalledWith(PROJECT_PATH, null);
+    });
+  });
+
+  test("pre-selects the project from the one-shot settings hint", () => {
+    const otherPath = "/projects/other-project";
+    mockProjectContext(
+      new Map([
+        [PROJECT_PATH, { workspaces: [] }],
+        [otherPath, { workspaces: [], customInstructions: "Other project guidance." }],
+      ]),
+      () => resolveVoidResult()
+    );
+    mockSettingsContext(otherPath);
+
+    const view = render(<InstructionsSection />);
+
+    const textarea = view.getByRole("textbox", { name: "Project custom instructions" });
+    expect((textarea as HTMLTextAreaElement).value).toBe("Other project guidance.");
+  });
+});

--- a/src/browser/features/Settings/Sections/InstructionsSection.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.tsx
@@ -136,6 +136,16 @@ export const InstructionsSection: React.FC = () => {
             onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
               setDraft(event.target.value);
             }}
+            onKeyDown={(event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+              // Enter intentionally inserts a newline; Cmd/Ctrl+Enter saves,
+              // matching the multi-line textarea convention (see GoalTab).
+              if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                if (isDirty && selectedProject && !saving) {
+                  void handleSave();
+                }
+              }
+            }}
             disabled={!selectedProject || saving}
             className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent mt-3 min-h-[200px] w-full resize-y rounded-md border p-3 font-mono text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
             placeholder="e.g. Always run the test suite before committing. Prefer functional patterns."

--- a/src/browser/features/Settings/Sections/InstructionsSection.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.tsx
@@ -38,24 +38,27 @@ export const InstructionsSection: React.FC = () => {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Consume the one-shot project hint from the sidebar menu. Projects load
-  // asynchronously, so keep the hint alive until the project appears.
+  // Consume the one-shot project hint from the sidebar menu, falling back to
+  // the first project. Projects load asynchronously, so the hint stays alive
+  // until its project appears. One effect, hint first: as separate effects
+  // both fired on mount against an empty selection and the later default
+  // update won the batch, opening the editor on the wrong project.
   useEffect(() => {
-    if (!instructionsProjectPath) return;
-    if (!isProjectInstructionsTarget(userProjects, instructionsProjectPath)) return;
-    setSelectedProject(instructionsProjectPath);
-    setDraft(null);
-    setError(null);
-    setInstructionsProjectPath(null);
-  }, [instructionsProjectPath, userProjects, setInstructionsProjectPath]);
-
-  // Default to the first project once projects are available.
-  useEffect(() => {
+    if (
+      instructionsProjectPath &&
+      isProjectInstructionsTarget(userProjects, instructionsProjectPath)
+    ) {
+      setSelectedProject(instructionsProjectPath);
+      setDraft(null);
+      setError(null);
+      setInstructionsProjectPath(null);
+      return;
+    }
     if (selectedProject && isProjectInstructionsTarget(userProjects, selectedProject)) {
       return;
     }
     setSelectedProject(getFirstTopLevelProjectPath(userProjects) ?? "");
-  }, [selectedProject, userProjects]);
+  }, [instructionsProjectPath, selectedProject, userProjects, setInstructionsProjectPath]);
 
   const savedInstructions = selectedProject
     ? (userProjects.get(selectedProject)?.customInstructions ?? "")

--- a/src/browser/features/Settings/Sections/InstructionsSection.tsx
+++ b/src/browser/features/Settings/Sections/InstructionsSection.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback, useEffect, useState } from "react";
+import type { ProjectConfig } from "@/common/types/project";
+import { useProjectContext } from "@/browser/contexts/ProjectContext";
+import { useSettings } from "@/browser/contexts/SettingsContext";
+import { Button } from "@/browser/components/Button/Button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/browser/components/SelectPrimitive/SelectPrimitive";
+import {
+  formatProjectHierarchyLabel,
+  getFirstTopLevelProjectPath,
+  getTopLevelProjectEntries,
+} from "@/common/utils/subProjects";
+
+// Workspaces are owned by top-level projects (sub-project rows only re-point
+// cwd/AGENTS.md context), so instructions on a sub-project entry would never
+// be applied. Mirror the Secrets page and keep sub-projects out of the picker.
+function isProjectInstructionsTarget(
+  userProjects: Map<string, ProjectConfig>,
+  projectPath: string
+): boolean {
+  const project = userProjects.get(projectPath);
+  return project !== undefined && project.parentProjectPath == null;
+}
+
+export const InstructionsSection: React.FC = () => {
+  const { userProjects, updateCustomInstructions } = useProjectContext();
+  const { instructionsProjectPath, setInstructionsProjectPath } = useSettings();
+  const projectList = getTopLevelProjectEntries(userProjects).map(([projectPath]) => projectPath);
+
+  const [selectedProject, setSelectedProject] = useState<string>("");
+  // null = untouched: the textarea shows the saved value for the selection.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Consume the one-shot project hint from the sidebar menu. Projects load
+  // asynchronously, so keep the hint alive until the project appears.
+  useEffect(() => {
+    if (!instructionsProjectPath) return;
+    if (!isProjectInstructionsTarget(userProjects, instructionsProjectPath)) return;
+    setSelectedProject(instructionsProjectPath);
+    setDraft(null);
+    setError(null);
+    setInstructionsProjectPath(null);
+  }, [instructionsProjectPath, userProjects, setInstructionsProjectPath]);
+
+  // Default to the first project once projects are available.
+  useEffect(() => {
+    if (selectedProject && isProjectInstructionsTarget(userProjects, selectedProject)) {
+      return;
+    }
+    setSelectedProject(getFirstTopLevelProjectPath(userProjects) ?? "");
+  }, [selectedProject, userProjects]);
+
+  const savedInstructions = selectedProject
+    ? (userProjects.get(selectedProject)?.customInstructions ?? "")
+    : "";
+  const draftValue = draft ?? savedInstructions;
+  const isDirty = draftValue !== savedInstructions;
+
+  const handleSelectProject = useCallback((projectPath: string) => {
+    setSelectedProject(projectPath);
+    setDraft(null);
+    setError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!selectedProject) return;
+    setSaving(true);
+    setError(null);
+    const result = await updateCustomInstructions(
+      selectedProject,
+      draftValue.trim() ? draftValue : null
+    );
+    if (result.success) {
+      setDraft(null);
+    } else {
+      setError(result.error ?? "Failed to save instructions");
+    }
+    setSaving(false);
+  }, [draftValue, selectedProject, updateCustomInstructions]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="text-muted text-xs">
+          Custom instructions are appended to the system prompt of every workspace in the selected
+          project. They are stored in <code className="text-accent">~/.mux/config.json</code> (kept
+          out of source control).
+        </p>
+        <p className="text-muted mt-1 text-xs">
+          For instructions shared with all agents and contributors, use the project&apos;s{" "}
+          <code className="text-accent">AGENTS.md</code>; for global personal instructions, use{" "}
+          <code className="text-accent">~/.mux/AGENTS.md</code>.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-foreground text-sm">Project</div>
+          <div className="text-muted text-xs">Select a project to configure</div>
+        </div>
+        <Select value={selectedProject} onValueChange={handleSelectProject}>
+          <SelectTrigger
+            className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto min-w-[160px] cursor-pointer rounded-md border px-3 text-sm transition-colors"
+            aria-label="Project"
+          >
+            <SelectValue placeholder="Select a project" />
+          </SelectTrigger>
+          <SelectContent>
+            {projectList.map((projectPath) => (
+              <SelectItem key={projectPath} value={projectPath}>
+                {formatProjectHierarchyLabel(projectPath, userProjects)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {projectList.length === 0 ? (
+        <p className="text-muted text-xs">Add a project to configure its instructions.</p>
+      ) : (
+        <div>
+          <label htmlFor="project-custom-instructions" className="block">
+            <div className="text-foreground text-sm font-medium">Custom instructions</div>
+          </label>
+          <textarea
+            id="project-custom-instructions"
+            rows={10}
+            value={draftValue}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+              setDraft(event.target.value);
+            }}
+            disabled={!selectedProject || saving}
+            className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent mt-3 min-h-[200px] w-full resize-y rounded-md border p-3 font-mono text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            placeholder="e.g. Always run the test suite before committing. Prefer functional patterns."
+            aria-label="Project custom instructions"
+          />
+
+          {error && (
+            <div className="bg-destructive/10 text-destructive mt-2 flex items-center gap-2 rounded-md px-3 py-2 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="mt-3 flex items-center justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setDraft(null);
+                setError(null);
+              }}
+              disabled={!isDirty || saving}
+            >
+              Reset
+            </Button>
+            <Button
+              onClick={() => {
+                void handleSave();
+              }}
+              disabled={!isDirty || !selectedProject || saving}
+            >
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
+++ b/src/browser/features/Settings/Sections/ProvidersSection.test.tsx
@@ -558,6 +558,8 @@ describe("ProvidersSection", () => {
       setRuntimesProjectPath: () => undefined,
       secretsProjectPath: null,
       setSecretsProjectPath: () => undefined,
+      instructionsProjectPath: null,
+      setInstructionsProjectPath: () => undefined,
     }));
 
     render(

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -17,6 +17,7 @@ import {
   Server,
   Lock,
   ArchiveRestore,
+  ScrollText,
 } from "lucide-react";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { useOnboardingPause } from "@/browser/features/SplashScreens/SplashScreenProvider";
@@ -32,6 +33,7 @@ import { MemorySection } from "./Sections/MemorySection";
 import { Button } from "@/browser/components/Button/Button";
 import { MCPSettingsSection } from "./Sections/MCPSettingsSection";
 import { SecretsSection } from "./Sections/SecretsSection";
+import { InstructionsSection } from "./Sections/InstructionsSection";
 import { LayoutsSection } from "./Sections/LayoutsSection";
 import { RuntimesSection } from "./Sections/RuntimesSection";
 import { ExperimentsSection } from "./Sections/ExperimentsSection";
@@ -55,6 +57,12 @@ const BASE_SECTIONS: SettingsSection[] = [
     label: "Agents",
     icon: <Bot className="h-4 w-4" />,
     component: TasksSection,
+  },
+  {
+    id: "instructions",
+    label: "Instructions",
+    icon: <ScrollText className="h-4 w-4" />,
+    component: InstructionsSection,
   },
   {
     id: "providers",

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -1386,6 +1386,18 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         }
         return Promise.resolve();
       },
+      setCustomInstructions: (input: {
+        projectPath: string;
+        customInstructions?: string | null;
+      }) => {
+        const project = projects.get(input.projectPath);
+        if (project) {
+          project.customInstructions = input.customInstructions?.trim()
+            ? input.customInstructions
+            : undefined;
+        }
+        return Promise.resolve();
+      },
       secrets: {
         get: (input: { projectPath: string }) =>
           Promise.resolve(projectSecrets.get(input.projectPath) ?? []),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -794,6 +794,15 @@ export const projects = {
       .passthrough(),
     output: z.void(),
   },
+  setCustomInstructions: {
+    input: z
+      .object({
+        projectPath: z.string(),
+        customInstructions: z.string().nullish(),
+      })
+      .passthrough(),
+    output: z.void(),
+  },
   mcp: {
     list: {
       input: z.object({ projectPath: z.string() }),

--- a/src/common/schemas/project.ts
+++ b/src/common/schemas/project.ts
@@ -296,6 +296,10 @@ export const ProjectConfigSchema = z.object({
     description:
       "Whether the user has confirmed trust for this project. Untrusted projects cannot run hooks or user scripts.",
   }),
+  customInstructions: z.string().optional().meta({
+    description:
+      "Custom system prompt appended for every workspace in this project (Settings → Instructions)",
+  }),
 });
 
 export type WorktreeArchiveSnapshotProject = z.infer<typeof WorktreeArchiveSnapshotProjectSchema>;

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -153,6 +153,34 @@ describe("Config", () => {
     });
   });
 
+  describe("loadConfigOrDefault customInstructions sanitizing", () => {
+    it("discards malformed non-string customInstructions and keeps valid ones", () => {
+      // A malformed value must not survive load: it would fail the
+      // projects.list z.string() output schema and brick the project list.
+      const configFile = path.join(tempDir, "config.json");
+      fs.writeFileSync(
+        configFile,
+        JSON.stringify({
+          projects: [
+            ["/home/user/number", { workspaces: [], customInstructions: 42 }],
+            ["/home/user/object", { workspaces: [], customInstructions: { nested: true } }],
+            ["/home/user/blank", { workspaces: [], customInstructions: "   " }],
+            ["/home/user/valid", { workspaces: [], customInstructions: "Keep this guidance." }],
+          ],
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.projects.get("/home/user/number")?.customInstructions).toBeUndefined();
+      expect(loaded.projects.get("/home/user/object")?.customInstructions).toBeUndefined();
+      expect(loaded.projects.get("/home/user/blank")?.customInstructions).toBeUndefined();
+      expect(loaded.projects.get("/home/user/valid")?.customInstructions).toBe(
+        "Keep this guidance."
+      );
+    });
+  });
+
   describe("legacy workflow schedule cleanup", () => {
     it("drops named workflow schedule config while loading", () => {
       const configFile = path.join(tempDir, "config.json");

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -728,6 +728,7 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
     defaultRuntime?: unknown;
     runtimeOverridesEnabled?: unknown;
     projectKind?: unknown;
+    customInstructions?: unknown;
   };
   const runtimeEnablement = normalizeRuntimeEnablementOverrides(record.runtimeEnablement);
   const defaultRuntime = normalizeRuntimeEnablementId(record.defaultRuntime);
@@ -761,6 +762,15 @@ function normalizeProjectRuntimeSettings(projectConfig: ProjectConfig): ProjectC
     next.projectKind = projectKind;
   } else {
     delete next.projectKind;
+  }
+
+  // config.json is hand-editable: a non-string customInstructions would fail
+  // the projects.list output schema (z.string()) and brick the whole project
+  // list, so discard malformed values here where both load and save pass.
+  if (typeof record.customInstructions === "string" && record.customInstructions.trim()) {
+    next.customInstructions = record.customInstructions;
+  } else {
+    delete next.customInstructions;
   }
 
   // Legacy named workflow schedules are intentionally dropped while workflow

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3492,6 +3492,24 @@ export const router = (authToken?: string) => {
             return config;
           });
         }),
+      setCustomInstructions: t
+        .input(schemas.projects.setCustomInstructions.input)
+        .output(schemas.projects.setCustomInstructions.output)
+        .handler(async ({ context, input }) => {
+          await context.config.editConfig((config) => {
+            const normalizedPath = stripTrailingSlashes(input.projectPath);
+            const project = config.projects.get(normalizedPath);
+            if (!project) {
+              throw new Error(`Project not found: ${normalizedPath}`);
+            }
+            // Store undefined for blank input to keep config.json minimal.
+            const customInstructions = input.customInstructions ?? undefined;
+            project.customInstructions = customInstructions?.trim()
+              ? customInstructions
+              : undefined;
+            return config;
+          });
+        }),
       remove: t
         .input(schemas.projects.remove.input)
         .output(schemas.projects.remove.output)

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -2198,7 +2198,8 @@ export class AIService extends EventEmitter {
         runtime,
         workspacePath,
         capabilityModelString,
-        agentSystemPromptSections
+        agentSystemPromptSections,
+        cfg.projects
       );
       recordStartupPhaseTiming("readToolInstructionsMs", readToolInstructionsStartedAt);
 

--- a/src/node/services/instructionsService.test.ts
+++ b/src/node/services/instructionsService.test.ts
@@ -1,0 +1,128 @@
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { InstructionsService } from "./instructionsService";
+import { Config } from "@/node/config";
+import type { AIService } from "@/node/services/aiService";
+import type { TokenizerService } from "@/node/services/tokenizerService";
+import type { WorkspaceMetadata } from "@/common/types/workspace";
+import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
+import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
+
+// Regression coverage for token counting in the Instructions tab: model
+// selection is persisted per-agent (aiSettingsByAgent), so resolution must not
+// stop at the legacy workspace-scoped aiSettings field.
+describe("InstructionsService model resolution", () => {
+  let tempDir: string;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "instructions-service-test-"));
+    projectDir = path.join(tempDir, "project");
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(path.join(projectDir, "AGENTS.md"), "Some instructions.\n");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function createService(metadata: WorkspaceMetadata, countedModels: string[]) {
+    const aiService = {
+      getWorkspaceMetadata: () => Promise.resolve({ success: true, data: metadata }),
+    } as unknown as AIService;
+    const tokenizerService = {
+      countTokens: (model: string, content: string) => {
+        countedModels.push(model);
+        return Promise.resolve(content.length);
+      },
+    } as unknown as TokenizerService;
+    return new InstructionsService(new Config(tempDir), aiService, tokenizerService);
+  }
+
+  function baseMetadata(): WorkspaceMetadata {
+    // projectPath === name selects the in-place workspace path shape, so the
+    // service reads AGENTS.md straight from projectDir without a worktree.
+    return {
+      id: "ws-1",
+      name: projectDir,
+      projectName: "project",
+      projectPath: projectDir,
+      runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    };
+  }
+
+  test("resolves model from the selected agent's aiSettingsByAgent entry", async () => {
+    const counted: string[] = [];
+    const service = createService(
+      {
+        ...baseMetadata(),
+        agentId: "plan",
+        aiSettingsByAgent: {
+          plan: { model: "anthropic:plan-model", thinkingLevel: "off" as const },
+          [WORKSPACE_DEFAULTS.agentId]: {
+            model: "anthropic:exec-model",
+            thinkingLevel: "off" as const,
+          },
+        },
+        aiSettings: { model: "anthropic:legacy-model", thinkingLevel: "off" as const },
+      },
+      counted
+    );
+
+    const result = await service.getWorkspaceInstructions("ws-1");
+    expect(result.model).toBe("anthropic:plan-model");
+    expect(counted.length).toBeGreaterThan(0);
+    expect(new Set(counted)).toEqual(new Set(["anthropic:plan-model"]));
+    expect(result.totalTokens).not.toBeNull();
+  });
+
+  test("falls back to the default agent's settings, then legacy aiSettings", async () => {
+    const counted: string[] = [];
+    const service = createService(
+      {
+        ...baseMetadata(),
+        agentId: "plan",
+        aiSettingsByAgent: {
+          [WORKSPACE_DEFAULTS.agentId]: {
+            model: "anthropic:exec-model",
+            thinkingLevel: "off" as const,
+          },
+        },
+      },
+      counted
+    );
+    const result = await service.getWorkspaceInstructions("ws-1");
+    expect(result.model).toBe("anthropic:exec-model");
+
+    const legacyOnly = createService(
+      {
+        ...baseMetadata(),
+        aiSettings: { model: "anthropic:legacy-model", thinkingLevel: "off" as const },
+      },
+      []
+    );
+    const legacyResult = await legacyOnly.getWorkspaceInstructions("ws-1");
+    expect(legacyResult.model).toBe("anthropic:legacy-model");
+  });
+
+  test("explicit model override wins over persisted settings", async () => {
+    const counted: string[] = [];
+    const service = createService(
+      {
+        ...baseMetadata(),
+        aiSettingsByAgent: {
+          [WORKSPACE_DEFAULTS.agentId]: {
+            model: "anthropic:exec-model",
+            thinkingLevel: "off" as const,
+          },
+        },
+      },
+      counted
+    );
+    const result = await service.getWorkspaceInstructions("ws-1", "openai:override-model");
+    expect(result.model).toBe("openai:override-model");
+    expect(new Set(counted)).toEqual(new Set(["openai:override-model"]));
+  });
+});

--- a/src/node/services/instructionsService.ts
+++ b/src/node/services/instructionsService.ts
@@ -5,6 +5,8 @@ import {
   type InstructionSources,
   type WorkspaceInstructions,
 } from "@/common/types/instructions";
+import { normalizeAgentId } from "@/common/utils/agentIds";
+import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 import type { Config } from "@/node/config";
 import {
   createRuntimeContextForWorkspace,
@@ -90,8 +92,14 @@ export class InstructionsService {
     );
 
     const trimmedOverride = modelOverride?.trim();
+    // Model selection is persisted per-agent (aiSettingsByAgent); workspace-scoped
+    // aiSettings is the legacy field. Resolve like the stream path does, otherwise
+    // token counting silently skips for workspaces without legacy settings.
+    const agentId = normalizeAgentId(metadata.agentId, WORKSPACE_DEFAULTS.agentId);
     const model =
       (trimmedOverride && trimmedOverride.length > 0 ? trimmedOverride : null) ??
+      metadata.aiSettingsByAgent?.[agentId]?.model ??
+      metadata.aiSettingsByAgent?.[WORKSPACE_DEFAULTS.agentId]?.model ??
       metadata.aiSettings?.model ??
       null;
     const flatRaw = flattenInstructionFiles(sources);

--- a/src/node/services/instructionsService.ts
+++ b/src/node/services/instructionsService.ts
@@ -82,7 +82,12 @@ export class InstructionsService {
     // historical bug in the prompt builder.
     const { runtime } = createRuntimeContextForWorkspace(metadata);
     const workspaceRootPath = resolveWorkspaceRootPath(metadata, runtime);
-    const sources = await loadInstructionSources(metadata, runtime, workspaceRootPath);
+    const sources = await loadInstructionSources(
+      metadata,
+      runtime,
+      workspaceRootPath,
+      this.config.loadConfigOrDefault().projects
+    );
 
     const trimmedOverride = modelOverride?.trim();
     const model =

--- a/src/node/services/streamContextBuilder.ts
+++ b/src/node/services/streamContextBuilder.ts
@@ -639,7 +639,11 @@ export async function buildStreamSystemContext(
     // and the agent id (so per-agent sections work). The effective mode names
     // the injected <mode-...> tag; agentDefinition.id (may have fallen back
     // to exec) is the prompt actually in effect.
-    { agentSystemPromptSections, modes: [effectiveMode, agentDefinition.id] }
+    {
+      agentSystemPromptSections,
+      modes: [effectiveMode, agentDefinition.id],
+      projectConfigs: cfg.projects,
+    }
   );
 
   // Append the hot-memories block (memory-hot-set sub-experiment). Placed at

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -373,6 +373,26 @@ Include the secondary project context too.
       expect(systemMessage).not.toContain("<custom-instructions>");
     });
 
+    test("survives malformed non-string customInstructions in config.json", async () => {
+      // config.json is hand-editable and loaded without schema validation; a
+      // malformed value must be skipped, not brick every send from the project.
+      const projectConfigs = new Map<string, ProjectConfig>([
+        [projectDir, { workspaces: [], customInstructions: 42 } as unknown as ProjectConfig],
+      ]);
+
+      const systemMessage = await buildSystemMessage(
+        singleProjectMetadata(projectDir),
+        runtime,
+        workspaceDir,
+        undefined,
+        undefined,
+        undefined,
+        { projectConfigs }
+      );
+
+      expect(systemMessage).not.toContain("<custom-instructions>");
+    });
+
     test("includes customInstructions from every project in a multi-project workspace", async () => {
       const { metadata } = await createMultiProjectFixture();
       const projectConfigs = new Map<string, ProjectConfig>(

--- a/src/node/services/systemMessage.test.ts
+++ b/src/node/services/systemMessage.test.ts
@@ -3,6 +3,7 @@ import * as os from "os";
 import * as path from "path";
 import { buildSystemMessage, extractToolInstructions, readToolInstructions } from "./systemMessage";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
+import type { ProjectConfig } from "@/common/types/project";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
 
 const extractTagContent = (message: string, tagName: string): string | null => {
@@ -319,6 +320,115 @@ Include the secondary project context too.
     const customInstructions = extractTagContent(systemMessage, "custom-instructions") ?? "";
     expect(customInstructions).toContain("Use the primary project context.");
     expect(customInstructions).toContain("Include the secondary project context too.");
+  });
+
+  describe("project customInstructions from config", () => {
+    const singleProjectMetadata = (projectPath: string): WorkspaceMetadata => ({
+      id: "test-workspace",
+      name: "test-workspace",
+      projectName: "test-project",
+      projectPath,
+      runtimeConfig: DEFAULT_RUNTIME_CONFIG,
+    });
+
+    test("appends only the workspace's own project instructions", async () => {
+      const projectConfigs = new Map<string, ProjectConfig>([
+        [projectDir, { workspaces: [], customInstructions: "Never touch the legacy folder." }],
+        [
+          path.join(tempDir, "other-project"),
+          { workspaces: [], customInstructions: "Unrelated project guidance." },
+        ],
+      ]);
+
+      const systemMessage = await buildSystemMessage(
+        singleProjectMetadata(projectDir),
+        runtime,
+        workspaceDir,
+        undefined,
+        undefined,
+        undefined,
+        { projectConfigs }
+      );
+
+      const customInstructions = extractTagContent(systemMessage, "custom-instructions") ?? "";
+      expect(customInstructions).toContain("Never touch the legacy folder.");
+      expect(customInstructions).not.toContain("Unrelated project guidance.");
+    });
+
+    test("skips blank customInstructions", async () => {
+      const projectConfigs = new Map<string, ProjectConfig>([
+        [projectDir, { workspaces: [], customInstructions: "   \n\t" }],
+      ]);
+
+      const systemMessage = await buildSystemMessage(
+        singleProjectMetadata(projectDir),
+        runtime,
+        workspaceDir,
+        undefined,
+        undefined,
+        undefined,
+        { projectConfigs }
+      );
+
+      expect(systemMessage).not.toContain("<custom-instructions>");
+    });
+
+    test("includes customInstructions from every project in a multi-project workspace", async () => {
+      const { metadata } = await createMultiProjectFixture();
+      const projectConfigs = new Map<string, ProjectConfig>(
+        (metadata.projects ?? []).map((project, index) => [
+          project.projectPath,
+          { workspaces: [], customInstructions: `Guidance for project number ${index + 1}.` },
+        ])
+      );
+
+      const systemMessage = await buildSystemMessage(
+        metadata,
+        runtime,
+        workspaceDir,
+        undefined,
+        undefined,
+        undefined,
+        { projectConfigs }
+      );
+
+      const customInstructions = extractTagContent(systemMessage, "custom-instructions") ?? "";
+      expect(customInstructions).toContain("Guidance for project number 1.");
+      expect(customInstructions).toContain("Guidance for project number 2.");
+    });
+
+    test("honors scoped Model: sections like other Mux-dedicated sources", async () => {
+      const projectConfigs = new Map<string, ProjectConfig>([
+        [
+          projectDir,
+          {
+            workspaces: [],
+            customInstructions: `Unscoped project guidance.
+## Model: sonnet
+Scoped project model guidance.
+`,
+          },
+        ],
+      ]);
+
+      const systemMessage = await buildSystemMessage(
+        singleProjectMetadata(projectDir),
+        runtime,
+        workspaceDir,
+        undefined,
+        "anthropic:claude-3.5-sonnet",
+        undefined,
+        { projectConfigs }
+      );
+
+      const customInstructions = extractTagContent(systemMessage, "custom-instructions") ?? "";
+      expect(customInstructions).toContain("Unscoped project guidance.");
+      expect(customInstructions).not.toContain("Scoped project model guidance.");
+
+      const modelSection =
+        extractTagContent(systemMessage, "model-anthropic-claude-3-5-sonnet") ?? "";
+      expect(modelSection).toContain("Scoped project model guidance.");
+    });
   });
 
   test("preserves bash tool instructions from every multi-project context source", async () => {

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -509,7 +509,11 @@ function buildProjectSettingsInstructionSets(
   const sets: InstructionSet[] = [];
   for (const project of getProjects(metadata)) {
     const normalizedPath = stripTrailingSlashes(project.projectPath);
-    const content = projectConfigs.get(normalizedPath)?.customInstructions?.trim();
+    // config.json is hand-editable and loaded without schema validation, so a
+    // malformed customInstructions (number, object, ...) can survive load.
+    // Guard instead of throwing, or every send from the project fails.
+    const raw: unknown = projectConfigs.get(normalizedPath)?.customInstructions;
+    const content = typeof raw === "string" ? raw.trim() : undefined;
     if (!content) continue;
     sets.push({
       scope: INSTRUCTION_SCOPE.PROJECT,

--- a/src/node/services/systemMessage.ts
+++ b/src/node/services/systemMessage.ts
@@ -30,6 +30,8 @@ import {
 import type { Runtime } from "@/node/runtime/Runtime";
 import { resolveWorkspaceRootPath } from "@/node/runtime/runtimeHelpers";
 import { getMuxHome } from "@/common/constants/paths";
+import { stripTrailingSlashes } from "@/node/utils/pathUtils";
+import type { ProjectConfig } from "@/common/types/project";
 import { getAvailableTools } from "@/common/utils/tools/toolDefinitions";
 import { getToolAvailabilityOptions } from "@/common/utils/tools/toolAvailability";
 import { assertNever } from "@/common/utils/assertNever";
@@ -303,13 +305,19 @@ export async function readToolInstructions(
   runtime: Runtime,
   workspacePath: string,
   modelString: string,
-  agentInstructions?: readonly string[]
+  agentInstructions?: readonly string[],
+  projectConfigs?: Map<string, ProjectConfig>
 ): Promise<Record<string, string>> {
   // Tool instructions read the same `AGENTS.md` files as the system prompt;
   // anchor at the workspace root so sub-project workspaces still see parent
   // project tool sections (see `loadInstructionSources` doc).
   const workspaceRootPath = subProjectAwareWorkspaceRoot(metadata, runtime, workspacePath);
-  const sources = await loadInstructionSources(metadata, runtime, workspaceRootPath);
+  const sources = await loadInstructionSources(
+    metadata,
+    runtime,
+    workspaceRootPath,
+    projectConfigs
+  );
   const globalContents = collectInstructionContents([sources.global]);
   const contextContents = collectInstructionContents(sources.context);
 
@@ -458,12 +466,14 @@ function deriveSubProjectRelativePath(projectPath: string, subProjectPath: strin
  * @param metadata - Workspace metadata (contains projectPath)
  * @param runtime - Runtime for reading workspace files (supports SSH)
  * @param workspacePath - Workspace directory path
+ * @param projectConfigs - Project configs from ~/.mux/config.json for per-project customInstructions
  * @returns Structured instruction sources (global + ordered context entries)
  */
 export async function loadInstructionSources(
   metadata: WorkspaceMetadata,
   runtime: Runtime,
-  workspaceRootPath: string
+  workspaceRootPath: string,
+  projectConfigs?: Map<string, ProjectConfig>
 ): Promise<InstructionSources> {
   // `workspaceRootPath` is the parent project's checkout root — *without* the
   // optional sub-project segment. Callers that hand us the execution path
@@ -475,7 +485,54 @@ export async function loadInstructionSources(
     ? await readMultiProjectContextInstructions(metadata, runtime, workspaceRootPath)
     : await readSingleProjectContextInstructions(metadata, runtime, workspaceRootPath);
 
-  return { global, context };
+  // Config-stored per-project instructions (Settings → Instructions) come after
+  // the repo-file sets so user settings layer on top of committed guidance.
+  const settingsSets = buildProjectSettingsInstructionSets(metadata, projectConfigs);
+
+  return { global, context: [...context, ...settingsSets] };
+}
+
+/**
+ * Synthesize instruction sets from `customInstructions` persisted per project
+ * in `~/.mux/config.json` (Settings → Instructions). Flowing them through
+ * `InstructionSources` keeps the right-sidebar Instructions tab and the prompt
+ * builder in lockstep, and `muxOnly: true` gives scoped Model:/Mode:/Tool:
+ * directives the same semantics as `.mux/AGENTS.md` (config.json is
+ * Mux-dedicated by construction).
+ */
+function buildProjectSettingsInstructionSets(
+  metadata: WorkspaceMetadata,
+  projectConfigs: Map<string, ProjectConfig> | undefined
+): InstructionSet[] {
+  if (!projectConfigs) return [];
+  const configPath = path.join(getMuxHome(), "config.json");
+  const sets: InstructionSet[] = [];
+  for (const project of getProjects(metadata)) {
+    const normalizedPath = stripTrailingSlashes(project.projectPath);
+    const content = projectConfigs.get(normalizedPath)?.customInstructions?.trim();
+    if (!content) continue;
+    sets.push({
+      scope: INSTRUCTION_SCOPE.PROJECT,
+      projectName: project.projectName,
+      directory: getMuxHome(),
+      files: [
+        {
+          // Suffix with the project path so multi-project workspaces keep a
+          // unique identity per file (the panel keys token counts by path).
+          path: `${configPath}#${normalizedPath}`,
+          filename: "Project instructions",
+          isLocal: false,
+          muxOnly: true,
+          scope: INSTRUCTION_SCOPE.PROJECT,
+          projectName: project.projectName,
+          content,
+          bytes: Buffer.byteLength(content, "utf8"),
+        },
+      ],
+      combinedContent: content,
+    });
+  }
+  return sets;
 }
 
 /**
@@ -485,7 +542,8 @@ export async function loadInstructionSources(
  * 1. Global: ~/.mux/AGENTS.md (always included; Mux-dedicated)
  * 2. Context: workspace/AGENTS.md (+ workspace/.mux/AGENTS.md) plus project repo instructions
  *    for multi-project workspaces, or workspace/AGENTS.md OR project/AGENTS.md for
- *    single-project workspaces
+ *    single-project workspaces, plus per-project `customInstructions` from
+ *    ~/.mux/config.json when options.projectConfigs is provided
  * 3. Model: Extracts "Model: <regex>" sections from Mux-dedicated sources only
  *    (agent definition → .mux/AGENTS.md context files → ~/.mux/AGENTS.md), if modelString provided
  * 4. Mode: Extracts "Mode: <mode>" sections from the same Mux-dedicated sources for every
@@ -526,6 +584,11 @@ export async function buildSystemMessage(
      * injected <mode-...> tag. Duplicates are ignored.
      */
     modes?: readonly string[];
+    /**
+     * Project configs from ~/.mux/config.json, used to append per-project
+     * `customInstructions` (Settings → Instructions) to the prompt.
+     */
+    projectConfigs?: Map<string, ProjectConfig>;
   }
 ): Promise<string> {
   if (!metadata) throw new Error("Invalid workspace metadata: metadata is required");
@@ -561,7 +624,12 @@ export async function buildSystemMessage(
   // back to the resolved root so the parent project's AGENTS.md is still read.
   // For non-sub-project workspaces this is a no-op (root === execution path).
   const workspaceRootPath = subProjectAwareWorkspaceRoot(metadata, runtime, workspacePath);
-  const instructionSources = await loadInstructionSources(metadata, runtime, workspaceRootPath);
+  const instructionSources = await loadInstructionSources(
+    metadata,
+    runtime,
+    workspaceRootPath,
+    options?.projectConfigs
+  );
   // Mux-dedicated per-file contents (<dir>/.mux/AGENTS.md context files, then
   // the global ~/.mux/AGENTS.md set, which is Mux-dedicated by construction).
   // Scoped Model:/Mode: directives are honored ONLY in Mux-dedicated sources


### PR DESCRIPTION
## Summary

Adds per-project custom system prompts: free-form instructions saved on a project in `~/.mux/config.json` that get injected into the system prompt (inside `<custom-instructions>`) for every workspace of that project, and surfaced in the right-sidebar Instructions tab.

## Background

Repo-level guidance lives in committed `AGENTS.md` files, but users need a private, uncommitted layer of per-project guidance (personal conventions, machine-local caveats) that applies to all workspaces of a project without touching the repo. This mirrors what global custom instructions do, scoped to one project.

## Implementation

- `ProjectConfigSchema` gains `customInstructions`; a new ORPC endpoint `projects.setCustomInstructions` (mirroring `setDisplayName`/`setColor`) persists it, storing `undefined` for blank input to keep config.json minimal.
- `loadInstructionSources` accepts project configs and synthesizes a `muxOnly` instruction set per matching project. Because injection goes through the same instruction-source pipeline as AGENTS.md, the Instructions tab shows the entry automatically ("Project instructions", `project:` badge, token count) and scoped `Model:`/`Mode:`/`Tool:` sections work unchanged.
- UI: an "Instructions" item in the project dropdown menu opens a new Settings -> Instructions page (top-level project picker, textarea, dirty-gated Save/Reset). A one-shot `instructionsProjectPath` hint in `SettingsContext` pre-selects the clicked project.
- Sub-projects are excluded from the picker (their workspaces live in the owning top-level project's bucket, so instructions on sub-project entries would never apply).

## Validation

- Behavioral tests: own-project-only lookup, blank skipping, multi-project inclusion, Model:-section scoping (`systemMessage.test.ts`); save flow, clear-saves-null, hint pre-selection (`InstructionsSection.test.tsx`); menu list + routing (`ProjectSidebar.test.tsx`).
- Remote UAT via a Coder Agents chat validated the full user workflow (menu -> settings pre-selection, save/reset/clear persistence into config.json, Instructions-tab surfacing, cross-project isolation, system prompt injection via devtools.jsonl). Verdict: PASS against a real `anthropic:claude-haiku-4-5` request (injection order, scoped `Model:` section routing, byte-identical special-character round-trips all confirmed). Evidence: https://dev.coder.com/agents/3bfcb42b-5c9b-4b09-9e5b-1189dbcfdabf

UAT also surfaced a pre-existing tab-wide defect: token counts never rendered in the Instructions tab because `getWorkspaceInstructions` only read the legacy workspace-scoped `aiSettings.model`, while model selection is now persisted per-agent in `aiSettingsByAgent`. Fixed here (with red-green regression tests) since this feature's display depends on it.

## Risks

Low. The prompt-injection path adds an additive instruction source; workspaces without project instructions produce identical prompts as before. The settings page and menu item are new surfaces with no existing behavior to regress.


---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
