### PR TITLE
🤖 fix: skip transcription for silent voice recordings

### DIFF
--- a/src/browser/hooks/useVoiceInput.test.tsx
+++ b/src/browser/hooks/useVoiceInput.test.tsx
@@ -1,0 +1,210 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { fileURLToPath } from "node:url";
+import type { APIClient } from "@/browser/contexts/API";
+import { requireTestModule } from "@/browser/testUtils";
+import { installDom } from "../../../tests/ui/dom";
+import type * as UseVoiceInputModule from "./useVoiceInput";
+
+let sampleByte = 128;
+let sampleAudioFrame: (() => void) | null = null;
+let stopTrack = mock(() => undefined);
+let stream = createMediaStream();
+
+class MediaRecorderMock {
+  static isTypeSupported(_mimeType: string): boolean {
+    return true;
+  }
+
+  readonly stream: MediaStream;
+  state: RecordingState = "inactive";
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(mediaStream: MediaStream) {
+    this.stream = mediaStream;
+  }
+
+  start(): void {
+    this.state = "recording";
+  }
+
+  stop(): void {
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["audio"]) });
+    this.onstop?.();
+  }
+}
+
+class AnalyserNodeMock {
+  frequencyBinCount = 128;
+  fftSize = 256;
+  smoothingTimeConstant = 0;
+
+  getByteTimeDomainData(data: Uint8Array<ArrayBufferLike>): void {
+    data.fill(sampleByte);
+  }
+}
+
+class AudioContextMock {
+  createAnalyser(): AnalyserNode {
+    return new AnalyserNodeMock() as unknown as AnalyserNode;
+  }
+
+  createMediaStreamSource(_stream: MediaStream): MediaStreamAudioSourceNode {
+    return {
+      connect: (_destination: AudioNode) => undefined,
+    } as unknown as MediaStreamAudioSourceNode;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function createMediaStream(): MediaStream {
+  return {
+    getTracks: () => [{ stop: stopTrack }],
+  } as unknown as MediaStream;
+}
+
+const getUserMedia = mock((_constraints: MediaStreamConstraints) => Promise.resolve(stream));
+const originalMediaRecorder = Object.getOwnPropertyDescriptor(globalThis, "MediaRecorder");
+const originalAudioContext = Object.getOwnPropertyDescriptor(globalThis, "AudioContext");
+const originalMediaDevices = Object.getOwnPropertyDescriptor(globalThis.navigator, "mediaDevices");
+
+function installVoiceGlobals(): void {
+  Object.defineProperty(globalThis, "MediaRecorder", {
+    configurable: true,
+    value: MediaRecorderMock as unknown as typeof MediaRecorder,
+  });
+  Object.defineProperty(globalThis, "AudioContext", {
+    configurable: true,
+    value: AudioContextMock as unknown as typeof AudioContext,
+  });
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  });
+}
+
+installVoiceGlobals();
+
+const { useVoiceInput } = requireTestModule<typeof UseVoiceInputModule>(
+  fileURLToPath(new URL("./useVoiceInput.ts", import.meta.url))
+);
+
+function restoreGlobal(
+  name: "MediaRecorder" | "AudioContext",
+  descriptor?: PropertyDescriptor
+): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+function sampleFrames(count: number): void {
+  const sample = sampleAudioFrame;
+  if (!sample) throw new Error("Expected voice input metering to be active");
+
+  for (let index = 0; index < count; index += 1) sample();
+}
+
+function renderVoiceInput() {
+  const transcribe = mock((_input: { audioBase64: string }) =>
+    Promise.resolve({
+      success: true as const,
+      data: "transcript",
+    })
+  );
+  const hook = renderHook(() =>
+    useVoiceInput({
+      api: { voice: { transcribe } } as unknown as APIClient,
+      isTranscriptionAvailable: true,
+      onTranscript: mock(() => undefined),
+    })
+  );
+
+  return { ...hook, transcribe };
+}
+
+describe("useVoiceInput silence gate", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+    stopTrack = mock(() => undefined);
+    stream = createMediaStream();
+    sampleByte = 128;
+    sampleAudioFrame = null;
+    getUserMedia.mockClear();
+    installVoiceGlobals();
+    setSystemTime(new Date("2026-08-20T12:00:00.000Z"));
+
+    window.setInterval = ((handler: () => void) => {
+      sampleAudioFrame = handler;
+      return 1;
+    }) as typeof window.setInterval;
+    window.clearInterval = ((_handle?: number) => {
+      sampleAudioFrame = null;
+    }) as typeof window.clearInterval;
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+    setSystemTime();
+  });
+
+  afterAll(() => {
+    restoreGlobal("MediaRecorder", originalMediaRecorder);
+    restoreGlobal("AudioContext", originalAudioContext);
+    if (originalMediaDevices) {
+      Object.defineProperty(globalThis.navigator, "mediaDevices", originalMediaDevices);
+    } else {
+      Reflect.deleteProperty(globalThis.navigator, "mediaDevices");
+    }
+  });
+
+  test("does not transcribe a silent recording", async () => {
+    const { result, transcribe } = renderVoiceInput();
+
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.state).toBe("recording"));
+    sampleFrames(5);
+    setSystemTime(new Date("2026-08-20T12:00:00.600Z"));
+
+    act(() => result.current.stop());
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+
+    expect(transcribe).not.toHaveBeenCalled();
+  });
+
+  test("transcribes a voiced recording", async () => {
+    const { result, transcribe } = renderVoiceInput();
+
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.state).toBe("recording"));
+    sampleByte = 160;
+    sampleFrames(5);
+    setSystemTime(new Date("2026-08-20T12:00:00.600Z"));
+
+    act(() => result.current.stop());
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+
+    expect(transcribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/hooks/useVoiceInput.test.tsx
+++ b/src/browser/hooks/useVoiceInput.test.tsx
@@ -9,11 +9,9 @@ import {
   test,
 } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { fileURLToPath } from "node:url";
 import type { APIClient } from "@/browser/contexts/API";
-import { requireTestModule } from "@/browser/testUtils";
 import { installDom } from "../../../tests/ui/dom";
-import type * as UseVoiceInputModule from "./useVoiceInput";
+import { useVoiceInput } from "./useVoiceInput";
 
 let sampleByte = 128;
 let sampleAudioFrame: (() => void) | null = null;
@@ -97,12 +95,6 @@ function installVoiceGlobals(): void {
     value: { getUserMedia },
   });
 }
