### PR TITLE
🤖 fix: pass ProxyCommand to cmd.exe verbatim on Windows (ssh2 premature close)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Run unit tests (Windows smoke)
         shell: pwsh
         run: |
-          bun test src/node/utils/paths.test.ts src/node/utils/main/bashPath.test.ts src/node/utils/main/resolveLocalPtyShell.test.ts
+          bun test src/node/utils/paths.test.ts src/node/utils/main/bashPath.test.ts src/node/utils/main/resolveLocalPtyShell.test.ts src/node/runtime/SSH2ConnectionPool.test.ts
       - name: Run Windows integration smoke tests
         shell: pwsh
         run: |

--- a/src/node/runtime/SSH2ConnectionPool.test.ts
+++ b/src/node/runtime/SSH2ConnectionPool.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { getProxyShellArgs, spawnProxyCommand } from "./SSH2ConnectionPool";
+
+const PROXY_TOKENS = { host: "example.test", port: 2222, user: "alice" };
+
+describe("getProxyShellArgs", () => {
+  // Shape mux's SSH config writer emits: every argument double-quoted.
+  const quotedCommand =
+    '"C:\\Program Files\\coder\\coder.exe" "ssh" "--stdio" "--hostname-suffix" "mux--coder" "my-ws.mux--coder"';
+
+  it("passes the command to cmd.exe verbatim so embedded quotes survive (win32)", () => {
+    const spec = getProxyShellArgs(quotedCommand, "win32");
+
+    // Node's default escaping rewrites embedded quotes as \" which cmd.exe
+    // cannot parse; the proxy process then dies instantly (#3110).
+    expect(spec.windowsVerbatimArguments).toBe(true);
+    expect(spec.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+
+    // cmd.exe /s strips the first and last quote of the /c payload; what
+    // remains must be the original ProxyCommand byte-for-byte.
+    const payload = spec.args[3];
+    expect(payload.startsWith('"')).toBe(true);
+    expect(payload.endsWith('"')).toBe(true);
+    expect(payload.slice(1, -1)).toBe(quotedCommand);
+  });
+
+  it("runs the command through /bin/sh -c unchanged on POSIX", () => {
+    const spec = getProxyShellArgs(quotedCommand, "linux");
+
+    expect(spec.command).toBe("/bin/sh");
+    expect(spec.args).toEqual(["-c", quotedCommand]);
+    expect(spec.windowsVerbatimArguments).toBe(false);
+  });
+});
+
+describe("spawnProxyCommand", () => {
+  it("executes a ProxyCommand with a double-quoted binary path and substitutes tokens", async () => {
+    // Quoted argv0 mirrors the ProxyCommand mux writes to ~/.ssh/config.
+    const command =
+      process.platform === "win32"
+        ? String.raw`"C:\Windows\System32\cmd.exe" /d /c echo proxy-ok:%h:%p:%r`
+        : '"/bin/echo" proxy-ok:%h:%p:%r';
+
+    const proxy = spawnProxyCommand(command, PROXY_TOKENS);
+    // stdin closes without finish when the child exits; swallow the resulting
+    // premature-close error like the production stream handlers do.
+    proxy.sock.on("error", () => undefined);
+
+    let stdout = "";
+    proxy.sock.on("data", (chunk: Buffer) => {
+      stdout += String(chunk);
+    });
+    await new Promise<void>((resolve) => proxy.process.once("close", () => resolve()));
+
+    expect(stdout).toContain("proxy-ok:example.test:2222:alice");
+    expect(proxy.process.exitCode).toBe(0);
+  });
+
+  it("describes exit status and stderr tail after the proxy dies", async () => {
+    const command =
+      process.platform === "win32" ? "echo oops 1>&2 & exit 7" : "echo oops >&2; exit 7";
+
+    const proxy = spawnProxyCommand(command, PROXY_TOKENS);
+    proxy.sock.on("error", () => undefined);
+
+    // Still running: nothing to describe yet.
+    expect(proxy.describeExit()).toBeUndefined();
+
+    await new Promise<void>((resolve) => proxy.process.once("close", () => resolve()));
+
+    const description = proxy.describeExit();
+    expect(description).toContain("code 7");
+    expect(description).toContain("oops");
+  });
+});

--- a/src/node/runtime/SSH2ConnectionPool.ts
+++ b/src/node/runtime/SSH2ConnectionPool.ts
@@ -159,34 +159,63 @@ function sanitizeProxyCommand(
   });
 }
 
