### PR TITLE
🤖 fix: support "/" in git branch names when creating workspaces

### DIFF
--- a/src/browser/features/ChatInput/CreationControls.stories.tsx
+++ b/src/browser/features/ChatInput/CreationControls.stories.tsx
@@ -420,7 +420,6 @@ export const NameGenerationAuthError: Story = {
     ),
 };
 
-/** Manual naming validation error for characters outside the workspace-name policy. */
 export const NameValidationError: Story = {
   render: () =>
     renderCreationControls(
@@ -430,7 +429,7 @@ export const NameValidationError: Story = {
         error: {
           kind: "validation",
           message:
-            "Workspace names can only contain lowercase letters, numbers, hyphens, and underscores",
+            'Branch names can only contain lowercase letters, numbers, hyphens, underscores, and "/" separators',
         },
       })
     ),

--- a/src/browser/features/ChatInput/CreationControls.tsx
+++ b/src/browser/features/ChatInput/CreationControls.tsx
@@ -776,7 +776,9 @@ function CreationControlsContent(props: CreationControlsProps) {
                      field-sizing-content focus:border focus:bg-bg-dark focus:outline-none 
                      disabled:opacity-50 max-w-[50vw] sm:max-w-[40vw] lg:max-w-[30vw]`,
                     nameState.autoGenerate ? "text-muted" : "text-foreground",
-                    nameState.error && "border-red-500"
+                    // focus:border-red-500 keeps the error border visible while typing;
+                    // focus:border-accent would otherwise override it.
+                    nameState.error && "border-red-500 focus:border-red-500"
                   )}
                 />
               </TooltipTrigger>

--- a/src/browser/features/ChatInput/CreationControls.tsx
+++ b/src/browser/features/ChatInput/CreationControls.tsx
@@ -80,12 +80,7 @@ function CredentialSharingCheckbox(props: {
   );
 }
 
-function NameErrorDisplay(props: { error: WorkspaceNameUIError }) {
-  // Validation and transport errors are already human-readable plain text.
-  if (props.error.kind === "validation" || props.error.kind === "transport") {
-    return <span className="text-xs text-red-500">{props.error.message}</span>;
-  }
-
+function NameErrorDisplay(props: { error: Extract<WorkspaceNameUIError, { kind: "generation" }> }) {
   const formatted = formatNameGenerationError(props.error.error);
   return (
     <div className="text-primary rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs">
@@ -729,9 +724,13 @@ function CreationControlsContent(props: CreationControlsProps) {
     nameState.setAutoGenerate(!nameState.autoGenerate);
   }, [nameState]);
 
+  const nameTooltipError =
+    nameState.error?.kind === "validation" || nameState.error?.kind === "transport"
+      ? nameState.error
+      : null;
+
   return (
     <div className="mb-3 flex flex-col gap-4">
-      {/* Project name / workspace name header row - wraps on narrow viewports */}
       <div
         className={cn("flex gap-y-2", nameState.error ? "items-start" : "items-center")}
         data-component="WorkspaceNameGroup"
@@ -760,7 +759,7 @@ function CreationControlsContent(props: CreationControlsProps) {
         <div className="flex min-w-0 flex-col gap-1" data-component="WorkspaceNameInputBlock">
           {/* Name input with magic wand */}
           <div className="flex items-center gap-1">
-            <Tooltip>
+            <Tooltip open={nameTooltipError ? true : undefined}>
               <TooltipTrigger asChild>
                 <input
                   id="workspace-name"
@@ -770,6 +769,7 @@ function CreationControlsContent(props: CreationControlsProps) {
                   onFocus={handleInputFocus}
                   placeholder={nameState.isGenerating ? "Generating..." : "workspace-name"}
                   disabled={props.disabled}
+                  aria-invalid={nameState.error ? true : undefined}
                   className={cn(
                     `border-border-medium focus:border-accent h-7 rounded-md
                      border border-transparent bg-transparent text-lg font-semibold 
@@ -780,9 +780,18 @@ function CreationControlsContent(props: CreationControlsProps) {
                   )}
                 />
               </TooltipTrigger>