-
-installVoiceGlobals();
-
-const { useVoiceInput } = requireTestModule<typeof UseVoiceInputModule>(
-  fileURLToPath(new URL("./useVoiceInput.ts", import.meta.url))
-);
 
 function restoreGlobal(
   name: "MediaRecorder" | "AudioContext",

--- a/src/browser/hooks/useVoiceInput.ts
+++ b/src/browser/hooks/useVoiceInput.ts
@@ -9,6 +9,10 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { matchesKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
+import {
+  shouldTranscribeRecording,
+  SILENCE_GATE_SAMPLE_INTERVAL_MS,
+} from "@/browser/utils/voice/silenceGate";
 import type { APIClient } from "@/browser/contexts/API";
 import { trackVoiceTranscription } from "@/common/telemetry";
 import { getErrorMessage } from "@/common/utils/errors";
@@ -122,6 +126,9 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
   const [mediaRecorder, setMediaRecorder] = useState<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const meterIntervalRef = useRef<number | null>(null);
+  const rmsFramesRef = useRef<number[]>([]);
 
   // Flags set before stopping to control post-stop behavior
   const shouldSendRef = useRef(false);
@@ -206,6 +213,60 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
     streamRef.current = null;
   }, []);
 
+  const stopMetering = useCallback(() => {
+    if (meterIntervalRef.current !== null) {
+      window.clearInterval(meterIntervalRef.current);
+      meterIntervalRef.current = null;
+    }
+
+    const audioContext = audioContextRef.current;
+    audioContextRef.current = null;
+    audioContext?.close().catch(() => undefined);
+  }, []);
+
+  const startMetering = useCallback(
+    (stream: MediaStream) => {
+      stopMetering();
+      rmsFramesRef.current = [];
+
+      try {
+        const audioContext = new AudioContext();
+        audioContextRef.current = audioContext;
+
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 256;
+        const source = audioContext.createMediaStreamSource(stream);
+        source.connect(analyser);
+        const data = new Uint8Array(analyser.frequencyBinCount);
+
+        meterIntervalRef.current = window.setInterval(() => {
+          if (data.length === 0) {
+            stopMetering();
+            return;
+          }
+
+          try {
+            analyser.getByteTimeDomainData(data);
+
+            let sum = 0;
+            for (const sample of data) {
+              const normalized = (sample - 128) / 128;
+              sum += normalized * normalized;
+            }
+            rmsFramesRef.current.push(Math.sqrt(sum / data.length));
+          } catch {
+            rmsFramesRef.current = [];
+            stopMetering();
+          }
+        }, SILENCE_GATE_SAMPLE_INTERVAL_MS);
+      } catch {
+        // Metering is best-effort; the gate fails open when no samples are available.
+        stopMetering();
+      }
+    },
+    [stopMetering]
+  );
+
   // ---------------------------------------------------------------------------
   // Start Recording
   // ---------------------------------------------------------------------------