-function getProxyShellArgs(command: string): { command: string; args: string[] } {
-  if (process.platform === "win32") {
+/**
+ * Build the shell invocation for a ProxyCommand string. Exported for tests.
+ *
+ * On Windows the command must reach cmd.exe verbatim. Without
+ * windowsVerbatimArguments, Node escapes the /c payload with MSVCRT rules
+ * (embedded `"` becomes `\"`), which cmd.exe does not understand. Mux's own
+ * ProxyCommand double-quotes every argument, so cmd.exe got a mangled
+ * command line, exited instantly, and the connection died with a bare
+ * "Premature close" (#3110). Mirror Node's `shell: true` handling instead:
+ * `cmd.exe /d /s /c "<command>"` passed verbatim, where /s strips the outer
+ * quotes so cmd.exe sees the original command byte-for-byte.
+ */
+export function getProxyShellArgs(
+  command: string,
+  platform: NodeJS.Platform = process.platform
+): { command: string; args: string[]; windowsVerbatimArguments: boolean } {
+  if (platform === "win32") {
     return {
       command: process.env.COMSPEC ?? "cmd.exe",
-      args: ["/d", "/s", "/c", command],
+      args: ["/d", "/s", "/c", `"${command}"`],
+      windowsVerbatimArguments: true,
     };
   }
 
-  return { command: "/bin/sh", args: ["-c", command] };
+  return { command: "/bin/sh", args: ["-c", command], windowsVerbatimArguments: false };
 }
 
-function spawnProxyCommand(
-  command: string,
-  tokens: { host: string; port: number; user: string }
-): {
+/** Bound the retained stderr so a chatty proxy can't grow memory unbounded. */
+const MAX_PROXY_STDERR_TAIL_CHARS = 2048;
+
+interface ProxyCommandHandle {
   sock: Duplex;
   process: ChildProcess;
-} {
-  const substituted = sanitizeProxyCommand(command, tokens);
-  const { command: shell, args } = getProxyShellArgs(substituted);
+  /** After the proxy process terminates, describes how (exit status + stderr tail). */
+  describeExit: () => string | undefined;
+}
 
-  const proc = spawn(shell, args, {
+/** Exported for tests. */
+export function spawnProxyCommand(
+  command: string,
+  tokens: { host: string; port: number; user: string }
+): ProxyCommandHandle {
+  const substituted = sanitizeProxyCommand(command, tokens);
+  const shell = getProxyShellArgs(substituted);
+
+  const proc = spawn(shell.command, shell.args, {
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
+    windowsVerbatimArguments: shell.windowsVerbatimArguments,
   });
 
-  proc.stderr?.on("data", () => {
-    // Drain stderr to avoid blocking proxy process.
+  // Retain a bounded stderr tail (also keeps stderr drained so the proxy
+  // process can't block on a full pipe). A dying proxy can then explain
+  // itself in the connection error instead of a bare "Premature close".
+  let stderrTail = "";
+  proc.stderr?.on("data", (chunk: Buffer | string) => {
+    stderrTail = (stderrTail + String(chunk)).slice(-MAX_PROXY_STDERR_TAIL_CHARS);
   });
 
   if (!proc.stdin || !proc.stdout) {
@@ -195,7 +224,17 @@ function spawnProxyCommand(
 
   const sock = Duplex.from({ writable: proc.stdin, readable: proc.stdout });
 
-  return { sock, process: proc };
+  const describeExit = () => {
+    if (proc.exitCode === null && proc.signalCode === null) {
+      return undefined;
+    }
+    const exit =
+      proc.signalCode !== null ? `signal ${proc.signalCode}` : `code ${proc.exitCode ?? "unknown"}`;
+    const stderr = stderrTail.trim();
+    return `ProxyCommand exited with ${exit}${stderr ? `: ${stderr}` : ""}`;
+  };
+
+  return { sock, process: proc, describeExit };
 }
 
 /** Extract a message string from an error for `.includes()` matching.
@@ -480,14 +519,18 @@ export class SSH2ConnectionPool {
           privateKey: Buffer | undefined,
           reportAuthFailure: boolean
         ): Promise<SSH2ConnectionEntry> => {
-          const proxy = resolvedConfigWithIdentities.proxyCommand
-            ? spawnProxyCommand(resolvedConfigWithIdentities.proxyCommand, proxyTokens)
-            : undefined;
-
           // Lazy-load ssh2 to avoid loading the native sshcrypto.node module at
           // startup. Bun doesn't support the libuv functions the NAPI module calls,
           // so eagerly importing ssh2 crashes the headless CLI in sandboxes.
+          // Import before spawning the proxy so everything from spawn to
+          // handler attachment below runs synchronously; an instantly-dying
+          // proxy can otherwise emit "error"/"close" during the await with no
+          // listeners attached.
           const { Client: SSH2Client } = await import("ssh2");
+
+          const proxy = resolvedConfigWithIdentities.proxyCommand
+            ? spawnProxyCommand(resolvedConfigWithIdentities.proxyCommand, proxyTokens)
+            : undefined;
           const client = new SSH2Client();
           const entry: SSH2ConnectionEntry = {
             client,
@@ -507,6 +550,17 @@ export class SSH2ConnectionPool {
               proxy.sock.destroy();
             }
             cleanupProxy();
+          };
+
+          // When the proxy process has died, a raw ssh2 error like "Premature
+          // close" hides the actual cause; append the proxy's exit status and
+          // stderr so the user sees why the proxy exited.
+          const withProxyExitContext = (err: Error): Error => {
+            const proxyExit = proxy?.describeExit();
+            if (proxyExit && !err.message.includes(proxyExit)) {
+              err.message = `${err.message} (${proxyExit})`;
+            }
+            return err;
           };
 
           if (proxy) {
@@ -550,7 +604,7 @@ export class SSH2ConnectionPool {
               clearTimeout(entry.idleTimer);
             }
             if (!aborted && (!isAuthFailure(err) || reportAuthFailure)) {
-              this.reportFailure(config, getErrorMessage(err));
+              this.reportFailure(config, getErrorMessage(withProxyExitContext(err)));
             }
             this.connections.delete(key);
             cleanupProxy();
@@ -564,7 +618,22 @@ export class SSH2ConnectionPool {
 
             const onError = (err: Error) => {
               cleanup();
-              reject(err);
+              reject(withProxyExitContext(err));
+            };
+
+            // Fail fast with the proxy's exit status + stderr when the proxy
+            // process dies before the handshake completes, instead of waiting
+            // for a readyTimeout or a bare stream error.
+            const onProxyClose = () => {
+              cleanup();
+              client.end();
+              cleanupProxySocket();
+              reject(
+                new Error(
+                  proxy?.describeExit() ??
+                    "ProxyCommand exited before the SSH connection was established"
+                )
+              );
             };
 
             const onAbort = () => {
@@ -578,11 +647,13 @@ export class SSH2ConnectionPool {
             const cleanup = () => {
               client.off("ready", onReady);
               client.off("error", onError);
+              proxy?.process.off("close", onProxyClose);
               abortSignal?.removeEventListener("abort", onAbort);
             };
 
             client.on("ready", onReady);
             client.on("error", onError);
+            proxy?.process.once("close", onProxyClose);
             abortSignal?.addEventListener("abort", onAbort, { once: true });
 
             if (abortSignal?.aborted) {


### PR DESCRIPTION
## Summary

Fixes the Coder Runtime on Windows: the ssh2 ProxyCommand child process was spawned through `cmd.exe /d /s /c` **without** `windowsVerbatimArguments`, so Node's default MSVCRT-style argument escaping rewrote the embedded quotes and cmd.exe received a mangled command line. The proxy process died instantly and every connection attempt failed with a bare `ERR_STREAM_PREMATURE_CLOSE` on `ssh2-proxy-socket`.

Fixes #3110

## Background

Mux's SSH config writer double-quotes every ProxyCommand argument (e.g. `"C:\Users\me\coder.exe" "ssh" "--stdio" ...`). System OpenSSH parses that fine, but `SSH2ConnectionPool.spawnProxyCommand` passed the same string as an argv element to `spawn(cmd.exe, ["/d", "/s", "/c", command])`. Without `windowsVerbatimArguments`, Node escapes each embedded `"` as `\"` on win32 — cmd.exe does not understand backslash-escaped quotes, so the coder CLI never launched, matching the reporter's symptoms (instant premature close, no handshake, while `coder ssh` and system OpenSSH both work).

## Implementation

- `getProxyShellArgs` now mirrors Node's own `shell: true` handling on win32: `cmd.exe /d /s /c "<command>"` with `windowsVerbatimArguments: true`, so cmd.exe sees the original ProxyCommand byte-for-byte (`/s` strips the added outer quotes). POSIX (`/bin/sh -c`) is unchanged.
- Error surfacing: the proxy's stderr is now retained as a bounded tail (2 KiB), and connection errors append the proxy's exit status + stderr when the proxy has died. A proxy that exits before the handshake now fails fast with that description instead of hanging until `readyTimeout` or surfacing a bare "Premature close".
- The `ssh2` dynamic import moved above the proxy spawn so spawn → handler attachment runs synchronously, eliminating a window where an instantly-dying proxy could emit `error`/`close` with no listeners attached.
- Added `SSH2ConnectionPool.test.ts` to the Windows CI smoke list; the spawn tests execute a real double-quoted-argv0 ProxyCommand on both platforms.

## Validation

- `bun test src/node/runtime/SSH2ConnectionPool.test.ts` (plus sshConfigParser/muxSshConfigWriter suites) green.
- `make static-check-full` green locally.
- Cannot run Windows locally; the mechanism was verified from Node.js win32 spawn semantics and the test asserts the verbatim payload contract. The new tests also run on the `Test / Windows` CI job.

## Risks

Low and scoped to the ssh2 ProxyCommand path (Coder Runtime / SSH configs with ProxyCommand). Main behavioral changes: Windows spawn semantics (previously broken for any quoted command, which mux always writes), and connect-time failure now fires on proxy death instead of waiting for the ready timeout.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
