### PR TITLE
🤖 fix: strip empty-string args for optional MCP tool params

### DIFF
--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -23,7 +23,7 @@ import type { Runtime } from "@/node/runtime/Runtime";
 import { DevcontainerRuntime } from "@/node/runtime/DevcontainerRuntime";
 import { RemoteRuntime } from "@/node/runtime/RemoteRuntime";
 import { DisposableTempDir } from "@/node/services/tempDir";
-import type { Tool } from "ai";
+import { jsonSchema, type Tool } from "ai";
 
 interface MCPServerManagerTestAccess {
   workspaceServers: Map<string, unknown>;
@@ -3383,5 +3383,82 @@ describe("wrapMCPTools", () => {
 
     const wrapped = wrapMCPTools({ noExec: tool });
     expect(wrapped.noExec).toBe(tool);
+  });
+
+  describe("argument sanitization", () => {
+    // Mirrors how mcpClient builds MCP tools: jsonSchema() wrapping the
+    // server-declared input schema.
+    const makeTool = (executeMock: ReturnType<typeof mock>, required: string[] = []) =>
+      ({
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            project_id: { type: "string" },
+            assignee_id: { type: "string" },
+            search: { type: "string" },
+            labels: { type: "array" },
+            milestone: { type: "string" },
+          },
+          required,
+          additionalProperties: false,
+        }),
+        execute: executeMock,
+      }) as unknown as Tool;
+
+    test("strips top-level empty strings for optional params before invoking the server", async () => {
+      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const wrapped = wrapMCPTools({ myTool: makeTool(executeMock, ["project_id"]) });
+
+      await wrapped.myTool.execute!(
+        { project_id: "42332", assignee_id: "", search: "", labels: [], milestone: null },
+        {} as never
+      );
+
+      expect(executeMock).toHaveBeenCalledTimes(1);
+      // null and [] pass through untouched; only optional "" is dropped.
+      expect(executeMock.mock.calls[0][0]).toEqual({
+        project_id: "42332",
+        labels: [],
+        milestone: null,
+      });
+    });
+
+    test("preserves empty string for schema-required params", async () => {
+      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const wrapped = wrapMCPTools({ myTool: makeTool(executeMock, ["project_id"]) });
+
+      await wrapped.myTool.execute!({ project_id: "", assignee_id: "" }, {} as never);
+
+      expect(executeMock.mock.calls[0][0]).toEqual({ project_id: "" });
+    });
+
+    test("passes args through unchanged when no empty strings are present", async () => {
+      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const wrapped = wrapMCPTools({ myTool: makeTool(executeMock) });
+
+      const args = { project_id: "42332", search: "bug" };
+      await wrapped.myTool.execute!(args, {} as never);
+
+      expect(executeMock.mock.calls[0][0]).toBe(args);
+    });
+
+    test("strips empty strings when the tool has no readable schema", async () => {
+      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const tool = { execute: executeMock } as unknown as Tool;
+      const wrapped = wrapMCPTools({ myTool: tool });
+
+      await wrapped.myTool.execute!({ project_id: "42332", search: "" }, {} as never);
+
+      expect(executeMock.mock.calls[0][0]).toEqual({ project_id: "42332" });
+    });
+
+    test("leaves non-record args untouched", async () => {
+      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const wrapped = wrapMCPTools({ myTool: makeTool(executeMock) });
+
+      await wrapped.myTool.execute!(undefined, {} as never);
+
+      expect(executeMock.mock.calls[0][0]).toBeUndefined();
+    });
   });
 });

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -3386,9 +3386,11 @@ describe("wrapMCPTools", () => {
   });
 
   describe("argument sanitization", () => {
+    const makeExecuteMock = () => mock((_args: unknown) => Promise.resolve({ content: [] }));
+
     // Mirrors how mcpClient builds MCP tools: jsonSchema() wrapping the
     // server-declared input schema.
-    const makeTool = (executeMock: ReturnType<typeof mock>, required: string[] = []) =>
+    const makeTool = (executeMock: ReturnType<typeof makeExecuteMock>, required: string[] = []) =>
       ({
         inputSchema: jsonSchema({
           type: "object",
@@ -3406,7 +3408,7 @@ describe("wrapMCPTools", () => {
       }) as unknown as Tool;
 
     test("strips top-level empty strings for optional params before invoking the server", async () => {
-      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const executeMock = makeExecuteMock();
       const wrapped = wrapMCPTools({ myTool: makeTool(executeMock, ["project_id"]) });
 
       await wrapped.myTool.execute!(
@@ -3424,7 +3426,7 @@ describe("wrapMCPTools", () => {
     });
 
     test("preserves empty string for schema-required params", async () => {
-      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const executeMock = makeExecuteMock();
       const wrapped = wrapMCPTools({ myTool: makeTool(executeMock, ["project_id"]) });
 
       await wrapped.myTool.execute!({ project_id: "", assignee_id: "" }, {} as never);
@@ -3433,7 +3435,7 @@ describe("wrapMCPTools", () => {
     });
 
     test("passes args through unchanged when no empty strings are present", async () => {
-      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const executeMock = makeExecuteMock();
       const wrapped = wrapMCPTools({ myTool: makeTool(executeMock) });
 
       const args = { project_id: "42332", search: "bug" };
@@ -3443,7 +3445,7 @@ describe("wrapMCPTools", () => {
     });
 
     test("strips empty strings when the tool has no readable schema", async () => {
-      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const executeMock = makeExecuteMock();
       const tool = { execute: executeMock } as unknown as Tool;
       const wrapped = wrapMCPTools({ myTool: tool });
 
@@ -3453,7 +3455,7 @@ describe("wrapMCPTools", () => {
     });
 
     test("leaves non-record args untouched", async () => {
-      const executeMock = mock(() => Promise.resolve({ content: [] }));
+      const executeMock = makeExecuteMock();
       const wrapped = wrapMCPTools({ myTool: makeTool(executeMock) });
 
       await wrapped.myTool.execute!(undefined, {} as never);

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -192,6 +192,49 @@ function shouldRecycleClientAfterToolError(error: unknown): boolean {
 }
 
 /**
+ * Top-level parameter names the tool's input schema marks as required.
+ *
+ * MCP tools built by mcpClient carry their server-declared JSON schema via
+ * the AI SDK's jsonSchema() wrapper ({ jsonSchema: <raw schema> }); anything
+ * else (or a malformed schema) yields an empty set.
+ */
+function requiredParamsFromSchema(inputSchema: unknown): ReadonlySet<string> {
+  if (inputSchema !== null && typeof inputSchema === "object" && "jsonSchema" in inputSchema) {
+    const raw = (inputSchema as { jsonSchema: unknown }).jsonSchema;
+    if (raw !== null && typeof raw === "object" && "required" in raw) {
+      const required = (raw as { required: unknown }).required;
+      if (Array.isArray(required)) {
+        return new Set(required.filter((entry): entry is string => typeof entry === "string"));
+      }
+    }
+  }
+  return new Set();
+}
+
+/**
+ * Drop top-level empty-string arguments the model emitted for optional
+ * parameters.
+ *
+ * LLMs often fill optional parameters with "" instead of omitting them, and
+ * strict REST-backed MCP servers (e.g. GitLab) treat present-but-empty as
+ * invalid and reject the call with 400 (#2887). A required parameter keeps
+ * its "" so a genuinely intended empty value is never silently dropped.
+ * Explicit null and empty arrays pass through untouched: servers may assign
+ * them meaning ("clear this field" / "no filter").
+ */
+function sanitizeMCPToolArgs(args: unknown, inputSchema: unknown): unknown {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    return args;
+  }
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (!entries.some(([, value]) => value === "")) {
+    return args;
+  }
+  const required = requiredParamsFromSchema(inputSchema);
+  return Object.fromEntries(entries.filter(([key, value]) => value !== "" || required.has(key)));
+}
+
+/**
  * Wrap MCP tools to transform their results to AI SDK format.
  * This ensures image content is properly converted to media type.
  */
@@ -222,8 +265,11 @@ export function wrapMCPTools(
               ? (context as { abortSignal?: AbortSignal }).abortSignal
               : undefined;
 
+          const sanitizedArgs = sanitizeMCPToolArgs(args, tool.inputSchema) as Parameters<
+            typeof originalExecute
+          >[0];
           const result: unknown = await runMCPToolWithDeadline(
-            () => Promise.resolve(originalExecute(args, context)) as Promise<unknown>,
+            () => Promise.resolve(originalExecute(sanitizedArgs, context)) as Promise<unknown>,
             { toolName, timeoutMs: MCP_TOOL_CALL_TIMEOUT_MS, signal: abortSignal }
           );
           return transformMCPResult(result as MCPCallToolResult);

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -265,9 +265,7 @@ export function wrapMCPTools(
               ? (context as { abortSignal?: AbortSignal }).abortSignal
               : undefined;
 
-          const sanitizedArgs = sanitizeMCPToolArgs(args, tool.inputSchema) as Parameters<
-            typeof originalExecute
-          >[0];
+          const sanitizedArgs = sanitizeMCPToolArgs(args, tool.inputSchema);
           const result: unknown = await runMCPToolWithDeadline(
             () => Promise.resolve(originalExecute(sanitizedArgs, context)) as Promise<unknown>,
             { toolName, timeoutMs: MCP_TOOL_CALL_TIMEOUT_MS, signal: abortSignal }


### PR DESCRIPTION
## Summary

MCP tool calls now drop top-level empty-string arguments that the model emitted for optional parameters before the call is forwarded to the server. Fixes #2887.

## Background

LLMs often fill optional tool parameters with `""` instead of omitting them. `wrapMCPTools` forwarded arguments verbatim, so strict REST-backed MCP servers (GitLab MCP is the confirmed case) rejected the call with `400 Bad Request` (e.g. `assignee_id should be an integer, none, or any, however got ""`), leaving the user with a failed tool call and no workaround.

## Implementation

Sanitization happens in `wrapMCPTools` (argument path only), just before `originalExecute` is invoked. Design decisions:

- **Schema-aware, not unconditional:** every MCP tool mux builds carries its server-declared JSON schema via the AI SDK's `jsonSchema()` wrapper (`tool.inputSchema.jsonSchema`), so the top-level `required` list is available at zero extra cost. `""` is stripped only for parameters not listed in `required`; a genuinely required empty string is never silently dropped (the server stays the arbiter of its validity). If the schema is missing or unreadable (not the case for tools built by `mcpClient`), all top-level `""` values are stripped, matching the issue's intent since the reported failure mode is far more common than a legitimately empty required value.
- **Top-level only:** matches the reported failure; no evidence found that nested empty strings cause this class of error. Recursive stripping can be added later if needed.
- **`null` and `[]` pass through untouched:** some servers assign them meaning ("clear this field" / "no filter"). Nothing else on the MCP argument path normalizes null vs. undefined today (the repo's `.nullish()` convention applies to mux's own tool schemas), so this change stays consistent by not introducing any null handling.

Kept deliberately clear of the result path (`transformMCPResult`) that #3891 touches; the only shared-file overlap is the `wrapMCPTools` body, which #3891 does not modify.

## Validation

Red-green verified: with the sanitization call bypassed, the three stripping tests fail and the two pass-through tests still pass.

## Risks

Low severity, scoped to MCP tool invocation. The behavior change is invisible unless a model emits `""` for an optional parameter; the main theoretical regression is a server that intentionally distinguishes optional-`""` from omitted, which the issue triage considered an acceptable tradeoff (a per-server opt-out can be added later if one surfaces).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
