### PR TITLE
🤖 fix: preserve a backup and log actionable guidance when config.json parsing fails

### DIFF
--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -207,6 +207,50 @@ describe("Config", () => {
       errorSpy.mockRestore();
     });
 
+    it("does not overwrite the corrupt config through edits until a backup is confirmed", async () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const origWrite = fs.writeFileSync.bind(fs);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (typeof file === "string" && file.includes(".corrupt-")) {
+          throw new Error("disk full");
+        }
+        origWrite(file, data, options);
+      });
+
+      await config.setUpdateChannel("nightly");
+
+      expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptData);
+      expect(corruptBackups()).toHaveLength(0);
+
+      writeSpy.mockRestore();
+
+      await config.setUpdateChannel("nightly");
+
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+      const rewritten = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(rewritten.updateChannel).toBe("nightly");
+      errorSpy.mockRestore();
+    });
+
+    it("logs a corrupt config once across Config instances on the same path", () => {
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFilePath(), corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+      new Config(tempDir).loadConfigOrDefault();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+    });
+
     it("recovers from an unreadable config without creating a backup", () => {
       const configFile = configFilePath();
       // A directory at the config path makes readFileSync fail before any bytes exist.

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -403,6 +403,85 @@ describe("Config", () => {
       }
     });
 
+    it("tightens permissions on a reused permissive sidecar", () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      const prevUmask = process.umask(0o022);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      try {
+        fs.writeFileSync(configFile, corruptData);
+        // A byte-identical sidecar left by an older build without the 0600 fix.
+        const stale = `${configFile}.corrupt-1`;
+        fs.writeFileSync(stale, corruptData);
+        fs.chmodSync(stale, 0o644);
+
+        config.loadConfigOrDefault();
+
+        expect(corruptBackups()).toHaveLength(1);
+        expect(fs.statSync(stale).mode & 0o777).toBe(0o600);
+      } finally {
+        process.umask(prevUmask);
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("aborts an edit write when the corrupt file changed after the edit loaded it", async () => {
+      const configFile = configFilePath();
+      const corruptA = '{ "projects": ';
+      const corruptB = '{ "taskSettings": ';
+      fs.writeFileSync(configFile, corruptA);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      // Simulate a concurrent writer replacing the file between this edit's load and write.
+      await config.editConfig((cfg) => {
+        fs.writeFileSync(configFile, corruptB);
+        return cfg;
+      });
+
+      // The write was skipped: B is still on disk instead of a defaults rewrite.
+      expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptB);
+
+      // The next edit's own load backs up B, so it may proceed.
+      await config.setUpdateChannel("nightly");
+      const contents = corruptBackups().map((p) => fs.readFileSync(p, "utf-8"));
+      expect(contents).toContain(corruptA);
+      expect(contents).toContain(corruptB);
+      const rewritten = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(rewritten.updateChannel).toBe("nightly");
+      errorSpy.mockRestore();
+    });
+
+    it("dedupes repeated backup failures whose messages embed the generated path", () => {
+      const configFile = configFilePath();
+      fs.writeFileSync(configFile, '{ "projects": ');
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const nowSpy = spyOn(Date, "now");
+      const origWrite = fs.writeFileSync.bind(fs);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (typeof file === "string" && file.includes(".corrupt-")) {
+          throw Object.assign(new Error(`ENOSPC: no space left on device, open '${file}'`), {
+            code: "ENOSPC",
+          });
+        }
+        origWrite(file, data, options);
+      });
+
+      nowSpy.mockReturnValue(1000);
+      config.loadConfigOrDefault();
+      nowSpy.mockReturnValue(2000);
+      config.loadConfigOrDefault();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      writeSpy.mockRestore();
+      nowSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it("logs a corrupt config once across Config instances on the same path", () => {
       const corruptData = '{ "projects": ';
       fs.writeFileSync(configFilePath(), corruptData);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -356,6 +356,53 @@ describe("Config", () => {
       errorSpy.mockRestore();
     });
 
+    it("logs again when the backup is re-verified at a different path", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const nowSpy = spyOn(Date, "now").mockReturnValue(1000);
+
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      // Delete the confirmed sidecar; recreation at a new path must replace the stale
+      // guidance that points at the deleted file.
+      fs.rmSync(`${configFile}.corrupt-1000`);
+      nowSpy.mockReturnValue(2000);
+      config.loadConfigOrDefault();
+
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(String(errorSpy.mock.calls[1]?.[0])).toContain("corrupt-2000");
+
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      nowSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it("creates sidecars with owner-only permissions", () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const configFile = configFilePath();
+      // Pin a permissive umask: under a 0077 umask this assertion would pass vacuously.
+      const prevUmask = process.umask(0o022);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      try {
+        fs.writeFileSync(configFile, '{ "projects": ');
+        config.loadConfigOrDefault();
+
+        const [backup] = corruptBackups();
+        // Sidecars can hold credentials; peer file proves the narrowing is not ambient.
+        expect(fs.statSync(backup).mode & 0o777).toBe(0o600);
+        expect(fs.statSync(configFile).mode & 0o777).toBe(0o644);
+      } finally {
+        process.umask(prevUmask);
+        errorSpy.mockRestore();
+      }
+    });
+
     it("logs a corrupt config once across Config instances on the same path", () => {
       const corruptData = '{ "projects": ';
       fs.writeFileSync(configFilePath(), corruptData);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -1,6 +1,8 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { log } from "@/node/services/log";
 import { Config } from "./config";
 import {
   CODER_ARCHIVE_BEHAVIORS,
@@ -37,6 +39,134 @@ describe("Config", () => {
   async function flushConfigEdits(): Promise<void> {
     await config.editConfig((cfg) => cfg);
   }
+
+  describe("loadConfigOrDefault corrupt config recovery", () => {
+    function configFilePath(): string {
+      return path.join(tempDir, "config.json");
+    }
+
+    function corruptBackups(): string[] {
+      return fs
+        .readdirSync(tempDir)
+        .filter((name) => name.startsWith("config.json.corrupt-"))
+        .map((name) => path.join(tempDir, name));
+    }
+
+    it("preserves malformed JSON and falls back to defaults", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.projects.size).toBe(0);
+      expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptData);
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain(configFile);
+      errorSpy.mockRestore();
+    });
+
+    it("does not create duplicate backups for identical corrupt bytes", () => {
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFilePath(), corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+      config.loadConfigOrDefault();
+      new Config(tempDir).loadConfigOrDefault();
+
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+      errorSpy.mockRestore();
+    });
+
+    it.each(["null", '"just a string"', "[1,2]"])(
+      "recovers from a non-object JSON root: %s",
+      (corruptData) => {
+        const configFile = configFilePath();
+        fs.writeFileSync(configFile, corruptData);
+        const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+        const loaded = config.loadConfigOrDefault();
+
+        expect(loaded.projects.size).toBe(0);
+        expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptData);
+        const backups = corruptBackups();
+        expect(backups).toHaveLength(1);
+        expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+        errorSpy.mockRestore();
+      }
+    );
+
+    it("heals invalid fields in an object without creating a backup", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          apiServerPort: "abc",
+          defaultModel: "openai:gpt-4o",
+          taskSettings: { preserveSubagentsUntilArchive: true },
+          migrations: {
+            defaultModelFallbacksSeeded: true,
+            persistentSubagentsDefaulted: true,
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.apiServerPort).toBeUndefined();
+      expect(loaded.defaultModel).toBe("openai:gpt-4o");
+      expect(corruptBackups()).toHaveLength(0);
+    });
+
+    it("treats a missing config as a silent fresh install", () => {
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.projects.size).toBe(0);
+      expect(corruptBackups()).toHaveLength(0);
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it("keeps the corrupt bytes after a settings edit rewrites config.json", async () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+      const [backupPath] = corruptBackups();
+      await config.setUpdateChannel("nightly");
+
+      const rewritten = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(rewritten.updateChannel).toBe("nightly");
+      expect(fs.readFileSync(backupPath)).toEqual(Buffer.from(corruptData));
+      errorSpy.mockRestore();
+    });
+
+    it("backs up malformed JSON before rethrowing for cleanup guards", () => {
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFilePath(), corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      expect(() => config.loadConfigOrDefault({ throwOnError: true })).toThrow();
+
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+      errorSpy.mockRestore();
+    });
+  });
 
   describe("loadConfigOrDefault settingsBackup sanitizing", () => {
     it("degrades a malformed settingsBackup instead of returning it", () => {
@@ -1493,8 +1623,8 @@ describe("Config", () => {
       });
 
       const raw = JSON.parse(fs.readFileSync(path.join(tempDir, "config.json"), "utf-8")) as {
-        agentAiDefaults?: Record<string, { modelString?: string }>;
-        subagentAiDefaults?: Record<string, { modelString?: string }>;
+        agentAiDefaults?: Record<string, { modelString?: string; thinkingLevel?: string }>;
+        subagentAiDefaults?: Record<string, { modelString?: string; thinkingLevel?: string }>;
       };
 
       expect(raw.agentAiDefaults).toEqual({

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -166,6 +166,65 @@ describe("Config", () => {
       expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
       errorSpy.mockRestore();
     });
+
+    it("retries the backup on the next load after a transient failure", () => {
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFilePath(), corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementationOnce(() => {
+        throw new Error("disk full");
+      });
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.projects.size).toBe(0);
+      expect(corruptBackups()).toHaveLength(0);
+
+      const retried = config.loadConfigOrDefault();
+      expect(retried.projects.size).toBe(0);
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+
+      writeSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it("never overwrites an existing sidecar on a timestamp collision", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const olderSnapshot = "older corrupt snapshot";
+      const nowSpy = spyOn(Date, "now").mockReturnValue(1234567890);
+      const collidingPath = `${configFile}.corrupt-1234567890`;
+      fs.writeFileSync(collidingPath, olderSnapshot);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+
+      expect(fs.readFileSync(collidingPath, "utf-8")).toBe(olderSnapshot);
+      expect(fs.readFileSync(`${collidingPath}-1`)).toEqual(Buffer.from(corruptData));
+      nowSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it("recovers from an unreadable config without creating a backup", () => {
+      const configFile = configFilePath();
+      // A directory at the config path makes readFileSync fail before any bytes exist.
+      fs.mkdirSync(configFile);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.projects.size).toBe(0);
+      expect(corruptBackups()).toHaveLength(0);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain(configFile);
+
+      // Repeated loads of the same unreadable state stay deduped.
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+    });
   });
 
   describe("loadConfigOrDefault settingsBackup sanitizing", () => {

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -273,6 +273,29 @@ describe("Config", () => {
       errorSpy.mockRestore();
     });
 
+    it("re-creates a deleted sidecar before an edit may overwrite the corrupt config", async () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+      const [firstBackup] = corruptBackups();
+      fs.rmSync(firstBackup);
+
+      await config.setUpdateChannel("nightly");
+
+      // The edit-time load must have re-verified against disk and restored preservation.
+      const backups = corruptBackups();
+      expect(backups).toHaveLength(1);
+      expect(fs.readFileSync(backups[0])).toEqual(Buffer.from(corruptData));
+      const rewritten = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(rewritten.updateChannel).toBe("nightly");
+      errorSpy.mockRestore();
+    });
+
     it("logs a corrupt config once across Config instances on the same path", () => {
       const corruptData = '{ "projects": ';
       fs.writeFileSync(configFilePath(), corruptData);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -296,6 +296,66 @@ describe("Config", () => {
       errorSpy.mockRestore();
     });
 
+    it("skips an unreadable stale sidecar and still creates a fresh backup", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const stalePath = `${configFile}.corrupt-1`;
+      fs.writeFileSync(stalePath, "older unrelated snapshot");
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const origRead = fs.readFileSync.bind(fs);
+      const readSpy = spyOn(fs, "readFileSync").mockImplementation(((
+        file: fs.PathOrFileDescriptor,
+        options?: Parameters<typeof fs.readFileSync>[1]
+      ) => {
+        if (file === stalePath) {
+          throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+        }
+        return origRead(file, options);
+      }) as typeof fs.readFileSync);
+
+      const loaded = config.loadConfigOrDefault();
+
+      expect(loaded.projects.size).toBe(0);
+      const fresh = corruptBackups().filter((p) => p !== stalePath);
+      expect(fresh).toHaveLength(1);
+      expect(origRead(fresh[0])).toEqual(Buffer.from(corruptData));
+      readSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it("logs again when a previously confirmed backup can no longer be restored", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+
+      const [backupPath] = corruptBackups();
+      fs.rmSync(backupPath);
+      const origWrite = fs.writeFileSync.bind(fs);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (typeof file === "string" && file.includes(".corrupt-")) {
+          throw new Error("disk full");
+        }
+        origWrite(file, data, options);
+      });
+
+      // Losing the backup must surface the new failure, not stay deduped.
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(String(errorSpy.mock.calls[1]?.[0])).toContain("Backup failed");
+
+      // The still-failing state stays deduped afterwards.
+      config.loadConfigOrDefault();
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+
+      writeSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it("logs a corrupt config once across Config instances on the same path", () => {
       const corruptData = '{ "projects": ';
       fs.writeFileSync(configFilePath(), corruptData);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -220,7 +220,12 @@ describe("Config", () => {
         origWrite(file, data, options);
       });
 
-      await config.setUpdateChannel("nightly");
+      // Callers must see the blocked write as a failure, not a silent success.
+      const blockedError = await config.setUpdateChannel("nightly").then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect(String(blockedError)).toContain("no confirmed backup yet");
 
       expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptData);
       expect(corruptBackups()).toHaveLength(0);
@@ -258,7 +263,11 @@ describe("Config", () => {
         origWrite(file, data, options);
       });
 
-      await config.setUpdateChannel("nightly");
+      const blockedError = await config.setUpdateChannel("nightly").then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect(String(blockedError)).toContain("no confirmed backup yet");
       expect(fs.readFileSync(configFile, "utf-8")).toBe(newCorrupt);
       expect(corruptBackups()).toHaveLength(1);
 
@@ -403,6 +412,31 @@ describe("Config", () => {
       }
     });
 
+    it("creates readable owner-only sidecars even under a restrictive umask", () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      // Write the corrupt config while file creation still works normally; only the
+      // sidecar creation should run under the restrictive umask.
+      fs.writeFileSync(configFile, corruptData);
+      // A 0777 umask strips the requested creation mode to 0000; the backup must still
+      // end up readable or recovery guidance points at an unusable file.
+      const prevUmask = process.umask(0o777);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      try {
+        config.loadConfigOrDefault();
+
+        const [backup] = corruptBackups();
+        expect(fs.statSync(backup).mode & 0o777).toBe(0o600);
+        expect(fs.readFileSync(backup)).toEqual(Buffer.from(corruptData));
+      } finally {
+        process.umask(prevUmask);
+        errorSpy.mockRestore();
+      }
+    });
+
     it("tightens permissions on a reused permissive sidecar", () => {
       if (process.platform === "win32") {
         return;
@@ -436,10 +470,16 @@ describe("Config", () => {
       const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
 
       // Simulate a concurrent writer replacing the file between this edit's load and write.
-      await config.editConfig((cfg) => {
-        fs.writeFileSync(configFile, corruptB);
-        return cfg;
-      });
+      const raceError = await config
+        .editConfig((cfg) => {
+          fs.writeFileSync(configFile, corruptB);
+          return cfg;
+        })
+        .then(
+          () => null,
+          (e: unknown) => e
+        );
+      expect(String(raceError)).toContain("changed after this edit loaded it");
 
       // The write was skipped: B is still on disk instead of a defaults rewrite.
       expect(fs.readFileSync(configFile, "utf-8")).toBe(corruptB);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -239,6 +239,40 @@ describe("Config", () => {
       errorSpy.mockRestore();
     });
 
+    it("re-blocks edits when new corrupt bytes appear after a confirmed backup", async () => {
+      const configFile = configFilePath();
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      fs.writeFileSync(configFile, '{ "projects": ');
+      config.loadConfigOrDefault();
+      expect(corruptBackups()).toHaveLength(1);
+
+      // Different corrupt bytes whose own backup fails must not inherit the
+      // earlier confirmation, or an edit would overwrite the only copy.
+      const newCorrupt = '{ "taskSettings": ';
+      fs.writeFileSync(configFile, newCorrupt);
+      const origWrite = fs.writeFileSync.bind(fs);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (typeof file === "string" && file.includes(".corrupt-")) {
+          throw new Error("disk full");
+        }
+        origWrite(file, data, options);
+      });
+
+      await config.setUpdateChannel("nightly");
+      expect(fs.readFileSync(configFile, "utf-8")).toBe(newCorrupt);
+      expect(corruptBackups()).toHaveLength(1);
+
+      writeSpy.mockRestore();
+
+      await config.setUpdateChannel("nightly");
+      expect(corruptBackups()).toHaveLength(2);
+      const rewritten = JSON.parse(fs.readFileSync(configFile, "utf-8")) as {
+        updateChannel?: unknown;
+      };
+      expect(rewritten.updateChannel).toBe("nightly");
+      errorSpy.mockRestore();
+    });
+
     it("logs a corrupt config once across Config instances on the same path", () => {
       const corruptData = '{ "projects": ';
       fs.writeFileSync(configFilePath(), corruptData);

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -462,6 +462,40 @@ describe("Config", () => {
       }
     });
 
+    it("reuses a later usable duplicate when the first cannot be secured", () => {
+      const configFile = configFilePath();
+      const corruptData = '{ "projects": ';
+      fs.writeFileSync(configFile, corruptData);
+      const untightenable = `${configFile}.corrupt-1`;
+      const usable = `${configFile}.corrupt-2`;
+      fs.writeFileSync(untightenable, corruptData);
+      fs.writeFileSync(usable, corruptData);
+      const errorSpy = spyOn(log, "error").mockImplementation(() => undefined);
+      const origChmod = fs.chmodSync.bind(fs);
+      const chmodSpy = spyOn(fs, "chmodSync").mockImplementation((file, mode) => {
+        if (file === untightenable) {
+          throw Object.assign(new Error("EPERM: operation not permitted"), { code: "EPERM" });
+        }
+        origChmod(file, mode);
+      });
+      // Creating a fresh sidecar must not be needed: the usable duplicate is reused.
+      const origWrite = fs.writeFileSync.bind(fs);
+      const writeSpy = spyOn(fs, "writeFileSync").mockImplementation((file, data, options) => {
+        if (typeof file === "string" && file.includes(".corrupt-") && file !== untightenable) {
+          throw new Error("unexpected sidecar creation");
+        }
+        origWrite(file, data, options);
+      });
+
+      config.loadConfigOrDefault();
+
+      expect(corruptBackups().sort()).toEqual([untightenable, usable].sort());
+      expect(String(errorSpy.mock.calls[0]?.[0])).toContain(usable);
+      writeSpy.mockRestore();
+      chmodSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
     it("aborts an edit write when the corrupt file changed after the edit loaded it", async () => {
       const configFile = configFilePath();
       const corruptA = '{ "projects": ';

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -984,30 +984,25 @@ export class Config {
       try {
         const configDir = path.dirname(this.configFile);
         const corruptPrefix = `${path.basename(this.configFile)}.corrupt-`;
-        const duplicate = fs.readdirSync(configDir, { withFileTypes: true }).find((entry) => {
-          if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
-            return false;
-          }
-          // An unreadable stale sidecar must not abort the scan; that would block backup
-          // creation (and therefore settings edits) until it is manually removed.
-          try {
-            return fs.readFileSync(path.join(configDir, entry.name)).equals(rawBytes);
-          } catch {
-            return false;
-          }
-        });
-
-        // A reused sidecar from an older build may be world-readable; tighten it to 0600
-        // before trusting it as the backup. If tightening fails (e.g. owned by another
-        // user), fall through and create a fresh restricted sidecar instead.
+        // Reuse a byte-identical sidecar only if it can also be secured: one from an older
+        // build may be world-readable, so tighten it to 0600 before trusting it as the
+        // backup. Skip candidates that are unreadable or untightenable (e.g. owned by
+        // another user) and keep scanning; a later usable duplicate must still be found
+        // even when creating a fresh sidecar would fail (read-only dir, full disk).
         let reusedPath: string | null = null;
-        if (duplicate) {
-          const duplicatePath = path.join(configDir, duplicate.name);
+        for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+          if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
+            continue;
+          }
+          const candidatePath = path.join(configDir, entry.name);
           try {
-            fs.chmodSync(duplicatePath, 0o600);
-            reusedPath = duplicatePath;
+            if (fs.readFileSync(candidatePath).equals(rawBytes)) {
+              fs.chmodSync(candidatePath, 0o600);
+              reusedPath = candidatePath;
+              break;
+            }
           } catch {
-            reusedPath = null;
+            // Unusable candidate; keep scanning.
           }
         }
         if (reusedPath) {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -845,6 +845,8 @@ export class Config {
   /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
   private migrationPersist: Promise<void> | null = null;
   private lastConfigLoadFailureSignature: string | null = null;
+  /** Content hash of corrupt config bytes whose sidecar backup has been confirmed on disk. */
+  private lastConfigBackupSignature: string | null = null;
 
   constructor(rootDir?: string) {
     this.rootDir = rootDir ?? getXumHome();
@@ -941,61 +943,98 @@ export class Config {
     return priority.length > 1 ? priority : undefined;
   }
 
-  private handleConfigLoadFailure(rawData: string | undefined, error: unknown): void {
+  private handleConfigLoadFailure(rawBytes: Buffer | undefined, error: unknown): void {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const failureSignature = crypto
       .createHash("sha256")
-      .update(rawData ?? "<config unreadable>")
+      .update(rawBytes ?? "<config unreadable>")
       .update("\0")
       .update(errorMessage)
       .digest("hex");
-    if (failureSignature === this.lastConfigLoadFailureSignature) {
+    const alreadyLogged = failureSignature === this.lastConfigLoadFailureSignature;
+    // Backup confirmation is keyed on content alone: the same corrupt bytes need only one
+    // sidecar regardless of which error message they produced.
+    const contentSignature =
+      rawBytes !== undefined ? crypto.createHash("sha256").update(rawBytes).digest("hex") : null;
+    if (
+      alreadyLogged &&
+      (rawBytes === undefined || contentSignature === this.lastConfigBackupSignature)
+    ) {
+      return;
+    }
+
+    let backupStatus = "No backup was created because the file contents could not be read.";
+    let backupJustConfirmed = false;
+    if (rawBytes !== undefined) {
+      try {
+        const configDir = path.dirname(this.configFile);
+        const corruptPrefix = `${path.basename(this.configFile)}.corrupt-`;
+        const duplicate = fs.readdirSync(configDir, { withFileTypes: true }).find((entry) => {
+          if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
+            return false;
+          }
+          return fs.readFileSync(path.join(configDir, entry.name)).equals(rawBytes);
+        });
+
+        if (duplicate) {
+          backupStatus = `Backup skipped because identical bytes already exist at ${path.join(configDir, duplicate.name)}.`;
+        } else {
+          // Write the bytes that actually failed parsing (not a re-read of the file, which
+          // another process may have replaced), leaving the corrupt source in place so
+          // throwOnError cleanup guards continue to reject it. "wx" creates exclusively;
+          // on a same-millisecond collision retry with a suffix instead of overwriting an
+          // earlier snapshot.
+          const basePath = `${this.configFile}.corrupt-${Date.now()}`;
+          let backupPath = basePath;
+          for (let suffix = 1; ; suffix++) {
+            try {
+              fs.writeFileSync(backupPath, rawBytes, { flag: "wx" });
+              break;
+            } catch (writeError) {
+              if ((writeError as NodeJS.ErrnoException).code !== "EEXIST") {
+                throw writeError;
+              }
+              backupPath = `${basePath}-${suffix}`;
+            }
+          }
+          backupStatus = `The original bytes were backed up to ${backupPath}.`;
+        }
+        this.lastConfigBackupSignature = contentSignature;
+        backupJustConfirmed = true;
+      } catch (backupError) {
+        // Leave lastConfigBackupSignature unset so the next load retries the backup;
+        // without a confirmed sidecar a later defaults write would be permanent data loss.
+        const backupErrorMessage =
+          backupError instanceof Error ? backupError.message : String(backupError);
+        backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load.`;
+      }
+    }
+
+    // Log on a new failure, and once more when a previously failed backup finally lands so
+    // the sidecar path becomes visible; silent otherwise to avoid per-load spam.
+    if (alreadyLogged && !backupJustConfirmed) {
       return;
     }
     this.lastConfigLoadFailureSignature = failureSignature;
 
-    let backupStatus = "Backup skipped because the config contents could not be read.";
-    if (rawData !== undefined) {
-      try {
-        const sourceBytes = fs.readFileSync(this.configFile);
-        const corruptPrefix = `${path.basename(this.configFile)}.corrupt-`;
-        const duplicate = fs
-          .readdirSync(path.dirname(this.configFile), { withFileTypes: true })
-          .find((entry) => {
-            if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
-              return false;
-            }
-            return fs
-              .readFileSync(path.join(path.dirname(this.configFile), entry.name))
-              .equals(sourceBytes);
-          });
-
-        if (duplicate) {
-          backupStatus = `Backup skipped because identical bytes already exist at ${path.join(path.dirname(this.configFile), duplicate.name)}.`;
-        } else {
-          const backupPath = `${this.configFile}.corrupt-${Date.now()}`;
-          // Copy instead of moving so cleanup guards continue to reject the corrupt source file.
-          fs.copyFileSync(this.configFile, backupPath);
-          backupStatus = `The original bytes were backed up to ${backupPath}.`;
-        }
-      } catch (backupError) {
-        const backupErrorMessage =
-          backupError instanceof Error ? backupError.message : String(backupError);
-        backupStatus = `Backup failed: ${backupErrorMessage}.`;
-      }
-    }
-
+    const guidance =
+      rawBytes === undefined
+        ? `Check that ${this.configFile} is a regular file readable by this user.`
+        : `Fix the reported problem in ${this.configFile} or restore it from the backup.`;
     log.error(
-      `Failed to load config file ${this.configFile}: ${errorMessage}. ${backupStatus} Fix the JSON syntax in ${this.configFile} or restore it from the backup. Xum will continue with default settings and may rewrite config.json with defaults at any time, including at startup, so use the backup to recover your original settings.`
+      `Failed to load config file ${this.configFile}: ${errorMessage}. ${backupStatus} ${guidance} Xum will continue with default settings and may rewrite config.json with defaults at any time, including at startup, so use the backup to recover your original settings.`
     );
   }
 
   loadConfigOrDefault(options?: { throwOnError?: boolean }): ProjectsConfig {
-    let rawData: string | undefined;
+    // Read as a Buffer and hand the same snapshot to the failure handler: backing up via a
+    // second read could preserve a concurrent writer's replacement instead of the bytes that
+    // actually failed parsing.
+    let rawBytes: Buffer | undefined;
     try {
       if (fs.existsSync(this.configFile)) {
-        rawData = fs.readFileSync(this.configFile, "utf-8");
-        const parsedValue: unknown = JSON.parse(rawData);
+        rawBytes = fs.readFileSync(this.configFile);
+        const parsedValue: unknown = JSON.parse(rawBytes.toString("utf-8"));
         if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) {
           throw new Error("Config root must be a JSON object");
         }
@@ -1373,6 +1412,9 @@ export class Config {
           : layoutPresetsRaw;
 
         this.lastConfigLoadFailureSignature = null;
+        // Also forget the confirmed backup: after a healthy load the user may prune sidecars,
+        // so a later re-corruption must re-verify the backup on disk.
+        this.lastConfigBackupSignature = null;
         return {
           projects: projectsMap,
           apiServerBindHost: parseOptionalNonEmptyString(parsed.apiServerBindHost),
@@ -1429,9 +1471,10 @@ export class Config {
         };
       } else {
         this.lastConfigLoadFailureSignature = null;
+        this.lastConfigBackupSignature = null;
       }
     } catch (error) {
-      this.handleConfigLoadFailure(rawData, error);
+      this.handleConfigLoadFailure(rawBytes, error);
       if (options?.throwOnError) {
         throw error;
       }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -975,6 +975,12 @@ export class Config {
     // sidecar regardless of which error message they produced.
     const contentSignature =
       rawBytes !== undefined ? crypto.createHash("sha256").update(rawBytes).digest("hex") : null;
+    // A confirmed backup only protects its own bytes. When the current content differs (or
+    // cannot be read), drop the stale confirmation so the edit gate blocks writes until the
+    // new bytes have their own confirmed sidecar.
+    if (state.backupSignature !== null && state.backupSignature !== contentSignature) {
+      state.backupSignature = null;
+    }
     if (alreadyLogged && (rawBytes === undefined || contentSignature === state.backupSignature)) {
       return;
     }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -986,7 +986,7 @@ export class Config {
     }
 
     log.error(
-      `Failed to load config file ${this.configFile}: ${errorMessage}. ${backupStatus} Fix the JSON syntax in ${this.configFile} or restore it from the backup. Until then, Xum will continue with default settings and the next settings change will rewrite config.json with defaults.`
+      `Failed to load config file ${this.configFile}: ${errorMessage}. ${backupStatus} Fix the JSON syntax in ${this.configFile} or restore it from the backup. Xum will continue with default settings and may rewrite config.json with defaults at any time, including at startup, so use the backup to recover your original settings.`
     );
   }
 

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -823,7 +823,10 @@ function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boole
 interface ConfigLoadFailureState {
   /** Signature (content + error) of the last logged load failure, for log dedupe. */
   failureSignature: string | null;
-  /** Content hash of corrupt config bytes whose sidecar backup has been confirmed on disk. */
+  /**
+   * Content hash of corrupt config bytes whose sidecar backup was verified on disk during
+   * the most recent failed load (re-checked every failed load, never trusted across loads).
+   */
   backupSignature: string | null;
 }
 
@@ -975,18 +978,14 @@ export class Config {
     // sidecar regardless of which error message they produced.
     const contentSignature =
       rawBytes !== undefined ? crypto.createHash("sha256").update(rawBytes).digest("hex") : null;
-    // A confirmed backup only protects its own bytes. When the current content differs (or
-    // cannot be read), drop the stale confirmation so the edit gate blocks writes until the
-    // new bytes have their own confirmed sidecar.
-    if (state.backupSignature !== null && state.backupSignature !== contentSignature) {
-      state.backupSignature = null;
-    }
-    if (alreadyLogged && (rawBytes === undefined || contentSignature === state.backupSignature)) {
-      return;
-    }
+    const wasConfirmed =
+      state.backupSignature !== null && state.backupSignature === contentSignature;
 
+    // Re-verify preservation against the disk on every failed load rather than trusting a
+    // cached confirmation: a sidecar deleted or truncated since the last load must re-block
+    // the edit gate (and be re-created) or a defaults write would destroy the only copy.
     let backupStatus = "No backup was created because the file contents could not be read.";
-    let backupJustConfirmed = false;
+    let backupConfirmed = false;
     if (rawBytes !== undefined) {
       try {
         const configDir = path.dirname(this.configFile);
@@ -1021,20 +1020,20 @@ export class Config {
           }
           backupStatus = `The original bytes were backed up to ${backupPath}.`;
         }
-        state.backupSignature = contentSignature;
-        backupJustConfirmed = true;
+        backupConfirmed = true;
       } catch (backupError) {
-        // Leave backupSignature unset so the next load retries the backup; until a sidecar
-        // is confirmed, enqueueConfigEdit refuses to overwrite the corrupt source.
         const backupErrorMessage =
           backupError instanceof Error ? backupError.message : String(backupError);
         backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load, and settings changes will not overwrite config.json until a backup succeeds.`;
       }
     }
+    // Until a sidecar is confirmed for these exact bytes, enqueueConfigEdit refuses to
+    // overwrite the corrupt source.
+    state.backupSignature = backupConfirmed ? contentSignature : null;
 
-    // Log on a new failure, and once more when a previously failed backup finally lands so
-    // the sidecar path becomes visible; silent otherwise to avoid per-load spam.
-    if (alreadyLogged && !backupJustConfirmed) {
+    // Log on a new failure, and once more when preservation transitions from unconfirmed to
+    // confirmed so the sidecar path becomes visible; silent otherwise to avoid per-load spam.
+    if (alreadyLogged && !(backupConfirmed && !wasConfirmed)) {
       return;
     }
     state.failureSignature = failureSignature;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -994,7 +994,13 @@ export class Config {
           if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
             return false;
           }
-          return fs.readFileSync(path.join(configDir, entry.name)).equals(rawBytes);
+          // An unreadable stale sidecar must not abort the scan; that would block backup
+          // creation (and therefore settings edits) until it is manually removed.
+          try {
+            return fs.readFileSync(path.join(configDir, entry.name)).equals(rawBytes);
+          } catch {
+            return false;
+          }
         });
 
         if (duplicate) {
@@ -1031,9 +1037,11 @@ export class Config {
     // overwrite the corrupt source.
     state.backupSignature = backupConfirmed ? contentSignature : null;
 
-    // Log on a new failure, and once more when preservation transitions from unconfirmed to
-    // confirmed so the sidecar path becomes visible; silent otherwise to avoid per-load spam.
-    if (alreadyLogged && !(backupConfirmed && !wasConfirmed)) {
+    // Log on a new failure and on preservation transitions in either direction: gaining a
+    // backup surfaces the sidecar path, and losing one (sidecar deleted, recreation failed)
+    // surfaces the actionable backup error while edits are blocked. Silent otherwise to
+    // avoid per-load spam.
+    if (alreadyLogged && backupConfirmed === wasConfirmed) {
       return;
     }
     state.failureSignature = failureSignature;

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -821,7 +821,7 @@ function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boole
 }
 
 interface ConfigLoadFailureState {
-  /** Signature (content + error) of the last logged load failure, for log dedupe. */
+  /** Signature (content + error + backup detail) of the last logged load failure, for log dedupe. */
   failureSignature: string | null;
   /**
    * Content hash of corrupt config bytes whose sidecar backup was verified on disk during
@@ -967,24 +967,18 @@ export class Config {
   private handleConfigLoadFailure(rawBytes: Buffer | undefined, error: unknown): void {
     const state = configLoadFailureState(this.configFile);
     const errorMessage = error instanceof Error ? error.message : String(error);
-    const failureSignature = crypto
-      .createHash("sha256")
-      .update(rawBytes ?? "<config unreadable>")
-      .update("\0")
-      .update(errorMessage)
-      .digest("hex");
-    const alreadyLogged = failureSignature === state.failureSignature;
     // Backup confirmation is keyed on content alone: the same corrupt bytes need only one
     // sidecar regardless of which error message they produced.
     const contentSignature =
       rawBytes !== undefined ? crypto.createHash("sha256").update(rawBytes).digest("hex") : null;
-    const wasConfirmed =
-      state.backupSignature !== null && state.backupSignature === contentSignature;
 
     // Re-verify preservation against the disk on every failed load rather than trusting a
     // cached confirmation: a sidecar deleted or truncated since the last load must re-block
     // the edit gate (and be re-created) or a defaults write would destroy the only copy.
     let backupStatus = "No backup was created because the file contents could not be read.";
+    // The actionable part of backupStatus (verified sidecar path, or the failure error);
+    // folded into the log-dedupe signature so any change in remediation logs again.
+    let backupDetail = "<unreadable>";
     let backupConfirmed = false;
     if (rawBytes !== undefined) {
       try {
@@ -1004,18 +998,21 @@ export class Config {
         });
 
         if (duplicate) {
-          backupStatus = `Backup skipped because identical bytes already exist at ${path.join(configDir, duplicate.name)}.`;
+          const duplicatePath = path.join(configDir, duplicate.name);
+          backupStatus = `Backup skipped because identical bytes already exist at ${duplicatePath}.`;
+          backupDetail = duplicatePath;
         } else {
           // Write the bytes that actually failed parsing (not a re-read of the file, which
           // another process may have replaced), leaving the corrupt source in place so
           // throwOnError cleanup guards continue to reject it. "wx" creates exclusively;
           // on a same-millisecond collision retry with a suffix instead of overwriting an
-          // earlier snapshot.
+          // earlier snapshot. Mode 0600 because config.json can hold credentials (e.g.
+          // muxGovernorToken) that the source file's permissions may protect.
           const basePath = `${this.configFile}.corrupt-${Date.now()}`;
           let backupPath = basePath;
           for (let suffix = 1; ; suffix++) {
             try {
-              fs.writeFileSync(backupPath, rawBytes, { flag: "wx" });
+              fs.writeFileSync(backupPath, rawBytes, { flag: "wx", mode: 0o600 });
               break;
             } catch (writeError) {
               if ((writeError as NodeJS.ErrnoException).code !== "EEXIST") {
@@ -1025,26 +1022,35 @@ export class Config {
             }
           }
           backupStatus = `The original bytes were backed up to ${backupPath}.`;
+          backupDetail = backupPath;
         }
         backupConfirmed = true;
       } catch (backupError) {
         const backupErrorMessage =
           backupError instanceof Error ? backupError.message : String(backupError);
         backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load, and settings changes will not overwrite config.json until a backup succeeds.`;
+        backupDetail = `failed: ${backupErrorMessage}`;
       }
     }
     // Until a sidecar is confirmed for these exact bytes, enqueueConfigEdit refuses to
     // overwrite the corrupt source.
     state.backupSignature = backupConfirmed ? contentSignature : null;
 
-    // Log on a new failure and on preservation transitions in either direction: gaining a
-    // backup surfaces the sidecar path, and losing one (sidecar deleted, recreation failed)
-    // surfaces the actionable backup error while edits are blocked. Silent otherwise to
-    // avoid per-load spam.
-    if (alreadyLogged && backupConfirmed === wasConfirmed) {
+    // Dedupe on content + error + actionable backup detail: repeated loads of the same
+    // state stay silent, while any change in remediation (backup gained or lost, sidecar
+    // verified at a different path, a different backup error) replaces stale guidance.
+    const logSignature = crypto
+      .createHash("sha256")
+      .update(rawBytes ?? "<config unreadable>")
+      .update("\0")
+      .update(errorMessage)
+      .update("\0")
+      .update(backupDetail)
+      .digest("hex");
+    if (logSignature === state.failureSignature) {
       return;
     }
-    state.failureSignature = failureSignature;
+    state.failureSignature = logSignature;
 
     const guidance =
       rawBytes === undefined

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -844,6 +844,7 @@ export class Config {
   private editConfigQueue: Promise<void> = Promise.resolve();
   /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
   private migrationPersist: Promise<void> | null = null;
+  private lastConfigLoadFailureSignature: string | null = null;
 
   constructor(rootDir?: string) {
     this.rootDir = rootDir ?? getXumHome();
@@ -940,11 +941,65 @@ export class Config {
     return priority.length > 1 ? priority : undefined;
   }
 
+  private handleConfigLoadFailure(rawData: string | undefined, error: unknown): void {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const failureSignature = crypto
+      .createHash("sha256")
+      .update(rawData ?? "<config unreadable>")
+      .update("\0")
+      .update(errorMessage)
+      .digest("hex");
+    if (failureSignature === this.lastConfigLoadFailureSignature) {
+      return;
+    }
+    this.lastConfigLoadFailureSignature = failureSignature;
+
+    let backupStatus = "Backup skipped because the config contents could not be read.";
+    if (rawData !== undefined) {
+      try {
+        const sourceBytes = fs.readFileSync(this.configFile);
+        const corruptPrefix = `${path.basename(this.configFile)}.corrupt-`;
+        const duplicate = fs
+          .readdirSync(path.dirname(this.configFile), { withFileTypes: true })
+          .find((entry) => {
+            if (!entry.isFile() || !entry.name.startsWith(corruptPrefix)) {
+              return false;
+            }
+            return fs
+              .readFileSync(path.join(path.dirname(this.configFile), entry.name))
+              .equals(sourceBytes);
+          });
+
+        if (duplicate) {
+          backupStatus = `Backup skipped because identical bytes already exist at ${path.join(path.dirname(this.configFile), duplicate.name)}.`;
+        } else {
+          const backupPath = `${this.configFile}.corrupt-${Date.now()}`;
+          // Copy instead of moving so cleanup guards continue to reject the corrupt source file.
+          fs.copyFileSync(this.configFile, backupPath);
+          backupStatus = `The original bytes were backed up to ${backupPath}.`;
+        }
+      } catch (backupError) {
+        const backupErrorMessage =
+          backupError instanceof Error ? backupError.message : String(backupError);
+        backupStatus = `Backup failed: ${backupErrorMessage}.`;
+      }
+    }
+
+    log.error(
+      `Failed to load config file ${this.configFile}: ${errorMessage}. ${backupStatus} Fix the JSON syntax in ${this.configFile} or restore it from the backup. Until then, Xum will continue with default settings and the next settings change will rewrite config.json with defaults.`
+    );
+  }
+
   loadConfigOrDefault(options?: { throwOnError?: boolean }): ProjectsConfig {
+    let rawData: string | undefined;
     try {
       if (fs.existsSync(this.configFile)) {
-        const data = fs.readFileSync(this.configFile, "utf-8");
-        const parsed = JSON.parse(data) as Partial<AppConfigOnDisk> & Record<string, unknown>;
+        rawData = fs.readFileSync(this.configFile, "utf-8");
+        const parsedValue: unknown = JSON.parse(rawData);
+        if (!parsedValue || typeof parsedValue !== "object" || Array.isArray(parsedValue)) {
+          throw new Error("Config root must be a JSON object");
+        }
+        const parsed = parsedValue as Partial<AppConfigOnDisk> & Record<string, unknown>;
         let configModified = false;
         let shouldInvalidateSessionUsageCaches = false;
 
@@ -1317,6 +1372,7 @@ export class Config {
           ? undefined
           : layoutPresetsRaw;
 
+        this.lastConfigLoadFailureSignature = null;
         return {
           projects: projectsMap,
           apiServerBindHost: parseOptionalNonEmptyString(parsed.apiServerBindHost),
@@ -1371,9 +1427,11 @@ export class Config {
             .parse(parsed.settingsBackup),
           legacyOnePasswordAccountName: parseOptionalNonEmptyString(parsed.onePasswordAccountName),
         };
+      } else {
+        this.lastConfigLoadFailureSignature = null;
       }
     } catch (error) {
-      log.error("Error loading config:", error);
+      this.handleConfigLoadFailure(rawData, error);
       if (options?.throwOnError) {
         throw error;
       }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -1033,6 +1033,9 @@ export class Config {
               backupPath = `${basePath}-${suffix}`;
             }
           }
+          // The creation mode is reduced by the process umask (a 0777 umask yields an
+          // owner-unreadable file); chmod is not, so pin the final mode explicitly.
+          fs.chmodSync(backupPath, 0o600);
           backupStatus = `The original bytes were backed up to ${backupPath}.`;
           backupDetail = backupPath;
         }
@@ -1880,34 +1883,38 @@ export class Config {
       // If that load failed, writing would replace the corrupt file with defaults. Only
       // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
       // no confirmed backup, a concurrent replacement since the load, or an unreadable
-      // file all skip the write (matching saveConfig's log-and-swallow contract). A
-      // missing file is safe to overwrite. This cannot fully close the cross-process
+      // file all reject the edit so callers do not treat the mutation as durable (unlike
+      // saveConfig's log-and-swallow of unexpected I/O errors, this skip is deliberate).
+      // A missing file is safe to overwrite. This cannot fully close the cross-process
       // race (that needs file locking, which editConfig has never had); it binds the
       // approval to the current bytes and shrinks the window to the atomic write itself.
       const failureState = configLoadFailureStates.get(this.configFile);
       if (failureState) {
+        const rejectEdit = (reason: string): never => {
+          const message = `Skipping config write to ${this.configFile}: ${reason}`;
+          log.error(message);
+          throw new Error(message);
+        };
         if (failureState.backupSignature === null) {
-          log.error(
-            `Skipping config write to ${this.configFile}: the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry.`
+          rejectEdit(
+            "the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry."
           );
-          return;
         }
+        let currentSignature: string | null = null;
         try {
           const currentBytes = fs.readFileSync(this.configFile);
-          const currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
-          if (currentSignature !== failureState.backupSignature) {
-            log.error(
-              `Skipping config write to ${this.configFile}: the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change.`
-            );
-            return;
-          }
+          currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
         } catch (readError) {
           if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
-            log.error(
-              `Skipping config write to ${this.configFile}: the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
+            rejectEdit(
+              `the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
             );
-            return;
           }
+        }
+        if (currentSignature !== null && currentSignature !== failureState.backupSignature) {
+          rejectEdit(
+            "the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change."
+          );
         }
       }
       await this.saveConfig(newConfig);

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -820,6 +820,27 @@ function removeLegacyMuxChatEntries(projects: Map<string, ProjectConfig>): boole
   return modified;
 }
 
+interface ConfigLoadFailureState {
+  /** Signature (content + error) of the last logged load failure, for log dedupe. */
+  failureSignature: string | null;
+  /** Content hash of corrupt config bytes whose sidecar backup has been confirmed on disk. */
+  backupSignature: string | null;
+}
+
+// Process-scoped, keyed by config file path: production creates short-lived Config
+// instances (e.g. runtimeFactory per runtime check), so instance-local dedupe would
+// re-log the same corrupt-config error once per instance.
+const configLoadFailureStates = new Map<string, ConfigLoadFailureState>();
+
+function configLoadFailureState(configFile: string): ConfigLoadFailureState {
+  let state = configLoadFailureStates.get(configFile);
+  if (!state) {
+    state = { failureSignature: null, backupSignature: null };
+    configLoadFailureStates.set(configFile, state);
+  }
+  return state;
+}
+
 /**
  * Config - Centralized configuration management
  *
@@ -844,9 +865,6 @@ export class Config {
   private editConfigQueue: Promise<void> = Promise.resolve();
   /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
   private migrationPersist: Promise<void> | null = null;
-  private lastConfigLoadFailureSignature: string | null = null;
-  /** Content hash of corrupt config bytes whose sidecar backup has been confirmed on disk. */
-  private lastConfigBackupSignature: string | null = null;
 
   constructor(rootDir?: string) {
     this.rootDir = rootDir ?? getXumHome();
@@ -944,6 +962,7 @@ export class Config {
   }
 
   private handleConfigLoadFailure(rawBytes: Buffer | undefined, error: unknown): void {
+    const state = configLoadFailureState(this.configFile);
     const errorMessage = error instanceof Error ? error.message : String(error);
     const failureSignature = crypto
       .createHash("sha256")
@@ -951,15 +970,12 @@ export class Config {
       .update("\0")
       .update(errorMessage)
       .digest("hex");
-    const alreadyLogged = failureSignature === this.lastConfigLoadFailureSignature;
+    const alreadyLogged = failureSignature === state.failureSignature;
     // Backup confirmation is keyed on content alone: the same corrupt bytes need only one
     // sidecar regardless of which error message they produced.
     const contentSignature =
       rawBytes !== undefined ? crypto.createHash("sha256").update(rawBytes).digest("hex") : null;
-    if (
-      alreadyLogged &&
-      (rawBytes === undefined || contentSignature === this.lastConfigBackupSignature)
-    ) {
+    if (alreadyLogged && (rawBytes === undefined || contentSignature === state.backupSignature)) {
       return;
     }
 
@@ -999,14 +1015,14 @@ export class Config {
           }
           backupStatus = `The original bytes were backed up to ${backupPath}.`;
         }
-        this.lastConfigBackupSignature = contentSignature;
+        state.backupSignature = contentSignature;
         backupJustConfirmed = true;
       } catch (backupError) {
-        // Leave lastConfigBackupSignature unset so the next load retries the backup;
-        // without a confirmed sidecar a later defaults write would be permanent data loss.
+        // Leave backupSignature unset so the next load retries the backup; until a sidecar
+        // is confirmed, enqueueConfigEdit refuses to overwrite the corrupt source.
         const backupErrorMessage =
           backupError instanceof Error ? backupError.message : String(backupError);
-        backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load.`;
+        backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load, and settings changes will not overwrite config.json until a backup succeeds.`;
       }
     }
 
@@ -1015,7 +1031,7 @@ export class Config {
     if (alreadyLogged && !backupJustConfirmed) {
       return;
     }
-    this.lastConfigLoadFailureSignature = failureSignature;
+    state.failureSignature = failureSignature;
 
     const guidance =
       rawBytes === undefined
@@ -1411,10 +1427,9 @@ export class Config {
           ? undefined
           : layoutPresetsRaw;
 
-        this.lastConfigLoadFailureSignature = null;
         // Also forget the confirmed backup: after a healthy load the user may prune sidecars,
         // so a later re-corruption must re-verify the backup on disk.
-        this.lastConfigBackupSignature = null;
+        configLoadFailureStates.delete(this.configFile);
         return {
           projects: projectsMap,
           apiServerBindHost: parseOptionalNonEmptyString(parsed.apiServerBindHost),
@@ -1470,8 +1485,7 @@ export class Config {
           legacyOnePasswordAccountName: parseOptionalNonEmptyString(parsed.onePasswordAccountName),
         };
       } else {
-        this.lastConfigLoadFailureSignature = null;
-        this.lastConfigBackupSignature = null;
+        configLoadFailureStates.delete(this.configFile);
       }
     } catch (error) {
       this.handleConfigLoadFailure(rawBytes, error);
@@ -1827,6 +1841,16 @@ export class Config {
   private enqueueConfigEdit(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
     const run = this.editConfigQueue.then(async () => {
       const config = this.loadConfigOrDefault();
+      // If that load just failed and no sidecar backup is confirmed for the corrupt bytes,
+      // writing would permanently destroy the only copy of the user's settings. Skip the
+      // write (matching saveConfig's log-and-swallow contract) until a backup lands.
+      const failureState = configLoadFailureStates.get(this.configFile);
+      if (failureState?.backupSignature === null) {
+        log.error(
+          `Skipping config write to ${this.configFile}: the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry.`
+        );
+        return;
+      }
       const newConfig = fn(config);
       await this.saveConfig(newConfig);
       // Backend-initiated config edits (for example gateway auth changes) use this signal

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -997,10 +997,22 @@ export class Config {
           }
         });
 
+        // A reused sidecar from an older build may be world-readable; tighten it to 0600
+        // before trusting it as the backup. If tightening fails (e.g. owned by another
+        // user), fall through and create a fresh restricted sidecar instead.
+        let reusedPath: string | null = null;
         if (duplicate) {
           const duplicatePath = path.join(configDir, duplicate.name);
-          backupStatus = `Backup skipped because identical bytes already exist at ${duplicatePath}.`;
-          backupDetail = duplicatePath;
+          try {
+            fs.chmodSync(duplicatePath, 0o600);
+            reusedPath = duplicatePath;
+          } catch {
+            reusedPath = null;
+          }
+        }
+        if (reusedPath) {
+          backupStatus = `Backup skipped because identical bytes already exist at ${reusedPath}.`;
+          backupDetail = reusedPath;
         } else {
           // Write the bytes that actually failed parsing (not a re-read of the file, which
           // another process may have replaced), leaving the corrupt source in place so
@@ -1029,7 +1041,11 @@ export class Config {
         const backupErrorMessage =
           backupError instanceof Error ? backupError.message : String(backupError);
         backupStatus = `Backup failed (${backupErrorMessage}); it will be retried on the next load, and settings changes will not overwrite config.json until a backup succeeds.`;
-        backupDetail = `failed: ${backupErrorMessage}`;
+        // Node fs errors embed the attempted (timestamped) sidecar path in the message, so
+        // dedupe on the stable errno code where present or repeated ENOSPC/EACCES failures
+        // would log on every load.
+        const backupErrorCode = (backupError as NodeJS.ErrnoException).code;
+        backupDetail = `failed: ${backupErrorCode ?? backupErrorMessage}`;
       }
     }
     // Until a sidecar is confirmed for these exact bytes, enqueueConfigEdit refuses to
@@ -1860,17 +1876,40 @@ export class Config {
   private enqueueConfigEdit(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
     const run = this.editConfigQueue.then(async () => {
       const config = this.loadConfigOrDefault();
-      // If that load just failed and no sidecar backup is confirmed for the corrupt bytes,
-      // writing would permanently destroy the only copy of the user's settings. Skip the
-      // write (matching saveConfig's log-and-swallow contract) until a backup lands.
-      const failureState = configLoadFailureStates.get(this.configFile);
-      if (failureState?.backupSignature === null) {
-        log.error(
-          `Skipping config write to ${this.configFile}: the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry.`
-        );
-        return;
-      }
       const newConfig = fn(config);
+      // If that load failed, writing would replace the corrupt file with defaults. Only
+      // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
+      // no confirmed backup, a concurrent replacement since the load, or an unreadable
+      // file all skip the write (matching saveConfig's log-and-swallow contract). A
+      // missing file is safe to overwrite. This cannot fully close the cross-process
+      // race (that needs file locking, which editConfig has never had); it binds the
+      // approval to the current bytes and shrinks the window to the atomic write itself.
+      const failureState = configLoadFailureStates.get(this.configFile);
+      if (failureState) {
+        if (failureState.backupSignature === null) {
+          log.error(
+            `Skipping config write to ${this.configFile}: the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry.`
+          );
+          return;
+        }
+        try {
+          const currentBytes = fs.readFileSync(this.configFile);
+          const currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
+          if (currentSignature !== failureState.backupSignature) {
+            log.error(
+              `Skipping config write to ${this.configFile}: the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change.`
+            );
+            return;
+          }
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
+            log.error(
+              `Skipping config write to ${this.configFile}: the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
+            );
+            return;
+          }
+        }
+      }
       await this.saveConfig(newConfig);
       // Backend-initiated config edits (for example gateway auth changes) use this signal
       // so frontend subscribers can refresh derived state without polling.


### PR DESCRIPTION
## Summary

When `~/.xum/config.json` fails to parse, xum now preserves the corrupt file's exact bytes in a `config.json.corrupt-<timestamp>` sidecar, emits one actionable default-on error log naming the file, the parse error, the backup path, and recovery guidance, and continues with default settings instead of silently losing the user's data.

Fixes #1911

## Background

Previously, a malformed `config.json` was caught with a bare `log.error("Error loading config:", error)` and the load fell back to an empty default config. The next `editConfig()` write (which reads-then-writes the full snapshot) then atomically overwrote the corrupt file with defaults, permanently destroying the user's projects and settings with no backup and no clear diagnostics.

## Implementation

- `loadConfigOrDefault` now rejects non-object JSON roots (`null`, arrays, primitives) as parse failures instead of letting them surface as incidental TypeErrors during normalization.
- A new failure handler copies the corrupt file to a `config.json.corrupt-<timestamp>` sidecar (matching the repo's existing quarantine naming) and logs one error with the file path, parse error, backup path, and recovery guidance. It copies rather than renames: `workspaceService`'s orphan-cleanup sweeps call `loadConfigOrDefault({ throwOnError: true })` as a guard and rely on the corrupt file continuing to fail parse so best-effort cleanup is skipped rather than treating failure as an empty reference set.
- Backups and logs are deduplicated: byte-identical corrupt content never accumulates extra sidecars (including across app restarts), and repeated loads of the same corrupt content within a session log once. The failure signature resets on a successful or missing-file load so later re-corruption logs again.
- Missing `config.json` remains a completely silent fresh-install no-op.

## Validation

- Behavioral tests cover: malformed JSON recovery with byte-exact sidecar preservation, non-object roots, sidecar dedupe across `Config` instances, schema-invalid fields still healing without a sidecar, missing-file silence, recovery via `editConfig` while the sidecar retains original bytes, and `throwOnError` still throwing for the cleanup guards.
- Remote dogfood UAT (PASS): corrupted a live config, verified app launch with defaults, single actionable log line, byte-identical sidecar (cmp + sha256), valid rewritten config after a settings edit, silent fresh install on missing file, and no sidecar/log spam across repeated restarts.

## Risks

Low. The recovery path only runs when config parsing already failed (previously guaranteed data loss). The main invariant to preserve was `throwOnError` semantics for the orphan-cleanup guards, which is covered by a dedicated test.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