@@ -243,12 +304,21 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
         // Check if this was a cancel (discard audio) or normal stop (transcribe)
         const cancelled = wasCancelledRef.current;
         wasCancelledRef.current = false;
+        const recordingDurationMs = Date.now() - recordingStartTimeRef.current;
+        const shouldTranscribe = shouldTranscribeRecording({
+          rmsFrames: rmsFramesRef.current,
+          durationMs: recordingDurationMs,
+        });
 
         const blob = new Blob(chunksRef.current, { type: mimeType });
         chunksRef.current = [];
         releaseStream();
+        stopMetering();
 
         if (cancelled) {
+          setState("idle");
+        } else if (!shouldTranscribe) {
+          shouldSendRef.current = false;
           setState("idle");
         } else {
           void transcribe(blob);
@@ -258,15 +328,20 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
       recorder.onerror = () => {
         callbacksRef.current.onError?.("Recording failed");
         releaseStream();
+        stopMetering();
         setState("idle");
       };
 
       recorderRef.current = recorder;
       setMediaRecorder(recorder);
+      startMetering(stream);
       recorder.start();
       recordingStartTimeRef.current = Date.now();
       setState("recording");
     } catch (err) {
+      stopMetering();
+      releaseStream();
+
       const msg = getErrorMessage(err);
       const isPermissionDenied = msg.includes("Permission denied") || msg.includes("NotAllowed");
 
@@ -277,7 +352,7 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
       );
       setState("idle");
     }
-  }, [state, transcribe, releaseStream]);
+  }, [state, transcribe, releaseStream, startMetering, stopMetering]);
 
   // ---------------------------------------------------------------------------
   // Stop Recording (triggers transcription)
@@ -319,8 +394,9 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
     return () => {
       recorderRef.current?.stop();
       releaseStream();
+      stopMetering();
     };
-  }, [releaseStream]);
+  }, [releaseStream, stopMetering]);
 
   // ---------------------------------------------------------------------------
   // Recording keybinds (when useRecordingKeybinds is true)

--- a/src/browser/hooks/useVoiceInput.ts
+++ b/src/browser/hooks/useVoiceInput.ts
@@ -240,11 +240,6 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
         const data = new Uint8Array(analyser.frequencyBinCount);
 
         meterIntervalRef.current = window.setInterval(() => {
-          if (data.length === 0) {
-            stopMetering();
-            return;
-          }
-
           try {
             analyser.getByteTimeDomainData(data);
 
@@ -310,7 +305,7 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
           durationMs: recordingDurationMs,
         });
 
-        const blob = new Blob(chunksRef.current, { type: mimeType });
+        const chunks = chunksRef.current;
         chunksRef.current = [];
         releaseStream();
         stopMetering();
@@ -321,7 +316,7 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
           shouldSendRef.current = false;
           setState("idle");
         } else {
-          void transcribe(blob);
+          void transcribe(new Blob(chunks, { type: mimeType }));
         }
       };
 

