### PR TITLE
🤖 ci: survive rename-broken OIDC trust policies

### DIFF
--- a/.github/actions/setup-windows-signing/action.yml
+++ b/.github/actions/setup-windows-signing/action.yml
@@ -11,6 +11,10 @@ inputs:
   gcp_service_account:
     description: "GCP Service Account"
     required: false
+  allow_unsigned_fallback:
+    description: "Continue with an unsigned build when GCP signing auth fails (CI/nightly only; keep stable releases fail-closed)"
+    required: false
+    default: "false"
 
 outputs:
   gcloud_access_token:
@@ -29,6 +33,13 @@ runs:
     - name: Authenticate to Google Cloud
       id: gcloud_auth
       if: inputs.gcp_workload_id_provider != ''
+      # The coder/shux -> coder/xum repo rename broke the GCP Workload Identity
+      # trust policy (matches owner/repo as a string), so this auth step fails
+      # with iam.serviceAccounts.getAccessToken PERMISSION_DENIED. Callers that
+      # opt in via allow_unsigned_fallback build unsigned until the GCP-side
+      # binding is updated for the new repo name; signing resumes automatically
+      # then. Stable releases keep the default and fail closed.
+      continue-on-error: ${{ inputs.allow_unsigned_fallback == 'true' }}
       uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
       with:
         workload_identity_provider: ${{ inputs.gcp_workload_id_provider }}
@@ -40,6 +51,14 @@ runs:
       run: |
         if (-not $env:EV_SIGNING_CERT) {
           Write-Host "⚠️ No Windows code signing certificate provided - building unsigned"
+          exit 0
+        }
+
+        # Signing requires a GCP access token for Cloud KMS. When auth failed
+        # (or was skipped) leave JSIGN_PATH unset so sign-windows.js skips
+        # signing instead of failing on the missing token.
+        if (-not $env:GCLOUD_ACCESS_TOKEN) {
+          Write-Host "::warning title=Windows build unsigned::GCP signing auth unavailable (rename broke WIF trust policy) - building unsigned"
           exit 0
         }
 
@@ -56,3 +75,4 @@ runs:
         Write-Host "✅ Windows EV code signing configured"
       env:
         EV_SIGNING_CERT: ${{ inputs.ev_signing_cert }}
+        GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}

--- a/.github/actions/setup-windows-signing/action.yml
+++ b/.github/actions/setup-windows-signing/action.yml
@@ -55,11 +55,16 @@ runs:
         }
 
         # Signing requires a GCP access token for Cloud KMS. When auth failed
-        # (or was skipped) leave JSIGN_PATH unset so sign-windows.js skips
-        # signing instead of failing on the missing token.
+        # or was skipped, only the opt-in fallback may continue (leaving
+        # JSIGN_PATH unset so sign-windows.js skips signing); otherwise fail
+        # closed so a certificate-bearing release can never ship unsigned.
         if (-not $env:GCLOUD_ACCESS_TOKEN) {
-          Write-Host "::warning title=Windows build unsigned::GCP signing auth unavailable (rename broke WIF trust policy) - building unsigned"
-          exit 0
+          if ($env:ALLOW_UNSIGNED_FALLBACK -eq 'true') {
+            Write-Host "::warning title=Windows build unsigned::GCP signing auth unavailable (rename broke WIF trust policy) - building unsigned"
+            exit 0
+          }
+          Write-Host "::error::EV certificate provided but GCP signing auth produced no access token - failing closed"
+          exit 1
         }
 
         # Save EV certificate to temp file
@@ -76,3 +81,4 @@ runs:
       env:
         EV_SIGNING_CERT: ${{ inputs.ev_signing_cert }}
         GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
+        ALLOW_UNSIGNED_FALLBACK: ${{ inputs.allow_unsigned_fallback }}

--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ""
+      allow_unsigned_windows:
+        description: "Build Windows unsigned when GCP signing auth fails (nightly only; stable releases stay fail-closed)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-macos:
@@ -232,6 +237,7 @@ jobs:
         id: signing
         uses: ./.github/actions/setup-windows-signing
         with:
+          allow_unsigned_fallback: "${{ inputs.allow_unsigned_windows }}"
           ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
           gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/_docker-release.yml
+++ b/.github/workflows/_docker-release.yml
@@ -23,15 +23,33 @@ on:
         default: false
 
 jobs:
-  docker-publish:
-    name: Build and Push Docker Image
-    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+  # The coder/shux -> coder/xum repo rename broke Depot's OIDC trust policy
+  # (matches owner/repo as a string), so a single `depot build` for
+  # linux/amd64,linux/arm64 fails with "permission_denied: Invalid token".
+  # Build each platform natively on its own runner instead: Depot still
+  # accelerates once its trust policy is updated, and buildx-fallback builds
+  # natively on the runner in the meantime. Per-arch native runners keep the
+  # fallback off QEMU emulation, which is critical for native modules like
+  # node-pty and ssh2. The push-manifest job stitches the per-arch digests
+  # into the final multi-arch tags.
+  build:
+    name: Build Image (${{ matrix.arch }})
+    runs-on: ${{ github.repository_owner == 'coder' && matrix.coder_runner || matrix.fallback_runner }}
     permissions:
       contents: read
       # OIDC token for Depot authentication (no static DEPOT_TOKEN needed)
       id-token: write
-      # Push to GitHub Container Registry
+      # Push per-arch images (by digest) to GitHub Container Registry
       packages: write
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            coder_runner: depot-ubuntu-22.04-16
+            fallback_runner: ubuntu-latest
+          - arch: arm64
+            coder_runner: depot-ubuntu-22.04-arm-16
+            fallback_runner: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -57,20 +75,94 @@ jobs:
             type=raw,value=latest,enable=${{ inputs.is_latest }}
             type=raw,value=nightly,enable=${{ inputs.is_latest_nightly }}
 
