### PR TITLE
🤖 fix: replay past reasoning traces to providers on subsequent sends

### DIFF
--- a/src/browser/utils/messages/modelMessageTransform.ts
+++ b/src/browser/utils/messages/modelMessageTransform.ts
@@ -921,25 +921,26 @@ function coalesceConsecutiveParts(messages: ModelMessage[]): ModelMessage[] {
       // Merge consecutive reasoning parts (extended thinking)
       if (part.type === "reasoning" && lastPart?.type === "reasoning") {
         lastPart.text += part.text;
-        // Streaming splits one reasoning block across many parts: Anthropic
-        // signatures arrive on the LAST part of a run, OpenAI/xAI itemId and
-        // encrypted content attach to the FIRST (later parts carry none), so
-        // adopting a later part's providerOptions preserves both shapes.
+        // Streaming splits one reasoning block across many parts and replay
+        // metadata can land on any of them: Anthropic signatures arrive on the
+        // LAST part of a run, while OpenAI/xAI itemId/encrypted content attach
+        // to the FIRST (and itemId may repeat on later deltas). Merge per
+        // provider namespace so a later partial object cannot clobber fields
+        // accumulated earlier (e.g. reasoningEncryptedContent under ZDR).
+        if (part.providerOptions) {
+          const existing = lastPart.providerOptions ?? {};
+          const merged: NonNullable<typeof lastPart.providerOptions> = { ...existing };
+          for (const [provider, fields] of Object.entries(part.providerOptions)) {
+            merged[provider] = { ...existing[provider], ...fields };
+          }
+          lastPart.providerOptions = merged;
+        }
         // The legacy top-level `signature` field predates providerOptions and
         // survives here only for defensiveness (conversion strips it upstream).
-        const partWithSig = part as typeof part & {
-          signature?: string;
-          providerOptions?: { anthropic?: { signature?: string } };
-        };
-        const lastWithSig = lastPart as typeof lastPart & {
-          signature?: string;
-          providerOptions?: { anthropic?: { signature?: string } };
-        };
+        const partWithSig = part as typeof part & { signature?: string };
+        const lastWithSig = lastPart as typeof lastPart & { signature?: string };
         if (partWithSig.signature) {
           lastWithSig.signature = partWithSig.signature;
-        }
-        if (partWithSig.providerOptions) {
-          lastWithSig.providerOptions = partWithSig.providerOptions;
         }
         continue;
       }

--- a/src/browser/utils/messages/modelMessageTransform.ts
+++ b/src/browser/utils/messages/modelMessageTransform.ts
@@ -921,10 +921,12 @@ function coalesceConsecutiveParts(messages: ModelMessage[]): ModelMessage[] {
       // Merge consecutive reasoning parts (extended thinking)
       if (part.type === "reasoning" && lastPart?.type === "reasoning") {
         lastPart.text += part.text;
-        // Preserve signature from later parts - during streaming, the signature
-        // arrives at the end and is attached to the last reasoning part.
-        // Cast needed because AI SDK's ReasoningPart doesn't have signature,
-        // but our XumReasoningPart (which flows through convertToModelMessages) does.
+        // Streaming splits one reasoning block across many parts: Anthropic
+        // signatures arrive on the LAST part of a run, OpenAI/xAI itemId and
+        // encrypted content attach to the FIRST (later parts carry none), so
+        // adopting a later part's providerOptions preserves both shapes.
+        // The legacy top-level `signature` field predates providerOptions and
+        // survives here only for defensiveness (conversion strips it upstream).
         const partWithSig = part as typeof part & {
           signature?: string;
           providerOptions?: { anthropic?: { signature?: string } };

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -835,12 +835,13 @@ export interface MuxReasoningPart {
    */
   signature?: string;
   /**
-   * Provider options for SDK compatibility.
-   * When converting to ModelMessages via the SDK's convertToModelMessages,
-   * this is passed through so reasoning can be replayed:
+   * Persisted replay data for reasoning parts. The SDK's convertToModelMessages
+   * only reads `providerMetadata` from UI parts, so attachReasoningReplayMetadata
+   * mirrors this field there at request time so reasoning can be replayed:
    * - Anthropic: { anthropic: { signature } }
    * - OpenAI/xAI Responses (esp. store=false/ZDR): itemId + reasoningEncryptedContent
    *   so the next turn can restore encrypted reasoning without server-side storage.
+   * - Google: { google: { thoughtSignature } }
    */
   providerOptions?: {
     anthropic?: {
@@ -853,6 +854,9 @@ export interface MuxReasoningPart {
     xai?: {
       itemId?: string;
       reasoningEncryptedContent?: string | null;
+    };
+    google?: {
+      thoughtSignature?: string;
     };
   };
 }

--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "bun:test";
 import type { AssistantModelMessage, ModelMessage } from "ai";
 
 import { transformModelMessages } from "@/browser/utils/messages/modelMessageTransform";
-import { createMuxMessage } from "@/common/types/message";
+import { createMuxMessage, type MuxMessage } from "@/common/types/message";
+import type { ThinkingLevel } from "@/common/types/thinking";
+import { createTestHistoryService } from "./testHistoryService";
 import { prepareMessagesForProvider, sanitizeAssistantModelMessages } from "./messagePipeline";
 
 function isAssistantMessage(message: ModelMessage | undefined): message is AssistantModelMessage {
@@ -122,5 +124,255 @@ describe("prepareMessagesForProvider log purity", () => {
     const serialized = JSON.stringify(result);
     expect(serialized).toContain("@src/foo.ts");
     expect(serialized).not.toContain("<mux-file");
+  });
+});
+
+describe("reasoning replay in built provider requests", () => {
+  function historyWith(assistantParts: MuxMessage["parts"]): MuxMessage[] {
+    return [
+      createMuxMessage("user-1", "user", "solve it", { timestamp: 1000 }),
+      { id: "assistant-1", role: "assistant", metadata: { timestamp: 1001 }, parts: assistantParts },
+      createMuxMessage("user-2", "user", "continue", { timestamp: 1002 }),
+    ];
+  }
+
+  function buildRequest(
+    provider: string,
+    thinkingLevel: ThinkingLevel,
+    messages: MuxMessage[]
+  ): Promise<ModelMessage[]> {
+    return prepareMessagesForProvider({
+      messagesWithSentinel: messages,
+      effectiveAgentId: "exec",
+      toolNamesForSentinel: [],
+      providerForMessages: provider,
+      effectiveThinkingLevel: thinkingLevel,
+      modelString: `${provider}:model`,
+      workspaceId: "test-ws",
+    });
+  }
+
+  type ReasoningRequestPart = { type: "reasoning"; text: string; providerOptions?: unknown };
+
+  function reasoningRequestParts(messages: ModelMessage[]): ReasoningRequestPart[] {
+    return messages
+      .filter(isAssistantMessage)
+      .flatMap((msg) => (Array.isArray(msg.content) ? msg.content : []))
+      .filter((part): part is ReasoningRequestPart => part.type === "reasoning");
+  }
+
+  it("includes signed Anthropic reasoning with its signature when thinking is enabled", async () => {
+    const result = await buildRequest(
+      "anthropic",
+      "medium",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "let me think",
+          providerOptions: { anthropic: { signature: "sig_live" } },
+        },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "let me think",
+        providerOptions: { anthropic: { signature: "sig_live" } },
+      },
+    ]);
+  });
+
+  it("omits unsigned Anthropic reasoning when thinking is enabled", async () => {
+    const result = await buildRequest(
+      "anthropic",
+      "medium",
+      historyWith([
+        { type: "reasoning", text: "secret thoughts" },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("secret thoughts");
+    expect(serialized).not.toContain("signature");
+  });
+
+  it("omits reasoning-only assistant messages when Anthropic thinking is off", async () => {
+    const result = await buildRequest(
+      "anthropic",
+      "off",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "orphan thoughts",
+          providerOptions: { anthropic: { signature: "sig_live" } },
+        },
+      ])
+    );
+
+    expect(result.some((msg) => msg.role === "assistant")).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("orphan thoughts");
+  });
+
+  it("includes OpenAI reasoning itemId and encrypted content", async () => {
+    const result = await buildRequest(
+      "openai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "redacted summary",
+          providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc_blob" } },
+        },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "redacted summary",
+        providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc_blob" } },
+      },
+    ]);
+  });
+
+  it("includes xAI reasoning itemId and encrypted content", async () => {
+    const result = await buildRequest(
+      "xai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "grok thoughts",
+          providerOptions: { xai: { itemId: "rs_x", reasoningEncryptedContent: "enc_x" } },
+        },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "grok thoughts",
+        providerOptions: { xai: { itemId: "rs_x", reasoningEncryptedContent: "enc_x" } },
+      },
+    ]);
+  });
+
+  it("bridges legacy signature-only histories to a replayable Anthropic signature", async () => {
+    const result = await buildRequest(
+      "anthropic",
+      "medium",
+      historyWith([
+        { type: "reasoning", text: "old style", signature: "legacy_sig" },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "old style",
+        providerOptions: { anthropic: { signature: "legacy_sig" } },
+      },
+    ]);
+  });
+
+  it("keeps the Anthropic signature from the last part when coalescing a streamed run", async () => {
+    const result = await buildRequest(
+      "anthropic",
+      "medium",
+      historyWith([
+        { type: "reasoning", text: "I " },
+        { type: "reasoning", text: "see " },
+        { type: "reasoning", text: "it", providerOptions: { anthropic: { signature: "sig_end" } } },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "I see it",
+        providerOptions: { anthropic: { signature: "sig_end" } },
+      },
+    ]);
+  });
+
+  it("keeps OpenAI options from the first part when coalescing a streamed run", async () => {
+    const result = await buildRequest(
+      "openai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "a",
+          providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+        },
+        { type: "reasoning", text: "b" },
+        { type: "reasoning", text: "c" },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "abc",
+        providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+      },
+    ]);
+  });
+
+  it("replays reasoning persisted by a prior turn when building the next request", async () => {
+    // The issue #11 scenario: a new sendMessage on an existing workspace must
+    // rebuild prior-turn reasoning from disk, so exercise the real history
+    // read/write path instead of in-memory fixtures.
+    const { historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "reasoning-replay-ws";
+      const turns = [
+        createMuxMessage("user-1", "user", "solve it", { timestamp: 1000 }),
+        {
+          id: "assistant-1",
+          role: "assistant",
+          metadata: { timestamp: 1001 },
+          parts: [
+            {
+              type: "reasoning",
+              text: "persisted thinking",
+              signature: "sig_disk",
+              providerOptions: { anthropic: { signature: "sig_disk" } },
+            },
+            { type: "text", text: "the answer" },
+          ],
+        } satisfies MuxMessage,
+        createMuxMessage("user-2", "user", "next question", { timestamp: 1002 }),
+      ];
+      for (const message of turns) {
+        const appendResult = await historyService.appendToHistory(workspaceId, message);
+        expect(appendResult.success).toBe(true);
+      }
+
+      const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+      if (!historyResult.success) {
+        throw new Error(historyResult.error);
+      }
+
+      const result = await buildRequest("anthropic", "medium", historyResult.data);
+
+      expect(reasoningRequestParts(result)).toEqual([
+        {
+          type: "reasoning",
+          text: "persisted thinking",
+          providerOptions: { anthropic: { signature: "sig_disk" } },
+        },
+      ]);
+    } finally {
+      await cleanup();
+    }
   });
 });

