### PR TITLE
🤖 fix: re-enable retry when provider config changes after credential errors

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -27,6 +27,7 @@ import {
 import type { TodoItem } from "@/common/types/tools";
 import { buildStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import { mergeTimelineEvents, WorkspaceStore } from "./WorkspaceStore";
+import { createControllableAsyncIterable } from "@/browser/testUtils";
 import type { ResponseCompleteEvent } from "@/browser/utils/messages/responseCompletionMetadata";
 
 interface LoadMoreResponse {
@@ -98,6 +99,16 @@ const mockTerminalActivitySubscribe = mock(async function* (
   await waitForAbortSignal(options?.signal);
 });
 
+let providerConfigChanges = createControllableAsyncIterable<void>();
+const mockGetProvidersConfig = mock(() => Promise.resolve({}));
+const mockResumeStream = mock(() => Promise.resolve({ success: true, data: { started: true } }));
+const mockSendMessage = mock(() => Promise.resolve({ success: true, data: undefined }));
+const mockOnProvidersConfigChanged = mock((_input?: void, options?: { signal?: AbortSignal }) => {
+  const subscription = providerConfigChanges;
+  options?.signal?.addEventListener("abort", () => subscription.close(), { once: true });
+  return Promise.resolve(subscription.iterable);
+});
+
 const mockSetAutoCompactionThreshold = mock(() =>
   Promise.resolve({ success: true, data: undefined })
 );
@@ -116,11 +127,17 @@ const mockClient = {
     },
     setAutoCompactionThreshold: mockSetAutoCompactionThreshold,
     getStartupAutoRetryModel: mockGetStartupAutoRetryModel,
+    resumeStream: mockResumeStream,
+    sendMessage: mockSendMessage,
   },
   terminal: {
     activity: {
       subscribe: mockTerminalActivitySubscribe,
     },
+  },
+  providers: {
+    getConfig: mockGetProvidersConfig,
+    onConfigChanged: mockOnProvidersConfigChanged,
   },
 };
 
@@ -764,6 +781,11 @@ describe("WorkspaceStore", () => {
     mockTerminalActivitySubscribe.mockClear();
     mockSetAutoCompactionThreshold.mockClear();
     mockGetStartupAutoRetryModel.mockClear();
+    mockGetProvidersConfig.mockClear();
+    mockOnProvidersConfigChanged.mockClear();
+    mockResumeStream.mockClear();
+    mockSendMessage.mockClear();
+    providerConfigChanges = createControllableAsyncIterable<void>();
     global.window.localStorage?.clear?.();
     mockHistoryLoadMore.mockResolvedValue({
       messages: [],
@@ -804,6 +826,58 @@ describe("WorkspaceStore", () => {
 
   afterEach(() => {
     store.dispose();
+  });
+
+  describe("provider config changes", () => {
+    it("clears provider-fixable abandoned retry state without resuming the stream", async () => {
+      const workspaceId = "provider-config-clears-authentication";
+      mockChatScript(
+        [caughtUpEvent(), { type: "auto-retry-abandoned", reason: "authentication" }],
+        { keepOpen: true }
+      );
+      createAndAddWorkspace(store, workspaceId);
+
+      expect(
+        await waitUntil(
+          () =>
+            store.getWorkspaceState(workspaceId).autoRetryStatus?.type === "auto-retry-abandoned"
+        )
+      ).toBe(true);
+
+      providerConfigChanges.push(undefined);
+
+      expect(
+        await waitUntil(() => store.getWorkspaceState(workspaceId).autoRetryStatus === null)
+      ).toBe(true);
+      expect(mockResumeStream).not.toHaveBeenCalled();
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it("preserves abandoned retry state that provider settings cannot fix", async () => {
+      const workspaceId = "provider-config-keeps-context-error";
+      mockChatScript(
+        [caughtUpEvent(), { type: "auto-retry-abandoned", reason: "context_exceeded" }],
+        { keepOpen: true }
+      );
+      createAndAddWorkspace(store, workspaceId);
+
+      expect(
+        await waitUntil(
+          () =>
+            store.getWorkspaceState(workspaceId).autoRetryStatus?.type === "auto-retry-abandoned"
+        )
+      ).toBe(true);
+
+      providerConfigChanges.push(undefined);
+      await tick();
+
+      expect(store.getWorkspaceState(workspaceId).autoRetryStatus).toEqual({
+        type: "auto-retry-abandoned",
+        reason: "context_exceeded",
+      });
+      expect(mockResumeStream).not.toHaveBeenCalled();
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
   });
 
   describe("pinned todo auto-collapse", () => {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -92,6 +92,7 @@ import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui
 import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
 import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
+import { isProviderConfigFixableError } from "@/common/utils/messages/retryEligibility";
 
 /** Stable empty reference returned when a workspace has no assisted hunks; keeps useSyncExternalStore snapshot identity stable. */
 const EMPTY_ASSISTED_REVIEW: AssistedReviewHunk[] = [];
@@ -1313,6 +1314,20 @@ export class WorkspaceStore {
     }
   }
 
+  private clearProviderConfigFixableAutoRetryStatuses(): void {
+    // Provider notifications are not provider-scoped. Clear every fixable banner rather than
+    // guessing which chat changed, but never resume a stream here (PR #2317 was rejected).
+    for (const [workspaceId, transient] of this.chatTransientState) {
+      const status = transient.autoRetryStatus;
+      if (status?.type !== "auto-retry-abandoned" || !isProviderConfigFixableError(status.reason)) {
+        continue;
+      }
+
+      transient.autoRetryStatus = null;
+      this.states.bump(workspaceId);
+    }
+  }
+
   private subscribeToProvidersConfig(client: RouterClient<AppRouter>): void {
     const { signal } = this.clientChangeController;
 
@@ -1337,6 +1352,7 @@ export class WorkspaceStore {
           }
 
           this.providersConfigFailureStreak = 0;
+          this.clearProviderConfigFixableAutoRetryStatuses();
           void this.refreshProvidersConfig(client);
         }
       } catch {

--- a/src/common/utils/messages/retryEligibility.test.ts
+++ b/src/common/utils/messages/retryEligibility.test.ts
@@ -4,7 +4,9 @@ import {
   hasInterruptedStream,
   isEligibleForAutoRetry,
   isNonRetryableSendError,
+  isNonRetryableStreamError,
   isPreTokenInterruptedUserTurn,
+  isProviderConfigFixableError,
   PENDING_STREAM_START_GRACE_PERIOD_MS,
 } from "./retryEligibility";
 import type { DisplayedMessage } from "@/common/types/message";
@@ -445,6 +447,41 @@ describe("isEligibleForAutoRetry", () => {
       expect(isEligibleForAutoRetry(messages, justSent)).toBe(false);
     });
   });
+});
+
+describe("isProviderConfigFixableError", () => {
+  const fixableStreamErrors = ["authentication", "quota"];
+  const fixableSendErrors = ["api_key_not_found", "oauth_not_connected", "provider_disabled"];
+
+  for (const type of fixableStreamErrors) {
+    it(`flags non-retryable stream error ${type} as config-fixable`, () => {
+      expect(isNonRetryableStreamError({ type })).toBe(true);
+      expect(isProviderConfigFixableError(type)).toBe(true);
+    });
+  }
+
+  for (const type of fixableSendErrors) {
+    it(`flags non-retryable send error ${type} as config-fixable`, () => {
+      expect(isNonRetryableSendError({ type })).toBe(true);
+      expect(isProviderConfigFixableError(type)).toBe(true);
+    });
+  }
+
+  for (const type of [
+    "network",
+    "server_error",
+    "rate_limit",
+    "unknown",
+    "context_exceeded",
+    "model_refusal",
+    "aborted",
+    "runtime_not_ready",
+    "model_not_found",
+  ]) {
+    it(`does not flag ${type} as config-fixable`, () => {
+      expect(isProviderConfigFixableError(type)).toBe(false);
+    });
+  }
 });
 
 describe("isNonRetryableSendError", () => {

--- a/src/common/utils/messages/retryEligibility.ts
+++ b/src/common/utils/messages/retryEligibility.ts
@@ -35,9 +35,19 @@ function isForceAllRetryableEnabled(): boolean {
  * Error types that should NOT be auto-retried because they require user action
  * These errors won't resolve on their own - the user must fix the underlying issue
  */
-const NON_RETRYABLE_STREAM_ERRORS = [
+const PROVIDER_CONFIG_FIXABLE_STREAM_ERRORS = [
   "authentication", // Bad API key - user must fix credentials
   "quota", // Billing/usage limits - user must upgrade or wait for reset
+] as const satisfies readonly StreamErrorType[];
+
+const PROVIDER_CONFIG_FIXABLE_SEND_ERRORS = [
+  "api_key_not_found",
+  "oauth_not_connected",
+  "provider_disabled",
+] as const;
+
+const NON_RETRYABLE_STREAM_ERRORS = [
+  ...PROVIDER_CONFIG_FIXABLE_STREAM_ERRORS,
   "model_not_found", // Invalid model - user must select different model
   "context_exceeded", // Message too long - user must reduce context
   "aborted", // User cancelled - should not auto-retry
@@ -46,6 +56,14 @@ const NON_RETRYABLE_STREAM_ERRORS = [
 ] as const satisfies readonly StreamErrorType[];
 
 const NON_RETRYABLE_STREAM_ERROR_SET = new Set<string>(NON_RETRYABLE_STREAM_ERRORS);
+const PROVIDER_CONFIG_FIXABLE_ERROR_SET = new Set<string>([
+  ...PROVIDER_CONFIG_FIXABLE_STREAM_ERRORS,
+  ...PROVIDER_CONFIG_FIXABLE_SEND_ERRORS,
+]);
+
+export function isProviderConfigFixableError(type: string): boolean {
+  return PROVIDER_CONFIG_FIXABLE_ERROR_SET.has(type);
+}
 
 /**
  * Check if a SendMessageError (from resumeStream failures) is non-retryable
@@ -56,10 +74,11 @@ export function isNonRetryableSendError(error: { type: string }): boolean {
     return false;
   }
 
+  if (PROVIDER_CONFIG_FIXABLE_ERROR_SET.has(error.type)) {
+    return true;
+  }
+
   switch (error.type) {
-    case "api_key_not_found": // Missing API key - user must configure
-    case "oauth_not_connected": // Missing OAuth connection - user must connect/sign in
-    case "provider_disabled": // Provider disabled in settings - user must re-enable
     case "provider_not_supported": // Unsupported provider - user must switch
     case "model_not_available": // Model missing from fetched provider catalog - user must refresh or switch
     case "invalid_model_string": // Bad model format - user must fix

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
-import { AgentSession } from "./agentSession";
+import { AgentSession, clearProviderConfigFixableAbandonMarkers } from "./agentSession";
 import { createAgentSessionHarness } from "./agentSession.testHarness";
 import { createTestHistoryService } from "./testHistoryService";
 import type { AIService } from "./aiService";
@@ -1028,6 +1028,69 @@ describe("AgentSession startup auto-retry recovery", () => {
     expect(await Bun.file(preferencePath).exists()).toBe(true);
     expect(streamMessageSpy).not.toHaveBeenCalled();
     expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
+  });
+
+  test("provider config sweep clears fixable markers for workspaces without live sessions", async () => {
+    const workspaceId = "startup-retry-sweep-closed-workspace";
+    const { session, config, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const privateSession = session as unknown as {
+      persistStartupAutoRetryAbandon: (reason: string, userMessageId?: string) => Promise<void>;
+      getAutoRetryPreferencePath: () => string;
+    };
+    await privateSession.persistStartupAutoRetryAbandon("authentication", "user-1");
+    const preferencePath = privateSession.getAutoRetryPreferencePath();
+    expect(await Bun.file(preferencePath).exists()).toBe(true);
+
+    // Not in the skip set = no live session for this workspace.
+    await clearProviderConfigFixableAbandonMarkers(config.sessionsDir, new Set());
+
+    expect(await Bun.file(preferencePath).exists()).toBe(false);
+  });
+
+  test("provider config sweep preserves non-fixable markers and skips live sessions", async () => {
+    const workspaceId = "startup-retry-sweep-preserve";
+    const { session, config, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const privateSession = session as unknown as {
+      persistStartupAutoRetryAbandon: (reason: string, userMessageId?: string) => Promise<void>;
+      getAutoRetryPreferencePath: () => string;
+    };
+    const preferencePath = privateSession.getAutoRetryPreferencePath();
+
+    await privateSession.persistStartupAutoRetryAbandon("context_exceeded", "user-1");
+    await clearProviderConfigFixableAbandonMarkers(config.sessionsDir, new Set());
+    expect(await Bun.file(preferencePath).exists()).toBe(true);
+
+    await privateSession.persistStartupAutoRetryAbandon("authentication", "user-1");
+    await clearProviderConfigFixableAbandonMarkers(config.sessionsDir, new Set([workspaceId]));
+    expect(await Bun.file(preferencePath).exists()).toBe(true);
+  });
+
+  test("provider config sweep keeps a persisted auto-retry opt-out while clearing the marker", async () => {
+    const workspaceId = "startup-retry-sweep-keep-opt-out";
+    const { session, config, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const privateSession = session as unknown as {
+      persistAutoRetryEnabledPreference: (enabled: boolean) => Promise<void>;
+      persistStartupAutoRetryAbandon: (reason: string, userMessageId?: string) => Promise<void>;
+      getAutoRetryPreferencePath: () => string;
+    };
+    await privateSession.persistAutoRetryEnabledPreference(false);
+    await privateSession.persistStartupAutoRetryAbandon("quota", "user-1");
+    const preferencePath = privateSession.getAutoRetryPreferencePath();
+
+    await clearProviderConfigFixableAbandonMarkers(config.sessionsDir, new Set());
+
+    const persisted = JSON.parse(await Bun.file(preferencePath).text()) as {
+      enabled?: boolean;
+      startupAutoRetryAbandon?: unknown;
+    };
+    expect(persisted.enabled).toBe(false);
+    expect(persisted.startupAutoRetryAbandon).toBeUndefined();
   });
 
   test("reschedules retry when resumeStream defers without starting a stream", async () => {

--- a/src/node/services/agentSession.startupAutoRetry.test.ts
+++ b/src/node/services/agentSession.startupAutoRetry.test.ts
@@ -983,6 +983,53 @@ describe("AgentSession startup auto-retry recovery", () => {
     session.dispose();
   });
 
+  test("provider config changes clear credential abandon state without starting a stream", async () => {
+    const workspaceId = "startup-retry-clear-abandon-on-provider-config";
+    const { session, aiService, events, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const privateSession = session as unknown as {
+      persistStartupAutoRetryAbandon: (reason: string, userMessageId?: string) => Promise<void>;
+      getAutoRetryPreferencePath: () => string;
+      startupAutoRetryAbandon: { reason: string; userMessageId?: string } | null;
+    };
+    await privateSession.persistStartupAutoRetryAbandon("authentication", "user-1");
+    const preferencePath = privateSession.getAutoRetryPreferencePath();
+    const streamMessageSpy = spyOn(aiService, "streamMessage");
+
+    await session.handleProviderConfigChanged();
+
+    expect(privateSession.startupAutoRetryAbandon).toBeNull();
+    expect(await Bun.file(preferencePath).exists()).toBe(false);
+    expect(streamMessageSpy).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
+  });
+
+  test("provider config changes preserve non-fixable abandon state without starting a stream", async () => {
+    const workspaceId = "startup-retry-keep-abandon-on-provider-config";
+    const { session, aiService, events, cleanup } = await createSessionBundle(workspaceId);
+    cleanups.push(cleanup);
+
+    const privateSession = session as unknown as {
+      persistStartupAutoRetryAbandon: (reason: string, userMessageId?: string) => Promise<void>;
+      getAutoRetryPreferencePath: () => string;
+      startupAutoRetryAbandon: { reason: string; userMessageId?: string } | null;
+    };
+    await privateSession.persistStartupAutoRetryAbandon("context_exceeded", "user-1");
+    const preferencePath = privateSession.getAutoRetryPreferencePath();
+    const streamMessageSpy = spyOn(aiService, "streamMessage");
+
+    await session.handleProviderConfigChanged();
+
+    expect(privateSession.startupAutoRetryAbandon).toEqual({
+      reason: "context_exceeded",
+      userMessageId: "user-1",
+    });
+    expect(await Bun.file(preferencePath).exists()).toBe(true);
+    expect(streamMessageSpy).not.toHaveBeenCalled();
+    expect(events.some((event) => event.type === "auto-retry-scheduled")).toBe(false);
+  });
+
   test("reschedules retry when resumeStream defers without starting a stream", async () => {
     const workspaceId = "startup-retry-resume-deferred";
     const { session, events, cleanup } = await createSessionBundle(workspaceId);

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -136,6 +136,7 @@ import { isAnthropic1MEffectivelyEnabled } from "@/common/utils/ai/providerOptio
 import {
   isNonRetryableSendError,
   isNonRetryableStreamError,
+  isProviderConfigFixableError,
 } from "@/common/utils/messages/retryEligibility";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import { readAgentSkill } from "@/node/services/agentSkills/agentSkillsService";
@@ -1261,6 +1262,17 @@ export class AgentSession {
 
     this.startupAutoRetryAbandon = null;
     await this.persistAutoRetryState();
+  }
+
+  async handleProviderConfigChanged(): Promise<void> {
+    await this.loadAutoRetryEnabledPreference();
+    if (!isProviderConfigFixableError(this.startupAutoRetryAbandon?.reason ?? "")) {
+      return;
+    }
+
+    // Config changes only unlock retry. They must not resume the live stream (PR #2317 was
+    // rejected); after a later restart, normal startup recovery may resume the interrupted tail.
+    await this.clearStartupAutoRetryAbandon();
   }
 
   private async updateStartupAutoRetryAbandonFromFailure(

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -1,7 +1,8 @@
 import assert from "@/common/utils/assert";
 import { EventEmitter } from "events";
 import * as path from "path";
-import { mkdir, readFile, unlink, writeFile } from "fs/promises";
+import { mkdir, readdir, readFile, unlink, writeFile } from "fs/promises";
+import type { Dirent } from "fs";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import { PlatformPaths } from "@/common/utils/paths";
 import { log } from "@/node/services/log";
@@ -392,6 +393,69 @@ function isCompactionRequestMetadata(meta: unknown): meta is CompactionRequestMe
 }
 
 const AUTO_RETRY_PREFERENCE_FILE = "auto-retry-preference.json";
+
+/**
+ * Clear provider-config-fixable startup abandon markers persisted by workspaces
+ * WITHOUT a live AgentSession (closed chats). Live sessions clear their own
+ * marker via handleProviderConfigChanged(); this sweep covers the rest so that
+ * reopening a chat after a credential fix does not resurrect the stale
+ * "auto-retry stopped" state. Like the live path, it only unlocks retry and
+ * never schedules or resumes a stream (PR #2317 was rejected).
+ */
+export async function clearProviderConfigFixableAbandonMarkers(
+  sessionsDir: string,
+  skipWorkspaceIds: ReadonlySet<string>
+): Promise<void> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(sessionsDir, { withFileTypes: true });
+  } catch (error) {
+    const errno =
+      typeof error === "object" && error !== null && "code" in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (errno === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || skipWorkspaceIds.has(entry.name)) {
+        return;
+      }
+
+      const preferencePath = path.join(sessionsDir, entry.name, AUTO_RETRY_PREFERENCE_FILE);
+      let parsed: { enabled?: unknown; startupAutoRetryAbandon?: unknown };
+      try {
+        parsed = JSON.parse(await readFile(preferencePath, "utf-8")) as typeof parsed;
+      } catch {
+        // Missing file is the default; corrupt files are self-healed by the
+        // session load path when the workspace reopens.
+        return;
+      }
+
+      const abandon = parsed.startupAutoRetryAbandon;
+      const reason =
+        typeof abandon === "object" && abandon !== null && "reason" in abandon
+          ? (abandon as { reason?: unknown }).reason
+          : undefined;
+      if (typeof reason !== "string" || !isProviderConfigFixableError(reason)) {
+        return;
+      }
+
+      // Mirror persistAutoRetryState(): the file only exists to carry an
+      // opt-out or an abandon marker, so dropping the last field deletes it.
+      if (parsed.enabled === false) {
+        await writeFile(preferencePath, JSON.stringify({ enabled: false }) + "\n", "utf-8");
+      } else {
+        await unlink(preferencePath);
+      }
+    })
+  );
+}
+
 const STARTUP_AUTO_RETRY_HISTORY_FAILURE_BASE_DELAY_MS = 1_000;
 const STARTUP_AUTO_RETRY_HISTORY_FAILURE_MAX_DELAY_MS = 30_000;
 const MAX_STARTUP_RECOVERY_DEFERRED_ATTEMPTS = 4;

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -606,6 +606,7 @@ export class AIService extends EventEmitter {
     this.telemetryService = telemetryService;
     this.experimentsService = experimentsService;
     this.providerService = providerService;
+    this.providerService.onConfigChanged(() => this.emit("providers-config-changed"));
     this.streamManager = new StreamManager(historyService, sessionUsageService, () =>
       this.providerService.getConfig()
     );

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -1724,6 +1724,23 @@ function extractUserPromptText(message: MuxMessage): string {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class WorkspaceService extends EventEmitter {
   private readonly sessions = new Map<string, AgentSession>();
+  private readonly providerConfigChangedListener = (): void => {
+    const liveSessions = new Map([
+      ...this.sessions.entries(),
+      ...this.transientStartupRecoverySessions.entries(),
+    ]);
+
+    // Clearing persisted credential failures restores the manual retry path only. The config
+    // change itself must never schedule or resume a stream (PR #2317 was rejected).
+    for (const [workspaceId, session] of liveSessions) {
+      void session.handleProviderConfigChanged().catch((error: unknown) => {
+        log.warn("Failed to clear provider-fixable auto-retry abandon state", {
+          workspaceId,
+          error: getErrorMessage(error),
+        });
+      });
+    }
+  };
   // Startup recovery may need a short-lived session even before the workspace is opened.
   // Promote only sessions that keep retry/stream activity alive after the initial check.
   private readonly transientStartupRecoverySessions = new Map<string, AgentSession>();
@@ -2002,6 +2019,7 @@ export class WorkspaceService extends EventEmitter {
     this.telemetryService = telemetryService;
     this.experimentsService = experimentsService;
     this.sessionTimingService = sessionTimingService;
+    this.aiService.on("providers-config-changed", this.providerConfigChangedListener);
     this.setupMetadataListeners();
     this.setupInitMetadataListeners();
   }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -26,7 +26,11 @@ import { eventSpine } from "@/node/services/events/eventSpine";
 import { agentPluginHookService } from "@/node/services/agentPlugins/hookService";
 import { sandboxHostService } from "@/node/services/sandbox/sandboxHostService";
 import { isPathInsideDir } from "@/node/utils/pathUtils";
-import { AgentSession, type StreamErrorRecoveryOutcome } from "@/node/services/agentSession";
+import {
+  AgentSession,
+  clearProviderConfigFixableAbandonMarkers,
+  type StreamErrorRecoveryOutcome,
+} from "@/node/services/agentSession";
 import type { HistoryService } from "@/node/services/historyService";
 import type { AIService } from "@/node/services/aiService";
 import type { InitStateManager } from "@/node/services/initStateManager";
@@ -1740,6 +1744,18 @@ export class WorkspaceService extends EventEmitter {
         });
       });
     }
+
+    // Closed chats have no session to clear their persisted marker, so sweep their
+    // preference files directly; otherwise reopening after a credential fix would
+    // resurrect the stale abandoned state from disk.
+    void clearProviderConfigFixableAbandonMarkers(
+      this.config.sessionsDir,
+      new Set(liveSessions.keys())
+    ).catch((error: unknown) => {
+      log.warn("Failed to sweep persisted auto-retry abandon markers", {
+        error: getErrorMessage(error),
+      });
+    });
   };
   // Startup recovery may need a short-lived session even before the workspace is opened.
   // Promote only sessions that keep retry/stream activity alive after the initial check.


### PR DESCRIPTION
## Summary

After a provider credential failure (bad API key, quota), the chat latched a non-retryable "Auto-retry stopped: authentication" state that nothing cleared when the user fixed the key in Settings. Provider config changes now clear that stuck state — in the live UI and in the persisted startup marker — so the chat immediately presents an active Retry affordance. The config change never resumes the stream itself.

Fixes #2051

## Background

The backend already reads provider credentials fresh on every send, so new sends use the new key. The remaining defect was frontend/session state: `RetryManager` emits `auto-retry-abandoned` for credential errors, `AgentSession` persists a `startupAutoRetryAbandon` marker that re-latches the banner on every restart, and the existing `providers.onConfigChanged` subscribers only reloaded provider metadata.

A previous attempt (#2317) auto-retried the stream on config change and was closed for deviating from the approved plan. This fix deliberately does NOT auto-resume: it only restores the user-facing retry path.

## Implementation

- `retryEligibility.ts` (common): new `isProviderConfigFixableError()` classifying the non-retryable errors a provider settings change can fix (`authentication`, `quota`, `api_key_not_found`, `oauth_not_connected`, `provider_disabled`), factored out of the existing non-retryable sets.
- `WorkspaceStore` (renderer): on each `providers.onConfigChanged` tick, clears `auto-retry-abandoned` statuses with config-fixable reasons (all chats; notifications are not provider-scoped). The RetryBarrier drops the stale "Auto-retry stopped" line and shows the normal Retry affordance.
- `AgentSession`/`WorkspaceService`/`AIService` (backend): provider config changes fan out to live sessions, which clear the persisted startup abandon marker only when its reason is config-fixable. No `resumeStream`, no retry scheduling.

## Validation

- Behavioral tests at all three layers: classification unit tests, store-level clear/preserve test (including that no send/resume is triggered), and `AgentSession` persisted-marker tests.
- Remote dogfood UAT passed on this exact head: invalid key → authentication barrier; fixing the key in Settings cleared the stale state with no reload and no auto-resume; Retry then succeeded; a non-credential stuck state (`disabled_by_user`) was correctly preserved; normal sends and the transient auto-retry countdown regressions were clean.
- UAT surfaced one pre-existing, out-of-scope gap: the Coder AI gateway returns HTTP 403 for bad keys, which `streamManager.categorizeError` maps to a generic retryable error (only 401/402/429 map to credential types), so gateway credential failures auto-retry instead of latching the authentication barrier. Not a regression from this PR.

## Risks

Low. The config-change path only clears state (never starts streams), the fixable set is a strict subset of already-non-retryable errors, and non-credential abandoned states are untouched. Worst case is a cleared banner while the credential is still broken — the next manual retry re-latches it.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->



