### PR TITLE
🤖 fix: preserve queued follow-ups during dispatch handoff

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -860,10 +860,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const handleEditQueuedMessage = useCallback(async () => {
     const queuedMessage = workspaceState?.queuedMessage;
-    if (!queuedMessage) return;
+    if (!queuedMessage || workspaceState?.isStreamStarting) return;
 
     await restoreQueuedDraft(queuedMessage);
-  }, [restoreQueuedDraft, workspaceState?.queuedMessage]);
+  }, [restoreQueuedDraft, workspaceState?.isStreamStarting, workspaceState?.queuedMessage]);
 
   const sendQueuedImmediatelyInFlightRef = useRef<string | null>(null);
 
@@ -958,7 +958,9 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     if (!current) return;
 
     if (current.queuedMessage) {
-      await restoreQueuedDraft(current.queuedMessage);
+      if (!current.isStreamStarting) {
+        await restoreQueuedDraft(current.queuedMessage);
+      }
       return;
     }
 
@@ -1818,6 +1820,7 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         node: (
           <QueuedMessage
             message={props.queuedMessage}
+            isDispatching={props.isStreamStarting}
             onEdit={() => void props.onEditQueuedMessage()}
             onChangeDispatchMode={props.onQueuedDispatchModeChange}
             onActionError={props.onQueuedActionError}

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -860,10 +860,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const handleEditQueuedMessage = useCallback(async () => {
     const queuedMessage = workspaceState?.queuedMessage;
-    if (!queuedMessage || workspaceState?.isStreamStarting) return;
+    if (!queuedMessage || queuedMessage.isDispatching) return;
 
     await restoreQueuedDraft(queuedMessage);
-  }, [restoreQueuedDraft, workspaceState?.isStreamStarting, workspaceState?.queuedMessage]);
+  }, [restoreQueuedDraft, workspaceState?.queuedMessage]);
 
   const sendQueuedImmediatelyInFlightRef = useRef<string | null>(null);
 