--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -270,6 +270,23 @@ describe("reasoning replay in built provider requests", () => {
     ]);
   });
 
+  it("omits a bare xAI itemId from an interrupted stream (store=false, unresolvable)", async () => {
+    const result = await buildRequest(
+      "xai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "interrupted thoughts",
+          providerOptions: { xai: { itemId: "rs_partial" } },
+        },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(JSON.stringify(result)).not.toContain("rs_partial");
+  });
+
   it("bridges legacy signature-only histories to a replayable Anthropic signature", async () => {
     const result = await buildRequest(
       "anthropic",

--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -131,7 +131,12 @@ describe("reasoning replay in built provider requests", () => {
   function historyWith(assistantParts: MuxMessage["parts"]): MuxMessage[] {
     return [
       createMuxMessage("user-1", "user", "solve it", { timestamp: 1000 }),
-      { id: "assistant-1", role: "assistant", metadata: { timestamp: 1001 }, parts: assistantParts },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        metadata: { timestamp: 1001 },
+        parts: assistantParts,
+      },
       createMuxMessage("user-2", "user", "continue", { timestamp: 1002 }),
     ];
   }
@@ -152,7 +157,10 @@ describe("reasoning replay in built provider requests", () => {
     });
   }
 
-  type ReasoningRequestPart = { type: "reasoning"; text: string; providerOptions?: unknown };
+  type ReasoningRequestPart = Extract<
+    Exclude<AssistantModelMessage["content"], string>[number],
+    { type: "reasoning" }
+  >;
 
   function reasoningRequestParts(messages: ModelMessage[]): ReasoningRequestPart[] {
     return messages

--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -287,6 +287,23 @@ describe("reasoning replay in built provider requests", () => {
     expect(JSON.stringify(result)).not.toContain("rs_partial");
   });
 
+  it("omits a bare OpenAI itemId from an interrupted stream (ZDR, unresolvable)", async () => {
+    const result = await buildRequest(
+      "openai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "interrupted thoughts",
+          providerOptions: { openai: { itemId: "rs_partial" } },
+        },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(JSON.stringify(result)).not.toContain("rs_partial");
+  });
+
   it("bridges legacy signature-only histories to a replayable Anthropic signature", async () => {
     const result = await buildRequest(
       "anthropic",

--- a/src/node/services/messagePipeline.test.ts
+++ b/src/node/services/messagePipeline.test.ts
@@ -310,6 +310,56 @@ describe("reasoning replay in built provider requests", () => {
     ]);
   });
 
+  it("merges later partial options without clobbering encrypted content when coalescing", async () => {
+    // ZDR shape: first part of the run carries itemId + encrypted content
+    // (attached at reasoning-end), a later delta repeats only the itemId.
+    // Coalescing must merge namespaces, not replace the accumulated object.
+    const result = await buildRequest(
+      "openai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "a",
+          providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+        },
+        { type: "reasoning", text: "b", providerOptions: { openai: { itemId: "rs_1" } } },
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    expect(reasoningRequestParts(result)).toEqual([
+      {
+        type: "reasoning",
+        text: "ab",
+        providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+      },
+    ]);
+  });
+
+  it("keeps a malformed history row from poisoning the built request", async () => {
+    // Self-healing doctrine: corrupt replay metadata in chat.jsonl must degrade
+    // to plain reasoning handling, not forward junk the provider rejects.
+    const result = await buildRequest(
+      "openai",
+      "high",
+      historyWith([
+        {
+          type: "reasoning",
+          text: "corrupt metadata",
+          signature: 999,
+          providerOptions: { openai: { itemId: 42 } },
+        } as unknown as MuxMessage["parts"][number],
+        { type: "text", text: "answer" },
+      ])
+    );
+
+    const assistant = result.filter(isAssistantMessage);
+    expect(assistant.length).toBeGreaterThan(0);
+    expect(JSON.stringify(result)).not.toContain('"itemId":42');
+    expect(JSON.stringify(result)).not.toContain("999");
+  });
+
   it("keeps OpenAI options from the first part when coalescing a streamed run", async () => {
     const result = await buildRequest(
       "openai",

--- a/src/node/services/messagePipeline.ts
+++ b/src/node/services/messagePipeline.ts
@@ -15,6 +15,7 @@ import { inlineSvgAsTextForProvider } from "@/node/utils/messages/inlineSvgAsTex
 import { extractToolMediaAsUserMessages } from "@/node/utils/messages/extractToolMediaAsUserMessages";
 import { sanitizeAnthropicPdfFilenames } from "@/node/utils/messages/sanitizeAnthropicDocumentFilename";
 import { convertDataUriFilePartsForSdk } from "@/node/utils/messages/convertDataUriFilePartsForSdk";
+import { attachReasoningReplayMetadata } from "@/node/utils/messages/reasoningProviderOptions";
 import type { MuxMessage } from "@/common/types/message";
 import type { PostCompactionAttachment } from "@/common/types/attachment";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
@@ -156,11 +157,15 @@ export async function prepareMessagesForProvider(
     messagesWithToolMediaExtracted
   );
 
+  // Mirror persisted reasoning replay data (signatures, encrypted reasoning) into
+  // providerMetadata, the only field convertToModelMessages forwards to the request.
+  const messagesWithReasoningReplay = attachReasoningReplayMetadata(messagesWithSdkSafeFileParts);
+
   // --- Convert to ModelMessage format ---
 
   // Type assertion needed because XumMessage has custom tool parts for interrupted tools
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
-  const rawModelMessages = await convertToModelMessages(messagesWithSdkSafeFileParts as any, {
+  const rawModelMessages = await convertToModelMessages(messagesWithReasoningReplay as any, {
     // Drop unfinished tool calls (input-streaming/input-available) so downstream
     // transforms only see tool calls that actually produced outputs.
     ignoreIncompleteToolCalls: true,

--- a/src/node/utils/messages/reasoningProviderOptions.test.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.test.ts
@@ -149,6 +149,39 @@ describe("attachReasoningReplayMetadata", () => {
     expect(output[1]).toBe(noReplay);
   });
 
+  test("drops a malformed non-string legacy signature instead of forwarding it", () => {
+    const input = assistantMessage([
+      { type: "reasoning", text: "corrupt", signature: 12345 as unknown as string },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(output).toBe(input);
+    expect("providerMetadata" in reasoningParts(output)[0]).toBe(false);
+  });
+
+  test("drops malformed providerOptions fields while keeping valid siblings", () => {
+    const input = assistantMessage([
+      {
+        type: "reasoning",
+        text: "partially corrupt",
+        providerOptions: {
+          anthropic: "not-an-object",
+          openai: { itemId: 42, reasoningEncryptedContent: "enc_ok" },
+          xai: { itemId: "rs_ok", reasoningEncryptedContent: { nested: true } },
+          google: { thoughtSignature: "" },
+        } as unknown as MuxReasoningPart["providerOptions"],
+      },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(reasoningParts(output)[0].providerMetadata).toEqual({
+      openai: { reasoningEncryptedContent: "enc_ok" },
+      xai: { itemId: "rs_ok" },
+    });
+  });
+
   test("does not mutate the input parts", () => {
     const part: MuxReasoningPart = {
       type: "reasoning",

--- a/src/node/utils/messages/reasoningProviderOptions.test.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
+import type { MuxMessage, MuxReasoningPart } from "@/common/types/message";
 import {
+  attachReasoningReplayMetadata,
   findFirstReasoningPartIndexInTrailingRun,
   mergeReasoningProviderOptions,
   reasoningProviderOptionsFromMetadata,
@@ -45,10 +47,19 @@ describe("reasoningProviderOptionsFromMetadata", () => {
     });
   });
 
+  test("maps Google thought signatures", () => {
+    expect(
+      reasoningProviderOptionsFromMetadata({ google: { thoughtSignature: "ts_1" } })
+    ).toEqual({
+      google: { thoughtSignature: "ts_1" },
+    });
+  });
+
   test("returns undefined when metadata is empty", () => {
     expect(reasoningProviderOptionsFromMetadata(undefined)).toBeUndefined();
     expect(reasoningProviderOptionsFromMetadata({})).toBeUndefined();
     expect(reasoningProviderOptionsFromMetadata({ xai: {} })).toBeUndefined();
+    expect(reasoningProviderOptionsFromMetadata({ google: {} })).toBeUndefined();
   });
 });
 
@@ -65,6 +76,92 @@ describe("mergeReasoningProviderOptions", () => {
         reasoningEncryptedContent: "enc_blob",
       },
     });
+  });
+});
+
+describe("attachReasoningReplayMetadata", () => {
+  function assistantMessage(parts: MuxMessage["parts"]): MuxMessage {
+    return { id: "a1", role: "assistant", metadata: { timestamp: 1 }, parts };
+  }
+
+  function reasoningParts(message: MuxMessage): Array<MuxReasoningPart & Record<string, unknown>> {
+    return message.parts.filter(
+      (part): part is MuxReasoningPart & Record<string, unknown> => part.type === "reasoning"
+    );
+  }
+
+  test("mirrors providerOptions into providerMetadata", () => {
+    const input = assistantMessage([
+      {
+        type: "reasoning",
+        text: "thinking",
+        providerOptions: { openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" } },
+      },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(reasoningParts(output)[0].providerMetadata).toEqual({
+      openai: { itemId: "rs_1", reasoningEncryptedContent: "enc" },
+    });
+  });
+
+  test("bridges the legacy top-level signature field from old histories", () => {
+    const input = assistantMessage([{ type: "reasoning", text: "old", signature: "legacy_sig" }]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(reasoningParts(output)[0].providerMetadata).toEqual({
+      anthropic: { signature: "legacy_sig" },
+    });
+  });
+
+  test("providerOptions wins over the legacy signature on conflict", () => {
+    const input = assistantMessage([
+      {
+        type: "reasoning",
+        text: "both",
+        signature: "stale_sig",
+        providerOptions: { anthropic: { signature: "fresh_sig" } },
+      },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(reasoningParts(output)[0].providerMetadata).toEqual({
+      anthropic: { signature: "fresh_sig" },
+    });
+  });
+
+  test("leaves messages without replay data untouched (same reference)", () => {
+    const noReplay = assistantMessage([
+      { type: "reasoning", text: "unsigned" },
+      { type: "text", text: "answer" },
+    ]);
+    const user: MuxMessage = {
+      id: "u1",
+      role: "user",
+      metadata: { timestamp: 0 },
+      parts: [{ type: "text", text: "hi" }],
+    };
+
+    const output = attachReasoningReplayMetadata([user, noReplay]);
+
+    expect(output[0]).toBe(user);
+    expect(output[1]).toBe(noReplay);
+  });
+
+  test("does not mutate the input parts", () => {
+    const part: MuxReasoningPart = {
+      type: "reasoning",
+      text: "thinking",
+      providerOptions: { anthropic: { signature: "sig" } },
+    };
+    const input = assistantMessage([part]);
+
+    attachReasoningReplayMetadata([input]);
+
+    expect("providerMetadata" in part).toBe(false);
   });
 });
 

--- a/src/node/utils/messages/reasoningProviderOptions.test.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.test.ts
@@ -48,9 +48,7 @@ describe("reasoningProviderOptionsFromMetadata", () => {
   });
 
   test("maps Google thought signatures", () => {
-    expect(
-      reasoningProviderOptionsFromMetadata({ google: { thoughtSignature: "ts_1" } })
-    ).toEqual({
+    expect(reasoningProviderOptionsFromMetadata({ google: { thoughtSignature: "ts_1" } })).toEqual({
       google: { thoughtSignature: "ts_1" },
     });
   });

--- a/src/node/utils/messages/reasoningProviderOptions.test.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.test.ts
@@ -196,6 +196,17 @@ describe("attachReasoningReplayMetadata", () => {
     expect("providerMetadata" in reasoningParts(output)[0]).toBe(false);
   });
 
+  test("drops a bare OpenAI itemId left behind by an interrupted stream (ZDR)", () => {
+    const input = assistantMessage([
+      { type: "reasoning", text: "cut off", providerOptions: { openai: { itemId: "rs_partial" } } },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(output).toBe(input);
+    expect("providerMetadata" in reasoningParts(output)[0]).toBe(false);
+  });
+
   test("keeps complete xAI replay metadata and other namespaces alongside a dropped bare itemId", () => {
     const input = assistantMessage([
       {

--- a/src/node/utils/messages/reasoningProviderOptions.test.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.test.ts
@@ -168,6 +168,8 @@ describe("attachReasoningReplayMetadata", () => {
         providerOptions: {
           anthropic: "not-an-object",
           openai: { itemId: 42, reasoningEncryptedContent: "enc_ok" },
+          // Malformed encrypted content leaves a bare xai itemId, which the
+          // store=false drop rule then removes as unresolvable.
           xai: { itemId: "rs_ok", reasoningEncryptedContent: { nested: true } },
           google: { thoughtSignature: "" },
         } as unknown as MuxReasoningPart["providerOptions"],
@@ -178,7 +180,38 @@ describe("attachReasoningReplayMetadata", () => {
 
     expect(reasoningParts(output)[0].providerMetadata).toEqual({
       openai: { reasoningEncryptedContent: "enc_ok" },
-      xai: { itemId: "rs_ok" },
+    });
+  });
+
+  test("drops a bare xAI itemId left behind by an interrupted stream", () => {
+    // store=false means the server never kept the item; replaying the bare
+    // reference would fail every subsequent request.
+    const input = assistantMessage([
+      { type: "reasoning", text: "cut off", providerOptions: { xai: { itemId: "rs_partial" } } },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(output).toBe(input);
+    expect("providerMetadata" in reasoningParts(output)[0]).toBe(false);
+  });
+
+  test("keeps complete xAI replay metadata and other namespaces alongside a dropped bare itemId", () => {
+    const input = assistantMessage([
+      {
+        type: "reasoning",
+        text: "mixed",
+        providerOptions: {
+          xai: { itemId: "rs_partial" },
+          anthropic: { signature: "sig_keep" },
+        },
+      },
+    ]);
+
+    const [output] = attachReasoningReplayMetadata([input]);
+
+    expect(reasoningParts(output)[0].providerMetadata).toEqual({
+      anthropic: { signature: "sig_keep" },
     });
   });
 

--- a/src/node/utils/messages/reasoningProviderOptions.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.ts
@@ -21,33 +21,45 @@ export interface ReasoningProviderMetadata {
   };
 }
 
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 /**
- * Extract replay data from stream providerMetadata into the persisted
- * providerOptions shape. Anthropic needs signatures; OpenAI/xAI Responses
- * need itemId + encrypted content when store=false (ZDR); Google needs
- * thought signatures. Replay happens via attachReasoningReplayMetadata.
+ * Runtime-validate reasoning replay data into the persisted providerOptions
+ * shape, keeping only recognized string/null fields. History rows are read
+ * with unchecked JSON casts, so a corrupt part must degrade to "no replay
+ * metadata" rather than forwarding junk the provider would reject (which
+ * would brick every subsequent request in the workspace).
  */
-export function reasoningProviderOptionsFromMetadata(
-  providerMetadata: ReasoningProviderMetadata | undefined
+export function sanitizeReasoningReplayMetadata(
+  value: unknown
 ): MuxReasoningPart["providerOptions"] | undefined {
-  if (!providerMetadata) return undefined;
+  const record = asRecord(value);
+  if (!record) return undefined;
 
   const options: NonNullable<MuxReasoningPart["providerOptions"]> = {};
 
-  const anthropicSignature = providerMetadata.anthropic?.signature;
-  if (typeof anthropicSignature === "string" && anthropicSignature.length > 0) {
+  const anthropicSignature = nonEmptyString(asRecord(record.anthropic)?.signature);
+  if (anthropicSignature) {
     options.anthropic = { signature: anthropicSignature };
   }
 
-  const googleThoughtSignature = providerMetadata.google?.thoughtSignature;
-  if (typeof googleThoughtSignature === "string" && googleThoughtSignature.length > 0) {
+  const googleThoughtSignature = nonEmptyString(asRecord(record.google)?.thoughtSignature);
+  if (googleThoughtSignature) {
     options.google = { thoughtSignature: googleThoughtSignature };
   }
 
   for (const provider of ["openai", "xai"] as const) {
-    const meta = providerMetadata[provider];
+    const meta = asRecord(record[provider]);
     if (!meta) continue;
-    const itemId = typeof meta.itemId === "string" ? meta.itemId : undefined;
+    const itemId = nonEmptyString(meta.itemId);
     const encrypted =
       typeof meta.reasoningEncryptedContent === "string"
         ? meta.reasoningEncryptedContent
@@ -62,6 +74,18 @@ export function reasoningProviderOptionsFromMetadata(
   }
 
   return Object.keys(options).length > 0 ? options : undefined;
+}
+
+/**
+ * Extract replay data from stream providerMetadata into the persisted
+ * providerOptions shape. Anthropic needs signatures; OpenAI/xAI Responses
+ * need itemId + encrypted content when store=false (ZDR); Google needs
+ * thought signatures. Replay happens via attachReasoningReplayMetadata.
+ */
+export function reasoningProviderOptionsFromMetadata(
+  providerMetadata: ReasoningProviderMetadata | undefined
+): MuxReasoningPart["providerOptions"] | undefined {
+  return sanitizeReasoningReplayMetadata(providerMetadata);
 }
 
 export function mergeReasoningProviderOptions(
@@ -111,11 +135,17 @@ export function attachReasoningReplayMetadata(messages: MuxMessage[]): MuxMessag
     const parts = message.parts.map((part) => {
       if (part.type !== "reasoning") return part;
 
-      const legacySignature = part.signature
-        ? { anthropic: { signature: part.signature } }
+      // Sanitize both sources: history rows are unchecked JSON casts, so
+      // malformed values must be dropped instead of forwarded to the provider.
+      const legacySignatureValue = nonEmptyString(part.signature);
+      const legacySignature = legacySignatureValue
+        ? { anthropic: { signature: legacySignatureValue } }
         : undefined;
       // providerOptions wins over the legacy field when both carry a signature.
-      const replayMetadata = mergeReasoningProviderOptions(legacySignature, part.providerOptions);
+      const replayMetadata = mergeReasoningProviderOptions(
+        legacySignature,
+        sanitizeReasoningReplayMetadata(part.providerOptions)
+      );
       if (!replayMetadata) return part;
 
       changed = true;

--- a/src/node/utils/messages/reasoningProviderOptions.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.ts
@@ -148,6 +148,19 @@ export function attachReasoningReplayMetadata(messages: MuxMessage[]): MuxMessag
       );
       if (!replayMetadata) return part;
 
+      // xAI always runs Responses with store=false (see providerOptions.ts), so a
+      // bare itemId from an interrupted stream (reasoning-end never delivered the
+      // encrypted content) is unresolvable server-side and would fail every
+      // subsequent request. Drop it at replay time only; stream-time accumulation
+      // keeps partial metadata so reasoning-end can still complete it.
+      if (
+        replayMetadata.xai &&
+        nonEmptyString(replayMetadata.xai.reasoningEncryptedContent) == null
+      ) {
+        delete replayMetadata.xai;
+        if (Object.keys(replayMetadata).length === 0) return part;
+      }
+
       changed = true;
       const bridged: ReasoningPartWithReplayMetadata = {
         ...part,

--- a/src/node/utils/messages/reasoningProviderOptions.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.ts
@@ -1,4 +1,4 @@
-import type { MuxReasoningPart } from "@/common/types/message";
+import type { MuxMessage, MuxReasoningPart } from "@/common/types/message";
 
 export interface ReasoningProviderMetadata {
   anthropic?: {
@@ -15,12 +15,17 @@ export interface ReasoningProviderMetadata {
     itemId?: string;
     reasoningEncryptedContent?: string | null;
   };
+  // Google attaches thought signatures that must be replayed on later turns.
+  google?: {
+    thoughtSignature?: string;
+  };
 }
 
 /**
- * Build providerOptions for reasoning parts that convertToModelMessages must
- * pass back to the provider. Anthropic needs signatures; OpenAI/xAI Responses
- * need itemId + encrypted content when store=false (ZDR).
+ * Extract replay data from stream providerMetadata into the persisted
+ * providerOptions shape. Anthropic needs signatures; OpenAI/xAI Responses
+ * need itemId + encrypted content when store=false (ZDR); Google needs
+ * thought signatures. Replay happens via attachReasoningReplayMetadata.
  */
 export function reasoningProviderOptionsFromMetadata(
   providerMetadata: ReasoningProviderMetadata | undefined
@@ -32,6 +37,11 @@ export function reasoningProviderOptionsFromMetadata(
   const anthropicSignature = providerMetadata.anthropic?.signature;
   if (typeof anthropicSignature === "string" && anthropicSignature.length > 0) {
     options.anthropic = { signature: anthropicSignature };
+  }
+
+  const googleThoughtSignature = providerMetadata.google?.thoughtSignature;
+  if (typeof googleThoughtSignature === "string" && googleThoughtSignature.length > 0) {
+    options.google = { thoughtSignature: googleThoughtSignature };
   }
 
   for (const provider of ["openai", "xai"] as const) {
@@ -66,12 +76,58 @@ export function mergeReasoningProviderOptions(
   if (incoming.anthropic) {
     merged.anthropic = { ...existing.anthropic, ...incoming.anthropic };
   }
+  if (incoming.google) {
+    merged.google = { ...existing.google, ...incoming.google };
+  }
   for (const provider of ["openai", "xai"] as const) {
     if (!incoming[provider]) continue;
     merged[provider] = { ...existing[provider], ...incoming[provider] };
   }
 
   return merged;
+}
+
+/**
+ * Request-only shape read by the AI SDK: convertToModelMessages copies UI-part
+ * `providerMetadata` into ModelMessage `providerOptions` and ignores any
+ * `providerOptions` field on the input part. Never persisted to history.
+ */
+type ReasoningPartWithReplayMetadata = MuxReasoningPart & {
+  providerMetadata?: MuxReasoningPart["providerOptions"];
+};
+
+/**
+ * Mirror persisted reasoning replay data (`providerOptions`, plus the legacy
+ * top-level `signature` field from old histories) into `providerMetadata` so
+ * convertToModelMessages passes it through to the provider request. Without
+ * this bridge, prior-turn reasoning is silently dropped for every provider.
+ * Non-mutating: history objects are reused elsewhere (e.g. debug logging).
+ */
+export function attachReasoningReplayMetadata(messages: MuxMessage[]): MuxMessage[] {
+  return messages.map((message) => {
+    if (message.role !== "assistant") return message;
+
+    let changed = false;
+    const parts = message.parts.map((part) => {
+      if (part.type !== "reasoning") return part;
+
+      const legacySignature = part.signature
+        ? { anthropic: { signature: part.signature } }
+        : undefined;
+      // providerOptions wins over the legacy field when both carry a signature.
+      const replayMetadata = mergeReasoningProviderOptions(legacySignature, part.providerOptions);
+      if (!replayMetadata) return part;
+
+      changed = true;
+      const bridged: ReasoningPartWithReplayMetadata = {
+        ...part,
+        providerMetadata: replayMetadata,
+      };
+      return bridged;
+    });
+
+    return changed ? { ...message, parts } : message;
+  });
 }
 
 /**

--- a/src/node/utils/messages/reasoningProviderOptions.ts
+++ b/src/node/utils/messages/reasoningProviderOptions.ts
@@ -148,18 +148,20 @@ export function attachReasoningReplayMetadata(messages: MuxMessage[]): MuxMessag
       );
       if (!replayMetadata) return part;
 
-      // xAI always runs Responses with store=false (see providerOptions.ts), so a
-      // bare itemId from an interrupted stream (reasoning-end never delivered the
-      // encrypted content) is unresolvable server-side and would fail every
-      // subsequent request. Drop it at replay time only; stream-time accumulation
+      // A bare itemId is the interrupted-stream shape: reasoning-end never
+      // delivered the encrypted content. Under store=false (always for frontier
+      // Grok, ZDR for OpenAI) the server-side reference is unresolvable and
+      // would fail every subsequent request; complete parts always carry
+      // encrypted content because requests include reasoning.encrypted_content.
+      // Drop bare references at replay time only; stream-time accumulation
       // keeps partial metadata so reasoning-end can still complete it.
-      if (
-        replayMetadata.xai &&
-        nonEmptyString(replayMetadata.xai.reasoningEncryptedContent) == null
-      ) {
-        delete replayMetadata.xai;
-        if (Object.keys(replayMetadata).length === 0) return part;
+      for (const provider of ["openai", "xai"] as const) {
+        const meta = replayMetadata[provider];
+        if (meta && nonEmptyString(meta.reasoningEncryptedContent) == null) {
+          delete replayMetadata[provider];
+        }
       }
+      if (Object.keys(replayMetadata).length === 0) return part;
 
       changed = true;
       const bridged: ReasoningPartWithReplayMetadata = {


### PR DESCRIPTION
Fixes #11

## Problem

Past reasoning traces were silently dropped from every subsequent provider request. `streamManager` persists replay metadata on reasoning parts under `providerOptions` (Anthropic thinking signatures; OpenAI/xAI Responses `itemId` + `reasoningEncryptedContent`), but the AI SDK's `convertToModelMessages` only reads `providerMetadata` from UI parts and ignores `providerOptions` entirely.

Consequences on the next `sendMessage`:

- **Anthropic (thinking enabled):** every reasoning part lost its signature, so `stripUnsignedAnthropicReasoning` removed all prior thinking and `ensureAnthropicThinkingBeforeToolCalls` substituted unsigned `"..."` placeholders, which the Anthropic SDK converter then dropped from the wire. No prior-turn thinking was ever replayed.
- **OpenAI/xAI Responses (esp. store=false/ZDR):** reasoning items lost `itemId`/`reasoningEncryptedContent`, so encrypted reasoning could not be restored.

## Fix

- `attachReasoningReplayMetadata` (in `reasoningProviderOptions.ts`): a non-mutating, request-only bridge that mirrors each reasoning part's `providerOptions` (plus the legacy top-level `signature` field from old histories, with `providerOptions` winning on conflict) into `providerMetadata`. Wired into `prepareMessagesForProvider` immediately before `convertToModelMessages`, covering every request-construction call site.
- Same defect class: capture Google `thoughtSignature` from stream metadata into the persisted shape (`reasoningProviderOptionsFromMetadata` / `mergeReasoningProviderOptions`), so the generic bridge replays it too.
- Corrected the stale comments that claimed `providerOptions` flowed through conversion.

No persisted-schema change; history files are untouched.

## Tests

All behavioral (red-green verified by unwiring the bridge and separately disabling the legacy fallback; each toggle failed exactly the matching tests):

- Bridge unit tests: passthrough, legacy fallback, precedence, untouched-part identity, input non-mutation.
- `prepareMessagesForProvider` request-construction tests per provider: Anthropic signed reasoning included with signature / unsigned omitted / reasoning-only dropped when thinking off; OpenAI and xAI `itemId` + encrypted content included; legacy signature-only history bridged; streamed-run coalescing keeps the Anthropic last-part signature and the OpenAI first-part options.
- HistoryService disk round-trip (real instance via `createTestHistoryService`, per testing doctrine): a new request built from re-read history replays the prior turn's reasoning.

## Validation

- `make static-check` green; `bun test src` green.
- Remote dogfood UAT passed with wire-level evidence: the second Anthropic request carried the prior-turn `thinking` block with a real 368-char signature, and the second OpenAI request referenced the prior reasoning item by `rs_...` id with encrypted content present in history; cross-provider switching leaked nothing; thinking-off regression normal.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
