### PR TITLE
🤖 fix: align npm provenance repository

### DIFF
--- a/.github/workflows/_npm-publish.yml
+++ b/.github/workflows/_npm-publish.yml
@@ -5,6 +5,7 @@ name: NPM Publish (Reusable)
 #
 # OIDC TRUSTED PUBLISHING SETUP (on npmjs.com):
 #   New packages must be published manually once before npm allows trusted publisher setup.
+#   Repository renames do not update npm settings; reconfigure every existing package.
 #   For each package (@coder/shux, mux, @coder/mux-chat-components):
 #   1. Go to package settings → Trusted Publisher → GitHub Actions
 #   2. Configure:

--- a/.github/workflows/_npm-publish.yml
+++ b/.github/workflows/_npm-publish.yml
@@ -9,7 +9,7 @@ name: NPM Publish (Reusable)
 #   1. Go to package settings → Trusted Publisher → GitHub Actions
 #   2. Configure:
 #      - Owner: coder
-#      - Repository: mux
+#      - Repository: shux
 #      - Workflow filename: publish-npm.yml  (the caller, NOT this reusable)
 #      - Allowed action: npm publish
 #      - Environment: (leave blank)

--- a/.github/workflows/_npm-publish.yml
+++ b/.github/workflows/_npm-publish.yml
@@ -60,6 +60,32 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Verify npm provenance repository metadata
+        env:
+          EXPECTED_REPOSITORY_URL: git+${{ github.server_url }}/${{ github.repository }}.git
+        run: |
+          node <<'NODE'
+          const fs = require("node:fs");
+          const manifests = [
+            "package.json",
+            "packages/mux-compat/package.json",
+            "packages/chat-components/package.json",
+          ];
+          const expected = process.env.EXPECTED_REPOSITORY_URL;
+          let valid = true;
+
+          // npm validates repository.url against the OIDC repository claim, so fail before building.
+          for (const manifest of manifests) {
+            const packageJson = JSON.parse(fs.readFileSync(manifest, "utf8"));
+            if (packageJson.repository?.url !== expected) {
+              console.error(`${manifest}: repository.url is ${JSON.stringify(packageJson.repository?.url)}, expected ${JSON.stringify(expected)}`);
+              valid = false;
+            }
+          }
+
+          if (!valid) process.exit(1);
+          NODE
+
       - name: Generate unique version from git
         id: version
         env:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,9 +9,9 @@ name: Publish to NPM
 # IMPORTANT: This workflow's filename (publish-npm.yml) must match the OIDC
 # trusted publisher configured on npmjs.com. Do not rename without updating
 # the npm trusted publisher settings for '@coder/shux', 'mux', and
-# '@coder/mux-chat-components'. Each trusted publisher must target repository
-# 'shux'; the old 'mux' repository name no longer matches the OIDC repository claim.
-# Publisher setup remains external.
+# '@coder/mux-chat-components'. Each trusted publisher must be reconfigured to
+# target repository 'shux'; npm does not follow the old 'mux' repository redirect
+# when validating OIDC claims. Publisher setup remains external.
 
 on:
   push:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,7 +9,9 @@ name: Publish to NPM
 # IMPORTANT: This workflow's filename (publish-npm.yml) must match the OIDC
 # trusted publisher configured on npmjs.com. Do not rename without updating
 # the npm trusted publisher settings for '@coder/shux', 'mux', and
-# '@coder/mux-chat-components'. Publisher setup remains external.
+# '@coder/mux-chat-components'. Each trusted publisher must target repository
+# 'shux'; the old 'mux' repository name no longer matches the OIDC repository claim.
+# Publisher setup remains external.
 
 on:
   push:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "AGPL-3.0-only",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coder/mux.git"
+    "url": "git+https://github.com/coder/shux.git"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/chat-components/package.json
+++ b/packages/chat-components/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coder/mux.git",
+    "url": "git+https://github.com/coder/shux.git",
     "directory": "packages/chat-components"
   },
   "license": "AGPL-3.0-only",

--- a/packages/mux-compat/README.md
+++ b/packages/mux-compat/README.md
@@ -1,5 +1,5 @@
 # mux compatibility package
 
