### PR TITLE
🤖 fix: consult agent definition ai defaults when spawning sub-agent tasks

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -287,6 +287,32 @@ async function saveLocalParentWorkspace(
   return { parentId, projectPath };
 }
 
+/** Write a runnable exec-derived custom agent definition into the project's .mux/agents. */
+async function writeCustomAgentDefinition(
+  projectPath: string,
+  extraFrontmatterLines: string[] = []
+): Promise<void> {
+  const agentsDir = path.join(projectPath, ".mux", "agents");
+  await fsPromises.mkdir(agentsDir, { recursive: true });
+  await fsPromises.writeFile(
+    path.join(agentsDir, "custom.md"),
+    [
+      "---",
+      "name: Custom",
+      "description: Exec-derived custom agent for tests",
+      "base: exec",
+      "subagent:",
+      "  runnable: true",
+      ...extraFrontmatterLines,
+      "---",
+      "",
+      "Test agent body.",
+      "",
+    ].join("\n"),
+    "utf-8"
+  );
+}
+
 function stubStableIds(config: Config, ids: string[], fallbackId = "fffffffff0"): void {
   let nextIdIndex = 0;
   const configWithStableId = config as unknown as { generateStableId: () => string };
@@ -9680,6 +9706,143 @@ describe("TaskService", () => {
         model: "openai:gpt-4o-mini",
         agentId: "custom",
         thinkingLevel: "off",
+        experiments: undefined,
+      },
+      { agentInitiated: true }
+    );
+  }, 20_000);
+
+  test("agent definition ai defaults outrank parent inheritance when spawning a sub-agent", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["aaaaaaaaaa"], "bbbbbbbbbb");
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
+    await writeCustomAgentDefinition(projectPath, [
+      "ai:",
+      "  model: openai:gpt-5.2",
+      "  thinkingLevel: medium",
+    ]);
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const created = await createAgentTask(taskService, parentId, "run task with pinned agent", {
+      agentType: "custom",
+      parentRuntimeAiSettings: { modelString: "openai:gpt-5.3-codex", thinkingLevel: "xhigh" },
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      created.data.taskId,
+      "run task with pinned agent",
+      {
+        model: "openai:gpt-5.2",
+        agentId: "custom",
+        thinkingLevel: "medium",
+        experiments: undefined,
+      },
+      { agentInitiated: true }
+    );
+    const childEntry = findWorkspaceInConfig(config, created.data.taskId);
+    expect(childEntry?.aiSettings).toEqual({ model: "openai:gpt-5.2", thinkingLevel: "medium" });
+    expect(childEntry?.taskModelString).toBe("openai:gpt-5.2");
+    expect(childEntry?.taskThinkingLevel).toBe("medium");
+  }, 20_000);
+
+  test("explicit task args outrank agent definition ai defaults", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["aaaaaaaaaa"], "bbbbbbbbbb");
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
+    await writeCustomAgentDefinition(projectPath, [
+      "ai:",
+      "  model: openai:gpt-5.2",
+      "  thinkingLevel: medium",
+    ]);
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const created = await createAgentTask(taskService, parentId, "run task with explicit model", {
+      agentType: "custom",
+      modelString: "openai:gpt-5.3-codex",
+      thinkingLevel: "xhigh",
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      created.data.taskId,
+      "run task with explicit model",
+      {
+        model: "openai:gpt-5.3-codex",
+        agentId: "custom",
+        thinkingLevel: "xhigh",
+        experiments: undefined,
+      },
+      { agentInitiated: true }
+    );
+  }, 20_000);
+
+  test("configured agent defaults outrank agent definition ai defaults", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["aaaaaaaaaa"], "bbbbbbbbbb");
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir, {
+      agentAiDefaults: {
+        custom: { modelString: "anthropic:claude-haiku-4-5", thinkingLevel: "off" },
+      },
+    });
+    await writeCustomAgentDefinition(projectPath, [
+      "ai:",
+      "  model: openai:gpt-5.2",
+      "  thinkingLevel: medium",
+    ]);
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const created = await createAgentTask(taskService, parentId, "run task with configured agent", {
+      agentType: "custom",
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      created.data.taskId,
+      "run task with configured agent",
+      {
+        model: "anthropic:claude-haiku-4-5",
+        agentId: "custom",
+        thinkingLevel: "off",
+        experiments: undefined,
+      },
+      { agentInitiated: true }
+    );
+  }, 20_000);
+
+  test("agent definition ai.model abbreviations resolve and missing fields inherit per field", async () => {
+    const config = await createTestConfig(rootDir);
+    stubStableIds(config, ["aaaaaaaaaa"], "bbbbbbbbbb");
+    const { parentId, projectPath } = await saveLocalParentWorkspace(config, rootDir);
+    // Model-only ai block using a documented abbreviation; thinkingLevel must
+    // still inherit from the parent (field-wise, not all-or-nothing).
+    await writeCustomAgentDefinition(projectPath, ["ai:", "  model: haiku"]);
+
+    const { workspaceService, sendMessage } = createWorkspaceServiceMocks();
+    const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+    const created = await createAgentTask(taskService, parentId, "run task with alias model", {
+      agentType: "custom",
+    });
+    expect(created.success).toBe(true);
+    if (!created.success) return;
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      created.data.taskId,
+      "run task with alias model",
+      {
+        model: "anthropic:claude-haiku-4-5",
+        agentId: "custom",
+        thinkingLevel: "high",
         experiments: undefined,
       },
       { agentInitiated: true }

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -68,6 +68,8 @@ import {
   createTaskReportMessageId,
 } from "@/node/services/utils/messageIds";
 import { defaultModel, normalizeSelectedModel } from "@/common/utils/ai/models";
+import { normalizeModelInput } from "@/common/utils/ai/normalizeModelInput";
+import type { AgentDefinitionFrontmatter } from "@/common/types/agentDefinition";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { SCRATCH_PROJECT_CONFIG_KEY, SCRATCH_PROJECT_NAME } from "@/common/constants/scratch";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
@@ -1816,6 +1818,8 @@ export class TaskService {
     modelString?: string;
     thinkingLevel?: ParsedThinkingInput;
     parentRuntimeAiSettings?: { modelString?: string; thinkingLevel?: ThinkingLevel };
+    /** `ai` defaults from the agent's resolved .md frontmatter (base chain applied). */
+    agentDefinitionAiDefaults?: AgentDefinitionFrontmatter["ai"];
   }): {
     taskModelString: string;
     canonicalModel: string;
@@ -1828,10 +1832,29 @@ export class TaskService {
     const agentDefault = params.cfg.agentAiDefaults?.[params.agentId];
     const parentRuntimeAiSettings = params.parentRuntimeAiSettings;
 
+    // Agent definition `ai` defaults sit below config-level defaults (Settings
+    // stays authoritative per docs/agents "overridable by user settings") and
+    // above parent inheritance, so a definition-pinned model beats silently
+    // inheriting the parent's model. `ai.model` may be an abbreviation (e.g.
+    // "sonnet"); resolve aliases the same way the explicit task-tool override
+    // does. An invalid value falls through to parent inheritance instead of
+    // failing the spawn (a typo in a .md must not brick the agent).
+    const definitionDefaults = params.agentDefinitionAiDefaults;
+    const definitionModelRaw = coerceNonEmptyString(definitionDefaults?.model);
+    const definitionModel =
+      definitionModelRaw != null ? normalizeModelInput(definitionModelRaw).model : null;
+    if (definitionModelRaw != null && definitionModel == null) {
+      log.warn("resolveTaskAISettings: ignoring invalid agent definition ai.model", {
+        agentId: params.agentId,
+        model: definitionModelRaw,
+      });
+    }
+
     const taskModelString =
       coerceNonEmptyString(params.modelString) ??
       coerceNonEmptyString(subagentDefault?.modelString) ??
       coerceNonEmptyString(agentDefault?.modelString) ??
+      definitionModel ??
       coerceNonEmptyString(parentRuntimeAiSettings?.modelString) ??
       coerceNonEmptyString(parentAiSettings?.model) ??
       defaultModel;
@@ -1858,6 +1881,7 @@ export class TaskService {
       overrideThinkingLevel ??
       subagentDefault?.thinkingLevel ??
       agentDefault?.thinkingLevel ??
+      definitionDefaults?.thinkingLevel ??
       parentRuntimeAiSettings?.thinkingLevel ??
       parentAiSettings?.thinkingLevel ??
       "off";
@@ -2815,16 +2839,6 @@ export class TaskService {
         );
       }
 
-      const { taskModelString, canonicalModel, effectiveThinkingLevel, effectiveReasoningMode } =
-        this.resolveTaskAISettings({
-          cfg,
-          parentMeta,
-          agentId,
-          modelString: args.modelString,
-          thinkingLevel: args.thinkingLevel,
-          parentRuntimeAiSettings: args.parentRuntimeAiSettings,
-        });
-
       const parentRuntimeConfig = parentMeta.runtimeConfig;
       const taskRuntimeConfig: RuntimeConfig = parentRuntimeConfig;
       // Supply the parent's persisted path so override-aware runtimes (worktree/SSH) resolve the
@@ -2910,6 +2924,7 @@ export class TaskService {
       };
 
       let skipInitHook = false;
+      let agentDefinitionAiDefaults: AgentDefinitionFrontmatter["ai"];
       try {
         const frontmatter = await resolveAgentFrontmatter(runtime, parentWorkspacePath, agentId);
         if (!isAgentRunnableAsChild(frontmatter, { workflowOwned: args.workflowTask != null })) {
@@ -2923,10 +2938,22 @@ export class TaskService {
           return Err(`Task.createMany: agentId is disabled (${agentId}). ${hint}`);
         }
         skipInitHook = frontmatter.subagent?.skip_init_hook === true;
+        agentDefinitionAiDefaults = frontmatter.ai;
       } catch {
         const hint = await getRunnableHint();
         return Err(`Task.createMany: unknown agentId (${agentId}). ${hint}`);
       }
+
+      const { taskModelString, canonicalModel, effectiveThinkingLevel, effectiveReasoningMode } =
+        this.resolveTaskAISettings({
+          cfg,
+          parentMeta,
+          agentId,
+          modelString: args.modelString,
+          thinkingLevel: args.thinkingLevel,
+          parentRuntimeAiSettings: args.parentRuntimeAiSettings,
+          agentDefinitionAiDefaults,
+        });
 
       const status: "queued" | "starting" =
         reservedActiveCount >= taskSettings.maxParallelAgentTasks ? "queued" : "starting";
@@ -3965,16 +3992,6 @@ export class TaskService {
       );
     }
 
-    const { taskModelString, canonicalModel, effectiveThinkingLevel, effectiveReasoningMode } =
-      this.resolveTaskAISettings({
-        cfg,
-        parentMeta,
-        agentId,
-        modelString: args.modelString,
-        thinkingLevel: args.thinkingLevel,
-        parentRuntimeAiSettings: args.parentRuntimeAiSettings,
-      });
-
     const parentRuntimeConfig = parentMeta.runtimeConfig;
     const taskRuntimeConfig: RuntimeConfig = parentRuntimeConfig;
 
@@ -4075,6 +4092,7 @@ export class TaskService {
     };
 
     let skipInitHook = false;
+    let agentDefinitionAiDefaults: AgentDefinitionFrontmatter["ai"];
     try {
       const frontmatter = await resolveAgentFrontmatter(runtime, parentWorkspacePath, agentId);
       if (!isAgentRunnableAsChild(frontmatter, { workflowOwned: args.workflowTask != null })) {
@@ -4093,10 +4111,22 @@ export class TaskService {
         return Err(`Task.create: agentId is disabled (${agentId}). ${hint}`);
       }
       skipInitHook = frontmatter.subagent?.skip_init_hook === true;
+      agentDefinitionAiDefaults = frontmatter.ai;
     } catch {
       const hint = await getRunnableHint();
       return Err(`Task.create: unknown agentId (${agentId}). ${hint}`);
     }
+
+    const { taskModelString, canonicalModel, effectiveThinkingLevel, effectiveReasoningMode } =
+      this.resolveTaskAISettings({
+        cfg,
+        parentMeta,
+        agentId,
+        modelString: args.modelString,
+        thinkingLevel: args.thinkingLevel,
+        parentRuntimeAiSettings: args.parentRuntimeAiSettings,
+        agentDefinitionAiDefaults,
+      });
 
     const createdAt = getIsoNow();
 


### PR DESCRIPTION
## Summary

Sub-agent tasks now honor `ai.model` / `ai.thinkingLevel` declared in an agent definition's frontmatter. Previously the task service's AI-settings resolution consulted app config and parent settings but never the agent definition, so definition-pinned models were silently ignored and sub-agents always inherited the parent's model.

Fixes #3038

## Precedence

`resolveTaskAISettings` resolves each field (model, thinkingLevel) independently in this order:

1. Explicit per-spawn override (task tool `model` / `thinking` params)
2. `subagentAiDefaults[agentId]` (Settings UI, sub-agent defaults)
3. `agentAiDefaults[agentId]` (Settings UI, agent defaults)
4. **Agent definition frontmatter `ai`** (new)
5. Parent runtime AI settings (`MUX_MODEL_STRING` / `MUX_THINKING_LEVEL`)
6. Parent workspace persisted settings
7. App default

Rationale: an explicit call-site choice must always win; user settings stay above definition defaults per the documented contract (docs/agents: "Per-agent AI defaults (overridable by user settings)"); and definition defaults beat silent inheritance of the parent's model so pinned agents work as documented.

## Implementation

- Both task-creation paths (`create` and `createMany`) already resolve the agent's frontmatter (base chain applied) to validate runnability; the resolution of AI settings now happens after that step and receives `frontmatter.ai`.
- `ai.model` may be an abbreviation per docs (e.g. `sonnet`); it is resolved with the same alias logic as the explicit task-tool override (`normalizeModelInput`). An invalid value is logged and falls through to parent inheritance instead of failing the spawn, so a typo in a `.md` cannot brick the agent.
- The plan→exec same-workspace continuation is intentionally unchanged: it cannot distinguish an explicit spawn-time model from ambient inheritance, so consulting exec's definition defaults there could override an explicit spawn choice.
- Queued task relaunches reuse the settings persisted at creation time, so they pick up the fix automatically.
- Built-in impact: only `desktop.md` declares `ai` defaults (`thinkingLevel: medium`), which now actually applies to desktop sub-agents as advertised.

## Validation

- New behavioral tests: definition defaults win over parent inheritance (including parent runtime settings); explicit caller override still wins; config agent defaults still win; abbreviations resolve; model-only `ai` blocks inherit thinkingLevel field-wise. Red-checked: the two new-behavior tests fail on the base commit, the two precedence-guard tests hold on both.
- `make static-check-full` green locally. The two `terminal recovery` test failures in `taskService.test.ts` reproduce on the base commit and are unrelated.

## Risks

Low. Behavior changes only for sub-agent spawns where the agent definition declares `ai` defaults and no higher-precedence source exists, which is exactly the reported defect. Agents without `ai` defaults keep the existing inheritance chain unchanged.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