-              <TooltipContent align="start" className="max-w-64">
-                A stable identifier used for git branches, worktree folders, and session
-                directories.
+              <TooltipContent
+                align="start"
+                className={cn("max-w-64", nameTooltipError && "border-red-500/40 text-red-500")}
+              >
+                {nameTooltipError ? (
+                  nameTooltipError.message
+                ) : (
+                  <>
+                    Use lowercase letters, numbers, hyphens, underscores, and the <code>/</code>
+                    separator. Slashes in git branches map to hyphens in folder and workspace names.
+                  </>
+                )}
               </TooltipContent>
             </Tooltip>
             {/* Magic wand / loading indicator */}
@@ -816,7 +825,7 @@ function CreationControlsContent(props: CreationControlsProps) {
               </Tooltip>
             )}
           </div>
-          {nameState.error && <NameErrorDisplay error={nameState.error} />}
+          {nameState.error?.kind === "generation" && <NameErrorDisplay error={nameState.error} />}
         </div>
       </div>
 

--- a/src/browser/hooks/useWorkspaceName.ts
+++ b/src/browser/hooks/useWorkspaceName.ts
@@ -5,7 +5,10 @@ import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { getWorkspaceNameStateKey } from "@/common/constants/storage";
 import { NAME_GEN_PREFERRED_MODELS } from "@/common/constants/nameGeneration";
 import type { NameGenerationError } from "@/common/types/errors";
-import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
+import {
+  validateWorkspaceBranchName,
+  validateWorkspaceName,
+} from "@/common/utils/validation/workspaceValidation";
 
 /** Discriminated error type for workspace name operations */
 export type WorkspaceNameUIError =