+      - name: Set up Docker Buildx
+        # Pushing by digest needs a docker-container builder when the Depot
+        # fallback runs `docker buildx build` locally.
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
       - name: Set up Depot CLI
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
-      - name: Build and push multi-arch image
+      - name: Build and push by digest
+        id: build
         uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
         with:
           project: 3pmt6zbws4
           context: .
-          # Depot routes each platform to a native builder — no QEMU emulation.
-          # This is critical for native modules like node-pty and ssh2.
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Push by digest only; push-manifest applies the human-readable tags.
+          outputs: type=image,name=ghcr.io/coder/mux,push-by-digest=true,name-canonical=true,push=true
+          # Fall back to a native local build while the Depot trust policy
+          # still rejects the renamed repo; Depot acceleration resumes
+          # automatically once it is updated.
+          buildx-fallback: true
           build-args: |
             VERSION=${{ inputs.version }}
             RELEASE_TAG=${{ startsWith(inputs.version, 'v') && inputs.version || format('v{0}', inputs.version) }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: digest-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push-manifest:
+    name: Push Multi-Arch Manifest
+    needs: build
+    runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      # Push the multi-arch manifest tags to GitHub Container Registry
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ghcr.io/coder/mux
+          tags: |
+            type=raw,value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.is_latest }}
+            type=raw,value=nightly,enable=${{ inputs.is_latest_nightly }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          # DOCKER_METADATA_OUTPUT_JSON is exported by metadata-action.
+          args=()
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          for digest in *; do
+            args+=("ghcr.io/coder/mux@sha256:${digest}")
+          done
+          docker buildx imagetools create "${args[@]}"
+
+      - name: Inspect manifest
+        env:
+          VERSION: ${{ inputs.version }}
+        run: docker buildx imagetools inspect "ghcr.io/coder/mux:${VERSION}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,6 +122,10 @@ jobs:
       ref: ${{ needs.compute-version.outputs.build_sha }}
       release_tag: ${{ needs.compute-version.outputs.release_tag }}
       version_override: ${{ needs.compute-version.outputs.nightly_version }}
+      # Nightly ships unsigned Windows builds while the repo rename breaks GCP
+      # WIF signing auth (see setup-windows-signing action). Stable releases
+      # keep the fail-closed default.
+      allow_unsigned_windows: true
     secrets: inherit # zizmor: ignore[secrets-inherit] -- reusable workflow needs platform signing secrets
 
   docker-publish:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -585,6 +585,9 @@ jobs:
           ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
           gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          # CI artifact only - keep main green while the repo rename breaks
+          # GCP WIF auth (see setup-windows-signing action for details).
+          allow_unsigned_fallback: "true"
       - name: Package for Windows
         run: make dist-win
         env:


### PR DESCRIPTION
## Summary

Makes CI survive the two OIDC trust policies that the `coder/shux` -> `coder/xum` repo rename broke: GCP Workload Identity for Windows EV signing and Depot build authentication. Both fixes are self-healing: once the external policies are updated for the new repo name, signing and Depot acceleration resume automatically with no further repo changes.

## Background

A repo rename changes the OIDC `repository` claim. Two integrations match it as a string:

- **GCP Workload Identity** (Windows EV signing): `google-github-actions/auth` now fails with `iam.serviceAccounts.getAccessToken` PERMISSION_DENIED. This failed every main-push `Build / Windows` job (the last ~8 `PR` workflow runs on main) and the Nightly Windows release.
- **Depot build OIDC**: `depot build` fails with `permission_denied: Invalid token`. The PR Docker smoke job already had `buildx-fallback: true` (#3898 era fix), but the multi-arch Docker release job did not, so nightly Docker publishing failed outright.

Durable fixes live in external dashboards (GCP WIF binding, Depot project trust policy). This PR keeps CI green until then.

## Implementation

- `setup-windows-signing` gains an opt-in `allow_unsigned_fallback` input (default `false` = fail closed). When enabled, a GCP auth failure emits a warning annotation and skips jsign setup, so `sign-windows.js` skips signing and the build proceeds unsigned. Opted in: `pr.yml` main-push Windows build and `nightly.yml`. Stable releases (`release.yml`) intentionally keep the fail-closed default so we can never ship an unsigned stable Windows binary.
- `_docker-release.yml` splits the single Depot multi-arch job into per-arch jobs on Depot managed runners (GitHub-App-based, unaffected by the rename) with `buildx-fallback: true`, pushing by digest, plus a manifest-merge job (`docker buildx imagetools create`). Per-arch native runners keep the fallback off QEMU emulation, which the full bun/vite build and native modules (node-pty, ssh2) cannot survive.

## Validation

- `make lint-actions` (actionlint + zizmor) green.
- Exercised all three paths against the real broken trust policies via a temporary dispatch workflow on a scratch branch ([run 32473931038](https://github.com/coder/xum/actions/runs/32473931038), all jobs green):
  - fallback enabled: GCP auth failed, signing setup skipped, build proceeds unsigned with warning annotation;
  - default: asserted the action fails closed;
  - Docker release: both arch builds hit `falling back to buildx: permission_denied`, still built and pushed by digest, and the merged manifest contains `linux/amd64` + `linux/arm64` (test tag `0.0.0-ci-rename-test`; scratch branch deleted).

## Risks

- Main-push and nightly Windows artifacts are unsigned until the GCP WIF binding is fixed (annotated with a warning in the job). Stable releases are unaffected: they fail closed.
- The Docker release path changes shape (two builds + manifest merge). Validated end to end above; reverting to the single Depot job is a small follow-up once the Depot trust policy is updated.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
