### PR TITLE
🤖 tests: fix Pixel phone-viewport story failing on main

### DIFF
--- a/src/browser/components/ProjectCreateModal/ProjectCreateModal.stories.tsx
+++ b/src/browser/components/ProjectCreateModal/ProjectCreateModal.stories.tsx
@@ -7,7 +7,11 @@
  */
 
 import type { APIClient } from "@/browser/contexts/API";
-import { expandProjects, selectWorkspace } from "@/browser/stories/helpers/uiState";
+import {
+  expandLeftSidebar,
+  expandProjects,
+  selectWorkspace,
+} from "@/browser/stories/helpers/uiState";
 import { createMockORPCClient } from "@/browser/stories/mocks/orpc";
 import { createWorkspace, groupWorkspacesByProject } from "@/browser/stories/mocks/workspaces";
 import type { AppStory } from "@/browser/stories/meta.js";
@@ -29,6 +33,9 @@ function setupProjectCreateStory(): APIClient {
   const workspaces = [createWorkspace({ id: "ws-1", name: "main", projectName: "my-app" })];
   selectWorkspace(workspaces[0]);
   expandProjects(["/mock/my-app"]);
+  // The sidebar defaults to collapsed at phone widths; the play functions need
+  // its "Add project" button visible to open the modal.
+  expandLeftSidebar();
   return createMockORPCClient({
     projects: groupWorkspacesByProject(workspaces),
     workspaces,

--- a/src/browser/stories/helpers/uiState.ts
+++ b/src/browser/stories/helpers/uiState.ts
@@ -1,3 +1,4 @@
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
   SELECTED_WORKSPACE_KEY,
@@ -55,10 +56,10 @@ export function expandRightSidebar(): void {
 }
 
 /**
- * Expand the left sidebar (project tree). The app defaults to collapsed when
- * window.innerWidth <= 768, so stories whose play functions click sidebar
- * controls must force it open to pass under Pixel's phone viewport.
+ * Expand the left sidebar (project tree). The app defaults it to collapsed at
+ * mobile widths, so stories whose play functions click sidebar controls must
+ * force it open to pass under Pixel's phone viewport.
  */
 export function expandLeftSidebar(): void {
-  localStorage.setItem(LEFT_SIDEBAR_COLLAPSED_KEY, JSON.stringify(false));
+  updatePersistedState(LEFT_SIDEBAR_COLLAPSED_KEY, false);
 }

--- a/src/browser/stories/helpers/uiState.ts
+++ b/src/browser/stories/helpers/uiState.ts
@@ -53,3 +53,12 @@ export function collapseLeftSidebar(): void {
 export function expandRightSidebar(): void {
   localStorage.setItem(RIGHT_SIDEBAR_COLLAPSED_KEY, JSON.stringify(false));
 }
+
+/**
+ * Expand the left sidebar (project tree). The app defaults to collapsed when
+ * window.innerWidth <= 768, so stories whose play functions click sidebar
+ * controls must force it open to pass under Pixel's phone viewport.
+ */
+export function expandLeftSidebar(): void {
+  localStorage.setItem(LEFT_SIDEBAR_COLLAPSED_KEY, JSON.stringify(false));
+}


### PR DESCRIPTION
## Summary

Fixes the Pixel commit status failing on `main` since #3923: the new `ProjectCreateModal` PhoneViewport story's play function timed out with `Unable to find a label with the text of: Add project`.

## Background

#3923 added a Pixel phone-viewport story that opens the Add Project modal by clicking the sidebar's "Add project" button. The app auto-collapses the left sidebar when `window.innerWidth <= 768`, and the collapsed sidebar does not render that button. Only Pixel executes the play at the pinned 390px viewport (the Storybook test-runner ignores viewport globals and runs at desktop width), so PR CI stayed green while every Pixel build on `main` since cc633c9cf reported "1 test failed" (build 1772).

## Implementation

Adds an `expandLeftSidebar()` helper to `stories/helpers/uiState.ts` (mirroring the existing `collapseLeftSidebar`) and calls it in the shared `setupProjectCreateStory()`, following the same pattern ScratchPage stories already use for mobile-viewport plays. Expanded is the desktop default, so the two desktop stories are unaffected.

## Validation

- Red-green via Storybook + agent-browser at a 390x844 viewport: without the fix the "Add project" button and dialog never appear (the exact CI failure); with it the dialog opens showing all three modes wrapping within the narrow dialog.
- Re-checked the desktop LocalFolder/CloneRepo stories still open the dialog at 1200px.
- `make static-check` passes.

Note: `tests/ui/storybook/budget.test.ts` fails on clean `main` already (budget drifted; CI never runs that file, it is jest-ignored and outside the CI unit-test `find src` glob). This change adds no stories or matrix variants, so it does not move those counts.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
