### PR TITLE
🤖 fix: list contained symlinked project skills in agent_skill_list

### DIFF
--- a/src/node/services/agentSkills/agentSkillsService.test.ts
+++ b/src/node/services/agentSkills/agentSkillsService.test.ts
@@ -1129,6 +1129,46 @@ describe("agentSkillsService", () => {
     expect(result.package.frontmatter.description).toBe("Kalshi API documentation");
   });
 
+  test("local containment rejects escaped skill dir whose SKILL.md symlinks back inside", async () => {
+    using project = new DisposableTempDir("agent-skills-two-level-symlink");
+    using escapedSource = new DisposableTempDir("agent-skills-two-level-symlink-escape");
+
+    const projectRoot = project.path;
+    const projectSkillsRoot = path.join(projectRoot, ".mux", "skills");
+    await fs.mkdir(projectSkillsRoot, { recursive: true });
+
+    // In-project decoy SKILL.md the attacker points back at to pass a file-only check.
+    const skillName = "evil-skill";
+    const decoyParent = path.join(projectRoot, "decoy");
+    await writeSkill(decoyParent, skillName, "dir escapes containment");
+
+    // Skill dir resolves OUTSIDE the project; its SKILL.md symlinks back inside.
+    const externalSkillDir = path.join(escapedSource.path, skillName);
+    await fs.mkdir(externalSkillDir, { recursive: true });
+    await fs.symlink(
+      path.join(decoyParent, skillName, "SKILL.md"),
+      path.join(externalSkillDir, "SKILL.md"),
+      "file"
+    );
+    await fs.symlink(
+      externalSkillDir,
+      path.join(projectSkillsRoot, skillName),
+      process.platform === "win32" ? "junction" : "dir"
+    );
+
+    const roots = { projectRoot: projectSkillsRoot, globalRoot: "/nonexistent" };
+    const runtime = new LocalRuntime(projectRoot);
+    const containment = { kind: "local" as const, root: projectRoot };
+
+    const discovered = await discoverAgentSkills(runtime, projectRoot, { roots, containment });
+    expect(discovered.find((skill) => skill.name === skillName)).toBeUndefined();
+
+    const parsed = SkillNameSchema.parse(skillName);
+    expect(readAgentSkill(runtime, projectRoot, parsed, { roots, containment })).rejects.toThrow(
+      /not found/i
+    );
+  });
+
   test("runtime containment filters escaped project skills for discovery, diagnostics, and read", async () => {
     using project = new DisposableTempDir("agent-skills-runtime-containment");
     using escapedSource = new DisposableTempDir("agent-skills-runtime-containment-escape");

--- a/src/node/services/agentSkills/agentSkillsService.ts
+++ b/src/node/services/agentSkills/agentSkillsService.ts
@@ -331,19 +331,33 @@ function resolveProjectSkillContainment(options?: {
 async function assertProjectSkillContained(args: {
   runtime: Runtime;
   containment: ProjectSkillContainment;
+  skillDir: string;
   skillFilePath: string;
 }): Promise<void> {
   if (args.containment.kind === "none") {
     return;
   }
 
+  // SECURITY: validate the skill DIRECTORY as well as SKILL.md. Checking only
+  // the file lets a skill-dir symlink resolve outside containment while its
+  // SKILL.md symlinks back inside; the skill would then be accepted and
+  // sibling files would be read from the external location.
   if (args.containment.kind === "local") {
+    await ensurePathContained(args.containment.root, args.skillDir, {
+      allowMissing: true,
+    });
     await ensurePathContained(args.containment.root, args.skillFilePath, {
       allowMissing: true,
     });
     return;
   }
 
+  await ensureRuntimePathWithinWorkspace(
+    args.runtime,
+    args.containment.root,
+    args.skillDir,
+    "Project skill directory"
+  );
   await ensureRuntimePathWithinWorkspace(
     args.runtime,
     args.containment.root,
@@ -360,11 +374,16 @@ async function assertProjectSkillContained(args: {
  */
 async function isPluginSkillContained(args: {
   pluginRoot: string;
+  skillDir: string;
   skillFilePath: string;
   directoryName: string;
   onEscape?: (message: string) => void;
 }): Promise<boolean> {
   try {
+    // SECURITY: validate the skill directory as well as SKILL.md so a dir
+    // symlink escaping the plugin root cannot hide behind a SKILL.md that
+    // symlinks back inside (see assertProjectSkillContained).
+    await ensurePathContained(args.pluginRoot, args.skillDir);
     await ensurePathContained(args.pluginRoot, args.skillFilePath);
     return true;
   } catch (error) {
@@ -590,6 +609,7 @@ export async function discoverAgentSkills(
         // was already validated against the project containment root.
         const contained = await isPluginSkillContained({
           pluginRoot: scan.pluginRoot,
+          skillDir,
           skillFilePath,
           directoryName,
         });
@@ -599,6 +619,7 @@ export async function discoverAgentSkills(
           await assertProjectSkillContained({
             runtime: scan.runtime,
             containment,
+            skillDir,
             skillFilePath,
           });
         } catch (error) {
@@ -729,6 +750,7 @@ export async function discoverAgentSkillsDiagnostics(
         // was already validated against the project containment root.
         const contained = await isPluginSkillContained({
           pluginRoot: scan.pluginRoot,
+          skillDir,
           skillFilePath,
           directoryName,
           onEscape: (message) => {
@@ -747,6 +769,7 @@ export async function discoverAgentSkillsDiagnostics(
           await assertProjectSkillContained({
             runtime: scan.runtime,
             containment,
+            skillDir,
             skillFilePath,
           });
         } catch (error) {
@@ -910,6 +933,7 @@ export async function readAgentSkill(
       // was already validated against the project containment root.
       const contained = await isPluginSkillContained({
         pluginRoot: candidate.pluginRoot,
+        skillDir,
         skillFilePath,
         directoryName: name,
       });
@@ -919,6 +943,7 @@ export async function readAgentSkill(
         await assertProjectSkillContained({
           runtime: candidate.runtime,
           containment,
+          skillDir,
           skillFilePath,
         });
       } catch (error) {

--- a/src/node/services/tools/agent_skill_list.test.ts
+++ b/src/node/services/tools/agent_skill_list.test.ts
@@ -1537,6 +1537,58 @@ describe("agent_skill_list", () => {
     });
   });
 
+  it("skips escaped symlinked skill dir even when its SKILL.md symlinks back inside the project", async () => {
+    using tempDir = new TestTempDir("test-agent-skill-list-two-level-symlink-escape");
+
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
+
+      const projectRoot = path.join(tempDir.path, "project");
+      const skillsDir = path.join(projectRoot, ".mux", "skills");
+      await fs.mkdir(skillsDir, { recursive: true });
+
+      // In-project decoy SKILL.md the attacker points back at to pass a file-only check.
+      const decoyDir = path.join(projectRoot, "decoy");
+      await fs.mkdir(decoyDir, { recursive: true });
+      const decoyFile = path.join(decoyDir, "SKILL.md");
+      await fs.writeFile(
+        decoyFile,
+        "---\nname: evil-skill\ndescription: dir escapes containment\n---\nBody\n",
+        "utf-8"
+      );
+
+      // Skill dir resolves OUTSIDE the project; its SKILL.md symlinks back inside.
+      const externalSkillDir = path.join(tempDir.path, "external", "evil-skill");
+      await fs.mkdir(externalSkillDir, { recursive: true });
+      await fs.symlink(decoyFile, path.join(externalSkillDir, "SKILL.md"));
+      await fs.symlink(externalSkillDir, path.join(skillsDir, "evil-skill"));
+
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
+
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.skills.find((s) => s.name === "evil-skill")).toBeUndefined();
+      }
+    });
+  });
+
   it("skips project skill when SKILL.md symlink target escapes project root", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-skillmd-symlink-escape");
 

--- a/src/node/services/tools/agent_skill_list.test.ts
+++ b/src/node/services/tools/agent_skill_list.test.ts
@@ -1432,7 +1432,7 @@ describe("agent_skill_list", () => {
     });
   });
 
-  it("skips symlinked project skill directories inside contained skills root", async () => {
+  it("skips symlinked project skill directories that resolve outside the project root", async () => {
     using tempDir = new TestTempDir("test-agent-skill-list-project-entry-symlink");
 
     await withHomeDir(tempDir.path, async () => {
@@ -1483,6 +1483,56 @@ describe("agent_skill_list", () => {
         expect(result.skills.map((s) => s.name)).toEqual(["global-skill", "real-skill"]);
         expect(result.skills.find((s) => s.name === "real-skill")?.scope).toBe("project");
         expect(result.skills.find((s) => s.name === "sneaky-skill")).toBeUndefined();
+      }
+    });
+  });
+
+  it("lists symlinked project skill directories whose target stays inside the project root", async () => {
+    using tempDir = new TestTempDir("test-agent-skill-list-project-entry-symlink-contained");
+
+    await withHomeDir(tempDir.path, async () => {
+      const workspaceSessionDir = await createWorkspaceSessionDir(
+        tempDir.path,
+        GLOBAL_WORKSPACE_ID
+      );
+
+      const projectRoot = path.join(tempDir.path, "project");
+      const skillsDir = path.join(projectRoot, ".mux", "skills");
+      await fs.mkdir(skillsDir, { recursive: true });
+
+      // Real skill stored elsewhere inside the project (not itself a skills root),
+      // symlinked into .mux/skills: the layout skill package managers install.
+      const storeSkillDir = path.join(projectRoot, "skill-store", "linked-skill");
+      await fs.mkdir(storeSkillDir, { recursive: true });
+      await fs.writeFile(
+        path.join(storeSkillDir, "SKILL.md"),
+        "---\nname: linked-skill\ndescription: contained symlinked skill\n---\nBody\n",
+        "utf-8"
+      );
+      await fs.symlink(storeSkillDir, path.join(skillsDir, "linked-skill"));
+
+      const projectScope: MuxToolScope = {
+        type: "project",
+        muxHome: tempDir.path,
+        projectRoot,
+        projectStorageAuthority: "host-local",
+      };
+
+      const config = createTestToolConfig(tempDir.path, {
+        workspaceId: GLOBAL_WORKSPACE_ID,
+        sessionsDir: workspaceSessionDir,
+        muxScope: projectScope,
+      });
+
+      const tool = createAgentSkillListTool(config);
+      const result = (await tool.execute!({}, mockToolCallOptions)) as AgentSkillListToolResult;
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const linked = result.skills.find((s) => s.name === "linked-skill");
+        expect(linked).toBeDefined();
+        expect(linked?.scope).toBe("project");
+        expect(linked?.description).toBe("contained symlinked skill");
       }
     });
   });

--- a/src/node/services/tools/agent_skill_list.ts
+++ b/src/node/services/tools/agent_skill_list.ts
@@ -63,12 +63,17 @@ async function readSkillDescriptor(
   }
 
   const directoryName = parsedDirectoryName.data;
-  const skillFilePath = path.join(skillsRoot, directoryName, "SKILL.md");
+  const skillDir = path.join(skillsRoot, directoryName);
+  const skillFilePath = path.join(skillDir, "SKILL.md");
 
-  // Validate SKILL.md canonical path stays within the containment root before any read.
-  // This prevents repo-controlled symlinks from escaping the project boundary.
+  // SECURITY: validate that BOTH the skill directory and SKILL.md canonical
+  // paths stay within the containment root before any read. Checking only the
+  // file would let a skill-dir symlink resolve outside containment while its
+  // SKILL.md symlinks back inside, advertising a skill whose sibling files
+  // agent_skill_read_file would then read from the external location.
   let containedPath: string;
   try {
+    await ensurePathContained(containmentRoot, skillDir);
     containedPath = await ensurePathContained(containmentRoot, skillFilePath);
   } catch (error) {
     if (hasErrorCode(error, "ENOENT")) {

--- a/src/node/services/tools/agent_skill_list.ts
+++ b/src/node/services/tools/agent_skill_list.ts
@@ -31,20 +31,15 @@ interface AgentSkillListToolArgs {
   includeUnadvertised?: boolean | null;
 }
 
-interface SkillDirectoryEntry {
-  name: string;
-  isSymbolicLink: boolean;
-}
-
-async function listSkillDirectories(skillsRoot: string): Promise<SkillDirectoryEntry[]> {
+async function listSkillDirectories(skillsRoot: string): Promise<string[]> {
   try {
     const entries = await fsPromises.readdir(skillsRoot, { withFileTypes: true });
+    // Include symlinked entries: skill package managers install skills by
+    // symlinking directories into skills roots. readSkillDescriptor enforces
+    // realpath containment per skill, so escaping symlinks stay rejected.
     return entries
       .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-      .map((entry) => ({
-        name: entry.name,
-        isSymbolicLink: entry.isSymbolicLink(),
-      }));
+      .map((entry) => entry.name);
   } catch (error) {
     log.warn(
       `Skipping skills root '${skillsRoot}' because directory entries could not be read: ${getErrorMessage(error)}`
@@ -228,12 +223,6 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
           skillsRoot: string;
           containmentRoot: string;
           scope: "global" | "project";
-          /**
-           * Agent Plugins root: per-skill containment anchors at the plugin
-           * root (§4.1), so contained symlinked skill dirs stay listed —
-           * matching stream discovery and agent_skill_read.
-           */
-          isPlugin?: boolean;
         }> = [
           {
             skillsRoot: path.join(muxScope.muxHome, "skills"),
@@ -315,14 +304,13 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
               skillsRoot: plugin.skillsDir,
               containmentRoot: plugin.rootPath,
               scope: plugin.scope,
-              isPlugin: true,
             });
           }
         }
 
         const skills: AgentSkillDescriptor[] = [];
         const seenByScope = new Set<string>();
-        for (const { skillsRoot, containmentRoot, scope, isPlugin } of roots) {
+        for (const { skillsRoot, containmentRoot, scope } of roots) {
           let skillsRootReal: string;
           try {
             skillsRootReal = await fsPromises.realpath(skillsRoot);
@@ -342,22 +330,15 @@ export const createAgentSkillListTool: ToolFactory = (config: ToolConfiguration)
             continue;
           }
 
-          const directoryEntries = await listSkillDirectories(skillsRootReal);
-          for (const entry of directoryEntries) {
-            // Project scope: reject symlinked skill directories to avoid resolving
-            // repo-controlled entries to out-of-project locations. Plugin roots
-            // are exempt: readSkillDescriptor enforces realpath containment at
-            // the plugin root, the same rule stream discovery applies.
-            if (scope === "project" && !isPlugin && entry.isSymbolicLink) {
-              log.warn(
-                `Skipping project skill '${entry.name}': skill directory is a symbolic link`
-              );
-              continue;
-            }
-
+          const directoryNames = await listSkillDirectories(skillsRootReal);
+          for (const directoryName of directoryNames) {
+            // SECURITY: symlinked skill directories are allowed only through
+            // readSkillDescriptor's realpath containment check, which rejects
+            // entries resolving outside the containment root. This matches the
+            // posture of stream discovery and plugin roots.
             const descriptor = await readSkillDescriptor(
               skillsRootReal,
-              entry.name,
+              directoryName,
               scope,
               containmentRoot
             );

--- a/src/node/services/tools/skillFileUtils.ts
+++ b/src/node/services/tools/skillFileUtils.ts
@@ -166,6 +166,14 @@ export async function resolveContainedSkillFilePath(
 /**
  * Unified directory-scope validation for local skill operations (write / delete).
  *
+ * SECURITY: mutations intentionally reject symlinked skills roots and skill
+ * directories even when the resolved target stays inside the containment root.
+ * Reads and discovery accept contained symlinks (agent_skill_list,
+ * agentSkillsService), but mutating through a symlink alias is exposed to
+ * check-to-use races and silently edits the link target owned by whoever
+ * installed the link (e.g. a skill package manager), so writes must address
+ * the real path instead.
+ *
  * Checks (in order):
  * 1. Skills root is not a symlink.
  * 2. Skill directory is not a symlink.


### PR DESCRIPTION
## Summary

Project skills installed as symlinks (the layout skill package managers such as Vercel's skills CLI produce) are now listed by `agent_skill_list` in host-local project workspaces, as long as the symlink resolves inside the project containment root. Symlinks that escape containment remain rejected everywhere, and containment is now enforced on the skill directory itself in addition to SKILL.md across all skill acceptance sites.

Fixes #2912

## Background

Skill package managers install skills by symlinking directories into `.mux/skills/` or `.agents/skills/`. The `agent_skill_list` tool's host-local branch skipped every symlinked project skill directory outright, so those skills never appeared in the tool listing even though stream discovery, `agent_skill_read`, and `agent_skill_read_file` already accepted them via realpath containment. This made the listing inconsistent with what the agent could actually invoke.

## Boundary decision

- **Read/list paths** accept symlinked skill directories when the resolved target stays inside the containment root (project checkout root for project skills, mux home / user home for global ones). Escaping symlinks (e.g. pointing at `/etc` or an unrelated repo) are still skipped.
- **Write/delete paths** intentionally keep the full symlink rejection (`validateLocalSkillDirectory`, leaf symlink checks in `agent_skill_write` / `agent_skill_delete`), even for contained targets. Mutating through a symlink alias is exposed to check-to-use races and silently edits the link target owned by the tool that installed the link. The user need is read-path support (symlinked skills should load and be invocable); managing such skills belongs to the package manager that created the links. A SECURITY comment at `validateLocalSkillDirectory` documents this boundary.

## Implementation

- `agent_skill_list.ts`: dropped the project-scope `isSymbolicLink` skip (and the now-unneeded `isPlugin` exemption plumbing); every entry flows through `readSkillDescriptor`'s per-skill realpath containment check, matching the posture of stream discovery and plugin roots.
- **Directory-level containment (Codex P1)**: checking only SKILL.md would let a skill-dir symlink resolve outside containment while its SKILL.md symlinks back inside, advertising a skill whose sibling files `agent_skill_read_file` would then read from the external location. All acceptance sites now containment-check the skill directory as well as SKILL.md: `readSkillDescriptor` (list tool), `assertProjectSkillContained` (stream discovery, diagnostics, `readAgentSkill`; both local and runtime containment kinds), and `isPluginSkillContained` (plugin roots).
- `skillFileUtils.ts`: documented why mutations still reject contained symlinks.
- Tests: contained symlinked project skill is listed; escaping symlinked skill dirs stay hidden; the two-level bypass shape (external dir + SKILL.md symlinking back inside) is rejected at both the list-tool and service layers.

## Validation

- Red-green at both layers: the contained-symlink test fails on the old code; the two-level bypass tests fail with the directory checks toggled off and pass with them on.
- All 220 tests across the skill suites pass; `make static-check-full` green locally.

## Risks

Low. The listing change only widens `agent_skill_list`'s host-local branch to match the containment rule every other skill surface already applies. The directory-level containment check is strictly tightening: a previously accepted skill is rejected only when its directory realpath escapes containment, which was already an unsupported (and now demonstrated exploitable) configuration.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