--- a/src/browser/hooks/useVoiceInput.ts
+++ b/src/browser/hooks/useVoiceInput.ts
@@ -74,12 +74,20 @@ function hasTouchDictation(): boolean {
   return hasTouch;
 }
 
-const HAS_TOUCH_DICTATION = hasTouchDictation();
-const HAS_MEDIA_RECORDER = typeof window !== "undefined" && typeof MediaRecorder !== "undefined";
-const HAS_GET_USER_MEDIA =
-  typeof window !== "undefined" &&
-  typeof navigator !== "undefined" &&
-  typeof navigator.mediaDevices?.getUserMedia === "function";
+// Capability checks run at call time, not module load: this module can be evaluated
+// before MediaRecorder/mediaDevices exist in the environment (notably under Bun's test
+// module caching), which would otherwise freeze stale negatives.
+function hasMediaRecorder(): boolean {
+  return typeof window !== "undefined" && typeof MediaRecorder !== "undefined";
+}
+
+function hasGetUserMedia(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function"
+  );
+}
 
 // =============================================================================
 // Global Key State Tracking
@@ -269,9 +277,9 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
   const start = useCallback(async () => {
     // Guard: only start from idle state with valid configuration
     const canStart =
-      HAS_MEDIA_RECORDER &&
-      HAS_GET_USER_MEDIA &&
-      !HAS_TOUCH_DICTATION &&
+      hasMediaRecorder() &&
+      hasGetUserMedia() &&
+      !hasTouchDictation() &&
       state === "idle" &&
       callbacksRef.current.isTranscriptionAvailable;
 
@@ -442,10 +450,10 @@ export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResul
 
   return {
     state,
-    isSupported: HAS_MEDIA_RECORDER && HAS_GET_USER_MEDIA,
+    isSupported: hasMediaRecorder() && hasGetUserMedia(),
     isAvailable: options.isTranscriptionAvailable,
-    shouldShowUI: HAS_MEDIA_RECORDER && !HAS_TOUCH_DICTATION,
-    requiresSecureContext: HAS_MEDIA_RECORDER && !HAS_GET_USER_MEDIA,
+    shouldShowUI: hasMediaRecorder() && !hasTouchDictation(),
+    requiresSecureContext: hasMediaRecorder() && !hasGetUserMedia(),
     mediaRecorder,
     start: () => void start(),
     stop,

--- a/src/browser/utils/voice/silenceGate.test.ts
+++ b/src/browser/utils/voice/silenceGate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { shouldTranscribeRecording } from "./silenceGate";
+
+describe("shouldTranscribeRecording", () => {
+  test("skips sustained silence", () => {
+    expect(
+      shouldTranscribeRecording({ rmsFrames: new Array<number>(8).fill(0), durationMs: 600 })
+    ).toBe(false);
+  });
+
+  test("transcribes sustained speech energy", () => {
+    expect(
+      shouldTranscribeRecording({
+        rmsFrames: [0.01, 0.05, 0.06, 0.05, 0.07, 0.01, 0.01, 0.01],
+        durationMs: 600,
+      })
+    ).toBe(true);
+  });
+
+  test("skips a brief energy blip", () => {
+    expect(
+      shouldTranscribeRecording({
+        rmsFrames: [0.08, 0.08, 0.08, 0.01, 0.01, 0.01, 0.01, 0.01],
+        durationMs: 600,
+      })
+    ).toBe(false);
+  });
+
+  test("skips trivially short recordings even when voiced", () => {
+    expect(
+      shouldTranscribeRecording({
+        rmsFrames: new Array<number>(8).fill(0.1),
+        durationMs: 499,
+      })
+    ).toBe(false);
+  });
+
+  test("fails open when metering produced no samples", () => {
+    expect(shouldTranscribeRecording({ rmsFrames: [], durationMs: 600 })).toBe(true);
+  });
+
+  test("requires energy to exceed the speech threshold", () => {
+    expect(
+      shouldTranscribeRecording({
+        rmsFrames: new Array<number>(8).fill(0.04),
+        durationMs: 600,
+      })
+    ).toBe(false);
+    expect(
+      shouldTranscribeRecording({
+        rmsFrames: [0.041, 0.041, 0.041, 0.041, 0, 0, 0, 0],
+        durationMs: 600,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/browser/utils/voice/silenceGate.ts
+++ b/src/browser/utils/voice/silenceGate.ts
@@ -1,0 +1,23 @@
+export const SILENCE_GATE_SAMPLE_INTERVAL_MS = 75;
+
+const MIN_RECORDING_DURATION_MS = 500;
+const SPEECH_RMS_THRESHOLD = 0.04;
+const MIN_VOICED_DURATION_MS = 300;
+const MIN_VOICED_FRAMES = Math.ceil(MIN_VOICED_DURATION_MS / SILENCE_GATE_SAMPLE_INTERVAL_MS);
+
+interface SilenceGateInput {
+  rmsFrames: readonly number[];
+  durationMs: number;
+}
+
+/**
+ * Whisper can hallucinate text from silence, so require sustained speech energy.
+ * Missing meter samples fail open so Web Audio failures never block real speech.
+ */
+export function shouldTranscribeRecording(input: SilenceGateInput): boolean {
+  if (input.durationMs < MIN_RECORDING_DURATION_MS) return false;
+  if (input.rmsFrames.length === 0) return true;
+
+  const voicedFrames = input.rmsFrames.filter((rms) => rms > SPEECH_RMS_THRESHOLD).length;
+  return voicedFrames >= MIN_VOICED_FRAMES;
+}


### PR DESCRIPTION
## Summary

Adds a client-side silence gate to voice input: recordings with no meaningful speech energy (or trivially short accidental taps) are dropped quietly instead of being sent to Whisper, which hallucinates phantom transcriptions (often in other languages) when given silence.

Fixes #2158

## Background

`useVoiceInput` bundled MediaRecorder chunks and called the transcription API unconditionally on stop. When the mic captured only silence, Whisper frequently produced hallucinated text that landed in the composer. `RecordingOverlay` already computed RMS from an `AnalyserNode`, but only for waveform visualization and only while rendered.

## Implementation

- New pure helper `src/browser/utils/voice/silenceGate.ts`: `shouldTranscribeRecording({ rmsFrames, durationMs })` skips recordings shorter than a minimum duration or without sustained speech energy (a minimum number of frames above an RMS threshold). It fails open when metering produced no samples, so Web Audio failures never block real speech.
- `useVoiceInput` now owns its own `AudioContext`/`AnalyserNode` metering (independent of the overlay being mounted), sampling RMS on an interval during recording. On stop, the gate decides transcribe vs quiet no-op (no toast, no telemetry event for an API call that never happened). Metering is torn down on stop, cancel, error, and unmount.
- Behavioral tests: unit tests for the gate decision branches (silence, sustained speech, brief blip, short tap, fail-open) and hook-level tests with mocked `MediaRecorder`/`AudioContext` proving a silent recording never calls the transcribe API while a voiced one does.

## CI unblock (included)

- `useVoiceInput` capability checks (MediaRecorder/getUserMedia/touch) now evaluate at call time instead of module load. Bun's test module caching could evaluate the module before the test's mocks existed, freezing stale negatives and making the new hook tests order-dependent in the full suite.

## Validation

- `make static-check`, `make build`, and targeted `bun test` for the gate and hook tests pass locally.
- Remote dogfood UAT ran against the pushed branch and passed. The remote workspace has no microphone hardware, so live-mic silence was substituted with scripted fake-device metering (silent, voiced, and short-tap cycles through the real UI): silence and short taps produced no transcription call and no error, the voiced cycle reached `/voice/transcribe` successfully. Evidence recorded in the workspace under `.mux-uat/round-1/`.

## Risks

Low and contained to voice input. The main tradeoff is a false-negative gate (dropping soft real speech); thresholds are conservative (RMS 0.04, ≥300ms voiced, ≥500ms total) and the gate fails open whenever metering is unavailable, so the worst regression is behavior identical to today.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->