@@ -359,7 +362,7 @@ export function useWorkspaceName(options: UseWorkspaceNameOptions): UseWorkspace
       setStored((prev) => ({ ...prev, manualName: newName }));
       // Validate in real-time as user types (skip empty - will show on submit)
       if (newName.trim()) {
-        const validation = validateWorkspaceName(newName);
+        const validation = validateWorkspaceBranchName(newName);
         setError(validation.error ? { kind: "validation", message: validation.error } : null);
       } else {
         setError(null);

--- a/src/common/utils/validation/workspaceValidation.test.ts
+++ b/src/common/utils/validation/workspaceValidation.test.ts
@@ -1,4 +1,9 @@
-import { validateWorkspaceName } from "./workspaceValidation";
+import {
+  getBranchWorkspaceNameConflict,
+  sanitizeBranchNameForWorkspace,
+  validateWorkspaceBranchName,
+  validateWorkspaceName,
+} from "./workspaceValidation";
 
 describe("validateWorkspaceName", () => {
   describe("valid names", () => {
@@ -80,5 +85,54 @@ describe("validateWorkspaceName", () => {
       expect(validateWorkspaceName("feature/branch").valid).toBe(false);
       expect(validateWorkspaceName("path\\to\\branch").valid).toBe(false);
     });
+  });
+});
+
+describe("validateWorkspaceBranchName", () => {
+  test.each(["feature/foo", "a/b/c", "plain-name", "branch_123"])("accepts %s", (name) => {
+    expect(validateWorkspaceBranchName(name).valid).toBe(true);
+  });
+
+  test.each(["", "/foo", "foo/", "a//b", "Feature/foo", "feature name"])("rejects %s", (name) => {
+    expect(validateWorkspaceBranchName(name).valid).toBe(false);
+  });
+
+  test("rejects names over 64 characters", () => {
+    expect(validateWorkspaceBranchName(`feature/${"a".repeat(57)}`).valid).toBe(false);
+  });
+});
+
+describe("sanitizeBranchNameForWorkspace", () => {
+  test.each([
+    ["feature/foo", "feature-foo"],
+    ["a/b/c", "a-b-c"],
+    ["plain-name", "plain-name"],
+  ])("maps %s to %s", (branchName, workspaceName) => {
+    expect(sanitizeBranchNameForWorkspace(branchName)).toBe(workspaceName);
+  });
+
+  test.each(["feature/foo", "a/b/c", "plain-name", "branch_123"])(
+    "produces a valid workspace name for %s",
+    (branchName) => {
+      expect(validateWorkspaceBranchName(branchName).valid).toBe(true);
+      expect(validateWorkspaceName(sanitizeBranchNameForWorkspace(branchName)).valid).toBe(true);
+    }
+  );
+});
+
+describe("getBranchWorkspaceNameConflict", () => {
+  test("reports the sanitized collision for slash branches", () => {
+    const conflict = getBranchWorkspaceNameConflict("feature/foo", ["other", "feature-foo"]);
+
+    expect(conflict).toContain('Branch "feature/foo"');
+    expect(conflict).toContain('workspace name "feature-foo"');
+  });
+
+  test("allows slash branches whose sanitized workspace name is unused", () => {
+    expect(getBranchWorkspaceNameConflict("feature/foo", ["feature-bar"])).toBeUndefined();
+  });
+
+  test("leaves slash-free collisions to the existing suffix policy", () => {
+    expect(getBranchWorkspaceNameConflict("feature-foo", ["feature-foo"])).toBeUndefined();
   });
 });

--- a/src/common/utils/validation/workspaceValidation.ts
+++ b/src/common/utils/validation/workspaceValidation.ts
@@ -26,3 +26,52 @@ export function validateWorkspaceName(name: string): { valid: boolean; error?: s
 
   return { valid: true };
 }
+
+export function validateWorkspaceBranchName(name: string): { valid: boolean; error?: string } {
+  if (!name || name.length === 0) {
+    return { valid: false, error: "Branch name cannot be empty" };
+  }
+
+  if (name.length > 64) {
+    return { valid: false, error: "Branch name cannot exceed 64 characters" };
+  }
+
+  const validPattern = /^[a-z0-9_-]+(?:\/[a-z0-9_-]+)*$/;
+  if (!validPattern.test(name)) {
+    return {
+      valid: false,
+      error:
+        'Branch names can only contain lowercase letters, numbers, hyphens, underscores, and "/" separators',
+    };
+  }
+
+  return { valid: true };
+}
+
+/** Valid branch names sanitize to valid workspace names without changing their length. */
+export function sanitizeBranchNameForWorkspace(branchName: string): string {
+  return branchName.replaceAll("/", "-");
+}
+
+export function formatBranchWorkspaceNameConflict(branchName: string): string {
+  const workspaceName = sanitizeBranchNameForWorkspace(branchName);
+  return `Branch "${branchName}" maps to workspace name "${workspaceName}", which conflicts with an existing workspace. Choose a different branch name.`;
+}
+
+export function getBranchWorkspaceNameConflict(
+  branchName: string,
+  existingWorkspaceNames: Iterable<string | undefined>
+): string | undefined {
+  const workspaceName = sanitizeBranchNameForWorkspace(branchName);
+  if (branchName === workspaceName) {
+    return undefined;
+  }
+
+  for (const existingName of existingWorkspaceNames) {
+    if (existingName === workspaceName) {
+      return formatBranchWorkspaceNameConflict(branchName);
+    }
+  }
+
+  return undefined;
+}

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -11556,6 +11556,44 @@ describe("WorkspaceService init cancellation", () => {
     expect(generateStableIdMock).not.toHaveBeenCalled();
   });
 
+  test("create() rejects slash branches whose sanitized workspace name already exists", async () => {
+    const projectPath = "/tmp/proj";
+    const generateStableIdMock = mock(() => "ws-conflict");
+    const mockConfig: Partial<Config> = {
+      rootDir: "/tmp/mux-root",
+      srcDir: "/tmp/src",
+      getSessionDir: mock(() => "/tmp/test/sessions"),
+      generateStableId: generateStableIdMock,
+      findWorkspace: mock(() => null),
+      loadConfigOrDefault: mock(() => ({
+        projects: new Map([
+          [
+            projectPath,
+            {
+              workspaces: [{ id: "existing", name: "feature-foo", path: "/tmp/proj/feature-foo" }],
+              trusted: true,
+            },
+          ],
+        ]),
+      })),
+    };
+    const workspaceService = createWorkspaceServiceForTest({
+      config: mockConfig,
+      historyService,
+    });
+
+    const result = await workspaceService.create(projectPath, "feature/foo", undefined, "title", {
+      type: "local",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Branch "feature/foo"');
+      expect(result.error).toContain('workspace name "feature-foo"');
+    }
+    expect(generateStableIdMock).not.toHaveBeenCalled();
+  });
+
   test("archive() aborts init and still archives when init is running", async () => {
     const workspaceId = "ws-init-running";
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -66,7 +66,13 @@ import { targetWorkspaceBucketToLayer } from "@/common/types/agentAiSettings";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import { resolveAgentAiSettings } from "@/common/utils/ai/resolveAgentAiSettings";
 import { getWorkspacePathHintForProject } from "@/node/services/workspaceProjectRepos";
-import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
+import {
+  formatBranchWorkspaceNameConflict,
+  getBranchWorkspaceNameConflict,
+  sanitizeBranchNameForWorkspace,
+  validateWorkspaceBranchName,
+  validateWorkspaceName,
+} from "@/common/utils/validation/workspaceValidation";
 import { ensurePrivateDir, isErrnoWithCode } from "@/node/utils/fs";
 import {
   CHAT_FILE_NAME,
@@ -4160,10 +4166,19 @@ export class WorkspaceService extends EventEmitter {
       resolvedBranchName = branchName;
     }
 
-    // Validate workspace name (covers both caller-provided and auto-generated names)
-    const validation = validateWorkspaceName(resolvedBranchName);
+    const validation = validateWorkspaceBranchName(resolvedBranchName);
     if (!validation.valid) {
-      return Err(validation.error ?? "Invalid workspace name");
+      return Err(validation.error ?? "Invalid branch name");
+    }
+
+    const initialWorkspaceName = sanitizeBranchNameForWorkspace(resolvedBranchName);
+    // Sanitized collisions must fail so distinct Git branches cannot share one workspace identity.
+    const initialConflict = getBranchWorkspaceNameConflict(
+      resolvedBranchName,
+      (projectConfig.workspaces ?? []).map((workspace) => workspace.name)
+    );
+    if (initialConflict) {
+      return Err(initialConflict);
     }
 
     // Generate stable workspace ID
@@ -4222,8 +4237,9 @@ export class WorkspaceService extends EventEmitter {
     const initLogger = this.createInitLogger(workspaceId);
 
     try {
-      // Create workspace with automatic collision retry
       let finalBranchName = resolvedBranchName;
+      let finalWorkspaceName = initialWorkspaceName;
+      const hasSanitizedWorkspaceName = finalBranchName !== finalWorkspaceName;
       let createResult: { success: boolean; workspacePath?: string; error?: string };
 
       // If runtime uses config-level collision detection (e.g., Coder - can't reach host),
@@ -4234,24 +4250,34 @@ export class WorkspaceService extends EventEmitter {
             (w) => w.name
           )
         );
+        const configConflict = getBranchWorkspaceNameConflict(finalBranchName, existingNames);
+        if (configConflict) {
+          initLogger.logComplete(-1);
+          return Err(configConflict);
+        }
+
         for (
           let i = 0;
-          i < MAX_WORKSPACE_NAME_COLLISION_RETRIES && existingNames.has(finalBranchName);
+          i < MAX_WORKSPACE_NAME_COLLISION_RETRIES && existingNames.has(finalWorkspaceName);
           i++
         ) {
-          log.debug(`Workspace name collision for "${finalBranchName}", adding suffix`);
+          log.debug(`Workspace name collision for "${finalWorkspaceName}", adding suffix`);
           finalBranchName = appendCollisionSuffix(resolvedBranchName);
+          finalWorkspaceName = sanitizeBranchNameForWorkspace(finalBranchName);
         }
       }
 
       const createEnv = await secretsToRecord(this.config.getEffectiveSecrets(owningProjectPath));
+      const maxCollisionRetries = hasSanitizedWorkspaceName
+        ? 0
+        : MAX_WORKSPACE_NAME_COLLISION_RETRIES;
 
-      for (let attempt = 0; attempt <= MAX_WORKSPACE_NAME_COLLISION_RETRIES; attempt++) {
+      for (let attempt = 0; attempt <= maxCollisionRetries; attempt++) {
         createResult = await runtime.createWorkspace({
           projectPath: owningProjectPath,
           branchName: finalBranchName,
           trunkBranch: normalizedTrunkBranch,
-          directoryName: finalBranchName,
+          directoryName: finalWorkspaceName,
           initLogger,
           abortSignal: initAbortController.signal,
           env: createEnv,
@@ -4260,13 +4286,18 @@ export class WorkspaceService extends EventEmitter {
 
         if (createResult.success) break;
 
-        // If collision and not last attempt, retry with suffix
+        if (hasSanitizedWorkspaceName && isWorkspaceNameCollision(createResult.error)) {
+          initLogger.logComplete(-1);
+          return Err(formatBranchWorkspaceNameConflict(finalBranchName));
+        }
+
         if (
           isWorkspaceNameCollision(createResult.error) &&
           attempt < MAX_WORKSPACE_NAME_COLLISION_RETRIES
         ) {
-          log.debug(`Workspace name collision for "${finalBranchName}", retrying with suffix`);
+          log.debug(`Workspace name collision for "${finalWorkspaceName}", retrying with suffix`);
           finalBranchName = appendCollisionSuffix(resolvedBranchName);
+          finalWorkspaceName = sanitizeBranchNameForWorkspace(finalBranchName);
           continue;
         }
         break;
@@ -4279,7 +4310,7 @@ export class WorkspaceService extends EventEmitter {
 
       // Let runtime finalize config (e.g., derive names, compute host) after collision handling
       if (runtime.finalizeConfig) {
-        const finalizeResult = await runtime.finalizeConfig(finalBranchName, finalRuntimeConfig);
+        const finalizeResult = await runtime.finalizeConfig(finalWorkspaceName, finalRuntimeConfig);
         if (!finalizeResult.success) {
           initLogger.logComplete(-1);
           return Err(finalizeResult.error);
@@ -4291,7 +4322,7 @@ export class WorkspaceService extends EventEmitter {
       // Let runtime validate before persisting (e.g., external collision checks)
       if (runtime.validateBeforePersist) {
         const validateResult = await runtime.validateBeforePersist(
-          finalBranchName,
+          finalWorkspaceName,
           finalRuntimeConfig
         );
         if (!validateResult.success) {
@@ -4305,7 +4336,7 @@ export class WorkspaceService extends EventEmitter {
 
       const metadata = {
         id: workspaceId,
-        name: finalBranchName,
+        name: finalWorkspaceName,
         title,
         projectName,
         projectPath: owningProjectPath,
@@ -4322,7 +4353,7 @@ export class WorkspaceService extends EventEmitter {
         projectConfig.workspaces.push({
           path: createResult!.workspacePath!,
           id: workspaceId,
-          name: finalBranchName,
+          name: finalWorkspaceName,
           title,
           createdAt: metadata.createdAt,
           runtimeConfig: finalRuntimeConfig,
@@ -4410,10 +4441,11 @@ export class WorkspaceService extends EventEmitter {
     let initLogger: ReturnType<WorkspaceService["createInitLogger"]> | null = null;
 
     try {
-      const validation = validateWorkspaceName(branchName);
+      const validation = validateWorkspaceBranchName(branchName);
       if (!validation.valid) {
-        return Err(validation.error ?? "Invalid workspace name");
+        return Err(validation.error ?? "Invalid branch name");
       }
+      const workspaceName = sanitizeBranchNameForWorkspace(branchName);
 
       const normalizedProjects = projects.map((project) => ({
         projectPath: stripTrailingSlashes(project.projectPath),
@@ -4443,6 +4475,24 @@ export class WorkspaceService extends EventEmitter {
             `Project ${project.projectName} must be trusted before creating workspaces. Trust the project in Settings → Security, or create a workspace from the project page.`
           );
         }
+      }
+
+      const existingWorkspaceNames = [
+        ...(configSnapshot.projects.get(MULTI_PROJECT_CONFIG_KEY)?.workspaces ?? []).map(
+          (workspace) => workspace.name
+        ),
+        ...normalizedProjects.flatMap((project) =>
+          (
+            configSnapshot.projects.get(stripTrailingSlashes(project.projectPath))?.workspaces ?? []
+          ).map((workspace) => workspace.name)
+        ),
+      ];
+      const workspaceNameConflict = getBranchWorkspaceNameConflict(
+        branchName,
+        existingWorkspaceNames
+      );
+      if (workspaceNameConflict) {
+        return Err(workspaceNameConflict);
       }
 
       const workspaceId = this.config.generateStableId();
@@ -4533,7 +4583,7 @@ export class WorkspaceService extends EventEmitter {
         project,
         runtime: createRuntime(finalRuntimeConfig, {
           projectPath: project.projectPath,
-          workspaceName: branchName,
+          workspaceName,
         }),
       }));
 
@@ -4554,7 +4604,7 @@ export class WorkspaceService extends EventEmitter {
             // also drop an older same-named branch in worktree runtimes.
             await createdWorkspace.runtime.deleteWorkspace(
               createdWorkspace.project.projectPath,
-              branchName,
+              workspaceName,
               false,
               initAbortController.signal,
               trusted
@@ -4600,7 +4650,7 @@ export class WorkspaceService extends EventEmitter {
           projectPath: projectRuntimeEntry.project.projectPath,
           branchName,
           trunkBranch: projectTrunkBranch,
-          directoryName: branchName,
+          directoryName: workspaceName,
           initLogger,
           abortSignal: initAbortController.signal,
           env: createEnv,
@@ -4610,6 +4660,9 @@ export class WorkspaceService extends EventEmitter {
         if (!createResult.success || !createResult.workspacePath) {
           await rollbackCreatedWorkspaces();
           initLogger.logComplete(-1);
+          if (branchName !== workspaceName && isWorkspaceNameCollision(createResult.error)) {
+            return Err(formatBranchWorkspaceNameConflict(branchName));
+          }
           return Err(
             createResult.error ??
               `Failed to create workspace for project ${projectRuntimeEntry.project.projectName}`
@@ -4628,7 +4681,7 @@ export class WorkspaceService extends EventEmitter {
       let containerPath: string;
       try {
         containerPath = await containerManager.createContainer(
-          branchName,
+          workspaceName,
           createdWorkspaces.map((workspace) => ({
             projectName: workspace.project.projectName,
             workspacePath: workspace.workspacePath,
@@ -4639,7 +4692,7 @@ export class WorkspaceService extends EventEmitter {
         const containerAlreadyExists = isErrnoWithCode(error, "EEXIST");
         if (!containerAlreadyExists) {
           try {
-            await containerManager.removeContainer(branchName);
+            await containerManager.removeContainer(workspaceName);
           } catch (cleanupError: unknown) {
             log.error("Failed to clean up multi-project container after create failure", {
               workspaceId,
@@ -4650,7 +4703,10 @@ export class WorkspaceService extends EventEmitter {
         }
         initLogger.logComplete(-1);
         if (containerAlreadyExists) {
-          return Err(`Failed to create multi-project container: ${branchName} already exists`);
+          if (branchName !== workspaceName) {
+            return Err(formatBranchWorkspaceNameConflict(branchName));
+          }
+          return Err(`Failed to create multi-project container: ${workspaceName} already exists`);
         }
         return Err(`Failed to create multi-project container: ${getErrorMessage(error)}`);
       }
@@ -4666,7 +4722,7 @@ export class WorkspaceService extends EventEmitter {
         multiProjectConfig.workspaces.push({
           path: containerPath,
           id: workspaceId,
-          name: branchName,
+          name: workspaceName,
           title,
           createdAt,
           runtimeConfig: finalRuntimeConfig,

--- a/src/node/worktree/WorktreeManager.test.ts
+++ b/src/node/worktree/WorktreeManager.test.ts
@@ -162,10 +162,10 @@ describe("WorktreeManager.createWorkspace", () => {
       20_000
     );
   }
-  it("uses directoryName for the workspace path while checking out the requested branch", async () => {
+  it("uses a sanitized directory for slash branch names and persists the mapping", async () => {
     const fixture = await createWorktreeManagerFixture();
-    const branchName = "feature-branch";
-    const directoryName = "review-slot";
+    const branchName = "feature/foo";
+    const directoryName = "feature-foo";
 
     try {
       const result = await fixture.manager.createWorkspace({
@@ -185,6 +185,14 @@ describe("WorktreeManager.createWorkspace", () => {
       expect(result.workspacePath).toBe(
         fixture.manager.getWorkspacePath(fixture.projectPath, directoryName)
       );
+      const nestedBranchDirectoryExists = await fsPromises
+        .access(fixture.manager.getWorkspacePath(fixture.projectPath, "feature"))
+        .then(
+          () => true,
+          () => false
+        );
+      expect(nestedBranchDirectoryExists).toBe(false);
+
       const checkedOutBranch = execSync("git branch --show-current", {
         cwd: result.workspacePath,
         stdio: ["ignore", "pipe", "ignore"],
@@ -192,6 +200,13 @@ describe("WorktreeManager.createWorkspace", () => {
         .toString()
         .trim();
       expect(checkedOutBranch).toBe(branchName);
+
+      const branchMapPath = path.join(fixture.projectPath, ".git", "mux-workspace-branches.json");
+      const branchMap = JSON.parse(await fsPromises.readFile(branchMapPath, "utf8")) as Record<
+        string,
+        string
+      >;
+      expect(branchMap[directoryName]).toBe(branchName);
     } finally {
       await fixture.cleanup();
     }


### PR DESCRIPTION
## Summary

Workspace creation now accepts Git branch names containing `/` (e.g. `feature/foo`). The Git branch keeps its slashes while the workspace/worktree folder name is derived by replacing `/` with `-`; if a slash branch sanitizes to a workspace name that already exists, creation fails with an explicit conflict error. Validation errors for the name input now render in a tooltip attached to the input instead of cramped inline text.

Fixes #407

## Background

`/` is legal in Git branch names, but the creation flow used one identifier for the branch, worktree folder, workspace name, and session directory, so validation rejected slashes outright. Per the maintainer guidance in #407: replace `/` with `-` for path purposes and fail on conflicts, plus clean up the cramped validation-error display with a tooltip.

## Implementation

- `workspaceValidation.ts`: new `validateWorkspaceBranchName` (slash-separated segments of the existing `[a-z0-9_-]` charset; rejects leading/trailing/consecutive slashes), `sanitizeBranchNameForWorkspace` (`/` → `-`; valid branch names always sanitize to valid workspace names), and a conflict helper that reports when a slash branch maps onto an existing workspace name.
- `WorkspaceService.create` / `createMultiProjectWorkspace`: track the branch name and sanitized workspace name separately; pass `branchName` (real branch) and `directoryName` (sanitized) to `runtime.createWorkspace`, which already supported the split. Persisted metadata/config use the sanitized name, and runtime hooks (`finalizeConfig`, `validateBeforePersist`) receive it since Coder-derived names cannot contain `/`.
- Conflict policy: slash branches fail fast with an explicit error naming both the branch and the conflicting workspace name; slash-free names keep the existing random-suffix retry behavior.
- UI: `useWorkspaceName` validates with the branch-name rules; the name input's tooltip shows validation/transport errors (forced open, error styling, `aria-invalid`) while generation errors keep their richer box below the input. The error border stays red while the input is focused.

## Validation

- Remote dogfood UAT (2 rounds, PASS): created `feature/uat-407` → worktree folder `feature-uat-407` with `git branch --show-current` = `feature/uat-407` and no nested directory; duplicate slash branch rejected with the explicit conflict error and no suffixed workspace; invalid names (`Feature Foo`, `/foo`, `foo//bar`, `foo/`) show the error tooltip incl. at ~375px width; slash-free creation, duplicate suffixing, and wand auto-naming regressions pass.
- Behavioral tests: branch-name validation/sanitizer invariants, conflict helper, service-level conflict rejection, and a WorktreeManager slash-branch worktree test (sanitized path + persisted directory→branch mapping).

## Risks

Creation-path change shared by all runtimes. For slash-free names (the overwhelmingly common case) the flow is unchanged: same validation charset, same collision suffixing. Slash branches are new input that was previously rejected, so regression risk concentrates in the new sanitized-name path; rename/fork/sub-agent naming intentionally keep the stricter slash-free validation. Worktree removal/rename for slash branches rides the existing persisted directory→branch mapping, covered by tests.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
