### PR TITLE
🤖 fix: make TitleBar tooltip CTAs clickable links

### DIFF
--- a/src/browser/components/TitleBar/TitleBar.tsx
+++ b/src/browser/components/TitleBar/TitleBar.tsx
@@ -47,6 +47,10 @@ import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 // Update check interval
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
+// Tooltip CTAs mirror their triggers so pointer users can act on the copy directly.
+const TOOLTIP_CTA_CLASSNAME =
+  "text-muted hover:text-foreground cursor-pointer border-0 bg-transparent p-0 text-left underline underline-offset-2 transition-colors";
+
 interface VersionRecord {
   git?: unknown;
   git_describe?: unknown;
@@ -119,6 +123,18 @@ export function TitleBar(props: TitleBarProps) {
 
   const gitDescribe = getGitDescribe(VERSION satisfies unknown);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ type: "idle" });
+  const [versionTooltipOpen, setVersionTooltipOpen] = useState(false);
+  const [routeTooltipOpen, setRouteTooltipOpen] = useState(false);
+
+  const handleOpenAboutDialog = () => {
+    setVersionTooltipOpen(false);
+    openAboutDialog();
+  };
+
+  const handleOpenRouteSettings = () => {
+    setRouteTooltipOpen(false);
+    openSettings("providers", { expandProvider: activeRouteProvider });
+  };
 
   useEffect(() => {
     // Skip update checks in browser mode - app updates only apply to Electron
@@ -204,7 +220,7 @@ export function TitleBar(props: TitleBarProps) {
           leftInset > 0 ? "flex-col" : "items-center gap-2"
         )}
       >
-        <Tooltip>
+        <Tooltip open={versionTooltipOpen} onOpenChange={setVersionTooltipOpen}>
           <TooltipTrigger asChild>
             <button
               type="button"
@@ -215,7 +231,7 @@ export function TitleBar(props: TitleBarProps) {
                 "flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 text-left text-inherit transition-opacity hover:opacity-70",
                 isDesktop && "titlebar-no-drag"
               )}
-              onClick={openAboutDialog}
+              onClick={handleOpenAboutDialog}
             >
               <div
                 className={cn(
@@ -232,16 +248,20 @@ export function TitleBar(props: TitleBarProps) {
               )}
             </button>
           </TooltipTrigger>
-          <TooltipContent align="start">Click for more details</TooltipContent>
+          <TooltipContent align="start">
+            <button type="button" className={TOOLTIP_CTA_CLASSNAME} onClick={handleOpenAboutDialog}>
+              Click for more details
+            </button>
+          </TooltipContent>
         </Tooltip>
       </div>
       <div className={cn("flex shrink-0 items-center gap-1.5", isDesktop && "titlebar-no-drag")}>
         {isNonDirectRoute && (
-          <Tooltip>
+          <Tooltip open={routeTooltipOpen} onOpenChange={setRouteTooltipOpen}>
             <TooltipTrigger asChild>
               <button
                 type="button"
-                onClick={() => openSettings("providers", { expandProvider: activeRouteProvider })}
+                onClick={handleOpenRouteSettings}
                 onMouseEnter={() => {
                   if (isMuxGatewayRoute) {
                     void refreshMuxGatewayAccountStatus();
@@ -288,10 +308,16 @@ export function TitleBar(props: TitleBarProps) {
                   Requests for this model route via {activeRoute.displayName}.
                 </div>
               )}
-              <div className="text-muted border-separator-light mt-2 border-t pt-1.5 text-[10px]">
-                {isMuxGatewayRoute
-                  ? "Click to open gateway settings"
-                  : "Click to open provider settings"}
+              <div className="border-separator-light mt-2 border-t pt-1.5 text-[10px]">
+                <button
+                  type="button"
+                  className={TOOLTIP_CTA_CLASSNAME}
+                  onClick={handleOpenRouteSettings}
+                >
+                  {isMuxGatewayRoute
+                    ? "Click to open gateway settings"
+                    : "Click to open provider settings"}
+                </button>
               </div>
             </TooltipContent>
           </Tooltip>


### PR DESCRIPTION
## Summary

Makes the call-to-action text in the TitleBar tooltips actually clickable: the version tooltip's "Click for more details" now opens the About dialog, and the gateway/provider route tooltip's "Click to open gateway settings" / "Click to open provider settings" now opens Settings → Providers with the active provider expanded.

Fixes #2330

## Background

Both tooltips ended in CTA copy that read like a link but was inert plain text, so clicking the words did nothing (UX papercut). The actions were only reachable by clicking the trigger buttons themselves.

## Implementation

- The two CTAs are now link-styled `<button>` elements inside the shared `TooltipContent`, invoking the exact same handlers as their triggers (`openAboutDialog`, `openSettings("providers", { expandProvider: activeRouteProvider })`). Shared link styling lives in a local `TOOLTIP_CTA_CLASSNAME` constant.
- Clicking inside tooltip content works because the app-level `TooltipProvider` keeps Radix hoverable-content enabled (pointer can travel from trigger into the tooltip).
- Both affected tooltips are now controlled (`open`/`onOpenChange`) so the CTA click closes the tooltip before the About dialog / Settings surface opens; otherwise the z-indexed tooltip lingers on top.

## Validation

- `make static-check` green locally.
- Remote dogfood UAT (browser-mode dev server at this exact head): PASS. Verified pointer travel into both tooltips, CTA clicks open the About dialog / Settings → Providers with the right provider expanded (OpenRouter via real UI flow; Xum Gateway branch incl. Balance/Concurrent rows in logged-out state), no lingering tooltips after any click (DOM-checked), trigger-click regressions unaffected, other TitleBar tooltips unchanged, no overflow at 375px.
- Known minor UAT observations (accepted, not fixed): tooltip CTA is pointer-only (Radix tooltips close on Tab; the focusable trigger performs the identical action), and the hover color shift is gated by `@media (hover: hover)` like all other hover styles.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
