### PR TITLE
🤖 fix: cap MCP tool result text output before it enters history

### DIFF
--- a/src/common/constants/toolLimits.ts
+++ b/src/common/constants/toolLimits.ts
@@ -26,6 +26,12 @@ export const WEB_FETCH_TIMEOUT_SECS = 15; // curl timeout
 export const WEB_FETCH_MAX_OUTPUT_BYTES = 64 * 1024; // 64KB markdown output
 export const WEB_FETCH_MAX_HTML_BYTES = 5 * 1024 * 1024; // 5MB HTML input (curl --max-filesize)
 
+// MCP tool results are server-controlled and previously unbounded: a 62MB
+// Grafana trace result persisted into chat.jsonl froze the renderer and made
+// every later provider request exceed API payload limits (#3138). Bound the
+// text surfaces like web_fetch output before results enter history.
+export const MCP_TOOL_RESULT_MAX_TEXT_BYTES = 64 * 1024;
+
 // MCP prompt expansions are server-controlled; bound them like web_fetch output.
 export const MCP_PROMPT_MAX_TEXT_BYTES = 64 * 1024;
 export const MCP_PROMPT_TRUNCATION_MARKER = "\n\n[Prompt text truncated]";

--- a/src/common/constants/toolLimits.ts
+++ b/src/common/constants/toolLimits.ts
@@ -32,6 +32,13 @@ export const WEB_FETCH_MAX_HTML_BYTES = 5 * 1024 * 1024; // 5MB HTML input (curl
 // text surfaces like web_fetch output before results enter history.
 export const MCP_TOOL_RESULT_MAX_TEXT_BYTES = 64 * 1024;
 
+// Backstop for MCP result surfaces the per-text caps cannot reach (result- and
+// part-level _meta, unknown fields, resource URIs): results whose total
+// serialized size still exceeds this after text capping are flattened to
+// bounded text parts. Sized so capped legitimate results (64KB text + 64KB
+// structuredContent + notices) never trip it.
+export const MCP_TOOL_RESULT_MAX_TOTAL_BYTES = 256 * 1024;
+
 // MCP prompt expansions are server-controlled; bound them like web_fetch output.
 export const MCP_PROMPT_MAX_TEXT_BYTES = 64 * 1024;
 export const MCP_PROMPT_TRUNCATION_MARKER = "\n\n[Prompt text truncated]";

--- a/src/common/constants/toolLimits.ts
+++ b/src/common/constants/toolLimits.ts
@@ -29,7 +29,9 @@ export const WEB_FETCH_MAX_HTML_BYTES = 5 * 1024 * 1024; // 5MB HTML input (curl
 // MCP tool results are server-controlled and previously unbounded: a 62MB
 // Grafana trace result persisted into chat.jsonl froze the renderer and made
 // every later provider request exceed API payload limits (#3138). Bound the
-// text surfaces like web_fetch output before results enter history.
+// text surfaces like web_fetch output before results enter history. Charged
+// in serialized JSON bytes (escape expansion + per-part wrapper overhead) so
+// part count and escape-heavy content cannot multiply the persisted size.
 export const MCP_TOOL_RESULT_MAX_TEXT_BYTES = 64 * 1024;
 
 // Backstop for MCP result surfaces the per-text caps cannot reach (result- and

--- a/src/node/services/mcpResultTransform.test.ts
+++ b/src/node/services/mcpResultTransform.test.ts
@@ -128,25 +128,54 @@ describe("transformMCPResult", () => {
       expect(original.content[0].text).toHaveLength(bigText.length);
     });
 
-    it("returns text-only results at the cap unchanged (same reference)", () => {
-      const atCap = {
-        content: [{ type: "text" as const, text: "a".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) }],
+    it("returns text-only results under the cap unchanged (same reference)", () => {
+      // 100 bytes of headroom covers the serialized part-wrapper overhead.
+      const underCap = {
+        content: [
+          { type: "text" as const, text: "a".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES - 100) },
+        ],
       };
-      expect(transformMCPResult(atCap)).toBe(atCap);
+      expect(transformMCPResult(underCap)).toBe(underCap);
     });
 
     it("shares one budget across parts and appends an omission notice", () => {
+      const nearCapText = "b".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES - 40);
       const result = transformMCPResult({
         content: [
-          { type: "text" as const, text: "b".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) },
+          { type: "text" as const, text: nearCapText },
           { type: "text" as const, text: "dropped entirely" },
           { type: "text" as const, text: "also dropped" },
         ],
       }) as TextContentResult;
 
       expect(result.content).toHaveLength(2);
-      expect(result.content[0].text).toBe("b".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES));
+      expect(result.content[0].text).toBe(nearCapText);
       expect(result.content[1].text).toContain("[2 content part(s) omitted:");
