### PR TITLE
🤖 ci: skip existing xvfb installation

### DIFF
--- a/.github/workflows/perf-profiles.yml
+++ b/.github/workflows/perf-profiles.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: ./.github/actions/setup-mux
       - name: Install xvfb
         run: |
+          if command -v Xvfb >/dev/null 2>&1 && command -v xvfb-run >/dev/null 2>&1; then
+            echo "Xvfb is already installed"
+            exit 0
+          fi
+
           sudo apt-get update
           sudo apt-get install -y xvfb
       - uses: ./.github/actions/setup-playwright

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -361,6 +361,11 @@ jobs:
       - name: Install xvfb
         if: matrix.os == 'linux'
         run: |
+          if command -v Xvfb >/dev/null 2>&1 && command -v xvfb-run >/dev/null 2>&1; then
+            echo "Xvfb is already installed"
+            exit 0
+          fi
+
           sudo apt-get update
           sudo apt-get install -y xvfb
       # Bound browser setup; Playwright downloads can stall after progress reaches 100%.


### PR DESCRIPTION
## Summary

Skip the slow APT update when the Linux runner already has Xvfb.

## Background

The Linux E2E job spent 7 minutes 42 seconds in `apt-get update`.
The runner already had the required Xvfb package installed.

## Implementation

Check for both `Xvfb` and `xvfb-run` before installing the package.
Run APT only when either command is missing.
Apply the same guard to the performance profile workflow.

## Validation

- `make static-check`
- `git diff --check`

## Risks

If a runner lacks either command, the workflow uses the existing APT install path.

---

_Generated with `mux` • Model: `openai:gpt-5.6-luna` • Thinking: `medium` • Cost: `$0.07`_

<!-- mux-attribution: model=openai:gpt-5.6-luna thinking=medium costs=0.07 -->
