### PR TITLE
🤖 fix: restore ${os} token in release artifact names

### DIFF
--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -180,8 +180,8 @@ jobs:
           # Upload only the AppImage (not latest-linux.yml) to avoid
           # overwriting the auto-update manifest produced by the x64 job.
           gh release upload "$RELEASE_TAG" \
-            release/xum-*-arm64.AppImage \
-            release/mux-*-arm64.AppImage \
+            release/xum-*-arm64-linux.AppImage \
+            release/mux-*-arm64-linux.AppImage \
             --clobber
 
   build-windows:

--- a/.github/workflows/_desktop-release.yml
+++ b/.github/workflows/_desktop-release.yml
@@ -288,10 +288,10 @@ jobs:
         run: |
           gh release download "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --pattern "xum-*-x86_64.AppImage" \
-            --pattern "xum-*-arm64.AppImage" \
-            --pattern "mux-*-x86_64.AppImage" \
-            --pattern "mux-*-arm64.AppImage" \
+            --pattern "xum-*-x86_64-linux.AppImage" \
+            --pattern "xum-*-arm64-linux.AppImage" \
+            --pattern "mux-*-x86_64-linux.AppImage" \
+            --pattern "mux-*-arm64-linux.AppImage" \
             --dir artifacts
 
           cd artifacts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,14 +70,14 @@ jobs:
             nightly-docker.txt
             # Versioned Linux release assets ensure reruns don't skip partially
             # published AppImage/checksum outputs.
