### PR TITLE
🤖 feat: add copy-file button to immersive review file view

### DIFF
--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1418,9 +1418,10 @@ describe("ImmersiveReviewView", () => {
     expect(resolveRead).toBeTruthy();
   });
 
-  test("caps copy reads and reports a size-specific failure for oversized files", async () => {
-    // Copy reads carry no awk line budget; overlay full-file reads do.
-    const copyReadScripts: string[] = [];
+  test("reports a size-specific failure for oversized files", async () => {
+    // Copy reads carry no awk line budget; overlay full-file reads do. The copy read
+    // budget itself is exercised behaviorally in fileRead.test.ts; here the backend
+    // returns the deterministic too-large exit it produces for oversized files.
     mockApi.workspace.executeBash = mock((...args: unknown[]) => {
       const { script } = args[0] as { script: string };
       if (script.includes("awk 'NR >")) {
@@ -1429,8 +1430,6 @@ describe("ImmersiveReviewView", () => {
           data: { success: false, output: "", exitCode: 43 },
         });
       }
-      copyReadScripts.push(script);
-      // The size guard trips: deterministic too-large exit, not a truncated payload.
       return Promise.resolve({
         success: true as const,
         data: { success: false, output: "", exitCode: 42 },
@@ -1453,10 +1452,7 @@ describe("ImmersiveReviewView", () => {
       ).toBe("failed")
     );
     expect(clipboardWrites).toHaveLength(0);
-    // The copy read must carry the IPC-safe size budget so oversize files fail
-    // deterministically instead of arriving truncated.
-    expect(copyReadScripts[0]).toContain(`-gt ${750 * 1024}`);
-    // And the failure must tell the user it is a size problem.
+    // The failure must tell the user it is a size problem, not a generic error.
     expect(view.container.textContent ?? "").toContain("file is larger than 750 KB");
   });
 

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -15,6 +15,7 @@ interface MockApiClient {
         success: boolean;
         output: string;
         exitCode: number;
+        truncated?: { reason: string; totalLines: number };
       };
     }>;
   };
@@ -1036,6 +1037,105 @@ describe("ImmersiveReviewView", () => {
     fireEvent.keyDown(input, { key: "y" });
     expect(executeBashCalls).toBe(callsAfterCopy);
     expect(clipboardWrites).toHaveLength(1);
+  });
+
+  test("discards a copy that completes after navigating to another file", async () => {
+    const fileAHunk = createHunk({ id: "hunk-a", filePath: "src/a.ts" });
+    const fileBHunk = createHunk({ id: "hunk-b", filePath: "src/b.ts" });
+
+    let resolveRead: ((value: unknown) => void) | undefined;
+    mockApi.workspace.executeBash = mock(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve as (value: unknown) => void;
+        })
+    ) as unknown as MockApiClient["workspace"]["executeBash"];
+
+    function NavigationHarness() {
+      const [selectedHunkId, setSelectedHunkId] = useState<string | null>(fileAHunk.id);
+      return (
+        <ThemeProvider forcedTheme="dark">
+          <ImmersiveReviewView
+            workspaceId="workspace-1"
+            fileTree={createFileTreeForPaths([fileAHunk.filePath, fileBHunk.filePath])}
+            hunks={[fileAHunk, fileBHunk]}
+            allHunks={[fileAHunk, fileBHunk]}
+            isRead={() => false}
+            onToggleRead={mock(() => undefined)}
+            onMarkFileAsRead={mock(() => undefined)}
+            selectedHunkId={selectedHunkId}
+            onSelectHunk={setSelectedHunkId}
+            onExit={mock(() => undefined)}
+            isTouchImmersive={true}
+            reviewsByFilePath={new Map()}
+            firstSeenMap={{}}
+          />
+        </ThemeProvider>
+      );
+    }
+
+    const view = render(<NavigationHarness />);
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+    await waitFor(() => expect(resolveRead).toBeTruthy());
+
+    // Navigate to file B while the read for file A is still in flight.
+    const nextFileButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Next file"]'
+    );
+    expect(nextFileButton).toBeTruthy();
+    fireEvent.click(nextFileButton!);
+    await waitFor(() => expect(view.container.textContent ?? "").toContain("b.ts"));
+
+    resolveRead!({
+      success: true as const,
+      data: { success: true, output: encodeFileReadOutput("file A contents"), exitCode: 0 },
+    });
+
+    // The stale completion must not reach the clipboard.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(clipboardWrites).toHaveLength(0);
+  });
+
+  test("rejects truncated reads instead of copying a partial file", async () => {
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: {
+          success: true,
+          output: encodeFileReadOutput("partial contents"),
+          exitCode: 0,
+          truncated: { reason: "too big", totalLines: 1 },
+        },
+      })
+    );
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(clipboardWrites).toHaveLength(0);
+  });
+
+  test("no copy affordance for a deleted file", () => {
+    const deletedHunk = createHunk({ changeType: "deleted" });
+
+    const view = renderImmersiveReview({
+      hunks: [deletedHunk],
+      allHunks: [deletedHunk],
+    });
+
+    expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
   });
 
   test("no copy affordance when the review is complete", () => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -21,6 +21,7 @@ interface MockApiClient {
 }
 
 let mockApi: MockApiClient;
+let clipboardWrites: string[] = [];
 
 void mock.module("@/browser/contexts/API", () => ({
   useAPI: () => ({
@@ -30,6 +31,13 @@ void mock.module("@/browser/contexts/API", () => ({
     authenticate: () => undefined,
     retry: () => undefined,
   }),
+}));
+
+void mock.module("@/browser/utils/clipboard", () => ({
+  copyToClipboard: (text: string) => {
+    clipboardWrites.push(text);
+    return Promise.resolve();
+  },
 }));
 
 import { ImmersiveReviewView, shouldPreserveImmersiveContextCursor } from "./ImmersiveReviewView";
@@ -120,6 +128,7 @@ describe("ImmersiveReviewView", () => {
   let originalNavigator: typeof globalThis.navigator;
   let originalRequestAnimationFrame: typeof globalThis.requestAnimationFrame;
   let originalCancelAnimationFrame: typeof globalThis.cancelAnimationFrame;
+  let originalHTMLElement: typeof globalThis.HTMLElement;
 
   beforeEach(() => {
     originalWindow = globalThis.window;
@@ -127,11 +136,15 @@ describe("ImmersiveReviewView", () => {
     originalNavigator = globalThis.navigator;
     originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    originalHTMLElement = globalThis.HTMLElement;
 
     const dom = new GlobalWindow({ url: "http://localhost" });
     globalThis.window = dom as unknown as Window & typeof globalThis;
     globalThis.document = dom.document as unknown as Document;
     globalThis.navigator = dom.navigator as unknown as Navigator;
+    // Keyboard handlers guard with `target instanceof HTMLElement`; expose the active
+    // dom's constructor so the guard sees this window's elements instead of throwing.
+    globalThis.HTMLElement = dom.HTMLElement as unknown as typeof globalThis.HTMLElement;
     globalThis.requestAnimationFrame = dom.requestAnimationFrame.bind(
       dom
     ) as unknown as typeof globalThis.requestAnimationFrame;
@@ -141,6 +154,7 @@ describe("ImmersiveReviewView", () => {
 
     globalThis.window.api = { platform: "linux", versions: {} };
 
+    clipboardWrites = [];
     mockApi = {
       workspace: {
         executeBash: mock(() =>
@@ -165,6 +179,7 @@ describe("ImmersiveReviewView", () => {
     globalThis.navigator = originalNavigator;
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    globalThis.HTMLElement = originalHTMLElement;
   });
 
   test("only preserves context cursors while overlay content is unchanged", () => {
@@ -963,5 +978,77 @@ describe("ImmersiveReviewView", () => {
     // the parent panel must NOT have reset the selection back to the first
     // visible hunk.
     expect(view.container.textContent ?? "").toContain(reviewedHunk.filePath);
+  });
+
+  test("copy button copies the entire on-disk file even when the display read is line-budgeted", async () => {
+    const fullContent = `first line\n${Array.from({ length: 60 }, (_, i) => `line ${i + 2}`).join("\n")}\nlast line`;
+
+    // The full-file display read carries an awk line budget; the copy read must not,
+    // so it still yields the whole file when the display falls back to compact hunks.
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      return Promise.resolve({
+        success: true as const,
+        data: { success: true, output: encodeFileReadOutput(fullContent), exitCode: 0 },
+      });
+    });
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+    expect(clipboardWrites[0]).toBe(fullContent);
+  });
+
+  test("pressing the copy-file key copies the file, but not while typing", async () => {
+    const fullContent = "first line\nmiddle\nlast line";
+    let executeBashCalls = 0;
+    mockApi.workspace.executeBash = mock(() => {
+      executeBashCalls += 1;
+      return Promise.resolve({
+        success: true as const,
+        data: { success: true, output: encodeFileReadOutput(fullContent), exitCode: 0 },
+      });
+    });
+
+    const view = renderImmersiveReview({ isTouchImmersive: false });
+
+    fireEvent.keyDown(globalThis.window as unknown as Element, { key: "y" });
+    await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+    expect(clipboardWrites[0]).toBe(fullContent);
+
+    // Typing "y" in an editable element must not trigger the copy. The guard is
+    // synchronous, so the read-call count must not move.
+    const callsAfterCopy = executeBashCalls;
+    const input = document.createElement("input");
+    view.container.appendChild(input);
+    fireEvent.keyDown(input, { key: "y" });
+    expect(executeBashCalls).toBe(callsAfterCopy);
+    expect(clipboardWrites).toHaveLength(1);
+  });
+
+  test("no copy affordance when the review is complete", () => {
+    const hunk = createHunk();
+
+    const view = renderImmersiveReview({
+      hunks: [],
+      allHunks: [hunk],
+      isRead: () => true,
+      selectedHunkId: null,
+    });
+
+    expect(view.container.textContent ?? "").toContain("Review complete");
+    expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
   });
 });

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1456,6 +1456,29 @@ describe("ImmersiveReviewView", () => {
     expect(view.container.textContent ?? "").toContain("file is larger than 750 KB");
   });
 
+  test("shows a visible failure when the API is unavailable", async () => {
+    // APIContext supplies api: null while connecting/reconnecting/errored.
+    mockApi = null as unknown as MockApiClient;
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() =>
+      expect(
+        view.container
+          .querySelector('button[aria-label="Copy file contents"]')
+          ?.getAttribute("data-copy-file-feedback")
+      ).toBe("failed")
+    );
+    expect(view.container.textContent ?? "").toContain("backend connection unavailable");
+    expect(clipboardWrites).toHaveLength(0);
+  });
+
   test("rejects partial payloads from unsuccessful script exits", async () => {
     // Simulates base64 dying after stat emitted the size: the script exits nonzero
     // but leaves parseable output that would decode to empty text.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1122,8 +1122,42 @@ describe("ImmersiveReviewView", () => {
     expect(copyButton).toBeTruthy();
     fireEvent.click(copyButton!);
 
-    await waitFor(() => expect(mockApi.workspace.executeBash).toHaveBeenCalled());
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // The rejection must be user-visible, not just a console log.
+    await waitFor(() =>
+      expect(
+        view.container
+          .querySelector('button[aria-label="Copy file contents"]')
+          ?.getAttribute("data-copy-file-feedback")
+      ).toBe("failed")
+    );
+    expect(clipboardWrites).toHaveLength(0);
+  });
+
+  test("shows a visible failure when copying a binary file", async () => {
+    // NUL bytes make processFileContents classify the payload as binary.
+    const binaryOutput = `4\n${Buffer.from([0x00, 0x01, 0x02, 0x03]).toString("base64")}`;
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { success: true, output: binaryOutput, exitCode: 0 },
+      })
+    );
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() =>
+      expect(
+        view.container
+          .querySelector('button[aria-label="Copy file contents"]')
+          ?.getAttribute("data-copy-file-feedback")
+      ).toBe("failed")
+    );
     expect(clipboardWrites).toHaveLength(0);
   });
 
@@ -1135,6 +1169,25 @@ describe("ImmersiveReviewView", () => {
       allHunks: [deletedHunk],
     });
 
+    expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
+  });
+
+  test("no copy affordance for a hunk-less deleted file known only to the file tree", () => {
+    // Deleting an empty or binary file yields no hunks; the active file then comes
+    // from the file tree, whose numstat entry still carries the deletion status.
+    const tree = createFileTree("src/gone.bin");
+    const leaf = tree.children[0]?.children[0];
+    expect(leaf?.path).toBe("src/gone.bin");
+    leaf.stats = { filePath: "src/gone.bin", additions: 0, deletions: 0, changeType: "deleted" };
+
+    const view = renderImmersiveReview({
+      fileTree: tree,
+      hunks: [],
+      allHunks: [],
+      selectedHunkId: null,
+    });
+
+    expect(view.container.textContent ?? "").toContain("gone.bin");
     expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
   });
 

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -986,14 +986,16 @@ describe("ImmersiveReviewView", () => {
 
     // The full-file display read carries an awk line budget; the copy read must not,
     // so it still yields the whole file when the display falls back to compact hunks.
+    const copyReadCalls: Array<{ script: string; options?: { cwdMode?: string } }> = [];
     mockApi.workspace.executeBash = mock((...args: unknown[]) => {
-      const { script } = args[0] as { script: string };
-      if (script.includes("awk 'NR >")) {
+      const input = args[0] as { script: string; options?: { cwdMode?: string } };
+      if (input.script.includes("awk 'NR >")) {
         return Promise.resolve({
           success: true as const,
           data: { success: false, output: "", exitCode: 43 },
         });
       }
+      copyReadCalls.push(input);
       return Promise.resolve({
         success: true as const,
         data: { success: true, output: encodeFileReadOutput(fullContent), exitCode: 0 },
@@ -1010,6 +1012,9 @@ describe("ImmersiveReviewView", () => {
 
     await waitFor(() => expect(clipboardWrites).toHaveLength(1));
     expect(clipboardWrites[0]).toBe(fullContent);
+    // Single-project hunk paths are repo-root-relative, so the copy read must run
+    // from the repo root (default mode would run from a subproject cwd).
+    expect(copyReadCalls[0]?.options).toEqual({ cwdMode: "repo-root" });
   });
 
   test("pressing the copy-file key copies the file, but not while typing", async () => {
@@ -1123,6 +1128,34 @@ describe("ImmersiveReviewView", () => {
     fireEvent.click(copyButton!);
 
     // The rejection must be user-visible, not just a console log.
+    await waitFor(() =>
+      expect(
+        view.container
+          .querySelector('button[aria-label="Copy file contents"]')
+          ?.getAttribute("data-copy-file-feedback")
+      ).toBe("failed")
+    );
+    expect(clipboardWrites).toHaveLength(0);
+  });
+
+  test("rejects partial payloads from unsuccessful script exits", async () => {
+    // Simulates base64 dying after stat emitted the size: the script exits nonzero
+    // but leaves parseable output that would decode to empty text.
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { success: false, output: "19\n", exitCode: 1 },
+      })
+    );
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
     await waitFor(() =>
       expect(
         view.container

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1418,6 +1418,48 @@ describe("ImmersiveReviewView", () => {
     expect(resolveRead).toBeTruthy();
   });
 
+  test("caps copy reads and reports a size-specific failure for oversized files", async () => {
+    // Copy reads carry no awk line budget; overlay full-file reads do.
+    const copyReadScripts: string[] = [];
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      copyReadScripts.push(script);
+      // The size guard trips: deterministic too-large exit, not a truncated payload.
+      return Promise.resolve({
+        success: true as const,
+        data: { success: false, output: "", exitCode: 42 },
+      });
+    });
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() =>
+      expect(
+        view.container
+          .querySelector('button[aria-label="Copy file contents"]')
+          ?.getAttribute("data-copy-file-feedback")
+      ).toBe("failed")
+    );
+    expect(clipboardWrites).toHaveLength(0);
+    // The copy read must carry the IPC-safe size budget so oversize files fail
+    // deterministically instead of arriving truncated.
+    expect(copyReadScripts[0]).toContain(`-gt ${750 * 1024}`);
+    // And the failure must tell the user it is a size problem.
+    expect(view.container.textContent ?? "").toContain("file is larger than 750 KB");
+  });
+
   test("rejects partial payloads from unsuccessful script exits", async () => {
     // Simulates base64 dying after stat emitted the size: the script exits nonzero
     // but leaves parseable output that would decode to empty text.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { useEffect, useState, type ComponentProps } from "react";
 
@@ -1101,8 +1101,14 @@ describe("ImmersiveReviewView", () => {
       data: { success: true, output: encodeFileReadOutput("file A contents"), exitCode: 0 },
     });
 
-    // The stale completion must not reach the clipboard.
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // The stale completion must not reach the clipboard. The handler continuation
+    // (including any would-be clipboard write) is a bounded microtask chain after the
+    // resolved read, so drain microtasks deterministically instead of sleeping.
+    await act(async () => {
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
     expect(clipboardWrites).toHaveLength(0);
   });
 
@@ -1159,11 +1165,12 @@ describe("ImmersiveReviewView", () => {
     fireEvent.click(copyButton!);
 
     await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+    expect(clipboardWrites[0]).toBe(fullContent);
     const copyRead = copyReadCalls.find((call) => !call.script.includes("awk 'NR >"));
     expect(copyRead).toBeTruthy();
-    // Container-root project entries are symlinks, so the read must anchor to the
-    // resolved project root and run in default (container-root) mode.
-    expect(copyRead!.script).toContain("anchor=$(realpath './src'");
+    // Multi-project hunk paths are container-root-relative, so the read must run in
+    // default (container-root) mode; the project-symlink containment invariant itself
+    // is covered behaviorally by the real-bash tests in fileRead.test.ts.
     expect(copyRead!.options).toBeUndefined();
   });
 

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1138,6 +1138,42 @@ describe("ImmersiveReviewView", () => {
     expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
   });
 
+  test("no copy affordance for a deleted file whose hunks are all filtered out", () => {
+    const deletedHunk = createHunk({ changeType: "deleted" });
+
+    // Filters (search/assisted/read) can empty the visible hunk list while the
+    // active file still resolves to the deleted file via the unfiltered set.
+    const view = renderImmersiveReview({
+      hunks: [],
+      allHunks: [deletedHunk],
+      selectedHunkId: deletedHunk.id,
+    });
+
+    expect(view.container.textContent ?? "").toContain(deletedHunk.filePath);
+    expect(view.container.querySelector('button[aria-label="Copy file contents"]')).toBeNull();
+  });
+
+  test("copies SVG markup as text instead of rejecting it as an image", async () => {
+    const svgSource = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>';
+    mockApi.workspace.executeBash = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { success: true, output: encodeFileReadOutput(svgSource), exitCode: 0 },
+      })
+    );
+
+    const view = renderImmersiveReview();
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+    expect(clipboardWrites[0]).toBe(svgSource);
+  });
+
   test("no copy affordance when the review is complete", () => {
     const hunk = createHunk();
 

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1138,6 +1138,116 @@ describe("ImmersiveReviewView", () => {
     expect(clipboardWrites).toHaveLength(0);
   });
 
+  test("multi-project copies anchor containment to the project symlink", async () => {
+    const fullContent = "multi project contents";
+    const copyReadCalls: Array<{ script: string; options?: { cwdMode?: string } }> = [];
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const input = args[0] as { script: string; options?: { cwdMode?: string } };
+      copyReadCalls.push(input);
+      return Promise.resolve({
+        success: true as const,
+        data: { success: true, output: encodeFileReadOutput(fullContent), exitCode: 0 },
+      });
+    });
+
+    const view = renderImmersiveReview({ isMultiProjectWorkspace: true });
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+
+    await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+    const copyRead = copyReadCalls.find((call) => !call.script.includes("awk 'NR >"));
+    expect(copyRead).toBeTruthy();
+    // Container-root project entries are symlinks, so the read must anchor to the
+    // resolved project root and run in default (container-root) mode.
+    expect(copyRead!.script).toContain("anchor=$(realpath './src'");
+    expect(copyRead!.options).toBeUndefined();
+  });
+
+  test("serializes same-file copies and ignores key repeat", async () => {
+    // Copy reads carry no awk line budget; overlay full-file reads do.
+    let executeBashCalls = 0;
+    let resolveRead: ((value: unknown) => void) | undefined;
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      executeBashCalls += 1;
+      return new Promise((resolve) => {
+        resolveRead = resolve as (value: unknown) => void;
+      });
+    }) as unknown as MockApiClient["workspace"]["executeBash"];
+
+    renderImmersiveReview({ isTouchImmersive: false });
+
+    fireEvent.keyDown(globalThis.window as unknown as Element, { key: "y" });
+    await waitFor(() => expect(executeBashCalls).toBe(1));
+
+    // OS key repeat and a second same-file request while the read is pending
+    // must not fan out more backend reads.
+    fireEvent.keyDown(globalThis.window as unknown as Element, { key: "y", repeat: true });
+    fireEvent.keyDown(globalThis.window as unknown as Element, { key: "y" });
+    expect(executeBashCalls).toBe(1);
+
+    resolveRead!({
+      success: true as const,
+      data: { success: true, output: encodeFileReadOutput("contents"), exitCode: 0 },
+    });
+    await waitFor(() => expect(clipboardWrites).toHaveLength(1));
+
+    // After completion the same file can be copied again.
+    fireEvent.keyDown(globalThis.window as unknown as Element, { key: "y" });
+    await waitFor(() => expect(executeBashCalls).toBe(2));
+  });
+
+  test("clears prior feedback while a new copy is pending", async () => {
+    // Copy reads carry no awk line budget; overlay full-file reads do.
+    let resolveRead: ((value: unknown) => void) | undefined;
+    let copyReadCount = 0;
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      copyReadCount += 1;
+      if (copyReadCount === 1) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: true, output: encodeFileReadOutput("contents"), exitCode: 0 },
+        });
+      }
+      return new Promise((resolve) => {
+        resolveRead = resolve as (value: unknown) => void;
+      });
+    }) as unknown as MockApiClient["workspace"]["executeBash"];
+
+    const view = renderImmersiveReview();
+
+    const findCopyButton = () =>
+      view.container.querySelector<HTMLButtonElement>('button[aria-label="Copy file contents"]');
+    fireEvent.click(findCopyButton()!);
+    await waitFor(() =>
+      expect(findCopyButton()?.getAttribute("data-copy-file-feedback")).toBe("copied")
+    );
+
+    // Starting a second copy must clear the stale success while the read hangs.
+    fireEvent.click(findCopyButton()!);
+    await waitFor(() =>
+      expect(findCopyButton()?.getAttribute("data-copy-file-feedback")).toBeNull()
+    );
+    expect(resolveRead).toBeTruthy();
+  });
+
   test("rejects partial payloads from unsuccessful script exits", async () => {
     // Simulates base64 dying after stat emitted the size: the script exits nonzero
     // but leaves parseable output that would decode to empty text.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1112,6 +1112,84 @@ describe("ImmersiveReviewView", () => {
     expect(clipboardWrites).toHaveLength(0);
   });
 
+  test("discards a copy when the file changes in place while the read is pending", async () => {
+    const hunkV1 = createHunk({ content: "-old line\n+new line" });
+
+    // Copy reads carry no awk line budget; overlay full-file reads do.
+    const pendingReads: Array<(value: unknown) => void> = [];
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      return new Promise((resolve) => {
+        pendingReads.push(resolve as (value: unknown) => void);
+      });
+    }) as unknown as MockApiClient["workspace"]["executeBash"];
+
+    function InPlaceEditHarness() {
+      const [hunks, setHunks] = useState([hunkV1]);
+      return (
+        <ThemeProvider forcedTheme="dark">
+          <button
+            type="button"
+            data-testid="edit-file"
+            onClick={() => setHunks([createHunk({ content: "-old line\n+edited line" })])}
+          >
+            edit
+          </button>
+          <ImmersiveReviewView
+            workspaceId="workspace-1"
+            fileTree={createFileTree(hunkV1.filePath)}
+            hunks={hunks}
+            allHunks={hunks}
+            isRead={() => false}
+            onToggleRead={mock(() => undefined)}
+            onMarkFileAsRead={mock(() => undefined)}
+            selectedHunkId={hunkV1.id}
+            onSelectHunk={mock(() => undefined)}
+            onExit={mock(() => undefined)}
+            isTouchImmersive={true}
+            reviewsByFilePath={new Map()}
+            firstSeenMap={{}}
+          />
+        </ThemeProvider>
+      );
+    }
+
+    const view = render(<InPlaceEditHarness />);
+
+    const copyButton = view.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy file contents"]'
+    );
+    expect(copyButton).toBeTruthy();
+    fireEvent.click(copyButton!);
+    await waitFor(() => expect(pendingReads).toHaveLength(1));
+
+    // An edit changes the same file's diff content while the read is pending.
+    fireEvent.click(view.getByTestId("edit-file"));
+
+    pendingReads[0]({
+      success: true as const,
+      data: { success: true, output: encodeFileReadOutput("pre-edit contents"), exitCode: 0 },
+    });
+    await act(async () => {
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
+    // The pre-edit payload must not reach the clipboard or report success.
+    expect(clipboardWrites).toHaveLength(0);
+    expect(
+      view.container
+        .querySelector('button[aria-label="Copy file contents"]')
+        ?.getAttribute("data-copy-file-feedback")
+    ).toBeNull();
+  });
+
   test("discards a copy that completes after navigating away and back (ABA)", async () => {
     const fileAHunk = createHunk({ id: "hunk-a", filePath: "src/a.ts" });
     const fileBHunk = createHunk({ id: "hunk-b", filePath: "src/b.ts" });

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.test.tsx
@@ -1112,6 +1112,91 @@ describe("ImmersiveReviewView", () => {
     expect(clipboardWrites).toHaveLength(0);
   });
 
+  test("discards a copy that completes after navigating away and back (ABA)", async () => {
+    const fileAHunk = createHunk({ id: "hunk-a", filePath: "src/a.ts" });
+    const fileBHunk = createHunk({ id: "hunk-b", filePath: "src/b.ts" });
+
+    // Copy reads carry no awk line budget; overlay full-file reads do.
+    const pendingReads: Array<(value: unknown) => void> = [];
+    mockApi.workspace.executeBash = mock((...args: unknown[]) => {
+      const { script } = args[0] as { script: string };
+      if (script.includes("awk 'NR >")) {
+        return Promise.resolve({
+          success: true as const,
+          data: { success: false, output: "", exitCode: 43 },
+        });
+      }
+      return new Promise((resolve) => {
+        pendingReads.push(resolve as (value: unknown) => void);
+      });
+    }) as unknown as MockApiClient["workspace"]["executeBash"];
+
+    function NavigationHarness() {
+      const [selectedHunkId, setSelectedHunkId] = useState<string | null>(fileAHunk.id);
+      return (
+        <ThemeProvider forcedTheme="dark">
+          <ImmersiveReviewView
+            workspaceId="workspace-1"
+            fileTree={createFileTreeForPaths([fileAHunk.filePath, fileBHunk.filePath])}
+            hunks={[fileAHunk, fileBHunk]}
+            allHunks={[fileAHunk, fileBHunk]}
+            isRead={() => false}
+            onToggleRead={mock(() => undefined)}
+            onMarkFileAsRead={mock(() => undefined)}
+            selectedHunkId={selectedHunkId}
+            onSelectHunk={setSelectedHunkId}
+            onExit={mock(() => undefined)}
+            isTouchImmersive={true}
+            reviewsByFilePath={new Map()}
+            firstSeenMap={{}}
+          />
+        </ThemeProvider>
+      );
+    }
+
+    const view = render(<NavigationHarness />);
+
+    const clickCopy = () => {
+      const button = view.container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Copy file contents"]'
+      );
+      expect(button).toBeTruthy();
+      fireEvent.click(button!);
+    };
+    const navigate = (label: "Next file" | "Previous file", expectText: string) => {
+      const button = view.container.querySelector<HTMLButtonElement>(
+        `button[aria-label="${label}"]`
+      );
+      expect(button).toBeTruthy();
+      fireEvent.click(button!);
+      return waitFor(() => expect(view.container.textContent ?? "").toContain(expectText));
+    };
+
+    clickCopy();
+    await waitFor(() => expect(pendingReads).toHaveLength(1));
+
+    // A -> B -> A while the read for A is still pending.
+    await navigate("Next file", "b.ts");
+    await navigate("Previous file", "a.ts");
+
+    // The stale read for A resolves after returning to A: it must be discarded even
+    // though the active path matches again.
+    pendingReads[0]({
+      success: true as const,
+      data: { success: true, output: encodeFileReadOutput("stale A contents"), exitCode: 0 },
+    });
+    await act(async () => {
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+    });
+    expect(clipboardWrites).toHaveLength(0);
+
+    // Navigation freed the pending slot, so a replacement copy of A can start.
+    clickCopy();
+    await waitFor(() => expect(pendingReads).toHaveLength(2));
+  });
+
   test("rejects truncated reads instead of copying a partial file", async () => {
     mockApi.workspace.executeBash = mock(() =>
       Promise.resolve({

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -62,6 +62,8 @@ import { copyToClipboard } from "@/browser/utils/clipboard";
 import {
   buildReadFileScript,
   decodeBase64Utf8,
+  EXIT_CODE_TOO_LARGE,
+  MAX_COPY_FILE_SIZE_BYTES,
   processFileContents,
 } from "@/browser/utils/fileRead";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
@@ -1388,6 +1390,8 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     kind: "copied" | "failed";
     filePath: string;
     contentVersion: string;
+    /** Failure-specific user-facing message; falls back to the generic copy for other failures. */
+    message?: string;
   } | null>(null);
   const copyFileRequestIdRef = useRef(0);
   const pendingCopyFilePathRef = useRef<string | null>(null);
@@ -1425,9 +1429,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const showCopyFileFeedback = (
     kind: "copied" | "failed",
     filePath: string,
-    contentVersion: string
+    contentVersion: string,
+    extra?: { message?: string }
   ) => {
-    setCopyFileFeedback({ kind, filePath, contentVersion });
+    setCopyFileFeedback({ kind, filePath, contentVersion, message: extra?.message });
   };
 
   // Deleted files no longer exist on disk, so a copy read would always fail;
@@ -1466,12 +1471,15 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     try {
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
-        script: buildReadFileScript(
-          filePath,
+        script: buildReadFileScript(filePath, {
+          // The IPC bash channel truncates output beyond 1MiB, so cap copies at what
+          // fits after base64 expansion and fail deterministically with a clear
+          // message instead of surfacing an opaque truncation.
+          maxSizeBytes: MAX_COPY_FILE_SIZE_BYTES,
           // Hunk paths are container-root-relative in multi-project workspaces, where
           // project entries are symlinks that containment must anchor to.
-          props.isMultiProjectWorkspace ? { containmentAnchor: "first-segment" } : {}
-        ),
+          ...(props.isMultiProjectWorkspace ? { containmentAnchor: "first-segment" as const } : {}),
+        }),
         // Multi-project default mode runs from the container root matching those
         // paths; single-project hunk paths are repo-root-relative, where default
         // mode would run from a subproject cwd and miss the file.
@@ -1484,7 +1492,12 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       // like base64 dying after stat) means the output cannot be trusted as the
       // full file; the IPC truncation marker likewise signals a partial payload.
       if (!result.success || !result.data.success || result.data.truncated) {
-        showCopyFileFeedback("failed", filePath, contentVersion);
+        const isTooLarge = result.success && result.data.exitCode === EXIT_CODE_TOO_LARGE;
+        showCopyFileFeedback("failed", filePath, contentVersion, {
+          message: isTooLarge
+            ? `Copy failed: file is larger than ${Math.floor(MAX_COPY_FILE_SIZE_BYTES / 1024)} KB`
+            : undefined,
+        });
         return;
       }
       const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
@@ -2092,7 +2105,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                 activeCopyFileFeedback === "copied" ? (
                   "Copied!"
                 ) : activeCopyFileFeedback === "failed" ? (
-                  "Copy failed: not a copyable text file"
+                  (copyFileFeedback?.message ?? "Copy failed: not a copyable text file")
                 ) : (
                   <span>
                     Copy file{" "}
@@ -2131,7 +2144,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                   {activeCopyFileFeedback === "copied"
                     ? "File copied to clipboard"
                     : activeCopyFileFeedback === "failed"
-                      ? "Copy failed: not a copyable text file"
+                      ? (copyFileFeedback?.message ?? "Copy failed: not a copyable text file")
                       : ""}
                 </span>
               </button>

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -19,6 +19,7 @@ import {
   ThumbsDown,
   ThumbsUp,
   Trash2,
+  TriangleAlert,
 } from "lucide-react";
 import { cn } from "@/common/lib/utils";
 import { SelectableDiffRenderer } from "../../Shared/DiffRenderer";
@@ -57,12 +58,13 @@ import {
 } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
-import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
+import { copyToClipboard } from "@/browser/utils/clipboard";
 import {
   buildReadFileScript,
   decodeBase64Utf8,
   processFileContents,
 } from "@/browser/utils/fileRead";
+import { COPY_FEEDBACK_DURATION_MS } from "@/common/constants/ui";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { getReviewSelectedHunkKey } from "@/common/constants/storage";
 import {
@@ -71,7 +73,7 @@ import {
   type Review,
   type ReviewNoteData,
 } from "@/common/types/review";
-import type { FileTreeNode } from "@/common/utils/git/numstatParser";
+import type { FileStats, FileTreeNode } from "@/common/utils/git/numstatParser";
 import type { ReviewActionCallbacks } from "../../Shared/InlineReviewNote";
 
 interface ImmersiveReviewViewProps {
@@ -230,6 +232,23 @@ export function shouldPreserveImmersiveContextCursor(input: {
     input.cursorLineIndex < input.previousRange.startIndex ||
     input.cursorLineIndex > input.previousRange.endIndex
   );
+}
+
+/** Find the numstat entry for a file leaf; carries change status even for hunk-less files. */
+function findFileTreeStats(node: FileTreeNode | null, filePath: string): FileStats | undefined {
+  if (!node) {
+    return undefined;
+  }
+  if (!node.isDirectory && node.path === filePath) {
+    return node.stats;
+  }
+  for (const child of node.children) {
+    const found = findFileTreeStats(child, filePath);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
 }
 
 /** Resolve the hunk that contains a given overlay line index using the lineHunkIds lookup. */
@@ -1359,18 +1378,48 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     }
   }, [resetViewCursorForHunk]);
 
-  const { copied: copiedFile, copyToClipboard: copyFileToClipboard } = useCopyToClipboard();
-  const [lastCopiedFilePath, setLastCopiedFilePath] = useState<string | null>(null);
+  const [copyFileFeedback, setCopyFileFeedback] = useState<{
+    kind: "copied" | "failed";
+    filePath: string;
+  } | null>(null);
+  const copyFileFeedbackTimeoutRef = useRef<number | null>(null);
   const copyFileRequestIdRef = useRef(0);
   const activeFilePathRef = useRef(activeFilePath);
   activeFilePathRef.current = activeFilePath;
 
+  useEffect(() => {
+    return () => {
+      if (copyFileFeedbackTimeoutRef.current != null) {
+        clearTimeout(copyFileFeedbackTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const showCopyFileFeedback = useCallback((kind: "copied" | "failed", filePath: string) => {
+    if (copyFileFeedbackTimeoutRef.current != null) {
+      clearTimeout(copyFileFeedbackTimeoutRef.current);
+    }
+    setCopyFileFeedback({ kind, filePath });
+    copyFileFeedbackTimeoutRef.current = window.setTimeout(() => {
+      setCopyFileFeedback(null);
+      copyFileFeedbackTimeoutRef.current = null;
+    }, COPY_FEEDBACK_DURATION_MS);
+  }, []);
+
   // Deleted files no longer exist on disk, so a copy read would always fail;
-  // hide the affordance instead of offering a broken action. Derive deletion from
-  // the UNFILTERED hunk set: search/assisted/read filters can empty the visible
-  // hunk list while the active file falls back to a deleted file.
-  const isActiveFileDeleted =
-    activeFilePath != null && getFileHunks(allHunks, activeFilePath)[0]?.changeType === "deleted";
+  // hide the affordance instead of offering a broken action. The file tree keeps
+  // deletion status even when the file contributes no hunks (empty/binary files),
+  // and the UNFILTERED hunk set covers trees without status while search/assisted
+  // filters empty the visible hunk list.
+  const isActiveFileDeleted = useMemo(() => {
+    if (!activeFilePath) {
+      return false;
+    }
+    return (
+      findFileTreeStats(props.fileTree, activeFilePath)?.changeType === "deleted" ||
+      getFileHunks(allHunks, activeFilePath)[0]?.changeType === "deleted"
+    );
+  }, [props.fileTree, allHunks, activeFilePath]);
 
   // Copy the entire on-disk file, not the overlay content: the overlay may hold only
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
@@ -1380,23 +1429,26 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       return;
     }
     const requestId = ++copyFileRequestIdRef.current;
+    // Discard stale completions: the user may have navigated to another file or
+    // started a newer copy while this read was in flight.
+    const isStale = () =>
+      requestId !== copyFileRequestIdRef.current || activeFilePathRef.current !== filePath;
     try {
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
         script: buildReadFileScript(filePath),
       });
-      // Discard stale completions: the user may have navigated to another file or
-      // started a newer copy while this read was in flight.
-      if (requestId !== copyFileRequestIdRef.current || activeFilePathRef.current !== filePath) {
+      if (isStale()) {
         return;
       }
       if (!result.success) {
+        showCopyFileFeedback("failed", filePath);
         return;
       }
       // The IPC bash transport caps output at 1MB; a truncated read would silently
       // copy only the beginning of the file, so reject it outright.
       if (result.data.truncated) {
-        console.error("Cannot copy file contents: file is too large to read in full");
+        showCopyFileFeedback("failed", filePath);
         return;
       }
       const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
@@ -1409,22 +1461,25 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
             ? decodeBase64Utf8(contents.base64)
             : null;
       if (text == null) {
-        console.error(
-          "Cannot copy file contents:",
-          contents.type === "error" ? contents.message : "not a text file"
-        );
+        showCopyFileFeedback("failed", filePath);
         return;
       }
-      await copyFileToClipboard(text);
-      setLastCopiedFilePath(filePath);
+      await copyToClipboard(text);
+      if (!isStale()) {
+        showCopyFileFeedback("copied", filePath);
+      }
     } catch (error) {
       console.error("Failed to copy file contents:", error);
+      if (!isStale()) {
+        showCopyFileFeedback("failed", filePath);
+      }
     }
-  }, [api, activeFilePath, isActiveFileDeleted, props.workspaceId, copyFileToClipboard]);
+  }, [api, activeFilePath, isActiveFileDeleted, props.workspaceId, showCopyFileFeedback]);
 
-  // Only surface copied feedback against the file that was actually copied, so
-  // navigating away within the feedback window cannot show a check on another file.
-  const showCopiedFileFeedback = copiedFile && lastCopiedFilePath === activeFilePath;
+  // Only surface feedback against the file the copy actually targeted, so navigating
+  // away within the feedback window cannot show it against another file.
+  const activeCopyFileFeedback =
+    copyFileFeedback?.filePath === activeFilePath ? copyFileFeedback.kind : null;
 
   const handleLineIndexSelect = useCallback(
     (lineIndex: number, shiftKey: boolean) => {
@@ -1986,8 +2041,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           {!isReviewComplete && activeFilePath && !isActiveFileDeleted && (
             <TooltipIfPresent
               tooltip={
-                showCopiedFileFeedback ? (
+                activeCopyFileFeedback === "copied" ? (
                   "Copied!"
+                ) : activeCopyFileFeedback === "failed" ? (
+                  "Copy failed: not a copyable text file"
                 ) : (
                   <span>
                     Copy file{" "}
@@ -2004,12 +2061,19 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                 onClick={() => void handleCopyFile()}
                 className={cn(
                   "flex shrink-0 cursor-pointer items-center border-none bg-transparent p-0 transition-colors",
-                  showCopiedFileFeedback ? "text-read" : "text-muted hover:text-foreground"
+                  activeCopyFileFeedback === "copied"
+                    ? "text-read"
+                    : activeCopyFileFeedback === "failed"
+                      ? "text-danger-soft"
+                      : "text-muted hover:text-foreground"
                 )}
                 aria-label="Copy file contents"
+                data-copy-file-feedback={activeCopyFileFeedback ?? undefined}
               >
-                {showCopiedFileFeedback ? (
+                {activeCopyFileFeedback === "copied" ? (
                   <Check aria-hidden="true" className="h-3.5 w-3.5" />
+                ) : activeCopyFileFeedback === "failed" ? (
+                  <TriangleAlert aria-hidden="true" className="h-3.5 w-3.5" />
                 ) : (
                   <Copy aria-hidden="true" className="h-3.5 w-3.5" />
                 )}

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1387,6 +1387,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const [copyFileFeedback, setCopyFileFeedback] = useState<{
     kind: "copied" | "failed";
     filePath: string;
+    contentVersion: string;
   } | null>(null);
   const copyFileRequestIdRef = useRef(0);
   const pendingCopyFilePathRef = useRef<string | null>(null);
@@ -1401,23 +1402,32 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     };
   }, []);
 
-  // Every file navigation invalidates in-flight copies and frees the pending slot.
-  // The request-id bump also covers the A -> B -> A case, where the path check alone
-  // would wrongly treat the stale read for A as current again.
+  // File navigation and in-place edits (same path, new diff content) invalidate
+  // in-flight copies and free the pending slot. The request-id bump also covers the
+  // A -> B -> A case, where the path check alone would wrongly treat the stale read
+  // for A as current again.
   useEffect(() => {
     copyFileRequestIdRef.current += 1;
     pendingCopyFilePathRef.current = null;
-  }, [activeFilePath]);
+  }, [activeFilePath, activeFileContentVersion]);
 
-  // Feedback persists until a deterministic event (file navigation or the next copy)
-  // instead of a wall-clock timer, and never shows against a file the copy did not
-  // target. Render-time adjustment per the React docs pattern.
-  if (copyFileFeedback && copyFileFeedback.filePath !== activeFilePath) {
+  // Feedback persists until a deterministic event (file navigation, an in-place edit,
+  // or the next copy) instead of a wall-clock timer, and never shows against content
+  // the copy did not target. Render-time adjustment per the React docs pattern.
+  if (
+    copyFileFeedback &&
+    (copyFileFeedback.filePath !== activeFilePath ||
+      copyFileFeedback.contentVersion !== activeFileContentVersion)
+  ) {
     setCopyFileFeedback(null);
   }
 
-  const showCopyFileFeedback = (kind: "copied" | "failed", filePath: string) => {
-    setCopyFileFeedback({ kind, filePath });
+  const showCopyFileFeedback = (
+    kind: "copied" | "failed",
+    filePath: string,
+    contentVersion: string
+  ) => {
+    setCopyFileFeedback({ kind, filePath, contentVersion });
   };
 
   // Deleted files no longer exist on disk, so a copy read would always fail;
@@ -1434,6 +1444,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
   const handleCopyFile = async () => {
     const filePath = activeFilePath;
+    const contentVersion = activeFileContentVersion;
     if (!api || !filePath || isActiveFileDeleted) {
       return;
     }
@@ -1447,8 +1458,9 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     // Clear the previous result so a slow re-copy cannot keep advertising success
     // for clipboard contents this operation is about to replace.
     setCopyFileFeedback(null);
-    // Discard stale completions: the user may have navigated to another file or
-    // started a newer copy while this read was in flight.
+    // Discard stale completions: the user may have navigated away, an edit may have
+    // changed the file in place (invalidation effect bumps the id), or a newer copy
+    // may have started while this read was in flight.
     const isStale = () =>
       requestId !== copyFileRequestIdRef.current || activeFilePathRef.current !== filePath;
     try {
@@ -1472,7 +1484,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       // like base64 dying after stat) means the output cannot be trusted as the
       // full file; the IPC truncation marker likewise signals a partial payload.
       if (!result.success || !result.data.success || result.data.truncated) {
-        showCopyFileFeedback("failed", filePath);
+        showCopyFileFeedback("failed", filePath, contentVersion);
         return;
       }
       const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
@@ -1485,17 +1497,17 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
             ? decodeBase64Utf8(contents.base64)
             : null;
       if (text == null) {
-        showCopyFileFeedback("failed", filePath);
+        showCopyFileFeedback("failed", filePath, contentVersion);
         return;
       }
       await copyToClipboard(text);
       if (!isStale()) {
-        showCopyFileFeedback("copied", filePath);
+        showCopyFileFeedback("copied", filePath, contentVersion);
       }
     } catch (error) {
       console.error("Failed to copy file contents:", error);
       if (!isStale()) {
-        showCopyFileFeedback("failed", filePath);
+        showCopyFileFeedback("failed", filePath, contentVersion);
       }
     } finally {
       // A superseding request owns the pending slot; only the current one releases it.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -64,7 +64,6 @@ import {
   decodeBase64Utf8,
   processFileContents,
 } from "@/browser/utils/fileRead";
-import { COPY_FEEDBACK_DURATION_MS } from "@/common/constants/ui";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { getReviewSelectedHunkKey } from "@/common/constants/storage";
 import {
@@ -1388,7 +1387,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     kind: "copied" | "failed";
     filePath: string;
   } | null>(null);
-  const copyFileFeedbackTimeoutRef = useRef<number | null>(null);
   const copyFileRequestIdRef = useRef(0);
   const activeFilePathRef = useRef(activeFilePath);
   activeFilePathRef.current = activeFilePath;
@@ -1398,21 +1396,18 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       // Invalidate any in-flight copy so a read that resolves after unmount cannot
       // write to the clipboard (isStale() sees the bumped request id).
       copyFileRequestIdRef.current += 1;
-      if (copyFileFeedbackTimeoutRef.current != null) {
-        clearTimeout(copyFileFeedbackTimeoutRef.current);
-      }
     };
   }, []);
 
+  // Feedback persists until a deterministic event (file navigation or the next copy)
+  // instead of a wall-clock timer, and never shows against a file the copy did not
+  // target. Render-time adjustment per the React docs pattern.
+  if (copyFileFeedback && copyFileFeedback.filePath !== activeFilePath) {
+    setCopyFileFeedback(null);
+  }
+
   const showCopyFileFeedback = (kind: "copied" | "failed", filePath: string) => {
-    if (copyFileFeedbackTimeoutRef.current != null) {
-      clearTimeout(copyFileFeedbackTimeoutRef.current);
-    }
     setCopyFileFeedback({ kind, filePath });
-    copyFileFeedbackTimeoutRef.current = window.setTimeout(() => {
-      setCopyFileFeedback(null);
-      copyFileFeedbackTimeoutRef.current = null;
-    }, COPY_FEEDBACK_DURATION_MS);
   };
 
   // Deleted files no longer exist on disk, so a copy read would always fail;
@@ -1486,10 +1481,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const handleCopyFileRef = useRef(handleCopyFile);
   handleCopyFileRef.current = handleCopyFile;
 
-  // Only surface feedback against the file the copy actually targeted, so navigating
-  // away within the feedback window cannot show it against another file.
-  const activeCopyFileFeedback =
-    copyFileFeedback?.filePath === activeFilePath ? copyFileFeedback.kind : null;
+  const activeCopyFileFeedback = copyFileFeedback?.kind ?? null;
 
   const handleLineIndexSelect = useCallback(
     (lineIndex: number, shiftKey: boolean) => {

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -58,7 +58,11 @@ import {
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
-import { buildReadFileScript, processFileContents } from "@/browser/utils/fileRead";
+import {
+  buildReadFileScript,
+  decodeBase64Utf8,
+  processFileContents,
+} from "@/browser/utils/fileRead";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { getReviewSelectedHunkKey } from "@/common/constants/storage";
 import {
@@ -1362,8 +1366,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   activeFilePathRef.current = activeFilePath;
 
   // Deleted files no longer exist on disk, so a copy read would always fail;
-  // hide the affordance instead of offering a broken action.
-  const isActiveFileDeleted = currentFileHunks[0]?.changeType === "deleted";
+  // hide the affordance instead of offering a broken action. Derive deletion from
+  // the UNFILTERED hunk set: search/assisted/read filters can empty the visible
+  // hunk list while the active file falls back to a deleted file.
+  const isActiveFileDeleted =
+    activeFilePath != null && getFileHunks(allHunks, activeFilePath)[0]?.changeType === "deleted";
 
   // Copy the entire on-disk file, not the overlay content: the overlay may hold only
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
@@ -1393,14 +1400,22 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         return;
       }
       const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
-      if (contents.type !== "text") {
+      // SVGs are classified as images for preview purposes, but they are text
+      // source and this action promises the file's contents; copy the markup.
+      const text =
+        contents.type === "text"
+          ? contents.content
+          : contents.type === "image" && contents.mimeType === "image/svg+xml"
+            ? decodeBase64Utf8(contents.base64)
+            : null;
+      if (text == null) {
         console.error(
           "Cannot copy file contents:",
           contents.type === "error" ? contents.message : "not a text file"
         );
         return;
       }
-      await copyFileToClipboard(contents.content);
+      await copyFileToClipboard(text);
       setLastCopiedFilePath(filePath);
     } catch (error) {
       console.error("Failed to copy file contents:", error);
@@ -1677,7 +1692,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         return;
       }
 
-      // Y: copy the active file's full contents to the clipboard.
+      // Copy the active file's full contents to the clipboard.
       if (matchesKeybind(e, KEYBINDS.REVIEW_COPY_FILE)) {
         e.preventDefault();
         void handleCopyFile();

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -13,6 +13,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Circle,
+  Copy,
   MessageSquare,
   Sparkles,
   ThumbsDown,
@@ -48,6 +49,7 @@ import {
   sortHunksInFileOrder,
 } from "@/browser/utils/review/navigation";
 import {
+  formatKeybind,
   isDialogOpen,
   isEditableElement,
   KEYBINDS,
@@ -55,6 +57,8 @@ import {
 } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { useCopyToClipboard } from "@/browser/hooks/useCopyToClipboard";
+import { buildReadFileScript, processFileContents } from "@/browser/utils/fileRead";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { getReviewSelectedHunkKey } from "@/common/constants/storage";
 import {
@@ -1351,6 +1355,41 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     }
   }, [resetViewCursorForHunk]);
 
+  const { copied: copiedFile, copyToClipboard: copyFileToClipboard } = useCopyToClipboard();
+  const copyFileInFlightRef = useRef(false);
+
+  // Copy the entire on-disk file, not the overlay content: the overlay may hold only
+  // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
+  const handleCopyFile = useCallback(async () => {
+    const filePath = activeFilePath;
+    if (!api || !filePath || copyFileInFlightRef.current) {
+      return;
+    }
+    copyFileInFlightRef.current = true;
+    try {
+      const result = await api.workspace.executeBash({
+        workspaceId: props.workspaceId,
+        script: buildReadFileScript(filePath),
+      });
+      if (!result.success) {
+        return;
+      }
+      const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
+      if (contents.type !== "text") {
+        console.error(
+          "Cannot copy file contents:",
+          contents.type === "error" ? contents.message : "not a text file"
+        );
+        return;
+      }
+      await copyFileToClipboard(contents.content);
+    } catch (error) {
+      console.error("Failed to copy file contents:", error);
+    } finally {
+      copyFileInFlightRef.current = false;
+    }
+  }, [api, activeFilePath, props.workspaceId, copyFileToClipboard]);
+
   const handleLineIndexSelect = useCallback(
     (lineIndex: number, shiftKey: boolean) => {
       const resolvedHunk = findHunkAtLine(lineIndex, overlayData, currentFileHunks);
@@ -1616,6 +1655,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         handleUndoLastRead();
         return;
       }
+
+      // Y: copy the active file's full contents to the clipboard.
+      if (matchesKeybind(e, KEYBINDS.REVIEW_COPY_FILE)) {
+        e.preventDefault();
+        void handleCopyFile();
+        return;
+      }
     };
 
     // Run in capture phase so immersive Escape handling can swallow the event before
@@ -1638,6 +1684,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     handleToggleReadWithUndo,
     handleMarkFileAsRead,
     handleUndoLastRead,
+    handleCopyFile,
     isTouchExperience,
   ]);
 
@@ -1900,6 +1947,39 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           >
             <ChevronRight className="h-4 w-4" />
           </button>
+          {!isReviewComplete && activeFilePath && (
+            <TooltipIfPresent
+              tooltip={
+                copiedFile ? (
+                  "Copied!"
+                ) : (
+                  <span>
+                    Copy file{" "}
+                    <span className="mobile-hide-shortcut-hints">
+                      ({formatKeybind(KEYBINDS.REVIEW_COPY_FILE)})
+                    </span>
+                  </span>
+                )
+              }
+              side="bottom"
+              align="start"
+            >
+              <button
+                onClick={() => void handleCopyFile()}
+                className={cn(
+                  "flex shrink-0 cursor-pointer items-center border-none bg-transparent p-0 transition-colors",
+                  copiedFile ? "text-read" : "text-muted hover:text-foreground"
+                )}
+                aria-label="Copy file contents"
+              >
+                {copiedFile ? (
+                  <Check aria-hidden="true" className="h-3.5 w-3.5" />
+                ) : (
+                  <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </TooltipIfPresent>
+          )}
         </div>
 
         <div className="bg-border-light hidden h-4 w-px shrink-0 sm:block" />

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1389,6 +1389,9 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
   useEffect(() => {
     return () => {
+      // Invalidate any in-flight copy so a read that resolves after unmount cannot
+      // write to the clipboard (isStale() sees the bumped request id).
+      copyFileRequestIdRef.current += 1;
       if (copyFileFeedbackTimeoutRef.current != null) {
         clearTimeout(copyFileFeedbackTimeoutRef.current);
       }
@@ -1411,15 +1414,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   // deletion status even when the file contributes no hunks (empty/binary files),
   // and the UNFILTERED hunk set covers trees without status while search/assisted
   // filters empty the visible hunk list.
-  const isActiveFileDeleted = useMemo(() => {
-    if (!activeFilePath) {
-      return false;
-    }
-    return (
-      findFileTreeStats(props.fileTree, activeFilePath)?.changeType === "deleted" ||
-      getFileHunks(allHunks, activeFilePath)[0]?.changeType === "deleted"
-    );
-  }, [props.fileTree, allHunks, activeFilePath]);
+  const isActiveFileDeleted =
+    activeFilePath != null &&
+    (findFileTreeStats(props.fileTree, activeFilePath)?.changeType === "deleted" ||
+      getFileHunks(allHunks, activeFilePath)[0]?.changeType === "deleted");
 
   // Copy the entire on-disk file, not the overlay content: the overlay may hold only
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1450,7 +1450,15 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   const handleCopyFile = async () => {
     const filePath = activeFilePath;
     const contentVersion = activeFileContentVersion;
-    if (!api || !filePath || isActiveFileDeleted) {
+    if (!filePath || isActiveFileDeleted) {
+      return;
+    }
+    // The API union supplies api: null while connecting/reconnecting/errored; the
+    // already-rendered view keeps its copy affordance, so fail visibly, not silently.
+    if (!api) {
+      showCopyFileFeedback("failed", filePath, contentVersion, {
+        message: "Copy failed: backend connection unavailable",
+      });
       return;
     }
     // Serialize same-file copies so key repeat or double-clicks cannot fan out

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -524,6 +524,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     selectedHunk,
     theme,
     fileContentVersion: activeFileContentVersion,
+    isMultiProjectWorkspace: props.isMultiProjectWorkspace,
     onRevealPending: setHunkJumpScroll,
   });
 
@@ -1388,6 +1389,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     filePath: string;
   } | null>(null);
   const copyFileRequestIdRef = useRef(0);
+  const pendingCopyFilePathRef = useRef<string | null>(null);
   const activeFilePathRef = useRef(activeFilePath);
   activeFilePathRef.current = activeFilePath;
 
@@ -1427,7 +1429,16 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     if (!api || !filePath || isActiveFileDeleted) {
       return;
     }
+    // Serialize same-file copies so key repeat or double-clicks cannot fan out
+    // concurrent reads; navigating to another file still supersedes normally.
+    if (pendingCopyFilePathRef.current === filePath) {
+      return;
+    }
     const requestId = ++copyFileRequestIdRef.current;
+    pendingCopyFilePathRef.current = filePath;
+    // Clear the previous result so a slow re-copy cannot keep advertising success
+    // for clipboard contents this operation is about to replace.
+    setCopyFileFeedback(null);
     // Discard stale completions: the user may have navigated to another file or
     // started a newer copy while this read was in flight.
     const isStale = () =>
@@ -1435,9 +1446,14 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     try {
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
-        script: buildReadFileScript(filePath),
-        // Hunk paths are container-root-relative in multi-project workspaces (default
-        // mode's cwd) but repo-root-relative in single-project ones, where default
+        script: buildReadFileScript(
+          filePath,
+          // Hunk paths are container-root-relative in multi-project workspaces, where
+          // project entries are symlinks that containment must anchor to.
+          props.isMultiProjectWorkspace ? { containmentAnchor: "first-segment" } : {}
+        ),
+        // Multi-project default mode runs from the container root matching those
+        // paths; single-project hunk paths are repo-root-relative, where default
         // mode would run from a subproject cwd and miss the file.
         options: props.isMultiProjectWorkspace ? undefined : { cwdMode: "repo-root" },
       });
@@ -1472,6 +1488,14 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       console.error("Failed to copy file contents:", error);
       if (!isStale()) {
         showCopyFileFeedback("failed", filePath);
+      }
+    } finally {
+      // A superseding request owns the pending slot; only the current one releases it.
+      if (
+        pendingCopyFilePathRef.current === filePath &&
+        copyFileRequestIdRef.current === requestId
+      ) {
+        pendingCopyFilePathRef.current = null;
       }
     }
   };
@@ -1749,10 +1773,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         return;
       }
 
-      // Copy the active file's full contents to the clipboard.
+      // Copy the active file's full contents to the clipboard. Ignore OS key
+      // repeat so holding the key cannot fan out repeated backend reads.
       if (matchesKeybind(e, KEYBINDS.REVIEW_COPY_FILE)) {
         e.preventDefault();
-        void handleCopyFileRef.current();
+        if (!e.repeat) {
+          void handleCopyFileRef.current();
+        }
         return;
       }
     };

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1395,8 +1395,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   } | null>(null);
   const copyFileRequestIdRef = useRef(0);
   const pendingCopyFilePathRef = useRef<string | null>(null);
+  // Both refs update during render so isStale() sees path AND content-version
+  // changes before passive effects run; a resolved read's microtask can otherwise
+  // beat the invalidation effect after a same-path refresh commits.
   const activeFilePathRef = useRef(activeFilePath);
   activeFilePathRef.current = activeFilePath;
+  const activeFileContentVersionRef = useRef(activeFileContentVersion);
+  activeFileContentVersionRef.current = activeFileContentVersion;
 
   useEffect(() => {
     return () => {
@@ -1472,10 +1477,13 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     // for clipboard contents this operation is about to replace.
     setCopyFileFeedback(null);
     // Discard stale completions: the user may have navigated away, an edit may have
-    // changed the file in place (invalidation effect bumps the id), or a newer copy
-    // may have started while this read was in flight.
+    // changed the file in place, or a newer copy may have started while this read
+    // was in flight. Path and content version are read from render-updated refs so
+    // staleness is visible even before the invalidation effect runs.
     const isStale = () =>
-      requestId !== copyFileRequestIdRef.current || activeFilePathRef.current !== filePath;
+      requestId !== copyFileRequestIdRef.current ||
+      activeFilePathRef.current !== filePath ||
+      activeFileContentVersionRef.current !== contentVersion;
     try {
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
@@ -2146,18 +2154,20 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                 ) : (
                   <Copy aria-hidden="true" className="h-3.5 w-3.5" />
                 )}
-                {/* The keyboard shortcut never focuses the button, so announce
-                    copy outcomes through a live region instead of icon swaps. */}
-                <span className="sr-only" role="status">
-                  {activeCopyFileFeedback === "copied"
-                    ? "File copied to clipboard"
-                    : activeCopyFileFeedback === "failed"
-                      ? (copyFileFeedback?.message ?? "Copy failed: not a copyable text file")
-                      : ""}
-                </span>
               </button>
             </TooltipIfPresent>
           )}
+          {/* The keyboard shortcut never focuses the button, so announce copy
+              outcomes through a live region. Rendered as a SIBLING: a button is an
+              accessibility leaf whose aria-label replaces descendant text, so a
+              nested status would not be exposed. */}
+          <span className="sr-only" role="status">
+            {activeCopyFileFeedback === "copied"
+              ? "File copied to clipboard"
+              : activeCopyFileFeedback === "failed"
+                ? (copyFileFeedback?.message ?? "Copy failed: not a copyable text file")
+                : ""}
+          </span>
         </div>
 
         <div className="bg-border-light hidden h-4 w-px shrink-0 sm:block" />

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -122,6 +122,12 @@ interface ImmersiveReviewViewProps {
   assistedCount?: number;
   /** Agent-flagged hunks still unread (mirrors the control bar's count). */
   assistedUnreadCount?: number;
+  /**
+   * Multi-project workspaces reproject hunk paths onto the shared container root,
+   * which is default script mode's cwd; single-project (incl. subproject) workspaces
+   * keep repo-root-relative paths and need repo-root execution for file reads.
+   */
+  isMultiProjectWorkspace?: boolean;
 }
 
 interface InlineComposerRequest {
@@ -1435,17 +1441,18 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
         script: buildReadFileScript(filePath),
+        // Hunk paths are container-root-relative in multi-project workspaces (default
+        // mode's cwd) but repo-root-relative in single-project ones, where default
+        // mode would run from a subproject cwd and miss the file.
+        options: props.isMultiProjectWorkspace ? undefined : { cwdMode: "repo-root" },
       });
       if (isStale()) {
         return;
       }
-      if (!result.success) {
-        showCopyFileFeedback("failed", filePath);
-        return;
-      }
-      // The IPC bash transport caps output at 1MB; a truncated read would silently
-      // copy only the beginning of the file, so reject it outright.
-      if (result.data.truncated) {
+      // Any unsuccessful script exit (budget/containment codes or partial failures
+      // like base64 dying after stat) means the output cannot be trusted as the
+      // full file; the IPC truncation marker likewise signals a partial payload.
+      if (!result.success || !result.data.success || result.data.truncated) {
         showCopyFileFeedback("failed", filePath);
         return;
       }

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1356,22 +1356,40 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
   }, [resetViewCursorForHunk]);
 
   const { copied: copiedFile, copyToClipboard: copyFileToClipboard } = useCopyToClipboard();
-  const copyFileInFlightRef = useRef(false);
+  const [lastCopiedFilePath, setLastCopiedFilePath] = useState<string | null>(null);
+  const copyFileRequestIdRef = useRef(0);
+  const activeFilePathRef = useRef(activeFilePath);
+  activeFilePathRef.current = activeFilePath;
+
+  // Deleted files no longer exist on disk, so a copy read would always fail;
+  // hide the affordance instead of offering a broken action.
+  const isActiveFileDeleted = currentFileHunks[0]?.changeType === "deleted";
 
   // Copy the entire on-disk file, not the overlay content: the overlay may hold only
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
   const handleCopyFile = useCallback(async () => {
     const filePath = activeFilePath;
-    if (!api || !filePath || copyFileInFlightRef.current) {
+    if (!api || !filePath || isActiveFileDeleted) {
       return;
     }
-    copyFileInFlightRef.current = true;
+    const requestId = ++copyFileRequestIdRef.current;
     try {
       const result = await api.workspace.executeBash({
         workspaceId: props.workspaceId,
         script: buildReadFileScript(filePath),
       });
+      // Discard stale completions: the user may have navigated to another file or
+      // started a newer copy while this read was in flight.
+      if (requestId !== copyFileRequestIdRef.current || activeFilePathRef.current !== filePath) {
+        return;
+      }
       if (!result.success) {
+        return;
+      }
+      // The IPC bash transport caps output at 1MB; a truncated read would silently
+      // copy only the beginning of the file, so reject it outright.
+      if (result.data.truncated) {
+        console.error("Cannot copy file contents: file is too large to read in full");
         return;
       }
       const contents = processFileContents(result.data.output ?? "", result.data.exitCode);
@@ -1383,12 +1401,15 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         return;
       }
       await copyFileToClipboard(contents.content);
+      setLastCopiedFilePath(filePath);
     } catch (error) {
       console.error("Failed to copy file contents:", error);
-    } finally {
-      copyFileInFlightRef.current = false;
     }
-  }, [api, activeFilePath, props.workspaceId, copyFileToClipboard]);
+  }, [api, activeFilePath, isActiveFileDeleted, props.workspaceId, copyFileToClipboard]);
+
+  // Only surface copied feedback against the file that was actually copied, so
+  // navigating away within the feedback window cannot show a check on another file.
+  const showCopiedFileFeedback = copiedFile && lastCopiedFilePath === activeFilePath;
 
   const handleLineIndexSelect = useCallback(
     (lineIndex: number, shiftKey: boolean) => {
@@ -1947,10 +1968,10 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
           >
             <ChevronRight className="h-4 w-4" />
           </button>
-          {!isReviewComplete && activeFilePath && (
+          {!isReviewComplete && activeFilePath && !isActiveFileDeleted && (
             <TooltipIfPresent
               tooltip={
-                copiedFile ? (
+                showCopiedFileFeedback ? (
                   "Copied!"
                 ) : (
                   <span>
@@ -1968,11 +1989,11 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                 onClick={() => void handleCopyFile()}
                 className={cn(
                   "flex shrink-0 cursor-pointer items-center border-none bg-transparent p-0 transition-colors",
-                  copiedFile ? "text-read" : "text-muted hover:text-foreground"
+                  showCopiedFileFeedback ? "text-read" : "text-muted hover:text-foreground"
                 )}
                 aria-label="Copy file contents"
               >
-                {copiedFile ? (
+                {showCopiedFileFeedback ? (
                   <Check aria-hidden="true" className="h-3.5 w-3.5" />
                 ) : (
                   <Copy aria-hidden="true" className="h-3.5 w-3.5" />

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1401,6 +1401,14 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     };
   }, []);
 
+  // Every file navigation invalidates in-flight copies and frees the pending slot.
+  // The request-id bump also covers the A -> B -> A case, where the path check alone
+  // would wrongly treat the stale read for A as current again.
+  useEffect(() => {
+    copyFileRequestIdRef.current += 1;
+    pendingCopyFilePathRef.current = null;
+  }, [activeFilePath]);
+
   // Feedback persists until a deterministic event (file navigation or the next copy)
   // instead of a wall-clock timer, and never shows against a file the copy did not
   // target. Render-time adjustment per the React docs pattern.

--- a/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ImmersiveReviewView.tsx
@@ -1398,7 +1398,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     };
   }, []);
 
-  const showCopyFileFeedback = useCallback((kind: "copied" | "failed", filePath: string) => {
+  const showCopyFileFeedback = (kind: "copied" | "failed", filePath: string) => {
     if (copyFileFeedbackTimeoutRef.current != null) {
       clearTimeout(copyFileFeedbackTimeoutRef.current);
     }
@@ -1407,7 +1407,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       setCopyFileFeedback(null);
       copyFileFeedbackTimeoutRef.current = null;
     }, COPY_FEEDBACK_DURATION_MS);
-  }, []);
+  };
 
   // Deleted files no longer exist on disk, so a copy read would always fail;
   // hide the affordance instead of offering a broken action. The file tree keeps
@@ -1421,7 +1421,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
 
   // Copy the entire on-disk file, not the overlay content: the overlay may hold only
   // compact diff hunks (large files) or prefixed diff rows rather than raw file text.
-  const handleCopyFile = useCallback(async () => {
+  const handleCopyFile = async () => {
     const filePath = activeFilePath;
     if (!api || !filePath || isActiveFileDeleted) {
       return;
@@ -1472,7 +1472,12 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
         showCopyFileFeedback("failed", filePath);
       }
     }
-  }, [api, activeFilePath, isActiveFileDeleted, props.workspaceId, showCopyFileFeedback]);
+  };
+
+  // Keyboard handling reads the handler through a ref (matching onToggleReadRef) so the
+  // effect does not depend on a per-render function identity.
+  const handleCopyFileRef = useRef(handleCopyFile);
+  handleCopyFileRef.current = handleCopyFile;
 
   // Only surface feedback against the file the copy actually targeted, so navigating
   // away within the feedback window cannot show it against another file.
@@ -1748,7 +1753,7 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
       // Copy the active file's full contents to the clipboard.
       if (matchesKeybind(e, KEYBINDS.REVIEW_COPY_FILE)) {
         e.preventDefault();
-        void handleCopyFile();
+        void handleCopyFileRef.current();
         return;
       }
     };
@@ -1773,7 +1778,6 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
     handleToggleReadWithUndo,
     handleMarkFileAsRead,
     handleUndoLastRead,
-    handleCopyFile,
     isTouchExperience,
   ]);
 
@@ -2075,6 +2079,15 @@ export const ImmersiveReviewView: React.FC<ImmersiveReviewViewProps> = (props) =
                 ) : (
                   <Copy aria-hidden="true" className="h-3.5 w-3.5" />
                 )}
+                {/* The keyboard shortcut never focuses the button, so announce
+                    copy outcomes through a live region instead of icon swaps. */}
+                <span className="sr-only" role="status">
+                  {activeCopyFileFeedback === "copied"
+                    ? "File copied to clipboard"
+                    : activeCopyFileFeedback === "failed"
+                      ? "Copy failed: not a copyable text file"
+                      : ""}
+                </span>
               </button>
             </TooltipIfPresent>
           )}

--- a/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
+++ b/src/browser/features/RightSidebar/CodeReview/ReviewPanel.tsx
@@ -2659,6 +2659,7 @@ export const ReviewPanel: React.FC<ReviewPanelProps> = ({
               assistedOnly={filters.assistedOnly}
               assistedCount={assistedHunks.length}
               assistedUnreadCount={unreadAssistedInDiff}
+              isMultiProjectWorkspace={(workspaceReviewMetadata?.projects?.length ?? 0) > 1}
             />,
             root
           );

--- a/src/browser/features/RightSidebar/CodeReview/useImmersiveOverlay.ts
+++ b/src/browser/features/RightSidebar/CodeReview/useImmersiveOverlay.ts
@@ -66,6 +66,12 @@ interface UseImmersiveOverlayDataInput {
    * refresh) without busting it when a hunk is merely filtered out by mark-read.
    */
   fileContentVersion: string;
+  /**
+   * Multi-project workspaces read from the shared container root, whose per-project
+   * entries are symlinks; their reads must anchor symlink containment to the resolved
+   * project root instead of the container cwd.
+   */
+  isMultiProjectWorkspace?: boolean;
 }
 
 interface UseImmersiveOverlayInput extends UseImmersiveOverlayDataInput {
@@ -440,6 +446,7 @@ function useImmersiveOverlayData(input: UseImmersiveOverlayDataInput) {
           script: buildReadFileScript(resolvedFilePath, {
             maxSizeBytes: MAX_FULL_FILE_CONTEXT_BYTES,
             maxLineCount: MAX_FULL_FILE_CONTEXT_LINES,
+            containmentAnchor: input.isMultiProjectWorkspace ? "first-segment" : "cwd",
           }),
         })
       );
@@ -510,6 +517,7 @@ function useImmersiveOverlayData(input: UseImmersiveOverlayDataInput) {
     activeFileContentCacheKey,
     input.activeFilePath,
     input.api,
+    input.isMultiProjectWorkspace,
     input.theme,
     input.workspaceId,
     shouldLoadFullFileContext,

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -99,6 +99,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   REVIEW_QUICK_DISLIKE: "Quick dislike (immersive)",
   REVIEW_COMMENT: "Add comment (immersive)",
   REVIEW_FOCUS_NOTES: "Focus notes sidebar (immersive)",
+  REVIEW_COPY_FILE: "Copy file contents (immersive)",
   TOGGLE_PLAN_ANNOTATE: "Toggle plan annotate mode",
   // Image-viewer-scoped keybinds (lightbox / image context menu); intentionally
   // omitted from KEYBIND_GROUPS because they only apply while an image surface
@@ -215,6 +216,7 @@ const KEYBIND_GROUPS: Array<{
       "REVIEW_QUICK_DISLIKE",
       "REVIEW_COMMENT",
       "REVIEW_FOCUS_NOTES",
+      "REVIEW_COPY_FILE",
     ],
   },
   {

--- a/src/browser/utils/executeBash.test.ts
+++ b/src/browser/utils/executeBash.test.ts
@@ -95,4 +95,18 @@ describe("executeBash repo-root helpers", () => {
       "src/example.ts"
     );
   });
+
+  test("preserves edge whitespace in git file paths through reprojection", () => {
+    // A file may literally be named ".env " (trailing space); trimming it here would
+    // point downstream reads (copy, overlay) at a different file such as an ignored
+    // ".env". Single-project reprojection must return the exact path.
+    expect(reprojectRepoRootFilePath(null, ".env ")).toBe(".env ");
+    // Multi-project: the repo-relative remainder keeps its edge whitespace too.
+    expect(reprojectRepoRootFilePath(workspaceMetadata, ".env ", "/tmp/project-b")).toBe(
+      "project-b/.env "
+    );
+    expect(normalizeRepoRootFilePath(workspaceMetadata, "project-b/.env ", "/tmp/project-b")).toBe(
+      ".env "
+    );
+  });
 });

--- a/src/browser/utils/executeBash.ts
+++ b/src/browser/utils/executeBash.ts
@@ -10,6 +10,15 @@ function normalizePath(path: string | null | undefined): string {
   return path?.replaceAll("\\", "/").trim() ?? "";
 }
 
+/**
+ * Git file paths may legitimately begin or end with whitespace (e.g. a file named
+ * ".env "), so file-path normalization must not trim; trimming belongs only to
+ * config-controlled project paths.
+ */
+function normalizeFilePath(path: string | null | undefined): string {
+  return path?.replaceAll("\\", "/") ?? "";
+}
+
 function matchesRepoRootProjectPath(
   projectPath: string | null | undefined,
   normalizedRepoRootProjectPath: string
@@ -26,7 +35,7 @@ function resolveWorkspaceRelativeProjectMatch(
     return undefined;
   }
 
-  const normalizedPath = normalizePath(workspaceRelativePath);
+  const normalizedPath = normalizeFilePath(workspaceRelativePath);
   if (!normalizedPath) {
     return undefined;
   }
@@ -43,10 +52,10 @@ function resolveWorkspaceRelativeProjectMatch(
     return undefined;
   }
 
+  // No trim: the repo-relative remainder is a git file path whose edge whitespace
+  // is significant.
   const repoRelativePath =
-    firstSlashIndex === -1
-      ? undefined
-      : normalizedPath.slice(firstSlashIndex + 1).trim() || undefined;
+    firstSlashIndex === -1 ? undefined : normalizedPath.slice(firstSlashIndex + 1) || undefined;
 
   return {
     normalizedPath,
@@ -94,7 +103,7 @@ export function normalizeRepoRootFilePath(
   const normalizedRepoRootProjectPath = normalizePath(repoRootProjectPath);
   const match = resolveWorkspaceRelativeProjectMatch(workspaceMetadata, workspaceRelativePath);
   if (!normalizedRepoRootProjectPath || !match) {
-    return normalizePath(workspaceRelativePath);
+    return normalizeFilePath(workspaceRelativePath);
   }
 
   return matchesRepoRootProjectPath(match.projectPath, normalizedRepoRootProjectPath)
@@ -112,7 +121,7 @@ export function reprojectRepoRootFilePath(
   repoRelativePath: string | null | undefined,
   repoRootProjectPath?: string | null
 ): string {
-  const normalizedPath = normalizePath(repoRelativePath);
+  const normalizedPath = normalizeFilePath(repoRelativePath);
   const normalizedRepoRootProjectPath = normalizePath(repoRootProjectPath);
   const projectName = resolveProjectNameForRepoRoot(
     workspaceMetadata,

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -1,10 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   buildReadFileScript,
+  EXIT_CODE_OUTSIDE_WORKSPACE,
   EXIT_CODE_TOO_LARGE,
   EXIT_CODE_TOO_MANY_LINES,
   processFileContents,
@@ -33,6 +34,44 @@ describe("buildReadFileScript", () => {
     expect(script).toContain('[ "$size" -gt 1234 ] && exit 42');
     expect(script).toContain("awk 'NR > 99 { exit 43 }' './test.txt'");
     expect(script).toContain('exit "$awk_status"');
+  });
+
+  test("rejects symlinks that resolve outside the workspace", () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "mux-file-read-outside-"));
+    const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));
+
+    try {
+      writeFileSync(join(outsideDir, "secret.txt"), "outside secret\n");
+      symlinkSync(join(outsideDir, "secret.txt"), join(workspaceDir, "escape.txt"));
+
+      const result = spawnSync("bash", ["-lc", buildReadFileScript("escape.txt")], {
+        cwd: workspaceDir,
+      });
+      expect(result.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      expect(result.stdout.toString()).not.toContain("outside secret");
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  test("still reads symlinks that stay inside the workspace", () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));
+
+    try {
+      writeFileSync(join(workspaceDir, "real.txt"), "inside contents\n");
+      symlinkSync(join(workspaceDir, "real.txt"), join(workspaceDir, "link.txt"));
+
+      const result = spawnSync("bash", ["-lc", buildReadFileScript("link.txt")], {
+        cwd: workspaceDir,
+      });
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      // stat sizes the link inode itself (pre-existing quirk), so assert the decoded content.
+      expect(processed).toMatchObject({ type: "text", content: "inside contents\n" });
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
   });
 
   test("reads files whose names look like command options", () => {

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -8,6 +8,7 @@ import {
   EXIT_CODE_OUTSIDE_WORKSPACE,
   EXIT_CODE_TOO_LARGE,
   EXIT_CODE_TOO_MANY_LINES,
+  MAX_COPY_FILE_SIZE_BYTES,
   processFileContents,
 } from "./fileRead";
 
@@ -139,6 +140,38 @@ describe("buildReadFileScript", () => {
       rmSync(containerDir, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });
       rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects files above the copy size budget deterministically", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "big.txt"), "x".repeat(MAX_COPY_FILE_SIZE_BYTES + 1));
+      const result = spawnSync(
+        "bash",
+        ["-lc", buildReadFileScript("big.txt", { maxSizeBytes: MAX_COPY_FILE_SIZE_BYTES })],
+        { cwd: tempDir }
+      );
+      // The whole point of the copy budget: a deterministic too-large exit with no
+      // payload, never a truncated stream.
+      expect(result.status).toBe(EXIT_CODE_TOO_LARGE);
+      expect(result.stdout.toString()).toBe("");
+
+      writeFileSync(join(tempDir, "small.txt"), "fits\n");
+      const okResult = spawnSync(
+        "bash",
+        ["-lc", buildReadFileScript("small.txt", { maxSizeBytes: MAX_COPY_FILE_SIZE_BYTES })],
+        { cwd: tempDir }
+      );
+      expect(okResult.status).toBe(0);
+      expect(processFileContents(okResult.stdout.toString(), okResult.status ?? 0)).toEqual({
+        type: "text",
+        content: "fits\n",
+        size: 5,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -14,8 +14,9 @@ import {
 describe("buildReadFileScript", () => {
   test("generates script with size check", () => {
     const script = buildReadFileScript("test.txt");
-    expect(script).toContain("stat -c %s './test.txt'");
-    expect(script).toContain("base64 < './test.txt'");
+    expect(script).toContain("realpath './test.txt'");
+    expect(script).toContain('stat -c %s "$resolved"');
+    expect(script).toContain('base64 < "$resolved"');
   });
 
   test("escapes paths with spaces", () => {
@@ -32,7 +33,7 @@ describe("buildReadFileScript", () => {
     const script = buildReadFileScript("test.txt", { maxSizeBytes: 1234, maxLineCount: 99 });
 
     expect(script).toContain('[ "$size" -gt 1234 ] && exit 42');
-    expect(script).toContain("awk 'NR > 99 { exit 43 }' './test.txt'");
+    expect(script).toContain("awk 'NR > 99 { exit 43 }' \"$resolved\"");
     expect(script).toContain('exit "$awk_status"');
   });
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -175,6 +175,65 @@ describe("buildReadFileScript", () => {
     }
   });
 
+  test("parses the payload despite prelude output before the script", () => {
+    // The bash IPC sources .mux/tool_env with output merged into the stream, so any
+    // prelude echo must not corrupt the size/base64 framing.
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "file.txt"), "framed contents\n");
+      const result = spawnSync(
+        "bash",
+        ["-lc", `echo ready; echo warming up; ${buildReadFileScript("file.txt")}`],
+        { cwd: tempDir }
+      );
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      expect(processed).toMatchObject({ type: "text", content: "framed contents\n" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves paths without realpath or readlink -f (BSD/macOS fallback)", () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "mux-file-read-outside-"));
+    const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));
+
+    try {
+      writeFileSync(join(workspaceDir, "real.txt"), "portable contents\n");
+      symlinkSync(join(workspaceDir, "real.txt"), join(workspaceDir, "link.txt"));
+      writeFileSync(join(outsideDir, "secret.txt"), "outside secret\n");
+      symlinkSync(join(outsideDir, "secret.txt"), join(workspaceDir, "escape.txt"));
+
+      // Shadow realpath entirely and reject readlink -f (plain readlink still works),
+      // modeling hosts that ship neither GNU tool.
+      const shims =
+        "realpath() { return 127; }; " +
+        'readlink() { if [ "$1" = "-f" ]; then return 127; fi; command readlink "$@"; }; ';
+
+      const okResult = spawnSync("bash", ["-lc", `${shims}${buildReadFileScript("link.txt")}`], {
+        cwd: workspaceDir,
+      });
+      expect(okResult.status).toBe(0);
+      expect(processFileContents(okResult.stdout.toString(), okResult.status ?? 0)).toMatchObject({
+        type: "text",
+        content: "portable contents\n",
+      });
+
+      // Containment still holds under the fallback resolver.
+      const escapeResult = spawnSync(
+        "bash",
+        ["-lc", `${shims}${buildReadFileScript("escape.txt")}`],
+        { cwd: workspaceDir }
+      );
+      expect(escapeResult.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      expect(escapeResult.stdout.toString()).not.toContain("outside secret");
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   test("reads files whose names look like command options", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -195,6 +195,26 @@ describe("buildReadFileScript", () => {
     }
   });
 
+  test("parses the payload despite persistent shell tracing from tool_env", () => {
+    // A tool_env can leave `set -x` (or -v) enabled; the IPC merges stderr into the
+    // output, so trace lines must not interleave with the framed payload.
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "file.txt"), "traced contents\n");
+      const result = spawnSync(
+        "bash",
+        ["-lc", `set -xv; echo prelude; ${buildReadFileScript("file.txt")} 2>&1`],
+        { cwd: tempDir }
+      );
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      expect(processed).toMatchObject({ type: "text", content: "traced contents\n" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("resolves paths without realpath or readlink -f (BSD/macOS fallback)", () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "mux-file-read-outside-"));
     const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -1,10 +1,11 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   buildReadFileScript,
+  EXIT_CODE_IS_SYMLINK,
   EXIT_CODE_OUTSIDE_WORKSPACE,
   EXIT_CODE_TOO_LARGE,
   EXIT_CODE_TOO_MANY_LINES,
@@ -56,7 +57,8 @@ describe("buildReadFileScript", () => {
       const result = spawnSync("bash", ["-lc", buildReadFileScript("escape.txt")], {
         cwd: workspaceDir,
       });
-      expect(result.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      // The final-component symlink check fires before containment resolution.
+      expect(result.status).toBe(EXIT_CODE_IS_SYMLINK);
       expect(result.stdout.toString()).not.toContain("outside secret");
     } finally {
       rmSync(outsideDir, { recursive: true, force: true });
@@ -64,7 +66,10 @@ describe("buildReadFileScript", () => {
     }
   });
 
-  test("still reads symlinks that stay inside the workspace", () => {
+  test("rejects symlinks even when their target stays inside the workspace", () => {
+    // A repo-controlled symlink to an in-repo ignored secret passes containment, and
+    // git renders a symlink as its target STRING, so following it would copy content
+    // the review never displayed. The final path component must not be a link.
     const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));
 
     try {
@@ -74,10 +79,21 @@ describe("buildReadFileScript", () => {
       const result = spawnSync("bash", ["-lc", buildReadFileScript("link.txt")], {
         cwd: workspaceDir,
       });
-      expect(result.status).toBe(0);
-      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
-      // stat sizes the link inode itself (pre-existing quirk), so assert the decoded content.
-      expect(processed).toMatchObject({ type: "text", content: "inside contents\n" });
+      expect(result.status).toBe(EXIT_CODE_IS_SYMLINK);
+      expect(result.stdout.toString()).not.toContain("inside contents");
+
+      // Directory symlinks along the path (e.g. multi-project container entries)
+      // remain readable; only a link at the final component is rejected.
+      mkdirSync(join(workspaceDir, "realdir"));
+      writeFileSync(join(workspaceDir, "realdir", "file.txt"), "dir contents\n");
+      symlinkSync(join(workspaceDir, "realdir"), join(workspaceDir, "dirlink"));
+      const throughDir = spawnSync("bash", ["-lc", buildReadFileScript("dirlink/file.txt")], {
+        cwd: workspaceDir,
+      });
+      expect(throughDir.status).toBe(0);
+      expect(
+        processFileContents(throughDir.stdout.toString(), throughDir.status ?? 0)
+      ).toMatchObject({ type: "text", content: "dir contents\n" });
     } finally {
       rmSync(workspaceDir, { recursive: true, force: true });
     }
@@ -134,7 +150,8 @@ describe("buildReadFileScript", () => {
         ],
         { cwd: containerDir }
       );
-      expect(result.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      // The final-component symlink check fires before containment resolution.
+      expect(result.status).toBe(EXIT_CODE_IS_SYMLINK);
       expect(result.stdout.toString()).not.toContain("outside secret");
     } finally {
       rmSync(containerDir, { recursive: true, force: true });
@@ -231,7 +248,7 @@ describe("buildReadFileScript", () => {
         "realpath() { return 127; }; " +
         'readlink() { if [ "$1" = "-f" ]; then return 127; fi; command readlink "$@"; }; ';
 
-      const okResult = spawnSync("bash", ["-lc", `${shims}${buildReadFileScript("link.txt")}`], {
+      const okResult = spawnSync("bash", ["-lc", `${shims}${buildReadFileScript("real.txt")}`], {
         cwd: workspaceDir,
       });
       expect(okResult.status).toBe(0);
@@ -246,7 +263,8 @@ describe("buildReadFileScript", () => {
         ["-lc", `${shims}${buildReadFileScript("escape.txt")}`],
         { cwd: workspaceDir }
       );
-      expect(escapeResult.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      // The final-component symlink check fires before containment resolution.
+      expect(escapeResult.status).toBe(EXIT_CODE_IS_SYMLINK);
       expect(escapeResult.stdout.toString()).not.toContain("outside secret");
     } finally {
       rmSync(workspaceDir, { recursive: true, force: true });

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -232,6 +232,26 @@ describe("buildReadFileScript", () => {
     }
   });
 
+  test("parses the payload despite a persistent DEBUG trap from tool_env", () => {
+    // A tool_env can install a DEBUG trap that keeps emitting after xtrace is off;
+    // it must be cleared before the framed payload.
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "file.txt"), "trapped contents\n");
+      const result = spawnSync(
+        "bash",
+        ["-lc", `trap 'echo diagnostic' DEBUG; ${buildReadFileScript("file.txt")} 2>&1`],
+        { cwd: tempDir }
+      );
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      expect(processed).toMatchObject({ type: "text", content: "trapped contents\n" });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("resolves paths without realpath or readlink -f (BSD/macOS fallback)", () => {
     const outsideDir = mkdtempSync(join(tmpdir(), "mux-file-read-outside-"));
     const workspaceDir = mkdtempSync(join(tmpdir(), "mux-file-read-ws-"));

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -75,6 +75,66 @@ describe("buildReadFileScript", () => {
     }
   });
 
+  test("first-segment anchor reads through xum-managed project symlinks", () => {
+    // Multi-project containers expose each project as a symlink to a checkout
+    // outside the container, so cwd containment would reject every project read.
+    const projectDir = mkdtempSync(join(tmpdir(), "mux-file-read-project-"));
+    const containerDir = mkdtempSync(join(tmpdir(), "mux-file-read-container-"));
+
+    try {
+      writeFileSync(join(projectDir, "file.txt"), "project contents\n");
+      symlinkSync(projectDir, join(containerDir, "project-a"));
+
+      const cwdAnchored = spawnSync("bash", ["-lc", buildReadFileScript("project-a/file.txt")], {
+        cwd: containerDir,
+      });
+      expect(cwdAnchored.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+
+      const projectAnchored = spawnSync(
+        "bash",
+        ["-lc", buildReadFileScript("project-a/file.txt", { containmentAnchor: "first-segment" })],
+        { cwd: containerDir }
+      );
+      expect(projectAnchored.status).toBe(0);
+      const processed = processFileContents(
+        projectAnchored.stdout.toString(),
+        projectAnchored.status ?? 0
+      );
+      expect(processed).toMatchObject({ type: "text", content: "project contents\n" });
+    } finally {
+      rmSync(containerDir, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test("first-segment anchor still rejects repo symlinks escaping the project", () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "mux-file-read-project-"));
+    const containerDir = mkdtempSync(join(tmpdir(), "mux-file-read-container-"));
+    const outsideDir = mkdtempSync(join(tmpdir(), "mux-file-read-outside-"));
+
+    try {
+      writeFileSync(join(outsideDir, "secret.txt"), "outside secret\n");
+      // Attacker-controlled symlink INSIDE the project escaping past the project root.
+      symlinkSync(join(outsideDir, "secret.txt"), join(projectDir, "escape.txt"));
+      symlinkSync(projectDir, join(containerDir, "project-a"));
+
+      const result = spawnSync(
+        "bash",
+        [
+          "-lc",
+          buildReadFileScript("project-a/escape.txt", { containmentAnchor: "first-segment" }),
+        ],
+        { cwd: containerDir }
+      );
+      expect(result.status).toBe(EXIT_CODE_OUTSIDE_WORKSPACE);
+      expect(result.stdout.toString()).not.toContain("outside secret");
+    } finally {
+      rmSync(containerDir, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   test("reads files whose names look like command options", () => {
     const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
 

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -13,26 +13,44 @@ import {
 describe("buildReadFileScript", () => {
   test("generates script with size check", () => {
     const script = buildReadFileScript("test.txt");
-    expect(script).toContain("stat -c %s 'test.txt'");
-    expect(script).toContain("base64 < 'test.txt'");
+    expect(script).toContain("stat -c %s './test.txt'");
+    expect(script).toContain("base64 < './test.txt'");
   });
 
   test("escapes paths with spaces", () => {
     const script = buildReadFileScript("path/to/my file.txt");
-    expect(script).toContain("'path/to/my file.txt'");
+    expect(script).toContain("'./path/to/my file.txt'");
   });
 
   test("escapes single quotes", () => {
     const script = buildReadFileScript("file'with'quotes.txt");
-    expect(script).toContain("'file'\"'\"'with'\"'\"'quotes.txt'");
+    expect(script).toContain("'./file'\"'\"'with'\"'\"'quotes.txt'");
   });
 
   test("supports smaller caller-specific size and line budgets", () => {
     const script = buildReadFileScript("test.txt", { maxSizeBytes: 1234, maxLineCount: 99 });
 
     expect(script).toContain('[ "$size" -gt 1234 ] && exit 42');
-    expect(script).toContain("awk 'NR > 99 { exit 43 }' 'test.txt'");
+    expect(script).toContain("awk 'NR > 99 { exit 43 }' './test.txt'");
     expect(script).toContain('exit "$awk_status"');
+  });
+
+  test("reads files whose names look like command options", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "-n"), "dash file contents\n");
+      const result = spawnSync("bash", ["-lc", buildReadFileScript("-n")], { cwd: tempDir });
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      expect(processed).toEqual({
+        type: "text",
+        content: "dash file contents\n",
+        size: 19,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("preserves non-budget awk failures while keeping line-budget exits", () => {

--- a/src/browser/utils/fileRead.test.ts
+++ b/src/browser/utils/fileRead.test.ts
@@ -12,11 +12,18 @@ import {
 } from "./fileRead";
 
 describe("buildReadFileScript", () => {
-  test("generates script with size check", () => {
-    const script = buildReadFileScript("test.txt");
-    expect(script).toContain("realpath './test.txt'");
-    expect(script).toContain('stat -c %s "$resolved"');
-    expect(script).toContain('base64 < "$resolved"');
+  test("reads a plain file end to end", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "mux-file-read-"));
+
+    try {
+      writeFileSync(join(tempDir, "test.txt"), "plain contents\n");
+      const result = spawnSync("bash", ["-lc", buildReadFileScript("test.txt")], { cwd: tempDir });
+      expect(result.status).toBe(0);
+      const processed = processFileContents(result.stdout.toString(), result.status ?? 0);
+      expect(processed).toEqual({ type: "text", content: "plain contents\n", size: 15 });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   test("escapes paths with spaces", () => {

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -183,7 +183,9 @@ awk_status=$?
   // POSIX loop (cd -P + plain readlink) for BSD/macOS hosts that lack both.
   //
   // The sentinel line frames the payload: the bash IPC sources .mux/tool_env with
-  // output merged into the stream, so parsing must skip any prelude output.
+  // output (stdout AND stderr) merged into the stream, so parsing must skip any
+  // prelude output, and xtrace/verbose diagnostics a tool_env may leave enabled are
+  // silenced before the payload so trace lines cannot interleave with it.
   return `mux_resolve_physical() {
   realpath "$1" 2>/dev/null && return 0
   readlink -f "$1" 2>/dev/null && return 0
@@ -215,6 +217,7 @@ case "$resolved" in
 esac
 size=$(stat -c %s "$resolved" 2>/dev/null || stat -f %z "$resolved")
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
+{ set +x +v; } 2>/dev/null
 echo "${FILE_READ_SENTINEL}"
 echo "$size"
 base64 < "$resolved"`;

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -31,6 +31,11 @@ function shellEscape(s: string): string {
   return "'" + s.replaceAll("'", "'\"'\"'") + "'";
 }
 
+/** Decode a base64 payload (e.g. an SVG classified as an image) back to UTF-8 text. */
+export function decodeBase64Utf8(base64: string): string {
+  return new TextDecoder("utf-8", { fatal: false }).decode(base64ToUint8Array(base64));
+}
+
 /** Decode a base64 string to bytes. */
 function base64ToUint8Array(base64: string): Uint8Array {
   const binaryString = atob(base64);

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -21,6 +21,13 @@ export const EXIT_CODE_OUTSIDE_WORKSPACE = 44;
  */
 export const MAX_COPY_FILE_SIZE_BYTES = 750 * 1024;
 
+/**
+ * Marks where the read script's own payload begins. The bash IPC sources
+ * `.mux/tool_env` with its output merged into the stream, so any prelude output
+ * would otherwise corrupt the size/base64 framing.
+ */
+const FILE_READ_SENTINEL = "__MUX_FILE_CONTENTS_V1__";
+
 interface ReadFileScriptOptions {
   maxSizeBytes?: number;
   maxLineCount?: number;
@@ -162,7 +169,7 @@ awk_status=$?
     relativePath.includes("/") &&
     firstSegment.length > 0;
   const anchorScript = useFirstSegmentAnchor
-    ? `anchor=$(realpath ${shellEscapePath(firstSegment)} 2>/dev/null || readlink -f ${shellEscapePath(firstSegment)} 2>/dev/null)`
+    ? `anchor=$(mux_resolve_physical ${shellEscapePath(firstSegment)})`
     : `anchor=$(pwd -P)`;
 
   // SECURITY AUDIT: repo-controlled paths are attacker-controlled input. A changed
@@ -171,21 +178,59 @@ awk_status=$?
   // it. Fail closed: an unresolvable path or anchor (loop, missing resolver) also
   // exits. All reads then use the validated physical path, not the original link, so
   // swapping the symlink between validation and read cannot redirect the read.
-  return `${anchorScript}
+  //
+  // mux_resolve_physical prefers realpath/readlink -f but falls back to a portable
+  // POSIX loop (cd -P + plain readlink) for BSD/macOS hosts that lack both.
+  //
+  // The sentinel line frames the payload: the bash IPC sources .mux/tool_env with
+  // output merged into the stream, so parsing must skip any prelude output.
+  return `mux_resolve_physical() {
+  realpath "$1" 2>/dev/null && return 0
+  readlink -f "$1" 2>/dev/null && return 0
+  mux_rp_path=$1
+  mux_rp_hops=0
+  while [ "$mux_rp_hops" -lt 40 ]; do
+    mux_rp_dir=$(CDPATH= cd -P -- "$(dirname -- "$mux_rp_path")" 2>/dev/null && pwd -P) || return 1
+    mux_rp_base=$(basename -- "$mux_rp_path")
+    if [ -h "$mux_rp_dir/$mux_rp_base" ]; then
+      mux_rp_target=$(readlink -- "$mux_rp_dir/$mux_rp_base" 2>/dev/null) || return 1
+      case "$mux_rp_target" in
+        /*) mux_rp_path=$mux_rp_target ;;
+        *) mux_rp_path="$mux_rp_dir/$mux_rp_target" ;;
+      esac
+      mux_rp_hops=$((mux_rp_hops + 1))
+    else
+      printf '%s\\n' "$mux_rp_dir/$mux_rp_base"
+      return 0
+    fi
+  done
+  return 1
+}
+${anchorScript}
 [ -n "$anchor" ] || exit ${EXIT_CODE_OUTSIDE_WORKSPACE}
-resolved=$(realpath ${file} 2>/dev/null || readlink -f ${file} 2>/dev/null)
+resolved=$(mux_resolve_physical ${file})
 case "$resolved" in
   "$anchor"/*) ;;
   *) exit ${EXIT_CODE_OUTSIDE_WORKSPACE} ;;
 esac
 size=$(stat -c %s "$resolved" 2>/dev/null || stat -f %z "$resolved")
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
+echo "${FILE_READ_SENTINEL}"
 echo "$size"
 base64 < "$resolved"`;
 }
 
 /** Parse the read file script output (size on first line, base64 on remaining lines). */
-function parseReadFileOutput(output: string): { size: number; base64: string } {
+function parseReadFileOutput(rawOutput: string): { size: number; base64: string } {
+  // Skip any prelude output (e.g. from sourcing .mux/tool_env) that precedes the
+  // sentinel. Use the LAST occurrence so prelude output echoing the sentinel string
+  // cannot truncate the real payload. Sentinel-less output (older callers, tests)
+  // parses as before.
+  let output = rawOutput;
+  const sentinelIndex = rawOutput.lastIndexOf(FILE_READ_SENTINEL);
+  if (sentinelIndex !== -1) {
+    output = rawOutput.slice(sentinelIndex + FILE_READ_SENTINEL.length).replace(/^\r?\n/, "");
+  }
   const firstNewline = output.indexOf("\n");
 
   if (firstNewline === -1) {

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -133,24 +133,26 @@ export function buildReadFileScript(
     maxLineCount == null
       ? ""
       : `
-awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' ${file}
+awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' "$resolved"
 awk_status=$?
 [ "$awk_status" -ne 0 ] && exit "$awk_status"`;
 
   // SECURITY AUDIT: repo-controlled paths are attacker-controlled input. A changed
   // symlink pointing outside the workspace must not let the UI read (and copy) files
   // beyond the execution root, so reject paths whose physical resolution escapes it.
-  // Fail closed: an unresolvable path (loop, missing resolver) also exits.
+  // Fail closed: an unresolvable path (loop, missing resolver) also exits. All reads
+  // then use the validated physical path, not the original link, so swapping the
+  // symlink between validation and read cannot redirect the read outside the root.
   return `root=$(pwd -P)
 resolved=$(realpath ${file} 2>/dev/null || readlink -f ${file} 2>/dev/null)
 case "$resolved" in
   "$root"/*) ;;
   *) exit ${EXIT_CODE_OUTSIDE_WORKSPACE} ;;
 esac
-size=$(stat -c %s ${file} 2>/dev/null || stat -f %z ${file})
+size=$(stat -c %s "$resolved" 2>/dev/null || stat -f %z "$resolved")
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
 echo "$size"
-base64 < ${file}`;
+base64 < "$resolved"`;
 }
 
 /** Parse the read file script output (size on first line, base64 on remaining lines). */

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -14,6 +14,9 @@ export const EXIT_CODE_TOO_MANY_LINES = 43;
 /** Exit code for "path resolves outside the workspace" (e.g. a symlink escape). */
 export const EXIT_CODE_OUTSIDE_WORKSPACE = 44;
 
+/** Exit code for "path itself is a symlink". */
+export const EXIT_CODE_IS_SYMLINK = 45;
+
 /**
  * Size budget for whole-file clipboard copies. The IPC bash channel caps total
  * output at 1MiB (BASH_TRUNCATE_MAX_TOTAL_BYTES) and base64 expands by 4/3, so
@@ -210,6 +213,7 @@ awk_status=$?
 }
 ${anchorScript}
 [ -n "$anchor" ] || exit ${EXIT_CODE_OUTSIDE_WORKSPACE}
+[ -h ${file} ] && exit ${EXIT_CODE_IS_SYMLINK}
 resolved=$(mux_resolve_physical ${file})
 case "$resolved" in
   "$anchor"/*) ;;
@@ -270,6 +274,10 @@ export function processFileContents(output: string, exitCode: number): FileConte
 
   if (exitCode === EXIT_CODE_OUTSIDE_WORKSPACE) {
     return { type: "error", message: "File resolves outside the workspace." };
+  }
+
+  if (exitCode === EXIT_CODE_IS_SYMLINK) {
+    return { type: "error", message: "File is a symbolic link." };
   }
 
   const { size, base64 } = parseReadFileOutput(output);

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -187,8 +187,9 @@ awk_status=$?
   //
   // The sentinel line frames the payload: the bash IPC sources .mux/tool_env with
   // output (stdout AND stderr) merged into the stream, so parsing must skip any
-  // prelude output, and xtrace/verbose diagnostics a tool_env may leave enabled are
-  // silenced before the payload so trace lines cannot interleave with it.
+  // prelude output, and persistent diagnostics a tool_env may leave enabled
+  // (xtrace/verbose, DEBUG traps) are cleared before the payload so their output
+  // cannot interleave with it.
   return `mux_resolve_physical() {
   realpath "$1" 2>/dev/null && return 0
   readlink -f "$1" 2>/dev/null && return 0
@@ -221,7 +222,7 @@ case "$resolved" in
 esac
 size=$(stat -c %s "$resolved" 2>/dev/null || stat -f %z "$resolved")
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
-{ set +x +v; } 2>/dev/null
+{ trap - DEBUG; set +x +v; } 2>/dev/null
 echo "${FILE_READ_SENTINEL}"
 echo "$size"
 base64 < "$resolved"`;

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -31,6 +31,14 @@ function shellEscape(s: string): string {
   return "'" + s.replaceAll("'", "'\"'\"'") + "'";
 }
 
+/**
+ * Quoting does not stop `stat`/`awk` from parsing a leading `-` as an option
+ * (e.g. a root-level file named `-n`), so anchor relative paths with `./`.
+ */
+function shellEscapePath(relativePath: string): string {
+  return shellEscape(relativePath.startsWith("/") ? relativePath : `./${relativePath}`);
+}
+
 /** Decode a base64 payload (e.g. an SVG classified as an image) back to UTF-8 text. */
 export function decodeBase64Utf8(base64: string): string {
   return new TextDecoder("utf-8", { fatal: false }).decode(base64ToUint8Array(base64));
@@ -114,7 +122,7 @@ export function buildReadFileScript(
   relativePath: string,
   options: ReadFileScriptOptions = {}
 ): string {
-  const file = shellEscape(relativePath);
+  const file = shellEscapePath(relativePath);
   const maxSizeBytes = Math.max(0, Math.trunc(options.maxSizeBytes ?? MAX_FILE_SIZE));
   const maxLineCount =
     options.maxLineCount == null ? null : Math.max(0, Math.trunc(options.maxLineCount));

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -14,6 +14,13 @@ export const EXIT_CODE_TOO_MANY_LINES = 43;
 /** Exit code for "path resolves outside the workspace" (e.g. a symlink escape). */
 export const EXIT_CODE_OUTSIDE_WORKSPACE = 44;
 
+/**
+ * Size budget for whole-file clipboard copies. The IPC bash channel caps total
+ * output at 1MiB (BASH_TRUNCATE_MAX_TOTAL_BYTES) and base64 expands by 4/3, so
+ * reads beyond ~768KB would arrive truncated; fail deterministically instead.
+ */
+export const MAX_COPY_FILE_SIZE_BYTES = 750 * 1024;
+
 interface ReadFileScriptOptions {
   maxSizeBytes?: number;
   maxLineCount?: number;

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -17,6 +17,15 @@ export const EXIT_CODE_OUTSIDE_WORKSPACE = 44;
 interface ReadFileScriptOptions {
   maxSizeBytes?: number;
   maxLineCount?: number;
+  /**
+   * Containment anchor for the symlink-escape check. "cwd" (default) requires the
+   * resolved path to stay under the execution root. Multi-project workspaces run
+   * from a shared container whose per-project entries are xum-managed symlinks to
+   * checkouts OUTSIDE the container, so they anchor containment to the resolved
+   * first path segment (the project root) instead. Repo-controlled symlinks deeper
+   * in the path still cannot escape that anchor.
+   */
+  containmentAnchor?: "cwd" | "first-segment";
 }
 
 /** Magic bytes for image type detection. */
@@ -137,16 +146,29 @@ awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' "$resolved"
 awk_status=$?
 [ "$awk_status" -ne 0 ] && exit "$awk_status"`;
 
+  // A first-segment anchor only makes sense for project-prefixed paths; bare
+  // container-root paths fall back to cwd containment (fail closed).
+  const firstSegment = relativePath.split("/")[0];
+  const useFirstSegmentAnchor =
+    options.containmentAnchor === "first-segment" &&
+    !relativePath.startsWith("/") &&
+    relativePath.includes("/") &&
+    firstSegment.length > 0;
+  const anchorScript = useFirstSegmentAnchor
+    ? `anchor=$(realpath ${shellEscapePath(firstSegment)} 2>/dev/null || readlink -f ${shellEscapePath(firstSegment)} 2>/dev/null)`
+    : `anchor=$(pwd -P)`;
+
   // SECURITY AUDIT: repo-controlled paths are attacker-controlled input. A changed
   // symlink pointing outside the workspace must not let the UI read (and copy) files
-  // beyond the execution root, so reject paths whose physical resolution escapes it.
-  // Fail closed: an unresolvable path (loop, missing resolver) also exits. All reads
-  // then use the validated physical path, not the original link, so swapping the
-  // symlink between validation and read cannot redirect the read outside the root.
-  return `root=$(pwd -P)
+  // beyond the containment anchor, so reject paths whose physical resolution escapes
+  // it. Fail closed: an unresolvable path or anchor (loop, missing resolver) also
+  // exits. All reads then use the validated physical path, not the original link, so
+  // swapping the symlink between validation and read cannot redirect the read.
+  return `${anchorScript}
+[ -n "$anchor" ] || exit ${EXIT_CODE_OUTSIDE_WORKSPACE}
 resolved=$(realpath ${file} 2>/dev/null || readlink -f ${file} 2>/dev/null)
 case "$resolved" in
-  "$root"/*) ;;
+  "$anchor"/*) ;;
   *) exit ${EXIT_CODE_OUTSIDE_WORKSPACE} ;;
 esac
 size=$(stat -c %s "$resolved" 2>/dev/null || stat -f %z "$resolved")

--- a/src/browser/utils/fileRead.ts
+++ b/src/browser/utils/fileRead.ts
@@ -11,6 +11,9 @@ export const EXIT_CODE_TOO_LARGE = 42;
 /** Exit code for "file has too many lines for the current UI budget". */
 export const EXIT_CODE_TOO_MANY_LINES = 43;
 
+/** Exit code for "path resolves outside the workspace" (e.g. a symlink escape). */
+export const EXIT_CODE_OUTSIDE_WORKSPACE = 44;
+
 interface ReadFileScriptOptions {
   maxSizeBytes?: number;
   maxLineCount?: number;
@@ -134,7 +137,17 @@ awk 'NR > ${maxLineCount} { exit ${EXIT_CODE_TOO_MANY_LINES} }' ${file}
 awk_status=$?
 [ "$awk_status" -ne 0 ] && exit "$awk_status"`;
 
-  return `size=$(stat -c %s ${file} 2>/dev/null || stat -f %z ${file})
+  // SECURITY AUDIT: repo-controlled paths are attacker-controlled input. A changed
+  // symlink pointing outside the workspace must not let the UI read (and copy) files
+  // beyond the execution root, so reject paths whose physical resolution escapes it.
+  // Fail closed: an unresolvable path (loop, missing resolver) also exits.
+  return `root=$(pwd -P)
+resolved=$(realpath ${file} 2>/dev/null || readlink -f ${file} 2>/dev/null)
+case "$resolved" in
+  "$root"/*) ;;
+  *) exit ${EXIT_CODE_OUTSIDE_WORKSPACE} ;;
+esac
+size=$(stat -c %s ${file} 2>/dev/null || stat -f %z ${file})
 [ "$size" -gt ${maxSizeBytes} ] && exit ${EXIT_CODE_TOO_LARGE}${lineLimitScript}
 echo "$size"
 base64 < ${file}`;
@@ -174,6 +187,10 @@ export function processFileContents(output: string, exitCode: number): FileConte
 
   if (exitCode === EXIT_CODE_TOO_MANY_LINES) {
     return { type: "error", message: "File has too many lines to display." };
+  }
+
+  if (exitCode === EXIT_CODE_OUTSIDE_WORKSPACE) {
+    return { type: "error", message: "File resolves outside the workspace." };
   }
 
   const { size, base64 } = parseReadFileOutput(output);

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -585,6 +585,9 @@ export const KEYBINDS = {
   /** Toggle focus between diff and notes sidebar in immersive review */
   REVIEW_FOCUS_NOTES: { key: "Tab" },
 
+  /** Copy the active file's full contents to the clipboard in immersive review */
+  REVIEW_COPY_FILE: { key: "y" },
+
   /** Toggle plan annotation mode in propose_plan */
   TOGGLE_PLAN_ANNOTATE: { key: "a", shift: true },
 

--- a/src/common/utils/git/nameStatusParser.test.ts
+++ b/src/common/utils/git/nameStatusParser.test.ts
@@ -42,4 +42,11 @@ describe("parseNameStatus", () => {
       { filePath: "other.ts", changeType: "added" },
     ]);
   });
+
+  it("preserves trailing whitespace in the last line's file path", () => {
+    // A whole-output trim would rewrite a file literally named ".env " to ".env",
+    // desyncing name-status paths from the exact paths parseNumstat preserves and
+    // losing the file's change status (e.g. deletion) in the tree.
+    expect(parseNameStatus("D\t.env \n")).toEqual([{ filePath: ".env ", changeType: "deleted" }]);
+  });
 });

--- a/src/common/utils/git/nameStatusParser.ts
+++ b/src/common/utils/git/nameStatusParser.ts
@@ -41,7 +41,10 @@ function toFileChangeType(statusCode: string): FileChangeType {
  * `deleted > added > renamed > modified`.
  */
 export function parseNameStatus(output: string): NameStatusEntry[] {
-  const lines = output.trim().split("\n").filter(Boolean);
+  // Split before filtering instead of trimming the whole output: a full trim would
+  // strip trailing whitespace from the LAST line's file path, desyncing it from the
+  // exact paths parseNumstat preserves and losing that file's change status.
+  const lines = output.split("\n").filter(Boolean);
   const byPath = new Map<string, NameStatusEntry>();
 
   for (const line of lines) {

--- a/src/common/utils/git/numstatParser.test.ts
+++ b/src/common/utils/git/numstatParser.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { extractNewPath } from "./numstatParser";
+import { extractNewPath, parseNumstat } from "./numstatParser";
+
+describe("parseNumstat", () => {
+  test("preserves trailing whitespace in the last line's file path", () => {
+    // A whole-output trim would rewrite a file literally named ".env " to ".env",
+    // pointing downstream file reads (copy, overlay) at the wrong file.
+    const stats = parseNumstat("0\t0\t.env \n");
+    expect(stats).toEqual([{ filePath: ".env ", additions: 0, deletions: 0 }]);
+  });
+});
 
 describe("extractNewPath", () => {
   test("returns unchanged path for normal files", () => {

--- a/src/common/utils/git/numstatParser.ts
+++ b/src/common/utils/git/numstatParser.ts
@@ -16,7 +16,10 @@ export interface FileStats {
  * Parse git diff --numstat output into structured file stats
  */
 export function parseNumstat(numstatOutput: string): FileStats[] {
-  const lines = numstatOutput.trim().split("\n").filter(Boolean);
+  // Split before filtering instead of trimming the whole output: a full trim would
+  // silently strip trailing whitespace from the LAST line's file path (e.g. a file
+  // literally named ".env "), making downstream file reads target the wrong file.
+  const lines = numstatOutput.split("\n").filter(Boolean);
   const stats: FileStats[] = [];
 
   for (const line of lines) {


### PR DESCRIPTION
## Summary

Adds a "copy file" button (and a `y` keyboard shortcut) to the immersive review file view that copies the entire viewed file's text to the clipboard, plus hardening of the shared file-read path that review surfaces rely on.

Fixes #2842

## Background

The file view offers no way to copy the whole file: Ctrl+A selects content beyond the viewed file. The issue predates the removal of the Explorer file viewer (#3208); the immersive review view is the current single-file surface, so the affordance lands in its header.

## Implementation

- `REVIEW_COPY_FILE` (`y`) keybind wired into the existing immersive keydown handler (editable-element/dialog/notes/touch gating applies; key repeat ignored). Surfaced in Settings → Keybinds.
- Header button next to the file navigation chevrons: lucide `Copy` icon flipping to `Check`/`TriangleAlert`, shared tooltip (shortcut hint hidden on mobile), sibling `role="status"` live region for screen readers. Hidden for deleted files (derived from file-tree numstat + unfiltered hunks) and when review is complete.
- The copy reads the file fresh via the shared `buildReadFileScript` with a deterministic 750KB budget (IPC-safe after base64 expansion), repo-root cwd for single-project workspaces and container-root + project-symlink containment anchor for multi-project ones. SVG source is copied as text; binary/oversized/unavailable cases show visible failure feedback.
- Staleness handling: copies are invalidated by navigation (including A→B→A), same-path content-version changes, unmount, and supersession; same-file copies are serialized; feedback is keyed to file + content version and cleared deterministically.
- Shared read-script hardening (also benefits overlay full-file hydration): reject paths resolving outside the workspace and final-component symlinks (fail closed), portable resolver fallback for hosts without `realpath`/GNU `readlink -f`, sentinel framing plus xtrace/verbose/DEBUG-trap silencing so `tool_env` output cannot corrupt the payload, and `./` anchoring for option-like filenames.
- Parser fidelity fixes surfaced by review: `parseNumstat`/`parseNameStatus` no longer trim whole output (preserving trailing-whitespace filenames), and path reprojection keeps edge whitespace.

## Validation

- `make static-check`, component tests (`ImmersiveReviewView.test.tsx`, 30+ scenarios incl. stale/ABA/in-place-edit races, deleted-file gating, size/binary/API failures), real-bash `fileRead` tests (symlink containment, portable resolver, sentinel framing under `set -xv` and DEBUG traps, size budget, `-n` filename), parser tests, and `tests/ui/review`.
- Remote dogfood UAT passed 10/10 scenarios, including full-file copy of a 2000-line file with one hunk in the diff, keybind guards, review-complete hiding, 375px layout, and immersive navigation regression checks.

## Risks

Core copy action is additive UI. The shared read script changed (sentinel framing, symlink rejection, containment): overlay full-file hydration consumes the same script and parser, and both were updated together with real-bash coverage; a regression there would degrade immersive review to compact-hunk display rather than lose data. Deep-dive follow-ups deferred: NUL-delimited git path parsing across diff/name-status/numstat, and a dedicated backend file-read IPC (fd-safe reads, >750KB copies).

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