+    });
+
+    it("bounds serialized size when a result carries very many tiny parts", () => {
+      // Per Codex review: budgeting only raw text bytes lets 40k one-byte
+      // parts serialize to >1MB of JSON wrapper overhead.
+      const result = transformMCPResult({
+        content: Array.from({ length: 40_000 }, () => ({ type: "text" as const, text: "x" })),
+      }) as TextContentResult;
+
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(
+        MCP_TOOL_RESULT_MAX_TOTAL_BYTES
+      );
+      expect(result.content.at(-1)!.text).toContain("content part(s) omitted:");
+    });
+
+    it("bounds serialized size of escape-heavy text (JSON escapes expand 6x)", () => {
+      // Raw-byte budgeting lets 64KB of control characters serialize to ~384KB.
+      const result = transformMCPResult({
+        content: [{ type: "text" as const, text: "\u0001".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) }],
+      }) as TextContentResult;
+
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(
+        MCP_TOOL_RESULT_MAX_TOTAL_BYTES
+      );
+      expect(result.content[0].text).toContain("[MCP tool result text truncated:");
     });
 
     it("caps oversized text resources in text-only results", () => {

--- a/src/node/services/mcpResultTransform.test.ts
+++ b/src/node/services/mcpResultTransform.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { MCP_TOOL_RESULT_MAX_TEXT_BYTES } from "@/common/constants/toolLimits";
+import {
+  MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+  MCP_TOOL_RESULT_MAX_TOTAL_BYTES,
+} from "@/common/constants/toolLimits";
 import { transformMCPResult, MAX_IMAGE_DATA_BYTES } from "./mcpResultTransform";
 
 describe("transformMCPResult", () => {
@@ -234,6 +237,67 @@ describe("transformMCPResult", () => {
 
       expect(result.content[0].type).toBe("text");
       expect(result.content[0].text).toContain("[MCP tool result omitted:");
+    });
+
+    it("passes small results with modest metadata through unchanged", () => {
+      const withMeta = {
+        content: [{ type: "text" as const, text: "ok" }],
+        _meta: { traceId: "abc123" },
+      };
+      expect(transformMCPResult(withMeta)).toBe(withMeta);
+    });
+
+    it("flattens results whose result-level metadata exceeds the total serialized cap", () => {
+      const result = transformMCPResult({
+        content: [{ type: "text" as const, text: "small useful text" }],
+        _meta: { blob: "m".repeat(MCP_TOOL_RESULT_MAX_TOTAL_BYTES + 10_000) },
+      }) as TextContentResult & { _meta?: unknown };
+
+      expect(result._meta).toBeUndefined();
+      expect(result.content[0].text).toBe("small useful text");
+      expect(result.content.at(-1)!.text).toContain("[MCP result metadata omitted:");
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(
+        MCP_TOOL_RESULT_MAX_TOTAL_BYTES
+      );
+    });
+
+    it("bounds oversized metadata riding on individual content parts", () => {
+      const result = transformMCPResult({
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "hello",
+            _meta: { blob: "m".repeat(MCP_TOOL_RESULT_MAX_TOTAL_BYTES + 10_000) },
+          },
+        ],
+      }) as TextContentResult;
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe("hello");
+      expect(result.content.at(-1)!.text).toContain("[MCP result metadata omitted:");
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(
+        MCP_TOOL_RESULT_MAX_TOTAL_BYTES
+      );
+    });
+
+    it("bounds resource parts with oversized URIs and no text", () => {
+      const result = transformMCPResult({
+        content: [
+          {
+            type: "resource" as const,
+            resource: { uri: "data:x," + "u".repeat(MCP_TOOL_RESULT_MAX_TOTAL_BYTES + 10_000) },
+          },
+        ],
+      }) as TextContentResult;
+
+      // Flattened to a truncated stringified text part plus the metadata notice.
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toContain("[MCP tool result text truncated:");
+      expect(result.content.at(-1)!.text).toContain("[MCP result metadata omitted:");
+      expect(Buffer.byteLength(JSON.stringify(result), "utf8")).toBeLessThan(
+        MCP_TOOL_RESULT_MAX_TOTAL_BYTES
+      );
     });
 
     it("truncates oversized primitive string results", () => {

--- a/src/node/services/mcpResultTransform.test.ts
+++ b/src/node/services/mcpResultTransform.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { MCP_TOOL_RESULT_MAX_TEXT_BYTES } from "@/common/constants/toolLimits";
 import { transformMCPResult, MAX_IMAGE_DATA_BYTES } from "./mcpResultTransform";
 
 describe("transformMCPResult", () => {
@@ -93,6 +94,155 @@ describe("transformMCPResult", () => {
       expect(transformed.value[0].text).toMatch(/Image omitted/);
       expect(transformed.value[0].text).toMatch(/per-image guard/i);
       expect(transformed.value[0].text).toMatch(/MB|KB/);
+    });
+  });
+
+  describe("text output cap", () => {
+    interface TextContentResult {
+      content: Array<{ type: string; text?: string; resource?: { uri: string; text?: string } }>;
+      isError?: boolean;
+      structuredContent?: unknown;
+    }
+
+    it("truncates an oversized text-only result with a notice, preserving MCP shape", () => {
+      const bigText = "x".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 10_000);
+      const original = {
+        isError: true,
+        content: [{ type: "text" as const, text: bigText }],
+      };
+
+      const result = transformMCPResult(original) as TextContentResult;
+
+      // MCP wire shape (and the isError flag) must survive so toModelOutput
+      // still surfaces errors to the model.
+      expect(result.isError).toBe(true);
+      expect(result.content).toHaveLength(1);
+      const text = result.content[0].text!;
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThan(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 300);
+      expect(text.startsWith("xxx")).toBe(true);
+      expect(text).toContain("[MCP tool result text truncated:");
+      // Original object must not be mutated.
+      expect(original.content[0].text).toHaveLength(bigText.length);
+    });
+
+    it("returns text-only results at the cap unchanged (same reference)", () => {
+      const atCap = {
+        content: [{ type: "text" as const, text: "a".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) }],
+      };
+      expect(transformMCPResult(atCap)).toBe(atCap);
+    });
+
+    it("shares one budget across parts and appends an omission notice", () => {
+      const result = transformMCPResult({
+        content: [
+          { type: "text" as const, text: "b".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) },
+          { type: "text" as const, text: "dropped entirely" },
+          { type: "text" as const, text: "also dropped" },
+        ],
+      }) as TextContentResult;
+
+      expect(result.content).toHaveLength(2);
+      expect(result.content[0].text).toBe("b".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES));
+      expect(result.content[1].text).toContain("[2 content part(s) omitted:");
+    });
+
+    it("caps oversized text resources in text-only results", () => {
+      const result = transformMCPResult({
+        content: [
+          {
+            type: "resource" as const,
+            resource: {
+              uri: "file:///big.json",
+              text: "r".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000),
+            },
+          },
+        ],
+      }) as TextContentResult;
+
+      const text = result.content[0].resource!.text!;
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThan(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 300);
+      expect(text).toContain("[MCP tool result text truncated:");
+      expect(result.content[0].resource!.uri).toBe("file:///big.json");
+    });
+
+    it("caps text parts in results that also carry binary content", () => {
+      const smallImageData = "img".repeat(100);
+      const result = transformMCPResult({
+        content: [
+          { type: "text" as const, text: "t".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000) },
+          { type: "image" as const, data: smallImageData, mimeType: "image/png" },
+        ],
+      }) as {
+        type: string;
+        value: Array<{ type: string; text?: string; data?: string; mediaType?: string }>;
+      };
+
+      expect(result.type).toBe("content");
+      expect(result.value[0].type).toBe("text");
+      expect(result.value[0].text).toContain("[MCP tool result text truncated:");
+      // Media parts are exempt from the text budget (guarded separately).
+      expect(result.value[1]).toEqual({
+        type: "media",
+        data: smallImageData,
+        mediaType: "image/png",
+      });
+    });
+
+    it("does not cut truncated text mid-way through a multi-byte character", () => {
+      const result = transformMCPResult({
+        content: [{ type: "text" as const, text: "€".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES) }],
+      }) as TextContentResult;
+
+      const text = result.content[0].text!;
+      expect(text).toContain("[MCP tool result text truncated:");
+      expect(text).not.toContain("\uFFFD");
+    });
+
+    it("passes small structuredContent through unchanged", () => {
+      const withStructured = {
+        content: [{ type: "text" as const, text: "ok" }],
+        structuredContent: { rows: [1, 2, 3] },
+      };
+      expect(transformMCPResult(withStructured)).toBe(withStructured);
+    });
+
+    it("drops oversized structuredContent with a notice", () => {
+      const result = transformMCPResult({
+        content: [{ type: "text" as const, text: "summary" }],
+        structuredContent: { blob: "s".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000) },
+      }) as TextContentResult;
+
+      expect(result.structuredContent).toBeUndefined();
+      expect("structuredContent" in result).toBe(false);
+      expect(result.content[0].text).toBe("summary");
+      expect(result.content[1].text).toContain("[MCP structuredContent omitted:");
+    });
+
+    it("replaces an oversized toolResult with a bounded notice", () => {
+      const result = transformMCPResult({
+        toolResult: { data: "t".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000) },
+      }) as { toolResult: string };
+
+      expect(result.toolResult).toContain("[MCP toolResult omitted:");
+      expect(result.toolResult.length).toBeLessThan(300);
+    });
+
+    it("replaces an oversized result without a content array with a bounded notice", () => {
+      const result = transformMCPResult({
+        something: "e".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000),
+      }) as TextContentResult;
+
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toContain("[MCP tool result omitted:");
+    });
+
+    it("truncates oversized primitive string results", () => {
+      const result = transformMCPResult(
+        "p".repeat(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 5_000)
+      ) as string;
+
+      expect(Buffer.byteLength(result, "utf8")).toBeLessThan(MCP_TOOL_RESULT_MAX_TEXT_BYTES + 300);
+      expect(result).toContain("[MCP tool result text truncated:");
     });
   });
 

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -1,3 +1,4 @@
+import { MCP_TOOL_RESULT_MAX_TEXT_BYTES } from "@/common/constants/toolLimits";
 import { log } from "@/node/services/log";
 
 /**
@@ -41,6 +42,7 @@ export interface MCPCallToolResult {
   content?: MCPContent[];
   isError?: boolean;
   toolResult?: unknown;
+  structuredContent?: unknown;
 }
 
 /**
@@ -60,6 +62,73 @@ function formatBytesSI(bytes: number): string {
     return `${(bytes / 1_000_000).toFixed(1)} MB`;
   }
   return `${Math.round(bytes / 1000)} KB`;
+}
+
+// Enforce byte budgets on UTF-8 bytes; non-ASCII text can use up to three
+// bytes per UTF-16 code unit. Backs up to a UTF-8 sequence boundary before
+// decoding.
+export function truncateUtf8Bytes(text: string, maxBytes: number, marker: string): string {
+  // Encoding at most maxBytes UTF-16 code units bounds the temporary buffer
+  // while still covering maxBytes UTF-8 bytes.
+  const prefix = text.length > maxBytes ? text.slice(0, maxBytes) : text;
+  const bytes = Buffer.from(prefix, "utf8");
+  if (prefix === text && bytes.length <= maxBytes) {
+    return text;
+  }
+  let end = maxBytes;
+  while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
+    end--;
+  }
+  return bytes.subarray(0, end).toString("utf8") + marker;
+}
+
+/**
+ * Shared text budget threaded through one result so many text parts cannot
+ * multiply the cap.
+ */
+interface TextBudget {
+  remaining: number;
+}
+
+function textTruncationNotice(byteLength: number): string {
+  return `[MCP tool result text truncated: ${formatBytesSI(byteLength)} exceeds the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TEXT_BYTES)} cap. Narrow the query to reduce output size.]`;
+}
+
+/**
+ * Charge `text` against the budget. Returns the (possibly truncated) text, or
+ * null when the budget is already exhausted and the part should be dropped.
+ */
+function capText(text: string, budget: TextBudget): { text: string; truncated: boolean } | null {
+  const size = Buffer.byteLength(text, "utf8");
+  if (size <= budget.remaining) {
+    budget.remaining -= size;
+    return { text, truncated: false };
+  }
+  if (budget.remaining <= 0) {
+    return null;
+  }
+  const kept = truncateUtf8Bytes(text, budget.remaining, "");
+  budget.remaining = 0;
+  return { text: `${kept}\n\n${textTruncationNotice(size)}`, truncated: true };
+}
+
+function omittedPartsNotice(count: number): string {
+  return `[${count} content part(s) omitted: MCP tool result exceeds the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TEXT_BYTES)} text cap]`;
+}
+
+function omittedValueNotice(kind: string, byteLength: number): string {
+  return `[MCP ${kind} omitted: ${formatBytesSI(byteLength)} exceeds the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TEXT_BYTES)} cap. Narrow the query to reduce output size.]`;
+}
+
+function jsonByteLength(value: unknown): number {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? 0 : Buffer.byteLength(json, "utf8");
+  } catch {
+    // Unserializable results (circular refs, BigInt) cannot be persisted to
+    // chat.jsonl anyway; treat them as oversized so they become a bounded notice.
+    return Number.POSITIVE_INFINITY;
+  }
 }
 
 /** Binary media guard shared by image/audio content and blob resources. */
