### PR TITLE
🤖 ci: remove unsigned Windows signing fallback

### DIFF
--- a/.github/actions/setup-windows-signing/action.yml
+++ b/.github/actions/setup-windows-signing/action.yml
@@ -11,10 +11,6 @@ inputs:
   gcp_service_account:
     description: "GCP Service Account"
     required: false
-  allow_unsigned_fallback:
-    description: "Continue with an unsigned build when GCP signing auth fails (CI/nightly only; keep stable releases fail-closed)"
-    required: false
-    default: "false"
 
 outputs:
   gcloud_access_token:
@@ -33,13 +29,6 @@ runs:
     - name: Authenticate to Google Cloud
       id: gcloud_auth
       if: inputs.gcp_workload_id_provider != ''
-      # The coder/shux -> coder/xum repo rename broke the GCP Workload Identity
-      # trust policy (matches owner/repo as a string), so this auth step fails
-      # with iam.serviceAccounts.getAccessToken PERMISSION_DENIED. Callers that
-      # opt in via allow_unsigned_fallback build unsigned until the GCP-side
-      # binding is updated for the new repo name; signing resumes automatically
-      # then. Stable releases keep the default and fail closed.
-      continue-on-error: ${{ inputs.allow_unsigned_fallback == 'true' }}
       uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
       with:
         workload_identity_provider: ${{ inputs.gcp_workload_id_provider }}
@@ -54,15 +43,11 @@ runs:
           exit 0
         }
 
-        # Signing requires a GCP access token for Cloud KMS. When auth failed
-        # or was skipped, only the opt-in fallback may continue (leaving
-        # JSIGN_PATH unset so sign-windows.js skips signing); otherwise fail
-        # closed so a certificate-bearing release can never ship unsigned.
+        # Signing requires a GCP access token for Cloud KMS. Fail closed when
+        # auth produced no token (e.g. skipped because no workload identity
+        # provider was configured) so a certificate-bearing release can never
+        # ship unsigned.
         if (-not $env:GCLOUD_ACCESS_TOKEN) {
-          if ($env:ALLOW_UNSIGNED_FALLBACK -eq 'true') {
-            Write-Host "::warning title=Windows build unsigned::GCP signing auth unavailable (rename broke WIF trust policy) - building unsigned"
-            exit 0
-          }
           Write-Host "::error::EV certificate provided but GCP signing auth produced no access token - failing closed"
           exit 1
         }
@@ -81,4 +66,3 @@ runs:
       env:
         EV_SIGNING_CERT: ${{ inputs.ev_signing_cert }}
         GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
-        ALLOW_UNSIGNED_FALLBACK: ${{ inputs.allow_unsigned_fallback }}

--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -16,11 +16,6 @@ on:
         required: false
         type: string
         default: ""
-      allow_unsigned_windows:
-        description: "Build Windows unsigned when GCP signing auth fails (nightly only; stable releases stay fail-closed)"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   build-macos:
@@ -237,7 +232,6 @@ jobs:
         id: signing
         uses: ./.github/actions/setup-windows-signing
         with:
-          allow_unsigned_fallback: "${{ inputs.allow_unsigned_windows }}"
           ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
           gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,10 +122,6 @@ jobs:
       ref: ${{ needs.compute-version.outputs.build_sha }}
       release_tag: ${{ needs.compute-version.outputs.release_tag }}
       version_override: ${{ needs.compute-version.outputs.nightly_version }}
-      # Nightly ships unsigned Windows builds while the repo rename breaks GCP
-      # WIF signing auth (see setup-windows-signing action). Stable releases
-      # keep the fail-closed default.
-      allow_unsigned_windows: true
     secrets: inherit # zizmor: ignore[secrets-inherit] -- reusable workflow needs platform signing secrets
 
   docker-publish:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -590,9 +590,6 @@ jobs:
           ev_signing_cert: ${{ secrets.EV_SIGNING_CERT }}
           gcp_workload_id_provider: ${{ vars.GCP_WORKLOAD_ID_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-          # CI artifact only - keep main green while the repo rename breaks
-          # GCP WIF auth (see setup-windows-signing action for details).
-          allow_unsigned_fallback: "true"
       - name: Package for Windows
         run: make dist-win
         env:


### PR DESCRIPTION
## Summary

Removes the unsigned-Windows-build fallback added in 584e4a85b, restoring fail-closed EV signing everywhere now that the GCP Workload Identity trust policy accepts `coder/xum`.

## Background

The coder/shux -> coder/xum rename broke the string-matched WIF attribute condition, so `google-github-actions/auth` failed with `iam.serviceAccounts.getAccessToken` PERMISSION_DENIED on every main-push Build/Windows job and nightly Windows release. `allow_unsigned_fallback` kept main green by building unsigned with a warning annotation.

coder/gcp#209 (merged + applied 2026-08-21 18:03 UTC) updated the trust policy for `coder/xum`. Verified end to end by re-running the previously-failing `Build / Windows` job on main ([job 96864601304](https://github.com/coder/xum/actions/runs/32507804897/job/96864601304)): auth minted a real token and jsign signed all binaries (`✅ Successfully signed ...xum.exe`), with no `Windows build unsigned` annotation. The pre-fix baseline run of the same job showed the PERMISSION_DENIED failure and unsigned fallback.

This removes the now-dead mechanism entirely:

- `setup-windows-signing`: drop the `allow_unsigned_fallback` input, `continue-on-error`, and the unsigned-warning branch; a missing token once again fails closed.
- `pr.yml`: drop the hardcoded `allow_unsigned_fallback: "true"`.
- `_desktop-release.yml` / `nightly.yml`: drop the `allow_unsigned_windows` plumbing.

The Depot `buildx-fallback` in `pr.yml`/`_docker-release.yml` is intentionally kept: it is self-healing (Depot acceleration already resumed, verified in merge-queue run 32506927400) and still guards against any future trust-policy drift.

## Risks

If GCP WIF auth breaks again, Build/Windows on main and nightly releases fail loudly instead of shipping unsigned artifacts. That is the intended pre-rename behavior.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