-            "xum-${RELEASE_VERSION}-x86_64.AppImage"
-            "xum-${RELEASE_VERSION}-arm64.AppImage"
-            "xum-${RELEASE_VERSION}-x86_64.AppImage.sha256"
-            "xum-${RELEASE_VERSION}-arm64.AppImage.sha256"
-            "mux-${RELEASE_VERSION}-x86_64.AppImage"
-            "mux-${RELEASE_VERSION}-arm64.AppImage"
-            "mux-${RELEASE_VERSION}-x86_64.AppImage.sha256"
-            "mux-${RELEASE_VERSION}-arm64.AppImage.sha256"
+            "xum-${RELEASE_VERSION}-x86_64-linux.AppImage"
+            "xum-${RELEASE_VERSION}-arm64-linux.AppImage"
+            "xum-${RELEASE_VERSION}-x86_64-linux.AppImage.sha256"
+            "xum-${RELEASE_VERSION}-arm64-linux.AppImage.sha256"
+            "mux-${RELEASE_VERSION}-x86_64-linux.AppImage"
+            "mux-${RELEASE_VERSION}-arm64-linux.AppImage"
+            "mux-${RELEASE_VERSION}-x86_64-linux.AppImage.sha256"
+            "mux-${RELEASE_VERSION}-arm64-linux.AppImage.sha256"
           )
 
           # Re-runs with no new commits may find an existing nightly release.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -541,14 +541,14 @@ jobs:
       - name: Upload x64 artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          path: release/*-x64.dmg
+          path: release/*-x64-mac.dmg
           retention-days: 30
           if-no-files-found: error
           archive: false
       - name: Upload arm64 artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          path: release/*-arm64.dmg
+          path: release/*-arm64-mac.dmg
           retention-days: 30
           if-no-files-found: error
           archive: false

--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -60,7 +60,7 @@ Prerequisites:
 - Install **Git for Windows** (includes Git Bash). **WSL is not supported.**
 - Restart Xum after installing Git for Windows.
 
-1. Download the installer exe from [releases](https://github.com/coder/mux/releases) (e.g., `xum-x.x.x-x64.exe`)
+1. Download the installer exe from [releases](https://github.com/coder/mux/releases) (e.g., `xum-x.x.x-x64-win.exe`)
 2. Run the installer
 3. Follow the installation prompts
 4. Launch Xum from the Start menu or desktop shortcut

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
         "zip"
       ],
       "icon": "build/icon.icns",
-      "artifactName": "xum-${version}-${arch}.${ext}",
+      "artifactName": "xum-${version}-${arch}-${os}.${ext}",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
@@ -305,7 +305,7 @@
       "target": "AppImage",
       "category": "Development",
       "icon": "build/icons",
-      "artifactName": "xum-${version}-${arch}.${ext}",
+      "artifactName": "xum-${version}-${arch}-${os}.${ext}",
       "desktop": {
         "StartupWMClass": "xum"
       }
@@ -313,7 +313,7 @@
     "win": {
       "target": "nsis",
       "icon": "build/icon.png",
-      "artifactName": "xum-${version}-${arch}.${ext}",
+      "artifactName": "xum-${version}-${arch}-${os}.${ext}",
       "sign": "scripts/sign-windows.js",
       "signingHashAlgorithms": [
         "sha256"

--- a/src/common/compat/legacyArtifactAliases.test.ts
+++ b/src/common/compat/legacyArtifactAliases.test.ts
@@ -44,43 +44,43 @@ afterEach(async () => {
 describe("create-legacy-mux-artifact-aliases", () => {
   test("aliases lowercase xum artifacts to matching mux names", async () => {
     const releaseDir = await createTempDir();
-    const canonicalName = "xum-0.28.2-arm64.dmg";
+    const canonicalName = "xum-0.28.2-arm64-mac.dmg";
     await writeFile(join(releaseDir, canonicalName), "canonical-bytes");
 
     const result = runAliasScript(releaseDir);
     expect(result.status).toBe(0);
 
-    const legacyPath = join(releaseDir, "mux-0.28.2-arm64.dmg");
+    const legacyPath = join(releaseDir, "mux-0.28.2-arm64-mac.dmg");
     const legacyStat = lstatSync(legacyPath);
     expect(legacyStat.isSymbolicLink()).toBe(true);
-    expect(releaseNames(releaseDir)).toEqual(["mux-0.28.2-arm64.dmg", canonicalName]);
+    expect(releaseNames(releaseDir)).toEqual(["mux-0.28.2-arm64-mac.dmg", canonicalName]);
     expect(releaseNames(releaseDir).some((name) => name.startsWith("mux-Xum-"))).toBe(false);
   });
 
   test("maps capitalized Xum leftovers to mux-* instead of mux-Xum-*", async () => {
     const releaseDir = await createTempDir();
-    await writeFile(join(releaseDir, "Xum-0.28.2-x64.AppImage"), "leaked-product-name");
+    await writeFile(join(releaseDir, "Xum-0.28.2-x64-linux.AppImage"), "leaked-product-name");
 
     const result = runAliasScript(releaseDir);
     expect(result.status).toBe(0);
     expect(releaseNames(releaseDir)).toEqual([
-      "Xum-0.28.2-x64.AppImage",
-      "mux-0.28.2-x64.AppImage",
+      "Xum-0.28.2-x64-linux.AppImage",
+      "mux-0.28.2-x64-linux.AppImage",
     ]);
     expect(releaseNames(releaseDir).some((name) => /mux-[Xx]um-/.test(name))).toBe(false);
 
-    const legacyStat = lstatSync(join(releaseDir, "mux-0.28.2-x64.AppImage"));
+    const legacyStat = lstatSync(join(releaseDir, "mux-0.28.2-x64-linux.AppImage"));
     expect(legacyStat.isSymbolicLink()).toBe(true);
   });
 
   test("leaves preexisting aliases in place and falls back to a byte-identical copy", async () => {
     const releaseDir = await createTempDir();
-    await writeFile(join(releaseDir, "xum-1.0.0-x64.exe"), "installer");
-    await symlink("already-present", join(releaseDir, "mux-1.0.0-x64.exe"));
+    await writeFile(join(releaseDir, "xum-1.0.0-x64-win.exe"), "installer");
+    await symlink("already-present", join(releaseDir, "mux-1.0.0-x64-win.exe"));
 
     const first = runAliasScript(releaseDir);
     expect(first.status).toBe(0);
-    expect(releaseNames(releaseDir)).toEqual(["mux-1.0.0-x64.exe", "xum-1.0.0-x64.exe"]);
+    expect(releaseNames(releaseDir)).toEqual(["mux-1.0.0-x64-win.exe", "xum-1.0.0-x64-win.exe"]);
 
     const blockedBin = join(await createTempDir(), "blocked-bin");
     await mkdir(blockedBin);
@@ -88,7 +88,7 @@ describe("create-legacy-mux-artifact-aliases", () => {
     await chmod(join(blockedBin, "ln"), 0o755);
 
     const copyDir = await createTempDir();
-    const canonicalName = "xum-1.0.0-arm64.zip";
+    const canonicalName = "xum-1.0.0-arm64-mac.zip";
     await writeFile(join(copyDir, canonicalName), "zip-bytes");
     const copyResult = runAliasScript(copyDir, {
       ...process.env,
@@ -96,7 +96,7 @@ describe("create-legacy-mux-artifact-aliases", () => {
     });
     expect(copyResult.status).toBe(0);
 
-    const copiedPath = join(copyDir, "mux-1.0.0-arm64.zip");
+    const copiedPath = join(copyDir, "mux-1.0.0-arm64-mac.zip");
     expect(lstatSync(copiedPath).isSymbolicLink()).toBe(false);
     expect(await readFile(copiedPath, "utf8")).toBe("zip-bytes");
   });

--- a/src/common/compat/productIdentity.test.ts
+++ b/src/common/compat/productIdentity.test.ts
@@ -27,11 +27,15 @@ const AppInfo = ElectronBuilderAppInfo as unknown as new (
 const LEGACY_MUX_BIN_PATH = fileURLToPath(
   new URL("../../../packages/mux-compat/bin/mux.js", import.meta.url)
 );
-const LOWERCASE_ARTIFACT_TEMPLATE = "xum-${version}-${arch}.${ext}";
+// `${os}` keeps an OS token ("mac"/"win"/"linux") in every published filename.
+// electron-builder includes it by default; dropping it makes release assets
+// invisible to installers that match assets by OS (mise/ubi, Homebrew, asdf).
+const LOWERCASE_ARTIFACT_TEMPLATE = "xum-${version}-${arch}-${os}.${ext}";
 
-function expandArtifactName(arch: string, ext: string): string {
+function expandArtifactName(arch: string, ext: string, os: string): string {
   return LOWERCASE_ARTIFACT_TEMPLATE.replaceAll("${version}", packageJson.version)
     .replaceAll("${arch}", arch)
+    .replaceAll("${os}", os)
     .replaceAll("${ext}", ext);
 }
 
@@ -94,8 +98,8 @@ describe("xum package transition contract", () => {
     expect(packageJson.build.linux.artifactName).toBe(LOWERCASE_ARTIFACT_TEMPLATE);
     expect(packageJson.build.win.artifactName).toBe(LOWERCASE_ARTIFACT_TEMPLATE);
 
-    const expanded = expandArtifactName("arm64", "dmg");
-    expect(expanded).toBe(`xum-${packageJson.version}-arm64.dmg`);
+    const expanded = expandArtifactName("arm64", "dmg", "mac");
+    expect(expanded).toBe(`xum-${packageJson.version}-arm64-mac.dmg`);
     expect(expanded.startsWith(`${packageJson.name}-`)).toBe(false);
     expect(expanded.startsWith(`${packageJson.build.productName}-`)).toBe(false);
   });

--- a/src/common/compat/productIdentity.test.ts
+++ b/src/common/compat/productIdentity.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 import { AppInfo as ElectronBuilderAppInfo } from "app-builder-lib/out/appInfo";
+import { expandMacro } from "app-builder-lib/out/util/macroExpander";
 import packageJson from "../../../package.json";
 import legacyPackageJson from "../../../packages/mux-compat/package.json";
 import vscodePackageJson from "../../../vscode/package.json";
@@ -32,11 +33,28 @@ const LEGACY_MUX_BIN_PATH = fileURLToPath(
 // invisible to installers that match assets by OS (mise/ubi, Homebrew, asdf).
 const LOWERCASE_ARTIFACT_TEMPLATE = "xum-${version}-${arch}-${os}.${ext}";
 
+// Expand through electron-builder's own macro expander rather than a local copy
+// of the substitution rules, so this exercises the builder's real behaviour: it
+// throws ERR_ELECTRON_BUILDER_MACRO_NOT_DEFINED on any macro it cannot resolve,
+// which is what makes `${os}` support an assertion instead of a restatement.
 function expandArtifactName(arch: string, ext: string, os: string): string {
-  return LOWERCASE_ARTIFACT_TEMPLATE.replaceAll("${version}", packageJson.version)
-    .replaceAll("${arch}", arch)
-    .replaceAll("${os}", os)
-    .replaceAll("${ext}", ext);
+  const appInfo = new AppInfo(
+    {
+      metadata: {
+        name: packageJson.name,
+        version: packageJson.version,
+        description: packageJson.description,
+      },
+      config: {
+        productName: packageJson.build.productName,
+        executableName: packageJson.build.executableName,
+      },
+    },
+    null
+  );
+  // `os` and `ext` are supplied by the packager as extras; `version` resolves
+  // off AppInfo, mirroring how electron-builder expands artifactName at build time.
+  return expandMacro(LOWERCASE_ARTIFACT_TEMPLATE, arch, appInfo as never, { os, ext });
 }
 
 describe("xum package transition contract", () => {

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -6569,7 +6569,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "- Install **Git for Windows** (includes Git Bash). **WSL is not supported.**",
       "- Restart Xum after installing Git for Windows.",
       "",
-      "1. Download the installer exe from [releases](https://github.com/coder/mux/releases) (e.g., `xum-x.x.x-x64.exe`)",
+      "1. Download the installer exe from [releases](https://github.com/coder/mux/releases) (e.g., `xum-x.x.x-x64-win.exe`)",
       "2. Run the installer",
       "3. Follow the installation prompts",
       "4. Launch Xum from the Start menu or desktop shortcut",


### PR DESCRIPTION
## Summary

Restores the `${os}` token in `build.{mac,linux,win}.artifactName` so every published release asset carries a `mac`/`linux`/`win` token in its filename, and updates every in-repo consumer of the old names. Without the token, installers that select release assets by operating system cannot find any xum asset at all.

## Background

electron-builder's default artifact pattern is `${productName}-${version}-${arch}-${os}.${ext}` (`app-builder-lib/out/targets/ArchiveTarget.js`). Our override exists to get the lowercase `xum-` slug instead of the `Xum` productName, but it also dropped `-${os}`.

The result is that v0.28.2 published `mux-0.28.2-arm64.dmg`, `mux-0.28.2-arm64.zip`, `mux-0.28.2-x64.exe`, and `mux-0.28.2-x86_64.AppImage` — not one of which says which OS it is for.

Asset-matching installers filter on an OS token before anything else, so they reject the entire asset list. Concretely, with `mise`:

```
$ mise install ubi:coder/xum
could not find a release asset for this OS (macos) from builder-debug.yml,
latest-linux.yml, latest-mac.yml, latest.yml, mux-0.1.0.vsix,
mux-0.28.2-arm64.AppImage, mux-0.28.2-arm64.dmg, mux-0.28.2-arm64.zip, ...
```

Worse is the silent failure mode: `mise install github:coder/xum` *reports success*. The only asset whose name contains an OS-ish token is `latest-mac.yml`, so mise installs that 785-byte electron-updater manifest and exits 0. The user gets a tool directory containing one YAML file, no binary, and no error. The same class of failure applies to Homebrew and asdf.

## Implementation

`xum-${version}-${arch}.${ext}` → `xum-${version}-${arch}-${os}.${ext}` for all three platforms. `${os}` expands to `mac`/`linux`/`win` from `platform.buildConfigurationKey`, and all targets (`ArchiveTarget`, `DmgTarget`, `NsisTarget`, `AppImageTarget`) route through the same `expandArtifactNamePattern`, so dmg/zip/exe/AppImage all pick it up.

The rename has in-repo consumers that hardcode the old suffixes; all are updated here:

| Location | Was | Why it breaks |
| --- | --- | --- |
| `_desktop-release.yml` arm64 AppImage upload | `release/xum-*-arm64.AppImage` | unmatched glob fails `gh release upload` |
| `_desktop-release.yml` Linux checksum job | `--pattern "xum-*-x86_64.AppImage"` etc. | `gh release download` errors `no assets match the file pattern`, before checksums publish |
| `nightly.yml` `REQUIRED_ASSETS` | `xum-${RELEASE_VERSION}-arm64.AppImage` etc. | a complete nightly reads as incomplete, gets deleted and rebuilt |
| `pr.yml` macOS dmg uploads | `release/*-x64.dmg`, `release/*-arm64.dmg` | `if-no-files-found: error` fails every macOS CI build after packaging |
| `docs/install.mdx` (+ generated skill copy) | `xum-x.x.x-x64.exe` | documents a filename that will no longer exist |

`scripts/create-legacy-mux-artifact-aliases.sh` needs no change — it rewrites the `xum-`/`Xum-` *prefix* and passes the remainder through untouched, so `mux-` aliases keep tracking canonical names. Its test fixtures are updated to realistic post-rename filenames so they actually demonstrate that.

`expandArtifactName` in `productIdentity.test.ts` now calls electron-builder's own `expandMacro` rather than reimplementing the substitution rules, so the test exercises the builder instead of comparing two copies of the same string.

## Validation

Verified the fix actually solves the problem end-to-end, rather than assuming it would. I published a scratch GitHub release carrying the post-fix asset names (`xum-0.29.0-arm64-mac.zip` plus the full set of dmg/blockmap/exe/AppImage/yml siblings, the zip containing only an `Xum.app` bundle) and pointed mise at it:

```
$ mise install github:matifali/xum@0.29.0
✓ installed
$ mise x github:matifali/xum@0.29.0 -- xum
xum 0.29.0 (scratch)
```

mise strips the `.app` wrapper, installs `Contents/MacOS/xum`, and the shim runs. No consumer-side options needed — `"github:coder/xum" = "latest"` is enough. Two things worth recording from that test:

- The rename alone is what unblocks it. Before adding the OS token, the same install either picks the wrong asset or fails.
- An `.app`-only archive is otherwise a hazard for these installers: without a resolvable executable they abort with `Is a directory (os error 21)`. Our bundle layout happens to resolve cleanly.

Confirmed the rewritten test is not tautological — `expandMacro` throws when the macro is absent, so the assertion has teeth:

```
cannot expand pattern "xum-${version}-${arch}-${os}.${ext}": macro os is not defined
```

Locally: `bun test src/common/compat src/desktop/updater.test.ts` green, `make typecheck` clean, `actionlint` clean on all three modified workflows. Grepped for residual old-pattern references and found none.

## What this unblocks for users

After this lands, installing xum's CLI via mise is one config line — no asset patterns, no per-user workarounds:

```toml
# ~/.config/mise/config.toml
[tools]
"github:coder/xum" = "latest"
```

`mise install`, `mise up`, and version pinning all work from there, and the same applies to any installer that matches release assets by OS token.

To be precise about scope: this gives users the **CLI on PATH**, not a Finder/Spotlight-registered application. mise installs under `~/.local/share/mise` — a hidden directory macOS does not index — and has no concept of an `.app` bundle; it unpacks ours to bare `Contents/MacOS/xum`. Anyone wanting the desktop app should still use the dmg. This PR is about making the assets *discoverable by tooling*, not about making mise a supported install path for the GUI.

Today, with no OS token, neither is possible — `github:coder/xum` silently installs a YAML manifest and reports success.

## Risks

Low, but it touches the release path, so worth being explicit.

**Auto-update is unaffected.** `src/desktop/updater.ts` is stock `electron-updater` with the GitHub provider and never reconstructs asset filenames from a pattern — it reads them out of `latest-mac.yml`, which electron-builder regenerates with the new names. A client on 0.28.2 reads the new manifest and downloads the new filename. I checked for hardcoded name-building specifically because that would have made this a coordinated change instead of a config one.

**Download links change.** Anything pinning an exact asset URL for a *future* release needs updating; already-published assets are untouched.

The residual risk is a hardcoded asset name *outside* this repo (website, install script, package manifest) that I can't see from here — worth a second pair of eyes. The first review round showed this rename has more consumers than a grep for the obvious prefix turns up.

Note: `Pixel / Review` fails on this PR and equally on unrelated PR #3926; this change touches no UI.

---

_Generated with `Claude Code` • Model: `claude-opus-5`_