@@ -958,7 +958,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     if (!current) return;
 
     if (current.queuedMessage) {
-      if (!current.isStreamStarting) {
+      if (!current.queuedMessage.isDispatching) {
         await restoreQueuedDraft(current.queuedMessage);
       }
       return;
@@ -1820,7 +1820,6 @@ const ChatInputPane: React.FC<ChatInputPaneProps> = (props) => {
         node: (
           <QueuedMessage
             message={props.queuedMessage}
-            isDispatching={props.isStreamStarting}
             onEdit={() => void props.onEditQueuedMessage()}
             onChangeDispatchMode={props.onQueuedDispatchModeChange}
             onActionError={props.onQueuedActionError}

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -3356,6 +3356,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       variant === "workspace" &&
       !editingMessageForUi &&
       props.queuedMessage != null &&
+      !isStreamStarting &&
       input.trim() === "" &&
       attachments.length === 0 &&
       reviewPanelItems.length === 0;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -3356,7 +3356,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       variant === "workspace" &&
       !editingMessageForUi &&
       props.queuedMessage != null &&
-      !isStreamStarting &&
+      props.queuedMessage.isDispatching !== true &&
       input.trim() === "" &&
       attachments.length === 0 &&
       reviewPanelItems.length === 0;

--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/common/lib/utils";
 
 interface QueuedMessageProps {
   message: QueuedMessageType;
+  isDispatching?: boolean;
   className?: string;
   onEdit?: () => void;
   onChangeDispatchMode?: (mode: QueueDispatchMode) => Promise<void>;
@@ -44,6 +45,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
   const queueDispatchMode = props.message.queueDispatchMode ?? "tool-end";
   const queueStatusLabel =
     queueDispatchMode === "turn-end" ? "Sends after this turn" : "Sends after this step";
+  const isDispatching = props.isDispatching === true;
   const isActionPending = pendingAction != null;
 
   const handleDispatchModeChange = (mode: QueueDispatchMode) => {
@@ -114,7 +116,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
             className="mt-1.5 flex max-w-full flex-wrap items-center justify-end gap-1 text-[11px]"
             data-component="QueuedMessageActions"
           >
-            {props.onEdit && (
+            {!isDispatching && props.onEdit && (
               <button
                 type="button"
                 onClick={props.onEdit}
@@ -141,10 +143,13 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
             >
               <button
                 type="button"
-                onClick={() => setIsMenuOpen((open) => !open)}
-                aria-haspopup="menu"
-                aria-expanded={isMenuOpen}
-                className="text-secondary bg-muted/10 hover:bg-hover hover:text-foreground flex h-6 max-w-full items-center gap-1.5 rounded-md px-2 font-medium transition-colors"
+                onClick={() => {
+                  if (!isDispatching) setIsMenuOpen((open) => !open);
+                }}
+                aria-haspopup={isDispatching ? undefined : "menu"}
+                aria-expanded={isDispatching ? undefined : isMenuOpen}
+                disabled={isDispatching}
+                className="text-secondary bg-muted/10 hover:bg-hover hover:text-foreground flex h-6 max-w-full items-center gap-1.5 rounded-md px-2 font-medium transition-colors disabled:cursor-default"
                 data-component="QueuedMessageStatus"
               >
                 {pendingAction === "mode" ? (
@@ -152,12 +157,14 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
                 ) : (
                   <Clock3 className="text-pending size-3 shrink-0" />
                 )}
-                <span className="text-foreground shrink-0">Queued</span>
-                <span className="truncate">{queueStatusLabel}</span>
-                <ChevronDown className="size-3 shrink-0" />
+                <span className="text-foreground shrink-0">
+                  {isDispatching ? "Sending" : "Queued"}
+                </span>
+                {!isDispatching && <span className="truncate">{queueStatusLabel}</span>}
+                {!isDispatching && <ChevronDown className="size-3 shrink-0" />}
               </button>
 
-              {isMenuOpen && (
+              {!isDispatching && isMenuOpen && (
                 <div
                   role="menu"
                   className="bg-separator border-border-light absolute right-0 bottom-full z-[1020] mb-1 min-w-[12rem] rounded-md border p-1.5 shadow-md"

--- a/src/browser/features/Messages/QueuedMessage.tsx
+++ b/src/browser/features/Messages/QueuedMessage.tsx
@@ -11,7 +11,6 @@ import { cn } from "@/common/lib/utils";
 
 interface QueuedMessageProps {
   message: QueuedMessageType;
-  isDispatching?: boolean;
   className?: string;
   onEdit?: () => void;
   onChangeDispatchMode?: (mode: QueueDispatchMode) => Promise<void>;
@@ -45,7 +44,7 @@ export const QueuedMessage: React.FC<QueuedMessageProps> = (props) => {
   const queueDispatchMode = props.message.queueDispatchMode ?? "tool-end";
   const queueStatusLabel =
     queueDispatchMode === "turn-end" ? "Sends after this turn" : "Sends after this step";
-  const isDispatching = props.isDispatching === true;
+  const isDispatching = props.message.isDispatching === true;
   const isActionPending = pendingAction != null;
 
   const handleDispatchModeChange = (mode: QueueDispatchMode) => {

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1132,12 +1132,14 @@ export class WorkspaceStore {
               data.reviews?.map((review) => [review.filePath, review.lineRange]) ?? [],
               data.queueDispatchMode,
               data.hasCompactionRequest,
+              data.isDispatching,
             ])}`,
             content: data.displayText,
             fileParts: data.fileParts,
             reviews: data.reviews,
             queueDispatchMode: data.queueDispatchMode,
             hasCompactionRequest: data.hasCompactionRequest,
+            isDispatching: data.isDispatching,
           }
         : null;
 

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -642,6 +642,8 @@ export const QueuedMessageChangedEventSchema = z.object({
   queueDispatchMode: z.enum(["tool-end", "turn-end"]).optional(),
   /** True when the queued message is a compaction request (/compact) */
   hasCompactionRequest: z.boolean().optional(),
+  /** True when the visible projection includes an entry being durably accepted. */
+  isDispatching: z.boolean().optional(),
 });
 
 export const RestoreToInputEventSchema = z.object({

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1079,6 +1079,8 @@ export interface QueuedMessage {
   queueDispatchMode?: QueueDispatchMode;
   /** True when the queued message is a compaction request (/compact) */
   hasCompactionRequest?: boolean;
+  /** True when this projection includes an entry being durably accepted. */
+  isDispatching?: boolean;
 }
 
 /** Keep every snapshot kind here so history scans and edits retain it with its user message. */

--- a/src/node/services/agentSession.disposeRace.test.ts
+++ b/src/node/services/agentSession.disposeRace.test.ts
@@ -426,7 +426,7 @@ describe("AgentSession disposal race conditions", () => {
       (
         _message: string,
         _options?: { model: string; agentId: string },
-        _internal?: { synthetic?: boolean }
+        _internal?: { synthetic?: boolean; onAccepted?: () => Promise<void> }
       ) => Promise.resolve(Ok(undefined))
     );
 
@@ -440,10 +440,11 @@ describe("AgentSession disposal race conditions", () => {
     session.sendQueuedMessages();
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledWith(
-      "Background compaction request",
-      expect.objectContaining({ model: "anthropic:claude-sonnet-4-5", agentId: "compact" }),
-      { synthetic: true }
-    );
+    const call = sendMessage.mock.calls[0];
+    if (!call) throw new Error("Expected queued message dispatch");
+    expect(call[0]).toBe("Background compaction request");
+    expect(call[1]).toMatchObject({ model: "anthropic:claude-sonnet-4-5", agentId: "compact" });
+    expect(call[2]?.synthetic).toBe(true);
+    expect(typeof call[2]?.onAccepted).toBe("function");
   });
 });

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -531,34 +531,48 @@ describe("AgentSession queued message tool-call dispatch", () => {
       }
     );
     const followUp = "Follow up after compaction";
+    const nextFollowUp = "A later queued message";
     const isFollowUpUserMessage = (event: (typeof events)[number]) =>
       event.type === "message" &&
       event.role === "user" &&
       event.parts.some((part) => part.type === "text" && part.text === followUp);
-    const latestQueuedMessages = () =>
-      events.filter((event) => event.type === "queued-message-changed").at(-1)?.queuedMessages;
+    const latestQueueEvent = () =>
+      events.filter((event) => event.type === "queued-message-changed").at(-1);
 
     try {
       session.queueMessage(followUp, { model: TEST_MODEL, agentId: "exec" });
+      const queueEventCountBeforeDispatch = events.filter(
+        (event) => event.type === "queued-message-changed"
+      ).length;
       session.sendQueuedMessages();
       await appendStarted.promise;
 
-      expect(latestQueuedMessages()).toEqual([followUp]);
+      expect(events.filter((event) => event.type === "queued-message-changed").length).toBe(
+        queueEventCountBeforeDispatch + 1
+      );
+      expect(latestQueueEvent()?.queuedMessages).toEqual([followUp]);
       expect(events.some(isFollowUpUserMessage)).toBe(false);
+
+      // Any queue mutation during persistence must retain the in-flight entry in the
+      // authoritative projection instead of falling back to a stale renderer snapshot.
+      session.queueMessage(nextFollowUp, { model: TEST_MODEL, agentId: "exec" });
+      expect(latestQueueEvent()?.queuedMessages).toEqual([followUp, nextFollowUp]);
 
       appendRelease.resolve();
       expect(await waitForCondition(() => events.some(isFollowUpUserMessage))).toBe(true);
-      expect(await waitForCondition(() => latestQueuedMessages()?.length === 0)).toBe(true);
+      expect(
+        await waitForCondition(() => latestQueueEvent()?.queuedMessages.join() === nextFollowUp)
+      ).toBe(true);
 
       const userMessageIndex = events.findIndex(isFollowUpUserMessage);
-      const clearedQueueIndex = events.findIndex(
+      const handoffIndex = events.findIndex(
         (event, index) =>
           index > userMessageIndex &&
           event.type === "queued-message-changed" &&
-          event.queuedMessages.length === 0
+          event.queuedMessages.join() === nextFollowUp
       );
       expect(userMessageIndex).toBeGreaterThanOrEqual(0);
-      expect(clearedQueueIndex).toBeGreaterThan(userMessageIndex);
+      expect(handoffIndex).toBeGreaterThan(userMessageIndex);
     } finally {
       appendRelease.resolve();
       appendSpy.mockRestore();

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -516,8 +516,21 @@ describe("AgentSession queued message tool-call dispatch", () => {
 
   test("keeps a dequeued user message visible until its durable row is emitted", async () => {
     const workspaceId = "queue-dispatch-visible-handoff";
+    const goalSyncStarted = Promise.withResolvers<void>();
+    const goalSyncRelease = Promise.withResolvers<void>();
+    const workspaceGoalService = {
+      assertPricedModelForBudgetedGoal: mock(() => Promise.resolve(Ok(undefined))),
+      syncGoalModeWithChatTail: mock(async () => {
+        goalSyncStarted.resolve();
+        await goalSyncRelease.promise;
+      }),
+      clearPendingContinuationForManualUserMessage: mock(() => undefined),
+      acknowledgeUser: mock(() => Promise.resolve(null)),
+    } as unknown as WorkspaceGoalService;
     const { session, cleanup, historyService, events } = await createAgentSessionHarness({
       workspaceId,
+      workspaceGoalService,
+      initStateManagerOverrides: { replayInit: mock(() => Promise.resolve()) },
       captureEvents: true,
     });
     const originalAppend = historyService.appendToHistory.bind(historyService);
@@ -559,6 +572,20 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(latestQueueEvent()?.queuedMessages).toEqual([followUp, nextFollowUp]);
 
       appendRelease.resolve();
+      await goalSyncStarted.promise;
+
+      // Reconnect replay already includes the persisted user row, so its queue snapshot must
+      // omit that dispatch while retaining later queued input.
+      const replayEvents: Array<(typeof events)[number]> = [];
+      await session.replayHistory(({ message }) => replayEvents.push(message));
+      expect(replayEvents.some(isFollowUpUserMessage)).toBe(true);
+      const replayQueueEvent = replayEvents.find(
+        (event) => event.type === "queued-message-changed"
+      );
+      expect(replayQueueEvent?.queuedMessages).toEqual([nextFollowUp]);
+      expect(replayQueueEvent?.isDispatching).toBe(false);
+
+      goalSyncRelease.resolve();
       expect(await waitForCondition(() => events.some(isFollowUpUserMessage))).toBe(true);
       expect(
         await waitForCondition(() => latestQueueEvent()?.queuedMessages.join() === nextFollowUp)
@@ -575,6 +602,7 @@ describe("AgentSession queued message tool-call dispatch", () => {
       expect(handoffIndex).toBeGreaterThan(userMessageIndex);
     } finally {
       appendRelease.resolve();
+      goalSyncRelease.resolve();
       appendSpy.mockRestore();
       session.dispose();
       await cleanup();

--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -514,6 +514,59 @@ describe("AgentSession queued message tool-call dispatch", () => {
     }
   });
 
+  test("keeps a dequeued user message visible until its durable row is emitted", async () => {
+    const workspaceId = "queue-dispatch-visible-handoff";
+    const { session, cleanup, historyService, events } = await createAgentSessionHarness({
+      workspaceId,
+      captureEvents: true,
+    });
+    const originalAppend = historyService.appendToHistory.bind(historyService);
+    const appendStarted = Promise.withResolvers<void>();
+    const appendRelease = Promise.withResolvers<void>();
+    const appendSpy = spyOn(historyService, "appendToHistory").mockImplementation(
+      async (...args) => {
+        appendStarted.resolve();
+        await appendRelease.promise;
+        return originalAppend(...args);
+      }
+    );
+    const followUp = "Follow up after compaction";
+    const isFollowUpUserMessage = (event: (typeof events)[number]) =>
+      event.type === "message" &&
+      event.role === "user" &&
+      event.parts.some((part) => part.type === "text" && part.text === followUp);
+    const latestQueuedMessages = () =>
+      events.filter((event) => event.type === "queued-message-changed").at(-1)?.queuedMessages;
+
+    try {
+      session.queueMessage(followUp, { model: TEST_MODEL, agentId: "exec" });
+      session.sendQueuedMessages();
+      await appendStarted.promise;
+
+      expect(latestQueuedMessages()).toEqual([followUp]);
+      expect(events.some(isFollowUpUserMessage)).toBe(false);
+
+      appendRelease.resolve();
+      expect(await waitForCondition(() => events.some(isFollowUpUserMessage))).toBe(true);
+      expect(await waitForCondition(() => latestQueuedMessages()?.length === 0)).toBe(true);
+
+      const userMessageIndex = events.findIndex(isFollowUpUserMessage);
+      const clearedQueueIndex = events.findIndex(
+        (event, index) =>
+          index > userMessageIndex &&
+          event.type === "queued-message-changed" &&
+          event.queuedMessages.length === 0
+      );
+      expect(userMessageIndex).toBeGreaterThanOrEqual(0);
+      expect(clearedQueueIndex).toBeGreaterThan(userMessageIndex);
+    } finally {
+      appendRelease.resolve();
+      appendSpy.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("cancel signal retracts a synthetic entry after dequeue while history append is preparing", async () => {
     const workspaceId = "queue-dispatch-cancel-preparing";
     const { session, cleanup, historyService, events } = await createAgentSessionHarness({

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -99,7 +99,7 @@ import {
   createRuntimeContextForWorkspace,
   createRuntimeForWorkspace,
 } from "@/node/runtime/runtimeHelpers";
-import { MessageQueue } from "./messageQueue";
+import { MessageQueue, type MessageQueueVisibleProjection } from "./messageQueue";
 import {
   copyStreamLifecycleSnapshot,
   type RuntimeStatusEvent,
@@ -706,14 +706,11 @@ export class AgentSession {
   /** Tracks whether the current stream included post-compaction attachments. */
   private activeStreamHadPostCompactionInjection = false;
 
-  /**
-   * muxMetadata of the queued entry currently being dispatched, held from
-   * dequeue until its sendMessage settles (the stream has started or failed).
-   * Lets hasPendingBashMonitorWakeContinuation see a wake continuation during
-   * the dequeue→stream-start window without consulting stale stream context.
-   */
-  private dispatchingQueuedEntry = false;
-  private dispatchingQueuedEntryMuxMetadata?: unknown;
+  /** Queued entry held through the dequeue→acceptance handoff for projection and correlation. */
+  private dispatchingQueuedEntry?: {
+    muxMetadata?: unknown;
+    visibleProjection?: MessageQueueVisibleProjection;
+  };
 
   /** Correlation of the direct send currently in the PREPARING phase, if any. */
   private preparingWorkspaceTurnMetadata?: WorkspaceTurnMuxMetadata;
@@ -2504,21 +2501,11 @@ export class AgentSession {
         emitCurrentReplayTerminalState();
       }
 
-      // Replay queued-message snapshot before caught-up so reconnect clients can
-      // rebuild queue UI state even when history replay errored mid-flight.
+      // Replay the authoritative queue projection before caught-up so reconnect clients
+      // retain a user entry that is between dequeue and durable transcript emission.
       listener({
         workspaceId: this.workspaceId,
-        message: {
-          type: "queued-message-changed",
-          workspaceId: this.workspaceId,
-          hasQueuedMessages: !this.messageQueue.isEmpty(),
-          queuedMessages: this.messageQueue.getVisibleMessages(),
-          displayText: this.messageQueue.getVisibleDisplayText(),
-          fileParts: this.messageQueue.getVisibleFileParts(),
-          reviews: this.messageQueue.getVisibleReviews(),
-          queueDispatchMode: this.messageQueue.getVisibleQueueDispatchMode(),
-          hasCompactionRequest: this.messageQueue.hasVisibleCompactionRequest(),
-        },
+        message: this.getQueuedMessageChangedEvent(),
       });
 
       // Rehydrate pending auto-retry countdown state on reconnect/reload so
@@ -4890,8 +4877,7 @@ export class AgentSession {
 
     forward("stream-start", (payload) => {
       if (payload.type === "stream-start") {
-        this.dispatchingQueuedEntry = false;
-        this.dispatchingQueuedEntryMuxMetadata = undefined;
+        this.dispatchingQueuedEntry = undefined;
         this.preparingWorkspaceTurnMetadata = undefined;
         this.activeStreamStartedAtMs = payload.startTime;
         this.queuedProviderToolEndAbortInFlight = false;
@@ -5389,8 +5375,7 @@ export class AgentSession {
     this.emitStreamLifecycleIfChanged();
 
     if (next === TurnPhase.IDLE) {
-      this.dispatchingQueuedEntry = false;
-      this.dispatchingQueuedEntryMuxMetadata = undefined;
+      this.dispatchingQueuedEntry = undefined;
       this.preparingWorkspaceTurnMetadata = undefined;
       // Turn ended: expire any mid-turn thinking override. Safe unconditionally
       // because a replacement turn (e.g. an edit) only creates its holder after
@@ -5657,7 +5642,7 @@ export class AgentSession {
 
     if (this.dispatchingQueuedEntry) {
       const dispatchingMetadata = getWorkspaceTurnMuxMetadata(
-        this.dispatchingQueuedEntryMuxMetadata
+        this.dispatchingQueuedEntry.muxMetadata
       );
       if (!hasSameWorkspaceTurnCorrelation(dispatchingMetadata, continuationMetadata)) {
         return true;
@@ -5692,7 +5677,7 @@ export class AgentSession {
     if (this.messageQueue.isNextEntryBashMonitorWake()) {
       return true;
     }
-    const dispatching = this.dispatchingQueuedEntryMuxMetadata as MuxMessageMetadata | undefined;
+    const dispatching = this.dispatchingQueuedEntry?.muxMetadata as MuxMessageMetadata | undefined;
     return dispatching?.type === "bash-monitor-wake";
   }
 
@@ -5716,7 +5701,7 @@ export class AgentSession {
       return true;
     }
 
-    const dispatching = this.dispatchingQueuedEntryMuxMetadata as MuxMessageMetadata | undefined;
+    const dispatching = this.dispatchingQueuedEntry?.muxMetadata as MuxMessageMetadata | undefined;
     return (
       dispatching?.type === "workspace-turn-task" &&
       dispatching.taskHandleId === metadata.taskHandleId &&
@@ -5837,10 +5822,8 @@ export class AgentSession {
       return;
     }
 
-    const queuedMessages = this.messageQueue.getVisibleMessages();
-    const displayText = this.messageQueue.getVisibleDisplayText();
-    const fileParts = this.messageQueue.getVisibleFileParts();
-    const reviews = this.messageQueue.getVisibleReviews();
+    const { queuedMessages, displayText, fileParts, reviews } =
+      this.messageQueue.getVisibleProjection();
     const hasVisibleContent =
       queuedMessages.length > 0 || fileParts.length > 0 || (reviews?.length ?? 0) > 0;
 
@@ -5859,18 +5842,30 @@ export class AgentSession {
     }
   }
 
-  private emitQueuedMessageChanged(): void {
-    this.emitChatEvent({
+  private getQueuedMessageChangedEvent(): Extract<
+    WorkspaceChatMessage,
+    { type: "queued-message-changed" }
+  > {
+    const pending = this.messageQueue.getVisibleProjection();
+    const dispatching = this.dispatchingQueuedEntry?.visibleProjection;
+    const reviews = [...(dispatching?.reviews ?? []), ...(pending.reviews ?? [])];
+
+    return {
       type: "queued-message-changed",
       workspaceId: this.workspaceId,
-      hasQueuedMessages: !this.messageQueue.isEmpty(),
-      queuedMessages: this.messageQueue.getVisibleMessages(),
-      displayText: this.messageQueue.getVisibleDisplayText(),
-      fileParts: this.messageQueue.getVisibleFileParts(),
-      reviews: this.messageQueue.getVisibleReviews(),
-      queueDispatchMode: this.messageQueue.getVisibleQueueDispatchMode(),
-      hasCompactionRequest: this.messageQueue.hasVisibleCompactionRequest(),
-    });
+      hasQueuedMessages: this.dispatchingQueuedEntry != null || !this.messageQueue.isEmpty(),
+      queuedMessages: [...(dispatching?.queuedMessages ?? []), ...pending.queuedMessages],
+      displayText: [dispatching?.displayText, pending.displayText].filter(Boolean).join("\n"),
+      fileParts: [...(dispatching?.fileParts ?? []), ...pending.fileParts],
+      reviews: reviews.length > 0 ? reviews : undefined,
+      queueDispatchMode: dispatching?.queueDispatchMode ?? pending.queueDispatchMode,
+      hasCompactionRequest:
+        dispatching?.hasCompactionRequest === true || pending.hasCompactionRequest,
+    };
+  }
+
+  private emitQueuedMessageChanged(): void {
+    this.emitChatEvent(this.getQueuedMessageChangedEvent());
   }
 
   /**
@@ -5906,16 +5901,20 @@ export class AgentSession {
       // Entries dispatch one at a time (FIFO): special sends (compaction, agent
       // skills, workspace-turn follow-ups) own their turn, and anything queued
       // behind them dispatches on a later drain instead of batching into them.
-      const { message, options, internal } = this.messageQueue.dequeueNext();
-      this.dispatchingQueuedEntry = true;
-      this.dispatchingQueuedEntryMuxMetadata = options?.muxMetadata;
+      const { message, options, internal, visibleProjection } = this.messageQueue.dequeueNext();
+      this.dispatchingQueuedEntry = {
+        muxMetadata: options?.muxMetadata,
+        visibleProjection,
+      };
+      // PREPARING disables queue actions while the authoritative projection includes
+      // the in-flight entry, preventing stale Edit/Send-now operations during persistence.
+      this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
+      this.setTurnPhase(TurnPhase.PREPARING);
+      this.emitQueuedMessageChanged();
 
-      // Keep the dequeued user entry visible until sendMessage emits its durable user row.
-      // Otherwise compaction completion clears the queue card before the transcript replacement exists.
       const finishDispatchWithoutStream = (): void => {
+        this.dispatchingQueuedEntry = undefined;
         this.emitQueuedMessageChanged();
-        this.dispatchingQueuedEntry = false;
-        this.dispatchingQueuedEntryMuxMetadata = undefined;
         if (this.turnPhase === TurnPhase.PREPARING) {
           this.setTurnPhase(TurnPhase.IDLE);
         }
@@ -5932,14 +5931,11 @@ export class AgentSession {
         );
       }
 
-      // Set PREPARING synchronously before the async sendMessage to prevent
-      // incoming messages from bypassing the queue during the await gap.
-      this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
-      this.setTurnPhase(TurnPhase.PREPARING);
-
       void this.sendMessage(message, options, {
         ...internal,
         onAccepted: async () => {
+          // sendMessage has emitted the durable user row, so the transient queue projection can hand off.
+          this.dispatchingQueuedEntry = undefined;
           this.emitQueuedMessageChanged();
           await internal?.onAccepted?.();
         },

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -5909,7 +5909,19 @@ export class AgentSession {
       const { message, options, internal } = this.messageQueue.dequeueNext();
       this.dispatchingQueuedEntry = true;
       this.dispatchingQueuedEntryMuxMetadata = options?.muxMetadata;
-      this.emitQueuedMessageChanged();
+
+      // Keep the dequeued user entry visible until sendMessage emits its durable user row.
+      // Otherwise compaction completion clears the queue card before the transcript replacement exists.
+      const finishDispatchWithoutStream = (): void => {
+        this.emitQueuedMessageChanged();
+        this.dispatchingQueuedEntry = false;
+        this.dispatchingQueuedEntryMuxMetadata = undefined;
+        if (this.turnPhase === TurnPhase.PREPARING) {
+          this.setTurnPhase(TurnPhase.IDLE);
+        }
+        // No stream will drain later entries, so continue now (each attempt pops one entry).
+        this.sendQueuedMessages();
+      };
 
       // Re-arm dispatch signals for the remaining entries so the stream we are
       // about to start drains them at its next tool end (or stream end).
@@ -5925,41 +5937,26 @@ export class AgentSession {
       this.preparingWorkspaceTurnMetadata = getWorkspaceTurnMuxMetadata(options?.muxMetadata);
       this.setTurnPhase(TurnPhase.PREPARING);
 
-      void this.sendMessage(message, options, internal)
+      void this.sendMessage(message, options, {
+        ...internal,
+        onAccepted: async () => {
+          this.emitQueuedMessageChanged();
+          await internal?.onAccepted?.();
+        },
+      })
         .then(async (result) => {
           // Keep the dispatch marker through the dequeue-to-stream-start window. A background
           // send can resolve before startup emits stream-start, and later reports must not claim
           // that window as the next continuation.
-          // If sendMessage fails before it can start streaming, ensure we don't
-          // leave the session stuck in PREPARING and notify correlated internal callers.
           if (!result.success) {
             await internal?.onAcceptedPreStreamFailure?.(result.error);
-            if (this.turnPhase === TurnPhase.PREPARING) {
-              this.setTurnPhase(TurnPhase.IDLE);
-            }
-            // No stream started, so no stream-end drain will fire for the
-            // remaining entries — try the next one now (each attempt pops an
-            // entry, so this terminates).
-            this.sendQueuedMessages();
-            return;
-          }
-          if (internal?.cancelState?.canceledBeforeAcceptance === true) {
-            // Cancellation can arrive after dequeue while sendMessage is validating or writing
-            // history. No stream will start, so release PREPARING and continue with later entries.
-            if (this.turnPhase === TurnPhase.PREPARING) {
-              this.setTurnPhase(TurnPhase.IDLE);
-            }
-            this.sendQueuedMessages();
+            finishDispatchWithoutStream();
+          } else if (internal?.cancelState?.canceledBeforeAcceptance === true) {
+            // Cancellation can arrive after dequeue while sendMessage is validating or writing.
+            finishDispatchWithoutStream();
           }
         })
-        .catch(() => {
-          this.dispatchingQueuedEntry = false;
-          this.dispatchingQueuedEntryMuxMetadata = undefined;
-          if (this.turnPhase === TurnPhase.PREPARING) {
-            this.setTurnPhase(TurnPhase.IDLE);
-          }
-          this.sendQueuedMessages();
-        });
+        .catch(finishDispatchWithoutStream);
     }
   }
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -710,6 +710,7 @@ export class AgentSession {
   private dispatchingQueuedEntry?: {
     muxMetadata?: unknown;
     visibleProjection?: MessageQueueVisibleProjection;
+    persisted: boolean;
   };
 
   /** Correlation of the direct send currently in the PREPARING phase, if any. */
@@ -2505,7 +2506,7 @@ export class AgentSession {
       // retain a user entry that is between dequeue and durable transcript emission.
       listener({
         workspaceId: this.workspaceId,
-        message: this.getQueuedMessageChangedEvent(),
+        message: this.getQueuedMessageChangedEvent(false),
       });
 
       // Rehydrate pending auto-retry countdown state on reconnect/reload so
@@ -3248,6 +3249,9 @@ export class AgentSession {
       persistedCancelableMessageIds.push(userMessage.id);
       if (await cancelBeforeAcceptance()) {
         return Ok(undefined);
+      }
+      if (this.dispatchingQueuedEntry) {
+        this.dispatchingQueuedEntry.persisted = true;
       }
     }
 
@@ -5842,12 +5846,15 @@ export class AgentSession {
     }
   }
 
-  private getQueuedMessageChangedEvent(): Extract<
-    WorkspaceChatMessage,
-    { type: "queued-message-changed" }
-  > {
+  private getQueuedMessageChangedEvent(
+    includePersistedDispatching = true
+  ): Extract<WorkspaceChatMessage, { type: "queued-message-changed" }> {
     const pending = this.messageQueue.getVisibleProjection();
-    const dispatching = this.dispatchingQueuedEntry?.visibleProjection;
+    const dispatchingState = this.dispatchingQueuedEntry;
+    const dispatching =
+      !includePersistedDispatching && dispatchingState?.persisted
+        ? undefined
+        : dispatchingState?.visibleProjection;
     const reviews = [...(dispatching?.reviews ?? []), ...(pending.reviews ?? [])];
 
     return {
@@ -5861,6 +5868,7 @@ export class AgentSession {
       queueDispatchMode: dispatching?.queueDispatchMode ?? pending.queueDispatchMode,
       hasCompactionRequest:
         dispatching?.hasCompactionRequest === true || pending.hasCompactionRequest,
+      isDispatching: dispatching != null,
     };
   }
 
@@ -5905,6 +5913,7 @@ export class AgentSession {
       this.dispatchingQueuedEntry = {
         muxMetadata: options?.muxMetadata,
         visibleProjection,
+        persisted: false,
       };
       // PREPARING disables queue actions while the authoritative projection includes
       // the in-flight entry, preventing stale Edit/Send-now operations during persistence.

--- a/src/node/services/messageQueue.test.ts
+++ b/src/node/services/messageQueue.test.ts
@@ -33,10 +33,12 @@ describe("MessageQueue", () => {
       // Content projection hides backend work, while the visible card reflects the FIFO head's
       // effective boundary until the user explicitly reprioritizes their queued follow-up.
       expect(queue.getMessages()).toEqual(["Background monitor wake", "User follow-up"]);
-      expect(queue.getVisibleMessages()).toEqual(["User follow-up"]);
-      expect(queue.getVisibleDisplayText()).toBe("User follow-up");
+      expect(queue.getVisibleProjection()).toMatchObject({
+        queuedMessages: ["User follow-up"],
+        displayText: "User follow-up",
+        queueDispatchMode: "tool-end",
+      });
       expect(queue.getQueueDispatchMode()).toBe("tool-end");
-      expect(queue.getVisibleQueueDispatchMode()).toBe("tool-end");
       const background = queue.dequeueNext();
       expect(background.message).toBe("Background monitor wake");
       expect(background.internal).toMatchObject({ synthetic: true, agentInitiated: true });

--- a/src/node/services/messageQueue.ts
+++ b/src/node/services/messageQueue.ts
@@ -103,6 +103,15 @@ type QueueClearCallbacks = Pick<
   "onCanceled" | "onAcceptedPreStreamFailure"
 >;
 
+export interface MessageQueueVisibleProjection {
+  queuedMessages: string[];
+  displayText: string;
+  fileParts: FilePart[];
+  reviews?: ReviewNoteData[];
+  queueDispatchMode: QueueDispatchMode;
+  hasCompactionRequest: boolean;
+}
+
 /**
  * One dispatchable unit in the queue. Plain follow-up messages batch into a single
  * entry (joined text, accumulated file parts); "special" sends (compaction requests,
@@ -536,14 +545,28 @@ export class MessageQueue {
     return reviews.length > 0 ? reviews : undefined;
   }
 
+  private getVisibleProjectionForEntries(
+    entries: readonly QueueEntry[],
+    queueDispatchMode: QueueDispatchMode
+  ): MessageQueueVisibleProjection {
+    return {
+      queuedMessages: this.getMessagesForEntries(entries),
+      displayText: this.getDisplayTextForEntries(entries),
+      fileParts: this.getFilePartsForEntries(entries),
+      reviews: this.getReviewsForEntries(entries),
+      queueDispatchMode,
+      hasCompactionRequest: entries.some((entry) => isCompactionMetadata(entry.muxMetadata)),
+    };
+  }
+
+  getVisibleProjection(): MessageQueueVisibleProjection {
+    const entries = this.getVisibleEntries();
+    return this.getVisibleProjectionForEntries(entries, this.getVisibleQueueDispatchMode());
+  }
+
   /** Get all queued message texts across entries (including synthetic entries). */
   getMessages(): string[] {
     return this.getMessagesForEntries(this.entries);
-  }
-
-  /** Get user-visible queued message texts for the renderer/composer. */
-  getVisibleMessages(): string[] {
-    return this.getMessagesForEntries(this.getVisibleEntries());
   }
 
   /**
@@ -555,34 +578,14 @@ export class MessageQueue {
     return this.getDisplayTextForEntries(this.entries);
   }
 
-  /** Get display text for user-visible entries only. */
-  getVisibleDisplayText(): string {
-    return this.getDisplayTextForEntries(this.getVisibleEntries());
-  }
-
   /** Get accumulated file parts across all entries. */
   getFileParts(): FilePart[] {
     return this.getFilePartsForEntries(this.entries);
   }
 
-  /** Get accumulated file parts for user-visible entries only. */
-  getVisibleFileParts(): FilePart[] {
-    return this.getFilePartsForEntries(this.getVisibleEntries());
-  }
-
   /** Get reviews across all entries' metadata. */
   getReviews(): ReviewNoteData[] | undefined {
     return this.getReviewsForEntries(this.entries);
-  }
-
-  /** Get reviews across user-visible entries' metadata only. */
-  getVisibleReviews(): ReviewNoteData[] | undefined {
-    return this.getReviewsForEntries(this.getVisibleEntries());
-  }
-
-  /** Whether a user-visible queued entry is a compaction request. */
-  hasVisibleCompactionRequest(): boolean {
-    return this.getVisibleEntries().some((entry) => isCompactionMetadata(entry.muxMetadata));
   }
 
   /**
@@ -701,12 +704,16 @@ export class MessageQueue {
     message: string;
     options?: SendMessageOptions & { fileParts?: FilePart[] };
     internal?: QueuedMessageInternalOptions;
+    visibleProjection?: MessageQueueVisibleProjection;
   } {
     const entry = this.entries.shift();
     if (entry === undefined) {
       return { message: "" };
     }
 
+    const visibleProjection = entry.userAuthored
+      ? this.getVisibleProjectionForEntries([entry], entry.dispatchMode)
+      : undefined;
     const joinedMessages = entry.messages.join("\n");
     const options = entry.latestOptions
       ? (() => {
@@ -748,7 +755,7 @@ export class MessageQueue {
         }
       : undefined;
 
-    return { message: joinedMessages, options, internal };
+    return { message: joinedMessages, options, internal, visibleProjection };
   }
 
   /**

--- a/tests/ui/chat/queuedMessageBanner.test.tsx
+++ b/tests/ui/chat/queuedMessageBanner.test.tsx
@@ -65,6 +65,23 @@ describe("QueuedMessage banner", () => {
     expect(view.getAllByRole("menuitem")).toHaveLength(3);
   });
 
+  test("keeps a dispatching message visible without editable queue actions", () => {
+    const view = render(
+      <QueuedMessage
+        message={createQueuedMessage()}
+        isDispatching
+        onEdit={mock(() => {})}
+        onChangeDispatchMode={mock(async () => {})}
+        onSendImmediately={mock(async () => {})}
+      />
+    );
+
+    expect(view.getByText("Review this change before sending")).toBeTruthy();
+    expect(view.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(view.getByRole("button", { name: "Sending" }).hasAttribute("disabled")).toBe(true);
+    expect(view.queryByRole("menu")).toBeNull();
+  });
+
   test("renders queued preview text and step-dispatch label", () => {
     const view = render(<QueuedMessage message={createQueuedMessage()} />);
 

--- a/tests/ui/chat/queuedMessageBanner.test.tsx
+++ b/tests/ui/chat/queuedMessageBanner.test.tsx
@@ -68,8 +68,7 @@ describe("QueuedMessage banner", () => {
   test("keeps a dispatching message visible without editable queue actions", () => {
     const view = render(
       <QueuedMessage
-        message={createQueuedMessage()}
-        isDispatching
+        message={createQueuedMessage({ isDispatching: true })}
         onEdit={mock(() => {})}
         onChangeDispatchMode={mock(async () => {})}
         onSendImmediately={mock(async () => {})}


### PR DESCRIPTION
## Summary

Fix the visual gap where a follow-up sent during compaction could disappear between leaving the queued-message card and appearing as a durable transcript row.

## Background

The composer clears as soon as a send begins, so a follow-up queued behind compaction is represented only by the queued-message card. Queue draining previously removed the entry and emitted an empty queue projection before asynchronous history persistence emitted the corresponding user row. During that interval the text appeared nowhere in the UI.

## Implementation

- Retain a dequeued user entry in an authoritative server-side dispatch projection until its durable acceptance callback runs.
- Use that projection for live events, reconnect snapshots, and subsequent queue mutations, so the card cannot disappear early or duplicate later entries.
- Enter the existing `PREPARING` lifecycle before publishing the projection and disable Edit, dispatch-mode, send-now, and queued-message keyboard actions during persistence.
- Consolidate the previous per-field visible queue getters into one projection and reuse one no-stream cleanup path.
- Add deterministic regression coverage that blocks history persistence, mutates the remaining queue, and verifies the card-to-transcript handoff order without duplication.

## Validation

- `make static-check`
- Targeted queued-message suite: 109 passed, 8 skipped
- `tests/ui/chat/queuedMessageBanner.test.tsx`: 21 passed
- `tests/ipc/streaming/queuedMessages.completing.test.ts`: 6 passed

## Risks

Moderate but scoped risk in queued-message projection and action timing. Persistence and FIFO dispatch semantics are unchanged; the added state only spans dequeue through durable acceptance. Tests cover reconnect-equivalent projection rebuilding, concurrent queue mutation, cancellation/failure cleanup, and disabled dispatching actions.

## Subtractive ledger

The authoritative in-flight projection and action gate require a small production addition. The same change removes five parallel visible-queue getters and consolidates three duplicated failure/cancellation cleanup paths in the queue/session modules.

---

_Generated with `xum` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$133.55`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=133.55 -->