-`mux` is the legacy package and command name for [Shux](https://github.com/coder/mux).
+`mux` is the legacy package and command name for [Shux](https://github.com/coder/shux).
 It forwards to the matching `@coder/shux` release so existing scripts keep working during
 the rename. New installations should use the `@coder/shux` package and `shux` command.

--- a/packages/mux-compat/package.json
+++ b/packages/mux-compat/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coder/mux.git",
+    "url": "git+https://github.com/coder/shux.git",
     "directory": "packages/mux-compat"
   },
   "license": "AGPL-3.0-only"

--- a/src/common/compat/productIdentity.test.ts
+++ b/src/common/compat/productIdentity.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { AppInfo as ElectronBuilderAppInfo } from "app-builder-lib/out/appInfo";
 import packageJson from "../../../package.json";
+import chatComponentsPackageJson from "../../../packages/chat-components/package.json";
 import legacyPackageJson from "../../../packages/mux-compat/package.json";
 import vscodePackageJson from "../../../vscode/package.json";
 import { resolveMacPackagedAppNames } from "./macPackagedApp";
@@ -103,6 +104,13 @@ describe("shux package transition contract", () => {
   test("keeps the Linux desktop name visible while WM class follows the slug", () => {
     expect(packageJson.build.linux.desktop?.StartupWMClass).toBe(packageJson.build.executableName);
     expect(packageJson.build.linux.desktop).not.toHaveProperty("Name");
+  });
+
+  test("matches all npm package metadata to the GitHub provenance repository", () => {
+    // npm trusted publishing rejects provenance when package metadata points at a renamed repo.
+    for (const publishedPackage of [packageJson, legacyPackageJson, chatComponentsPackageJson]) {
+      expect(publishedPackage.repository.url).toBe("git+https://github.com/coder/shux.git");
+    }
   });
 
   test("keeps the published mux forwarding package version-locked to @coder/shux", () => {

--- a/src/common/compat/productIdentity.test.ts
+++ b/src/common/compat/productIdentity.test.ts
@@ -6,7 +6,6 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { AppInfo as ElectronBuilderAppInfo } from "app-builder-lib/out/appInfo";
 import packageJson from "../../../package.json";
-import chatComponentsPackageJson from "../../../packages/chat-components/package.json";
 import legacyPackageJson from "../../../packages/mux-compat/package.json";
 import vscodePackageJson from "../../../vscode/package.json";
 import { resolveMacPackagedAppNames } from "./macPackagedApp";
@@ -104,13 +103,6 @@ describe("shux package transition contract", () => {
   test("keeps the Linux desktop name visible while WM class follows the slug", () => {
     expect(packageJson.build.linux.desktop?.StartupWMClass).toBe(packageJson.build.executableName);
     expect(packageJson.build.linux.desktop).not.toHaveProperty("Name");
-  });
-
-  test("matches all npm package metadata to the GitHub provenance repository", () => {
-    // npm trusted publishing rejects provenance when package metadata points at a renamed repo.
-    for (const publishedPackage of [packageJson, legacyPackageJson, chatComponentsPackageJson]) {
-      expect(publishedPackage.repository.url).toBe("git+https://github.com/coder/shux.git");
-    }
   });
 
   test("keeps the published mux forwarding package version-locked to @coder/shux", () => {


### PR DESCRIPTION
## Summary

Fix npm trusted-publishing provenance after the repository rename from `coder/mux` to `coder/shux`. The first post-merge `@coder/shux` publish failed with npm `E422` because package metadata still identified the old repository.

## Background

Publish workflow run `32397676492` signed provenance for `https://github.com/coder/shux`, but npm rejected `@coder/shux` because its `package.json` declared `git+https://github.com/coder/mux.git`.

## Implementation

- updates repository metadata to `git+https://github.com/coder/shux.git` for all packages published by the workflow:
  - `@coder/shux`
  - `mux`
  - `@coder/mux-chat-components`
- updates the `mux` compatibility README link
- corrects trusted-publisher setup guidance to use repository `shux`
- adds a publish-time preflight derived from the GitHub Actions repository context, covering every published package manifest

## Operator actions

**Required before merging:** update the npm trusted publisher for both existing downstream packages:

- `mux`
- `@coder/mux-chat-components`

For each package, use:

- Provider: GitHub Actions
- Owner: `coder`
- Repository: `shux`
- Workflow: `publish-npm.yml`
- Allowed action: `npm publish`
- Environment: blank

The `@coder/shux` trusted publisher is already configured correctly. No bootstrap publish is required for the downstream packages because they already exist. If this PR is merged before the two settings are updated, the root package can publish successfully before the workflow fails at `mux`; update the settings first or rerun the workflow afterward.

## Validation

- `make static-check`
- `bun test src/common/compat/productIdentity.test.ts`
- `npm pack --dry-run --json` for all three published package manifests
- confirmed no published package manifest retains `git+https://github.com/coder/mux.git`

## Risks

Low. This changes npm package metadata, release preflight validation, and documentation only. The preflight prevents stale repository metadata from reaching npm provenance validation for any package in the workflow.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$27.59`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=27.59 -->


