### PR TITLE
🤖 fix: preserve auto-compaction follow-ups

### DIFF
--- a/src/node/services/agentSession.autoCompaction.test.ts
+++ b/src/node/services/agentSession.autoCompaction.test.ts
@@ -131,6 +131,51 @@ describe("AgentSession on-send auto-compaction snapshot deferral", () => {
     session.dispose();
   });
 
+  test("tracks a compaction request when a synthetic snapshot follows it", async () => {
+    const model = "openai:gpt-4o";
+    const { session } = await createSessionHarness({
+      workspaceId: "ws-auto-compaction-request-correlation",
+    });
+    const compactionMetadata = {
+      type: "compaction-request" as const,
+      rawCommand: "/compact",
+      parsed: {},
+      source: "auto-compaction" as const,
+    };
+    const compactionRequest = createMuxMessage(
+      "compaction-request",
+      "user",
+      "Summarize the conversation",
+      {
+        synthetic: true,
+        muxMetadata: compactionMetadata,
+      }
+    );
+    const snapshot = createMuxMessage("file-change", "user", "<file-change />", {
+      synthetic: true,
+    });
+    const internals = session as unknown as {
+      resolveCompactionRequest: (
+        history: MuxMessage[],
+        modelString: string,
+        options: SendMessageOptions
+      ) => { id: string; source?: string } | undefined;
+    };
+
+    const request = internals.resolveCompactionRequest([compactionRequest, snapshot], model, {
+      model,
+      agentId: "compact",
+      muxMetadata: compactionMetadata,
+    });
+
+    expect(request).toMatchObject({
+      id: compactionRequest.id,
+      source: "auto-compaction",
+    });
+
+    session.dispose();
+  });
+
   test("does not materialize skill snapshots (or run their directives) on deferred on-send compaction turns", async () => {
     const workspaceId = "ws-auto-compaction-skill-snapshot-deferral";
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -4385,21 +4385,28 @@ export class AgentSession {
         source?: "idle-compaction" | "auto-compaction";
       }
     | undefined {
+    const streamIsCompaction = isCompactionRequestMetadata(options?.muxMetadata);
+
     for (let index = history.length - 1; index >= 0; index -= 1) {
       const message = history[index];
       if (message.role !== "user") {
         continue;
       }
       const muxMetadata = message.metadata?.muxMetadata;
-      if (!isCompactionRequestMetadata(muxMetadata)) {
+      if (isCompactionRequestMetadata(muxMetadata)) {
+        return {
+          id: message.id,
+          modelString,
+          options,
+          source: muxMetadata.source,
+        };
+      }
+
+      // Snapshot rows can follow a synthetic compaction request before stream startup.
+      // Skip only those rows when the current send options identify this stream as compaction.
+      if (!streamIsCompaction || message.metadata?.synthetic !== true) {
         return undefined;
       }
-      return {
-        id: message.id,
-        modelString,
-        options,
-        source: muxMetadata.source,
-      };
     }
     return undefined;
   }
@@ -5157,7 +5164,10 @@ export class AgentSession {
         });
         this.clearLiveUsageState();
 
-        const handled = await this.compactionHandler.handleCompletion(streamEndPayload);
+        const handled = await this.compactionHandler.handleCompletion(
+          streamEndPayload,
+          completedCompactionRequest?.id
+        );
 
         await this.recordGoalAccountingFromUsage({
           model: streamEndPayload.metadata.model,

--- a/src/node/services/compactionHandler.test.ts
+++ b/src/node/services/compactionHandler.test.ts
@@ -209,6 +209,49 @@ describe("CompactionHandler", () => {
       expect(result).toBe(false);
     });
 
+    it("uses the correlated compaction request when a synthetic snapshot follows it", async () => {
+      const followUpContent = {
+        text: "Continue",
+        model: "openai:gpt-4o",
+        agentId: "exec",
+      };
+      const compactionRequest = createMuxMessage(
+        "correlated-compaction-request",
+        "user",
+        "Please summarize the conversation",
+        {
+          synthetic: true,
+          muxMetadata: {
+            type: "compaction-request",
+            rawCommand: "/compact",
+            parsed: { followUpContent },
+            source: "auto-compaction",
+          },
+        }
+      );
+      const snapshot = createMuxMessage("file-change-snapshot", "user", "<file-change />", {
+        synthetic: true,
+      });
+      await seedHistory(compactionRequest, snapshot);
+
+      const handled = await handler.handleCompletion(
+        createStreamEndEvent("Compacted context"),
+        compactionRequest.id
+      );
+
+      expect(handled).toBe(true);
+      const history = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      expect(history.success).toBe(true);
+      if (!history.success) {
+        throw new Error(history.error);
+      }
+      expect(history.data).toHaveLength(1);
+      expect(history.data[0]?.metadata?.muxMetadata).toEqual({
+        type: "compaction-summary",
+        pendingFollowUp: followUpContent,
+      });
+    });
+
     it("reports the latest durable context boundary sequence in completion metadata", async () => {
       const onCompactionComplete = mock((_metadata: CompactionCompletionMetadata) => undefined);
       handler = new CompactionHandler({

--- a/src/node/services/compactionHandler.ts
+++ b/src/node/services/compactionHandler.ts
@@ -744,20 +744,28 @@ export class CompactionHandler {
    * Detects when a compaction stream finishes, extracts the summary,
    * and appends a durable compaction boundary message.
    */
-  async handleCompletion(event: StreamEndEvent): Promise<boolean> {
-    // Check if the last user message is a compaction-request.
-    // Only need recent messages — the compaction-request is always near the tail.
-    const historyResult = await this.historyService.getLastMessages(this.workspaceId, 10);
+  async handleCompletion(
+    event: StreamEndEvent,
+    compactionRequestMessageId?: string
+  ): Promise<boolean> {
+    // The current stream identifies its request when available. Synthetic prompt snapshots can
+    // follow that request in history, so the last user row is not always the compaction request.
+    const historyResult = compactionRequestMessageId
+      ? await this.historyService.getHistoryFromLatestBoundary(this.workspaceId)
+      : await this.historyService.getLastMessages(this.workspaceId, 10);
     if (!historyResult.success) {
       return false;
     }
 
     const messages = historyResult.data;
-    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
-    const muxMeta = lastUserMsg?.metadata?.muxMetadata;
-    const isCompaction = muxMeta?.type === "compaction-request";
+    const compactionRequestMessage = compactionRequestMessageId
+      ? messages.find((message) => message.id === compactionRequestMessageId)
+      : [...messages].reverse().find((message) => message.role === "user");
+    const muxMeta = compactionRequestMessage?.metadata?.muxMetadata;
+    const isCompaction =
+      compactionRequestMessage?.role === "user" && muxMeta?.type === "compaction-request";
 
-    if (!isCompaction || !lastUserMsg) {
+    if (!isCompaction || !compactionRequestMessage) {
       return false;
     }
 
@@ -767,7 +775,7 @@ export class CompactionHandler {
       muxMeta?.type === "compaction-request" && muxMeta.source === "idle-compaction";
 
     // Dedupe: If we've already processed this compaction-request, skip
-    if (this.processedCompactionRequestIds.has(lastUserMsg.id)) {
+    if (this.processedCompactionRequestIds.has(compactionRequestMessage.id)) {
       return true;
     }
 
@@ -815,23 +823,26 @@ export class CompactionHandler {
     const pendingFollowUp = getCompactionFollowUpContent(muxMeta);
 
     // Mark as processed before performing compaction
-    this.processedCompactionRequestIds.add(lastUserMsg.id);
+    this.processedCompactionRequestIds.add(compactionRequestMessage.id);
 
-    // Use boundary-aware read so getNextCompactionEpoch (called inside performCompaction)
-    // sees the prior boundary's epoch even if it's beyond the last-10 messages window.
-    const boundaryHistoryResult = await this.historyService.getHistoryFromLatestBoundary(
-      this.workspaceId
-    );
-    const messagesForCompaction = boundaryHistoryResult.success
-      ? boundaryHistoryResult.data
-      : messages; // fallback to last-10 if boundary read fails
+    // Use boundary-aware history so getNextCompactionEpoch sees the prior boundary's epoch.
+    // The correlated path already loaded that history to find the exact request.
+    let messagesForCompaction = messages;
+    if (!compactionRequestMessageId) {
+      const boundaryHistoryResult = await this.historyService.getHistoryFromLatestBoundary(
+        this.workspaceId
+      );
+      if (boundaryHistoryResult.success) {
+        messagesForCompaction = boundaryHistoryResult.data;
+      }
+    }
 
     const result = await this.performCompaction(
       summary,
       event.metadata,
       messagesForCompaction,
       event.messageId,
-      lastUserMsg.id,
+      compactionRequestMessage.id,
       isIdleCompaction,
       pendingFollowUp
     );


### PR DESCRIPTION
## Summary

Fix auto-compaction when a synthetic snapshot follows the compaction request. The completion path now preserves the compacted boundary and sends the pending continuation.

## Background

Auto-compaction can persist a synthetic file-change snapshot after its request. The completion handler previously treated that snapshot as the latest user message. It then skipped compaction completion and did not send `Continue`.

## Implementation

- Track the active compaction request across synthetic snapshot rows.
- Pass the exact request ID to the compaction completion handler.
- Resolve pending follow-up data from the correlated request.
- Add regression tests for boundary creation and follow-up preservation.

## Validation

- `make static-check`
- `bun test src/node/services/agentSession.autoCompaction.test.ts src/node/services/compactionHandler.test.ts`

## Risks

The change affects compaction request detection and completion. The fallback behavior remains unchanged for callers without request correlation.

---

_Generated with `mux` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$0.01`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=0.01 -->
