### PR TITLE
🤖 fix: render Browser Preview crisply on HiDPI displays

### DIFF
--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.test.tsx
@@ -75,7 +75,7 @@ describe("BrowserViewport", () => {
     ).toBeNull();
   });
 
-  test("maps intrinsic frame size so capped streams are not stretched into gutters", () => {
+  test("defaults intrinsic frame mapping to 1x display scale", () => {
     const highResolutionMetadata = {
       ...FRAME_METADATA,
       deviceWidth: 2160,
@@ -100,6 +100,63 @@ describe("BrowserViewport", () => {
         { frameImageSize: { width: 720, height: 720 } }
       )
     ).toBeNull();
+  });
+
+  test("maps input within the DPR-capped frame", () => {
+    const highResolutionMetadata = {
+      ...FRAME_METADATA,
+      deviceWidth: 2160,
+      deviceHeight: 2160,
+    };
+    const options = {
+      devicePixelRatio: 2,
+      frameImageSize: { width: 720, height: 720 },
+    };
+
+    expect(
+      mapDomPointToViewport(
+        500,
+        500,
+        { left: 0, top: 0, width: 1000, height: 1000 },
+        highResolutionMetadata,
+        options
+      )
+    ).toEqual({ x: 1080, y: 1080 });
+    expect(
+      mapDomPointToViewport(
+        330,
+        500,
+        { left: 0, top: 0, width: 1000, height: 1000 },
+        highResolutionMetadata,
+        options
+      )
+    ).toEqual({ x: 60, y: 1080 });
+    expect(
+      mapDomPointToViewport(
+        300,
+        500,
+        { left: 0, top: 0, width: 1000, height: 1000 },
+        highResolutionMetadata,
+        options
+      )
+    ).toBeNull();
+  });
+
+  test("does not enlarge the frame when device pixel ratio is below 1", () => {
+    const highResolutionMetadata = {
+      ...FRAME_METADATA,
+      deviceWidth: 2160,
+      deviceHeight: 2160,
+    };
+    const surface = { left: 0, top: 0, width: 360, height: 360 };
+    const frameImageSize = { width: 720, height: 720 };
+
+    expect(
+      mapDomPointToViewport(180, 180, surface, highResolutionMetadata, {
+        devicePixelRatio: 0.5,
+        frameImageSize,
+      })
+    ).toEqual(mapDomPointToViewport(180, 180, surface, highResolutionMetadata, { frameImageSize }));
   });
 
   test("maps decoded frame height when Chrome outer height differs from the page viewport", () => {
@@ -251,7 +308,11 @@ describe("BrowserViewport", () => {
     });
   });
 
-  test("uses loaded screenshot dimensions for pointer hit testing", () => {
+  test("DPR-caps the loaded screenshot and pointer hit testing", () => {
+    Object.defineProperty(globalThis.window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
     const view = renderViewport(
       createSession({
         frameMetadata: {
@@ -261,12 +322,15 @@ describe("BrowserViewport", () => {
         },
       })
     );
-    const image = view.getByAltText("Browser session screenshot");
+    const image = view.getByAltText("Browser session screenshot") as HTMLImageElement;
     Object.defineProperties(image, {
       naturalWidth: { configurable: true, value: 720 },
       naturalHeight: { configurable: true, value: 720 },
     });
     fireEvent.load(image);
+
+    expect(image.style.maxWidth).toBe("min(100%, 360px)");
+    expect(image.style.maxHeight).toBe("min(100%, 360px)");
 
     const viewport = view.getByRole("region", { name: "Browser viewport" });
     Object.assign(viewport, {
@@ -293,7 +357,7 @@ describe("BrowserViewport", () => {
       pointerId: 7,
       button: 0,
       buttons: 1,
-      clientX: 100,
+      clientX: 500,
       clientY: 500,
       detail: 1,
     });
@@ -301,7 +365,7 @@ describe("BrowserViewport", () => {
       pointerId: 8,
       button: 0,
       buttons: 1,
-      clientX: 500,
+      clientX: 300,
       clientY: 500,
       detail: 1,
     });

--- a/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
+++ b/src/browser/features/RightSidebar/BrowserTab/BrowserViewport.tsx
@@ -8,6 +8,7 @@ import {
   type WheelEvent,
 } from "react";
 import { TriangleAlert } from "lucide-react";
+import { useDevicePixelRatio } from "@/browser/hooks/useDevicePixelRatio";
 import { BROWSER_VIEWPORT_ATTR } from "@/browser/utils/ui/keybinds";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { cn } from "@/common/lib/utils";
@@ -71,6 +72,7 @@ interface QueuedPointerMove {
 export function BrowserViewport(props: BrowserViewportProps) {
   assert(props.workspaceId.trim().length > 0, "BrowserViewport requires a workspaceId");
 
+  const devicePixelRatio = useDevicePixelRatio();
   const [hasFocus, setHasFocus] = useState(false);
   const [frameImageSnapshot, setFrameImageSnapshot] = useState<BrowserFrameImageSnapshot | null>(
     null
@@ -173,7 +175,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       queuedMove.clientY,
       currentSurface.getBoundingClientRect(),
       session.frameMetadata,
-      { clampOutsideContent: true, frameImageSize }
+      { clampOutsideContent: true, frameImageSize, devicePixelRatio }
     );
     if (mappedPoint == null) {
       return;
@@ -292,7 +294,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
       props.session.frameMetadata,
-      { frameImageSize }
+      { frameImageSize, devicePixelRatio }
     );
     if (mappedPoint == null) {
       return;
@@ -369,7 +371,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
       props.session.frameMetadata,
-      { clampOutsideContent: true, frameImageSize }
+      { clampOutsideContent: true, frameImageSize, devicePixelRatio }
     );
     if (mappedPoint != null) {
       sendInput(
@@ -405,7 +407,7 @@ export function BrowserViewport(props: BrowserViewportProps) {
       event.clientY,
       event.currentTarget.getBoundingClientRect(),
       props.session.frameMetadata,
-      { frameImageSize }
+      { frameImageSize, devicePixelRatio }
     );
     if (mappedPoint == null) {
       return;
@@ -508,8 +510,16 @@ export function BrowserViewport(props: BrowserViewportProps) {
           src={props.screenshotSrc}
           alt="Browser session screenshot"
           onLoad={handleScreenshotLoad}
-          // agent-browser may cap screencast frames below the viewport size; rendering the
-          // captured bitmap at intrinsic size avoids making that capped stream blurrier.
+          // Capture caps can make the bitmap smaller than its CSS viewport. Avoid rendering it
+          // larger in physical pixels, even when that leaves a smaller preview (issue #3115).
+          style={
+            frameImageSize == null
+              ? undefined
+              : {
+                  maxWidth: `min(100%, ${frameImageSize.width / devicePixelRatio}px)`,
+                  maxHeight: `min(100%, ${frameImageSize.height / devicePixelRatio}px)`,
+                }
+          }
           className="pointer-events-none absolute top-1/2 left-1/2 max-h-full max-w-full -translate-x-1/2 -translate-y-1/2 select-none"
           draggable={false}
         />
@@ -698,7 +708,11 @@ export function mapDomPointToViewport(
   clientY: number,
   surfaceRect: MeasuredViewportRect,
   metadata: BrowserViewportMetadata | null,
-  options?: { clampOutsideContent?: boolean; frameImageSize?: BrowserFrameImageSize | null }
+  options?: {
+    clampOutsideContent?: boolean;
+    devicePixelRatio?: number;
+    frameImageSize?: BrowserFrameImageSize | null;
+  }
 ): ViewportPoint | null {
   assert(metadata != null, "BrowserViewport requires frame metadata to map viewport coordinates");
   assert(Number.isFinite(metadata.deviceWidth), "BrowserViewport deviceWidth must be finite");
@@ -708,7 +722,17 @@ export function mapDomPointToViewport(
   assert(surfaceRect.width > 0, "BrowserViewport surface width must be positive");
   assert(surfaceRect.height > 0, "BrowserViewport surface height must be positive");
 
-  const renderedFrameRect = getRenderedFrameRect(surfaceRect, metadata, options?.frameImageSize);
+  const requestedDevicePixelRatio = options?.devicePixelRatio ?? 1;
+  const devicePixelRatio =
+    Number.isFinite(requestedDevicePixelRatio) && requestedDevicePixelRatio > 0
+      ? requestedDevicePixelRatio
+      : 1;
+  const renderedFrameRect = getRenderedFrameRect(
+    surfaceRect,
+    metadata,
+    options?.frameImageSize,
+    devicePixelRatio
+  );
   const relativeX = clientX - renderedFrameRect.left;
   const relativeY = clientY - renderedFrameRect.top;
   const clampOutsideContent = options?.clampOutsideContent ?? false;
@@ -743,7 +767,8 @@ export function mapDomPointToViewport(
 function getRenderedFrameRect(
   surfaceRect: MeasuredViewportRect,
   metadata: BrowserViewportMetadata,
-  frameImageSize: BrowserFrameImageSize | null | undefined
+  frameImageSize: BrowserFrameImageSize | null | undefined,
+  devicePixelRatio: number
 ): MeasuredViewportRect {
   if (frameImageSize != null) {
     assert(
@@ -753,7 +778,7 @@ function getRenderedFrameRect(
     const renderedScale = Math.min(
       surfaceRect.width / frameImageSize.width,
       surfaceRect.height / frameImageSize.height,
-      1
+      Math.min(1, 1 / devicePixelRatio)
     );
     const renderedWidth = frameImageSize.width * renderedScale;
     const renderedHeight = frameImageSize.height * renderedScale;

--- a/src/browser/hooks/useDevicePixelRatio.ts
+++ b/src/browser/hooks/useDevicePixelRatio.ts
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from "react";
+
+function subscribeToDevicePixelRatio(callback: () => void): () => void {
+  if (typeof window.matchMedia !== "function") {
+    return () => undefined;
+  }
+
+  let disposed = false;
+  let mediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+
+  const handleChange = () => {
+    mediaQuery.removeEventListener("change", handleChange);
+    if (disposed) {
+      return;
+    }
+
+    mediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+    mediaQuery.addEventListener("change", handleChange);
+    callback();
+  };
+
+  mediaQuery.addEventListener("change", handleChange);
+  return () => {
+    disposed = true;
+    mediaQuery.removeEventListener("change", handleChange);
+  };
+}
+
+export function useDevicePixelRatio(): number {
+  return useSyncExternalStore(
+    subscribeToDevicePixelRatio,
+    () => window.devicePixelRatio || 1,
+    () => 1
+  );
+}


### PR DESCRIPTION
## Summary

Fix the Browser Preview panel rendering pixelated/blurry on HiDPI (Retina) displays by capping the rendered frame at `naturalSize / devicePixelRatio` CSS pixels, so one stream bitmap pixel is never stretched past one physical display pixel.

Fixes #3115

## Background

Browser Preview frames come from agent-browser's stream server, which captures via CDP `Page.startScreencast`. That capture is bounded by the remote session's CSS viewport size (in DIPs): `deviceScaleFactor` never raises the bitmap above CSS resolution, and older agent-browser versions additionally capped frames at 1280x720. Xum is a passive session viewer and cannot increase capture resolution.

PR #3396 stopped upscaling frames beyond their intrinsic size in CSS pixels. On a HiDPI display that is still up to `devicePixelRatio`x physical upscaling: a 1280x720 bitmap rendered at 1280 CSS px covers 2560 physical px on a 2x Mac, which is exactly the "renders at 1x DPI and gets scaled up" blur reported in the issue.

## Implementation

- New `useDevicePixelRatio` hook (`useSyncExternalStore` + a self-re-arming `matchMedia` resolution listener) so the cap tracks monitor moves and zoom changes.
- `BrowserViewport` caps the frame `<img>` with inline `max-width`/`max-height: min(100%, naturalSize/dpr px)`. A smaller-but-crisp centered preview is preferred over fill-and-blur; at 1x displays behavior is unchanged.
- Pointer-input mapping (`mapDomPointToViewport`/`getRenderedFrameRect`) mirrors the cap (`min(1, 1/dpr)` scale bound) so clicks, drags, and wheel events land correctly; the metadata-only fallback branch is untouched.

## Validation

- `bun test src/browser/features/RightSidebar/BrowserTab/` (58 pass, including new DPR mapping + component cap tests)
- `make static-check`
- Remote dogfood UAT on this exact head (PASS): at emulated dpr=2 the img caps at `min(100%, 1080px)` for a 2160px frame and letterboxes crisply when the cap binds; at dpr=1 behavior is unchanged; click mapping accurate to ~2px, gutter clicks ignored, wheel + typing forwarded.

## Risks

Low. Display sizing and input mapping change only when `devicePixelRatio > 1`; capture side and bridge protocol untouched.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