@@ -91,25 +160,62 @@ function toGuardedMediaPart(
  * overflow.
  */
 export function transformMCPResult(result: unknown): unknown {
+  // Primitive string results skip the content-array capping below, so bound
+  // them directly.
+  if (typeof result === "string") {
+    const size = Buffer.byteLength(result, "utf8");
+    if (size <= MCP_TOOL_RESULT_MAX_TEXT_BYTES) {
+      return result;
+    }
+    log.warn("[MCP] string tool result too large, truncating", {
+      size,
+      cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+    });
+    return truncateUtf8Bytes(
+      result,
+      MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+      `\n\n${textTruncationNotice(size)}`
+    );
+  }
+
   if (!result || typeof result !== "object") {
     return result;
   }
 
   const typed = result as MCPCallToolResult;
 
-  // If it has toolResult (non-standard result shape), pass through as-is
+  // If it has toolResult (non-standard result shape), pass through as-is when
+  // it fits the cap; otherwise replace it with a bounded notice.
   if (typed.toolResult !== undefined) {
-    return result;
+    const size = jsonByteLength(result);
+    if (size <= MCP_TOOL_RESULT_MAX_TEXT_BYTES) {
+      return result;
+    }
+    log.warn("[MCP] toolResult too large, omitting", {
+      size,
+      cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+    });
+    return { toolResult: omittedValueNotice("toolResult", size) };
   }
 
-  // If no content array, pass through
+  // If no content array, pass through when it fits the cap; otherwise replace
+  // with a bounded notice in MCP text shape so toModelOutput surfaces it.
   if (!typed.content || !Array.isArray(typed.content)) {
-    return result;
+    const size = jsonByteLength(result);
+    if (size <= MCP_TOOL_RESULT_MAX_TEXT_BYTES) {
+      return result;
+    }
+    log.warn("[MCP] tool result too large, omitting", {
+      size,
+      cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+    });
+    return { content: [{ type: "text", text: omittedValueNotice("tool result", size) }] };
   }
 
   // Only rewrite results carrying binary payloads; text-only results
-  // (including text-only errors) pass through in MCP shape (converted by the
-  // tool's toModelOutput, which keeps the isError flag visible to the model).
+  // (including text-only errors) stay in MCP shape (converted by the tool's
+  // toModelOutput, which keeps the isError flag visible to the model), with
+  // oversized text capped in place.
   const hasBinaryContent = typed.content.some(
     (c) =>
       c.type === "image" ||
@@ -117,7 +223,7 @@ export function transformMCPResult(result: unknown): unknown {
       (c.type === "resource" && typeof c.resource?.blob === "string")
   );
   if (!hasBinaryContent) {
-    return result;
+    return capTextOnlyResult(typed);
   }
 
   // Debug: log what we received from MCP
@@ -126,31 +232,54 @@ export function transformMCPResult(result: unknown): unknown {
   });
 
   // Transform to AI SDK content format
-  const transformedContent: AISDKContentPart[] = typed.content.map((item) => {
+  const budget: TextBudget = { remaining: MCP_TOOL_RESULT_MAX_TEXT_BYTES };
+  let omitted = 0;
+  let truncated = false;
+  const transformedContent: AISDKContentPart[] = [];
+  const pushCappedText = (text: string): void => {
+    const capped = capText(text, budget);
+    if (capped === null) {
+      omitted += 1;
+      return;
+    }
+    truncated ||= capped.truncated;
+    transformedContent.push({ type: "text", text: capped.text });
+  };
+  for (const item of typed.content) {
     if (item.type === "text") {
-      return { type: "text" as const, text: item.text };
-    }
-    if (item.type === "image") {
+      pushCappedText(item.text);
+    } else if (item.type === "image") {
       // Ensure mediaType is present - default to image/png if missing
-      return toGuardedMediaPart("Image", item.data, item.mimeType || "image/png");
-    }
-    if (item.type === "audio") {
-      return toGuardedMediaPart("Audio", item.data, item.mimeType || "audio/wav");
-    }
-    if (item.type === "resource") {
+      transformedContent.push(toGuardedMediaPart("Image", item.data, item.mimeType || "image/png"));
+    } else if (item.type === "audio") {
+      transformedContent.push(toGuardedMediaPart("Audio", item.data, item.mimeType || "audio/wav"));
+    } else if (item.type === "resource") {
       if (typeof item.resource.blob === "string") {
-        return toGuardedMediaPart(
-          "Resource",
-          item.resource.blob,
-          item.resource.mimeType ?? "application/octet-stream"
+        transformedContent.push(
+          toGuardedMediaPart(
+            "Resource",
+            item.resource.blob,
+            item.resource.mimeType ?? "application/octet-stream"
+          )
         );
+      } else {
+        // Text resources: surface the text (or the URI as a reference).
+        pushCappedText(item.resource.text ?? item.resource.uri);
       }
-      // Text resources: surface the text (or the URI as a reference).
-      return { type: "text" as const, text: item.resource.text ?? item.resource.uri };
+    } else {
+      // Fallback: stringify unknown content
+      pushCappedText(JSON.stringify(item));
     }
-    // Fallback: stringify unknown content
-    return { type: "text" as const, text: JSON.stringify(item) };
-  });
+  }
+  if (omitted > 0) {
+    transformedContent.push({ type: "text", text: omittedPartsNotice(omitted) });
+  }
+  if (truncated || omitted > 0) {
+    log.warn("[MCP] tool result text exceeded cap, truncated", {
+      cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+      omittedParts: omitted,
+    });
+  }
 
   // The model-output "content" shape has no error flag, so error results
   // carrying binary payloads get an explicit text marker instead of bypassing
@@ -160,4 +289,77 @@ export function transformMCPResult(result: unknown): unknown {
   }
 
   return { type: "content", value: transformedContent };
+}
+
+/**
+ * Cap the text surfaces of a text-only MCP result while preserving its wire
+ * shape (content array + isError). Returns the original object when nothing
+ * exceeds the cap.
+ */
+function capTextOnlyResult(typed: MCPCallToolResult): unknown {
+  const budget: TextBudget = { remaining: MCP_TOOL_RESULT_MAX_TEXT_BYTES };
+  let changed = false;
+  let omitted = 0;
+  const cappedContent: MCPContent[] = [];
+
+  for (const item of typed.content ?? []) {
+    if (item.type === "text") {
+      const capped = capText(item.text, budget);
+      if (capped === null) {
+        omitted += 1;
+        continue;
+      }
+      changed ||= capped.truncated;
+      cappedContent.push(capped.truncated ? { ...item, text: capped.text } : item);
+      continue;
+    }
+    if (item.type === "resource" && typeof item.resource?.text === "string") {
+      const capped = capText(item.resource.text, budget);
+      if (capped === null) {
+        omitted += 1;
+        continue;
+      }
+      changed ||= capped.truncated;
+      cappedContent.push(
+        capped.truncated ? { ...item, resource: { ...item.resource, text: capped.text } } : item
+      );
+      continue;
+    }
+    cappedContent.push(item);
+  }
+
+  if (omitted > 0) {
+    changed = true;
+    cappedContent.push({ type: "text", text: omittedPartsNotice(omitted) });
+  }
+
+  // structuredContent duplicates the content text as JSON and is invisible to
+  // the model (toModelOutput only reads content), so drop it wholesale when
+  // oversized instead of truncating JSON mid-structure.
+  const structuredSize =
+    typed.structuredContent !== undefined ? jsonByteLength(typed.structuredContent) : 0;
+  const dropStructured = structuredSize > MCP_TOOL_RESULT_MAX_TEXT_BYTES;
+  if (dropStructured) {
+    changed = true;
+    cappedContent.push({
+      type: "text",
+      text: omittedValueNotice("structuredContent", structuredSize),
+    });
+  }
+
+  if (!changed) {
+    return typed;
+  }
+
+  log.warn("[MCP] tool result text exceeded cap, truncated", {
+    cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+    omittedParts: omitted,
+    structuredContentDropped: dropStructured,
+  });
+
+  const capped: MCPCallToolResult = { ...typed, content: cappedContent };
+  if (dropStructured) {
+    delete capped.structuredContent;
+  }
+  return capped;
 }

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -1,4 +1,7 @@
-import { MCP_TOOL_RESULT_MAX_TEXT_BYTES } from "@/common/constants/toolLimits";
+import {
+  MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+  MCP_TOOL_RESULT_MAX_TOTAL_BYTES,
+} from "@/common/constants/toolLimits";
 import { log } from "@/node/services/log";
 
 /**
@@ -118,6 +121,10 @@ function omittedPartsNotice(count: number): string {
 
 function omittedValueNotice(kind: string, byteLength: number): string {
   return `[MCP ${kind} omitted: ${formatBytesSI(byteLength)} exceeds the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TEXT_BYTES)} cap. Narrow the query to reduce output size.]`;
+}
+
+function metadataOmittedNotice(byteLength: number): string {
+  return `[MCP result metadata omitted: result serialized to ${formatBytesSI(byteLength)}, exceeding the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TOTAL_BYTES)} total cap. Narrow the query to reduce output size.]`;
 }
 
 function jsonByteLength(value: unknown): number {
@@ -347,19 +354,66 @@ function capTextOnlyResult(typed: MCPCallToolResult): unknown {
     });
   }
 
-  if (!changed) {
-    return typed;
+  if (changed) {
+    log.warn("[MCP] tool result text exceeded cap, truncated", {
+      cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
+      omittedParts: omitted,
+      structuredContentDropped: dropStructured,
+    });
   }
 
-  log.warn("[MCP] tool result text exceeded cap, truncated", {
-    cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
-    omittedParts: omitted,
-    structuredContentDropped: dropStructured,
+  const candidate: MCPCallToolResult = changed ? { ...typed, content: cappedContent } : typed;
+  if (changed && dropStructured) {
+    delete candidate.structuredContent;
+  }
+
+  // The per-surface caps above cannot reach server-controlled metadata
+  // (result- and part-level _meta, unknown fields, resource URIs), so a total
+  // serialized budget backstops them: anything still oversized is flattened to
+  // bounded text parts so no unbounded bytes reach history.
+  const totalSize = jsonByteLength(candidate);
+  if (totalSize <= MCP_TOOL_RESULT_MAX_TOTAL_BYTES) {
+    return candidate;
+  }
+
+  log.warn("[MCP] tool result metadata exceeded total cap, flattening", {
+    totalSize,
+    cap: MCP_TOOL_RESULT_MAX_TOTAL_BYTES,
   });
 
-  const capped: MCPCallToolResult = { ...typed, content: cappedContent };
-  if (dropStructured) {
-    delete capped.structuredContent;
+  const rebuildBudget: TextBudget = { remaining: MCP_TOOL_RESULT_MAX_TEXT_BYTES };
+  let dropped = 0;
+  const boundedContent: MCPContent[] = [];
+  for (const item of cappedContent) {
+    let text: string;
+    if (item.type === "text") {
+      text = item.text;
+    } else {
+      try {
+        text = JSON.stringify(item);
+      } catch {
+        text = "[unserializable content part omitted]";
+      }
+    }
+    const capped = capText(text, rebuildBudget);
+    if (capped === null) {
+      dropped += 1;
+      continue;
+    }
+    boundedContent.push({ type: "text", text: capped.text });
   }
-  return capped;
+  if (dropped > 0) {
+    boundedContent.push({ type: "text", text: omittedPartsNotice(dropped) });
+  }
+  boundedContent.push({ type: "text", text: metadataOmittedNotice(totalSize) });
+
+  return {
+    // Strictly-true check: hostile servers can put unbounded junk in isError.
+    ...(typed.isError === true ? { isError: true } : {}),
+    content: boundedContent,
+    // Kept structuredContent is already bounded by its own cap above.
+    ...(typed.structuredContent !== undefined && !dropStructured
+      ? { structuredContent: typed.structuredContent }
+      : {}),
+  };
 }

--- a/src/node/services/mcpResultTransform.ts
+++ b/src/node/services/mcpResultTransform.ts
@@ -87,32 +87,76 @@ export function truncateUtf8Bytes(text: string, maxBytes: number, marker: string
 
 /**
  * Shared text budget threaded through one result so many text parts cannot
- * multiply the cap.
+ * multiply the cap. Charged in serialized JSON bytes (escape expansion plus
+ * per-part wrapper overhead), so neither part count nor escape-heavy content
+ * (control characters serialize 6x) can multiply the persisted size.
  */
 interface TextBudget {
   remaining: number;
 }
 
+// Serialized wrapper cost of one {"type":"text","text":"..."} part plus its
+// array comma; kept parts may carry small extra fields, which the total
+// serialized backstop still bounds.
+const PART_SERIALIZATION_OVERHEAD_BYTES = 32;
+// Below this many payload bytes a truncated fragment carries no signal; drop
+// the part instead.
+const MIN_KEPT_TEXT_BYTES = 16;
+
 function textTruncationNotice(byteLength: number): string {
   return `[MCP tool result text truncated: ${formatBytesSI(byteLength)} exceeds the ${formatBytesSI(MCP_TOOL_RESULT_MAX_TEXT_BYTES)} cap. Narrow the query to reduce output size.]`;
 }
 
+/** Serialized byte length of `text` as a JSON string, minus the outer quotes. */
+function escapedTextBytes(text: string): number {
+  return Buffer.byteLength(JSON.stringify(text), "utf8") - 2;
+}
+
 /**
- * Charge `text` against the budget. Returns the (possibly truncated) text, or
- * null when the budget is already exhausted and the part should be dropped.
+ * Charge `text` against the budget in serialized bytes. Returns the (possibly
+ * truncated) text, or null when the remaining budget is too small to carry a
+ * useful fragment and the part should be dropped.
  */
 function capText(text: string, budget: TextBudget): { text: string; truncated: boolean } | null {
-  const size = Buffer.byteLength(text, "utf8");
-  if (size <= budget.remaining) {
-    budget.remaining -= size;
-    return { text, truncated: false };
+  const rawBytes = Buffer.byteLength(text, "utf8");
+  // JSON escaping only expands (multi-byte characters serialize as-is), so raw
+  // bytes lower-bound the serialized cost; only measure exactly when the raw
+  // size already fits, keeping stringify off pathologically large inputs.
+  if (rawBytes + PART_SERIALIZATION_OVERHEAD_BYTES <= budget.remaining) {
+    const cost = escapedTextBytes(text) + PART_SERIALIZATION_OVERHEAD_BYTES;
+    if (cost <= budget.remaining) {
+      budget.remaining -= cost;
+      return { text, truncated: false };
+    }
   }
-  if (budget.remaining <= 0) {
+  const allowed = budget.remaining - PART_SERIALIZATION_OVERHEAD_BYTES;
+  if (allowed < MIN_KEPT_TEXT_BYTES) {
     return null;
   }
-  const kept = truncateUtf8Bytes(text, budget.remaining, "");
+  // Escaped size is monotonic in the kept prefix but not linear, so shrink
+  // proportionally until the serialized fragment fits. Raw bytes strictly
+  // decrease each pass and one escape-dense pass reduces size by at least the
+  // overshoot ratio, so this converges in a few iterations.
+  let candidate = truncateUtf8Bytes(text, allowed, "");
+  let fits = false;
+  for (let i = 0; i < 32; i += 1) {
+    const escaped = escapedTextBytes(candidate);
+    if (escaped <= allowed) {
+      fits = true;
+      break;
+    }
+    const candidateRaw = Buffer.byteLength(candidate, "utf8");
+    const shrunk = Math.min(candidateRaw - 1, Math.floor((candidateRaw * allowed) / escaped));
+    if (shrunk < MIN_KEPT_TEXT_BYTES) {
+      return null;
+    }
+    candidate = truncateUtf8Bytes(candidate, shrunk, "");
+  }
+  if (!fits) {
+    return null;
+  }
   budget.remaining = 0;
-  return { text: `${kept}\n\n${textTruncationNotice(size)}`, truncated: true };
+  return { text: `${candidate}\n\n${textTruncationNotice(rawBytes)}`, truncated: true };
 }
 
 function omittedPartsNotice(count: number): string {
@@ -168,21 +212,17 @@ function toGuardedMediaPart(
  */
 export function transformMCPResult(result: unknown): unknown {
   // Primitive string results skip the content-array capping below, so bound
-  // them directly.
+  // them directly. A full budget always yields a non-null capText result.
   if (typeof result === "string") {
-    const size = Buffer.byteLength(result, "utf8");
-    if (size <= MCP_TOOL_RESULT_MAX_TEXT_BYTES) {
+    const capped = capText(result, { remaining: MCP_TOOL_RESULT_MAX_TEXT_BYTES });
+    if (!capped?.truncated) {
       return result;
     }
     log.warn("[MCP] string tool result too large, truncating", {
-      size,
+      size: Buffer.byteLength(result, "utf8"),
       cap: MCP_TOOL_RESULT_MAX_TEXT_BYTES,
     });
-    return truncateUtf8Bytes(
-      result,
-      MCP_TOOL_RESULT_MAX_TEXT_BYTES,
-      `\n\n${textTruncationNotice(size)}`
-    );
+    return capped.text;
   }
 
   if (!result || typeof result !== "object") {
@@ -407,13 +447,29 @@ function capTextOnlyResult(typed: MCPCallToolResult): unknown {
   }
   boundedContent.push({ type: "text", text: metadataOmittedNotice(totalSize) });
 
-  return {
+  const rebuilt: MCPCallToolResult = {
     // Strictly-true check: hostile servers can put unbounded junk in isError.
     ...(typed.isError === true ? { isError: true } : {}),
     content: boundedContent,
-    // Kept structuredContent is already bounded by its own cap above.
+    // Kept structuredContent is already bounded by its own serialized cap above.
     ...(typed.structuredContent !== undefined && !dropStructured
       ? { structuredContent: typed.structuredContent }
       : {}),
   };
+
+  // Remeasure the rebuilt output. Unreachable while every component above is
+  // budgeted in serialized bytes, but a bounded collapse beats trusting that
+  // invariant with history durability at stake.
+  const rebuiltSize = jsonByteLength(rebuilt);
+  if (rebuiltSize > MCP_TOOL_RESULT_MAX_TOTAL_BYTES) {
+    log.error("[MCP] rebuilt tool result still exceeds total cap, collapsing", {
+      rebuiltSize,
+      cap: MCP_TOOL_RESULT_MAX_TOTAL_BYTES,
+    });
+    return {
+      ...(typed.isError === true ? { isError: true } : {}),
+      content: [{ type: "text", text: metadataOmittedNotice(totalSize) }],
+    };
+  }
+  return rebuilt;
 }

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -36,7 +36,11 @@ import {
   type McpOauthService,
 } from "@/node/services/mcpOauthService";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
-import { transformMCPResult, type MCPCallToolResult } from "@/node/services/mcpResultTransform";
+import {
+  transformMCPResult,
+  truncateUtf8Bytes,
+  type MCPCallToolResult,
+} from "@/node/services/mcpResultTransform";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import {
   buildMcpPromptBaseKey,
@@ -796,24 +800,6 @@ function flattenPromptContent(content: MCPPromptContent): string {
     default:
       return "[Unsupported content omitted]";
   }
-}
-
-// Enforce the expansion budget on UTF-8 bytes; non-ASCII text can use up to
-// three bytes per UTF-16 code unit. Backs up to a UTF-8 sequence boundary
-// before decoding.
-function truncateUtf8Bytes(text: string, maxBytes: number, marker: string): string {
-  // Encoding at most maxBytes UTF-16 code units bounds the temporary buffer
-  // while still covering maxBytes UTF-8 bytes.
-  const prefix = text.length > maxBytes ? text.slice(0, maxBytes) : text;
-  const bytes = Buffer.from(prefix, "utf8");
-  if (prefix === text && bytes.length <= maxBytes) {
-    return text;
-  }
-  let end = maxBytes;
-  while (end > 0 && (bytes[end] & 0xc0) === 0x80) {
-    end--;
-  }
-  return bytes.subarray(0, end).toString("utf8") + marker;
 }
 
 // Accumulates at most the cap plus one body code unit and fixed


### PR DESCRIPTION
Fixes #3138

## Summary

MCP tool results had no byte cap: a ~62MB Grafana trace query result was persisted verbatim into `chat.jsonl`, freezing the renderer and (on the reporter's build) permanently bricking the workspace because every later provider request exceeded API payload limits (OpenAI caps strings at ~10MB). This PR caps MCP tool result text at 64KB in `transformMCPResult`, the single conversion layer every wrapped MCP tool result passes through before the AI SDK sees it, so oversized text is truncated with an explicit notice before it ever enters history.

## Background

- `wrapMCPTools` → `transformMCPResult` already guarded binary payloads (8MB per-image guard) but passed text-only results through untouched.
- Built-in tools are already bounded (bash: 16KB total / 1KB per line; web_fetch: 64KB; MCP prompt expansions: 64KB). MCP tool results were the remaining unbounded server-controlled surface. The new `MCP_TOOL_RESULT_MAX_TEXT_BYTES = 64KB` matches the web_fetch/prompt caps.

## Implementation

- One shared 64KB text budget per result (mirroring `flattenMcpPrompt`'s total budget) so many parts cannot multiply the cap. The budget is charged in serialized JSON bytes (escape expansion plus per-part wrapper overhead, per Codex review), so neither part count (for example 65k one-byte parts) nor escape-heavy content (control characters serialize 6x) can multiply the persisted size. The part that crosses the budget is truncated on a UTF-8 boundary with an inline notice telling the model to narrow the query; fully dropped parts are summarized in one omission notice part.
- Text-only results keep their MCP wire shape (so `toModelOutput` keeps the `isError` flag visible to the model); results with binary content get the cap applied to their text parts during the existing AI SDK conversion. Media parts stay exempt (they have their own guard).
- Peer surfaces of the same class are also bounded: `resource.text`, oversized `structuredContent` (dropped wholesale with a notice; it is invisible to the model anyway), the non-standard `toolResult` passthrough, content-less result objects, and primitive string results.
- Total serialized-size backstop (`MCP_TOOL_RESULT_MAX_TOTAL_BYTES` = 256KB, per Codex review): the per-text caps cannot reach server-controlled metadata (result- and part-level `_meta`, unknown fields, oversized resource URIs). Results whose full JSON still exceeds the total cap after text capping are flattened to bounded text parts with an explicit notice, so no unbounded bytes reach history. The rebuilt output is remeasured and collapses to a single notice if it would still exceed the cap.
- `truncateUtf8Bytes` moved from `mcpServerManager.ts` (where the prompt path uses it) to `mcpResultTransform.ts` and is now shared.

### Read-side recovery (existing bricked workspaces)

Deliberately not expanded in this PR: since #3287, the request-building path (`applyToolOutputRedaction` → `sanitizeUnknownForProviderOutput`) already clamps every string leaf of persisted tool outputs to 12k chars, so a workspace with an already-persisted oversized result can send provider requests again on current main (the reporter's build predated #3287). What #3287 does not fix is renderer/IPC load cost of an existing multi-MB `chat.jsonl`; healing that would require rewriting persisted history at load and grows the diff disproportionately, so this PR is write-side only.

## Validation

- Red-green: with the fix reverted, 9 of the first 11 new tests fail; with only the metadata backstop reverted, 3 of the 4 metadata tests fail; with only serialized-byte budgeting reverted, the 2 serialization-overhead tests (tiny-parts, escape-heavy) fail. Identity-passthrough tests pass in both states by design.
- The `Test / Integration` CI failures on earlier heads were pre-existing flakes, not this diff: three different tests failed across three runs (`modelNotFound.test.ts` with a network `fetch failed`, then two different `sendModeDropdown.test.ts` cases), and the flaky suite passes locally under Jest on both this head and the pristine base.

## Risks

Low. Results ≤64KB of text return the identical object reference (no behavior change). Larger MCP text results are now truncated, but the request path already clamped any single string to 12k chars for the model, so model-visible content only changes for results that were already being cut, and the UI/history gain a hard bound.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
