### PR TITLE
🤖 feat: validated make update-models refresh + full catalog in Treat as

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -49,6 +49,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
         with:
+          # Pin to main so a workflow_dispatch from a feature branch cannot leak
+          # unrelated commits into the shared bot/update-models branch.
+          ref: refs/heads/main
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
@@ -56,13 +59,11 @@ jobs:
         with:
           bun-version: 1.3.5
 
-      - name: Install dependencies
-        if: ${{ steps.precheck.outputs.enabled == 'true' }}
-        run: bun install --frozen-lockfile
-
       - name: Update models.json
         if: ${{ steps.precheck.outputs.enabled == 'true' }}
-        run: bun scripts/update_models.ts
+        # Go through the Makefile target (which installs dependencies first) so
+        # automation and local refreshes share one entry point.
+        run: make update-models
 
       - name: Push branch and open PR if changed
         if: ${{ steps.precheck.outputs.enabled == 'true' }}

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -1,0 +1,93 @@
+# Weekly refresh of the vendored LiteLLM model catalog
+# (src/common/utils/tokens/models.json) via scripts/update_models.ts, which
+# validates pricing shape and curated-model coverage before writing (#3727).
+# Opens or updates a bot PR only when the data changed.
+# SETUP: reuses the auto-cleanup GitHub App credentials (XUM_APP_ID and
+# XUM_APP_PRIVATE_KEY) so the PR triggers CI.
+
+name: Update Models
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly, Mondays 6 AM UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-models
+  cancel-in-progress: true
+
+jobs:
+  update-models:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check required secrets
+        id: precheck
+        env:
+          XUM_APP_ID: ${{ secrets.XUM_APP_ID || secrets.MUX_APP_ID }}
+          XUM_APP_PRIVATE_KEY: ${{ secrets.XUM_APP_PRIVATE_KEY || secrets.MUX_APP_PRIVATE_KEY }}
+        run: |
+          if [ -z "$XUM_APP_ID" ] || [ -z "$XUM_APP_PRIVATE_KEY" ]; then
+            echo "Skipping (missing XUM_APP_ID / XUM_APP_PRIVATE_KEY)."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        with:
+          # Use a GitHub App token so PR events trigger CI. PRs opened via
+          # GITHUB_TOKEN intentionally do not trigger other workflows.
+          app-id: ${{ secrets.XUM_APP_ID || secrets.MUX_APP_ID }}
+          private-key: ${{ secrets.XUM_APP_PRIVATE_KEY || secrets.MUX_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        with:
+          bun-version: 1.3.5
+
+      - name: Install dependencies
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        run: bun install --frozen-lockfile
+
+      - name: Update models.json
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        run: bun scripts/update_models.ts
+
+      - name: Push branch and open PR if changed
+        if: ${{ steps.precheck.outputs.enabled == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if git diff --quiet -- src/common/utils/tokens/models.json; then
+            echo "models.json already up to date; no PR needed."
+            exit 0
+          fi
+
+          git config user.name "mux-bot[bot]"
+          git config user.email "264182336+mux-bot[bot]@users.noreply.github.com"
+          git checkout -B bot/update-models
+          git add src/common/utils/tokens/models.json
+          git commit -m "🤖 chore: refresh models.json from LiteLLM"
+          git push --force origin bot/update-models
+
+          open_prs=$(gh pr list --head bot/update-models --state open --json number --jq length)
+          if [ "$open_prs" = "0" ]; then
+            gh pr create \
+              --title "🤖 chore: refresh models.json from LiteLLM" \
+              --body "Automated weekly refresh of the vendored LiteLLM model catalog via \`make update-models\` (#3727)." \
+              --base main \
+              --head bot/update-models
+          else
+            echo "Existing open PR for bot/update-models updated by push."
+          fi

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Check required secrets
         id: precheck
         env:
-          XUM_APP_ID: ${{ secrets.XUM_APP_ID || secrets.MUX_APP_ID }}
-          XUM_APP_PRIVATE_KEY: ${{ secrets.XUM_APP_PRIVATE_KEY || secrets.MUX_APP_PRIVATE_KEY }}
+          XUM_APP_ID: ${{ secrets.XUM_APP_ID }}
+          XUM_APP_PRIVATE_KEY: ${{ secrets.XUM_APP_PRIVATE_KEY }}
         run: |
           if [ -z "$XUM_APP_ID" ] || [ -z "$XUM_APP_PRIVATE_KEY" ]; then
             echo "Skipping (missing XUM_APP_ID / XUM_APP_PRIVATE_KEY)."
@@ -43,8 +43,8 @@ jobs:
         with:
           # Use a GitHub App token so PR events trigger CI. PRs opened via
           # GITHUB_TOKEN intentionally do not trigger other workflows.
-          app-id: ${{ secrets.XUM_APP_ID || secrets.MUX_APP_ID }}
-          private-key: ${{ secrets.XUM_APP_PRIVATE_KEY || secrets.MUX_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.XUM_APP_ID }}
+          private-key: ${{ secrets.XUM_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{ steps.precheck.outputs.enabled == 'true' }}

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -79,14 +79,23 @@ jobs:
           git config user.email "264182336+mux-bot[bot]@users.noreply.github.com"
           git checkout -B bot/update-models
           git add src/common/utils/tokens/models.json
-          git commit -m "🤖 chore: refresh models.json from LiteLLM"
+          # Attribution footer per .xum/skills/pull-requests: automation
+          # commits use the workflow marker instead of model/thinking/cost.
+          footer="---
+
+          _Automated by the \`update-models\` workflow (GitHub Actions)._
+
+          <!-- xum-attribution: workflow=update-models -->"
+          git commit -m "🤖 chore: refresh models.json from LiteLLM" -m "$footer"
           git push --force origin bot/update-models
 
           open_prs=$(gh pr list --head bot/update-models --state open --json number --jq length)
           if [ "$open_prs" = "0" ]; then
             gh pr create \
               --title "🤖 chore: refresh models.json from LiteLLM" \
-              --body "Automated weekly refresh of the vendored LiteLLM model catalog via \`make update-models\` (#3727)." \
+              --body "Automated weekly refresh of the vendored LiteLLM model catalog via \`make update-models\` (#3727).
+
+          $footer" \
               --base main \
               --head bot/update-models
           else

--- a/.xum/skills/pull-requests/SKILL.md
+++ b/.xum/skills/pull-requests/SKILL.md
@@ -19,6 +19,16 @@ _Generated with `xum` • Model: `<modelString>` • Thinking: `<thinkingLevel>`
 
 Always check `$XUM_MODEL_STRING`, `$XUM_THINKING_LEVEL`, and `$XUM_COSTS_USD` via bash before creating or updating PRs—include them in the footer if set.
 
+Scheduled automation (non-AI) commits and PRs from GitHub Actions workflows use this footer instead, since model/thinking/cost do not apply:
+
+```md
+---
+
+_Automated by the `<workflow-name>` workflow (GitHub Actions)._
+
+<!-- xum-attribution: workflow=<workflow-name> -->
+```
+
 ## Lifecycle Rules
 
 - Before submitting a PR, ensure the branch name reflects the work and the base branch is correct.

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,9 @@ $(BUILTIN_SKILLS_GENERATED): $(BUILTIN_SKILL_SOURCES) $(DOCS_SOURCES) scripts/ge
 $(WORKFLOW_RUNTIME_SOURCES_GENERATED): $(WORKFLOW_RUNTIME_SOURCES) scripts/gen_workflow_runtime_sources.ts
 	@bun scripts/gen_workflow_runtime_sources.ts
 
-dist/cli/index.js: src/cli/index.ts src/desktop/main.ts src/cli/server.ts src/version.ts tsconfig.main.json tsconfig.json $(TS_SOURCES) $(BUILTIN_AGENTS_GENERATED) $(BUILTIN_SKILLS_GENERATED) $(BUILTIN_WORKFLOWS_GENERATED) $(WORKFLOW_RUNTIME_SOURCES_GENERATED)
+# models.json is bundled but not in $(TS_SOURCES); without this prerequisite a
+# catalog-only refresh would leave a stale main bundle (#3727).
+dist/cli/index.js: src/cli/index.ts src/desktop/main.ts src/cli/server.ts src/version.ts tsconfig.main.json tsconfig.json $(TS_SOURCES) src/common/utils/tokens/models.json $(BUILTIN_AGENTS_GENERATED) $(BUILTIN_SKILLS_GENERATED) $(BUILTIN_WORKFLOWS_GENERATED) $(WORKFLOW_RUNTIME_SOURCES_GENERATED)
 	@echo "Building main process..."
 	@NODE_ENV=production $(TSGO) -p tsconfig.main.json
 	@NODE_ENV=production bun x tsc-alias -p tsconfig.main.json

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,16 @@ start: node_modules/.installed build-main build-preload build-static ## Build an
 ## Build targets (can run in parallel)
 build: node_modules/.installed src/version.ts build-renderer build-main build-preload build-icons build-static ## Build all targets
 
+.PHONY: update-models
+update-models: node_modules/.installed ## Fetch latest LiteLLM model data, validate it, update models.json if changed
+	@bun scripts/update_models.ts
+
+# #3727: `make build UPDATE_MODELS=1` refreshes the vendored models.json before
+# building; plain `make build` stays network-free and reproducible.
+ifeq ($(UPDATE_MODELS),1)
+build: update-models
+endif
+
 build-main: node_modules/.installed dist/cli/index.js dist/cli/api.mjs ## Build main process
 
 BUILTIN_AGENTS_GENERATED := src/node/services/agentDefinitions/builtInAgentContent.generated.ts

--- a/Makefile
+++ b/Makefile
@@ -224,9 +224,13 @@ update-models: node_modules/.installed ## Fetch latest LiteLLM model data, valid
 	@bun scripts/update_models.ts
 
 # #3727: `make build UPDATE_MODELS=1` refreshes the vendored models.json before
-# building; plain `make build` stays network-free and reproducible.
+# building; plain `make build` stays network-free and reproducible. The refresh
+# must be a prerequisite of every catalog-consuming bundle (not just `build`) so
+# parallel make cannot bundle the old catalog, and the phony prerequisite forces
+# those bundles stale because models.json is not part of $(TS_SOURCES).
 ifeq ($(UPDATE_MODELS),1)
 build: update-models
+build-renderer dist/cli/index.js dist/cli/api.mjs: update-models
 endif
 
 build-main: node_modules/.installed dist/cli/index.js dist/cli/api.mjs ## Build main process

--- a/scripts/update_models.ts
+++ b/scripts/update_models.ts
@@ -12,9 +12,7 @@ import {
   pruneModelData,
   sanitizePricing,
   serializeModelData,
-  summarizeCatalog,
   validateModelData,
-  type CatalogSummary,
   type ModelCatalogData,
 } from "../src/common/utils/tokens/updateModelsData";
 
@@ -42,14 +40,14 @@ async function updateModels() {
   const existing = await Bun.file(OUTPUT_PATH)
     .text()
     .catch(() => null);
-  // Validate shrinkage against the vendored catalog so a truncated upstream
-  // response or a pricing-field rename cannot silently degrade known models.
-  let baseline: CatalogSummary | undefined;
+  // Validate against the vendored catalog so a truncated upstream response, a
+  // field rename, or a targeted repricing cannot silently degrade known models.
+  let baseline: ModelCatalogData | undefined;
   if (existing !== null) {
     try {
-      baseline = summarizeCatalog(JSON.parse(existing) as ModelCatalogData);
+      baseline = JSON.parse(existing) as ModelCatalogData;
     } catch {
-      console.warn(`Could not parse existing ${OUTPUT_PATH}; skipping baseline size check`);
+      console.warn(`Could not parse existing ${OUTPUT_PATH}; skipping baseline checks`);
     }
   }
   validateModelData(sanitized, baseline);

--- a/scripts/update_models.ts
+++ b/scripts/update_models.ts
@@ -1,61 +1,23 @@
 #!/usr/bin/env bun
 
 /**
- * Downloads the latest model prices and context window data from LiteLLM
- * and saves the subset Xum consumes to src/common/utils/tokens/models.json.
+ * Refreshes src/common/utils/tokens/models.json from LiteLLM. The transform and
+ * validation logic lives in src/common/utils/tokens/updateModelsData.ts so unit
+ * tests cover it. Writes only when the validated content changed, keeping
+ * `make update-models`, `make build UPDATE_MODELS=1`, and the scheduled
+ * update-models workflow idempotent (#3727).
  */
+
+import {
+  pruneModelData,
+  sanitizePricing,
+  serializeModelData,
+  validateModelData,
+} from "../src/common/utils/tokens/updateModelsData";
 
 const LITELLM_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const OUTPUT_PATH = "src/common/utils/tokens/models.json";
-
-const RETAINED_FIELDS = [
-  "max_input_tokens",
-  "max_output_tokens",
-  "input_cost_per_token",
-  "output_cost_per_token",
-  "output_cost_per_image_token",
-  "input_cost_per_token_above_200k_tokens",
-  "output_cost_per_token_above_200k_tokens",
-  "cache_creation_input_token_cost",
-  "cache_creation_input_token_cost_above_200k_tokens",
-  "cache_read_input_token_cost",
-  "cache_read_input_token_cost_above_200k_tokens",
-  "tiered_pricing_threshold_tokens",
-  "mode",
-  "litellm_provider",
-  "supports_pdf_input",
-  "supports_vision",
-  "supports_audio_input",
-  "supports_video_input",
-  "max_pdf_size_mb",
-] as const;
-
-function pruneModelData(data: unknown): Record<string, Record<string, unknown>> {
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
-    throw new Error("Expected LiteLLM model metadata object");
-  }
-
-  const pruned: Record<string, Record<string, unknown>> = {};
-  for (const [modelId, rawMetadata] of Object.entries(data)) {
-    if (!rawMetadata || typeof rawMetadata !== "object" || Array.isArray(rawMetadata)) {
-      continue;
-    }
-
-    const metadata = rawMetadata as Record<string, unknown>;
-    const retained: Record<string, unknown> = {};
-    // Keep models.json small: Xum only reads pricing, token limits, provider, mode, and media
-    // capability fields, while upstream LiteLLM ships many provider-specific fields we never use.
-    for (const field of RETAINED_FIELDS) {
-      if (metadata[field] !== undefined) {
-        retained[field] = metadata[field];
-      }
-    }
-    pruned[modelId] = retained;
-  }
-
-  return pruned;
-}
 
 async function updateModels() {
   console.log(`Fetching model data from ${LITELLM_URL}...`);
@@ -66,12 +28,26 @@ async function updateModels() {
     throw new Error(`Failed to fetch model data: ${response.status} ${response.statusText}`);
   }
 
-  const data = pruneModelData(await response.json());
+  const sanitized = sanitizePricing(pruneModelData(await response.json()));
+  if (sanitized.droppedModelIds.length > 0) {
+    console.warn(
+      `Dropped ${sanitized.droppedModelIds.length} entries with invalid pricing: ` +
+        sanitized.droppedModelIds.slice(0, 10).join(", ")
+    );
+  }
+  validateModelData(sanitized);
 
-  console.log(`Writing model data to ${OUTPUT_PATH}...`);
-  await Bun.write(OUTPUT_PATH, `${JSON.stringify(data, null, 2)}\n`);
+  const serialized = serializeModelData(sanitized.catalog);
+  const existing = await Bun.file(OUTPUT_PATH)
+    .text()
+    .catch(() => null);
+  if (existing === serialized) {
+    console.log("✓ models.json already up to date");
+    return;
+  }
 
-  console.log("✓ Model data updated successfully");
+  await Bun.write(OUTPUT_PATH, serialized);
+  console.log(`✓ Updated ${OUTPUT_PATH} (${Object.keys(sanitized.catalog).length} models)`);
 }
 
 updateModels().catch((error) => {

--- a/scripts/update_models.ts
+++ b/scripts/update_models.ts
@@ -9,10 +9,12 @@
  */
 
 import {
+  countChatModels,
   pruneModelData,
   sanitizePricing,
   serializeModelData,
   validateModelData,
+  type ModelCatalogData,
 } from "../src/common/utils/tokens/updateModelsData";
 
 const LITELLM_URL =
@@ -35,12 +37,23 @@ async function updateModels() {
         sanitized.droppedModelIds.slice(0, 10).join(", ")
     );
   }
-  validateModelData(sanitized);
 
-  const serialized = serializeModelData(sanitized.catalog);
   const existing = await Bun.file(OUTPUT_PATH)
     .text()
     .catch(() => null);
+  // Validate shrinkage against the vendored catalog so a truncated upstream
+  // response cannot silently drop metadata for thousands of known models.
+  let baselineChatCount = 0;
+  if (existing !== null) {
+    try {
+      baselineChatCount = countChatModels(JSON.parse(existing) as ModelCatalogData);
+    } catch {
+      console.warn(`Could not parse existing ${OUTPUT_PATH}; skipping baseline size check`);
+    }
+  }
+  validateModelData(sanitized, baselineChatCount);
+
+  const serialized = serializeModelData(sanitized.catalog);
   if (existing === serialized) {
     console.log("✓ models.json already up to date");
     return;

--- a/scripts/update_models.ts
+++ b/scripts/update_models.ts
@@ -9,11 +9,12 @@
  */
 
 import {
-  countChatModels,
   pruneModelData,
   sanitizePricing,
   serializeModelData,
+  summarizeCatalog,
   validateModelData,
+  type CatalogSummary,
   type ModelCatalogData,
 } from "../src/common/utils/tokens/updateModelsData";
 
@@ -42,16 +43,16 @@ async function updateModels() {
     .text()
     .catch(() => null);
   // Validate shrinkage against the vendored catalog so a truncated upstream
-  // response cannot silently drop metadata for thousands of known models.
-  let baselineChatCount = 0;
+  // response or a pricing-field rename cannot silently degrade known models.
+  let baseline: CatalogSummary | undefined;
   if (existing !== null) {
     try {
-      baselineChatCount = countChatModels(JSON.parse(existing) as ModelCatalogData);
+      baseline = summarizeCatalog(JSON.parse(existing) as ModelCatalogData);
     } catch {
       console.warn(`Could not parse existing ${OUTPUT_PATH}; skipping baseline size check`);
     }
   }
-  validateModelData(sanitized, baselineChatCount);
+  validateModelData(sanitized, baseline);
 
   const serialized = serializeModelData(sanitized.catalog);
   if (existing === serialized) {

--- a/src/browser/features/Settings/Components/SearchableModelSelect.tsx
+++ b/src/browser/features/Settings/Components/SearchableModelSelect.tsx
@@ -6,6 +6,10 @@ import { stopKeyboardPropagation } from "@/browser/utils/events";
 import { cn } from "@/common/lib/utils";
 import { getModelName, getModelProvider } from "@/common/utils/ai/models";
 
+// The full model catalog is ~2k entries; rendering every row makes the popover
+// janky, so cap the list and prompt the user to narrow the search instead.
+const MAX_RENDERED_MODELS = 200;
+
 /** Searchable model dropdown with keyboard navigation */
 export function SearchableModelSelect(props: {
   value: string;
@@ -34,6 +38,9 @@ export function SearchableModelSelect(props: {
       model.toLowerCase().includes(searchLower) ||
       (getModelName(model)?.toLowerCase().includes(searchLower) ?? false)
   );
+  const hiddenModelCount = Math.max(0, filteredModels.length - MAX_RENDERED_MODELS);
+  const visibleModels =
+    hiddenModelCount > 0 ? filteredModels.slice(0, MAX_RENDERED_MODELS) : filteredModels;
 
   // Build list of all selectable items (empty option + filtered models)
   const items: Array<{ value: string; label: string; provider?: string; isMuted?: boolean }> = [];
@@ -44,7 +51,7 @@ export function SearchableModelSelect(props: {
       isMuted: true,
     });
   }
-  for (const model of filteredModels) {
+  for (const model of visibleModels) {
     items.push({
       value: model,
       label: getModelName(model) ?? model,
@@ -179,6 +186,11 @@ export function SearchableModelSelect(props: {
                 <span className={cn("truncate", item.isMuted && "text-muted")}>{item.label}</span>
               </button>
             ))
+          )}
+          {hiddenModelCount > 0 && (
+            <div className="text-muted px-2 py-1 text-center text-[10px]">
+              +{hiddenModelCount} more, keep typing to filter
+            </div>
           )}
         </div>
       </PopoverContent>

--- a/src/browser/features/Settings/Sections/ModelsSection.tsx
+++ b/src/browser/features/Settings/Sections/ModelsSection.tsx
@@ -19,6 +19,7 @@ import { useMinThinkingLevels } from "@/browser/hooks/useMinThinkingLevels";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useProvidersConfig } from "@/browser/hooks/useProvidersConfig";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { listModelCatalogIds } from "@/common/utils/tokens/modelCatalog";
 import { isCodexOauthRequiredModelId } from "@/common/constants/codexOAuth";
 import { usePolicy } from "@/browser/contexts/PolicyContext";
 import {
@@ -160,12 +161,10 @@ export function ModelsSection() {
   // cross-hook timing mismatches while settings are loading/refetching.
   const codexOauthConfigured = config?.openai?.codexOauthSet === true;
 
-  // "Treat as" dropdown should only list known models — custom models don't have
-  // the metadata (pricing, context window, tokenizer) that mapping inherits.
-  // Static list — React Compiler handles memoization; no manual useMemo needed.
-  const knownModelIds = Object.values(KNOWN_MODELS)
-    .map((model) => model.id)
-    .sort();
+  // "Treat as" targets must carry the metadata (pricing, context window) that
+  // mapping inherits: any model in the token catalog qualifies, not just the
+  // curated KNOWN_MODELS list (#3727).
+  const treatAsModelIds = listModelCatalogIds();
 
   // Check if a model already exists (for duplicate prevention)
   const modelExists = useCallback(
@@ -473,7 +472,7 @@ export function ModelsSection() {
                       editMappedToModel={isModelEditing ? editing.mappedToModel : undefined}
                       editAutofocus={isModelEditing ? editing.focus : undefined}
                       customContextWindowTokens={model.contextWindowTokens}
-                      allModels={knownModelIds}
+                      allModels={treatAsModelIds}
                       editError={isModelEditing ? error : undefined}
                       saving={false}
                       hasActiveEdit={editing !== null}

--- a/src/common/constants/knownModels.test.ts
+++ b/src/common/constants/knownModels.test.ts
@@ -5,29 +5,16 @@
 import { describe, test, expect } from "@jest/globals";
 import { KNOWN_MODELS, MODEL_ABBREVIATIONS } from "@/common/constants/knownModels";
 import modelsJson from "@/common/utils/tokens/models.json";
-import { modelsExtra } from "@/common/utils/tokens/models-extra";
+import { findMissingKnownModels } from "@/common/utils/tokens/updateModelsData";
 
 describe("Known Models Integration", () => {
   test("all known models exist in token metadata", () => {
-    const missingModels: string[] = [];
-
-    for (const [key, model] of Object.entries(KNOWN_MODELS)) {
-      const modelId = model.providerModelId;
-
-      // xAI and Moonshot models are provider-prefixed in token metadata.
-      const lookupKey =
-        model.provider === "xai" || model.provider === "moonshotai"
-          ? `${model.provider}/${modelId}`
-          : modelId;
-      if (!(lookupKey in modelsJson) && !(lookupKey in modelsExtra) && !(modelId in modelsExtra)) {
-        missingModels.push(`${key}: ${model.provider}:${modelId}`);
-      }
-    }
+    const missingModels = findMissingKnownModels(modelsJson);
 
     if (missingModels.length > 0) {
       throw new Error(
         `The following known models are missing from token metadata:\n${missingModels.join("\n")}\n\n` +
-          `Run 'bun scripts/update_models.ts' to refresh models.json from LiteLLM.`
+          `Run 'make update-models' to refresh models.json from LiteLLM.`
       );
     }
   });

--- a/src/common/utils/ai/modelCapabilities.test.ts
+++ b/src/common/utils/ai/modelCapabilities.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { getModelCapabilities, getSupportedInputMediaTypes } from "./modelCapabilities";
+import {
+  extractModelCapabilities,
+  getModelCapabilities,
+  getSupportedInputMediaTypes,
+} from "./modelCapabilities";
 
 describe("getModelCapabilities", () => {
   it("returns capabilities for known models", () => {
@@ -49,11 +53,12 @@ describe("getModelCapabilities", () => {
     expect(caps?.supportsVision).toBe(true);
   });
 
-  it("returns maxPdfSizeMb when present in model metadata", () => {
-    const caps = getModelCapabilities("google:gemini-1.5-flash");
-    expect(caps).not.toBeNull();
-    expect(caps?.supportsPdfInput).toBe(true);
-    expect(caps?.maxPdfSizeMb).toBeGreaterThan(0);
+  it("returns maxPdfSizeMb and infers PDF support when metadata carries the field", () => {
+    // Injected metadata: upstream LiteLLM dropped max_pdf_size_mb, but
+    // models-extra overrides can still supply it.
+    const caps = extractModelCapabilities({ max_pdf_size_mb: 30 });
+    expect(caps.supportsPdfInput).toBe(true);
+    expect(caps.maxPdfSizeMb).toBe(30);
   });
 
   it("returns multimodal capabilities for Gemini 3.5 Flash", () => {

--- a/src/common/utils/ai/modelCapabilities.ts
+++ b/src/common/utils/ai/modelCapabilities.ts
@@ -62,7 +62,9 @@ function generateLookupKeys(modelString: string): string[] {
   return keys;
 }
 
-function extractModelCapabilities(data: RawModelCapabilitiesData): ModelCapabilities {
+// Exported for tests: upstream LiteLLM no longer ships max_pdf_size_mb, so the
+// inference branches can only be exercised with injected metadata.
+export function extractModelCapabilities(data: RawModelCapabilitiesData): ModelCapabilities {
   const maxPdfSizeMb = typeof data.max_pdf_size_mb === "number" ? data.max_pdf_size_mb : undefined;
   const provider = typeof data.litellm_provider === "string" ? data.litellm_provider : undefined;
 

--- a/src/common/utils/ai/modelCapabilities.ts
+++ b/src/common/utils/ai/modelCapabilities.ts
@@ -2,6 +2,7 @@ import type { ProvidersConfigMap } from "@/common/orpc/types";
 import { resolveModelForMetadata } from "@/common/utils/providers/modelEntries";
 import modelsData from "../tokens/models.json";
 import { modelsExtra } from "../tokens/models-extra";
+import { generateModelLookupKeys } from "../tokens/modelStats";
 import { normalizeToCanonical } from "./models";
 
 interface RawModelCapabilitiesData {
@@ -23,44 +24,6 @@ export interface ModelCapabilities {
 }
 
 export type SupportedInputMediaType = "image" | "pdf" | "audio" | "video";
-
-const PROVIDER_KEY_ALIASES: Record<string, string> = {
-  // GitHub Copilot keys in models.json use underscores for LiteLLM provider names.
-  "github-copilot": "github_copilot",
-};
-
-/**
- * Generates lookup keys for a model string with multiple naming patterns.
- *
- * Keep this aligned with getModelStats(): many providers/layers use slightly different
- * conventions (e.g. "ollama/model-cloud", "provider/model").
- */
-function generateLookupKeys(modelString: string): string[] {
-  const colonIndex = modelString.indexOf(":");
-  const provider = colonIndex !== -1 ? modelString.slice(0, colonIndex) : "";
-  const modelName = colonIndex !== -1 ? modelString.slice(colonIndex + 1) : modelString;
-  const litellmProvider = PROVIDER_KEY_ALIASES[provider] ?? provider;
-
-  const keys: string[] = [
-    modelName, // Direct model name (e.g., "claude-opus-4-5")
-  ];
-
-  if (provider) {
-    keys.push(
-      `${litellmProvider}/${modelName}`, // "ollama/gpt-oss:20b"
-      `${litellmProvider}/${modelName}-cloud` // "ollama/gpt-oss:20b-cloud" (LiteLLM convention)
-    );
-
-    // Fallback: strip size suffix for base model lookup
-    // "ollama:gpt-oss:20b" → "ollama/gpt-oss"
-    if (modelName.includes(":")) {
-      const baseModel = modelName.split(":")[0];
-      keys.push(`${litellmProvider}/${baseModel}`);
-    }
-  }
-
-  return keys;
-}
 
 // Exported for tests: upstream LiteLLM no longer ships max_pdf_size_mb, so the
 // inference branches can only be exercised with injected metadata.
@@ -87,7 +50,9 @@ export function extractModelCapabilities(data: RawModelCapabilitiesData): ModelC
 
 export function getModelCapabilities(modelString: string): ModelCapabilities | null {
   const normalized = normalizeToCanonical(modelString);
-  const lookupKeys = generateLookupKeys(normalized);
+  // Shared with getModelStats so capabilities and stats resolve from the same
+  // catalog entry (provider-scoped keys win over bare-name entries).
+  const lookupKeys = generateModelLookupKeys(normalized);
 
   // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
   const modelsExtraRecord = modelsExtra as unknown as Record<string, RawModelCapabilitiesData>;

--- a/src/common/utils/tokens/modelCatalog.test.ts
+++ b/src/common/utils/tokens/modelCatalog.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect } from "@jest/globals";
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { listModelCatalogIds } from "./modelCatalog";
+import { getModelStats } from "./modelStats";
+
+describe("listModelCatalogIds", () => {
+  const ids = listModelCatalogIds();
+
+  test("includes every curated known model", () => {
+    for (const model of Object.values(KNOWN_MODELS)) {
+      expect(ids).toContain(model.id);
+    }
+  });
+
+  test("exposes the full catalog, far beyond the curated list", () => {
+    expect(ids.length).toBeGreaterThan(Object.keys(KNOWN_MODELS).length * 10);
+    // Bare LiteLLM key: provider derived from litellm_provider.
+    expect(ids).toContain("openai:gpt-4o-mini");
+    // Provider-prefixed LiteLLM key: provider derived from the key itself.
+    expect(ids).toContain("gemini:gemini-2.5-pro");
+  });
+
+  test("every id is canonical provider:model and resolves to model stats", () => {
+    const invalid = ids.filter((id) => {
+      const colonIndex = id.indexOf(":");
+      return colonIndex <= 0 || colonIndex >= id.length - 1;
+    });
+    expect(invalid).toEqual([]);
+
+    const unresolved = ids.filter((id) => getModelStats(id) === null);
+    expect(unresolved).toEqual([]);
+  });
+
+  test("excludes models without chat-style metadata", () => {
+    expect(ids).not.toContain("openai:text-embedding-3-small");
+  });
+
+  test("is sorted, deduplicated, and stable across calls", () => {
+    expect(new Set(ids).size).toBe(ids.length);
+    expect([...ids].sort()).toEqual(ids);
+    expect(listModelCatalogIds()).toBe(ids);
+  });
+});

--- a/src/common/utils/tokens/modelCatalog.test.ts
+++ b/src/common/utils/tokens/modelCatalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "@jest/globals";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import modelsJson from "./models.json";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { listModelCatalogIds } from "./modelCatalog";
 import { getModelStats } from "./modelStats";
@@ -34,6 +35,14 @@ describe("listModelCatalogIds", () => {
 
   test("excludes models without chat-style metadata", () => {
     expect(ids).not.toContain("openai:text-embedding-3-small");
+  });
+
+  test("excludes provider-scoped duplicates whose stats resolve to another entry", () => {
+    // snowflake/claude-sonnet-4-6 exists upstream, but stats resolution prefers
+    // the bare models-extra override, so exposing the scoped row would inherit
+    // metadata from a different entry than the row represents.
+    expect(Object.keys(modelsJson)).toContain("snowflake/claude-sonnet-4-6");
+    expect(ids).not.toContain("snowflake:claude-sonnet-4-6");
   });
 
   test("every id is self-canonical so selection metadata matches the visible row", () => {

--- a/src/common/utils/tokens/modelCatalog.test.ts
+++ b/src/common/utils/tokens/modelCatalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "@jest/globals";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { listModelCatalogIds } from "./modelCatalog";
 import { getModelStats } from "./modelStats";
 
@@ -33,6 +34,14 @@ describe("listModelCatalogIds", () => {
 
   test("excludes models without chat-style metadata", () => {
     expect(ids).not.toContain("openai:text-embedding-3-small");
+  });
+
+  test("every id is self-canonical so selection metadata matches the visible row", () => {
+    // Gateway keys like openrouter/deepseek/x normalize to the direct provider id
+    // during stats resolution; exposing non-canonical ids would create rows that
+    // look distinct but inherit another entry's metadata.
+    const nonCanonical = ids.filter((id) => normalizeToCanonical(id) !== id);
+    expect(nonCanonical).toEqual([]);
   });
 
   test("is sorted, deduplicated, and stable across calls", () => {

--- a/src/common/utils/tokens/modelCatalog.ts
+++ b/src/common/utils/tokens/modelCatalog.ts
@@ -7,7 +7,7 @@
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import modelsData from "./models.json";
-import { getModelStats } from "./modelStats";
+import { resolveRawModelEntry } from "./modelStats";
 
 // Only modes whose metadata (pricing, context window) applies to chat-style usage.
 const MAPPABLE_MODES = new Set(["chat", "responses"]);
@@ -53,9 +53,14 @@ export function listModelCatalogIds(): string[] {
       // gateway duplicates; otherwise a gateway row would silently inherit the
       // direct entry's metadata while looking like a distinct option.
       const normalized = normalizeToCanonical(id);
-      // getModelStats enforces the validity bar (usable token limits), so every
-      // listed id inherits real metadata when selected as a mapping target.
-      if (getModelStats(normalized) === null) {
+      // Only expose rows whose stats resolve from this very entry (same validity
+      // bar as getModelStats). A provider-scoped duplicate like
+      // snowflake/claude-sonnet-4-6 loses stats resolution to the bare
+      // models-extra override, so selecting it would inherit metadata from a
+      // different entry than the row represents; the id stays selectable through
+      // whichever entry actually backs it.
+      const resolved = resolveRawModelEntry(normalized);
+      if (resolved?.key !== key) {
         continue;
       }
       ids.add(normalized);

--- a/src/common/utils/tokens/modelCatalog.ts
+++ b/src/common/utils/tokens/modelCatalog.ts
@@ -1,0 +1,57 @@
+/**
+ * Full catalog of model ids usable as custom-model metadata mapping targets
+ * ("Treat as" in Settings). Exposes every models.json entry with usable
+ * chat metadata instead of only the curated KNOWN_MODELS list (#3727).
+ */
+
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import modelsData from "./models.json";
+import { getModelStats } from "./modelStats";
+
+// Only modes whose metadata (pricing, context window) applies to chat-style usage.
+const MAPPABLE_MODES = new Set(["chat", "responses"]);
+
+function toCanonicalModelId(catalogKey: string, metadata: Record<string, unknown>): string | null {
+  // LiteLLM keys are either "provider/model" or a bare model id whose provider
+  // lives in litellm_provider. Both canonical forms round-trip through
+  // getModelStats: generateLookupKeys tries "provider/model" first and the bare
+  // model name as a fallback.
+  const slashIndex = catalogKey.indexOf("/");
+  if (slashIndex > 0) {
+    return `${catalogKey.slice(0, slashIndex)}:${catalogKey.slice(slashIndex + 1)}`;
+  }
+  const provider = metadata.litellm_provider;
+  return typeof provider === "string" && provider.length > 0 ? `${provider}:${catalogKey}` : null;
+}
+
+let cachedIds: string[] | undefined;
+
+/**
+ * Canonical `provider:model` ids for every catalog entry with resolvable model
+ * stats, unioned with the curated KNOWN_MODELS ids. Sorted. Cached because
+ * models.json is static for the process lifetime.
+ */
+export function listModelCatalogIds(): string[] {
+  if (cachedIds === undefined) {
+    const ids = new Set<string>();
+    for (const model of Object.values(KNOWN_MODELS)) {
+      ids.add(model.id);
+    }
+    for (const [key, metadata] of Object.entries(
+      modelsData as Record<string, Record<string, unknown>>
+    )) {
+      if (typeof metadata.mode !== "string" || !MAPPABLE_MODES.has(metadata.mode)) {
+        continue;
+      }
+      const id = toCanonicalModelId(key, metadata);
+      // getModelStats enforces the validity bar (usable token limits), so every
+      // listed id inherits real metadata when selected as a mapping target.
+      if (id === null || getModelStats(id) === null) {
+        continue;
+      }
+      ids.add(id);
+    }
+    cachedIds = [...ids].sort();
+  }
+  return cachedIds;
+}

--- a/src/common/utils/tokens/modelCatalog.ts
+++ b/src/common/utils/tokens/modelCatalog.ts
@@ -8,20 +8,7 @@ import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import modelsData from "./models.json";
 import { resolveRawModelEntry } from "./modelStats";
-import { MAPPABLE_MODES } from "./updateModelsData";
-
-function toCanonicalModelId(catalogKey: string, metadata: Record<string, unknown>): string | null {
-  // LiteLLM keys are either "provider/model" or a bare model id whose provider
-  // lives in litellm_provider. Both canonical forms round-trip through
-  // getModelStats: generateLookupKeys tries "provider/model" first and the bare
-  // model name as a fallback.
-  const slashIndex = catalogKey.indexOf("/");
-  if (slashIndex > 0) {
-    return `${catalogKey.slice(0, slashIndex)}:${catalogKey.slice(slashIndex + 1)}`;
-  }
-  const provider = metadata.litellm_provider;
-  return typeof provider === "string" && provider.length > 0 ? `${provider}:${catalogKey}` : null;
-}
+import { MAPPABLE_MODES, toCanonicalModelId } from "./updateModelsData";
 
 let cachedIds: string[] | undefined;
 

--- a/src/common/utils/tokens/modelCatalog.ts
+++ b/src/common/utils/tokens/modelCatalog.ts
@@ -8,9 +8,7 @@ import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { normalizeToCanonical } from "@/common/utils/ai/models";
 import modelsData from "./models.json";
 import { resolveRawModelEntry } from "./modelStats";
-
-// Only modes whose metadata (pricing, context window) applies to chat-style usage.
-const MAPPABLE_MODES = new Set(["chat", "responses"]);
+import { MAPPABLE_MODES } from "./updateModelsData";
 
 function toCanonicalModelId(catalogKey: string, metadata: Record<string, unknown>): string | null {
   // LiteLLM keys are either "provider/model" or a bare model id whose provider

--- a/src/common/utils/tokens/modelCatalog.ts
+++ b/src/common/utils/tokens/modelCatalog.ts
@@ -5,6 +5,7 @@
  */
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import modelsData from "./models.json";
 import { getModelStats } from "./modelStats";
 
@@ -44,12 +45,20 @@ export function listModelCatalogIds(): string[] {
         continue;
       }
       const id = toCanonicalModelId(key, metadata);
-      // getModelStats enforces the validity bar (usable token limits), so every
-      // listed id inherits real metadata when selected as a mapping target.
-      if (id === null || getModelStats(id) === null) {
+      if (id === null) {
         continue;
       }
-      ids.add(id);
+      // Stats resolution normalizes gateway ids (openrouter:deepseek/x resolves as
+      // deepseek:x), so expose the normalized identity and let the Set collapse
+      // gateway duplicates; otherwise a gateway row would silently inherit the
+      // direct entry's metadata while looking like a distinct option.
+      const normalized = normalizeToCanonical(id);
+      // getModelStats enforces the validity bar (usable token limits), so every
+      // listed id inherits real metadata when selected as a mapping target.
+      if (getModelStats(normalized) === null) {
+        continue;
+      }
+      ids.add(normalized);
     }
     cachedIds = [...ids].sort();
   }

--- a/src/common/utils/tokens/modelStats.ts
+++ b/src/common/utils/tokens/modelStats.ts
@@ -226,12 +226,19 @@ export function generateModelLookupKeys(modelString: string): string[] {
   return keys;
 }
 
+export interface ResolvedRawModelEntry {
+  /** The models-extra/models.json key the stats actually come from. */
+  key: string;
+  data: RawModelData;
+}
+
 /**
- * Gets model statistics for a given Vercel AI SDK model string
- * @param modelString - Format: "provider:model-name" (e.g., "anthropic:claude-opus-4-1", "ollama:gpt-oss:20b")
- * @returns ModelStats or null if model not found
+ * Resolves the raw override/catalog entry backing a model string, preserving
+ * getModelStats' precedence: models-extra across every lookup key first, then
+ * models.json. Exported so the Treat-as catalog can exclude ids whose stats
+ * would resolve from a different entry than the row represents.
  */
-export function getModelStats(modelString: string): ModelStats | null {
+export function resolveRawModelEntry(modelString: string): ResolvedRawModelEntry | null {
   const normalized = normalizeToCanonical(modelString);
   const lookupKeys = generateModelLookupKeys(normalized);
 
@@ -239,7 +246,7 @@ export function getModelStats(modelString: string): ModelStats | null {
   for (const key of lookupKeys) {
     const data = (modelsExtra as Record<string, RawModelData>)[key];
     if (data && hasUsableTokenLimits(data)) {
-      return extractModelStats(data);
+      return { key, data };
     }
   }
 
@@ -247,11 +254,21 @@ export function getModelStats(modelString: string): ModelStats | null {
   for (const key of lookupKeys) {
     const data = (modelsData as Record<string, RawModelData>)[key];
     if (data && hasUsableTokenLimits(data)) {
-      return extractModelStats(data);
+      return { key, data };
     }
   }
 
   return null;
+}
+
+/**
+ * Gets model statistics for a given Vercel AI SDK model string
+ * @param modelString - Format: "provider:model-name" (e.g., "anthropic:claude-opus-4-1", "ollama:gpt-oss:20b")
+ * @returns ModelStats or null if model not found
+ */
+export function getModelStats(modelString: string): ModelStats | null {
+  const entry = resolveRawModelEntry(modelString);
+  return entry === null ? null : extractModelStats(entry.data);
 }
 
 export function getModelStatsResolved(

--- a/src/common/utils/tokens/modelStats.ts
+++ b/src/common/utils/tokens/modelStats.ts
@@ -41,7 +41,12 @@ const PROVIDER_KEY_ALIASES: Record<string, string> = {
   "github-copilot": "github_copilot",
 };
 
-function parseNum(value: unknown): number | null {
+/**
+ * Runtime numeric semantics for raw catalog values (accepts numeric strings
+ * with comma separators). Exported so update-models validation compares
+ * magnitudes exactly as getModelStats would parse them.
+ */
+export function parseNum(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
   }

--- a/src/common/utils/tokens/modelStats.ts
+++ b/src/common/utils/tokens/modelStats.ts
@@ -70,9 +70,10 @@ function hasTieredPricing(data: RawModelData): boolean {
 }
 
 /**
- * Validates raw model data has required fields
+ * Whether raw model metadata is usable for stats resolution. Exported so the
+ * update-models validation applies the same bar as getModelStats.
  */
-function isValidModelData(data: RawModelData): boolean {
+export function hasUsableTokenLimits(data: RawModelData): boolean {
   const maxInputTokens = parseNum(data.max_input_tokens);
   return maxInputTokens != null && maxInputTokens > 0;
 }
@@ -234,7 +235,7 @@ export function getModelStats(modelString: string): ModelStats | null {
   // Check models-extra.ts first (overrides for models with incorrect upstream data)
   for (const key of lookupKeys) {
     const data = (modelsExtra as Record<string, RawModelData>)[key];
-    if (data && isValidModelData(data)) {
+    if (data && hasUsableTokenLimits(data)) {
       return extractModelStats(data);
     }
   }
@@ -242,7 +243,7 @@ export function getModelStats(modelString: string): ModelStats | null {
   // Fall back to main models.json
   for (const key of lookupKeys) {
     const data = (modelsData as Record<string, RawModelData>)[key];
-    if (data && isValidModelData(data)) {
+    if (data && hasUsableTokenLimits(data)) {
       return extractModelStats(data);
     }
   }

--- a/src/common/utils/tokens/modelStats.ts
+++ b/src/common/utils/tokens/modelStats.ts
@@ -136,10 +136,13 @@ function stripLatestSuffix(modelName: string): string {
 }
 
 /**
- * Generates lookup keys for a model string with multiple naming patterns
- * Handles LiteLLM conventions like "ollama/model-cloud" and "provider/model"
+ * Generates lookup keys for a model string with multiple naming patterns.
+ * Handles LiteLLM conventions like "ollama/model-cloud" and "provider/model".
+ * Exported so capability resolution shares the exact same key preference:
+ * provider-scoped entries must win over bare-name entries in both lookups,
+ * otherwise a model can inherit stats and capabilities from different entries.
  */
-function generateLookupKeys(modelString: string): string[] {
+export function generateModelLookupKeys(modelString: string): string[] {
   const colonIndex = modelString.indexOf(":");
   const provider = colonIndex !== -1 ? modelString.slice(0, colonIndex) : "";
   const modelName = colonIndex !== -1 ? modelString.slice(colonIndex + 1) : modelString;
@@ -230,7 +233,7 @@ function generateLookupKeys(modelString: string): string[] {
  */
 export function getModelStats(modelString: string): ModelStats | null {
   const normalized = normalizeToCanonical(modelString);
-  const lookupKeys = generateLookupKeys(normalized);
+  const lookupKeys = generateModelLookupKeys(normalized);
 
   // Check models-extra.ts first (overrides for models with incorrect upstream data)
   for (const key of lookupKeys) {

--- a/src/common/utils/tokens/models.json
+++ b/src/common/utils/tokens/models.json
@@ -134,7 +134,17 @@
     "mode": "image_generation",
     "litellm_provider": "aiml"
   },
+  "aiml/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "aiml",
+    "supports_vision": true
+  },
   "amazon.nova-canvas-v1:0": {
+    "max_input_tokens": 2600,
+    "mode": "image_generation",
+    "litellm_provider": "bedrock"
+  },
+  "us.amazon.nova-canvas-v1:0": {
     "max_input_tokens": 2600,
     "mode": "image_generation",
     "litellm_provider": "bedrock"
@@ -197,12 +207,36 @@
     "supports_vision": true,
     "supports_video_input": true
   },
+  "amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
   "apac.amazon.nova-2-lite-v1:0": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 3.3e-7,
     "output_cost_per_token": 0.00000275,
     "cache_read_input_token_cost": 8.25e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "apac.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -221,12 +255,36 @@
     "supports_vision": true,
     "supports_video_input": true
   },
+  "eu.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
   "us.amazon.nova-2-lite-v1:0": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 3.3e-7,
     "output_cost_per_token": 0.00000275,
     "cache_read_input_token_cost": 8.25e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "us.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -282,9 +340,16 @@
     "mode": "embedding",
     "litellm_provider": "bedrock"
   },
+  "amazon.titan-embed-g1-text-02": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock"
+  },
   "amazon.titan-embed-text-v2:0": {
     "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
+    "input_cost_per_token": 2e-8,
     "output_cost_per_token": 0,
     "mode": "embedding",
     "litellm_provider": "bedrock"
@@ -400,22 +465,32 @@
     "supports_vision": true
   },
   "anthropic.claude-3-5-sonnet-20240620-v1:0": {
-    "max_input_tokens": 200000,
+    "max_input_tokens": 1000000,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.00003,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
     "supports_vision": true
   },
   "anthropic.claude-3-5-sonnet-20241022-v2:0": {
-    "max_input_tokens": 200000,
+    "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.00003,
     "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -450,6 +525,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
+    "cache_creation_input_token_cost": 3.125e-7,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -460,6 +537,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_vision": true
@@ -469,6 +548,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -513,6 +594,483 @@
     "output_cost_per_token": 0.000025,
     "cache_creation_input_token_cost": 0.00000625,
     "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-mythos-preview": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000011,
+    "output_cost_per_token": 0.000055,
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_read_input_token_cost": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000011,
+    "output_cost_per_token": 0.000055,
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_read_input_token_cost": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -695,6 +1253,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -717,6 +1277,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
+    "cache_creation_input_token_cost": 3.125e-7,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -739,6 +1301,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -834,6 +1398,66 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure_ai/claude-opus-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure_ai/claude-opus-4-1": {
     "max_input_tokens": 200000,
     "max_output_tokens": 32000,
@@ -848,6 +1472,30 @@
   },
   "azure_ai/claude-sonnet-4-5": {
     "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
@@ -876,6 +1524,122 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-mini-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-nano-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/model_router": {
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
@@ -915,7 +1679,7 @@
     "input_cost_per_token": 6.6e-7,
     "output_cost_per_token": 0.00000264,
     "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -925,7 +1689,7 @@
     "input_cost_per_token": 0.0000055,
     "output_cost_per_token": 0.000022,
     "cache_read_input_token_cost": 0.00000275,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -935,7 +1699,7 @@
     "input_cost_per_token": 0.0000055,
     "output_cost_per_token": 0.000022,
     "cache_read_input_token_cost": 0.00000275,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1188,22 +1952,6 @@
     "mode": "chat",
     "litellm_provider": "azure"
   },
-  "azure/gpt-35-turbo-0301": {
-    "max_input_tokens": 4097,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "azure"
-  },
-  "azure/gpt-35-turbo-0613": {
-    "max_input_tokens": 4097,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "azure"
-  },
   "azure/gpt-35-turbo-1106": {
     "max_input_tokens": 16384,
     "max_output_tokens": 4096,
@@ -1434,6 +2182,24 @@
     "litellm_provider": "azure",
     "supports_vision": false
   },
+  "azure/gpt-audio-1.5-2026-02-23": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
+  "azure/gpt-audio-mini": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
   "azure/gpt-audio-mini-2025-10-06": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -1487,7 +2253,7 @@
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1497,7 +2263,27 @@
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
     "cache_read_input_token_cost": 0.000004,
-    "mode": "chat",
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-1.5-2026-02-23": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 0.000004,
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-mini": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1507,7 +2293,7 @@
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "cache_read_input_token_cost": 6e-8,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1531,7 +2317,7 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00002,
     "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1541,7 +2327,7 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00002,
     "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -1560,6 +2346,11 @@
     "output_cost_per_token": 0.00001,
     "mode": "audio_transcription",
     "litellm_provider": "azure"
+  },
+  "azure/gpt-realtime-whisper": {
+    "mode": "audio_transcription",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
   },
   "azure/gpt-5.1-2025-11-13": {
     "max_input_tokens": 272000,
@@ -1814,12 +2605,34 @@
     "supports_vision": true
   },
   "azure/gpt-5.2-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.3-chat": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
     "cache_read_input_token_cost": 1.75e-7,
     "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.3-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "responses",
     "litellm_provider": "azure",
     "supports_pdf_input": true,
     "supports_vision": true
@@ -1840,6 +2653,358 @@
     "input_cost_per_token": 0.000021,
     "output_cost_per_token": 0.000168,
     "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-pro-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-mini-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-nano-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
     "litellm_provider": "azure",
     "supports_pdf_input": true,
     "supports_vision": true
@@ -1922,6 +3087,26 @@
     "cache_read_input_token_cost": 0.00000125,
     "mode": "image_generation",
     "litellm_provider": "azure"
+  },
+  "azure/gpt-image-2": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-image-2-2026-04-21": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "azure/low/1024-x-1024/gpt-image-1-mini": {
     "mode": "image_generation",
@@ -2172,6 +3357,10 @@
     "mode": "audio_speech",
     "litellm_provider": "azure"
   },
+  "azure/speech/azure-stt": {
+    "mode": "audio_transcription",
+    "litellm_provider": "azure"
+  },
   "azure/tts-1": {
     "mode": "audio_speech",
     "litellm_provider": "azure"
@@ -2246,7 +3435,7 @@
     "input_cost_per_token": 6.6e-7,
     "output_cost_per_token": 0.00000264,
     "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -2256,7 +3445,7 @@
     "input_cost_per_token": 0.0000055,
     "output_cost_per_token": 0.000022,
     "cache_read_input_token_cost": 0.00000275,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -2266,7 +3455,7 @@
     "input_cost_per_token": 0.0000055,
     "output_cost_per_token": 0.000022,
     "cache_read_input_token_cost": 0.00000275,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
   },
@@ -2434,6 +3623,155 @@
     "litellm_provider": "azure_ai"
   },
   "azure_ai/flux.2-pro": {
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-DeepSeek-V3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "cache_read_input_token_cost": 3.1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-DeepSeek-V4-Pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.000001925,
+    "output_cost_per_token": 0.000003828,
+    "cache_read_input_token_cost": 1.65e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-GLM-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.00000352,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-GLM-5.1": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000154,
+    "output_cost_per_token": 0.00000484,
+    "cache_read_input_token_cost": 2.86e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-GLM-5.2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000154,
+    "output_cost_per_token": 0.00000484,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-GLM-5.2-Fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-Inkling": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 1048576,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.00000405,
+    "cache_read_input_token_cost": 1.7e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-Kimi-K2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6.6e-7,
+    "output_cost_per_token": 0.0000033,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
+  "azure_ai/FW-Kimi-K2.6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.000001045,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.76e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
+  "azure_ai/FW-Kimi-K2.7-Code": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.00000105,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
+  "azure_ai/FW-Kimi-K3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
+  "azure_ai/FW-MiniMax-M2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 3.3e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 3.3e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/FW-MiniMax-M3": {
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
+    "input_cost_per_token": 3.3e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 6.6e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
+  "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 1.19e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2.5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.000047,
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2.5-Flash": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_image_token": 0.000033,
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2e": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.0000195,
     "mode": "image_generation",
     "litellm_provider": "azure_ai"
   },
@@ -2641,6 +3979,10 @@
     "mode": "ocr",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/mistral-document-ai-2512": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
   "azure_ai/doc-intelligence/prebuilt-read": {
     "mode": "ocr",
     "litellm_provider": "azure_ai"
@@ -2741,6 +4083,30 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/deepseek-v3.1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000123,
+    "output_cost_per_token": 0.00000494,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000174,
+    "output_cost_per_token": 0.00000348,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 1.9e-7,
+    "output_cost_per_token": 5.1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
   "azure_ai/embed-v-4-0": {
     "max_input_tokens": 128000,
     "input_cost_per_token": 1.2e-7,
@@ -2788,6 +4154,16 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/grok-4.3": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
+  },
   "azure_ai/grok-4-fast-non-reasoning": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -2797,6 +4173,22 @@
     "litellm_provider": "azure_ai"
   },
   "azure_ai/grok-4-fast-reasoning": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/grok-4-1-fast-non-reasoning": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/grok-4-1-fast-reasoning": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
     "input_cost_per_token": 2e-7,
@@ -2827,6 +4219,25 @@
     "output_cost_per_token": 7e-7,
     "mode": "chat",
     "litellm_provider": "azure_ai"
+  },
+  "azure_ai/kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "azure_ai/kimi-k2.6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
   },
   "azure_ai/ministral-3b": {
     "max_input_tokens": 128000,
@@ -2896,8 +4307,8 @@
   "azure_ai/mistral-small-2503": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
     "mode": "chat",
     "litellm_provider": "azure_ai",
     "supports_vision": true
@@ -2932,6 +4343,10 @@
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/guardrails": {
+    "mode": "guardrail",
     "litellm_provider": "bedrock"
   },
   "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
@@ -2994,6 +4409,73 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/ap-northeast-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-northeast-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-northeast-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-northeast-1/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.3e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-northeast-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/ap-northeast-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.3e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
   "bedrock/ap-south-1/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -3007,6 +4489,104 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 3.6e-7,
     "output_cost_per_token": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-south-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-south-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-south-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-south-1/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.1e-7,
+    "output_cost_per_token": 0.00000294,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-south-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/ap-south-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-southeast-2/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.09e-7,
+    "output_cost_per_token": 0.000001236,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-southeast-3/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-southeast-3/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-southeast-3/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/ap-southeast-3/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/ap-southeast-3/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -3025,6 +4605,39 @@
     "output_cost_per_token": 6.9e-7,
     "mode": "chat",
     "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
   },
   "bedrock/eu-central-1/1-month-commitment/anthropic.claude-instant-v1": {
     "max_input_tokens": 100000,
@@ -3086,6 +4699,30 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/eu-central-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-central-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-central-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/eu-west-1/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -3102,6 +4739,30 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/eu-west-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-west-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-west-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/eu-west-2/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -3115,6 +4776,30 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 3.9e-7,
     "output_cost_per_token": 7.8e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-west-2/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4.7e-7,
+    "output_cost_per_token": 0.00000186,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-west-2/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4.7e-7,
+    "output_cost_per_token": 0.00000186,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-west-2/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 7.8e-7,
+    "output_cost_per_token": 0.00000186,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -3142,11 +4827,37 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/eu-south-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-south-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-south-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_vision": true
@@ -3164,6 +4875,55 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.00000101,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/sa-east-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/sa-east-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/sa-east-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/sa-east-1/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.3e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/sa-east-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/sa-east-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -3267,6 +5027,104 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/us-east-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/us-east-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-2/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-2/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-2/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-2/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-2/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/us-east-2/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/us-gov-east-1/amazon.nova-pro-v1:0": {
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
@@ -3320,6 +5178,8 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.0000036,
     "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3330,6 +5190,20 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000015,
+    "cache_creation_input_token_cost": 3.75e-7,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "bedrock/us-gov-east-1/anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3337,9 +5211,11 @@
   },
   "bedrock/us-gov-east-1/claude-sonnet-4-5-20250929-v1:0": {
     "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3428,6 +5304,8 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.0000036,
     "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3438,6 +5316,20 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000015,
+    "cache_creation_input_token_cost": 3.75e-7,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "bedrock/us-gov-west-1/anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3445,9 +5337,11 @@
   },
   "bedrock/us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": {
     "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_read_input_token_cost": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -3571,6 +5465,55 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/us-west-2/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/us-west-2/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -3581,6 +5524,38 @@
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
+  },
+  "black_forest_labs/flux-kontext-pro": {
+    "mode": "image_edit",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-kontext-max": {
+    "mode": "image_edit",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro-1.0-fill": {
+    "mode": "image_edit",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro-1.0-expand": {
+    "mode": "image_edit",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro-1.1": {
+    "mode": "image_generation",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro-1.1-ultra": {
+    "mode": "image_generation",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-dev": {
+    "mode": "image_generation",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro": {
+    "mode": "image_generation",
+    "litellm_provider": "black_forest_labs"
   },
   "cerebras/llama-3.3-70b": {
     "max_input_tokens": 128000,
@@ -3609,8 +5584,8 @@
   "cerebras/gpt-oss-120b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 6.9e-7,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 7.5e-7,
     "mode": "chat",
     "litellm_provider": "cerebras"
   },
@@ -3638,46 +5613,6 @@
     "mode": "chat",
     "litellm_provider": "cerebras"
   },
-  "chat-bison": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-chat-models"
-  },
-  "chat-bison-32k": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-chat-models"
-  },
-  "chat-bison-32k@002": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-chat-models"
-  },
-  "chat-bison@001": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-chat-models"
-  },
-  "chat-bison@002": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-chat-models"
-  },
   "chatdolphin": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
@@ -3704,30 +5639,6 @@
     "mode": "audio_transcription",
     "litellm_provider": "openai"
   },
-  "claude-3-5-haiku-20241022": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.000004,
-    "cache_creation_input_token_cost": 0.000001,
-    "cache_read_input_token_cost": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-3-5-haiku-latest": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "claude-haiku-4-5-20251001": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -3752,55 +5663,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-3-5-sonnet-20240620": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-3-5-sonnet-20241022": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-3-5-sonnet-latest": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "claude-3-7-sonnet-20250219": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-3-7-sonnet-latest": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 0.000003,
@@ -3824,17 +5687,6 @@
     "supports_vision": true
   },
   "claude-3-opus-20240229": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
-    "cache_creation_input_token_cost": 0.00001875,
-    "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_vision": true
-  },
-  "claude-3-opus-latest": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000015,
@@ -3900,6 +5752,30 @@
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_read_input_token_cost": 3e-7,
     "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "anthropic",
     "supports_pdf_input": true,
@@ -3981,6 +5857,90 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "claude-opus-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-opus-4-6-20260205": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-opus-4-7-20260416": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "claude-sonnet-4-20250514": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -4029,125 +5989,217 @@
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
-  "code-bison": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+  "cloudflare/@cf/openai/gpt-oss-120b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 7.5e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-text-models"
+    "litellm_provider": "cloudflare"
   },
-  "code-bison-32k@002": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-bison32k": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-bison@001": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-bison@002": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-gecko": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 64,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-gecko-latest": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 64,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-gecko@001": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 64,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "code-gecko@002": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 64,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-code-text-models"
-  },
-  "codechat-bison": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
-  },
-  "codechat-bison-32k": {
-    "max_input_tokens": 32000,
+  "cloudflare/@cf/google/gemma-2b-it-lora": {
+    "max_input_tokens": 8192,
     "max_output_tokens": 8192,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
+    "litellm_provider": "cloudflare"
   },
-  "codechat-bison-32k@002": {
+  "cloudflare/@cf/meta/llama-3.2-3b-instruct": {
+    "max_input_tokens": 80000,
+    "max_output_tokens": 80000,
+    "input_cost_per_token": 5.09e-8,
+    "output_cost_per_token": 3.35e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-guard-3-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 4.84e-7,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/mistral/mistral-7b-instruct-v0.2-lora": {
+    "max_input_tokens": 15000,
+    "max_output_tokens": 15000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/moonshotai/kimi-k2.7-code": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "max_input_tokens": 80000,
+    "max_output_tokens": 80000,
+    "input_cost_per_token": 4.97e-7,
+    "output_cost_per_token": 0.000004881,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": {
     "max_input_tokens": 32000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 1.52e-7,
+    "output_cost_per_token": 2.87e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-3.2-1b-instruct": {
+    "max_input_tokens": 60000,
+    "max_output_tokens": 60000,
+    "input_cost_per_token": 2.7e-8,
+    "output_cost_per_token": 2.01e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/moonshotai/kimi-k2.6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.6e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/zai-org/glm-4.7-flash": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6.05e-8,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta-llama/llama-2-7b-chat-hf-lora": {
+    "max_input_tokens": 8192,
     "max_output_tokens": 8192,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
+    "litellm_provider": "cloudflare"
   },
-  "codechat-bison@001": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+  "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+    "max_input_tokens": 24000,
+    "max_output_tokens": 24000,
+    "input_cost_per_token": 2.93e-7,
+    "output_cost_per_token": 0.000002253,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
+    "litellm_provider": "cloudflare"
   },
-  "codechat-bison@002": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+  "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
+    "max_input_tokens": 131000,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 1.7e-8,
+    "output_cost_per_token": 1.12e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
+    "litellm_provider": "cloudflare"
   },
-  "codechat-bison@latest": {
-    "max_input_tokens": 6144,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
+  "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6.6e-7,
+    "output_cost_per_token": 0.000001,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-code-chat-models"
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/zai-org/glm-5.2": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.51e-7,
+    "output_cost_per_token": 5.55e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5.09e-8,
+    "output_cost_per_token": 3.35e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/google/gemma-7b-it-lora": {
+    "max_input_tokens": 3500,
+    "max_output_tokens": 3500,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/google/gemma-4-26b-a4b-it": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.51e-7,
+    "output_cost_per_token": 5.55e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-3.2-11b-vision-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 4.85e-8,
+    "output_cost_per_token": 6.76e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare",
+    "supports_vision": true
+  },
+  "cloudflare/@cf/openai/gpt-oss-20b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-4-scout-17b-16e-instruct": {
+    "max_input_tokens": 131000,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 8.5e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/qwen/qwq-32b": {
+    "max_input_tokens": 24000,
+    "max_output_tokens": 24000,
+    "input_cost_per_token": 6.6e-7,
+    "output_cost_per_token": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
   },
   "codestral/codestral-2405": {
     "max_input_tokens": 32000,
@@ -4311,8 +6363,8 @@
   "command-r7b-12-2024": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 3.75e-8,
+    "input_cost_per_token": 3.75e-8,
+    "output_cost_per_token": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "cohere_chat"
   },
@@ -4350,6 +6402,61 @@
     "cache_read_input_token_cost": 2.8e-8,
     "mode": "chat",
     "litellm_provider": "deepseek"
+  },
+  "dashscope/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/deepseek-v4-flash-0731": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 0.0000024,
+    "output_cost_per_token": 0.0000048,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/glm-5.1": {
+    "max_input_tokens": 202745,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/glm-5.2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/kimi-k2.7-code": {
+    "max_input_tokens": 229376,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
   },
   "dashscope/qwen-coder": {
     "max_input_tokens": 1000000,
@@ -4497,12 +6604,124 @@
     "mode": "chat",
     "litellm_provider": "dashscope"
   },
+  "dashscope/qwen3-max": {
+    "max_input_tokens": 258048,
+    "max_output_tokens": 65536,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3-max-2026-01-23": {
+    "max_input_tokens": 258048,
+    "max_output_tokens": 65536,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3-next-80b-a3b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3-next-80b-a3b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3-vl-235b-a22b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3-vl-235b-a22b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000004,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3-vl-32b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.6e-7,
+    "output_cost_per_token": 6.4e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3-vl-32b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.6e-7,
+    "output_cost_per_token": 0.00000287,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3-vl-plus": {
+    "max_input_tokens": 260096,
+    "max_output_tokens": 32768,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3.5-plus": {
+    "max_input_tokens": 991808,
+    "max_output_tokens": 65536,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3.7-max": {
+    "max_input_tokens": 991808,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000075,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3.7-plus": {
+    "max_input_tokens": 991808,
+    "max_output_tokens": 65536,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
+  "dashscope/qwen3.8-max": {
+    "max_input_tokens": 991808,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "dashscope",
+    "supports_vision": true
+  },
   "dashscope/qwq-plus": {
     "max_input_tokens": 98304,
     "max_output_tokens": 8192,
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.0000024,
     "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen-image-2.0": {
+    "mode": "image_generation",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen-image-2.0-pro": {
+    "mode": "image_generation",
     "litellm_provider": "dashscope"
   },
   "databricks/databricks-bge-large-en": {
@@ -4552,6 +6771,14 @@
     "mode": "chat",
     "litellm_provider": "databricks"
   },
+  "databricks/databricks-claude-opus-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000500003,
+    "output_cost_per_token": 0.000025000010000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
   "databricks/databricks-claude-sonnet-4": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -4576,6 +6803,14 @@
     "mode": "chat",
     "litellm_provider": "databricks"
   },
+  "databricks/databricks-claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000029999900000000002,
+    "output_cost_per_token": 0.000015000020000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
   "databricks/databricks-gemini-2-5-flash": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
@@ -4589,6 +6824,38 @@
     "max_output_tokens": 65536,
     "input_cost_per_token": 0.00000124999,
     "output_cost_per_token": 0.000009999990000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gemini-3-1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3.1248e-7,
+    "output_cost_per_token": 0.00000187502,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gemini-3-1-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000249998,
+    "output_cost_per_token": 0.000015000020000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gemini-3-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 6.2503e-7,
+    "output_cost_per_token": 0.00000374997,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gemini-3-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000249998,
+    "output_cost_per_token": 0.000015000020000000002,
     "mode": "chat",
     "litellm_provider": "databricks"
   },
@@ -4613,6 +6880,70 @@
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.00000124999,
     "output_cost_per_token": 0.000009999990000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-1-codex-max": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000124999,
+    "output_cost_per_token": 0.000009999990000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-1-codex-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.4997e-7,
+    "output_cost_per_token": 0.00000199997,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-2": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-2-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-3-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-4": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000249998,
+    "output_cost_per_token": 0.000015000020000000002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.4998e-7,
+    "output_cost_per_token": 0.00000450002,
+    "mode": "chat",
+    "litellm_provider": "databricks"
+  },
+  "databricks/databricks-gpt-5-4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.9999e-7,
+    "output_cost_per_token": 0.00000124999,
     "mode": "chat",
     "litellm_provider": "databricks"
   },
@@ -5393,6 +7724,13 @@
     "mode": "chat",
     "litellm_provider": "deepinfra"
   },
+  "deepinfra/nvidia/NVIDIA-Nemotron-3.5-Lightning": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "deepinfra"
+  },
   "deepinfra/nvidia/NVIDIA-Nemotron-Nano-9B-v2": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -5426,7 +7764,7 @@
     "litellm_provider": "deepinfra"
   },
   "deepseek/deepseek-chat": {
-    "max_input_tokens": 128000,
+    "max_input_tokens": 131072,
     "max_output_tokens": 8192,
     "input_cost_per_token": 2.8e-7,
     "output_cost_per_token": 4.2e-7,
@@ -5452,8 +7790,8 @@
     "litellm_provider": "deepseek"
   },
   "deepseek/deepseek-reasoner": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
     "input_cost_per_token": 2.8e-7,
     "output_cost_per_token": 4.2e-7,
     "cache_read_input_token_cost": 2.8e-8,
@@ -5486,6 +7824,14 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
   "dolphin": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
@@ -5493,6 +7839,30 @@
     "output_cost_per_token": 5e-7,
     "mode": "completion",
     "litellm_provider": "nlp_cloud"
+  },
+  "deepseek-v3-2-251201": {
+    "max_input_tokens": 98304,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "volcengine"
+  },
+  "glm-4-7-251222": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "volcengine"
+  },
+  "kimi-k2-thinking-251104": {
+    "max_input_tokens": 229376,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "volcengine"
   },
   "doubao-embedding": {
     "max_input_tokens": 4096,
@@ -5545,12 +7915,44 @@
     "mode": "search",
     "litellm_provider": "searxng"
   },
+  "serper/search": {
+    "mode": "search",
+    "litellm_provider": "serper"
+  },
+  "apiserpent/search": {
+    "mode": "search",
+    "litellm_provider": "apiserpent"
+  },
+  "apiserpent/deep_search": {
+    "mode": "search",
+    "litellm_provider": "apiserpent"
+  },
+  "agentcore/search": {
+    "mode": "search",
+    "litellm_provider": "agentcore"
+  },
+  "tinyfish/search": {
+    "mode": "search",
+    "litellm_provider": "tinyfish"
+  },
+  "nimble/search": {
+    "mode": "search",
+    "litellm_provider": "nimble"
+  },
   "elevenlabs/scribe_v1": {
     "mode": "audio_transcription",
     "litellm_provider": "elevenlabs"
   },
   "elevenlabs/scribe_v1_experimental": {
     "mode": "audio_transcription",
+    "litellm_provider": "elevenlabs"
+  },
+  "elevenlabs/eleven_v3": {
+    "mode": "audio_speech",
+    "litellm_provider": "elevenlabs"
+  },
+  "elevenlabs/eleven_multilingual_v2": {
+    "mode": "audio_speech",
     "litellm_provider": "elevenlabs"
   },
   "embed-english-light-v2.0": {
@@ -5635,6 +8037,8 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
+    "cache_creation_input_token_cost": 3.125e-7,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
@@ -5656,6 +8060,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5666,6 +8072,8 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5676,6 +8084,8 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5686,6 +8096,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
+    "cache_creation_input_token_cost": 3.125e-7,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5696,6 +8108,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_vision": true
@@ -5705,6 +8119,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5838,6 +8254,299 @@
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
+  "fal_ai/fal-ai/nano-banana": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai"
+  },
+  "fal_ai/fal-ai/gemini-25-flash-image": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai"
+  },
+  "fal_ai/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1024/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1024/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1920-x-1080/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/3840-x-2160/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1024/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1024/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1024/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1024/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1920-x-1080/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/3840-x-2160/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
   "featherless_ai/featherless-ai/Qwerky-72B": {
     "max_input_tokens": 32768,
     "max_output_tokens": 4096,
@@ -5969,6 +8678,26 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000174,
+    "output_cost_per_token": 0.00000348,
+    "cache_read_input_token_cost": 1.45e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
   "fireworks_ai/accounts/fireworks/models/firefunction-v2": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -6001,21 +8730,54 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
-  "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+  "fireworks_ai/accounts/fireworks/models/glm-4p7": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/glm-5p1": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/glm-5p2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "cache_read_input_token_cost": 1.5e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
   "fireworks_ai/accounts/fireworks/models/gpt-oss-20b": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 2e-7,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 3.5e-8,
     "mode": "chat",
-    "litellm_provider": "fireworks_ai"
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
   },
   "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct": {
     "max_input_tokens": 131072,
@@ -6040,6 +8802,35 @@
     "output_cost_per_token": 0.0000025,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/kimi-k2p5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/kimi-k2p6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/kimi-k2p7-code": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
   },
   "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
     "max_input_tokens": 128000,
@@ -6107,6 +8898,35 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/minimax-m2p1": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 204800,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/minimax-m2p7": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/minimax-m3": {
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
   "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
     "max_input_tokens": 65536,
     "max_output_tokens": 65536,
@@ -6138,6 +8958,173 @@
     "output_cost_per_token": 0.000003,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/deepseek-v4-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/deepseek-v4-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000174,
+    "output_cost_per_token": 0.00000348,
+    "cache_read_input_token_cost": 1.45e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-4p7": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 202800,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/glm-5p1": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p1-fast": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000028,
+    "output_cost_per_token": 0.0000088,
+    "cache_read_input_token_cost": 5.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "cache_read_input_token_cost": 1.5e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 3.5e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/kimi-k2p5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/kimi-k2p6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k2p6-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k2p7-code": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k2p7-code-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.0000019,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/minimax-m2p1": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 204800,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/minimax-m2p7": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/minimax-m3": {
+    "max_input_tokens": 512000,
+    "max_output_tokens": 512000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/qwen3p7-plus": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "cache_read_input_token_cost": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
   },
   "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
     "max_input_tokens": 8192,
@@ -6306,166 +9293,6 @@
     "mode": "chat",
     "litellm_provider": "openai"
   },
-  "gemini-1.0-pro": {
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.0-pro-001": {
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.0-pro-002": {
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.0-pro-vision": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-vision-models",
-    "supports_vision": true
-  },
-  "gemini-1.0-pro-vision-001": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-vision-models",
-    "supports_vision": true
-  },
-  "gemini-1.0-ultra": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.0-ultra-001": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.5-flash": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-1.5-flash-001": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-1.5-flash-002": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-1.5-flash-exp-0827": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 4.688e-9,
-    "output_cost_per_token": 4.6875e-9,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-1.5-flash-preview-0514": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 4.6875e-9,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-1.5-pro": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-1.5-pro-001": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini-1.5-pro-002": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini-1.5-pro-preview-0215": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.8125e-8,
-    "output_cost_per_token": 3.125e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.5-pro-preview-0409": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.8125e-8,
-    "output_cost_per_token": 3.125e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-1.5-pro-preview-0514": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.8125e-8,
-    "output_cost_per_token": 3.125e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
   "gemini-2.0-flash": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 8192,
@@ -6475,8 +9302,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true
   },
   "gemini-2.0-flash-001": {
     "max_input_tokens": 1048576,
@@ -6486,19 +9312,7 @@
     "cache_read_input_token_cost": 3.75e-8,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.0-flash-exp": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "cache_read_input_token_cost": 3.75e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.0-flash-lite": {
     "max_input_tokens": 1048576,
@@ -6508,8 +9322,7 @@
     "cache_read_input_token_cost": 1.875e-8,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 50
+    "supports_vision": true
   },
   "gemini-2.0-flash-lite-001": {
     "max_input_tokens": 1048576,
@@ -6519,70 +9332,7 @@
     "cache_read_input_token_cost": 1.875e-8,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 50
-  },
-  "gemini-2.0-flash-live-preview-04-09": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000002,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.0-flash-preview-image-generation": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.0-flash-thinking-exp": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.0-flash-thinking-exp-01-21": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.0-pro-exp-02-05": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 3.125e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.5-flash": {
     "max_input_tokens": 1048576,
@@ -6593,8 +9343,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.5-flash-image": {
     "max_input_tokens": 32768,
@@ -6606,23 +9355,101 @@
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
-  "gemini-2.5-flash-image-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.00003,
+  "gemini-3-pro-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-3-pro-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-3.1-flash-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-3.1-flash-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-3.1-flash-lite-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
     "output_cost_per_image_token": 0.00003,
-    "cache_read_input_token_cost": 7.5e-8,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
-  "gemini-3-pro-image-preview": {
+  "gemini-3.1-flash-lite-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-3.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "deep-research-pro-preview-12-2025": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
     "input_cost_per_token": 0.000002,
@@ -6641,8 +9468,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.5-flash-lite-preview-09-2025": {
     "max_input_tokens": 1048576,
@@ -6653,8 +9479,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.5-flash-preview-09-2025": {
     "max_input_tokens": 1048576,
@@ -6665,8 +9490,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-live-2.5-flash-preview-native-audio-09-2025": {
     "max_input_tokens": 1048576,
@@ -6674,12 +9498,11 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.000002,
     "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true
   },
   "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
     "max_input_tokens": 1048576,
@@ -6687,12 +9510,11 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.000002,
     "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true
   },
   "gemini-2.5-flash-lite-preview-06-17": {
     "max_input_tokens": 1048576,
@@ -6703,32 +9525,7 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.5-flash-preview-04-17": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "cache_read_input_token_cost": 3.75e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini-2.5-flash-preview-05-20": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini-2.5-pro": {
     "max_input_tokens": 1048576,
@@ -6745,8 +9542,7 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
   "gemini-3-pro-preview": {
     "max_input_tokens": 1048576,
@@ -6763,8 +9559,41 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
+  },
+  "gemini-3.1-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "vertex_ai/gemini-3-pro-preview": {
     "max_input_tokens": 1048576,
@@ -6781,8 +9610,7 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
   "vertex_ai/gemini-3-flash-preview": {
     "max_input_tokens": 1048576,
@@ -6795,70 +9623,80 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
-  "gemini-2.5-pro-exp-03-25": {
+  "vertex_ai/gemini-3.5-flash": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
+    "litellm_provider": "vertex_ai",
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
-  "gemini-2.5-pro-preview-03-25": {
+  "vertex_ai/gemini-3.6-flash": {
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
+    "litellm_provider": "vertex_ai",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
-  "gemini-2.5-pro-preview-05-06": {
+  "vertex_ai/gemini-3.7-flash": {
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
+    "litellm_provider": "vertex_ai",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
-  "gemini-2.5-pro-preview-06-05": {
+  "vertex_ai/gemini-3.1-pro-preview": {
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
+    "litellm_provider": "vertex_ai",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.1-pro-preview-customtools": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini-2.5-pro-preview-tts": {
     "max_input_tokens": 1048576,
@@ -6871,8 +9709,52 @@
     "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-robotics-er-1.5-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini/gemini-robotics-er-1.5-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-robotics-er-2-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-robotics-er-1.6-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "max_input_tokens": 128000,
@@ -6892,38 +9774,41 @@
     "mode": "embedding",
     "litellm_provider": "vertex_ai-embedding-models"
   },
+  "gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "vertex_ai/gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai"
+  },
+  "vertex_ai/gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai"
+  },
   "gemini-flash-experimental": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0,
     "output_cost_per_token": 0,
-    "mode": "chat",
+    "mode": "embedding",
     "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-pro": {
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-pro-experimental": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini-pro-vision": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-vision-models",
-    "supports_vision": true
   },
   "gemini/gemini-embedding-001": {
     "max_input_tokens": 2048,
@@ -6932,143 +9817,26 @@
     "mode": "embedding",
     "litellm_provider": "gemini"
   },
+  "gemini/gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
+  },
   "gemini/gemini-1.5-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
+    "max_input_tokens": 8192,
     "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-001": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "cache_creation_input_token_cost": 0.000001,
-    "cache_read_input_token_cost": 1.875e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-002": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "cache_creation_input_token_cost": 0.000001,
-    "cache_read_input_token_cost": 1.875e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-8b": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
     "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-8b-exp-0827": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-8b-exp-0924": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-exp-0827": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-flash-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-1.5-pro": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.0000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-1.5-pro-001": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.0000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-1.5-pro-002": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.0000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-1.5-pro-exp-0801": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.0000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-1.5-pro-exp-0827": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-1.5-pro-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.00000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
+    "mode": "embedding",
+    "litellm_provider": "gemini"
   },
   "gemini/gemini-2.0-flash": {
     "max_input_tokens": 1048576,
@@ -7079,8 +9847,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true
   },
   "gemini/gemini-2.0-flash-001": {
     "max_input_tokens": 1048576,
@@ -7090,19 +9857,7 @@
     "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-flash-exp": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.0-flash-lite": {
     "max_input_tokens": 1048576,
@@ -7112,79 +9867,7 @@
     "cache_read_input_token_cost": 1.875e-8,
     "mode": "chat",
     "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 50
-  },
-  "gemini/gemini-2.0-flash-lite-preview-02-05": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "cache_read_input_token_cost": 1.875e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-flash-live-001": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-flash-preview-image-generation": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-flash-thinking-exp": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-flash-thinking-exp-01-21": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.0-pro-exp-02-05": {
-    "max_input_tokens": 2097152,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash": {
     "max_input_tokens": 1048576,
@@ -7195,8 +9878,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash-image": {
     "max_input_tokens": 32768,
@@ -7206,25 +9888,61 @@
     "output_cost_per_image_token": 0.00003,
     "cache_read_input_token_cost": 3e-8,
     "mode": "image_generation",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.5-flash-image-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.00003,
-    "output_cost_per_image_token": 0.00003,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "image_generation",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
+  },
+  "gemini/gemini-3-pro-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
   },
   "gemini/gemini-3-pro-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-lite-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "output_cost_per_image_token": 0.00003,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/deep-research-pro-preview-12-2025": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
     "input_cost_per_token": 0.000002,
@@ -7243,8 +9961,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash-lite-preview-09-2025": {
     "max_input_tokens": 1048576,
@@ -7255,8 +9972,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash-preview-09-2025": {
     "max_input_tokens": 1048576,
@@ -7267,8 +9983,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-flash-latest": {
     "max_input_tokens": 1048576,
@@ -7279,8 +9994,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-flash-lite-latest": {
     "max_input_tokens": 1048576,
@@ -7291,8 +10005,7 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash-lite-preview-06-17": {
     "max_input_tokens": 1048576,
@@ -7303,43 +10016,13 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.5-flash-preview-04-17": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "cache_read_input_token_cost": 3.75e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.5-flash-preview-05-20": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-2.5-flash-preview-tts": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "cache_read_input_token_cost": 3.75e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
   },
   "gemini/gemini-2.5-pro": {
     "max_input_tokens": 1048576,
@@ -7355,8 +10038,7 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
   "gemini/gemini-2.5-computer-use-preview-10-2025": {
     "max_input_tokens": 128000,
@@ -7383,8 +10065,46 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-flash-lite-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini/gemini-3-flash-preview": {
     "max_input_tokens": 1048576,
@@ -7395,8 +10115,89 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-3.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.6-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.7-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-omni-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-pro-preview-customtools": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini-3-flash-preview": {
     "max_input_tokens": 1048576,
@@ -7407,69 +10208,57 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
-  "gemini/gemini-2.5-pro-exp-03-25": {
+  "gemini-omni-flash-preview": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "input_cost_per_token_above_200k_tokens": 0,
-    "output_cost_per_token_above_200k_tokens": 0,
-    "cache_read_input_token_cost": 0,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
     "mode": "chat",
-    "litellm_provider": "gemini",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-3.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
-  "gemini/gemini-2.5-pro-preview-03-25": {
+  "gemini-3.6-flash": {
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "gemini",
+    "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
-  "gemini/gemini-2.5-pro-preview-05-06": {
+  "gemini-3.7-flash": {
     "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "gemini",
+    "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
-  },
-  "gemini/gemini-2.5-pro-preview-06-05": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini/gemini-2.5-pro-preview-tts": {
     "max_input_tokens": 1048576,
@@ -7482,8 +10271,7 @@
     "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
     "mode": "chat",
     "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-exp-1114": {
     "max_input_tokens": 1048576,
@@ -7492,8 +10280,7 @@
     "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-exp-1206": {
     "max_input_tokens": 2097152,
@@ -7502,8 +10289,7 @@
     "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "gemini",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "gemini/gemini-gemma-2-27b-it": {
     "max_output_tokens": 8192,
@@ -7515,23 +10301,6 @@
   },
   "gemini/gemini-gemma-2-9b-it": {
     "max_output_tokens": 8192,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 0.00000105,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-pro": {
-    "max_input_tokens": 32760,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 0.00000105,
-    "mode": "chat",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-pro-vision": {
-    "max_input_tokens": 30720,
-    "max_output_tokens": 2048,
     "input_cost_per_token": 3.5e-7,
     "output_cost_per_token": 0.00000105,
     "mode": "chat",
@@ -7580,17 +10349,27 @@
     "litellm_provider": "gemini",
     "supports_vision": true
   },
+  "gemini/lyria-3-clip-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": false,
+    "supports_audio_input": false
+  },
+  "gemini/lyria-3-pro-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": false,
+    "supports_audio_input": false
+  },
   "gemini/veo-2.0-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "gemini"
-  },
-  "gemini/veo-3.0-fast-generate-preview": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "gemini"
-  },
-  "gemini/veo-3.0-generate-preview": {
     "max_input_tokens": 1024,
     "mode": "video_generation",
     "litellm_provider": "gemini"
@@ -7601,6 +10380,11 @@
     "litellm_provider": "gemini"
   },
   "gemini/veo-3.1-generate-preview": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "gemini"
+  },
+  "gemini/veo-3.1-lite-generate-preview": {
     "max_input_tokens": 1024,
     "mode": "video_generation",
     "litellm_provider": "gemini"
@@ -7623,6 +10407,13 @@
     "supports_vision": true
   },
   "github_copilot/claude-opus-4.5": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16000,
+    "mode": "chat",
+    "litellm_provider": "github_copilot",
+    "supports_vision": true
+  },
+  "github_copilot/claude-opus-4.6-fast": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16000,
     "mode": "chat",
@@ -7786,6 +10577,31 @@
     "litellm_provider": "github_copilot",
     "supports_vision": true
   },
+  "github_copilot/gpt-5.3-codex": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "github_copilot",
+    "supports_vision": true
+  },
+  "github_copilot/mai-code-1-flash": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "github_copilot"
+  },
+  "github_copilot/mai-code-1-flash-internal": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "github_copilot"
+  },
   "github_copilot/text-embedding-3-small": {
     "max_input_tokens": 8191,
     "mode": "embedding",
@@ -7800,6 +10616,48 @@
     "max_input_tokens": 8191,
     "mode": "embedding",
     "litellm_provider": "github_copilot"
+  },
+  "chatgpt/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-codex": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-codex-spark": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-instant": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
   },
   "chatgpt/gpt-5.2-codex": {
     "max_input_tokens": 128000,
@@ -8004,6 +10862,72 @@
     "mode": "chat",
     "litellm_provider": "gmi"
   },
+  "baseten/MiniMaxAI/MiniMax-M2.5": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/nvidia/Nemotron-120B-A12B": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-5": {
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.00000315,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-4.7": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-4.6": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2.5": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2-Thinking": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2-Instruct-0905": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/openai/gpt-oss-120b": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/deepseek-ai/DeepSeek-V3.1": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/deepseek-ai/DeepSeek-V3-0324": {
+    "input_cost_per_token": 7.7e-7,
+    "output_cost_per_token": 7.7e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
   "gmi/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {
     "max_input_tokens": 262144,
     "max_output_tokens": 16384,
@@ -8124,22 +11048,6 @@
     "mode": "chat",
     "litellm_provider": "openai"
   },
-  "gpt-3.5-turbo-0301": {
-    "max_input_tokens": 4097,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "gpt-3.5-turbo-0613": {
-    "max_input_tokens": 4097,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
   "gpt-3.5-turbo-1106": {
     "max_input_tokens": 16385,
     "max_output_tokens": 4096,
@@ -8149,14 +11057,6 @@
     "litellm_provider": "openai"
   },
   "gpt-3.5-turbo-16k": {
-    "max_input_tokens": 16385,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000004,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "gpt-3.5-turbo-16k-0613": {
     "max_input_tokens": 16385,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
@@ -8220,40 +11120,6 @@
     "mode": "chat",
     "litellm_provider": "openai"
   },
-  "gpt-4-1106-vision-preview": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-4-32k": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.00006,
-    "output_cost_per_token": 0.00012,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "gpt-4-32k-0314": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.00006,
-    "output_cost_per_token": 0.00012,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "gpt-4-32k-0613": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.00006,
-    "output_cost_per_token": 0.00012,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
   "gpt-4-turbo": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
@@ -8282,16 +11148,6 @@
     "mode": "chat",
     "litellm_provider": "openai",
     "supports_pdf_input": true
-  },
-  "gpt-4-vision-preview": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
   },
   "gpt-4.1": {
     "max_input_tokens": 1047576,
@@ -8359,28 +11215,6 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gpt-4.5-preview": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000075,
-    "output_cost_per_token": 0.00015,
-    "cache_read_input_token_cost": 0.0000375,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-4.5-preview-2025-02-27": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000075,
-    "output_cost_per_token": 0.00015,
-    "cache_read_input_token_cost": 0.0000375,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "gpt-4o": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -8433,15 +11267,6 @@
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
-  "gpt-4o-audio-preview-2024-10-01": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
   "gpt-4o-audio-preview-2024-12-17": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -8461,6 +11286,16 @@
     "supports_audio_input": true
   },
   "gpt-audio": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-1.5": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
     "input_cost_per_token": 0.0000025,
@@ -8556,7 +11391,7 @@
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -8566,7 +11401,7 @@
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -8612,17 +11447,7 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00002,
     "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "gpt-4o-realtime-preview-2024-10-01": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00002,
-    "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -8632,7 +11457,7 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00002,
     "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -8642,7 +11467,7 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00002,
     "cache_read_input_token_cost": 0.0000025,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -8690,6 +11515,26 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.00001,
     "output_cost_per_image_token": 0.000032,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-image-2": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-image-2-2026-04-21": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
     "cache_read_input_token_cost": 0.00000125,
     "mode": "image_generation",
     "litellm_provider": "openai",
@@ -8953,6 +11798,17 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "gpt-5.3-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "gpt-5.2-pro": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
@@ -8973,8 +11829,235 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 2.5e-7,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-cyber": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000125,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.000015625,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "daybreak-red-latest": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000125,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.000015625,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "daybreak-blue-latest": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "chat-latest": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-pro-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "gpt-5-pro": {
-    "max_input_tokens": 128000,
+    "max_input_tokens": 400000,
     "max_output_tokens": 272000,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00012,
@@ -8984,7 +12067,7 @@
     "supports_vision": true
   },
   "gpt-5-pro-2025-10-06": {
-    "max_input_tokens": 128000,
+    "max_input_tokens": 400000,
     "max_output_tokens": 272000,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00012,
@@ -9071,7 +12154,18 @@
     "supports_vision": true
   },
   "gpt-5.2-codex": {
-    "max_input_tokens": 400000,
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.3-codex": {
+    "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
@@ -9145,7 +12239,47 @@
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
     "cache_read_input_token_cost": 4e-7,
-    "mode": "chat",
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-1.5": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-2": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-2.1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000024,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-2.1-mini": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -9154,7 +12288,7 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -9164,77 +12298,103 @@
     "input_cost_per_token": 0.000004,
     "output_cost_per_token": 0.000016,
     "cache_read_input_token_cost": 4e-7,
-    "mode": "chat",
+    "mode": "realtime",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
   "gradient_ai/alibaba-qwen3-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 40960,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/anthropic-claude-3-opus": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 1024,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/anthropic-claude-3.5-haiku": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 1024,
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.000004,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/anthropic-claude-3.5-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 1024,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/anthropic-claude-3.7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 1024,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/deepseek-r1-distill-llama-70b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8000,
     "input_cost_per_token": 9.9e-7,
     "output_cost_per_token": 9.9e-7,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/llama3-8b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 512,
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 2e-7,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/llama3.3-70b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 2048,
     "input_cost_per_token": 6.5e-7,
     "output_cost_per_token": 6.5e-7,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/mistral-nemo-instruct-2407": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 512,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 3e-7,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/openai-gpt-4o": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/openai-gpt-4o-mini": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/openai-o3": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000008,
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
   "gradient_ai/openai-o3-mini": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 100000,
     "input_cost_per_token": 0.0000011,
     "output_cost_per_token": 0.0000044,
     "mode": "chat",
@@ -9319,15 +12479,15 @@
     "supports_vision": true
   },
   "groq/llama-3.1-8b-instant": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 8e-8,
     "mode": "chat",
     "litellm_provider": "groq"
   },
   "groq/llama-3.3-70b-versatile": {
-    "max_input_tokens": 128000,
+    "max_input_tokens": 131072,
     "max_output_tokens": 32768,
     "input_cost_per_token": 5.9e-7,
     "output_cost_per_token": 7.9e-7,
@@ -9339,6 +12499,22 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 5e-8,
     "output_cost_per_token": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/meta-llama/llama-prompt-guard-2-22m": {
+    "max_input_tokens": 512,
+    "max_output_tokens": 512,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/meta-llama/llama-prompt-guard-2-86m": {
+    "max_input_tokens": 512,
+    "max_output_tokens": 512,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 4e-8,
     "mode": "chat",
     "litellm_provider": "groq"
   },
@@ -9379,7 +12555,7 @@
   },
   "groq/openai/gpt-oss-120b": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 32766,
+    "max_output_tokens": 65536,
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "cache_read_input_token_cost": 7.5e-8,
@@ -9388,11 +12564,32 @@
   },
   "groq/openai/gpt-oss-20b": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
+    "max_output_tokens": 65536,
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "cache_read_input_token_cost": 3.75e-8,
     "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/openai/gpt-oss-safeguard-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 3.7e-8,
+    "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/canopylabs/orpheus-v1-english": {
+    "max_input_tokens": 4000,
+    "max_output_tokens": 50000,
+    "mode": "audio_speech",
+    "litellm_provider": "groq"
+  },
+  "groq/canopylabs/orpheus-arabic-saudi": {
+    "max_input_tokens": 4000,
+    "max_output_tokens": 50000,
+    "mode": "audio_speech",
     "litellm_provider": "groq"
   },
   "groq/playai-tts": {
@@ -9400,6 +12597,15 @@
     "max_output_tokens": 10000,
     "mode": "audio_speech",
     "litellm_provider": "groq"
+  },
+  "groq/qwen/qwen3.6-27b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "groq",
+    "supports_vision": true
   },
   "groq/qwen/qwen3-32b": {
     "max_input_tokens": 131000,
@@ -9430,18 +12636,26 @@
     "litellm_provider": "openai"
   },
   "heroku/claude-3-5-haiku": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
     "mode": "chat",
     "litellm_provider": "heroku"
   },
   "heroku/claude-3-5-sonnet-latest": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
     "mode": "chat",
     "litellm_provider": "heroku"
   },
   "heroku/claude-3-7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
     "mode": "chat",
     "litellm_provider": "heroku"
   },
   "heroku/claude-4-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
     "mode": "chat",
     "litellm_provider": "heroku"
   },
@@ -9717,6 +12931,81 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "crusoe/deepseek-ai/DeepSeek-R1-0528": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000007,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/deepseek-ai/DeepSeek-V3-0324": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/google/gemma-3-12b-it": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe",
+    "supports_vision": true
+  },
+  "crusoe/meta-llama/Llama-3.3-70B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/moonshotai/Kimi-K2-Thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "inception/mercury-2": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 50000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "inception"
+  },
+  "text-completion-inception/mercury-edit-2": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "completion",
+    "litellm_provider": "text-completion-inception"
+  },
   "lambda_ai/deepseek-llama3.3-70b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -9890,42 +13179,6 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
-  "luminous-base": {
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.000033,
-    "mode": "completion",
-    "litellm_provider": "aleph_alpha"
-  },
-  "luminous-base-control": {
-    "input_cost_per_token": 0.0000375,
-    "output_cost_per_token": 0.00004125,
-    "mode": "chat",
-    "litellm_provider": "aleph_alpha"
-  },
-  "luminous-extended": {
-    "input_cost_per_token": 0.000045,
-    "output_cost_per_token": 0.0000495,
-    "mode": "completion",
-    "litellm_provider": "aleph_alpha"
-  },
-  "luminous-extended-control": {
-    "input_cost_per_token": 0.00005625,
-    "output_cost_per_token": 0.000061875,
-    "mode": "chat",
-    "litellm_provider": "aleph_alpha"
-  },
-  "luminous-supreme": {
-    "input_cost_per_token": 0.000175,
-    "output_cost_per_token": 0.0001925,
-    "mode": "completion",
-    "litellm_provider": "aleph_alpha"
-  },
-  "luminous-supreme-control": {
-    "input_cost_per_token": 0.00021875,
-    "output_cost_per_token": 0.000240625,
-    "mode": "chat",
-    "litellm_provider": "aleph_alpha"
-  },
   "max-x-max/50-steps/stability.stable-diffusion-xl-v0": {
     "max_input_tokens": 77,
     "mode": "image_generation",
@@ -10098,6 +13351,39 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "meta/muse-spark-1.1": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00000425,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "meta",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "meta/muse-spark-1.2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00000425,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "meta",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "meta/muse-spark-1.2-contributor": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 2e-7,
+    "cache_read_input_token_cost": 2e-9,
+    "mode": "chat",
+    "litellm_provider": "meta",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "meta_llama/Llama-3.3-70B-Instruct": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4028,
@@ -10124,6 +13410,22 @@
   },
   "minimax.minimax-m2": {
     "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000012,
@@ -10166,6 +13468,26 @@
     "mode": "chat",
     "litellm_provider": "minimax"
   },
+  "minimax/MiniMax-M2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 3.75e-7,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "minimax"
+  },
+  "minimax/MiniMax-M2.5-lightning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_creation_input_token_cost": 3.75e-7,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "minimax"
+  },
   "minimax/MiniMax-M2": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -10175,6 +13497,24 @@
     "cache_read_input_token_cost": 3e-8,
     "mode": "chat",
     "litellm_provider": "minimax"
+  },
+  "minimax/MiniMax-M3": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "minimax",
+    "supports_vision": true
+  },
+  "mistral.devstral-2-123b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
   },
   "mistral.magistral-small-2509": {
     "max_input_tokens": 128000,
@@ -10283,18 +13623,18 @@
     "litellm_provider": "mistral"
   },
   "mistral/codestral-2508": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 9e-7,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
   "mistral/codestral-latest": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 9e-7,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
@@ -10330,6 +13670,14 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/devstral-small-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "mistral/labs-devstral-small-2512": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
@@ -10338,11 +13686,45 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/devstral-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/devstral-medium-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "mistral/devstral-2512": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/zai-glm-5-2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/glm-5-2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
@@ -10362,11 +13744,31 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/magistral-medium-1-2-2509": {
+    "max_input_tokens": 40000,
+    "max_output_tokens": 40000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "mistral/mistral-ocr-latest": {
     "mode": "ocr",
     "litellm_provider": "mistral"
   },
+  "mistral/mistral-ocr-4-0": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-4-1": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
   "mistral/mistral-ocr-2505-completion": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-2512": {
     "mode": "ocr",
     "litellm_provider": "mistral"
   },
@@ -10387,6 +13789,14 @@
     "litellm_provider": "mistral"
   },
   "mistral/magistral-small-latest": {
+    "max_input_tokens": 40000,
+    "max_output_tokens": 40000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/magistral-small-1-2-2509": {
     "max_input_tokens": 40000,
     "max_output_tokens": 40000,
     "input_cost_per_token": 5e-7,
@@ -10437,16 +13847,26 @@
     "litellm_provider": "mistral"
   },
   "mistral/mistral-large-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000006,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
     "mode": "chat",
-    "litellm_provider": "mistral"
+    "litellm_provider": "mistral",
+    "supports_vision": true
   },
   "mistral/mistral-large-3": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 8191,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-large-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.0000015,
     "mode": "chat",
@@ -10477,13 +13897,50 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/mistral-medium-latest": {
+  "mistral/mistral-medium-2508": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 8191,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
-    "litellm_provider": "mistral"
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-medium-2604": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-medium-latest": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-medium-3-1-2508": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-medium-3-5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
   },
   "mistral/mistral-small": {
     "max_input_tokens": 32000,
@@ -10494,12 +13951,67 @@
     "litellm_provider": "mistral"
   },
   "mistral/mistral-small-latest": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 3e-7,
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
     "mode": "chat",
-    "litellm_provider": "mistral"
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-small-3-2-2506": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 1.8e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-3-3b-2512": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-3-8b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-3-14b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-8b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-8b-latest": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
   },
   "mistral/mistral-tiny": {
     "max_input_tokens": 32000,
@@ -10592,6 +14104,15 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
   "moonshot/kimi-k2-0711-preview": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -10618,6 +14139,39 @@
     "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "moonshot"
+  },
+  "moonshot/kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "moonshot",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "moonshot/kimi-k2.6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.6e-7,
+    "mode": "chat",
+    "litellm_provider": "moonshot",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "moonshot/kimi-k3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 1048576,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "moonshot",
+    "supports_vision": true,
+    "supports_video_input": true
   },
   "moonshot/kimi-latest": {
     "max_input_tokens": 131072,
@@ -10894,6 +14448,247 @@
     "mode": "image_generation",
     "litellm_provider": "nscale"
   },
+  "nebius/deepseek-ai/DeepSeek-R1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-R1-0528": {
+    "max_input_tokens": 164000,
+    "max_output_tokens": 164000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-V3": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-V3-0324": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/google/gemma-3-27b-it": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/meta-llama/Llama-3.3-70B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Llama-Guard-3-8B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-70B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-405B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/mistralai/Mistral-Nemo-Instruct-2407": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/NousResearch/Hermes-3-Llama-3.1-405B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-235B-A22B": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-32B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-30B-A3B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-14B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-4B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/QwQ-32B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-72B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-32B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-Coder-7B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-VL-72B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/Qwen/Qwen2-VL-72B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/Qwen/Qwen2-VL-7B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/BAAI/bge-en-icl": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
+  "nebius/BAAI/bge-multilingual-gemma2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
+  "nebius/intfloat/e5-mistral-7b-instruct": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
   "nvidia.nemotron-nano-12b-v2": {
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
@@ -10911,6 +14706,22 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "nvidia.nemotron-nano-3-30b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "nvidia.nemotron-super-3-120b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
   "o1": {
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
@@ -10925,50 +14736,6 @@
   "o1-2024-12-17": {
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
-    "cache_read_input_token_cost": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "o1-mini": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "o1-mini-2024-09-12": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000012,
-    "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "o1-preview": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
-    "cache_read_input_token_cost": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "o1-preview-2024-09-12": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.00006,
     "cache_read_input_token_cost": 0.0000075,
@@ -11125,6 +14892,22 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "oci/meta.llama-3.1-8b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/meta.llama-3.1-70b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
   "oci/meta.llama-3.1-405b-instruct": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4000,
@@ -11139,7 +14922,8 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
-    "litellm_provider": "oci"
+    "litellm_provider": "oci",
+    "supports_vision": true
   },
   "oci/meta.llama-3.3-70b-instruct": {
     "max_input_tokens": 128000,
@@ -11150,16 +14934,17 @@
     "litellm_provider": "oci"
   },
   "oci/meta.llama-4-maverick-17b-128e-instruct-fp8": {
-    "max_input_tokens": 512000,
-    "max_output_tokens": 4000,
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
     "input_cost_per_token": 7.2e-7,
     "output_cost_per_token": 7.2e-7,
     "mode": "chat",
-    "litellm_provider": "oci"
+    "litellm_provider": "oci",
+    "supports_vision": true
   },
   "oci/meta.llama-4-scout-17b-16e-instruct": {
-    "max_input_tokens": 192000,
-    "max_output_tokens": 4000,
+    "max_input_tokens": 10485760,
+    "max_output_tokens": 8192,
     "input_cost_per_token": 7.2e-7,
     "output_cost_per_token": 7.2e-7,
     "mode": "chat",
@@ -11169,7 +14954,7 @@
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "oci"
   },
@@ -11201,7 +14986,7 @@
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "oci"
   },
@@ -11227,6 +15012,238 @@
     "input_cost_per_token": 0.00000156,
     "output_cost_per_token": 0.00000156,
     "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/google.gemini-2.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/google.gemini-2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/google.gemini-2.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-a-vision": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-a-reasoning": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "mode": "embedding",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-a-reasoning-08-2025": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-a-vision-07-2025": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-a-translate-08-2025": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 9e-8,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-r-08-2024": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-r-plus-08-2024": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/meta.llama-3.2-11b-vision-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/meta.llama-3.3-70b-instruct-fp8-dynamic": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/xai.grok-4-fast": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/xai.grok-4.1-fast": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/xai.grok-4.20": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/xai.grok-4.20-multi-agent": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/xai.grok-code-fast-1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/openai.gpt-5": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/openai.gpt-5-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/openai.gpt-5-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.embed-english-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-light-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-light-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-light-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-light-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-v4.0": {
+    "max_input_tokens": 128000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
     "litellm_provider": "oci"
   },
   "ollama/codegeex4": {
@@ -11477,14 +15494,6 @@
     "mode": "moderation",
     "litellm_provider": "openai"
   },
-  "omni-moderation-latest-intents": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 0,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "moderation",
-    "litellm_provider": "openai"
-  },
   "openai.gpt-oss-120b-1:0": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
@@ -11517,69 +15526,16 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
-  "openrouter/anthropic/claude-2": {
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 0.00001102,
-    "output_cost_per_token": 0.00003268,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/anthropic/claude-3-5-haiku": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/anthropic/claude-3-5-haiku-20241022": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/anthropic/claude-3-haiku": {
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000125,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-3-haiku-20240307": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-3-opus": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-3-sonnet": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
   "openrouter/anthropic/claude-3.5-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-3.5-sonnet:beta": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.000003,
@@ -11596,22 +15552,6 @@
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": true
-  },
-  "openrouter/anthropic/claude-3.7-sonnet:beta": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-instant-v1": {
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 0.00000163,
-    "output_cost_per_token": 0.00000551,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
   },
   "openrouter/anthropic/claude-opus-4": {
     "max_input_tokens": 200000,
@@ -11650,9 +15590,35 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/anthropic/claude-sonnet-4.6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
   "openrouter/anthropic/claude-opus-4.5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/anthropic/claude-opus-4.6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "cache_creation_input_token_cost": 0.00000625,
@@ -11687,29 +15653,35 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/anthropic/claude-opus-4.7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "openrouter/anthropic/claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "openrouter/bytedance/ui-tars-1.5-7b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 2048,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/cognitivecomputations/dolphin-mixtral-8x7b": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/cohere/command-r-plus": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/databricks/dbrx-instruct": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 6e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -11753,14 +15725,6 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/deepseek/deepseek-coder": {
-    "max_input_tokens": 66000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/deepseek/deepseek-r1": {
     "max_input_tokens": 65336,
     "max_output_tokens": 8192,
@@ -11777,9 +15741,19 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/fireworks/firellava-13b": {
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
+  "openrouter/deepseek/deepseek-v4-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/deepseek/deepseek-v4-pro-0813": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -11790,8 +15764,7 @@
     "output_cost_per_token": 4e-7,
     "mode": "chat",
     "litellm_provider": "openrouter",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "openrouter/google/gemini-2.5-flash": {
     "max_input_tokens": 1048576,
@@ -11800,8 +15773,7 @@
     "output_cost_per_token": 0.0000025,
     "mode": "chat",
     "litellm_provider": "openrouter",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "openrouter/google/gemini-2.5-pro": {
     "max_input_tokens": 1048576,
@@ -11810,8 +15782,7 @@
     "output_cost_per_token": 0.00001,
     "mode": "chat",
     "litellm_provider": "openrouter",
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
   },
   "openrouter/google/gemini-3-pro-preview": {
     "max_input_tokens": 1048576,
@@ -11828,8 +15799,7 @@
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
-    "supports_video_input": true,
-    "max_pdf_size_mb": 30
+    "supports_video_input": true
   },
   "openrouter/google/gemini-3-flash-preview": {
     "max_input_tokens": 1048576,
@@ -11840,36 +15810,49 @@
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "openrouter/google/gemini-3.1-flash-lite-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_pdf_input": true,
     "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
-  "openrouter/google/gemini-pro-1.5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.0000075,
+  "openrouter/google/gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "openrouter",
-    "supports_vision": true
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
-  "openrouter/google/gemini-pro-vision": {
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 3.75e-7,
+  "openrouter/google/gemini-3.1-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
     "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/google/palm-2-chat-bison": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/google/palm-2-codechat-bison": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true
   },
   "openrouter/gryphe/mythomax-l2-13b": {
     "input_cost_per_token": 0.000001875,
@@ -11877,63 +15860,19 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/jondurbin/airoboros-l2-70b-2.1": {
-    "input_cost_per_token": 0.000013875,
-    "output_cost_per_token": 0.000013875,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/mancer/weaver": {
+    "max_input_tokens": 8000,
+    "max_output_tokens": 2000,
     "input_cost_per_token": 0.000005625,
     "output_cost_per_token": 0.000005625,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/meta-llama/codellama-34b-instruct": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/meta-llama/llama-2-13b-chat": {
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/meta-llama/llama-2-70b-chat": {
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/meta-llama/llama-3-70b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8000,
     "input_cost_per_token": 5.9e-7,
     "output_cost_per_token": 7.9e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/meta-llama/llama-3-70b-instruct:nitro": {
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/meta-llama/llama-3-8b-instruct:extended": {
-    "input_cost_per_token": 2.25e-7,
-    "output_cost_per_token": 0.00000225,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/meta-llama/llama-3-8b-instruct:free": {
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/microsoft/wizardlm-2-8x22b:nitro": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000001,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -11944,15 +15883,6 @@
     "output_cost_per_token": 0.00000102,
     "mode": "chat",
     "litellm_provider": "openrouter"
-  },
-  "openrouter/mistralai/devstral-2512:free": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
   },
   "openrouter/mistralai/devstral-2512": {
     "max_input_tokens": 262144,
@@ -12000,83 +15930,88 @@
     "supports_vision": true
   },
   "openrouter/mistralai/mistral-7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8191,
     "input_cost_per_token": 1.3e-7,
     "output_cost_per_token": 1.3e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/mistralai/mistral-7b-instruct:free": {
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/mistralai/mistral-large": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8191,
     "input_cost_per_token": 0.000008,
     "output_cost_per_token": 0.000024,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/mistralai/mistral-small-3.1-24b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 3e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/mistralai/mistral-small-3.2-24b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 3e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/mistralai/mixtral-8x22b-instruct": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
     "input_cost_per_token": 6.5e-7,
     "output_cost_per_token": 6.5e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/nousresearch/nous-hermes-llama2-13b": {
-    "input_cost_per_token": 2e-7,
+  "openrouter/moonshotai/kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "openrouter/nvidia/nemotron-3.5-lightning": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 5e-8,
     "output_cost_per_token": 2e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/openai/gpt-3.5-turbo": {
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/openai/gpt-3.5-turbo-16k": {
+    "max_input_tokens": 16385,
+    "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000004,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
   "openrouter/openai/gpt-4": {
+    "max_input_tokens": 8191,
+    "max_output_tokens": 4096,
     "input_cost_per_token": 0.00003,
     "output_cost_per_token": 0.00006,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/openai/gpt-4-vision-preview": {
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00003,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
   "openrouter/openai/gpt-4.1": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/openai/gpt-4.1-2025-04-14": {
     "max_input_tokens": 1047576,
     "max_output_tokens": 32768,
     "input_cost_per_token": 0.000002,
@@ -12096,27 +16031,7 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/openai/gpt-4.1-mini-2025-04-14": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
   "openrouter/openai/gpt-4.1-nano": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/openai/gpt-4.1-nano-2025-04-14": {
     "max_input_tokens": 1047576,
     "max_output_tokens": 32768,
     "input_cost_per_token": 1e-7,
@@ -12163,7 +16078,7 @@
     "litellm_provider": "openrouter"
   },
   "openrouter/openai/gpt-5.2-codex": {
-    "max_input_tokens": 400000,
+    "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.00000175,
     "output_cost_per_token": 0.000014,
@@ -12197,6 +16112,16 @@
     "cache_read_input_token_cost": 5e-9,
     "mode": "chat",
     "litellm_provider": "openrouter"
+  },
+  "openrouter/openai/gpt-5.1-codex-max": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
   },
   "openrouter/openai/gpt-5.2": {
     "max_input_tokens": 272000,
@@ -12253,42 +16178,6 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/openai/o1-mini": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000012,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
-  "openrouter/openai/o1-mini-2024-09-12": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000012,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
-  "openrouter/openai/o1-preview": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
-  "openrouter/openai/o1-preview-2024-09-12": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
   "openrouter/openai/o3-mini": {
     "max_input_tokens": 128000,
     "max_output_tokens": 65536,
@@ -12306,12 +16195,6 @@
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": false
-  },
-  "openrouter/pygmalionai/mythalion-13b": {
-    "input_cost_per_token": 0.000001875,
-    "output_cost_per_token": 0.000001875,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
   },
   "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
     "max_input_tokens": 33792,
@@ -12338,6 +16221,93 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
+  "openrouter/qwen/qwen3-coder-plus": {
+    "max_input_tokens": 997952,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/qwen/qwen3-235b-a22b-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.1e-8,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/qwen/qwen3-235b-a22b-thinking-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.1e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/qwen/qwen3.6-plus": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3.25e-7,
+    "output_cost_per_token": 0.00000195,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-35b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-27b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-122b-a10b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-flash-02-23": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-plus-02-15": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-397b-a17b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
   "openrouter/switchpoint/router": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -12347,6 +16317,8 @@
     "litellm_provider": "openrouter"
   },
   "openrouter/undi95/remm-slerp-l2-13b": {
+    "max_input_tokens": 6144,
+    "max_output_tokens": 4096,
     "input_cost_per_token": 0.000001875,
     "output_cost_per_token": 0.000001875,
     "mode": "chat",
@@ -12357,14 +16329,6 @@
     "max_output_tokens": 256000,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/x-ai/grok-4-fast:free": {
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 30000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -12381,6 +16345,127 @@
     "max_output_tokens": 131000,
     "input_cost_per_token": 4.5e-7,
     "output_cost_per_token": 0.0000019,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/xiaomi/mimo-v2-flash": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": false
+  },
+  "openrouter/xiaomi/mimo-v2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": false
+  },
+  "openrouter/xiaomi/mimo-v2.5": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "openrouter/z-ai/glm-4.7": {
+    "max_input_tokens": 202752,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/z-ai/glm-4.7-flash": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 4e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/z-ai/glm-5": {
+    "max_input_tokens": 202752,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.00000256,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/z-ai/glm-5.1": {
+    "max_input_tokens": 202752,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000105,
+    "output_cost_per_token": 0.0000035,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 5.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/minimax/minimax-m2.1": {
+    "max_input_tokens": 204000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/minimax/minimax-m2.5": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000011,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": false
+  },
+  "openrouter/openrouter/auto": {
+    "max_input_tokens": 2000000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "openrouter/openrouter/free": {
+    "max_input_tokens": 200000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/openrouter/bodybuilder": {
+    "max_input_tokens": 128000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -12603,46 +16688,6 @@
     "mode": "chat",
     "litellm_provider": "perplexity"
   },
-  "perplexity/llama-3.1-sonar-huge-128k-online": {
-    "max_input_tokens": 127072,
-    "max_output_tokens": 127072,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/llama-3.1-sonar-large-128k-chat": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/llama-3.1-sonar-large-128k-online": {
-    "max_input_tokens": 127072,
-    "max_output_tokens": 127072,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/llama-3.1-sonar-small-128k-chat": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/llama-3.1-sonar-small-128k-online": {
-    "max_input_tokens": 127072,
-    "max_output_tokens": 127072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "perplexity"
-  },
   "perplexity/mistral-7b-instruct": {
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
@@ -12807,6 +16852,120 @@
     "mode": "chat",
     "litellm_provider": "publicai"
   },
+  "perplexity/preset/fast-search": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/pro-search": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/deep-research": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/advanced-deep-research": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/openai/gpt-5.2": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/openai/gpt-5.1": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/openai/gpt-5-mini": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-6": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-7": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-sonnet-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-haiku-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-3-pro-preview": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-3-flash-preview": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-2.5-pro": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-2.5-flash": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/xai/grok-4-1-fast-non-reasoning": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/sonar": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/deepseek-v4-flash-0731": {
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 2.6e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/glm-5.2": {
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/kimi-k3": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/kimi-k2.7-code": {
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-v1-0.6b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 4e-9,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-v1-4b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
   "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
     "max_input_tokens": 32768,
     "max_output_tokens": 4096,
@@ -12879,6 +17038,22 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_vision": true
+  },
+  "qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "reducto/parse-legacy": {
+    "mode": "ocr",
+    "litellm_provider": "reducto"
+  },
+  "reducto/parse-v3": {
+    "mode": "ocr",
+    "litellm_provider": "reducto"
   },
   "recraft/recraftv2": {
     "mode": "image_generation",
@@ -12999,7 +17174,7 @@
     "litellm_provider": "replicate",
     "supports_vision": true
   },
-  "replicateopenai/gpt-oss-20b": {
+  "replicate/openai/gpt-oss-20b": {
     "input_cost_per_token": 9e-8,
     "output_cost_per_token": 3.6e-7,
     "mode": "chat",
@@ -13281,6 +17456,14 @@
     "mode": "chat",
     "litellm_provider": "sagemaker"
   },
+  "sambanova/MiniMax-M2.7": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "sambanova"
+  },
   "sambanova/DeepSeek-R1": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
@@ -13396,8 +17579,8 @@
     "litellm_provider": "sambanova"
   },
   "sambanova/DeepSeek-V3.1": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.0000045,
     "mode": "chat",
@@ -13406,20 +17589,63 @@
   "sambanova/gpt-oss-120b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 5.9e-7,
+    "mode": "chat",
+    "litellm_provider": "sambanova"
+  },
+  "sambanova/DeepSeek-V3.2": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.0000045,
     "mode": "chat",
     "litellm_provider": "sambanova"
   },
-  "snowflake/claude-3-5-sonnet": {
-    "max_input_tokens": 18000,
-    "max_output_tokens": 8192,
+  "sambanova/gemma-4-31B-it": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 3.8e-7,
+    "output_cost_per_token": 0.00000115,
     "mode": "chat",
-    "litellm_provider": "snowflake"
+    "litellm_provider": "sambanova",
+    "supports_vision": true
+  },
+  "scx-ai/GLM-5.2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6.1e-7,
+    "output_cost_per_token": 0.00000198,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "scx-ai",
+    "supports_vision": false
+  },
+  "scx-ai/Qwen3.8-Max": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.00000165,
+    "output_cost_per_token": 0.00000499,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "scx-ai",
+    "supports_vision": true
+  },
+  "snowflake/claude-3-5-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
   },
   "snowflake/deepseek-r1": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000135,
+    "output_cost_per_token": 0.0000054,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
@@ -13467,19 +17693,25 @@
   },
   "snowflake/llama3.1-405b": {
     "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
   "snowflake/llama3.1-70b": {
     "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
   "snowflake/llama3.1-8b": {
     "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.4e-7,
+    "output_cost_per_token": 2.4e-7,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
@@ -13497,7 +17729,9 @@
   },
   "snowflake/llama3.3-70b": {
     "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
@@ -13515,7 +17749,9 @@
   },
   "snowflake/mistral-large2": {
     "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
@@ -13550,8 +17786,10 @@
     "litellm_provider": "snowflake"
   },
   "snowflake/snowflake-llama-3.3-70b": {
-    "max_input_tokens": 8000,
-    "max_output_tokens": 8192,
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
@@ -13770,39 +18008,9 @@
     "mode": "search",
     "litellm_provider": "tavily"
   },
-  "text-bison": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 2048,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-text-models"
-  },
-  "text-bison32k": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-text-models"
-  },
-  "text-bison32k@002": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 1.25e-7,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-text-models"
-  },
-  "text-bison@001": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 1024,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-text-models"
-  },
-  "text-bison@002": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 1024,
-    "mode": "completion",
-    "litellm_provider": "vertex_ai-text-models"
+  "you_com/search": {
+    "mode": "search",
+    "litellm_provider": "you_com"
   },
   "text-completion-codestral/codestral-2405": {
     "max_input_tokens": 32000,
@@ -13907,13 +18115,6 @@
     "mode": "embedding",
     "litellm_provider": "vertex_ai-embedding-models"
   },
-  "text-multilingual-embedding-preview-0409": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 6.25e-9,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
   "text-unicorn": {
     "max_input_tokens": 8192,
     "max_output_tokens": 1024,
@@ -13929,41 +18130,6 @@
     "output_cost_per_token": 0.000028,
     "mode": "completion",
     "litellm_provider": "vertex_ai-text-models"
-  },
-  "textembedding-gecko": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "textembedding-gecko-multilingual": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "textembedding-gecko-multilingual@001": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "textembedding-gecko@001": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "textembedding-gecko@003": {
-    "max_input_tokens": 3072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
   },
   "together-ai-21.1b-41b": {
     "input_cost_per_token": 8e-7,
@@ -14087,6 +18253,8 @@
     "litellm_provider": "together_ai"
   },
   "together_ai/deepseek-ai/DeepSeek-V3.1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000017,
     "mode": "chat",
@@ -14159,7 +18327,8 @@
     "litellm_provider": "together_ai"
   },
   "together_ai/openai/gpt-oss-120b": {
-    "max_input_tokens": 128000,
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "mode": "chat",
@@ -14191,6 +18360,23 @@
     "mode": "chat",
     "litellm_provider": "together_ai"
   },
+  "together_ai/zai-org/GLM-4.7": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/moonshotai/Kimi-K2.5": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000028,
+    "mode": "chat",
+    "litellm_provider": "together_ai",
+    "supports_vision": true
+  },
   "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
     "max_input_tokens": 262144,
     "input_cost_per_token": 0.000001,
@@ -14209,6 +18395,13 @@
     "max_input_tokens": 262144,
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/Qwen/Qwen3.5-397B-A17B": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
     "mode": "chat",
     "litellm_provider": "together_ai"
   },
@@ -14302,6 +18495,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -14336,6 +18531,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000125,
+    "cache_creation_input_token_cost": 3.125e-7,
+    "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -14346,6 +18543,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000015,
     "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_vision": true
@@ -14355,6 +18554,8 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -14383,6 +18584,22 @@
     "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
     "cache_read_input_token_cost": 3.3e-7,
     "cache_read_input_token_cost_above_200k_tokens": 6.6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "input_cost_per_token_above_200k_tokens": 0.0000072,
+    "output_cost_per_token_above_200k_tokens": 0.000027,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.000009,
+    "cache_read_input_token_cost": 3.6e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -14469,6 +18686,22 @@
     "max_output_tokens": 4096,
     "input_cost_per_token": 0.00000135,
     "output_cost_per_token": 0.0000054,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "us.deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "eu.deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -14635,7 +18868,8 @@
     "input_cost_per_token": 6e-8,
     "output_cost_per_token": 2.4e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/amazon/nova-micro": {
     "max_input_tokens": 128000,
@@ -14651,7 +18885,8 @@
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.0000032,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/amazon/titan-embed-text-v2": {
     "max_input_tokens": 0,
@@ -14669,7 +18904,8 @@
     "cache_creation_input_token_cost": 3e-7,
     "cache_read_input_token_cost": 3e-8,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-3-opus": {
     "max_input_tokens": 200000,
@@ -14679,7 +18915,8 @@
     "cache_creation_input_token_cost": 0.00001875,
     "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-3.5-haiku": {
     "max_input_tokens": 200000,
@@ -14689,7 +18926,8 @@
     "cache_creation_input_token_cost": 0.000001,
     "cache_read_input_token_cost": 8e-8,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-3.5-sonnet": {
     "max_input_tokens": 200000,
@@ -14699,7 +18937,8 @@
     "cache_creation_input_token_cost": 0.00000375,
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-3.7-sonnet": {
     "max_input_tokens": 200000,
@@ -14709,7 +18948,8 @@
     "cache_creation_input_token_cost": 0.00000375,
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-4-opus": {
     "max_input_tokens": 200000,
@@ -14719,7 +18959,8 @@
     "cache_creation_input_token_cost": 0.00001875,
     "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-4-sonnet": {
     "max_input_tokens": 200000,
@@ -14730,6 +18971,116 @@
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "vercel_ai_gateway"
+  },
+  "vercel_ai_gateway/anthropic/claude-3-5-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-3-5-sonnet-20241022": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-3-7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-haiku-4.5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-opus-4": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-opus-4.1": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-opus-4.5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-opus-4.6": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-sonnet-4": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-sonnet-4.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/cohere/command-a": {
     "max_input_tokens": 256000,
@@ -14793,7 +19144,8 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/google/gemini-2.0-flash-lite": {
     "max_input_tokens": 1048576,
@@ -14801,7 +19153,8 @@
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/google/gemini-2.5-flash": {
     "max_input_tokens": 1000000,
@@ -14809,7 +19162,8 @@
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000025,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/google/gemini-2.5-pro": {
     "max_input_tokens": 1048576,
@@ -14817,7 +19171,8 @@
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/google/gemini-embedding-001": {
     "max_input_tokens": 0,
@@ -14833,7 +19188,8 @@
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 2e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/google/text-embedding-005": {
     "max_input_tokens": 0,
@@ -14897,7 +19253,8 @@
     "input_cost_per_token": 1.6e-7,
     "output_cost_per_token": 1.6e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/meta/llama-3.2-1b": {
     "max_input_tokens": 128000,
@@ -14921,7 +19278,8 @@
     "input_cost_per_token": 7.2e-7,
     "output_cost_per_token": 7.2e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/meta/llama-3.3-70b": {
     "max_input_tokens": 128000,
@@ -14945,7 +19303,8 @@
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 3e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/mistral/codestral": {
     "max_input_tokens": 256000,
@@ -15001,7 +19360,8 @@
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 1e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/mistral/mistral-embed": {
     "max_input_tokens": 0,
@@ -15049,7 +19409,8 @@
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 1.5e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/mistral/pixtral-large": {
     "max_input_tokens": 128000,
@@ -15057,7 +19418,8 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000006,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/moonshotai/kimi-k2": {
     "max_input_tokens": 131072,
@@ -15105,7 +19467,8 @@
     "input_cost_per_token": 0.00001,
     "output_cost_per_token": 0.00003,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/gpt-4.1": {
     "max_input_tokens": 1047576,
@@ -15115,7 +19478,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 5e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/gpt-4.1-mini": {
     "max_input_tokens": 1047576,
@@ -15125,7 +19489,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/gpt-4.1-nano": {
     "max_input_tokens": 1047576,
@@ -15135,7 +19500,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 2.5e-8,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/gpt-4o": {
     "max_input_tokens": 128000,
@@ -15145,7 +19511,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 0.00000125,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/gpt-4o-mini": {
     "max_input_tokens": 128000,
@@ -15155,7 +19522,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/o1": {
     "max_input_tokens": 200000,
@@ -15165,7 +19533,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 0.0000075,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/o3": {
     "max_input_tokens": 200000,
@@ -15175,7 +19544,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 5e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/o3-mini": {
     "max_input_tokens": 200000,
@@ -15195,7 +19565,8 @@
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 2.75e-7,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/openai/text-embedding-3-large": {
     "max_input_tokens": 0,
@@ -15259,7 +19630,8 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/vercel/v0-1.5-md": {
     "max_input_tokens": 128000,
@@ -15267,7 +19639,8 @@
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/xai/grok-2": {
     "max_input_tokens": 131072,
@@ -15283,7 +19656,8 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.00001,
     "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway"
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
   },
   "vercel_ai_gateway/xai/grok-3": {
     "max_input_tokens": 131072,
@@ -15354,6 +19728,10 @@
     "mode": "audio_speech",
     "litellm_provider": "vertex_ai"
   },
+  "vertex_ai/chirp_3": {
+    "mode": "audio_transcription",
+    "litellm_provider": "vertex_ai"
+  },
   "vertex_ai/claude-3-5-haiku": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -15372,6 +19750,18 @@
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true
   },
+  "vertex_ai/claude-haiku-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "vertex_ai/claude-haiku-4-5@20251001": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -15381,29 +19771,10 @@
     "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "vertex_ai/claude-3-5-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-3-5-sonnet-v2": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-3-5-sonnet-v2@20241022": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.000003,
@@ -15547,6 +19918,126 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "vertex_ai/claude-opus-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4-6@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4-7@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-fable-5@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-5@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4-8@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "vertex_ai/claude-sonnet-4-5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -15558,6 +20049,30 @@
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_read_input_token_cost": 3e-7,
     "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true,
@@ -15682,8 +20197,8 @@
   "vertex_ai/deepseek-ai/deepseek-v3.1-maas": {
     "max_input_tokens": 163840,
     "max_output_tokens": 32768,
-    "input_cost_per_token": 0.00000135,
-    "output_cost_per_token": 0.0000054,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000017,
     "mode": "chat",
     "litellm_provider": "vertex_ai-deepseek_models"
   },
@@ -15713,10 +20228,97 @@
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "max_pdf_size_mb": 30
+    "supports_vision": true
+  },
+  "vertex_ai/gemini-3-pro-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models"
   },
   "vertex_ai/gemini-3-pro-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models"
+  },
+  "vertex_ai/gemini-3.1-flash-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models"
+  },
+  "vertex_ai/gemini-3.1-flash-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models"
+  },
+  "vertex_ai/gemini-3.1-flash-lite-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.1-flash-lite-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/deep-research-pro-preview-12-2025": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
     "input_cost_per_token": 0.000002,
@@ -15913,6 +20515,15 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-zai_models"
   },
+  "vertex_ai/zai-org/glm-5-maas": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-zai_models"
+  },
   "vertex_ai/mistral-medium-3": {
     "max_input_tokens": 128000,
     "max_output_tokens": 8191,
@@ -16020,11 +20631,20 @@
     "mode": "ocr",
     "litellm_provider": "vertex_ai"
   },
+  "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-openai_models",
+    "supports_vision": true
+  },
   "vertex_ai/openai/gpt-oss-120b-maas": {
     "max_input_tokens": 131072,
     "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 3.6e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-openai_models"
   },
@@ -16036,19 +20656,59 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-openai_models"
   },
+  "vertex_ai/xai/grok-4.1-fast-non-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_vision": true
+  },
+  "vertex_ai/xai/grok-4.1-fast-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_vision": true
+  },
+  "vertex_ai/xai/grok-4.20-non-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_vision": true
+  },
+  "vertex_ai/xai/grok-4.20-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_vision": true
+  },
   "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
     "max_input_tokens": 262144,
     "max_output_tokens": 16384,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000001,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-qwen_models"
   },
   "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas": {
     "max_input_tokens": 262144,
     "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000004,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.0000018,
     "mode": "chat",
     "litellm_provider": "vertex_ai-qwen_models"
   },
@@ -16069,16 +20729,6 @@
     "litellm_provider": "vertex_ai-qwen_models"
   },
   "vertex_ai/veo-2.0-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.0-fast-generate-preview": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.0-generate-preview": {
     "max_input_tokens": 1024,
     "mode": "video_generation",
     "litellm_provider": "vertex_ai-video-models"
@@ -16303,6 +20953,24 @@
     "max_output_tokens": 128000,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/moonshotai/Kimi-K2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "wandb",
+    "supports_vision": true
+  },
+  "wandb/MiniMaxAI/MiniMax-M2.5": {
+    "max_input_tokens": 197000,
+    "max_output_tokens": 197000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "wandb"
   },
@@ -16680,6 +21348,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 7.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16688,6 +21357,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 7.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16696,6 +21366,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
+    "cache_read_input_token_cost": 0.00000125,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16704,6 +21375,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
+    "cache_read_input_token_cost": 0.00000125,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16712,6 +21384,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 7.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16720,6 +21393,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16728,6 +21402,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16736,6 +21411,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16744,6 +21420,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16752,6 +21429,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16760,6 +21438,7 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
     "litellm_provider": "xai"
   },
@@ -16860,6 +21539,123 @@
     "supports_vision": true,
     "supports_audio_input": true
   },
+  "xai/grok-4.20-multi-agent-beta-0309": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-beta-0309-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-0309-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-beta-0309-non-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.3": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.3-latest": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.5": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000012,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.5-latest": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000012,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000012,
+    "cache_read_input_token_cost": 5e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
   "xai/grok-beta": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -16872,29 +21668,41 @@
   "xai/grok-code-fast": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2e-8,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "input_cost_per_token_above_200k_tokens": 0.000002,
+    "output_cost_per_token_above_200k_tokens": 0.000004,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
-    "litellm_provider": "xai"
+    "litellm_provider": "xai",
+    "supports_vision": true
   },
   "xai/grok-code-fast-1": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2e-8,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "input_cost_per_token_above_200k_tokens": 0.000002,
+    "output_cost_per_token_above_200k_tokens": 0.000004,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
-    "litellm_provider": "xai"
+    "litellm_provider": "xai",
+    "supports_vision": true
   },
   "xai/grok-code-fast-1-0825": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2e-8,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "input_cost_per_token_above_200k_tokens": 0.000002,
+    "output_cost_per_token_above_200k_tokens": 0.000004,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
-    "litellm_provider": "xai"
+    "litellm_provider": "xai",
+    "supports_vision": true
   },
   "xai/grok-vision-beta": {
     "max_input_tokens": 8192,
@@ -16904,6 +21712,60 @@
     "mode": "chat",
     "litellm_provider": "xai",
     "supports_vision": true
+  },
+  "zai.glm-4.7": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "zai.glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "zai.glm-4.7-flash": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "zai/glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-5.1": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-5-code": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "zai"
   },
   "zai/glm-4.7": {
     "max_input_tokens": 200000,
@@ -16915,11 +21777,23 @@
     "mode": "chat",
     "litellm_provider": "zai"
   },
+  "zai/glm-4.7-flash": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
   "zai/glm-4.6": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000022,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1.1e-7,
     "mode": "chat",
     "litellm_provider": "zai"
   },
@@ -16993,6 +21867,10 @@
     "litellm_provider": "openai"
   },
   "openai/sora-2-pro": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "openai/sora-2-pro-high-res": {
     "mode": "video_generation",
     "litellm_provider": "openai"
   },
@@ -18704,6 +23582,16 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/qwen3p7-plus": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "cache_read_input_token_cost": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
   "fireworks_ai/accounts/fireworks/models/qwq-32b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -18792,22 +23680,6 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
-  "fireworks_ai/accounts/fireworks/models/whisper-v3": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "audio_transcription",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/whisper-v3-turbo": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "audio_transcription",
-    "litellm_provider": "fireworks_ai"
-  },
   "fireworks_ai/accounts/fireworks/models/yi-34b": {
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
@@ -18847,6 +23719,174 @@
     "output_cost_per_token": 2e-7,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p1-fast": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000028,
+    "output_cost_per_token": 0.0000088,
+    "cache_read_input_token_cost": 5.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k2p6-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k2p7-code-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.0000019,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "scaleway/qwen/qwen3.5-397b-a17b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/qwen/qwen3.6-35b-a3b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/qwen/qwen3-235b-a22b-instruct-2507": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000225,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3-embedding-8b": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3-coder-30b-a3b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/openai/gpt-oss-120b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/openai/whisper-large-v3": {
+    "output_cost_per_token": 0,
+    "mode": "audio_transcription",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/google/gemma-4-26b-a4b-it": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/google/gemma-3-27b-it": {
+    "max_input_tokens": 40000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/hcompany/holo2-30b-a3b": {
+    "max_input_tokens": 22000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 7e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/mistral-medium-3.5-128b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/devstral-2-123b-instruct-2512": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/mistralai/voxtral-small-24b-2507": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 3.5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_audio_input": true
+  },
+  "scaleway/mistralai/mistral-small-3.2-24b-instruct-2506": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 3.5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/pixtral-12b-2409": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/BAAI/bge-multilingual-gemma2": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/meta/llama-3.3-70b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
   },
   "novita/deepseek/deepseek-v3.2": {
     "max_input_tokens": 163840,
@@ -19696,6 +24736,112 @@
     "mode": "embedding",
     "litellm_provider": "llamagate"
   },
+  "libertai/hermes-3-8b-tee": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/gemma-4-31b-it": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/gemma-4-31b-it-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-27b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-27b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-35b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-35b-a3b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.5-122b-a10b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.5-122b-a10b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/deepseek-v4-flash": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/deepseek-v4-flash-thinking": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/bge-m3": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "libertai"
+  },
   "sarvam/sarvam-m": {
     "max_input_tokens": 8192,
     "max_output_tokens": 32000,
@@ -19705,5 +24851,1362 @@
     "cache_read_input_token_cost": 0,
     "mode": "chat",
     "litellm_provider": "sarvam"
+  },
+  "tts-1-1106": {
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "tts-1-hd-1106": {
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.000005,
+    "mode": "audio_transcription",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.000005,
+    "mode": "audio_transcription",
+    "litellm_provider": "openai"
+  },
+  "gpt-5-search-api": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5-search-api-2025-10-14": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-realtime-mini-2025-10-06": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-whisper": {
+    "mode": "audio_transcription",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "sora-2": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "sora-2-pro": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "sora-2-pro-high-res": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "chatgpt-image-latest": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.00004,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
+  "gemini-2.0-flash-exp-image-generation": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.0-flash-exp-image-generation": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.0-flash-lite-001": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 1.875e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini-2.5-flash-native-audio-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-2.5-flash-native-audio-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-2.5-flash-native-audio-preview-12-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-3.1-flash-live-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-3.1-flash-live-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini/gemini-3.1-flash-tts-preview": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.00002,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
+  },
+  "gemini-flash-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-flash-lite-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-pro-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-pro-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-exp-1206": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-5@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4-6@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "duckduckgo/search": {
+    "mode": "search",
+    "litellm_provider": "duckduckgo"
+  },
+  "bedrock_mantle/openai.gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-safeguard-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-safeguard-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 2.75e-7,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "us.openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "us.openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "us.openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 2.75e-7,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 2.5e-7,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.5": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.4": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.75e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/google.gemma-4-31b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/google.gemma-4-26b-a4b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/google.gemma-4-e2b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/xai.grok-4.3": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "us.xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "volcengine/doubao-seed-2-0-pro-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
+  },
+  "volcengine/doubao-seed-2-0-lite-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
+  },
+  "volcengine/doubao-seed-2-0-mini-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
+  },
+  "volcengine/doubao-seed-2-0-code-preview-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
+  },
+  "bedrock/us-east-1/zai.glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/zai.glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-gov-east-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000006,
+    "cache_creation_input_token_cost": 0.0000015,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "bedrock/us-gov-west-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000006,
+    "cache_creation_input_token_cost": 0.0000015,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "snowflake/claude-sonnet-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-sonnet-4-6": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-4-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-4-opus": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-haiku-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-3-7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/openai-gpt-4.1": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/openai-gpt-5": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/openai-gpt-5-mini": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/openai-gpt-5-nano": {
+    "max_input_tokens": 5000000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/llama4-maverick": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.4e-7,
+    "output_cost_per_token": 9.7e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/snowflake-arctic-embed-l-v2.0": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/snowflake-arctic-embed-m-v2.0": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "snowflake"
+  },
+  "soniox/stt-async-v4": {
+    "max_output_tokens": 8000,
+    "mode": "audio_transcription",
+    "litellm_provider": "soniox",
+    "supports_audio_input": true
+  },
+  "soniox/stt-async-v5": {
+    "max_output_tokens": 8000,
+    "mode": "audio_transcription",
+    "litellm_provider": "soniox",
+    "supports_audio_input": true
+  },
+  "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 0.0000018,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/Qwen/Qwen3.6-27B-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 3.2e-7,
+    "output_cost_per_token": 0.0000032,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/lukealonso/GLM-5.1-NVFP4-MTP": {
+    "max_input_tokens": 202752,
+    "max_output_tokens": 202752,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/deepseek-ai/DeepSeek-V4-Flash": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/moonshotai/Kimi-K2.6": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.6e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/MiniMaxAI/MiniMax-M2.5": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/google/gemma-4-31B-it": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 5.6e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/openai/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 4.4e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 4.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "deepseek/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 4.4e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "deepseek/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 4.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "tencent/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 3.625e-9,
+    "mode": "chat",
+    "litellm_provider": "tencent",
+    "supports_vision": false
+  },
+  "tencent/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2.8e-9,
+    "mode": "chat",
+    "litellm_provider": "tencent",
+    "supports_vision": false
+  },
+  "cognition/swe-1.6": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "cognition"
+  },
+  "cognition/swe-1.7": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "cognition"
+  },
+  "cognition/swe-1.7-lightning": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "cognition"
+  },
+  "pinstripes/ps/glm-4.5-air": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.25e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3.6-35b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3-30b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3-coder-30b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/deepseek-v4-flash": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/minimax-m2.7": {
+    "max_input_tokens": 1000192,
+    "max_output_tokens": 1000192,
+    "input_cost_per_token": 2.55e-7,
+    "output_cost_per_token": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "darkbloom/gemma-4-26b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 1.65e-7,
+    "mode": "chat",
+    "litellm_provider": "darkbloom"
+  },
+  "darkbloom/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.45e-8,
+    "output_cost_per_token": 7e-8,
+    "mode": "chat",
+    "litellm_provider": "darkbloom"
+  },
+  "xai/grok-4.20-0309-non-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-multi-agent-0309": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-build-0.1": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "input_cost_per_token_above_200k_tokens": 0.000002,
+    "output_cost_per_token_above_200k_tokens": 0.000004,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "gpt-transcribe": {
+    "mode": "audio_transcription",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-live-transcribe": {
+    "mode": "audio_transcription",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-translate": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "claude-mythos-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-mythos-preview": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-robotics-er-2-streaming-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "mistral/mistral-small-2603": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/labs-leanstral-1-5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-moderation-2603": {
+    "max_input_tokens": 131072,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "moderation",
+    "litellm_provider": "mistral"
+  },
+  "mistral/voxtral-mini-2602": {
+    "mode": "audio_transcription",
+    "litellm_provider": "mistral",
+    "supports_audio_input": true
+  },
+  "mistral/voxtral-mini-transcribe-realtime-2602": {
+    "mode": "audio_transcription",
+    "litellm_provider": "mistral",
+    "supports_audio_input": true
+  },
+  "mistral/voxtral-mini-tts-2603": {
+    "mode": "audio_speech",
+    "litellm_provider": "mistral"
+  },
+  "fallback_generalizations": {},
+  "gemini/gemini-3.5-live-translate-preview": {
+    "input_cost_per_token": 0.0000035,
+    "output_cost_per_token": 0.000021,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "perplexity/pplx-embed-context-v1-0.6b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 8e-9,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-context-v1-4b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "voyage/voyage-4-large": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-4": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-4-lite": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-code-4": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-context-4": {
+    "max_input_tokens": 120000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-multimodal-3.5": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/kimi-k3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/deepseek-v4-flash-0731": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p2-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p2-fast-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/kimi-k3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k3-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000045,
+    "output_cost_per_token": 0.0000225,
+    "cache_read_input_token_cost": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k3-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/qwen3p8-max": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/muse-glimmer-30b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/nemotron-lightning-3p5-30b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/nemotron-3-ultra-nvfp4": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3p8-max": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000045,
+    "output_cost_per_token": 0.0000225,
+    "cache_read_input_token_cost": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
   }
 }

--- a/src/common/utils/tokens/models.json
+++ b/src/common/utils/tokens/models.json
@@ -1,14 +1,4 @@
 {
-  "sample_spec": {
-    "max_input_tokens": "max input tokens, if the provider specifies it. if not default to max_tokens",
-    "max_output_tokens": "max output tokens, if the provider specifies it. if not default to max_tokens",
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "one of: chat, embedding, completion, image_generation, audio_transcription, audio_speech, image_generation, moderation, rerank, search",
-    "litellm_provider": "one of https://docs.litellm.ai/docs/providers",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
   "1024-x-1024/50-steps/bedrock/amazon.nova-canvas-v1:0": {
     "max_input_tokens": 2600,
     "mode": "image_generation",
@@ -23,10 +13,46 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "1024-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "1024-x-1024/max-steps/stability.stable-diffusion-xl-v1": {
     "max_input_tokens": 77,
     "mode": "image_generation",
     "litellm_provider": "bedrock"
+  },
+  "1024-x-1536/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "1536-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "256-x-256/dall-e-2": {
     "mode": "image_generation",
@@ -45,6 +71,10 @@
     "max_input_tokens": 77,
     "mode": "image_generation",
     "litellm_provider": "bedrock"
+  },
+  "agentcore/search": {
+    "mode": "search",
+    "litellm_provider": "agentcore"
   },
   "ai21.j2-mid-v1": {
     "max_input_tokens": 8191,
@@ -139,59 +169,41 @@
     "litellm_provider": "aiml",
     "supports_vision": true
   },
-  "amazon.nova-canvas-v1:0": {
-    "max_input_tokens": 2600,
-    "mode": "image_generation",
-    "litellm_provider": "bedrock"
-  },
-  "us.amazon.nova-canvas-v1:0": {
-    "max_input_tokens": 2600,
-    "mode": "image_generation",
-    "litellm_provider": "bedrock"
-  },
-  "us.writer.palmyra-x4-v1:0": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true
-  },
-  "us.writer.palmyra-x5-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.000006,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true
-  },
-  "writer.palmyra-x4-v1:0": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true
-  },
-  "writer.palmyra-x5-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.000006,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true
-  },
-  "amazon.nova-lite-v1:0": {
+  "amazon-nova/nova-lite-v1": {
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
     "input_cost_per_token": 6e-8,
     "output_cost_per_token": 2.4e-7,
     "mode": "chat",
-    "litellm_provider": "bedrock_converse",
+    "litellm_provider": "amazon_nova",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "amazon-nova/nova-micro-v1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 10000,
+    "input_cost_per_token": 3.5e-8,
+    "output_cost_per_token": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "amazon_nova"
+  },
+  "amazon-nova/nova-premier-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 10000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000125,
+    "mode": "chat",
+    "litellm_provider": "amazon_nova",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "amazon-nova/nova-pro-v1": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000032,
+    "mode": "chat",
+    "litellm_provider": "amazon_nova",
     "supports_pdf_input": true,
     "supports_vision": true
   },
@@ -207,6 +219,15 @@
     "supports_vision": true,
     "supports_video_input": true
   },
+  "amazon.nova-2-multimodal-embeddings-v1:0": {
+    "max_input_tokens": 8172,
+    "input_cost_per_token": 1.35e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock",
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
   "amazon.nova-2-pro-preview-20251202-v1:0": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
@@ -219,86 +240,20 @@
     "supports_vision": true,
     "supports_video_input": true
   },
-  "apac.amazon.nova-2-lite-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 3.3e-7,
-    "output_cost_per_token": 0.00000275,
-    "cache_read_input_token_cost": 8.25e-8,
+  "amazon.nova-canvas-v1:0": {
+    "max_input_tokens": 2600,
+    "mode": "image_generation",
+    "litellm_provider": "bedrock"
+  },
+  "amazon.nova-lite-v1:0": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 10000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2.4e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "apac.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000021875,
-    "output_cost_per_token": 0.0000175,
-    "cache_read_input_token_cost": 5.46875e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "eu.amazon.nova-2-lite-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 3.3e-7,
-    "output_cost_per_token": 0.00000275,
-    "cache_read_input_token_cost": 8.25e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "eu.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000021875,
-    "output_cost_per_token": 0.0000175,
-    "cache_read_input_token_cost": 5.46875e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "us.amazon.nova-2-lite-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 3.3e-7,
-    "output_cost_per_token": 0.00000275,
-    "cache_read_input_token_cost": 8.25e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "us.amazon.nova-2-pro-preview-20251202-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000021875,
-    "output_cost_per_token": 0.0000175,
-    "cache_read_input_token_cost": 5.46875e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
-  },
-  "amazon.nova-2-multimodal-embeddings-v1:0": {
-    "max_input_tokens": 8172,
-    "input_cost_per_token": 1.35e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "bedrock",
-    "supports_audio_input": true,
-    "supports_video_input": true
+    "supports_vision": true
   },
   "amazon.nova-micro-v1:0": {
     "max_input_tokens": 128000,
@@ -326,6 +281,13 @@
     "mode": "rerank",
     "litellm_provider": "bedrock"
   },
+  "amazon.titan-embed-g1-text-02": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock"
+  },
   "amazon.titan-embed-image-v1": {
     "max_input_tokens": 128,
     "input_cost_per_token": 8e-7,
@@ -334,13 +296,6 @@
     "litellm_provider": "bedrock"
   },
   "amazon.titan-embed-text-v1": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "bedrock"
-  },
-  "amazon.titan-embed-g1-text-02": {
     "max_input_tokens": 8192,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 0,
@@ -365,45 +320,6 @@
   "amazon.titan-image-generator-v2:0": {
     "mode": "image_generation",
     "litellm_provider": "bedrock"
-  },
-  "twelvelabs.marengo-embed-2-7-v1:0": {
-    "max_input_tokens": 77,
-    "input_cost_per_token": 0.00007,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "bedrock"
-  },
-  "us.twelvelabs.marengo-embed-2-7-v1:0": {
-    "max_input_tokens": 77,
-    "input_cost_per_token": 0.00007,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "bedrock"
-  },
-  "eu.twelvelabs.marengo-embed-2-7-v1:0": {
-    "max_input_tokens": 77,
-    "input_cost_per_token": 0.00007,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "bedrock"
-  },
-  "twelvelabs.pegasus-1-2-v1:0": {
-    "output_cost_per_token": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_video_input": true
-  },
-  "us.twelvelabs.pegasus-1-2-v1:0": {
-    "output_cost_per_token": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_video_input": true
-  },
-  "eu.twelvelabs.pegasus-1-2-v1:0": {
-    "output_cost_per_token": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_video_input": true
   },
   "amazon.titan-text-express-v1": {
     "max_input_tokens": 42000,
@@ -439,30 +355,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
-  },
-  "anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-haiku-4-5@20251001": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
   },
   "anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "max_input_tokens": 1000000,
@@ -555,6 +447,42 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-haiku-4-5@20251001": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "anthropic.claude-instant-v1": {
     "max_input_tokens": 100000,
     "max_output_tokens": 8191,
@@ -562,6 +490,15 @@
     "output_cost_per_token": 0.0000024,
     "mode": "chat",
     "litellm_provider": "bedrock"
+  },
+  "anthropic.claude-mythos-preview": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
   },
   "anthropic.claude-opus-4-1-20250805-v1:0": {
     "max_input_tokens": 200000,
@@ -611,54 +548,6 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "global.anthropic.claude-opus-4-6-v1": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-opus-4-6-v1": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-opus-4-6-v1": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-opus-4-6-v1": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "anthropic.claude-opus-4-7": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -666,183 +555,6 @@
     "output_cost_per_token": 0.000025,
     "cache_creation_input_token_cost": 0.00000625,
     "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-mythos-preview": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_vision": true
-  },
-  "global.anthropic.claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000011,
-    "output_cost_per_token": 0.000055,
-    "cache_creation_input_token_cost": 0.00001375,
-    "cache_read_input_token_cost": 0.0000011,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000011,
-    "output_cost_per_token": 0.000055,
-    "cache_creation_input_token_cost": 0.00001375,
-    "cache_read_input_token_cost": 0.0000011,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "jp.anthropic.claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -860,217 +572,13 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "global.anthropic.claude-opus-4-8": {
+  "anthropic.claude-opus-5": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "cache_creation_input_token_cost": 0.00000625,
     "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-opus-4-8": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-opus-4-8": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-opus-4-8": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "jp.anthropic.claude-opus-4-8": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "jp.anthropic.claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.0000275,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.000011,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.000011,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.000011,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "jp.anthropic.claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.000011,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_creation_input_token_cost": 0.000004125,
-    "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "eu.anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_creation_input_token_cost": 0.000004125,
-    "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_creation_input_token_cost": 0.000004125,
-    "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "jp.anthropic.claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_creation_input_token_cost": 0.000004125,
-    "cache_read_input_token_cost": 3.3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -1103,6 +611,30 @@
     "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
     "cache_read_input_token_cost": 3e-7,
     "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -1220,6 +752,30 @@
     "mode": "chat",
     "litellm_provider": "anyscale"
   },
+  "apac.amazon.nova-2-lite-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 3.3e-7,
+    "output_cost_per_token": 0.00000275,
+    "cache_read_input_token_cost": 8.25e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "apac.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
   "apac.amazon.nova-lite-v1:0": {
     "max_input_tokens": 300000,
     "max_output_tokens": 10000,
@@ -1284,18 +840,6 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000055,
-    "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
@@ -1305,6 +849,18 @@
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000055,
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
     "supports_vision": true
   },
@@ -1324,6 +880,14 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "apiserpent/deep_search": {
+    "mode": "search",
+    "litellm_provider": "apiserpent"
+  },
+  "apiserpent/search": {
+    "mode": "search",
+    "litellm_provider": "apiserpent"
+  },
   "assemblyai/best": {
     "mode": "audio_transcription",
     "litellm_provider": "assemblyai"
@@ -1331,6 +895,66 @@
   "assemblyai/nano": {
     "mode": "audio_transcription",
     "litellm_provider": "assemblyai"
+  },
+  "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000055,
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "max_input_tokens": 200000,
@@ -1347,6 +971,46 @@
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
     "supports_vision": true
+  },
+  "au.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "au.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "aws_polly/generative": {
+    "mode": "audio_speech",
+    "litellm_provider": "aws_polly"
+  },
+  "aws_polly/long-form": {
+    "mode": "audio_speech",
+    "litellm_provider": "aws_polly"
+  },
+  "aws_polly/neural": {
+    "mode": "audio_speech",
+    "litellm_provider": "aws_polly"
+  },
+  "aws_polly/standard": {
+    "mode": "audio_speech",
+    "litellm_provider": "aws_polly"
   },
   "azure/ada": {
     "max_input_tokens": 8191,
@@ -1374,138 +1038,6 @@
     "mode": "chat",
     "litellm_provider": "azure"
   },
-  "azure_ai/claude-haiku-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-4-7": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-4-8": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-opus-4-1": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
-    "cache_creation_input_token_cost": 0.00001875,
-    "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-sonnet-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-sonnet-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "azure/computer-use-preview": {
     "max_input_tokens": 8192,
     "max_output_tokens": 1024,
@@ -1518,130 +1050,6 @@
   "azure/container": {
     "mode": "chat",
     "litellm_provider": "azure"
-  },
-  "azure_ai/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/gpt-5.5": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.5-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-pro-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-mini": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-mini-2026-03-17": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-nano": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/gpt-5.4-nano-2026-03-17": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure_ai/model_router": {
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
   },
   "azure/eu/gpt-4o-2024-08-06": {
     "max_input_tokens": 128000,
@@ -1725,6 +1133,17 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/eu/gpt-5-nano-2025-08-07": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5.5e-8,
+    "output_cost_per_token": 4.4e-7,
+    "cache_read_input_token_cost": 5.5e-9,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure/eu/gpt-5.1": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
@@ -1769,12 +1188,89 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "azure/eu/gpt-5-nano-2025-08-07": {
-    "max_input_tokens": 272000,
+  "azure/eu/gpt-5.4": {
+    "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 5.5e-8,
-    "output_cost_per_token": 4.4e-7,
-    "cache_read_input_token_cost": 5.5e-9,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/eu/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_read_input_token_cost": 2.2e-7,
     "mode": "chat",
     "litellm_provider": "azure",
     "supports_pdf_input": true,
@@ -2173,42 +1669,6 @@
     "litellm_provider": "azure",
     "supports_vision": true
   },
-  "azure/gpt-audio-2025-08-28": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_vision": false
-  },
-  "azure/gpt-audio-1.5-2026-02-23": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_vision": false
-  },
-  "azure/gpt-audio-mini": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_vision": false
-  },
-  "azure/gpt-audio-mini-2025-10-06": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_vision": false
-  },
   "azure/gpt-4o-audio-preview-2024-12-17": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -2253,46 +1713,6 @@
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000024,
     "cache_read_input_token_cost": 3e-7,
-    "mode": "realtime",
-    "litellm_provider": "azure",
-    "supports_audio_input": true
-  },
-  "azure/gpt-realtime-2025-08-28": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "cache_read_input_token_cost": 0.000004,
-    "mode": "realtime",
-    "litellm_provider": "azure",
-    "supports_audio_input": true
-  },
-  "azure/gpt-realtime-1.5-2026-02-23": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "cache_read_input_token_cost": 0.000004,
-    "mode": "realtime",
-    "litellm_provider": "azure",
-    "supports_audio_input": true
-  },
-  "azure/gpt-realtime-mini": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 6e-8,
-    "mode": "realtime",
-    "litellm_provider": "azure",
-    "supports_audio_input": true
-  },
-  "azure/gpt-realtime-mini-2025-10-06": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 6e-8,
     "mode": "realtime",
     "litellm_provider": "azure",
     "supports_audio_input": true
@@ -2346,55 +1766,6 @@
     "output_cost_per_token": 0.00001,
     "mode": "audio_transcription",
     "litellm_provider": "azure"
-  },
-  "azure/gpt-realtime-whisper": {
-    "mode": "audio_transcription",
-    "litellm_provider": "azure",
-    "supports_audio_input": true
-  },
-  "azure/gpt-5.1-2025-11-13": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.1-chat-2025-11-13": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.1-codex-2025-11-13": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.1-codex-mini-2025-11-13": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
   },
   "azure/gpt-5": {
     "max_input_tokens": 272000,
@@ -2516,6 +1887,17 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/gpt-5.1-2025-11-13": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure/gpt-5.1-chat": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
@@ -2527,7 +1909,29 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/gpt-5.1-chat-2025-11-13": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure/gpt-5.1-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.1-codex-2025-11-13": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.00000125,
@@ -2550,6 +1954,17 @@
     "supports_vision": true
   },
   "azure/gpt-5.1-codex-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.1-codex-mini-2025-11-13": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 2.5e-7,
@@ -2615,6 +2030,26 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/gpt-5.2-pro": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000021,
+    "output_cost_per_token": 0.000168,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.2-pro-2025-12-11": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000021,
+    "output_cost_per_token": 0.000168,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure/gpt-5.3-chat": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -2637,54 +2072,12 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "azure/gpt-5.2-pro": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000021,
-    "output_cost_per_token": 0.000168,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.2-pro-2025-12-11": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000021,
-    "output_cost_per_token": 0.000168,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "azure/gpt-5.4": {
     "max_input_tokens": 1050000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.000015,
     "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.4": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000275,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.4": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000275,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 2.8e-7,
     "mode": "chat",
     "litellm_provider": "azure",
     "supports_pdf_input": true,
@@ -2697,270 +2090,6 @@
     "output_cost_per_token": 0.000015,
     "cache_read_input_token_cost": 2.5e-7,
     "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.4-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000275,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.4-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000275,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.4-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.4-pro-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.6": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.6-sol": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.6-terra": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.6-luna": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.6": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.6-sol": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.6-terra": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000132,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.6-luna": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.00000132,
-    "cache_read_input_token_cost": 2.2e-8,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.6": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.6-sol": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.6-terra": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000132,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.6-luna": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.00000132,
-    "cache_read_input_token_cost": 2.2e-8,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.5": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.5": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.5": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.5-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/us/gpt-5.5-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/eu/gpt-5.5-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.5-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "azure",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "azure/gpt-5.5-pro-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
     "litellm_provider": "azure",
     "supports_pdf_input": true,
     "supports_vision": true
@@ -3009,61 +2138,156 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.5-pro-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/gpt-audio-1.5-2026-02-23": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
+  "azure/gpt-audio-2025-08-28": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
+  "azure/gpt-audio-mini": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
+  "azure/gpt-audio-mini-2025-10-06": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_vision": false
+  },
   "azure/gpt-image-1": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_image_token": 0.00004,
     "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/hd/1024-x-1024/dall-e-3": {
-    "output_cost_per_token": 0,
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/hd/1024-x-1792/dall-e-3": {
-    "output_cost_per_token": 0,
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/hd/1792-x-1024/dall-e-3": {
-    "output_cost_per_token": 0,
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/high/1024-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/high/1024-x-1536/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/high/1536-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/low/1024-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/low/1024-x-1536/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/low/1536-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/medium/1024-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/medium/1024-x-1536/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/medium/1536-x-1024/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
@@ -3108,27 +2332,67 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "azure/low/1024-x-1024/gpt-image-1-mini": {
+  "azure/gpt-realtime-1.5-2026-02-23": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 0.000004,
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-2025-08-28": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 0.000004,
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-mini": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-mini-2025-10-06": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/gpt-realtime-whisper": {
+    "mode": "audio_transcription",
+    "litellm_provider": "azure",
+    "supports_audio_input": true
+  },
+  "azure/hd/1024-x-1024/dall-e-3": {
+    "output_cost_per_token": 0,
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
-  "azure/low/1024-x-1536/gpt-image-1-mini": {
+  "azure/hd/1024-x-1792/dall-e-3": {
+    "output_cost_per_token": 0,
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
-  "azure/low/1536-x-1024/gpt-image-1-mini": {
+  "azure/hd/1792-x-1024/dall-e-3": {
+    "output_cost_per_token": 0,
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
-  "azure/medium/1024-x-1024/gpt-image-1-mini": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/medium/1024-x-1536/gpt-image-1-mini": {
-    "mode": "image_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/medium/1536-x-1024/gpt-image-1-mini": {
+  "azure/high/1024-x-1024/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
@@ -3136,11 +2400,67 @@
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
+  "azure/high/1024-x-1536/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
   "azure/high/1024-x-1536/gpt-image-1-mini": {
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
+  "azure/high/1536-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
   "azure/high/1536-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1024-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1024-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1024-x-1536/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1024-x-1536/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1536-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/low/1536-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1024-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1024-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1024-x-1536/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1024-x-1536/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1536-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/medium/1536-x-1024/gpt-image-1-mini": {
     "mode": "image_generation",
     "litellm_provider": "azure"
   },
@@ -3308,6 +2628,30 @@
     "litellm_provider": "azure",
     "supports_vision": true
   },
+  "azure/sora-2": {
+    "mode": "video_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/sora-2-pro": {
+    "mode": "video_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/sora-2-pro-high-res": {
+    "mode": "video_generation",
+    "litellm_provider": "azure"
+  },
+  "azure/speech/azure-stt": {
+    "mode": "audio_transcription",
+    "litellm_provider": "azure"
+  },
+  "azure/speech/azure-tts": {
+    "mode": "audio_speech",
+    "litellm_provider": "azure"
+  },
+  "azure/speech/azure-tts-hd": {
+    "mode": "audio_speech",
+    "litellm_provider": "azure"
+  },
   "azure/standard/1024-x-1024/dall-e-2": {
     "output_cost_per_token": 0,
     "mode": "image_generation",
@@ -3347,18 +2691,6 @@
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 0,
     "mode": "embedding",
-    "litellm_provider": "azure"
-  },
-  "azure/speech/azure-tts": {
-    "mode": "audio_speech",
-    "litellm_provider": "azure"
-  },
-  "azure/speech/azure-tts-hd": {
-    "mode": "audio_speech",
-    "litellm_provider": "azure"
-  },
-  "azure/speech/azure-stt": {
-    "mode": "audio_transcription",
     "litellm_provider": "azure"
   },
   "azure/tts-1": {
@@ -3536,6 +2868,94 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "azure/us/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure/us/gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "azure/us/o1-2024-12-17": {
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
@@ -3619,10 +3039,6 @@
     "litellm_provider": "azure_ai"
   },
   "azure_ai/FLUX.1-Kontext-pro": {
-    "mode": "image_generation",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/flux.2-pro": {
     "mode": "image_generation",
     "litellm_provider": "azure_ai"
   },
@@ -3757,24 +3173,6 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/MAI-Image-2.5": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_image_token": 0.000047,
-    "mode": "image_generation",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/MAI-Image-2.5-Flash": {
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_image_token": 0.000033,
-    "mode": "image_generation",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/MAI-Image-2e": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_image_token": 0.0000195,
-    "mode": "image_generation",
-    "litellm_provider": "azure_ai"
-  },
   "azure_ai/Llama-3.2-11B-Vision-Instruct": {
     "max_input_tokens": 128000,
     "max_output_tokens": 2048,
@@ -3818,6 +3216,32 @@
     "mode": "chat",
     "litellm_provider": "azure_ai",
     "supports_vision": true
+  },
+  "azure_ai/MAI-DS-R1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000135,
+    "output_cost_per_token": 0.0000054,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2.5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.000047,
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2.5-Flash": {
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_image_token": 0.000033,
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/MAI-Image-2e": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.0000195,
+    "mode": "image_generation",
+    "litellm_provider": "azure_ai"
   },
   "azure_ai/Meta-Llama-3-70B-Instruct": {
     "max_input_tokens": 8192,
@@ -3949,6 +3373,14 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/Phi-4-mini-reasoning": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 3.2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
   "azure_ai/Phi-4-multimodal-instruct": {
     "max_input_tokens": 131072,
     "max_output_tokens": 4096,
@@ -3959,14 +3391,6 @@
     "supports_vision": true,
     "supports_audio_input": true
   },
-  "azure_ai/Phi-4-mini-reasoning": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 3.2e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
-  },
   "azure_ai/Phi-4-reasoning": {
     "max_input_tokens": 32768,
     "max_output_tokens": 4096,
@@ -3975,33 +3399,137 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/mistral-document-ai-2505": {
-    "mode": "ocr",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/mistral-document-ai-2512": {
-    "mode": "ocr",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/doc-intelligence/prebuilt-read": {
-    "mode": "ocr",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/doc-intelligence/prebuilt-layout": {
-    "mode": "ocr",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/doc-intelligence/prebuilt-document": {
-    "mode": "ocr",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/MAI-DS-R1": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000135,
-    "output_cost_per_token": 0.0000054,
+  "azure_ai/claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
     "mode": "chat",
-    "litellm_provider": "azure_ai"
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-haiku-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-1": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-sonnet-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "azure_ai/cohere-rerank-v3-english": {
     "max_input_tokens": 4096,
@@ -4027,14 +3555,6 @@
     "mode": "rerank",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/cohere-rerank-v4.0-pro": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "azure_ai"
-  },
   "azure_ai/cohere-rerank-v4.0-fast": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
@@ -4043,20 +3563,12 @@
     "mode": "rerank",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/deepseek-v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 5.8e-7,
-    "output_cost_per_token": 0.00000168,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/deepseek-v3.2-speciale": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 5.8e-7,
-    "output_cost_per_token": 0.00000168,
-    "mode": "chat",
+  "azure_ai/cohere-rerank-v4.0-pro": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
     "litellm_provider": "azure_ai"
   },
   "azure_ai/deepseek-r1": {
@@ -4091,11 +3603,19 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/deepseek-v4-pro": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 384000,
-    "input_cost_per_token": 0.00000174,
-    "output_cost_per_token": 0.00000348,
+  "azure_ai/deepseek-v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 5.8e-7,
+    "output_cost_per_token": 0.00000168,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/deepseek-v3.2-speciale": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 5.8e-7,
+    "output_cost_per_token": 0.00000168,
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
@@ -4107,11 +3627,35 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 0.00000174,
+    "output_cost_per_token": 0.00000348,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/doc-intelligence/prebuilt-document": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/doc-intelligence/prebuilt-layout": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/doc-intelligence/prebuilt-read": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
   "azure_ai/embed-v-4-0": {
     "max_input_tokens": 128000,
     "input_cost_per_token": 1.2e-7,
     "output_cost_per_token": 0,
     "mode": "embedding",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/flux.2-pro": {
+    "mode": "image_generation",
     "litellm_provider": "azure_ai"
   },
   "azure_ai/global/grok-3": {
@@ -4127,6 +3671,124 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.00000127,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-mini-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-nano-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "azure_ai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
@@ -4154,15 +3816,21 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/grok-4.3": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
+  "azure_ai/grok-4-1-fast-non-reasoning": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
     "mode": "chat",
-    "litellm_provider": "azure_ai",
-    "supports_vision": true
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/grok-4-1-fast-reasoning": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
   },
   "azure_ai/grok-4-fast-non-reasoning": {
     "max_input_tokens": 131072,
@@ -4180,21 +3848,15 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/grok-4-1-fast-non-reasoning": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
+  "azure_ai/grok-4.3": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
     "mode": "chat",
-    "litellm_provider": "azure_ai"
-  },
-  "azure_ai/grok-4-1-fast-reasoning": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
+    "litellm_provider": "azure_ai",
+    "supports_vision": true
   },
   "azure_ai/grok-code-fast-1": {
     "max_input_tokens": 131072,
@@ -4247,6 +3909,14 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
+  "azure_ai/mistral-document-ai-2505": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
+  "azure_ai/mistral-document-ai-2512": {
+    "mode": "ocr",
+    "litellm_provider": "azure_ai"
+  },
   "azure_ai/mistral-large": {
     "max_input_tokens": 32000,
     "max_output_tokens": 8191,
@@ -4263,14 +3933,6 @@
     "mode": "chat",
     "litellm_provider": "azure_ai"
   },
-  "azure_ai/mistral-large-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000006,
-    "mode": "chat",
-    "litellm_provider": "azure_ai"
-  },
   "azure_ai/mistral-large-3": {
     "max_input_tokens": 256000,
     "max_output_tokens": 8191,
@@ -4279,6 +3941,14 @@
     "mode": "chat",
     "litellm_provider": "azure_ai",
     "supports_vision": true
+  },
+  "azure_ai/mistral-large-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
   },
   "azure_ai/mistral-medium-2505": {
     "max_input_tokens": 131072,
@@ -4313,6 +3983,12 @@
     "litellm_provider": "azure_ai",
     "supports_vision": true
   },
+  "azure_ai/model_router": {
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "azure_ai"
+  },
   "babbage-002": {
     "max_input_tokens": 16384,
     "max_output_tokens": 4096,
@@ -4320,6 +3996,72 @@
     "output_cost_per_token": 4e-7,
     "mode": "completion",
     "litellm_provider": "text-completion-openai"
+  },
+  "baseten/MiniMaxAI/MiniMax-M2.5": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/deepseek-ai/DeepSeek-V3-0324": {
+    "input_cost_per_token": 7.7e-7,
+    "output_cost_per_token": 7.7e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/deepseek-ai/DeepSeek-V3.1": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2-Instruct-0905": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2-Thinking": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/moonshotai/Kimi-K2.5": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/nvidia/Nemotron-120B-A12B": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/openai/gpt-oss-120b": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-4.6": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-4.7": {
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "baseten"
+  },
+  "baseten/zai-org/GLM-5": {
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.00000315,
+    "mode": "chat",
+    "litellm_provider": "baseten"
   },
   "bedrock/*/1-month-commitment/cohere.command-light-text-v14": {
     "max_input_tokens": 4096,
@@ -4343,10 +4085,6 @@
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
     "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/guardrails": {
-    "mode": "guardrail",
     "litellm_provider": "bedrock"
   },
   "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
@@ -4458,23 +4196,13 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/moonshotai.kimi-k2-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 7.3e-7,
-    "output_cost_per_token": 0.00000303,
+  "bedrock/ap-south-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
     "mode": "chat",
     "litellm_provider": "bedrock"
-  },
-  "bedrock/moonshotai.kimi-k2.5": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.00000303,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_vision": true,
-    "supports_video_input": true
   },
   "bedrock/ap-south-1/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
@@ -4489,14 +4217,6 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 3.6e-7,
     "output_cost_per_token": 7.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/ap-south-1/deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 7.4e-7,
-    "output_cost_per_token": 0.00000222,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -4606,39 +4326,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/eu-north-1/deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 7.4e-7,
-    "output_cost_per_token": 0.00000222,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/eu-north-1/minimax.minimax-m2.1": {
-    "max_input_tokens": 196000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.6e-7,
-    "output_cost_per_token": 0.00000144,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/eu-north-1/minimax.minimax-m2.5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.6e-7,
-    "output_cost_per_token": 0.00000144,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/eu-north-1/moonshotai.kimi-k2.5": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 7.2e-7,
-    "output_cost_per_token": 0.0000036,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_vision": true
-  },
   "bedrock/eu-central-1/1-month-commitment/anthropic.claude-instant-v1": {
     "max_input_tokens": 100000,
     "max_output_tokens": 8191,
@@ -4716,6 +4403,63 @@
     "litellm_provider": "bedrock"
   },
   "bedrock/eu-central-1/qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-north-1/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true
+  },
+  "bedrock/eu-south-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-south-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.6e-7,
+    "output_cost_per_token": 0.00000144,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/eu-south-1/qwen.qwen3-coder-next": {
     "max_input_tokens": 262144,
     "max_output_tokens": 8192,
     "input_cost_per_token": 6e-7,
@@ -4827,28 +4571,8 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/eu-south-1/minimax.minimax-m2.1": {
-    "max_input_tokens": 196000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.6e-7,
-    "output_cost_per_token": 0.00000144,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/eu-south-1/minimax.minimax-m2.5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.6e-7,
-    "output_cost_per_token": 0.00000144,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/eu-south-1/qwen.qwen3-coder-next": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.00000144,
-    "mode": "chat",
+  "bedrock/guardrails": {
+    "mode": "guardrail",
     "litellm_provider": "bedrock"
   },
   "bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0": {
@@ -4861,6 +4585,32 @@
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_vision": true
+  },
+  "bedrock/moonshotai.kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 7.3e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.00000303,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "bedrock/sa-east-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
   },
   "bedrock/sa-east-1/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
@@ -4875,14 +4625,6 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.00000101,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/sa-east-1/deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 7.4e-7,
-    "output_cost_per_token": 0.00000222,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -4987,6 +4729,14 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/us-east-1/deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/us-east-1/meta.llama3-70b-instruct-v1:0": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -5000,6 +4750,22 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/minimax.minimax-m2.1": {
+    "max_input_tokens": 196000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/minimax.minimax-m2.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -5027,30 +4793,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/us-east-1/deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 6.2e-7,
-    "output_cost_per_token": 0.00000185,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-east-1/minimax.minimax-m2.1": {
-    "max_input_tokens": 196000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-east-1/minimax.minimax-m2.5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
   "bedrock/us-east-1/moonshotai.kimi-k2-thinking": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
@@ -5073,6 +4815,14 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-east-1/zai.glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -5197,6 +4947,18 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "bedrock/us-gov-east-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000006,
+    "cache_creation_input_token_cost": 0.0000015,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "bedrock/us-gov-east-1/anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -5287,7 +5049,7 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
+  "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.0000036,
@@ -5299,7 +5061,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "bedrock/us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0": {
+  "bedrock/us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
     "input_cost_per_token": 0.0000036,
@@ -5318,6 +5080,18 @@
     "output_cost_per_token": 0.0000015,
     "cache_creation_input_token_cost": 3.75e-7,
     "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "bedrock/us-gov-west-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000006,
+    "cache_creation_input_token_cost": 0.0000015,
+    "cache_read_input_token_cost": 1.2e-7,
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true,
@@ -5441,30 +5215,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
-  "bedrock/us-west-2/mistral.mistral-7b-instruct-v0:2": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-west-2/mistral.mistral-large-2402-v1:0": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 0.000008,
-    "output_cost_per_token": 0.000024,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 4.5e-7,
-    "output_cost_per_token": 7e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
   "bedrock/us-west-2/deepseek.v3.2": {
     "max_input_tokens": 163840,
     "max_output_tokens": 163840,
@@ -5486,6 +5236,30 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 3e-7,
     "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/mistral.mistral-7b-instruct-v0:2": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/mistral.mistral-large-2402-v1:0": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 0.000008,
+    "output_cost_per_token": 0.000024,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
+  "bedrock/us-west-2/mistral.mixtral-8x7b-instruct-v0:1": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 7e-7,
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
@@ -5514,6 +5288,14 @@
     "mode": "chat",
     "litellm_provider": "bedrock"
   },
+  "bedrock/us-west-2/zai.glm-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "mode": "chat",
+    "litellm_provider": "bedrock"
+  },
   "bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -5525,19 +5307,159 @@
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
   },
-  "black_forest_labs/flux-kontext-pro": {
-    "mode": "image_edit",
+  "bedrock_mantle/google.gemma-4-26b-a4b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/google.gemma-4-31b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/google.gemma-4-e2b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.4": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000275,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 2.75e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.5": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 2.75e-7,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "responses",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/openai.gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-safeguard-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/openai.gpt-oss-safeguard-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle"
+  },
+  "bedrock_mantle/xai.grok-4.3": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "bedrock_mantle/xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_mantle",
+    "supports_vision": true
+  },
+  "black_forest_labs/flux-dev": {
+    "mode": "image_generation",
     "litellm_provider": "black_forest_labs"
   },
   "black_forest_labs/flux-kontext-max": {
     "mode": "image_edit",
     "litellm_provider": "black_forest_labs"
   },
-  "black_forest_labs/flux-pro-1.0-fill": {
+  "black_forest_labs/flux-kontext-pro": {
     "mode": "image_edit",
     "litellm_provider": "black_forest_labs"
   },
+  "black_forest_labs/flux-pro": {
+    "mode": "image_generation",
+    "litellm_provider": "black_forest_labs"
+  },
   "black_forest_labs/flux-pro-1.0-expand": {
+    "mode": "image_edit",
+    "litellm_provider": "black_forest_labs"
+  },
+  "black_forest_labs/flux-pro-1.0-fill": {
     "mode": "image_edit",
     "litellm_provider": "black_forest_labs"
   },
@@ -5549,13 +5471,13 @@
     "mode": "image_generation",
     "litellm_provider": "black_forest_labs"
   },
-  "black_forest_labs/flux-dev": {
-    "mode": "image_generation",
-    "litellm_provider": "black_forest_labs"
-  },
-  "black_forest_labs/flux-pro": {
-    "mode": "image_generation",
-    "litellm_provider": "black_forest_labs"
+  "cerebras/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "cerebras"
   },
   "cerebras/llama-3.3-70b": {
     "max_input_tokens": 128000,
@@ -5578,14 +5500,6 @@
     "max_output_tokens": 128000,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "cerebras"
-  },
-  "cerebras/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 7.5e-7,
     "mode": "chat",
     "litellm_provider": "cerebras"
   },
@@ -5613,6 +5527,17 @@
     "mode": "chat",
     "litellm_provider": "cerebras"
   },
+  "chat-latest": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "chatdolphin": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
@@ -5631,36 +5556,81 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gpt-4o-transcribe-diarize": {
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "audio_transcription",
+  "chatgpt-image-latest": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_image_token": 0.00004,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
     "litellm_provider": "openai"
   },
-  "claude-haiku-4-5-20251001": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
+  "chatgpt/gpt-5.1-codex-max": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
     "supports_vision": true
   },
-  "claude-haiku-4-5": {
-    "max_input_tokens": 200000,
+  "chatgpt/gpt-5.1-codex-mini": {
+    "max_input_tokens": 128000,
     "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.2": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.2-codex": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-codex": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-codex-spark": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.3-instant": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
+    "supports_vision": true
+  },
+  "chatgpt/gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "mode": "responses",
+    "litellm_provider": "chatgpt",
     "supports_vision": true
   },
   "claude-3-7-sonnet-20250219": {
@@ -5725,75 +5695,63 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-sonnet-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-sonnet-4-5-20250929": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-sonnet-5": {
+  "claude-fable-5": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
     "mode": "chat",
     "litellm_provider": "anthropic",
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-sonnet-4-6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-sonnet-4-5-20250929-v1:0": {
+  "claude-haiku-4-5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
-    "litellm_provider": "bedrock",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-haiku-4-5-20251001": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-mythos-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-mythos-preview": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
     "supports_pdf_input": true,
     "supports_vision": true
   },
@@ -5833,7 +5791,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-opus-4-5-20251101": {
+  "claude-opus-4-5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 0.000005,
@@ -5845,7 +5803,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-opus-4-5": {
+  "claude-opus-4-5-20251101": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 0.000005,
@@ -5905,19 +5863,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-fable-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-opus-5": {
+  "claude-opus-4-8": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.000005,
@@ -5929,7 +5875,7 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "claude-opus-4-8": {
+  "claude-opus-5": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.000005,
@@ -5957,6 +5903,134 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "claude-sonnet-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-4-5-20250929": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "anthropic",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.51e-7,
+    "output_cost_per_token": 5.55e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "max_input_tokens": 80000,
+    "max_output_tokens": 80000,
+    "input_cost_per_token": 4.97e-7,
+    "output_cost_per_token": 0.000004881,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/google/gemma-2b-it-lora": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/google/gemma-4-26b-a4b-it": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/google/gemma-7b-it-lora": {
+    "max_input_tokens": 3500,
+    "max_output_tokens": 3500,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
+    "max_input_tokens": 131000,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 1.7e-8,
+    "output_cost_per_token": 1.12e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta-llama/llama-2-7b-chat-hf-lora": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
   "cloudflare/@cf/meta/llama-2-7b-chat-fp16": {
     "max_input_tokens": 3072,
     "max_output_tokens": 3072,
@@ -5973,198 +6047,11 @@
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
-  "cloudflare/@cf/mistral/mistral-7b-instruct-v0.1": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000001923,
-    "output_cost_per_token": 0.000001923,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@hf/thebloke/codellama-7b-instruct-awq": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000001923,
-    "output_cost_per_token": 0.000001923,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/openai/gpt-oss-120b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 7.5e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/google/gemma-2b-it-lora": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/meta/llama-3.2-3b-instruct": {
-    "max_input_tokens": 80000,
-    "max_output_tokens": 80000,
-    "input_cost_per_token": 5.09e-8,
-    "output_cost_per_token": 3.35e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/meta/llama-guard-3-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 4.84e-7,
-    "output_cost_per_token": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/mistral/mistral-7b-instruct-v0.2-lora": {
-    "max_input_tokens": 15000,
-    "max_output_tokens": 15000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/moonshotai/kimi-k2.7-code": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 9.5e-7,
-    "output_cost_per_token": 0.000004,
-    "cache_read_input_token_cost": 1.9e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
-    "max_input_tokens": 80000,
-    "max_output_tokens": 80000,
-    "input_cost_per_token": 4.97e-7,
-    "output_cost_per_token": 0.000004881,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
   "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": {
     "max_input_tokens": 32000,
     "max_output_tokens": 32000,
     "input_cost_per_token": 1.52e-7,
     "output_cost_per_token": 2.87e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/meta/llama-3.2-1b-instruct": {
-    "max_input_tokens": 60000,
-    "max_output_tokens": 60000,
-    "input_cost_per_token": 2.7e-8,
-    "output_cost_per_token": 2.01e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/moonshotai/kimi-k2.6": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 9.5e-7,
-    "output_cost_per_token": 0.000004,
-    "cache_read_input_token_cost": 1.6e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/zai-org/glm-4.7-flash": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 6.05e-8,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/meta-llama/llama-2-7b-chat-hf-lora": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
-    "max_input_tokens": 24000,
-    "max_output_tokens": 24000,
-    "input_cost_per_token": 2.93e-7,
-    "output_cost_per_token": 0.000002253,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
-    "max_input_tokens": 131000,
-    "max_output_tokens": 131000,
-    "input_cost_per_token": 1.7e-8,
-    "output_cost_per_token": 1.12e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 6.6e-7,
-    "output_cost_per_token": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/zai-org/glm-5.2": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.0000014,
-    "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 2.6e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 3.51e-7,
-    "output_cost_per_token": 5.55e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5.09e-8,
-    "output_cost_per_token": 3.35e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/google/gemma-7b-it-lora": {
-    "max_input_tokens": 3500,
-    "max_output_tokens": 3500,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/google/gemma-4-26b-a4b-it": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "cloudflare"
-  },
-  "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 3.51e-7,
-    "output_cost_per_token": 5.55e-7,
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
@@ -6177,11 +6064,27 @@
     "litellm_provider": "cloudflare",
     "supports_vision": true
   },
-  "cloudflare/@cf/openai/gpt-oss-20b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 3e-7,
+  "cloudflare/@cf/meta/llama-3.2-1b-instruct": {
+    "max_input_tokens": 60000,
+    "max_output_tokens": 60000,
+    "input_cost_per_token": 2.7e-8,
+    "output_cost_per_token": 2.01e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-3.2-3b-instruct": {
+    "max_input_tokens": 80000,
+    "max_output_tokens": 80000,
+    "input_cost_per_token": 5.09e-8,
+    "output_cost_per_token": 3.35e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+    "max_input_tokens": 24000,
+    "max_output_tokens": 24000,
+    "input_cost_per_token": 2.93e-7,
+    "output_cost_per_token": 0.000002253,
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
@@ -6193,11 +6096,126 @@
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
+  "cloudflare/@cf/meta/llama-guard-3-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 4.84e-7,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/mistral/mistral-7b-instruct-v0.1": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000001923,
+    "output_cost_per_token": 0.000001923,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/mistral/mistral-7b-instruct-v0.2-lora": {
+    "max_input_tokens": 15000,
+    "max_output_tokens": 15000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.51e-7,
+    "output_cost_per_token": 5.55e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/moonshotai/kimi-k2.6": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.6e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/moonshotai/kimi-k2.7-code": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/openai/gpt-oss-120b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/openai/gpt-oss-20b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6.6e-7,
+    "output_cost_per_token": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5.09e-8,
+    "output_cost_per_token": 3.35e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
   "cloudflare/@cf/qwen/qwq-32b": {
     "max_input_tokens": 24000,
     "max_output_tokens": 24000,
     "input_cost_per_token": 6.6e-7,
     "output_cost_per_token": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/zai-org/glm-4.7-flash": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6.05e-8,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@cf/zai-org/glm-5.2": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 2.6e-7,
+    "mode": "chat",
+    "litellm_provider": "cloudflare"
+  },
+  "cloudflare/@hf/thebloke/codellama-7b-instruct-awq": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000001923,
+    "output_cost_per_token": 0.000001923,
     "mode": "chat",
     "litellm_provider": "cloudflare"
   },
@@ -6227,6 +6245,27 @@
     "litellm_provider": "openai",
     "supports_pdf_input": true,
     "supports_vision": true
+  },
+  "cognition/swe-1.6": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "cognition"
+  },
+  "cognition/swe-1.7": {
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "cognition"
+  },
+  "cognition/swe-1.7-lightning": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "cognition"
   },
   "cohere.command-light-text-v14": {
     "max_input_tokens": 4096,
@@ -6281,13 +6320,6 @@
     "mode": "embedding",
     "litellm_provider": "bedrock"
   },
-  "cohere/embed-v4.0": {
-    "max_input_tokens": 128000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "cohere"
-  },
   "cohere.rerank-v3-5:0": {
     "max_input_tokens": 32000,
     "max_output_tokens": 32000,
@@ -6295,6 +6327,13 @@
     "output_cost_per_token": 0,
     "mode": "rerank",
     "litellm_provider": "bedrock"
+  },
+  "cohere/embed-v4.0": {
+    "max_input_tokens": 128000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "cohere"
   },
   "command": {
     "max_input_tokens": 4096,
@@ -6377,6 +6416,63 @@
     "litellm_provider": "azure",
     "supports_vision": true
   },
+  "crusoe/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/deepseek-ai/DeepSeek-R1-0528": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000007,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/deepseek-ai/DeepSeek-V3-0324": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/google/gemma-3-12b-it": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe",
+    "supports_vision": true
+  },
+  "crusoe/meta-llama/Llama-3.3-70B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/moonshotai/Kimi-K2-Thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
+  "crusoe/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "crusoe"
+  },
   "dall-e-2": {
     "mode": "image_generation",
     "litellm_provider": "openai"
@@ -6385,23 +6481,21 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
-  "deepseek-chat": {
+  "darkbloom/gemma-4-26b": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 4.2e-7,
-    "cache_read_input_token_cost": 2.8e-8,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 1.65e-7,
     "mode": "chat",
-    "litellm_provider": "deepseek"
+    "litellm_provider": "darkbloom"
   },
-  "deepseek-reasoner": {
+  "darkbloom/gpt-oss-20b": {
     "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 4.2e-7,
-    "cache_read_input_token_cost": 2.8e-8,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.45e-8,
+    "output_cost_per_token": 7e-8,
     "mode": "chat",
-    "litellm_provider": "deepseek"
+    "litellm_provider": "darkbloom"
   },
   "dashscope/deepseek-v4-flash": {
     "max_input_tokens": 1000000,
@@ -6476,6 +6570,14 @@
     "max_input_tokens": 997952,
     "max_output_tokens": 32768,
     "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen-image-2.0": {
+    "mode": "image_generation",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen-image-2.0-pro": {
+    "mode": "image_generation",
     "litellm_provider": "dashscope"
   },
   "dashscope/qwen-max": {
@@ -6598,12 +6700,6 @@
     "mode": "chat",
     "litellm_provider": "dashscope"
   },
-  "dashscope/qwen3-max-preview": {
-    "max_input_tokens": 258048,
-    "max_output_tokens": 65536,
-    "mode": "chat",
-    "litellm_provider": "dashscope"
-  },
   "dashscope/qwen3-max": {
     "max_input_tokens": 258048,
     "max_output_tokens": 65536,
@@ -6611,6 +6707,12 @@
     "litellm_provider": "dashscope"
   },
   "dashscope/qwen3-max-2026-01-23": {
+    "max_input_tokens": 258048,
+    "max_output_tokens": 65536,
+    "mode": "chat",
+    "litellm_provider": "dashscope"
+  },
+  "dashscope/qwen3-max-preview": {
     "max_input_tokens": 258048,
     "max_output_tokens": 65536,
     "mode": "chat",
@@ -6714,14 +6816,6 @@
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 0.0000024,
     "mode": "chat",
-    "litellm_provider": "dashscope"
-  },
-  "dashscope/qwen-image-2.0": {
-    "mode": "image_generation",
-    "litellm_provider": "dashscope"
-  },
-  "dashscope/qwen-image-2.0-pro": {
-    "mode": "image_generation",
     "litellm_provider": "dashscope"
   },
   "databricks/databricks-bge-large-en": {
@@ -7069,6 +7163,40 @@
     "output_cost_per_token": 0.000002,
     "mode": "completion",
     "litellm_provider": "text-completion-openai"
+  },
+  "daybreak-blue-latest": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "daybreak-red-latest": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000125,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.000015625,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "deep-research-pro-preview-12-2025": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
   },
   "deepgram/base": {
     "mode": "audio_transcription",
@@ -7763,6 +7891,70 @@
     "mode": "chat",
     "litellm_provider": "deepinfra"
   },
+  "deepseek-chat": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 4.2e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek"
+  },
+  "deepseek-reasoner": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 4.2e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek"
+  },
+  "deepseek-v3-2-251201": {
+    "max_input_tokens": 98304,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "volcengine"
+  },
+  "deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 4.4e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 4.4e-8,
+    "mode": "chat",
+    "litellm_provider": "deepseek",
+    "supports_vision": false
+  },
+  "deepseek.v3-v1:0": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 81920,
+    "input_cost_per_token": 5.8e-7,
+    "output_cost_per_token": 0.00000168,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 0.00000185,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
   "deepseek/deepseek-chat": {
     "max_input_tokens": 131072,
     "max_output_tokens": 8192,
@@ -7816,21 +8008,27 @@
     "mode": "chat",
     "litellm_provider": "deepseek"
   },
-  "deepseek.v3-v1:0": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 81920,
-    "input_cost_per_token": 5.8e-7,
-    "output_cost_per_token": 0.00000168,
+  "deepseek/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 4.4e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 1.4e-8,
     "mode": "chat",
-    "litellm_provider": "bedrock_converse"
+    "litellm_provider": "deepseek",
+    "supports_vision": false
   },
-  "deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 6.2e-7,
-    "output_cost_per_token": 0.00000185,
+  "deepseek/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 393216,
+    "input_cost_per_token": 0.00000132,
+    "output_cost_per_token": 0.00000396,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 4.4e-8,
     "mode": "chat",
-    "litellm_provider": "bedrock_converse"
+    "litellm_provider": "deepseek",
+    "supports_vision": false
   },
   "dolphin": {
     "max_input_tokens": 16384,
@@ -7839,30 +8037,6 @@
     "output_cost_per_token": 5e-7,
     "mode": "completion",
     "litellm_provider": "nlp_cloud"
-  },
-  "deepseek-v3-2-251201": {
-    "max_input_tokens": 98304,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "volcengine"
-  },
-  "glm-4-7-251222": {
-    "max_input_tokens": 204800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "volcengine"
-  },
-  "kimi-k2-thinking-251104": {
-    "max_input_tokens": 229376,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "volcengine"
   },
   "doubao-embedding": {
     "max_input_tokens": 4096,
@@ -7899,45 +8073,17 @@
     "mode": "embedding",
     "litellm_provider": "volcengine"
   },
-  "exa_ai/search": {
+  "duckduckgo/search": {
     "mode": "search",
-    "litellm_provider": "exa_ai"
+    "litellm_provider": "duckduckgo"
   },
-  "firecrawl/search": {
-    "mode": "search",
-    "litellm_provider": "firecrawl"
+  "elevenlabs/eleven_multilingual_v2": {
+    "mode": "audio_speech",
+    "litellm_provider": "elevenlabs"
   },
-  "perplexity/search": {
-    "mode": "search",
-    "litellm_provider": "perplexity"
-  },
-  "searxng/search": {
-    "mode": "search",
-    "litellm_provider": "searxng"
-  },
-  "serper/search": {
-    "mode": "search",
-    "litellm_provider": "serper"
-  },
-  "apiserpent/search": {
-    "mode": "search",
-    "litellm_provider": "apiserpent"
-  },
-  "apiserpent/deep_search": {
-    "mode": "search",
-    "litellm_provider": "apiserpent"
-  },
-  "agentcore/search": {
-    "mode": "search",
-    "litellm_provider": "agentcore"
-  },
-  "tinyfish/search": {
-    "mode": "search",
-    "litellm_provider": "tinyfish"
-  },
-  "nimble/search": {
-    "mode": "search",
-    "litellm_provider": "nimble"
+  "elevenlabs/eleven_v3": {
+    "mode": "audio_speech",
+    "litellm_provider": "elevenlabs"
   },
   "elevenlabs/scribe_v1": {
     "mode": "audio_transcription",
@@ -7945,14 +8091,6 @@
   },
   "elevenlabs/scribe_v1_experimental": {
     "mode": "audio_transcription",
-    "litellm_provider": "elevenlabs"
-  },
-  "elevenlabs/eleven_v3": {
-    "mode": "audio_speech",
-    "litellm_provider": "elevenlabs"
-  },
-  "elevenlabs/eleven_multilingual_v2": {
-    "mode": "audio_speech",
     "litellm_provider": "elevenlabs"
   },
   "embed-english-light-v2.0": {
@@ -7983,6 +8121,13 @@
     "mode": "embedding",
     "litellm_provider": "cohere"
   },
+  "embed-multilingual-light-v3.0": {
+    "max_input_tokens": 1024,
+    "input_cost_per_token": 0.0001,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "cohere"
+  },
   "embed-multilingual-v2.0": {
     "max_input_tokens": 768,
     "input_cost_per_token": 1e-7,
@@ -7997,12 +8142,29 @@
     "mode": "embedding",
     "litellm_provider": "cohere"
   },
-  "embed-multilingual-light-v3.0": {
-    "max_input_tokens": 1024,
-    "input_cost_per_token": 0.0001,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "cohere"
+  "eu.amazon.nova-2-lite-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 3.3e-7,
+    "output_cost_per_token": 0.00000275,
+    "cache_read_input_token_cost": 8.25e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "eu.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
   },
   "eu.amazon.nova-lite-v1:0": {
     "max_input_tokens": 300000,
@@ -8042,18 +8204,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
-  },
-  "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000055,
-    "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
   },
   "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "max_input_tokens": 200000,
@@ -8126,6 +8276,30 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "eu.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000011,
+    "output_cost_per_token": 0.000055,
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_read_input_token_cost": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000055,
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "eu.anthropic.claude-opus-4-1-20250805-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 32000,
@@ -8145,6 +8319,66 @@
     "output_cost_per_token": 0.000075,
     "cache_creation_input_token_cost": 0.00001875,
     "cache_read_input_token_cost": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -8182,6 +8416,38 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "eu.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "eu.deepseek.v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 7.4e-7,
+    "output_cost_per_token": 0.00000222,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
   "eu.meta.llama3-2-1b-instruct-v1:0": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
@@ -8206,7 +8472,32 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "eu.twelvelabs.marengo-embed-2-7-v1:0": {
+    "max_input_tokens": 77,
+    "input_cost_per_token": 0.00007,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock"
+  },
+  "eu.twelvelabs.pegasus-1-2-v1:0": {
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_video_input": true
+  },
+  "exa_ai/search": {
+    "mode": "search",
+    "litellm_provider": "exa_ai"
+  },
   "fal_ai/bria/text-to-image/3.2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai"
+  },
+  "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai"
+  },
+  "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
@@ -8222,11 +8513,7 @@
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
-  "fal_ai/fal-ai/bytedance/seedream/v3/text-to-image": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai"
-  },
-  "fal_ai/fal-ai/bytedance/dreamina/v3.1/text-to-image": {
+  "fal_ai/fal-ai/gemini-25-flash-image": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
@@ -8246,6 +8533,10 @@
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
+  "fal_ai/fal-ai/nano-banana": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai"
+  },
   "fal_ai/fal-ai/recraft/v3/text-to-image": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
@@ -8254,175 +8545,7 @@
     "mode": "image_generation",
     "litellm_provider": "fal_ai"
   },
-  "fal_ai/fal-ai/nano-banana": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai"
-  },
-  "fal_ai/fal-ai/gemini-25-flash-image": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai"
-  },
-  "fal_ai/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-768/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1024/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1536/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1920-x-1080/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/2560-x-1440/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/3840-x-2160/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-768/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1024/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1536/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1920-x-1080/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/2560-x-1440/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/3840-x-2160/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1024-x-768/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1024-x-1024/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1024-x-1536/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1920-x-1080/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/2560-x-1440/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/3840-x-2160/openai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
   "fal_ai/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-768/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1024/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1536/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1920-x-1080/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/2560-x-1440/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/3840-x-2160/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-768/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1024/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1536/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1920-x-1080/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/2560-x-1440/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/3840-x-2160/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1024-x-768/gpt-image-2": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai",
     "supports_vision": true
@@ -8432,92 +8555,7 @@
     "litellm_provider": "fal_ai",
     "supports_vision": true
   },
-  "fal_ai/high/1024-x-1536/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1920-x-1080/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/2560-x-1440/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/3840-x-2160/gpt-image-2": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-768/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1024/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1024-x-1536/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/1920-x-1080/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/2560-x-1440/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/low/3840-x-2160/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-768/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1024/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1024-x-1536/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/1920-x-1080/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/2560-x-1440/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/medium/3840-x-2160/openai/gpt-image-2/edit": {
-    "mode": "image_generation",
-    "litellm_provider": "fal_ai",
-    "supports_vision": true
-  },
-  "fal_ai/high/1024-x-768/openai/gpt-image-2/edit": {
+  "fal_ai/high/1024-x-1024/openai/gpt-image-2": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai",
     "supports_vision": true
@@ -8527,7 +8565,42 @@
     "litellm_provider": "fal_ai",
     "supports_vision": true
   },
+  "fal_ai/high/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
   "fal_ai/high/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/1920-x-1080/openai/gpt-image-2": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai",
     "supports_vision": true
@@ -8537,7 +8610,27 @@
     "litellm_provider": "fal_ai",
     "supports_vision": true
   },
+  "fal_ai/high/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
   "fal_ai/high/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/high/3840-x-2160/openai/gpt-image-2": {
     "mode": "image_generation",
     "litellm_provider": "fal_ai",
     "supports_vision": true
@@ -8547,6 +8640,197 @@
     "litellm_provider": "fal_ai",
     "supports_vision": true
   },
+  "fal_ai/low/1024-x-1024/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1024/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1024/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/1920-x-1080/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/low/3840-x-2160/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1024/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-1536/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1024-x-768/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/1920-x-1080/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/2560-x-1440/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/medium/3840-x-2160/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/openai/gpt-image-2": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fal_ai/openai/gpt-image-2/edit": {
+    "mode": "image_generation",
+    "litellm_provider": "fal_ai",
+    "supports_vision": true
+  },
+  "fallback_generalizations": {},
   "featherless_ai/featherless-ai/Qwerky-72B": {
     "max_input_tokens": 32768,
     "max_output_tokens": 4096,
@@ -8558,6 +8842,10 @@
     "max_output_tokens": 4096,
     "mode": "chat",
     "litellm_provider": "featherless_ai"
+  },
+  "firecrawl/search": {
+    "mode": "search",
+    "litellm_provider": "firecrawl"
   },
   "fireworks-ai-4.1b-to-16b": {
     "input_cost_per_token": 2e-7,
@@ -8606,9 +8894,273 @@
     "mode": "embedding",
     "litellm_provider": "fireworks_ai-embedding-models"
   },
+  "fireworks_ai/accounts/fireworks/models/": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/SSD-1B": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1.3e-10,
+    "output_cost_per_token": 1.3e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/chronos-hermes-13b-v2": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-13b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-13b-instruct": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-13b-python": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-34b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-34b-instruct": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-34b-python": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-70b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-70b-instruct": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-70b-python": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-7b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-7b-instruct": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-llama-7b-python": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/code-qwen-1p5-7b": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/codegemma-2b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/codegemma-7b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-671b-v2-p1": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-70b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/dbrx-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-1b-base": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-33b-instruct": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-instruct": {
     "max_input_tokens": 65536,
     "max_output_tokens": 65536,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-base": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-prover-v2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
     "input_cost_per_token": 0.0000012,
     "output_cost_per_token": 0.0000012,
     "mode": "chat",
@@ -8630,11 +9182,83 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/deepseek-r1-basic": {
     "max_input_tokens": 128000,
     "max_output_tokens": 20480,
     "input_cost_per_token": 5.5e-7,
     "output_cost_per_token": 0.00000219,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v2-lite-chat": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v2p5": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
@@ -8688,6 +9312,16 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": false
   },
+  "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
   "fireworks_ai/accounts/fireworks/models/deepseek-v4-pro": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 384000,
@@ -8698,11 +9332,211 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": false
   },
+  "fireworks_ai/accounts/fireworks/models/devstral-small-2505": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/fare-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/firefunction-v1": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/firefunction-v2": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
     "input_cost_per_token": 9e-7,
     "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/firellava-13b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/firesearch-ocr-v6": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/fireworks-asr-large": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "audio_transcription",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/fireworks-asr-v2": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "audio_transcription",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-1-dev": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-1-dev-controlnet-union": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-9,
+    "output_cost_per_token": 1e-9,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-1-dev-fp8": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 5e-10,
+    "output_cost_per_token": 5e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-1-schnell": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-1-schnell-fp8": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 3.5e-10,
+    "output_cost_per_token": 3.5e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-kontext-max": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 8e-8,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/flux-kontext-pro": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 4e-8,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gemma-2b-it": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gemma-3-27b-it": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gemma-7b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gemma-7b-it": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gemma2-9b-it": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
@@ -8719,6 +9553,14 @@
     "max_output_tokens": 96000,
     "input_cost_per_token": 2.2e-7,
     "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/glm-4p5v": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
@@ -8779,6 +9621,86 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": false
   },
+  "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/hermes-2-pro-mistral-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/internvl3-38b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/internvl3-78b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/internvl3-8b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/japanese-stable-diffusion-xl": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1.3e-10,
+    "output_cost_per_token": 1.3e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/kat-coder": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/kat-dev-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/kat-dev-72b-exp": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/kimi-k2-instruct": {
     "max_input_tokens": 131072,
     "max_output_tokens": 16384,
@@ -8832,6 +9754,120 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
+  "fireworks_ai/accounts/fireworks/models/kimi-k3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-guard-2-8b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-guard-3-1b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-guard-3-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-13b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-13b-chat": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-70b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-70b-chat": {
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-7b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v2-7b-chat": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct-hf": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3-8b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3-8b-instruct-hf": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -8840,11 +9876,43 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/llama-v3p1-8b-instruct": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
@@ -8857,9 +9925,25 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p2-1b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/llama-v3p2-1b-instruct": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p2-3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 1e-7,
     "output_cost_per_token": 1e-7,
     "mode": "chat",
@@ -8882,6 +9966,14 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
+  "fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/llama4-maverick-instruct-basic": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -8895,6 +9987,38 @@
     "max_output_tokens": 131072,
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llamaguard-7b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/llava-yi-34b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/minimax-m1-80k": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/minimax-m2": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
@@ -8927,6 +10051,118 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
+  "fireworks_ai/accounts/fireworks/models/ministral-3-14b-instruct-2512": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/ministral-3-3b-instruct-2512": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/ministral-3-8b-instruct-2512": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-4k": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v0p2": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v3": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-7b-v0p2": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-large-3-fp8": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-nemo-base-2407": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-nemo-instruct-2407": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mistral-small-24b-instruct-2501": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mixtral-8x22b": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
     "max_input_tokens": 65536,
     "max_output_tokens": 65536,
@@ -8935,7 +10171,429 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/mythomax-l2-13b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-capybara-7b-v1p9": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-hermes-2-yi-34b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-13b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-70b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-7b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/openchat-3p5-0106-7b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/openhermes-2-mistral-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/openhermes-2p5-mistral-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/openorca-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phi-2-3b": {
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phi-3-mini-128k-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phi-3-vision-128k-instruct": {
+    "max_input_tokens": 32064,
+    "max_output_tokens": 32064,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-python-v1": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v1": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v2": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/playground-v2-1024px-aesthetic": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1.3e-10,
+    "output_cost_per_token": 1.3e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1.3e-10,
+    "output_cost_per_token": 1.3e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/pythia-12b": {
+    "max_input_tokens": 2048,
+    "max_output_tokens": 2048,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen-qwq-32b-preview": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen-v2p5-14b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen-v2p5-7b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen1p5-72b-chat": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/qwen2-72b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2-7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2-vl-2b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2-vl-72b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2-vl-7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-0p5b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-14b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-1p5b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-32b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-72b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-72b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
     "input_cost_per_token": 9e-7,
@@ -8951,6 +10609,497 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-32k-rope": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-64k": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-math-72b-instruct": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-32b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-3b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-72b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-7b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-0p6b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-14b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-131072": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-40960": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-4b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-4b-instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-8b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-embedding-0p6b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-embedding-4b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-0p6b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-4b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-8b": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 40960,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-32b-instruct": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3-vl-8b-instruct": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3p7-plus": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "cache_read_input_token_cost": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/qwen3p8-max": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/models/qwq-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/rolm-ocr": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1.3e-10,
+    "output_cost_per_token": 1.3e-10,
+    "mode": "image_generation",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/stablecode-3b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/starcoder-16b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/starcoder-7b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/starcoder2-15b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/starcoder2-3b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/starcoder2-7b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/toppy-m-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/yi-34b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/yi-34b-200k-capybara": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/yi-34b-chat": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/models/yi-6b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
   "fireworks_ai/accounts/fireworks/models/yi-large": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
@@ -8959,9 +11108,97 @@
     "mode": "chat",
     "litellm_provider": "fireworks_ai"
   },
+  "fireworks_ai/accounts/fireworks/models/zephyr-7b-beta": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai"
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p1-fast": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000028,
+    "output_cost_per_token": 0.0000088,
+    "cache_read_input_token_cost": 5.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k2p6-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k2p7-code-fast": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.0000019,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 3.8e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000045,
+    "output_cost_per_token": 0.0000225,
+    "cache_read_input_token_cost": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/accounts/fireworks/routers/kimi-k3-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
   "fireworks_ai/deepseek-v4-flash": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 384000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/deepseek-v4-flash-0731": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 1.4e-7,
     "output_cost_per_token": 2.8e-7,
     "cache_read_input_token_cost": 2.8e-8,
@@ -9014,6 +11251,26 @@
     "input_cost_per_token": 0.0000014,
     "output_cost_per_token": 0.0000044,
     "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p2-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/glm-5p2-fast-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000021,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 2.1e-7,
     "mode": "chat",
     "litellm_provider": "fireworks_ai",
     "supports_vision": false
@@ -9087,6 +11344,36 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
+  "fireworks_ai/kimi-k3": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k3-fast": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000045,
+    "output_cost_per_token": 0.0000225,
+    "cache_read_input_token_cost": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/kimi-k3-us": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
   "fireworks_ai/minimax-m2p1": {
     "max_input_tokens": 204800,
     "max_output_tokens": 204800,
@@ -9116,15 +11403,35 @@
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
   },
-  "fireworks_ai/qwen3p7-plus": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
-    "cache_read_input_token_cost": 8e-8,
+  "fireworks_ai/muse-glimmer-30b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 4e-8,
     "mode": "chat",
     "litellm_provider": "fireworks_ai",
     "supports_vision": true
+  },
+  "fireworks_ai/nemotron-3-ultra-nvfp4": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
+  },
+  "fireworks_ai/nemotron-lightning-3p5-30b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": false
   },
   "fireworks_ai/nomic-ai/nomic-embed-text-v1": {
     "max_input_tokens": 8192,
@@ -9139,6 +11446,25 @@
     "output_cost_per_token": 0,
     "mode": "embedding",
     "litellm_provider": "fireworks_ai-embedding-models"
+  },
+  "fireworks_ai/qwen3p7-plus": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
+    "cache_read_input_token_cost": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
+  },
+  "fireworks_ai/qwen3p8-max": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "fireworks_ai",
+    "supports_vision": true
   },
   "fireworks_ai/thenlper/gte-base": {
     "max_input_tokens": 512,
@@ -9226,6 +11552,33 @@
     "mode": "chat",
     "litellm_provider": "openai"
   },
+  "ft:gpt-4.1-2025-04-14": {
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000012,
+    "cache_read_input_token_cost": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai"
+  },
+  "ft:gpt-4.1-mini-2025-04-14": {
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000032,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openai"
+  },
+  "ft:gpt-4.1-nano-2025-04-14": {
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 8e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "openai"
+  },
   "ft:gpt-4o-2024-08-06": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -9257,33 +11610,6 @@
     "litellm_provider": "openai",
     "supports_pdf_input": true
   },
-  "ft:gpt-4.1-2025-04-14": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000012,
-    "cache_read_input_token_cost": 7.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "ft:gpt-4.1-mini-2025-04-14": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000032,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "ft:gpt-4.1-nano-2025-04-14": {
-    "max_input_tokens": 1047576,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 8e-7,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
   "ft:o4-mini-2025-04-16": {
     "max_input_tokens": 200000,
     "max_output_tokens": 100000,
@@ -9314,6 +11640,15 @@
     "litellm_provider": "vertex_ai-language-models",
     "supports_vision": true
   },
+  "gemini-2.0-flash-exp-image-generation": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
   "gemini-2.0-flash-lite": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 8192,
@@ -9330,6 +11665,17 @@
     "input_cost_per_token": 7.5e-8,
     "output_cost_per_token": 3e-7,
     "cache_read_input_token_cost": 1.875e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-2.5-computer-use-preview-10-2025": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_vision": true
@@ -9357,6 +11703,124 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "gemini-2.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-2.5-flash-lite-preview-06-17": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-2.5-flash-lite-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-2.5-flash-native-audio-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-2.5-flash-native-audio-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-2.5-flash-native-audio-preview-12-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini-2.5-flash-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-2.5-flash-preview-tts": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
+  },
+  "gemini-2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-2.5-pro-preview-tts": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini-3-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "gemini-3-pro-image": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
@@ -9377,6 +11841,23 @@
     "litellm_provider": "vertex_ai-language-models",
     "supports_vision": true
   },
+  "gemini-3-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
   "gemini-3.1-flash-image": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
@@ -9396,6 +11877,19 @@
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models",
     "supports_vision": true
+  },
+  "gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini-3.1-flash-lite-image": {
     "max_input_tokens": 65536,
@@ -9423,143 +11917,15 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "gemini-3.1-flash-lite": {
-    "max_input_tokens": 1048576,
+  "gemini-3.1-flash-live-preview": {
+    "max_input_tokens": 131072,
     "max_output_tokens": 65536,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2.5e-8,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-3.5-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "deep-research-pro-preview-12-2025": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "output_cost_per_image_token": 0.00012,
-    "mode": "image_generation",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini-2.5-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-2.5-flash-lite-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-2.5-flash-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-live-2.5-flash-preview-native-audio-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.000002,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "realtime",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.000002,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "realtime",
     "litellm_provider": "gemini",
-    "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true
-  },
-  "gemini-2.5-flash-lite-preview-06-17": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-2.5-pro": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-3-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
   },
   "gemini-3.1-pro-preview": {
     "max_input_tokens": 1048576,
@@ -9595,638 +11961,25 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "vertex_ai/gemini-3-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3.5-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000009,
-    "cache_read_input_token_cost": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3.6-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.00000375,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3.7-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.00000375,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3.1-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "vertex_ai/gemini-3.1-pro-preview-customtools": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-2.5-pro-preview-tts": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini-robotics-er-1.5-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini/gemini-robotics-er-1.5-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-robotics-er-2-preview": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-robotics-er-1.6-preview": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-2.5-computer-use-preview-10-2025": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true
-  },
-  "gemini-embedding-001": {
-    "max_input_tokens": 2048,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "gemini-embedding-2-preview": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "gemini-embedding-2": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-embedding-models"
-  },
-  "vertex_ai/gemini-embedding-2-preview": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai"
-  },
-  "vertex_ai/gemini-embedding-2": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai"
-  },
-  "gemini-flash-experimental": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "vertex_ai-language-models"
-  },
-  "gemini/gemini-embedding-001": {
-    "max_input_tokens": 2048,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-embedding-2-preview": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-embedding-2": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-1.5-flash": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-2.0-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "gemini/gemini-2.0-flash-001": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-2.0-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "cache_read_input_token_cost": 1.875e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-image": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "output_cost_per_image_token": 0.00003,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-3-pro-image": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "output_cost_per_image_token": 0.00012,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-3-pro-image-preview": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "output_cost_per_image_token": 0.00012,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-3.1-flash-image": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "output_cost_per_image_token": 0.00006,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-3.1-flash-image-preview": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "output_cost_per_image_token": 0.00006,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-3.1-flash-lite-image": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "output_cost_per_image_token": 0.00003,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/deep-research-pro-preview-12-2025": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "output_cost_per_image_token": 0.00012,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-lite-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-flash-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-flash-lite-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-lite-preview-06-17": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-2.5-flash-preview-tts": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "audio_speech",
-    "litellm_provider": "gemini"
-  },
-  "gemini/gemini-2.5-pro": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-2.5-computer-use-preview-10-2025": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-3-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.1-flash-lite-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.1-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.5-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-3.5-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000009,
-    "cache_read_input_token_cost": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.6-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.00000375,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.7-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.00000375,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-omni-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000009,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.1-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-3.1-pro-preview-customtools": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "input_cost_per_token_above_200k_tokens": 0.000004,
-    "output_cost_per_token_above_200k_tokens": 0.000018,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-3-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-omni-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.000009,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
   "gemini-3.5-flash": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
     "input_cost_per_token": 0.0000015,
     "output_cost_per_token": 0.000009,
     "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-3.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
     "mode": "chat",
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
@@ -10260,6 +12013,311 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
+  "gemini-embedding-001": {
+    "max_input_tokens": 2048,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "gemini-exp-1206": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-flash-experimental": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai-language-models"
+  },
+  "gemini-flash-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-flash-lite-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini-live-2.5-flash-preview-native-audio-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.000002,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "realtime",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini-omni-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-pro-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini-robotics-er-1.5-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_vision": true
+  },
+  "gemini/deep-research-pro-preview-12-2025": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-1.5-flash": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-2.0-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.0-flash-001": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.0-flash-exp-image-generation": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.0-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 1.875e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.0-flash-lite-001": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 1.875e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-computer-use-preview-10-2025": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-image": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-lite-preview-06-17": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-lite-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-2.5-flash-preview-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-2.5-flash-preview-tts": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
   "gemini/gemini-2.5-pro-preview-tts": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
@@ -10272,6 +12330,239 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_vision": true
+  },
+  "gemini/gemini-3-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-3-pro-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3-pro-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-flash-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-image-preview": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "output_cost_per_image_token": 0.00006,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-flash-lite-image": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "output_cost_per_image_token": 0.00003,
+    "mode": "image_generation",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-3.1-flash-lite-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-flash-live-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini/gemini-3.1-flash-tts-preview": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.00002,
+    "mode": "audio_speech",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-3.1-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.1-pro-preview-customtools": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.5-live-translate-preview": {
+    "input_cost_per_token": 0.0000035,
+    "output_cost_per_token": 0.000021,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_audio_input": true
+  },
+  "gemini/gemini-3.6-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-3.7-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-embedding-001": {
+    "max_input_tokens": 2048,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
+  },
+  "gemini/gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gemini"
   },
   "gemini/gemini-exp-1114": {
     "max_input_tokens": 1048576,
@@ -10291,6 +12582,28 @@
     "litellm_provider": "gemini",
     "supports_vision": true
   },
+  "gemini/gemini-flash-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gemini/gemini-flash-lite-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "gemini/gemini-gemma-2-27b-it": {
     "max_output_tokens": 8192,
     "input_cost_per_token": 3.5e-7,
@@ -10306,6 +12619,89 @@
     "mode": "chat",
     "litellm_provider": "gemini",
     "supports_vision": true
+  },
+  "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.000002,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "realtime",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "gemini/gemini-omni-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-pro-latest": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000015,
+    "cache_read_input_token_cost": 1.25e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-robotics-er-1.5-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true
+  },
+  "gemini/gemini-robotics-er-1.6-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-robotics-er-2-preview": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "gemini/gemini-robotics-er-2-streaming-preview": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "gemini",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "gemini/gemma-3-27b-it": {
     "max_input_tokens": 131072,
@@ -10374,7 +12770,17 @@
     "mode": "video_generation",
     "litellm_provider": "gemini"
   },
+  "gemini/veo-3.1-fast-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "gemini"
+  },
   "gemini/veo-3.1-fast-generate-preview": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "gemini"
+  },
+  "gemini/veo-3.1-generate-001": {
     "max_input_tokens": 1024,
     "mode": "video_generation",
     "litellm_provider": "gemini"
@@ -10389,15 +12795,52 @@
     "mode": "video_generation",
     "litellm_provider": "gemini"
   },
-  "gemini/veo-3.1-fast-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "gemini"
+  "gigachat/Embeddings": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gigachat"
   },
-  "gemini/veo-3.1-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "gemini"
+  "gigachat/Embeddings-2": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gigachat"
+  },
+  "gigachat/EmbeddingsGigaR": {
+    "max_input_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "gigachat"
+  },
+  "gigachat/GigaChat-2-Lite": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "gigachat"
+  },
+  "gigachat/GigaChat-2-Max": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "gigachat",
+    "supports_vision": true
+  },
+  "gigachat/GigaChat-2-Pro": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "gigachat",
+    "supports_vision": true
   },
   "github_copilot/claude-haiku-4.5": {
     "max_input_tokens": 128000,
@@ -10617,146 +13060,222 @@
     "mode": "embedding",
     "litellm_provider": "github_copilot"
   },
-  "chatgpt/gpt-5.4": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.4-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.3-codex": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.3-codex-spark": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.3-instant": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.3-chat-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.2-codex": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.2": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.1-codex-max": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "chatgpt/gpt-5.1-codex-mini": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 64000,
-    "mode": "responses",
-    "litellm_provider": "chatgpt",
-    "supports_vision": true
-  },
-  "gigachat/GigaChat-2-Lite": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
+  "glm-4-7-251222": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
     "input_cost_per_token": 0,
     "output_cost_per_token": 0,
     "mode": "chat",
-    "litellm_provider": "gigachat"
+    "litellm_provider": "volcengine"
   },
-  "gigachat/GigaChat-2-Max": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
+  "global.amazon.nova-2-lite-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 7.5e-8,
     "mode": "chat",
-    "litellm_provider": "gigachat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "global.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gigachat/GigaChat-2-Pro": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
+  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
-    "litellm_provider": "gigachat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gigachat/Embeddings": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gigachat"
-  },
-  "gigachat/Embeddings-2": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gigachat"
-  },
-  "gigachat/EmbeddingsGigaR": {
-    "max_input_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "gigachat"
-  },
-  "gmi/anthropic/claude-opus-4.5": {
-    "max_input_tokens": 409600,
-    "max_output_tokens": 32000,
+  "global.anthropic.claude-opus-4-5-20251101-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
     "mode": "chat",
-    "litellm_provider": "gmi",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gmi/anthropic/claude-sonnet-4.5": {
-    "max_input_tokens": 409600,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+  "global.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
     "mode": "chat",
-    "litellm_provider": "gmi",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
-  "gmi/anthropic/claude-sonnet-4": {
-    "max_input_tokens": 409600,
-    "max_output_tokens": 32000,
+  "global.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-4-20250514-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 2.5e-7,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "global.xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000006,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "gmi/MiniMaxAI/MiniMax-M2.1": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "gmi"
+  },
+  "gmi/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000014,
     "mode": "chat",
     "litellm_provider": "gmi",
     "supports_vision": true
@@ -10770,27 +13289,72 @@
     "litellm_provider": "gmi",
     "supports_vision": true
   },
-  "gmi/openai/gpt-5.2": {
+  "gmi/anthropic/claude-opus-4.5": {
     "max_input_tokens": 409600,
     "max_output_tokens": 32000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "mode": "chat",
+    "litellm_provider": "gmi",
+    "supports_vision": true
+  },
+  "gmi/anthropic/claude-sonnet-4": {
+    "max_input_tokens": 409600,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "gmi",
+    "supports_vision": true
+  },
+  "gmi/anthropic/claude-sonnet-4.5": {
+    "max_input_tokens": 409600,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "gmi",
+    "supports_vision": true
+  },
+  "gmi/deepseek-ai/DeepSeek-V3-0324": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 8.8e-7,
     "mode": "chat",
     "litellm_provider": "gmi"
   },
-  "gmi/openai/gpt-5.1": {
-    "max_input_tokens": 409600,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+  "gmi/deepseek-ai/DeepSeek-V3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 4e-7,
     "mode": "chat",
     "litellm_provider": "gmi"
   },
-  "gmi/openai/gpt-5": {
-    "max_input_tokens": 409600,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+  "gmi/google/gemini-3-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "gmi",
+    "supports_vision": true
+  },
+  "gmi/google/gemini-3-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "mode": "chat",
+    "litellm_provider": "gmi",
+    "supports_vision": true
+  },
+  "gmi/moonshotai/Kimi-K2-Thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "gmi"
   },
@@ -10812,130 +13376,29 @@
     "litellm_provider": "gmi",
     "supports_vision": true
   },
-  "gmi/deepseek-ai/DeepSeek-V3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 4e-7,
+  "gmi/openai/gpt-5": {
+    "max_input_tokens": 409600,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
     "mode": "chat",
     "litellm_provider": "gmi"
   },
-  "gmi/deepseek-ai/DeepSeek-V3-0324": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 8.8e-7,
+  "gmi/openai/gpt-5.1": {
+    "max_input_tokens": 409600,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
     "mode": "chat",
     "litellm_provider": "gmi"
   },
-  "gmi/google/gemini-3-pro-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "mode": "chat",
-    "litellm_provider": "gmi",
-    "supports_vision": true
-  },
-  "gmi/google/gemini-3-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "gmi",
-    "supports_vision": true
-  },
-  "gmi/moonshotai/Kimi-K2-Thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000012,
+  "gmi/openai/gpt-5.2": {
+    "max_input_tokens": 409600,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
     "mode": "chat",
     "litellm_provider": "gmi"
-  },
-  "gmi/MiniMaxAI/MiniMax-M2.1": {
-    "max_input_tokens": 196608,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "gmi"
-  },
-  "baseten/MiniMaxAI/MiniMax-M2.5": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/nvidia/Nemotron-120B-A12B": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 7.5e-7,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/zai-org/GLM-5": {
-    "input_cost_per_token": 9.5e-7,
-    "output_cost_per_token": 0.00000315,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/zai-org/GLM-4.7": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/zai-org/GLM-4.6": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/moonshotai/Kimi-K2.5": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/moonshotai/Kimi-K2-Thinking": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/moonshotai/Kimi-K2-Instruct-0905": {
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/openai/gpt-oss-120b": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/deepseek-ai/DeepSeek-V3.1": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "baseten/deepseek-ai/DeepSeek-V3-0324": {
-    "input_cost_per_token": 7.7e-7,
-    "output_cost_per_token": 7.7e-7,
-    "mode": "chat",
-    "litellm_provider": "baseten"
-  },
-  "gmi/Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000014,
-    "mode": "chat",
-    "litellm_provider": "gmi",
-    "supports_vision": true
   },
   "gmi/zai-org/GLM-4.7-FP8": {
     "max_input_tokens": 202752,
@@ -10975,62 +13438,6 @@
   "google_pse/search": {
     "mode": "search",
     "litellm_provider": "google_pse"
-  },
-  "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-sonnet-4-20250514-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "global.amazon.nova-2-lite-v1:0": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_video_input": true
   },
   "gpt-3.5-turbo": {
     "max_input_tokens": 16385,
@@ -11285,66 +13692,6 @@
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
-  "gpt-audio": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
-  "gpt-audio-1.5": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
-  "gpt-audio-2025-08-28": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
-  "gpt-audio-mini": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
-  "gpt-audio-mini-2025-10-06": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
-  "gpt-audio-mini-2025-12-15": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_vision": false,
-    "supports_audio_input": true
-  },
   "gpt-4o-mini": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -11435,7 +13782,35 @@
     "mode": "audio_transcription",
     "litellm_provider": "openai"
   },
+  "gpt-4o-mini-transcribe-2025-03-20": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.000005,
+    "mode": "audio_transcription",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-transcribe-2025-12-15": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.000005,
+    "mode": "audio_transcription",
+    "litellm_provider": "openai"
+  },
   "gpt-4o-mini-tts": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-tts-2025-03-20": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "gpt-4o-mini-tts-2025-12-15": {
     "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
     "mode": "audio_speech",
@@ -11501,225 +13876,13 @@
     "mode": "audio_transcription",
     "litellm_provider": "openai"
   },
-  "gpt-image-1.5": {
-    "input_cost_per_token": 0.000005,
+  "gpt-4o-transcribe-diarize": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "input_cost_per_token": 0.0000025,
     "output_cost_per_token": 0.00001,
-    "output_cost_per_image_token": 0.000032,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-image-1.5-2025-12-16": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00001,
-    "output_cost_per_image_token": 0.000032,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-image-2": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00001,
-    "output_cost_per_image_token": 0.00003,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-image-2-2026-04-21": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00001,
-    "output_cost_per_image_token": 0.00003,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1024-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1024-x-1536/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1536-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1024-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1024-x-1536/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1536-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1024-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1024-x-1536/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1536-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1024-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1024-x-1536/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1536-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1024-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1024-x-1536/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1536-x-1024/gpt-image-1.5": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "low/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "medium/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "high/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "standard/1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1024-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1024-x-1536/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "1536-x-1024/gpt-image-1.5-2025-12-16": {
-    "mode": "image_generation",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
+    "mode": "audio_transcription",
+    "litellm_provider": "openai"
   },
   "gpt-5": {
     "max_input_tokens": 272000,
@@ -11728,350 +13891,6 @@
     "output_cost_per_token": 0.00001,
     "cache_read_input_token_cost": 1.25e-7,
     "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1-2025-11-13": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1-chat-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2-2025-12-11": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2-chat-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.3-chat-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2-pro": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000021,
-    "output_cost_per_token": 0.000168,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2-pro-2025-12-11": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000021,
-    "output_cost_per_token": 0.000168,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.6": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.00002,
-    "cache_creation_input_token_cost": 0.000005,
-    "cache_read_input_token_cost": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.6-sol": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.00002,
-    "cache_creation_input_token_cost": 0.000005,
-    "cache_read_input_token_cost": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.6-terra": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.6-luna": {
-    "max_input_tokens": 922000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_creation_input_token_cost": 2.5e-7,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.6-cyber": {
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000125,
-    "output_cost_per_token": 0.000075,
-    "cache_creation_input_token_cost": 0.000015625,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "daybreak-red-latest": {
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000125,
-    "output_cost_per_token": 0.000075,
-    "cache_creation_input_token_cost": 0.000015625,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "daybreak-blue-latest": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.00002,
-    "cache_creation_input_token_cost": 0.000005,
-    "cache_read_input_token_cost": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "chat-latest": {
-    "max_input_tokens": 400000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.5": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.5-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.5-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.5-pro-2026-04-23": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-pro": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-pro-2026-03-05": {
-    "max_input_tokens": 1050000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00003,
-    "output_cost_per_token": 0.00018,
-    "cache_read_input_token_cost": 0.000003,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-mini": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-mini-2026-03-17": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "cache_read_input_token_cost": 7.5e-8,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-nano": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.4-nano-2026-03-17": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.00000125,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5-pro": {
-    "max_input_tokens": 400000,
-    "max_output_tokens": 272000,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00012,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5-pro-2025-10-06": {
-    "max_input_tokens": 400000,
-    "max_output_tokens": 272000,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00012,
-    "mode": "responses",
     "litellm_provider": "openai",
     "supports_pdf_input": true,
     "supports_vision": true
@@ -12115,61 +13934,6 @@
     "input_cost_per_token": 0.00000125,
     "output_cost_per_token": 0.00001,
     "cache_read_input_token_cost": 1.25e-7,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1-codex": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1-codex-max": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.1-codex-mini": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.2-codex": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "responses",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5.3-codex": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
     "mode": "responses",
     "litellm_provider": "openai",
     "supports_pdf_input": true,
@@ -12219,6 +13983,452 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "gpt-5-pro": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 272000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.00012,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5-pro-2025-10-06": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 272000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.00012,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5-search-api": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5-search-api-2025-10-14": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1-2025-11-13": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1-codex-max": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.1-codex-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2-2025-12-11": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2-pro": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000021,
+    "output_cost_per_token": 0.000168,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.2-pro-2025-12-11": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000021,
+    "output_cost_per_token": 0.000168,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.3-chat-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.3-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-mini-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.0000045,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-nano-2026-03-17": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.00000125,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.4-pro-2026-03-05": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00003,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-pro": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.5-pro-2026-04-23": {
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00003,
+    "output_cost_per_token": 0.00018,
+    "cache_read_input_token_cost": 0.000003,
+    "mode": "responses",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-cyber": {
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000125,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.000015625,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-luna": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 2.5e-7,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-sol": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.00002,
+    "cache_creation_input_token_cost": 0.000005,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-5.6-terra": {
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-audio": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-1.5": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-2025-08-28": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-mini": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-mini-2025-10-06": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
+  "gpt-audio-mini-2025-12-15": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "openai",
+    "supports_vision": false,
+    "supports_audio_input": true
+  },
   "gpt-image-1": {
     "input_cost_per_token": 0.000005,
     "output_cost_per_image_token": 0.00004,
@@ -12232,6 +14442,51 @@
     "cache_read_input_token_cost": 2e-7,
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "gpt-image-1.5": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.000032,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-image-1.5-2025-12-16": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.000032,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-image-2": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-image-2-2026-04-21": {
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.00001,
+    "output_cost_per_image_token": 0.00003,
+    "cache_read_input_token_cost": 0.00000125,
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "gpt-live-transcribe": {
+    "mode": "audio_transcription",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
   },
   "gpt-realtime": {
     "max_input_tokens": 32000,
@@ -12283,6 +14538,16 @@
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
+  "gpt-realtime-2025-08-28": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0.000004,
+    "output_cost_per_token": 0.000016,
+    "cache_read_input_token_cost": 4e-7,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
   "gpt-realtime-mini": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
@@ -12292,13 +14557,40 @@
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
-  "gpt-realtime-2025-08-28": {
-    "max_input_tokens": 32000,
+  "gpt-realtime-mini-2025-10-06": {
+    "max_input_tokens": 128000,
     "max_output_tokens": 4096,
-    "input_cost_per_token": 0.000004,
-    "output_cost_per_token": 0.000016,
-    "cache_read_input_token_cost": 4e-7,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
     "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-mini-2025-12-15": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-translate": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 2000,
+    "mode": "realtime",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-realtime-whisper": {
+    "mode": "audio_transcription",
+    "litellm_provider": "openai",
+    "supports_audio_input": true
+  },
+  "gpt-transcribe": {
+    "mode": "audio_transcription",
     "litellm_provider": "openai",
     "supports_audio_input": true
   },
@@ -12400,83 +14692,25 @@
     "mode": "chat",
     "litellm_provider": "gradient_ai"
   },
-  "lemonade/Qwen3-Coder-30B-A3B-Instruct-GGUF": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "lemonade"
+  "groq/canopylabs/orpheus-arabic-saudi": {
+    "max_input_tokens": 4000,
+    "max_output_tokens": 50000,
+    "mode": "audio_speech",
+    "litellm_provider": "groq"
   },
-  "lemonade/gpt-oss-20b-mxfp4-GGUF": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "lemonade"
+  "groq/canopylabs/orpheus-v1-english": {
+    "max_input_tokens": 4000,
+    "max_output_tokens": 50000,
+    "mode": "audio_speech",
+    "litellm_provider": "groq"
   },
-  "lemonade/gpt-oss-120b-mxfp-GGUF": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "lemonade"
-  },
-  "lemonade/Gemma-3-4b-it-GGUF": {
-    "max_input_tokens": 128000,
+  "groq/gemma-7b-it": {
+    "max_input_tokens": 8192,
     "max_output_tokens": 8192,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 8e-8,
     "mode": "chat",
-    "litellm_provider": "lemonade"
-  },
-  "lemonade/Qwen3-4B-Instruct-2507-GGUF": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "lemonade"
-  },
-  "amazon-nova/nova-micro-v1": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 10000,
-    "input_cost_per_token": 3.5e-8,
-    "output_cost_per_token": 1.4e-7,
-    "mode": "chat",
-    "litellm_provider": "amazon_nova"
-  },
-  "amazon-nova/nova-lite-v1": {
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 2.4e-7,
-    "mode": "chat",
-    "litellm_provider": "amazon_nova",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "amazon-nova/nova-premier-v1": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 10000,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.0000125,
-    "mode": "chat",
-    "litellm_provider": "amazon_nova",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "amazon-nova/nova-pro-v1": {
-    "max_input_tokens": 300000,
-    "max_output_tokens": 10000,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000032,
-    "mode": "chat",
-    "litellm_provider": "amazon_nova",
-    "supports_pdf_input": true,
-    "supports_vision": true
+    "litellm_provider": "groq"
   },
   "groq/llama-3.1-8b-instant": {
     "max_input_tokens": 131072,
@@ -12491,38 +14725,6 @@
     "max_output_tokens": 32768,
     "input_cost_per_token": 5.9e-7,
     "output_cost_per_token": 7.9e-7,
-    "mode": "chat",
-    "litellm_provider": "groq"
-  },
-  "groq/gemma-7b-it": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "groq"
-  },
-  "groq/meta-llama/llama-prompt-guard-2-22m": {
-    "max_input_tokens": 512,
-    "max_output_tokens": 512,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "groq"
-  },
-  "groq/meta-llama/llama-prompt-guard-2-86m": {
-    "max_input_tokens": 512,
-    "max_output_tokens": 512,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 4e-8,
-    "mode": "chat",
-    "litellm_provider": "groq"
-  },
-  "groq/meta-llama/llama-guard-4-12b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
     "mode": "chat",
     "litellm_provider": "groq"
   },
@@ -12543,6 +14745,30 @@
     "mode": "chat",
     "litellm_provider": "groq",
     "supports_vision": true
+  },
+  "groq/meta-llama/llama-guard-4-12b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/meta-llama/llama-prompt-guard-2-22m": {
+    "max_input_tokens": 512,
+    "max_output_tokens": 512,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "groq"
+  },
+  "groq/meta-llama/llama-prompt-guard-2-86m": {
+    "max_input_tokens": 512,
+    "max_output_tokens": 512,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "groq"
   },
   "groq/moonshotai/kimi-k2-instruct-0905": {
     "max_input_tokens": 262144,
@@ -12580,22 +14806,18 @@
     "mode": "chat",
     "litellm_provider": "groq"
   },
-  "groq/canopylabs/orpheus-v1-english": {
-    "max_input_tokens": 4000,
-    "max_output_tokens": 50000,
-    "mode": "audio_speech",
-    "litellm_provider": "groq"
-  },
-  "groq/canopylabs/orpheus-arabic-saudi": {
-    "max_input_tokens": 4000,
-    "max_output_tokens": 50000,
-    "mode": "audio_speech",
-    "litellm_provider": "groq"
-  },
   "groq/playai-tts": {
     "max_input_tokens": 10000,
     "max_output_tokens": 10000,
     "mode": "audio_speech",
+    "litellm_provider": "groq"
+  },
+  "groq/qwen/qwen3-32b": {
+    "max_input_tokens": 131000,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 2.9e-7,
+    "output_cost_per_token": 5.9e-7,
+    "mode": "chat",
     "litellm_provider": "groq"
   },
   "groq/qwen/qwen3.6-27b": {
@@ -12606,14 +14828,6 @@
     "mode": "chat",
     "litellm_provider": "groq",
     "supports_vision": true
-  },
-  "groq/qwen/qwen3-32b": {
-    "max_input_tokens": 131000,
-    "max_output_tokens": 131000,
-    "input_cost_per_token": 2.9e-7,
-    "output_cost_per_token": 5.9e-7,
-    "mode": "chat",
-    "litellm_provider": "groq"
   },
   "groq/whisper-large-v3": {
     "mode": "audio_transcription",
@@ -12663,13 +14877,49 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "high/1024-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "high/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "high/1024-x-1536/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "high/1024-x-1536/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "high/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "high/1536-x-1024/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "high/1536-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "high/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "hyperbolic/NousResearch/Hermes-3-Llama-3.1-70B": {
     "max_input_tokens": 32768,
@@ -12799,6 +15049,15 @@
     "mode": "chat",
     "litellm_provider": "hyperbolic"
   },
+  "inception/mercury-2": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 50000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "inception"
+  },
   "j2-light": {
     "max_input_tokens": 8192,
     "max_output_tokens": 8192,
@@ -12903,6 +15162,54 @@
     "mode": "rerank",
     "litellm_provider": "jina_ai"
   },
+  "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000055,
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "jp.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 64000,
@@ -12919,92 +15226,37 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
+  "jp.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000055,
-    "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1e-7,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "crusoe/deepseek-ai/DeepSeek-R1-0528": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000007,
+  "jp.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
     "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "crusoe/deepseek-ai/DeepSeek-V3-0324": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "crusoe/google/gemma-3-12b-it": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "crusoe",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
-  "crusoe/meta-llama/Llama-3.3-70B-Instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
+  "kimi-k2-thinking-251104": {
+    "max_input_tokens": 229376,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "crusoe/moonshotai/Kimi-K2-Thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "crusoe/openai/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 8e-7,
-    "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "crusoe/Qwen/Qwen3-235B-A22B-Instruct-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "crusoe"
-  },
-  "inception/mercury-2": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 50000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 7.5e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "chat",
-    "litellm_provider": "inception"
-  },
-  "text-completion-inception/mercury-edit-2": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 7.5e-7,
-    "cache_read_input_token_cost": 2.5e-8,
-    "mode": "completion",
-    "litellm_provider": "text-completion-inception"
+    "litellm_provider": "volcengine"
   },
   "lambda_ai/deepseek-llama3.3-70b": {
     "max_input_tokens": 131072,
@@ -13167,17 +15419,348 @@
     "mode": "chat",
     "litellm_provider": "lambda_ai"
   },
+  "lemonade/Gemma-3-4b-it-GGUF": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "lemonade"
+  },
+  "lemonade/Qwen3-4B-Instruct-2507-GGUF": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "lemonade"
+  },
+  "lemonade/Qwen3-Coder-30B-A3B-Instruct-GGUF": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "lemonade"
+  },
+  "lemonade/gpt-oss-120b-mxfp-GGUF": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "lemonade"
+  },
+  "lemonade/gpt-oss-20b-mxfp4-GGUF": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "lemonade"
+  },
+  "libertai/bge-m3": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "libertai"
+  },
+  "libertai/deepseek-v4-flash": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/deepseek-v4-flash-thinking": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/gemma-4-31b-it": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/gemma-4-31b-it-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/hermes-3-8b-tee": {
+    "max_input_tokens": 16000,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": false
+  },
+  "libertai/qwen3.5-122b-a10b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.5-122b-a10b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-27b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-27b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-35b-a3b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "libertai/qwen3.6-35b-a3b-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "libertai",
+    "supports_vision": true
+  },
+  "linkup/search": {
+    "mode": "search",
+    "litellm_provider": "linkup"
+  },
+  "linkup/search-deep": {
+    "mode": "search",
+    "litellm_provider": "linkup"
+  },
+  "llamagate/codellama-7b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/deepseek-coder-6.7b": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/deepseek-r1-7b-qwen": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/deepseek-r1-8b": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/dolphin3-8b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/gemma3-4b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "llamagate",
+    "supports_vision": true
+  },
+  "llamagate/llama-3.1-8b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/llama-3.2-3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 8e-8,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/llava-7b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 2048,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate",
+    "supports_vision": true
+  },
+  "llamagate/mistral-7b-v0.3": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/nomic-embed-text": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/openthinker-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/qwen2.5-coder-7b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/qwen3-8b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/qwen3-embedding-8b": {
+    "max_input_tokens": 40960,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "llamagate"
+  },
+  "llamagate/qwen3-vl-8b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "llamagate",
+    "supports_vision": true
+  },
   "low/1024-x-1024/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "low/1024-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
+  "low/1024-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "low/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "low/1024-x-1536/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "low/1024-x-1536/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
+  "low/1024-x-1536/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "low/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "low/1536-x-1024/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "low/1536-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
+  "low/1536-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "low/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "max-x-max/50-steps/stability.stable-diffusion-xl-v0": {
     "max_input_tokens": 77,
@@ -13193,27 +15776,23 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
-  "medium/1024-x-1536/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
-  "medium/1536-x-1024/gpt-image-1": {
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
-  "low/1024-x-1024/gpt-image-1-mini": {
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
-  "low/1024-x-1536/gpt-image-1-mini": {
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
-  "low/1536-x-1024/gpt-image-1-mini": {
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
   "medium/1024-x-1024/gpt-image-1-mini": {
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
+  "medium/1024-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "medium/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "medium/1024-x-1536/gpt-image-1": {
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
@@ -13221,9 +15800,37 @@
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "medium/1024-x-1536/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "medium/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "medium/1536-x-1024/gpt-image-1": {
+    "mode": "image_generation",
+    "litellm_provider": "openai"
+  },
   "medium/1536-x-1024/gpt-image-1-mini": {
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "medium/1536-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "medium/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "medlm-large": {
     "max_input_tokens": 8192,
@@ -13432,20 +16039,14 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
-  "minimax/speech-02-hd": {
-    "mode": "audio_speech",
-    "litellm_provider": "minimax"
-  },
-  "minimax/speech-02-turbo": {
-    "mode": "audio_speech",
-    "litellm_provider": "minimax"
-  },
-  "minimax/speech-2.6-hd": {
-    "mode": "audio_speech",
-    "litellm_provider": "minimax"
-  },
-  "minimax/speech-2.6-turbo": {
-    "mode": "audio_speech",
+  "minimax/MiniMax-M2": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 3.75e-7,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
     "litellm_provider": "minimax"
   },
   "minimax/MiniMax-M2.1": {
@@ -13488,16 +16089,6 @@
     "mode": "chat",
     "litellm_provider": "minimax"
   },
-  "minimax/MiniMax-M2": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_creation_input_token_cost": 3.75e-7,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "minimax"
-  },
   "minimax/MiniMax-M3": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -13507,6 +16098,22 @@
     "mode": "chat",
     "litellm_provider": "minimax",
     "supports_vision": true
+  },
+  "minimax/speech-02-hd": {
+    "mode": "audio_speech",
+    "litellm_provider": "minimax"
+  },
+  "minimax/speech-02-turbo": {
+    "mode": "audio_speech",
+    "litellm_provider": "minimax"
+  },
+  "minimax/speech-2.6-hd": {
+    "mode": "audio_speech",
+    "litellm_provider": "minimax"
+  },
+  "minimax/speech-2.6-turbo": {
+    "mode": "audio_speech",
+    "litellm_provider": "minimax"
   },
   "mistral.devstral-2-123b": {
     "max_input_tokens": 256000,
@@ -13630,6 +16237,18 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/codestral-embed": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1.5e-7,
+    "mode": "embedding",
+    "litellm_provider": "mistral"
+  },
+  "mistral/codestral-embed-2505": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1.5e-7,
+    "mode": "embedding",
+    "litellm_provider": "mistral"
+  },
   "mistral/codestral-latest": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
@@ -13646,9 +16265,33 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/devstral-2512": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/devstral-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "mistral/devstral-medium-2507": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
+  "mistral/devstral-medium-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
     "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
@@ -13678,6 +16321,15 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
+  "mistral/glm-5-2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "mistral/labs-devstral-small-2512": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
@@ -13686,45 +16338,19 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/devstral-latest": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "mistral"
-  },
-  "mistral/devstral-medium-latest": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "mistral"
-  },
-  "mistral/devstral-2512": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "mistral"
-  },
-  "mistral/zai-glm-5-2": {
-    "max_input_tokens": 1048576,
+  "mistral/labs-leanstral-1-5": {
+    "max_input_tokens": 262144,
     "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000014,
-    "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 1.4e-7,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/glm-5-2": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000014,
-    "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 1.4e-7,
+  "mistral/magistral-medium-1-2-2509": {
+    "max_input_tokens": 40000,
+    "max_output_tokens": 40000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000005,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
@@ -13744,7 +16370,7 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/magistral-medium-1-2-2509": {
+  "mistral/magistral-medium-latest": {
     "max_input_tokens": 40000,
     "max_output_tokens": 40000,
     "input_cost_per_token": 0.000002,
@@ -13752,31 +16378,11 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/mistral-ocr-latest": {
-    "mode": "ocr",
-    "litellm_provider": "mistral"
-  },
-  "mistral/mistral-ocr-4-0": {
-    "mode": "ocr",
-    "litellm_provider": "mistral"
-  },
-  "mistral/mistral-ocr-4-1": {
-    "mode": "ocr",
-    "litellm_provider": "mistral"
-  },
-  "mistral/mistral-ocr-2505-completion": {
-    "mode": "ocr",
-    "litellm_provider": "mistral"
-  },
-  "mistral/mistral-ocr-2512": {
-    "mode": "ocr",
-    "litellm_provider": "mistral"
-  },
-  "mistral/magistral-medium-latest": {
+  "mistral/magistral-small-1-2-2509": {
     "max_input_tokens": 40000,
     "max_output_tokens": 40000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000005,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
     "mode": "chat",
     "litellm_provider": "mistral"
   },
@@ -13796,29 +16402,54 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/magistral-small-1-2-2509": {
-    "max_input_tokens": 40000,
-    "max_output_tokens": 40000,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
+  "mistral/ministral-3-14b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
     "mode": "chat",
-    "litellm_provider": "mistral"
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-3-3b-2512": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-3-8b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-8b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/ministral-8b-latest": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
   },
   "mistral/mistral-embed": {
     "max_input_tokens": 8192,
     "input_cost_per_token": 1e-7,
-    "mode": "embedding",
-    "litellm_provider": "mistral"
-  },
-  "mistral/codestral-embed": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 1.5e-7,
-    "mode": "embedding",
-    "litellm_provider": "mistral"
-  },
-  "mistral/codestral-embed-2505": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 1.5e-7,
     "mode": "embedding",
     "litellm_provider": "mistral"
   },
@@ -13846,7 +16477,7 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/mistral-large-latest": {
+  "mistral/mistral-large-2512": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "input_cost_per_token": 5e-7,
@@ -13864,7 +16495,7 @@
     "litellm_provider": "mistral",
     "supports_vision": true
   },
-  "mistral/mistral-large-2512": {
+  "mistral/mistral-large-latest": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "input_cost_per_token": 5e-7,
@@ -13915,15 +16546,6 @@
     "litellm_provider": "mistral",
     "supports_vision": true
   },
-  "mistral/mistral-medium-latest": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
   "mistral/mistral-medium-3-1-2508": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -13942,6 +16564,42 @@
     "litellm_provider": "mistral",
     "supports_vision": true
   },
+  "mistral/mistral-medium-latest": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "mistral",
+    "supports_vision": true
+  },
+  "mistral/mistral-moderation-2603": {
+    "max_input_tokens": 131072,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "moderation",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-2505-completion": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-2512": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-4-0": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-4-1": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
+  "mistral/mistral-ocr-latest": {
+    "mode": "ocr",
+    "litellm_provider": "mistral"
+  },
   "mistral/mistral-small": {
     "max_input_tokens": 32000,
     "max_output_tokens": 8191,
@@ -13950,7 +16608,7 @@
     "mode": "chat",
     "litellm_provider": "mistral"
   },
-  "mistral/mistral-small-latest": {
+  "mistral/mistral-small-2603": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "input_cost_per_token": 1.5e-7,
@@ -13968,47 +16626,11 @@
     "litellm_provider": "mistral",
     "supports_vision": true
   },
-  "mistral/ministral-3-3b-2512": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
-  "mistral/ministral-3-8b-2512": {
+  "mistral/mistral-small-latest": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
-  "mistral/ministral-3-14b-2512": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
-  "mistral/ministral-8b-2512": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
-  "mistral/ministral-8b-latest": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
     "mode": "chat",
     "litellm_provider": "mistral",
     "supports_vision": true
@@ -14096,6 +16718,29 @@
     "litellm_provider": "mistral",
     "supports_vision": true
   },
+  "mistral/voxtral-mini-2602": {
+    "mode": "audio_transcription",
+    "litellm_provider": "mistral",
+    "supports_audio_input": true
+  },
+  "mistral/voxtral-mini-transcribe-realtime-2602": {
+    "mode": "audio_transcription",
+    "litellm_provider": "mistral",
+    "supports_audio_input": true
+  },
+  "mistral/voxtral-mini-tts-2603": {
+    "mode": "audio_speech",
+    "litellm_provider": "mistral"
+  },
+  "mistral/zai-glm-5-2": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "mistral"
+  },
   "moonshot.kimi-k2-thinking": {
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
@@ -14103,15 +16748,6 @@
     "output_cost_per_token": 0.0000025,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
-  },
-  "moonshotai.kimi-k2.5": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
   },
   "moonshot/kimi-k2-0711-preview": {
     "max_input_tokens": 131072,
@@ -14127,6 +16763,24 @@
     "max_output_tokens": 262144,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "moonshot"
+  },
+  "moonshot/kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "moonshot"
+  },
+  "moonshot/kimi-k2-thinking-turbo": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.00000115,
+    "output_cost_per_token": 0.000008,
     "cache_read_input_token_cost": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "moonshot"
@@ -14223,24 +16877,6 @@
     "litellm_provider": "moonshot",
     "supports_vision": true
   },
-  "moonshot/kimi-k2-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "moonshot"
-  },
-  "moonshot/kimi-k2-thinking-turbo": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.00000115,
-    "output_cost_per_token": 0.000008,
-    "cache_read_input_token_cost": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "moonshot"
-  },
   "moonshot/moonshot-v1-128k": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -14324,6 +16960,15 @@
     "mode": "chat",
     "litellm_provider": "moonshot"
   },
+  "moonshotai.kimi-k2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
   "morph/morph-v3-fast": {
     "max_input_tokens": 16000,
     "max_output_tokens": 16000,
@@ -14355,6 +17000,970 @@
     "output_cost_per_token": 0,
     "mode": "embedding",
     "litellm_provider": "vertex_ai-embedding-models"
+  },
+  "nebius/BAAI/bge-en-icl": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
+  "nebius/BAAI/bge-multilingual-gemma2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
+  "nebius/NousResearch/Hermes-3-Llama-3.1-405B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/QwQ-32B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2-VL-72B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/Qwen/Qwen2-VL-7B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/Qwen/Qwen2.5-32B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-72B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-Coder-7B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen2.5-VL-72B-Instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/Qwen/Qwen3-14B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-235B-A22B": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-30B-A3B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-32B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/Qwen/Qwen3-4B": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-R1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-R1-0528": {
+    "max_input_tokens": 164000,
+    "max_output_tokens": 164000,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-V3": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/deepseek-ai/DeepSeek-V3-0324": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/google/gemma-3-27b-it": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius",
+    "supports_vision": true
+  },
+  "nebius/intfloat/e5-mistral-7b-instruct": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Llama-3.3-70B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Llama-Guard-3-8B": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-405B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-70B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/mistralai/Mistral-Nemo-Instruct-2407": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 1.2e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nebius/nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "nebius"
+  },
+  "nimble/search": {
+    "mode": "search",
+    "litellm_provider": "nimble"
+  },
+  "novita/Sao10K/L3-8B-Stheno-v3.2": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/baai/bge-m3": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 96000,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 1e-8,
+    "mode": "embedding",
+    "litellm_provider": "novita"
+  },
+  "novita/baai/bge-reranker-v2-m3": {
+    "max_input_tokens": 8000,
+    "max_output_tokens": 8000,
+    "input_cost_per_token": 1e-8,
+    "output_cost_per_token": 1e-8,
+    "mode": "rerank",
+    "litellm_provider": "novita"
+  },
+  "novita/baichuan/baichuan-m2-32b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 7e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/baidu/ernie-4.5-21B-a3b": {
+    "max_input_tokens": 120000,
+    "max_output_tokens": 8000,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/baidu/ernie-4.5-21B-a3b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 2.8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/baidu/ernie-4.5-300b-a47b-paddle": {
+    "max_input_tokens": 123000,
+    "max_output_tokens": 12000,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/baidu/ernie-4.5-vl-28b-a3b": {
+    "max_input_tokens": 30000,
+    "max_output_tokens": 8000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 5.6e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/baidu/ernie-4.5-vl-28b-a3b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3.9e-7,
+    "output_cost_per_token": 3.9e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/baidu/ernie-4.5-vl-424b-a47b": {
+    "max_input_tokens": 123000,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 4.2e-7,
+    "output_cost_per_token": 0.00000125,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/deepseek/deepseek-ocr": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/deepseek/deepseek-prover-v2-671b": {
+    "max_input_tokens": 160000,
+    "max_output_tokens": 160000,
+    "input_cost_per_token": 7e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-0528": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7e-7,
+    "output_cost_per_token": 0.0000025,
+    "cache_read_input_token_cost": 3.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-0528-qwen3-8b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 9e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-distill-llama-70b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-distill-qwen-14b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-distill-qwen-32b": {
+    "max_input_tokens": 64000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-r1-turbo": {
+    "max_input_tokens": 64000,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 7e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3-0324": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 0.00000112,
+    "cache_read_input_token_cost": 1.35e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3-turbo": {
+    "max_input_tokens": 64000,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000013,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3.1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 0.000001,
+    "cache_read_input_token_cost": 1.35e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3.1-terminus": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 0.000001,
+    "cache_read_input_token_cost": 1.35e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.69e-7,
+    "output_cost_per_token": 4e-7,
+    "cache_read_input_token_cost": 1.345e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/deepseek/deepseek-v3.2-exp": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 4.1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/google/gemma-3-12b-it": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/google/gemma-3-27b-it": {
+    "max_input_tokens": 98304,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.19e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/gryphe/mythomax-l2-13b": {
+    "max_input_tokens": 4096,
+    "max_output_tokens": 3200,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 9e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/kwaipilot/kat-coder-pro": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 6e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-3-70b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8000,
+    "input_cost_per_token": 5.1e-7,
+    "output_cost_per_token": 7.4e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-3-8b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 4e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-3.1-8b-instruct": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-3.2-3b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-3.3-70b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 120000,
+    "input_cost_per_token": 1.35e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 8.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/meta-llama/llama-4-scout-17b-16e-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.8e-7,
+    "output_cost_per_token": 5.9e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/microsoft/wizardlm-2-8x22b": {
+    "max_input_tokens": 65535,
+    "max_output_tokens": 8000,
+    "input_cost_per_token": 6.2e-7,
+    "output_cost_per_token": 6.2e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/minimax/minimax-m2": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/minimax/minimax-m2.1": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/minimaxai/minimax-m1-80k": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 40000,
+    "input_cost_per_token": 5.5e-7,
+    "output_cost_per_token": 0.0000022,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/mistralai/mistral-nemo": {
+    "max_input_tokens": 60288,
+    "max_output_tokens": 16000,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 1.7e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/moonshotai/kimi-k2-0905": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/moonshotai/kimi-k2-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 5.7e-7,
+    "output_cost_per_token": 0.0000023,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/moonshotai/kimi-k2-thinking": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/nousresearch/hermes-2-pro-llama-3-8b": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 1.4e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/openai/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 4e-8,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/paddlepaddle/paddleocr-vl": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen-2.5-72b-instruct": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 3.8e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen-mt-plus": {
+    "max_input_tokens": 16384,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen2.5-7b-instruct": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 7e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen2.5-vl-72b-instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen3-235b-a22b-fp8": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 20000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-235b-a22b-instruct-2507": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 5.8e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-235b-a22b-thinking-2507": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-30b-a3b-fp8": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 20000,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-32b-fp8": {
+    "max_input_tokens": 40960,
+    "max_output_tokens": 20000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-4b-fp8": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20000,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 3e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-8b-fp8": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 20000,
+    "input_cost_per_token": 3.5e-8,
+    "output_cost_per_token": 1.38e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-coder-30b-a3b-instruct": {
+    "max_input_tokens": 160000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 2.7e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-coder-480b-a35b-instruct": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000013,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-embedding-0.6b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-embedding-8b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-max": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000211,
+    "output_cost_per_token": 0.00000845,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-next-80b-a3b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-next-80b-a3b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-omni-30b-a3b-instruct": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 9.7e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "novita/qwen/qwen3-omni-30b-a3b-thinking": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 9.7e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "novita/qwen/qwen3-reranker-8b": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "rerank",
+    "litellm_provider": "novita"
+  },
+  "novita/qwen/qwen3-vl-235b-a22b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen3-vl-235b-a22b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.8e-7,
+    "output_cost_per_token": 0.00000395,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen3-vl-30b-a3b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 7e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen3-vl-30b-a3b-thinking": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/qwen/qwen3-vl-8b-instruct": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 8e-8,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/sao10k/l3-70b-euryale-v2.1": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000148,
+    "output_cost_per_token": 0.00000148,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/sao10k/l3-8b-lunaris": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/sao10k/l31-70b-euryale-v2.2": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000148,
+    "output_cost_per_token": 0.00000148,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/skywork/r1v4-lite": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/xiaomimimo/mimo-v2-flash": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 3e-7,
+    "cache_read_input_token_cost": 2e-8,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/zai-org/autoglm-phone-9b-multilingual": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3.5e-8,
+    "output_cost_per_token": 1.38e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/zai-org/glm-4.5": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 98304,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/zai-org/glm-4.5-air": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 98304,
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 8.5e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/zai-org/glm-4.5v": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000018,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/zai-org/glm-4.6": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 5.5e-7,
+    "output_cost_per_token": 0.0000022,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
+  },
+  "novita/zai-org/glm-4.6v": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 9e-7,
+    "cache_read_input_token_cost": 5.5e-8,
+    "mode": "chat",
+    "litellm_provider": "novita",
+    "supports_vision": true
+  },
+  "novita/zai-org/glm-4.7": {
+    "max_input_tokens": 204800,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "novita"
   },
   "nscale/Qwen/QwQ-32B": {
     "input_cost_per_token": 1.8e-7,
@@ -14448,247 +18057,6 @@
     "mode": "image_generation",
     "litellm_provider": "nscale"
   },
-  "nebius/deepseek-ai/DeepSeek-R1": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/deepseek-ai/DeepSeek-R1-0528": {
-    "max_input_tokens": 164000,
-    "max_output_tokens": 164000,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/deepseek-ai/DeepSeek-R1-Distill-Llama-70B": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 7.5e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/deepseek-ai/DeepSeek-V3": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/deepseek-ai/DeepSeek-V3-0324": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/google/gemma-3-27b-it": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius",
-    "supports_vision": true
-  },
-  "nebius/meta-llama/Llama-3.3-70B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/meta-llama/Llama-Guard-3-8B": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 6e-8,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/meta-llama/Meta-Llama-3.1-8B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 6e-8,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/meta-llama/Meta-Llama-3.1-70B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/meta-llama/Meta-Llama-3.1-405B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/mistralai/Mistral-Nemo-Instruct-2407": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/NousResearch/Hermes-3-Llama-3.1-405B": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/nvidia/Llama-3.1-Nemotron-Ultra-253B-v1": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000018,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/nvidia/Llama-3.3-Nemotron-Super-49B-v1": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen3-235B-A22B": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen3-32B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen3-30B-A3B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen3-14B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 2.4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen3-4B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 2.4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/QwQ-32B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen2.5-72B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen2.5-32B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen2.5-Coder-7B": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "nebius"
-  },
-  "nebius/Qwen/Qwen2.5-VL-72B-Instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius",
-    "supports_vision": true
-  },
-  "nebius/Qwen/Qwen2-VL-72B-Instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "nebius",
-    "supports_vision": true
-  },
-  "nebius/Qwen/Qwen2-VL-7B-Instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 6e-8,
-    "mode": "chat",
-    "litellm_provider": "nebius",
-    "supports_vision": true
-  },
-  "nebius/BAAI/bge-en-icl": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "nebius"
-  },
-  "nebius/BAAI/bge-multilingual-gemma2": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "nebius"
-  },
-  "nebius/intfloat/e5-mistral-7b-instruct": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "nebius"
-  },
   "nvidia.nemotron-nano-12b-v2": {
     "max_input_tokens": 128000,
     "max_output_tokens": 8192,
@@ -14698,19 +18066,19 @@
     "litellm_provider": "bedrock_converse",
     "supports_vision": true
   },
-  "nvidia.nemotron-nano-9b-v2": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 2.3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse"
-  },
   "nvidia.nemotron-nano-3-30b": {
     "max_input_tokens": 262144,
     "max_output_tokens": 8192,
     "input_cost_per_token": 6e-8,
     "output_cost_per_token": 2.4e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "nvidia.nemotron-nano-9b-v2": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 2.3e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -14721,6 +18089,24 @@
     "output_cost_per_token": 6.5e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
+  },
+  "nvidia_nim/nvidia/llama-3_2-nv-rerankqa-1b-v2": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "nvidia_nim"
+  },
+  "nvidia_nim/nvidia/nv-rerankqa-mistral-4b-v3": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "nvidia_nim"
+  },
+  "nvidia_nim/ranking/nvidia/llama-3.2-nv-rerankqa-1b-v2": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "rerank",
+    "litellm_provider": "nvidia_nim"
   },
   "o1": {
     "max_input_tokens": 200000,
@@ -14892,11 +18278,183 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "oci/meta.llama-3.1-8b-instruct": {
+  "oci/cohere.command-a-03-2025": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-a-reasoning": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-a-reasoning-08-2025": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-a-translate-08-2025": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 9e-8,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-a-vision": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-a-vision-07-2025": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4000,
-    "input_cost_per_token": 7.2e-7,
-    "output_cost_per_token": 7.2e-7,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.command-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-plus-latest": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-r-08-2024": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.command-r-plus-08-2024": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00000156,
+    "output_cost_per_token": 0.00000156,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-light-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-light-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-english-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "mode": "embedding",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/cohere.embed-multilingual-light-image-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-light-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-multilingual-v3.0": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/cohere.embed-v4.0": {
+    "max_input_tokens": 128000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "oci"
+  },
+  "oci/google.gemini-2.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/google.gemini-2.5-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-8,
+    "output_cost_per_token": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/google.gemini-2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/meta.llama-3.1-405b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.00001068,
+    "output_cost_per_token": 0.00001068,
     "mode": "chat",
     "litellm_provider": "oci"
   },
@@ -14908,13 +18466,22 @@
     "mode": "chat",
     "litellm_provider": "oci"
   },
-  "oci/meta.llama-3.1-405b-instruct": {
+  "oci/meta.llama-3.1-8b-instruct": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00001068,
-    "output_cost_per_token": 0.00001068,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "oci"
+  },
+  "oci/meta.llama-3.2-11b-vision-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
   },
   "oci/meta.llama-3.2-90b-vision-instruct": {
     "max_input_tokens": 128000,
@@ -14926,6 +18493,14 @@
     "supports_vision": true
   },
   "oci/meta.llama-3.3-70b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4000,
+    "input_cost_per_token": 7.2e-7,
+    "output_cost_per_token": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "oci"
+  },
+  "oci/meta.llama-3.3-70b-instruct-fp8-dynamic": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4000,
     "input_cost_per_token": 7.2e-7,
@@ -14949,6 +18524,33 @@
     "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "oci"
+  },
+  "oci/openai.gpt-5": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/openai.gpt-5-mini": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
+  },
+  "oci/openai.gpt-5-nano": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "oci",
+    "supports_vision": true
   },
   "oci/xai.grok-3": {
     "max_input_tokens": 131072,
@@ -14990,139 +18592,6 @@
     "mode": "chat",
     "litellm_provider": "oci"
   },
-  "oci/cohere.command-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.command-a-03-2025": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.command-plus-latest": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/google.gemini-2.5-flash": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/google.gemini-2.5-pro": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/google.gemini-2.5-flash-lite": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/cohere.command-a-vision": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/cohere.command-a-reasoning": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-multilingual-image-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "mode": "embedding",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/cohere.command-a-reasoning-08-2025": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.command-a-vision-07-2025": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/cohere.command-a-translate-08-2025": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 9e-8,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.command-r-08-2024": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.command-r-plus-08-2024": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.00000156,
-    "output_cost_per_token": 0.00000156,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/meta.llama-3.2-11b-vision-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/meta.llama-3.3-70b-instruct-fp8-dynamic": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4000,
-    "input_cost_per_token": 7.2e-7,
-    "output_cost_per_token": 7.2e-7,
-    "mode": "chat",
-    "litellm_provider": "oci"
-  },
   "oci/xai.grok-4-fast": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -15161,89 +18630,6 @@
     "input_cost_per_token": 0.000005,
     "output_cost_per_token": 0.000025,
     "mode": "chat",
-    "litellm_provider": "oci"
-  },
-  "oci/openai.gpt-5": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/openai.gpt-5-mini": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/openai.gpt-5-nano": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "oci",
-    "supports_vision": true
-  },
-  "oci/cohere.embed-english-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-english-light-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-multilingual-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-multilingual-light-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-english-image-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-english-light-image-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-multilingual-light-image-v3.0": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "oci"
-  },
-  "oci/cohere.embed-v4.0": {
-    "max_input_tokens": 128000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
     "litellm_provider": "oci"
   },
   "ollama/codegeex4": {
@@ -15526,6 +18912,22 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
+  "openai/container": {
+    "mode": "chat",
+    "litellm_provider": "openai"
+  },
+  "openai/sora-2": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "openai/sora-2-pro": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
+  "openai/sora-2-pro-high-res": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
+  },
   "openrouter/anthropic/claude-3-haiku": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
@@ -15553,6 +18955,17 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/anthropic/claude-haiku-4.5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 200000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
   "openrouter/anthropic/claude-opus-4": {
     "max_input_tokens": 200000,
     "max_output_tokens": 32000,
@@ -15571,36 +18984,6 @@
     "output_cost_per_token": 0.000075,
     "cache_creation_input_token_cost": 0.00001875,
     "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-sonnet-4": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-sonnet-4.6": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": true
@@ -15627,32 +19010,6 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/anthropic/claude-sonnet-4.5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/anthropic/claude-haiku-4.5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
   "openrouter/anthropic/claude-opus-4.7": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
@@ -15675,6 +19032,51 @@
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "openrouter/anthropic/claude-sonnet-4": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/anthropic/claude-sonnet-4.5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/anthropic/claude-sonnet-4.6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
     "supports_vision": true
   },
   "openrouter/bytedance/ui-tars-1.5-7b": {
@@ -15709,22 +19111,6 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/deepseek/deepseek-v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/deepseek/deepseek-v3.2-exp": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/deepseek/deepseek-r1": {
     "max_input_tokens": 65336,
     "max_output_tokens": 8192,
@@ -15738,6 +19124,22 @@
     "max_output_tokens": 8192,
     "input_cost_per_token": 5e-7,
     "output_cost_per_token": 0.00000215,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/deepseek/deepseek-v3.2": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 2.8e-7,
+    "output_cost_per_token": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/deepseek/deepseek-v3.2-exp": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 4e-7,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -15784,6 +19186,17 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/google/gemini-3-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "openrouter/google/gemini-3-pro-preview": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65535,
@@ -15801,18 +19214,7 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "openrouter/google/gemini-3-flash-preview": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.000003,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "openrouter/google/gemini-3.1-flash-lite-preview": {
+  "openrouter/google/gemini-3.1-flash-lite": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65536,
     "input_cost_per_token": 2.5e-7,
@@ -15825,7 +19227,7 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "openrouter/google/gemini-3.1-flash-lite": {
+  "openrouter/google/gemini-3.1-flash-lite-preview": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65536,
     "input_cost_per_token": 2.5e-7,
@@ -15884,6 +19286,27 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
+  "openrouter/minimax/minimax-m2.1": {
+    "max_input_tokens": 204000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 2.7e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/minimax/minimax-m2.5": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000011,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": false
+  },
   "openrouter/mistralai/devstral-2512": {
     "max_input_tokens": 262144,
     "max_output_tokens": 65536,
@@ -15892,6 +19315,15 @@
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": false
+  },
+  "openrouter/mistralai/ministral-14b-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
   },
   "openrouter/mistralai/ministral-3b-2512": {
     "max_input_tokens": 131072,
@@ -15911,24 +19343,6 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/mistralai/ministral-14b-2512": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/mistralai/mistral-large-2512": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
   "openrouter/mistralai/mistral-7b-instruct": {
     "max_input_tokens": 32768,
     "max_output_tokens": 8191,
@@ -15944,6 +19358,15 @@
     "output_cost_per_token": 0.000024,
     "mode": "chat",
     "litellm_provider": "openrouter"
+  },
+  "openrouter/mistralai/mistral-large-2512": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
   },
   "openrouter/mistralai/mistral-small-3.1-24b-instruct": {
     "max_input_tokens": 131072,
@@ -16059,6 +19482,15 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/openai/gpt-5": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
   "openrouter/openai/gpt-5-chat": {
     "max_input_tokens": 128000,
     "max_output_tokens": 16384,
@@ -16069,24 +19501,6 @@
     "litellm_provider": "openrouter"
   },
   "openrouter/openai/gpt-5-codex": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/openai/gpt-5.2-codex": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000175,
-    "output_cost_per_token": 0.000014,
-    "cache_read_input_token_cost": 1.75e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/openai/gpt-5": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.00000125,
@@ -16143,6 +19557,15 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
+  "openrouter/openai/gpt-5.2-codex": {
+    "max_input_tokens": 272000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00000175,
+    "output_cost_per_token": 0.000014,
+    "cache_read_input_token_cost": 1.75e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
   "openrouter/openai/gpt-5.2-pro": {
     "max_input_tokens": 272000,
     "max_output_tokens": 128000,
@@ -16196,6 +19619,31 @@
     "litellm_provider": "openrouter",
     "supports_vision": false
   },
+  "openrouter/openrouter/auto": {
+    "max_input_tokens": 2000000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "openrouter/openrouter/bodybuilder": {
+    "max_input_tokens": 128000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/openrouter/free": {
+    "max_input_tokens": 200000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
   "openrouter/qwen/qwen-2.5-coder-32b-instruct": {
     "max_input_tokens": 33792,
     "max_output_tokens": 33792,
@@ -16213,22 +19661,6 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/qwen/qwen3-coder": {
-    "max_input_tokens": 262100,
-    "max_output_tokens": 262100,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 9.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/qwen/qwen3-coder-plus": {
-    "max_input_tokens": 997952,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/qwen/qwen3-235b-a22b-2507": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
@@ -16245,19 +19677,26 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/qwen/qwen3.6-plus": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3.25e-7,
-    "output_cost_per_token": 0.00000195,
+  "openrouter/qwen/qwen3-coder": {
+    "max_input_tokens": 262100,
+    "max_output_tokens": 262100,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 9.5e-7,
     "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
+    "litellm_provider": "openrouter"
   },
-  "openrouter/qwen/qwen3.5-35b-a3b": {
+  "openrouter/qwen/qwen3-coder-plus": {
+    "max_input_tokens": 997952,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/qwen/qwen3.5-122b-a10b": {
     "max_input_tokens": 262144,
     "max_output_tokens": 65536,
-    "input_cost_per_token": 2.5e-7,
+    "input_cost_per_token": 4e-7,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
     "litellm_provider": "openrouter",
@@ -16272,11 +19711,20 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/qwen/qwen3.5-122b-a10b": {
+  "openrouter/qwen/qwen3.5-35b-a3b": {
     "max_input_tokens": 262144,
     "max_output_tokens": 65536,
-    "input_cost_per_token": 4e-7,
+    "input_cost_per_token": 2.5e-7,
     "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": true
+  },
+  "openrouter/qwen/qwen3.5-397b-a17b": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": true
@@ -16299,11 +19747,11 @@
     "litellm_provider": "openrouter",
     "supports_vision": true
   },
-  "openrouter/qwen/qwen3.5-397b-a17b": {
-    "max_input_tokens": 262144,
+  "openrouter/qwen/qwen3.6-plus": {
+    "max_input_tokens": 1000000,
     "max_output_tokens": 65536,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000036,
+    "input_cost_per_token": 3.25e-7,
+    "output_cost_per_token": 0.00000195,
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": true
@@ -16332,22 +19780,6 @@
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
-  "openrouter/z-ai/glm-4.6": {
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131000,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.00000175,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/z-ai/glm-4.6:exacto": {
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131000,
-    "input_cost_per_token": 4.5e-7,
-    "output_cost_per_token": 0.0000019,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
   "openrouter/xiaomi/mimo-v2-flash": {
     "max_input_tokens": 262144,
     "max_output_tokens": 16384,
@@ -16355,17 +19787,6 @@
     "output_cost_per_token": 3e-7,
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
-  "openrouter/xiaomi/mimo-v2.5-pro": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 2e-7,
     "mode": "chat",
     "litellm_provider": "openrouter",
     "supports_vision": false
@@ -16382,6 +19803,33 @@
     "supports_vision": true,
     "supports_audio_input": true,
     "supports_video_input": true
+  },
+  "openrouter/xiaomi/mimo-v2.5-pro": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "openrouter",
+    "supports_vision": false
+  },
+  "openrouter/z-ai/glm-4.6": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.00000175,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
+  },
+  "openrouter/z-ai/glm-4.6:exacto": {
+    "max_input_tokens": 202800,
+    "max_output_tokens": 131000,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 0.0000019,
+    "mode": "chat",
+    "litellm_provider": "openrouter"
   },
   "openrouter/z-ai/glm-4.7": {
     "max_input_tokens": 202752,
@@ -16420,52 +19868,6 @@
     "output_cost_per_token": 0.0000035,
     "cache_creation_input_token_cost": 0,
     "cache_read_input_token_cost": 5.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter"
-  },
-  "openrouter/minimax/minimax-m2.1": {
-    "max_input_tokens": 204000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/minimax/minimax-m2.5": {
-    "max_input_tokens": 196608,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000011,
-    "cache_read_input_token_cost": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": false
-  },
-  "openrouter/openrouter/auto": {
-    "max_input_tokens": 2000000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "openrouter/openrouter/free": {
-    "max_input_tokens": 200000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "openrouter",
-    "supports_vision": true
-  },
-  "openrouter/openrouter/bodybuilder": {
-    "max_input_tokens": 128000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
     "mode": "chat",
     "litellm_provider": "openrouter"
   },
@@ -16648,6 +20050,26 @@
     "mode": "search",
     "litellm_provider": "parallel_ai"
   },
+  "perplexity/anthropic/claude-haiku-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-6": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-opus-4-7": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/anthropic/claude-sonnet-4-5": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
   "perplexity/codellama-34b-instruct": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
@@ -16662,6 +20084,22 @@
     "input_cost_per_token": 7e-7,
     "output_cost_per_token": 0.0000028,
     "mode": "chat",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-2.5-flash": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-2.5-pro": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-3-flash-preview": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/google/gemini-3-pro-preview": {
+    "mode": "responses",
     "litellm_provider": "perplexity"
   },
   "perplexity/llama-2-70b-chat": {
@@ -16704,6 +20142,50 @@
     "mode": "chat",
     "litellm_provider": "perplexity"
   },
+  "perplexity/openai/gpt-5-mini": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/openai/gpt-5.1": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/openai/gpt-5.2": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/deepseek-v4-flash-0731": {
+    "input_cost_per_token": 1.3e-7,
+    "output_cost_per_token": 2.6e-7,
+    "cache_read_input_token_cost": 2.8e-8,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/glm-5.2": {
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 1.4e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/kimi-k2.7-code": {
+    "input_cost_per_token": 9.5e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 1.9e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/kimi-k3": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/perplexity/sonar": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
   "perplexity/pplx-70b-chat": {
     "max_input_tokens": 4096,
     "max_output_tokens": 4096,
@@ -16734,6 +20216,54 @@
     "input_cost_per_token": 0,
     "output_cost_per_token": 2.8e-7,
     "mode": "chat",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-context-v1-0.6b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 8e-9,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-context-v1-4b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 5e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-v1-0.6b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 4e-9,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/pplx-embed-v1-4b": {
+    "max_input_tokens": 32768,
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/advanced-deep-research": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/deep-research": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/fast-search": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/preset/pro-search": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
+  },
+  "perplexity/search": {
+    "mode": "search",
     "litellm_provider": "perplexity"
   },
   "perplexity/sonar": {
@@ -16804,23 +20334,59 @@
     "mode": "chat",
     "litellm_provider": "perplexity"
   },
-  "publicai/swiss-ai/apertus-8b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "publicai"
+  "perplexity/xai/grok-4-1-fast-non-reasoning": {
+    "mode": "responses",
+    "litellm_provider": "perplexity"
   },
-  "publicai/swiss-ai/apertus-70b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
+  "pinstripes/ps/deepseek-v4-flash": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 2e-7,
     "mode": "chat",
-    "litellm_provider": "publicai"
+    "litellm_provider": "pinstripes"
   },
-  "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
+  "pinstripes/ps/glm-4.5-air": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.25e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/minimax-m2.7": {
+    "max_input_tokens": 1000192,
+    "max_output_tokens": 1000192,
+    "input_cost_per_token": 2.55e-7,
+    "output_cost_per_token": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3-30b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3-coder-30b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "pinstripes/ps/qwen3.6-35b-a3b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 4.5e-7,
+    "mode": "chat",
+    "litellm_provider": "pinstripes"
+  },
+  "publicai/BSC-LT/ALIA-40b-instruct_Q8_0": {
     "max_input_tokens": 8192,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0,
@@ -16836,7 +20402,7 @@
     "mode": "chat",
     "litellm_provider": "publicai"
   },
-  "publicai/BSC-LT/ALIA-40b-instruct_Q8_0": {
+  "publicai/aisingapore/Gemma-SEA-LION-v4-27B-IT": {
     "max_input_tokens": 8192,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0,
@@ -16844,137 +20410,7 @@
     "mode": "chat",
     "litellm_provider": "publicai"
   },
-  "publicai/allenai/Olmo-3-7B-Instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "publicai"
-  },
-  "perplexity/preset/fast-search": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/preset/pro-search": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/preset/deep-research": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/preset/advanced-deep-research": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/openai/gpt-5.2": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/openai/gpt-5.1": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/openai/gpt-5-mini": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/anthropic/claude-opus-4-6": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/anthropic/claude-opus-4-7": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/anthropic/claude-opus-4-5": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/anthropic/claude-sonnet-4-5": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/anthropic/claude-haiku-4-5": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/google/gemini-3-pro-preview": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/google/gemini-3-flash-preview": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/google/gemini-2.5-pro": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/google/gemini-2.5-flash": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/xai/grok-4-1-fast-non-reasoning": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/perplexity/sonar": {
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/perplexity/deepseek-v4-flash-0731": {
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 2.6e-7,
-    "cache_read_input_token_cost": 2.8e-8,
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/perplexity/glm-5.2": {
-    "input_cost_per_token": 0.0000014,
-    "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 1.4e-7,
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/perplexity/kimi-k3": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/perplexity/kimi-k2.7-code": {
-    "input_cost_per_token": 9.5e-7,
-    "output_cost_per_token": 0.000004,
-    "cache_read_input_token_cost": 1.9e-7,
-    "mode": "responses",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/pplx-embed-v1-0.6b": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 4e-9,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/pplx-embed-v1-4b": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "perplexity"
-  },
   "publicai/aisingapore/Qwen-SEA-LION-v4-32B-IT": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "publicai"
-  },
-  "publicai/allenai/Olmo-3-7B-Think": {
     "max_input_tokens": 32768,
     "max_output_tokens": 4096,
     "input_cost_per_token": 0,
@@ -16990,19 +20426,51 @@
     "mode": "chat",
     "litellm_provider": "publicai"
   },
-  "qwen.qwen3-coder-480b-a35b-v1:0": {
-    "max_input_tokens": 262000,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.0000018,
+  "publicai/allenai/Olmo-3-7B-Instruct": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
     "mode": "chat",
-    "litellm_provider": "bedrock_converse"
+    "litellm_provider": "publicai"
+  },
+  "publicai/allenai/Olmo-3-7B-Think": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "publicai"
+  },
+  "publicai/swiss-ai/apertus-70b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "publicai"
+  },
+  "publicai/swiss-ai/apertus-8b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "publicai"
   },
   "qwen.qwen3-235b-a22b-2507-v1:0": {
     "max_input_tokens": 262144,
     "max_output_tokens": 131072,
     "input_cost_per_token": 2.2e-7,
     "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "qwen.qwen3-32b-v1:0": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -17014,11 +20482,19 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
-  "qwen.qwen3-32b-v1:0": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+  "qwen.qwen3-coder-480b-a35b-v1:0": {
+    "max_input_tokens": 262000,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "qwen.qwen3-coder-next": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -17039,13 +20515,13 @@
     "litellm_provider": "bedrock_converse",
     "supports_vision": true
   },
-  "qwen.qwen3-coder-next": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse"
+  "recraft/recraftv2": {
+    "mode": "image_generation",
+    "litellm_provider": "recraft"
+  },
+  "recraft/recraftv3": {
+    "mode": "image_generation",
+    "litellm_provider": "recraft"
   },
   "reducto/parse-legacy": {
     "mode": "ocr",
@@ -17055,13 +20531,91 @@
     "mode": "ocr",
     "litellm_provider": "reducto"
   },
-  "recraft/recraftv2": {
-    "mode": "image_generation",
-    "litellm_provider": "recraft"
+  "replicate/anthropic/claude-3.5-haiku": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
   },
-  "recraft/recraftv3": {
-    "mode": "image_generation",
-    "litellm_provider": "recraft"
+  "replicate/anthropic/claude-3.5-sonnet": {
+    "input_cost_per_token": 0.00000375,
+    "output_cost_per_token": 0.00001875,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/anthropic/claude-3.7-sonnet": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/anthropic/claude-4-sonnet": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/anthropic/claude-4.5-haiku": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/anthropic/claude-4.5-sonnet": {
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/deepseek-ai/deepseek-r1": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000375,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/deepseek-ai/deepseek-v3": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000145,
+    "output_cost_per_token": 0.00000145,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/deepseek-ai/deepseek-v3.1": {
+    "max_input_tokens": 163840,
+    "max_output_tokens": 163840,
+    "input_cost_per_token": 6.72e-7,
+    "output_cost_per_token": 0.000002016,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/google/gemini-2.5-flash": {
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/google/gemini-3-pro": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "mode": "chat",
+    "litellm_provider": "replicate",
+    "supports_vision": true
+  },
+  "replicate/ibm-granite/granite-3.3-8b-instruct": {
+    "input_cost_per_token": 3e-8,
+    "output_cost_per_token": 2.5e-7,
+    "mode": "chat",
+    "litellm_provider": "replicate"
   },
   "replicate/meta/llama-2-13b": {
     "max_input_tokens": 4096,
@@ -17167,29 +20721,23 @@
     "mode": "chat",
     "litellm_provider": "replicate"
   },
-  "replicate/openai/gpt-5": {
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
+  "replicate/openai/gpt-4.1": {
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
     "mode": "chat",
     "litellm_provider": "replicate",
     "supports_vision": true
   },
-  "replicate/openai/gpt-oss-20b": {
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 3.6e-7,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/anthropic/claude-4.5-haiku": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
+  "replicate/openai/gpt-4.1-mini": {
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.0000016,
     "mode": "chat",
     "litellm_provider": "replicate",
     "supports_vision": true
   },
-  "replicate/ibm-granite/granite-3.3-8b-instruct": {
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 2.5e-7,
+  "replicate/openai/gpt-4.1-nano": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 4e-7,
     "mode": "chat",
     "litellm_provider": "replicate"
   },
@@ -17201,24 +20749,6 @@
     "supports_vision": true,
     "supports_audio_input": true
   },
-  "replicate/openai/o4-mini": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000004,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/openai/o1-mini": {
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000044,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/openai/o1": {
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.00006,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
   "replicate/openai/gpt-4o-mini": {
     "input_cost_per_token": 1.5e-7,
     "output_cost_per_token": 6e-7,
@@ -17226,78 +20756,16 @@
     "litellm_provider": "replicate",
     "supports_vision": true
   },
-  "replicate/qwen/qwen3-235b-a22b-instruct-2507": {
-    "input_cost_per_token": 2.64e-7,
-    "output_cost_per_token": 0.00000106,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/anthropic/claude-4-sonnet": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
+  "replicate/openai/gpt-5": {
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
     "mode": "chat",
     "litellm_provider": "replicate",
     "supports_vision": true
   },
-  "replicate/deepseek-ai/deepseek-v3": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000145,
-    "output_cost_per_token": 0.00000145,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/anthropic/claude-3.7-sonnet": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/anthropic/claude-3.5-haiku": {
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/anthropic/claude-3.5-sonnet": {
-    "input_cost_per_token": 0.00000375,
-    "output_cost_per_token": 0.00001875,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/google/gemini-3-pro": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/anthropic/claude-4.5-sonnet": {
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/openai/gpt-4.1": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/openai/gpt-4.1-nano": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/openai/gpt-4.1-mini": {
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
+  "replicate/openai/gpt-5-mini": {
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.000002,
     "mode": "chat",
     "litellm_provider": "replicate",
     "supports_vision": true
@@ -17308,45 +20776,45 @@
     "mode": "chat",
     "litellm_provider": "replicate"
   },
-  "replicate/openai/gpt-5-mini": {
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
-  "replicate/google/gemini-2.5-flash": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "replicate",
-    "supports_vision": true
-  },
   "replicate/openai/gpt-oss-120b": {
     "input_cost_per_token": 1.8e-7,
     "output_cost_per_token": 7.2e-7,
     "mode": "chat",
     "litellm_provider": "replicate"
   },
-  "replicate/deepseek-ai/deepseek-v3.1": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 6.72e-7,
-    "output_cost_per_token": 0.000002016,
+  "replicate/openai/gpt-oss-20b": {
+    "input_cost_per_token": 9e-8,
+    "output_cost_per_token": 3.6e-7,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/openai/o1": {
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.00006,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/openai/o1-mini": {
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000044,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/openai/o4-mini": {
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000004,
+    "mode": "chat",
+    "litellm_provider": "replicate"
+  },
+  "replicate/qwen/qwen3-235b-a22b-instruct-2507": {
+    "input_cost_per_token": 2.64e-7,
+    "output_cost_per_token": 0.00000106,
     "mode": "chat",
     "litellm_provider": "replicate"
   },
   "replicate/xai/grok-4": {
     "input_cost_per_token": 0.0000072,
     "output_cost_per_token": 0.000036,
-    "mode": "chat",
-    "litellm_provider": "replicate"
-  },
-  "replicate/deepseek-ai/deepseek-r1": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000375,
-    "output_cost_per_token": 0.00001,
     "mode": "chat",
     "litellm_provider": "replicate"
   },
@@ -17390,23 +20858,29 @@
     "mode": "rerank",
     "litellm_provider": "cohere"
   },
-  "nvidia_nim/nvidia/nv-rerankqa-mistral-4b-v3": {
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "nvidia_nim"
+  "runwayml/eleven_multilingual_v2": {
+    "mode": "audio_speech",
+    "litellm_provider": "runwayml"
   },
-  "nvidia_nim/nvidia/llama-3_2-nv-rerankqa-1b-v2": {
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "nvidia_nim"
+  "runwayml/gen3a_turbo": {
+    "mode": "video_generation",
+    "litellm_provider": "runwayml"
   },
-  "nvidia_nim/ranking/nvidia/llama-3.2-nv-rerankqa-1b-v2": {
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "nvidia_nim"
+  "runwayml/gen4_aleph": {
+    "mode": "video_generation",
+    "litellm_provider": "runwayml"
+  },
+  "runwayml/gen4_image": {
+    "mode": "image_generation",
+    "litellm_provider": "runwayml"
+  },
+  "runwayml/gen4_image_turbo": {
+    "mode": "image_generation",
+    "litellm_provider": "runwayml"
+  },
+  "runwayml/gen4_turbo": {
+    "mode": "video_generation",
+    "litellm_provider": "runwayml"
   },
   "sagemaker/meta-textgeneration-llama-2-13b": {
     "max_input_tokens": 4096,
@@ -17456,14 +20930,6 @@
     "mode": "chat",
     "litellm_provider": "sagemaker"
   },
-  "sambanova/MiniMax-M2.7": {
-    "max_input_tokens": 196608,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "mode": "chat",
-    "litellm_provider": "sambanova"
-  },
   "sambanova/DeepSeek-R1": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
@@ -17481,6 +20947,22 @@
     "litellm_provider": "sambanova"
   },
   "sambanova/DeepSeek-V3-0324": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "sambanova"
+  },
+  "sambanova/DeepSeek-V3.1": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "sambanova"
+  },
+  "sambanova/DeepSeek-V3.2": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
     "input_cost_per_token": 0.000003,
@@ -17553,6 +21035,14 @@
     "mode": "chat",
     "litellm_provider": "sambanova"
   },
+  "sambanova/MiniMax-M2.7": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000024,
+    "mode": "chat",
+    "litellm_provider": "sambanova"
+  },
   "sambanova/QwQ-32B": {
     "max_input_tokens": 16384,
     "max_output_tokens": 16384,
@@ -17578,13 +21068,14 @@
     "mode": "chat",
     "litellm_provider": "sambanova"
   },
-  "sambanova/DeepSeek-V3.1": {
+  "sambanova/gemma-4-31B-it": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.0000045,
+    "input_cost_per_token": 3.8e-7,
+    "output_cost_per_token": 0.00000115,
     "mode": "chat",
-    "litellm_provider": "sambanova"
+    "litellm_provider": "sambanova",
+    "supports_vision": true
   },
   "sambanova/gpt-oss-120b": {
     "max_input_tokens": 131072,
@@ -17594,21 +21085,162 @@
     "mode": "chat",
     "litellm_provider": "sambanova"
   },
-  "sambanova/DeepSeek-V3.2": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.0000045,
-    "mode": "chat",
-    "litellm_provider": "sambanova"
+  "sample_spec": {
+    "max_input_tokens": "max input tokens, if the provider specifies it. if not default to max_tokens",
+    "max_output_tokens": "max output tokens, if the provider specifies it. if not default to max_tokens",
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "one of: chat, embedding, completion, image_generation, audio_transcription, audio_speech, image_generation, moderation, rerank, search",
+    "litellm_provider": "one of https://docs.litellm.ai/docs/providers",
+    "supports_vision": true,
+    "supports_audio_input": true
   },
-  "sambanova/gemma-4-31B-it": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 3.8e-7,
-    "output_cost_per_token": 0.00000115,
+  "sarvam/sarvam-m": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 0,
     "mode": "chat",
-    "litellm_provider": "sambanova",
+    "litellm_provider": "sarvam"
+  },
+  "scaleway/BAAI/bge-multilingual-gemma2": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/google/gemma-3-27b-it": {
+    "max_input_tokens": 40000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/google/gemma-4-26b-a4b-it": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/hcompany/holo2-30b-a3b": {
+    "max_input_tokens": 22000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 7e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/meta/llama-3.3-70b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 9e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/mistralai/devstral-2-123b-instruct-2512": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/mistralai/mistral-medium-3.5-128b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/mistral-small-3.2-24b-instruct-2506": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 3.5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/pixtral-12b-2409": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 4096,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/mistralai/voxtral-small-24b-2507": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 3.5e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_audio_input": true
+  },
+  "scaleway/openai/gpt-oss-120b": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/openai/whisper-large-v3": {
+    "output_cost_per_token": 0,
+    "mode": "audio_transcription",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3-235b-a22b-instruct-2507": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000225,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3-coder-30b-a3b-instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 8e-7,
+    "mode": "chat",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3-embedding-8b": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "scaleway"
+  },
+  "scaleway/qwen/qwen3.5-397b-a17b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
+    "supports_vision": true
+  },
+  "scaleway/qwen/qwen3.6-35b-a3b": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "scaleway",
     "supports_vision": true
   },
   "scx-ai/GLM-5.2": {
@@ -17631,7 +21263,75 @@
     "litellm_provider": "scx-ai",
     "supports_vision": true
   },
+  "searxng/search": {
+    "mode": "search",
+    "litellm_provider": "searxng"
+  },
+  "serper/search": {
+    "mode": "search",
+    "litellm_provider": "serper"
+  },
   "snowflake/claude-3-5-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-3-7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-4-opus": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-4-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-haiku-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-sonnet-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/claude-sonnet-4-6": {
     "max_input_tokens": 200000,
     "max_output_tokens": 16384,
     "input_cost_per_token": 0.000003,
@@ -17735,6 +21435,14 @@
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
+  "snowflake/llama4-maverick": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.4e-7,
+    "output_cost_per_token": 9.7e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
   "snowflake/mistral-7b": {
     "max_input_tokens": 32000,
     "max_output_tokens": 8192,
@@ -17761,6 +21469,42 @@
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
+  "snowflake/openai-gpt-4.1": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000008,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/openai-gpt-5": {
+    "max_input_tokens": 300000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.00001,
+    "cache_read_input_token_cost": 1.25e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake",
+    "supports_vision": true
+  },
+  "snowflake/openai-gpt-5-mini": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/openai-gpt-5-nano": {
+    "max_input_tokens": 5000000,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "snowflake"
+  },
   "snowflake/reka-core": {
     "max_input_tokens": 32000,
     "max_output_tokens": 8192,
@@ -17779,6 +21523,20 @@
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
+  "snowflake/snowflake-arctic-embed-l-v2.0": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "snowflake"
+  },
+  "snowflake/snowflake-arctic-embed-m-v2.0": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "snowflake"
+  },
   "snowflake/snowflake-llama-3.1-405b": {
     "max_input_tokens": 8000,
     "max_output_tokens": 8192,
@@ -17793,97 +21551,29 @@
     "mode": "chat",
     "litellm_provider": "snowflake"
   },
-  "stability/sd3": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
+  "soniox/stt-async-v4": {
+    "max_output_tokens": 8000,
+    "mode": "audio_transcription",
+    "litellm_provider": "soniox",
+    "supports_audio_input": true
   },
-  "stability/sd3-large": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
+  "soniox/stt-async-v5": {
+    "max_output_tokens": 8000,
+    "mode": "audio_transcription",
+    "litellm_provider": "soniox",
+    "supports_audio_input": true
   },
-  "stability/sd3-large-turbo": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
+  "sora-2": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
   },
-  "stability/sd3-medium": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
+  "sora-2-pro": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
   },
-  "stability/sd3.5-large": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
-  },
-  "stability/sd3.5-large-turbo": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
-  },
-  "stability/sd3.5-medium": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
-  },
-  "stability/stable-image-ultra": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
-  },
-  "stability/inpaint": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/outpaint": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/erase": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/search-and-replace": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/search-and-recolor": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/remove-background": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/replace-background-and-relight": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/sketch": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/structure": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/style": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/style-transfer": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/fast": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/conservative": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/creative": {
-    "mode": "image_edit",
-    "litellm_provider": "stability"
-  },
-  "stability/stable-image-core": {
-    "mode": "image_generation",
-    "litellm_provider": "stability"
+  "sora-2-pro-high-res": {
+    "mode": "video_generation",
+    "litellm_provider": "openai"
   },
   "stability.sd3-5-large-v1:0": {
     "max_input_tokens": 77,
@@ -17891,11 +21581,6 @@
     "litellm_provider": "bedrock"
   },
   "stability.sd3-large-v1:0": {
-    "max_input_tokens": 77,
-    "mode": "image_generation",
-    "litellm_provider": "bedrock"
-  },
-  "stability.stable-image-core-v1:0": {
     "max_input_tokens": 77,
     "mode": "image_generation",
     "litellm_provider": "bedrock"
@@ -17915,11 +21600,6 @@
     "mode": "image_edit",
     "litellm_provider": "bedrock"
   },
-  "stability.stable-outpaint-v1:0": {
-    "max_input_tokens": 77,
-    "mode": "image_edit",
-    "litellm_provider": "bedrock"
-  },
   "stability.stable-image-control-sketch-v1:0": {
     "max_input_tokens": 77,
     "mode": "image_edit",
@@ -17928,6 +21608,16 @@
   "stability.stable-image-control-structure-v1:0": {
     "max_input_tokens": 77,
     "mode": "image_edit",
+    "litellm_provider": "bedrock"
+  },
+  "stability.stable-image-core-v1:0": {
+    "max_input_tokens": 77,
+    "mode": "image_generation",
+    "litellm_provider": "bedrock"
+  },
+  "stability.stable-image-core-v1:1": {
+    "max_input_tokens": 77,
+    "mode": "image_generation",
     "litellm_provider": "bedrock"
   },
   "stability.stable-image-erase-object-v1:0": {
@@ -17960,16 +21650,6 @@
     "mode": "image_edit",
     "litellm_provider": "bedrock"
   },
-  "stability.stable-style-transfer-v1:0": {
-    "max_input_tokens": 77,
-    "mode": "image_edit",
-    "litellm_provider": "bedrock"
-  },
-  "stability.stable-image-core-v1:1": {
-    "max_input_tokens": 77,
-    "mode": "image_generation",
-    "litellm_provider": "bedrock"
-  },
   "stability.stable-image-ultra-v1:0": {
     "max_input_tokens": 77,
     "mode": "image_generation",
@@ -17980,25 +21660,155 @@
     "mode": "image_generation",
     "litellm_provider": "bedrock"
   },
+  "stability.stable-outpaint-v1:0": {
+    "max_input_tokens": 77,
+    "mode": "image_edit",
+    "litellm_provider": "bedrock"
+  },
+  "stability.stable-style-transfer-v1:0": {
+    "max_input_tokens": 77,
+    "mode": "image_edit",
+    "litellm_provider": "bedrock"
+  },
+  "stability/conservative": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/creative": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/erase": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/fast": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/inpaint": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/outpaint": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/remove-background": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/replace-background-and-relight": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3-large": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3-large-turbo": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3-medium": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3.5-large": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3.5-large-turbo": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/sd3.5-medium": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/search-and-recolor": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/search-and-replace": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/sketch": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/stable-image-core": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/stable-image-ultra": {
+    "mode": "image_generation",
+    "litellm_provider": "stability"
+  },
+  "stability/structure": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/style": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
+  "stability/style-transfer": {
+    "mode": "image_edit",
+    "litellm_provider": "stability"
+  },
   "standard/1024-x-1024/dall-e-3": {
     "mode": "image_generation",
     "litellm_provider": "openai"
+  },
+  "standard/1024-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "standard/1024-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "standard/1024-x-1536/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "standard/1024-x-1536/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "standard/1024-x-1792/dall-e-3": {
     "mode": "image_generation",
     "litellm_provider": "openai"
   },
+  "standard/1536-x-1024/gpt-image-1.5": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "standard/1536-x-1024/gpt-image-1.5-2025-12-16": {
+    "mode": "image_generation",
+    "litellm_provider": "openai",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "standard/1792-x-1024/dall-e-3": {
     "mode": "image_generation",
     "litellm_provider": "openai"
-  },
-  "linkup/search": {
-    "mode": "search",
-    "litellm_provider": "linkup"
-  },
-  "linkup/search-deep": {
-    "mode": "search",
-    "litellm_provider": "linkup"
   },
   "tavily/search": {
     "mode": "search",
@@ -18008,9 +21818,117 @@
     "mode": "search",
     "litellm_provider": "tavily"
   },
-  "you_com/search": {
-    "mode": "search",
-    "litellm_provider": "you_com"
+  "tencent/deepseek-v4-flash": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 2.8e-9,
+    "mode": "chat",
+    "litellm_provider": "tencent",
+    "supports_vision": false
+  },
+  "tencent/deepseek-v4-pro": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 384000,
+    "input_cost_per_token": 4.35e-7,
+    "output_cost_per_token": 8.7e-7,
+    "cache_creation_input_token_cost": 0,
+    "cache_read_input_token_cost": 3.625e-9,
+    "mode": "chat",
+    "litellm_provider": "tencent",
+    "supports_vision": false
+  },
+  "tensormesh/MiniMaxAI/MiniMax-M2.5": {
+    "max_input_tokens": 196608,
+    "max_output_tokens": 196608,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 4.5e-7,
+    "output_cost_per_token": 0.0000018,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/Qwen/Qwen3.6-27B-FP8": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 3.2e-7,
+    "output_cost_per_token": 0.0000032,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/deepseek-ai/DeepSeek-V4-Flash": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/google/gemma-4-31B-it": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 1.4e-7,
+    "output_cost_per_token": 5.6e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/lukealonso/GLM-5.1-NVFP4-MTP": {
+    "max_input_tokens": 202752,
+    "max_output_tokens": 202752,
+    "input_cost_per_token": 0.0000014,
+    "output_cost_per_token": 0.0000044,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/moonshotai/Kimi-K2.6": {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 9.6e-7,
+    "output_cost_per_token": 0.000004,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
+  },
+  "tensormesh/openai/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 7e-8,
+    "output_cost_per_token": 2.8e-7,
+    "cache_read_input_token_cost": 0,
+    "mode": "chat",
+    "litellm_provider": "tensormesh"
   },
   "text-completion-codestral/codestral-2405": {
     "max_input_tokens": 32000,
@@ -18027,6 +21945,15 @@
     "output_cost_per_token": 0,
     "mode": "completion",
     "litellm_provider": "text-completion-codestral"
+  },
+  "text-completion-inception/mercury-edit-2": {
+    "max_input_tokens": 32000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 7.5e-7,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "completion",
+    "litellm_provider": "text-completion-inception"
   },
   "text-embedding-004": {
     "max_input_tokens": 2048,
@@ -18131,6 +22058,10 @@
     "mode": "completion",
     "litellm_provider": "vertex_ai-text-models"
   },
+  "tinyfish/search": {
+    "mode": "search",
+    "litellm_provider": "tinyfish"
+  },
   "together-ai-21.1b-41b": {
     "input_cost_per_token": 8e-7,
     "output_cost_per_token": 8e-7,
@@ -18173,11 +22104,10 @@
     "mode": "embedding",
     "litellm_provider": "together_ai"
   },
-  "together_ai/baai/bge-base-en-v1.5": {
-    "max_input_tokens": 512,
-    "input_cost_per_token": 8e-9,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
+  "together-ai-up-to-4b": {
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
+    "mode": "chat",
     "litellm_provider": "together_ai"
   },
   "together_ai/BAAI/bge-base-en-v1.5": {
@@ -18185,12 +22115,6 @@
     "input_cost_per_token": 8e-9,
     "output_cost_per_token": 0,
     "mode": "embedding",
-    "litellm_provider": "together_ai"
-  },
-  "together-ai-up-to-4b": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
     "litellm_provider": "together_ai"
   },
   "together_ai/Qwen/Qwen2.5-72B-Instruct-Turbo": {
@@ -18227,6 +22151,34 @@
     "input_cost_per_token": 0.000002,
     "output_cost_per_token": 0.000002,
     "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/Qwen/Qwen3.5-397B-A17B": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000036,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/baai/bge-base-en-v1.5": {
+    "max_input_tokens": 512,
+    "input_cost_per_token": 8e-9,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
     "litellm_provider": "together_ai"
   },
   "together_ai/deepseek-ai/DeepSeek-R1": {
@@ -18326,6 +22278,22 @@
     "mode": "chat",
     "litellm_provider": "together_ai"
   },
+  "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
+    "max_input_tokens": 262144,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000003,
+    "mode": "chat",
+    "litellm_provider": "together_ai"
+  },
+  "together_ai/moonshotai/Kimi-K2.5": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.0000028,
+    "mode": "chat",
+    "litellm_provider": "together_ai",
+    "supports_vision": true
+  },
   "together_ai/openai/gpt-oss-120b": {
     "max_input_tokens": 131072,
     "max_output_tokens": 131072,
@@ -18368,44 +22336,11 @@
     "mode": "chat",
     "litellm_provider": "together_ai"
   },
-  "together_ai/moonshotai/Kimi-K2.5": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000028,
-    "mode": "chat",
-    "litellm_provider": "together_ai",
-    "supports_vision": true
-  },
-  "together_ai/moonshotai/Kimi-K2-Instruct-0905": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "together_ai"
-  },
-  "together_ai/Qwen/Qwen3-Next-80B-A3B-Instruct": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "together_ai"
-  },
-  "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "together_ai"
-  },
-  "together_ai/Qwen/Qwen3.5-397B-A17B": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000036,
-    "mode": "chat",
-    "litellm_provider": "together_ai"
-  },
   "tts-1": {
+    "mode": "audio_speech",
+    "litellm_provider": "openai"
+  },
+  "tts-1-1106": {
     "mode": "audio_speech",
     "litellm_provider": "openai"
   },
@@ -18413,21 +22348,67 @@
     "mode": "audio_speech",
     "litellm_provider": "openai"
   },
-  "aws_polly/standard": {
+  "tts-1-hd-1106": {
     "mode": "audio_speech",
-    "litellm_provider": "aws_polly"
+    "litellm_provider": "openai"
   },
-  "aws_polly/neural": {
-    "mode": "audio_speech",
-    "litellm_provider": "aws_polly"
+  "twelvelabs.marengo-embed-2-7-v1:0": {
+    "max_input_tokens": 77,
+    "input_cost_per_token": 0.00007,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock"
   },
-  "aws_polly/long-form": {
-    "mode": "audio_speech",
-    "litellm_provider": "aws_polly"
+  "twelvelabs.pegasus-1-2-v1:0": {
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_video_input": true
   },
-  "aws_polly/generative": {
-    "mode": "audio_speech",
-    "litellm_provider": "aws_polly"
+  "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000036,
+    "output_cost_per_token": 0.000018,
+    "input_cost_per_token_above_200k_tokens": 0.0000072,
+    "output_cost_per_token_above_200k_tokens": 0.000027,
+    "cache_creation_input_token_cost": 0.0000045,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.000009,
+    "cache_read_input_token_cost": 3.6e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 7.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.amazon.nova-2-lite-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 3.3e-7,
+    "output_cost_per_token": 0.00000275,
+    "cache_read_input_token_cost": 8.25e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "us.amazon.nova-2-pro-preview-20251202-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000021875,
+    "output_cost_per_token": 0.0000175,
+    "cache_read_input_token_cost": 5.46875e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_video_input": true
+  },
+  "us.amazon.nova-canvas-v1:0": {
+    "max_input_tokens": 2600,
+    "mode": "image_generation",
+    "litellm_provider": "bedrock"
   },
   "us.amazon.nova-lite-v1:0": {
     "max_input_tokens": 300000,
@@ -18477,18 +22458,6 @@
     "mode": "chat",
     "litellm_provider": "bedrock",
     "supports_pdf_input": true
-  },
-  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000055,
-    "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
   },
   "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
     "max_input_tokens": 200000,
@@ -18561,6 +22530,30 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "us.anthropic.claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000011,
+    "output_cost_per_token": 0.000055,
+    "cache_creation_input_token_cost": 0.00001375,
+    "cache_read_input_token_cost": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000055,
+    "cache_creation_input_token_cost": 0.000001375,
+    "cache_read_input_token_cost": 1.1e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "us.anthropic.claude-opus-4-1-20250805-v1:0": {
     "max_input_tokens": 200000,
     "max_output_tokens": 32000,
@@ -18568,50 +22561,6 @@
     "output_cost_per_token": 0.000075,
     "cache_creation_input_token_cost": 0.00001875,
     "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "input_cost_per_token_above_200k_tokens": 0.0000066,
-    "output_cost_per_token_above_200k_tokens": 0.00002475,
-    "cache_creation_input_token_cost": 0.000004125,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
-    "cache_read_input_token_cost": 3.3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6.6e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000036,
-    "output_cost_per_token": 0.000018,
-    "input_cost_per_token_above_200k_tokens": 0.0000072,
-    "output_cost_per_token_above_200k_tokens": 0.000027,
-    "cache_creation_input_token_cost": 0.0000045,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.000009,
-    "cache_read_input_token_cost": 3.6e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 7.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000055,
-    "cache_creation_input_token_cost": 0.000001375,
-    "cache_read_input_token_cost": 1.1e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -18641,25 +22590,49 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "global.anthropic.claude-opus-4-5-20251101-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
+  "us.anthropic.claude-opus-4-6-v1": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
+  "us.anthropic.claude-opus-4-7": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-4-8": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-opus-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.0000275,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
     "mode": "chat",
     "litellm_provider": "bedrock_converse",
     "supports_pdf_input": true,
@@ -18681,6 +22654,46 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
+  "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "input_cost_per_token_above_200k_tokens": 0.0000066,
+    "output_cost_per_token_above_200k_tokens": 0.00002475,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.00000825,
+    "cache_read_input_token_cost": 3.3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6.6e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.0000033,
+    "output_cost_per_token": 0.0000165,
+    "cache_creation_input_token_cost": 0.000004125,
+    "cache_read_input_token_cost": 3.3e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "us.anthropic.claude-sonnet-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.000011,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
   "us.deepseek.r1-v1:0": {
     "max_input_tokens": 128000,
     "max_output_tokens": 4096,
@@ -18694,14 +22707,6 @@
     "max_output_tokens": 163840,
     "input_cost_per_token": 6.2e-7,
     "output_cost_per_token": 0.00000185,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse"
-  },
-  "eu.deepseek.v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 7.4e-7,
-    "output_cost_per_token": 0.00000222,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -18794,6 +22799,80 @@
     "output_cost_per_token": 0.000006,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
+  },
+  "us.openai.gpt-5.6-luna": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.00000132,
+    "cache_creation_input_token_cost": 2.75e-7,
+    "cache_read_input_token_cost": 2.2e-8,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "us.openai.gpt-5.6-sol": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000055,
+    "output_cost_per_token": 0.000033,
+    "cache_creation_input_token_cost": 0.000006875,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "us.openai.gpt-5.6-terra": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000132,
+    "cache_creation_input_token_cost": 0.00000275,
+    "cache_read_input_token_cost": 2.2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
+  },
+  "us.twelvelabs.marengo-embed-2-7-v1:0": {
+    "max_input_tokens": 77,
+    "input_cost_per_token": 0.00007,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "bedrock"
+  },
+  "us.twelvelabs.pegasus-1-2-v1:0": {
+    "output_cost_per_token": 0.0000075,
+    "mode": "chat",
+    "litellm_provider": "bedrock",
+    "supports_video_input": true
+  },
+  "us.writer.palmyra-x4-v1:0": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true
+  },
+  "us.writer.palmyra-x5-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000006,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true
+  },
+  "us.xai.grok-4.6": {
+    "max_input_tokens": 500000,
+    "max_output_tokens": 500000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000066,
+    "cache_read_input_token_cost": 5.5e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_vision": true
   },
   "v0/v0-1.0-md": {
     "max_input_tokens": 128000,
@@ -18896,6 +22975,39 @@
     "mode": "chat",
     "litellm_provider": "vercel_ai_gateway"
   },
+  "vercel_ai_gateway/anthropic/claude-3-5-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-3-5-sonnet-20241022": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
+  "vercel_ai_gateway/anthropic/claude-3-7-sonnet": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vercel_ai_gateway",
+    "supports_vision": true
+  },
   "vercel_ai_gateway/anthropic/claude-3-haiku": {
     "max_input_tokens": 200000,
     "max_output_tokens": 4096,
@@ -18971,39 +23083,6 @@
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
     "litellm_provider": "vercel_ai_gateway"
-  },
-  "vercel_ai_gateway/anthropic/claude-3-5-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway",
-    "supports_vision": true
-  },
-  "vercel_ai_gateway/anthropic/claude-3-5-sonnet-20241022": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway",
-    "supports_vision": true
-  },
-  "vercel_ai_gateway/anthropic/claude-3-7-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vercel_ai_gateway",
-    "supports_vision": true
   },
   "vercel_ai_gateway/anthropic/claude-haiku-4.5": {
     "max_input_tokens": 200000,
@@ -19750,30 +23829,6 @@
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true
   },
-  "vertex_ai/claude-haiku-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-haiku-4-5@20251001": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_creation_input_token_cost": 0.00000125,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
   "vertex_ai/claude-3-5-sonnet": {
     "max_input_tokens": 200000,
     "max_output_tokens": 8192,
@@ -19858,6 +23913,54 @@
     "output_cost_per_token": 0.000015,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_vision": true
+  },
+  "vertex_ai/claude-fable-5": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-fable-5@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.00001,
+    "output_cost_per_token": 0.00005,
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_read_input_token_cost": 0.000001,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-haiku-4-5": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-haiku-4-5@20251001": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000005,
+    "cache_creation_input_token_cost": 0.00000125,
+    "cache_read_input_token_cost": 1e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
     "supports_vision": true
   },
   "vertex_ai/claude-opus-4": {
@@ -19966,25 +24069,37 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "vertex_ai/claude-fable-5": {
+  "vertex_ai/claude-opus-4-8": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "vertex_ai/claude-fable-5@default": {
+  "vertex_ai/claude-opus-4-8@default": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000025,
+    "cache_creation_input_token_cost": 0.00000625,
+    "cache_read_input_token_cost": 5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-opus-4@20250514": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.000015,
+    "output_cost_per_token": 0.000075,
+    "cache_creation_input_token_cost": 0.00001875,
+    "cache_read_input_token_cost": 0.0000015,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true,
@@ -20014,25 +24129,17 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "vertex_ai/claude-opus-4-8": {
+  "vertex_ai/claude-sonnet-4": {
     "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-opus-4-8@default": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-anthropic_models",
     "supports_pdf_input": true,
@@ -20040,6 +24147,62 @@
   },
   "vertex_ai/claude-sonnet-4-5": {
     "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4-5@20250929": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "input_cost_per_token_above_200k_tokens": 0.000006,
+    "output_cost_per_token_above_200k_tokens": 0.0000225,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4-6": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4-6@default": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 64000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "cache_creation_input_token_cost": 0.00000375,
+    "cache_read_input_token_cost": 3e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
+  },
+  "vertex_ai/claude-sonnet-4@20250514": {
+    "max_input_tokens": 1000000,
     "max_output_tokens": 64000,
     "input_cost_per_token": 0.000003,
     "output_cost_per_token": 0.000015,
@@ -20066,103 +24229,19 @@
     "supports_pdf_input": true,
     "supports_vision": true
   },
-  "vertex_ai/claude-sonnet-4-6": {
+  "vertex_ai/claude-sonnet-5@default": {
     "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-sonnet-4-5@20250929": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-opus-4@20250514": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.000015,
-    "output_cost_per_token": 0.000075,
-    "cache_creation_input_token_cost": 0.00001875,
-    "cache_read_input_token_cost": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-sonnet-4": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-sonnet-4@20250514": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "input_cost_per_token_above_200k_tokens": 0.000006,
-    "output_cost_per_token_above_200k_tokens": 0.0000225,
-    "cache_creation_input_token_cost": 0.00000375,
-    "cache_creation_input_token_cost_above_200k_tokens": 0.0000075,
-    "cache_read_input_token_cost": 3e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/mistralai/codestral-2@001": {
-    "max_input_tokens": 128000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 9e-7,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.00001,
+    "cache_creation_input_token_cost": 0.0000025,
+    "cache_read_input_token_cost": 2e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
+    "litellm_provider": "vertex_ai-anthropic_models",
+    "supports_pdf_input": true,
+    "supports_vision": true
   },
   "vertex_ai/codestral-2": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
-  "vertex_ai/codestral-2@001": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
-  "vertex_ai/mistralai/codestral-2": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 3e-7,
@@ -20175,6 +24254,14 @@
     "max_output_tokens": 128000,
     "input_cost_per_token": 2e-7,
     "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/codestral-2@001": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 9e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-mistral_models"
   },
@@ -20194,6 +24281,29 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-mistral_models"
   },
+  "vertex_ai/deep-research-pro-preview-12-2025": {
+    "max_input_tokens": 65536,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "output_cost_per_image_token": 0.00012,
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-language-models"
+  },
+  "vertex_ai/deepseek-ai/deepseek-ocr-maas": {
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "ocr",
+    "litellm_provider": "vertex_ai"
+  },
+  "vertex_ai/deepseek-ai/deepseek-r1-0528-maas": {
+    "max_input_tokens": 65336,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.00000135,
+    "output_cost_per_token": 0.0000054,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-deepseek_models"
+  },
   "vertex_ai/deepseek-ai/deepseek-v3.1-maas": {
     "max_input_tokens": 163840,
     "max_output_tokens": 32768,
@@ -20210,14 +24320,6 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-deepseek_models"
   },
-  "vertex_ai/deepseek-ai/deepseek-r1-0528-maas": {
-    "max_input_tokens": 65336,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000135,
-    "output_cost_per_token": 0.0000054,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-deepseek_models"
-  },
   "vertex_ai/gemini-2.5-flash-image": {
     "max_input_tokens": 32768,
     "max_output_tokens": 32768,
@@ -20229,6 +24331,19 @@
     "litellm_provider": "vertex_ai-language-models",
     "supports_pdf_input": true,
     "supports_vision": true
+  },
+  "vertex_ai/gemini-3-flash-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 5e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "vertex_ai/gemini-3-pro-image": {
     "max_input_tokens": 65536,
@@ -20248,6 +24363,23 @@
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models"
   },
+  "vertex_ai/gemini-3-pro-preview": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
   "vertex_ai/gemini-3.1-flash-image": {
     "max_input_tokens": 65536,
     "max_output_tokens": 32768,
@@ -20265,6 +24397,19 @@
     "output_cost_per_image_token": 0.00006,
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-language-models"
+  },
+  "vertex_ai/gemini-3.1-flash-lite": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 2.5e-7,
+    "output_cost_per_token": 0.0000015,
+    "cache_read_input_token_cost": 2.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-language-models",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
   },
   "vertex_ai/gemini-3.1-flash-lite-image": {
     "max_input_tokens": 65536,
@@ -20292,14 +24437,48 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "vertex_ai/gemini-3.1-flash-lite": {
+  "vertex_ai/gemini-3.1-pro-preview": {
     "max_input_tokens": 1048576,
     "max_output_tokens": 65536,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 2.5e-8,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-language-models",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.1-pro-preview-customtools": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 0.000002,
+    "output_cost_per_token": 0.000012,
+    "input_cost_per_token_above_200k_tokens": 0.000004,
+    "output_cost_per_token_above_200k_tokens": 0.000018,
+    "cache_creation_input_token_cost_above_200k_tokens": 2.5e-7,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.5-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_token": 0.0000015,
+    "output_cost_per_token": 0.000009,
+    "cache_read_input_token_cost": 1.5e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
     "supports_pdf_input": true,
     "supports_vision": true,
     "supports_audio_input": true,
@@ -20318,16 +24497,60 @@
     "supports_audio_input": true,
     "supports_video_input": true
   },
-  "vertex_ai/deep-research-pro-preview-12-2025": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "output_cost_per_image_token": 0.00012,
-    "mode": "image_generation",
-    "litellm_provider": "vertex_ai-language-models"
+  "vertex_ai/gemini-3.6-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-3.7-flash": {
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_token": 7.5e-7,
+    "output_cost_per_token": 0.00000375,
+    "cache_read_input_token_cost": 7.5e-8,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai",
+    "supports_pdf_input": true,
+    "supports_vision": true,
+    "supports_audio_input": true,
+    "supports_video_input": true
+  },
+  "vertex_ai/gemini-embedding-2": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai"
+  },
+  "vertex_ai/gemini-embedding-2-preview": {
+    "max_input_tokens": 8192,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "vertex_ai"
+  },
+  "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 6e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-openai_models",
+    "supports_vision": true
   },
   "vertex_ai/imagegeneration@006": {
+    "mode": "image_generation",
+    "litellm_provider": "vertex_ai-image-models"
+  },
+  "vertex_ai/imagen-3.0-capability-001": {
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-image-models"
   },
@@ -20340,10 +24563,6 @@
     "litellm_provider": "vertex_ai-image-models"
   },
   "vertex_ai/imagen-3.0-generate-002": {
-    "mode": "image_generation",
-    "litellm_provider": "vertex_ai-image-models"
-  },
-  "vertex_ai/imagen-3.0-capability-001": {
     "mode": "image_generation",
     "litellm_provider": "vertex_ai-image-models"
   },
@@ -20499,63 +24718,6 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-minimax_models"
   },
-  "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-moonshot_models"
-  },
-  "vertex_ai/zai-org/glm-4.7-maas": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-zai_models"
-  },
-  "vertex_ai/zai-org/glm-5-maas": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.0000032,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-zai_models"
-  },
-  "vertex_ai/mistral-medium-3": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
-  "vertex_ai/mistral-medium-3@001": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
-  "vertex_ai/mistralai/mistral-medium-3": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
-  "vertex_ai/mistralai/mistral-medium-3@001": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8191,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-mistral_models"
-  },
   "vertex_ai/mistral-large-2411": {
     "max_input_tokens": 128000,
     "max_output_tokens": 8191,
@@ -20588,6 +24750,22 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-mistral_models"
   },
+  "vertex_ai/mistral-medium-3": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/mistral-medium-3@001": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
   "vertex_ai/mistral-nemo@2407": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
@@ -20603,6 +24781,10 @@
     "output_cost_per_token": 1.5e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/mistral-ocr-2505": {
+    "mode": "ocr",
+    "litellm_provider": "vertex_ai"
   },
   "vertex_ai/mistral-small-2503": {
     "max_input_tokens": 128000,
@@ -20621,24 +24803,45 @@
     "mode": "chat",
     "litellm_provider": "vertex_ai-mistral_models"
   },
-  "vertex_ai/mistral-ocr-2505": {
-    "mode": "ocr",
-    "litellm_provider": "vertex_ai"
-  },
-  "vertex_ai/deepseek-ai/deepseek-ocr-maas": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "ocr",
-    "litellm_provider": "vertex_ai"
-  },
-  "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
-    "max_input_tokens": 256000,
+  "vertex_ai/mistralai/codestral-2": {
+    "max_input_tokens": 128000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 9e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-openai_models",
-    "supports_vision": true
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/mistralai/codestral-2@001": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 9e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/mistralai/mistral-medium-3": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/mistralai/mistral-medium-3@001": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8191,
+    "input_cost_per_token": 4e-7,
+    "output_cost_per_token": 0.000002,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-mistral_models"
+  },
+  "vertex_ai/moonshotai/kimi-k2-thinking-maas": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-moonshot_models"
   },
   "vertex_ai/openai/gpt-oss-120b-maas": {
     "max_input_tokens": 131072,
@@ -20655,6 +24858,77 @@
     "output_cost_per_token": 3e-7,
     "mode": "chat",
     "litellm_provider": "vertex_ai-openai_models"
+  },
+  "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 8.8e-7,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-qwen_models"
+  },
+  "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 32768,
+    "input_cost_per_token": 2.2e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-qwen_models"
+  },
+  "vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-qwen_models"
+  },
+  "vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 1.5e-7,
+    "output_cost_per_token": 0.0000012,
+    "mode": "chat",
+    "litellm_provider": "vertex_ai-qwen_models"
+  },
+  "vertex_ai/search_api": {
+    "mode": "vector_store",
+    "litellm_provider": "vertex_ai"
+  },
+  "vertex_ai/veo-2.0-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.0-fast-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.0-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.1-fast-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.1-fast-generate-preview": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.1-generate-001": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
+  },
+  "vertex_ai/veo-3.1-generate-preview": {
+    "max_input_tokens": 1024,
+    "mode": "video_generation",
+    "litellm_provider": "vertex_ai-video-models"
   },
   "vertex_ai/xai/grok-4.1-fast-non-reasoning": {
     "max_input_tokens": 2000000,
@@ -20696,72 +24970,50 @@
     "litellm_provider": "vertex_ai",
     "supports_vision": true
   },
-  "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
+  "vertex_ai/zai-org/glm-4.7-maas": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-qwen_models"
+    "litellm_provider": "vertex_ai-zai_models"
   },
-  "vertex_ai/qwen/qwen3-coder-480b-a35b-instruct-maas": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.0000018,
+  "vertex_ai/zai-org/glm-5-maas": {
+    "max_input_tokens": 200000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
+    "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-qwen_models"
+    "litellm_provider": "vertex_ai-zai_models"
   },
-  "vertex_ai/qwen/qwen3-next-80b-a3b-instruct-maas": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000012,
+  "volcengine/doubao-seed-2-0-code-preview-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-qwen_models"
+    "litellm_provider": "volcengine",
+    "supports_vision": true
   },
-  "vertex_ai/qwen/qwen3-next-80b-a3b-thinking-maas": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000012,
+  "volcengine/doubao-seed-2-0-lite-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-qwen_models"
+    "litellm_provider": "volcengine",
+    "supports_vision": true
   },
-  "vertex_ai/veo-2.0-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
+  "volcengine/doubao-seed-2-0-mini-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
   },
-  "vertex_ai/veo-3.0-fast-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.0-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.1-generate-preview": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.1-fast-generate-preview": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.1-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
-  },
-  "vertex_ai/veo-3.1-fast-generate-001": {
-    "max_input_tokens": 1024,
-    "mode": "video_generation",
-    "litellm_provider": "vertex_ai-video-models"
+  "volcengine/doubao-seed-2-0-pro-260215": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 128000,
+    "mode": "chat",
+    "litellm_provider": "volcengine",
+    "supports_vision": true
   },
   "voyage/rerank-2": {
     "max_input_tokens": 16000,
@@ -20837,6 +25089,27 @@
     "mode": "embedding",
     "litellm_provider": "voyage"
   },
+  "voyage/voyage-4": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 6e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-4-large": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-4-lite": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 2e-8,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
   "voyage/voyage-code-2": {
     "max_input_tokens": 16000,
     "input_cost_per_token": 1.2e-7,
@@ -20851,9 +25124,23 @@
     "mode": "embedding",
     "litellm_provider": "voyage"
   },
+  "voyage/voyage-code-4": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
   "voyage/voyage-context-3": {
     "max_input_tokens": 120000,
     "input_cost_per_token": 1.8e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
+  },
+  "voyage/voyage-context-4": {
+    "max_input_tokens": 120000,
+    "input_cost_per_token": 1.2e-7,
     "output_cost_per_token": 0,
     "mode": "embedding",
     "litellm_provider": "voyage"
@@ -20900,31 +25187,30 @@
     "mode": "embedding",
     "litellm_provider": "voyage"
   },
-  "wandb/openai/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.015,
-    "output_cost_per_token": 0.06,
-    "mode": "chat",
-    "litellm_provider": "wandb"
+  "voyage/voyage-multimodal-3.5": {
+    "max_input_tokens": 32000,
+    "input_cost_per_token": 1.2e-7,
+    "output_cost_per_token": 0,
+    "mode": "embedding",
+    "litellm_provider": "voyage"
   },
-  "wandb/openai/gpt-oss-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.005,
-    "output_cost_per_token": 0.02,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/zai-org/GLM-4.5": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.055,
-    "output_cost_per_token": 0.2,
+  "wandb/MiniMaxAI/MiniMax-M2.5": {
+    "max_input_tokens": 197000,
+    "max_output_tokens": 197000,
+    "input_cost_per_token": 3e-7,
+    "output_cost_per_token": 0.0000012,
     "mode": "chat",
     "litellm_provider": "wandb"
   },
   "wandb/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 0.01,
+    "output_cost_per_token": 0.01,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
     "max_input_tokens": 262144,
     "max_output_tokens": 262144,
     "input_cost_per_token": 0.01,
@@ -20937,56 +25223,6 @@
     "max_output_tokens": 262144,
     "input_cost_per_token": 0.1,
     "output_cost_per_token": 0.15,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/Qwen/Qwen3-235B-A22B-Thinking-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 0.01,
-    "output_cost_per_token": 0.01,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/moonshotai/Kimi-K2-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/moonshotai/Kimi-K2.5": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.000003,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "wandb",
-    "supports_vision": true
-  },
-  "wandb/MiniMaxAI/MiniMax-M2.5": {
-    "max_input_tokens": 197000,
-    "max_output_tokens": 197000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/meta-llama/Llama-3.1-8B-Instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.022,
-    "output_cost_per_token": 0.022,
-    "mode": "chat",
-    "litellm_provider": "wandb"
-  },
-  "wandb/deepseek-ai/DeepSeek-V3.1": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.055,
-    "output_cost_per_token": 0.165,
     "mode": "chat",
     "litellm_provider": "wandb"
   },
@@ -21003,6 +25239,22 @@
     "max_output_tokens": 161000,
     "input_cost_per_token": 0.114,
     "output_cost_per_token": 0.275,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/deepseek-ai/DeepSeek-V3.1": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.055,
+    "output_cost_per_token": 0.165,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/meta-llama/Llama-3.1-8B-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 0.022,
+    "output_cost_per_token": 0.022,
     "mode": "chat",
     "litellm_provider": "wandb"
   },
@@ -21030,25 +25282,47 @@
     "mode": "chat",
     "litellm_provider": "wandb"
   },
-  "watsonx/ibm/granite-3-8b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 1024,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
+  "wandb/moonshotai/Kimi-K2-Instruct": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 128000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000025,
     "mode": "chat",
-    "litellm_provider": "watsonx",
-    "supports_vision": false,
-    "supports_audio_input": false
+    "litellm_provider": "wandb"
   },
-  "watsonx/mistralai/mistral-large": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.00001,
+  "wandb/moonshotai/Kimi-K2.5": {
+    "max_input_tokens": 262144,
+    "max_output_tokens": 262144,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000003,
+    "cache_read_input_token_cost": 1e-7,
     "mode": "chat",
-    "litellm_provider": "watsonx",
-    "supports_vision": false,
-    "supports_audio_input": false
+    "litellm_provider": "wandb",
+    "supports_vision": true
+  },
+  "wandb/openai/gpt-oss-120b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.015,
+    "output_cost_per_token": 0.06,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/openai/gpt-oss-20b": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.005,
+    "output_cost_per_token": 0.02,
+    "mode": "chat",
+    "litellm_provider": "wandb"
+  },
+  "wandb/zai-org/GLM-4.5": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 131072,
+    "input_cost_per_token": 0.055,
+    "output_cost_per_token": 0.2,
+    "mode": "chat",
+    "litellm_provider": "wandb"
   },
   "watsonx/bigscience/mt0-xxl-13b": {
     "max_input_tokens": 8192,
@@ -21103,6 +25377,16 @@
     "mode": "chat",
     "litellm_provider": "watsonx",
     "supports_vision": false
+  },
+  "watsonx/ibm/granite-3-8b-instruct": {
+    "max_input_tokens": 8192,
+    "max_output_tokens": 1024,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "watsonx",
+    "supports_vision": false,
+    "supports_audio_input": false
   },
   "watsonx/ibm/granite-4-h-small": {
     "max_input_tokens": 20480,
@@ -21230,6 +25514,16 @@
     "litellm_provider": "watsonx",
     "supports_vision": true
   },
+  "watsonx/mistralai/mistral-large": {
+    "max_input_tokens": 131072,
+    "max_output_tokens": 16384,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "watsonx",
+    "supports_vision": false,
+    "supports_audio_input": false
+  },
   "watsonx/mistralai/mistral-medium-2505": {
     "max_input_tokens": 128000,
     "max_output_tokens": 128000,
@@ -21291,6 +25585,24 @@
   "whisper-1": {
     "mode": "audio_transcription",
     "litellm_provider": "openai"
+  },
+  "writer.palmyra-x4-v1:0": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0000025,
+    "output_cost_per_token": 0.00001,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true
+  },
+  "writer.palmyra-x5-v1:0": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.000006,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse",
+    "supports_pdf_input": true
   },
   "xai/grok-2": {
     "max_input_tokens": 131072,
@@ -21450,24 +25762,6 @@
     "mode": "chat",
     "litellm_provider": "xai"
   },
-  "xai/grok-4-fast-reasoning": {
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "xai"
-  },
-  "xai/grok-4-fast-non-reasoning": {
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "xai"
-  },
   "xai/grok-4-0709": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
@@ -21476,37 +25770,7 @@
     "mode": "chat",
     "litellm_provider": "xai"
   },
-  "xai/grok-4-latest": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "mode": "chat",
-    "litellm_provider": "xai"
-  },
   "xai/grok-4-1-fast": {
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "xai",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "xai/grok-4-1-fast-reasoning": {
-    "max_input_tokens": 2000000,
-    "max_output_tokens": 2000000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 5e-7,
-    "cache_read_input_token_cost": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "xai",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "xai/grok-4-1-fast-reasoning-latest": {
     "max_input_tokens": 2000000,
     "max_output_tokens": 2000000,
     "input_cost_per_token": 2e-7,
@@ -21539,20 +25803,55 @@
     "supports_vision": true,
     "supports_audio_input": true
   },
-  "xai/grok-4.20-multi-agent-beta-0309": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.0000025,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000005,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+  "xai/grok-4-1-fast-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
     "mode": "chat",
     "litellm_provider": "xai",
-    "supports_vision": true
+    "supports_vision": true,
+    "supports_audio_input": true
   },
-  "xai/grok-4.20-beta-0309-reasoning": {
+  "xai/grok-4-1-fast-reasoning-latest": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true,
+    "supports_audio_input": true
+  },
+  "xai/grok-4-fast-non-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "xai"
+  },
+  "xai/grok-4-fast-reasoning": {
+    "max_input_tokens": 2000000,
+    "max_output_tokens": 2000000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 5e-7,
+    "cache_read_input_token_cost": 5e-8,
+    "mode": "chat",
+    "litellm_provider": "xai"
+  },
+  "xai/grok-4-latest": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 0.000003,
+    "output_cost_per_token": 0.000015,
+    "mode": "chat",
+    "litellm_provider": "xai"
+  },
+  "xai/grok-4.20-0309-non-reasoning": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 1000000,
     "input_cost_per_token": 0.00000125,
@@ -21579,6 +25878,45 @@
     "supports_vision": true
   },
   "xai/grok-4.20-beta-0309-non-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-beta-0309-reasoning": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-multi-agent-0309": {
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 1000000,
+    "input_cost_per_token": 0.00000125,
+    "output_cost_per_token": 0.0000025,
+    "input_cost_per_token_above_200k_tokens": 0.0000025,
+    "output_cost_per_token_above_200k_tokens": 0.000005,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
+  "xai/grok-4.20-multi-agent-beta-0309": {
     "max_input_tokens": 1000000,
     "max_output_tokens": 1000000,
     "input_cost_per_token": 0.00000125,
@@ -21665,6 +26003,19 @@
     "litellm_provider": "xai",
     "supports_vision": true
   },
+  "xai/grok-build-0.1": {
+    "max_input_tokens": 256000,
+    "max_output_tokens": 256000,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.000002,
+    "input_cost_per_token_above_200k_tokens": 0.000002,
+    "output_cost_per_token_above_200k_tokens": 0.000004,
+    "cache_read_input_token_cost": 2e-7,
+    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
+    "mode": "chat",
+    "litellm_provider": "xai",
+    "supports_vision": true
+  },
   "xai/grok-code-fast": {
     "max_input_tokens": 256000,
     "max_output_tokens": 256000,
@@ -21713,19 +26064,15 @@
     "litellm_provider": "xai",
     "supports_vision": true
   },
+  "you_com/search": {
+    "mode": "search",
+    "litellm_provider": "you_com"
+  },
   "zai.glm-4.7": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 6e-7,
     "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse"
-  },
-  "zai.glm-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.0000032,
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
@@ -21737,33 +26084,78 @@
     "mode": "chat",
     "litellm_provider": "bedrock_converse"
   },
-  "zai/glm-5": {
+  "zai.glm-5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
     "input_cost_per_token": 0.000001,
     "output_cost_per_token": 0.0000032,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 2e-7,
+    "mode": "chat",
+    "litellm_provider": "bedrock_converse"
+  },
+  "zai/glm-4-32b-0414-128k": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 1e-7,
+    "output_cost_per_token": 1e-7,
     "mode": "chat",
     "litellm_provider": "zai"
   },
-  "zai/glm-5.1": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000014,
-    "output_cost_per_token": 0.0000044,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 2.6e-7,
+  "zai/glm-4.5": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
     "mode": "chat",
     "litellm_provider": "zai"
   },
-  "zai/glm-5-code": {
+  "zai/glm-4.5-air": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 2e-7,
+    "output_cost_per_token": 0.0000011,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-4.5-airx": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.0000011,
+    "output_cost_per_token": 0.0000045,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-4.5-flash": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-4.5-x": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 0.0000022,
+    "output_cost_per_token": 0.0000089,
+    "mode": "chat",
+    "litellm_provider": "zai"
+  },
+  "zai/glm-4.5v": {
+    "max_input_tokens": 128000,
+    "max_output_tokens": 32000,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000018,
+    "mode": "chat",
+    "litellm_provider": "zai",
+    "supports_vision": true
+  },
+  "zai/glm-4.6": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.000005,
+    "input_cost_per_token": 6e-7,
+    "output_cost_per_token": 0.0000022,
     "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 3e-7,
+    "cache_read_input_token_cost": 1.1e-7,
     "mode": "chat",
     "litellm_provider": "zai"
   },
@@ -21787,4426 +26179,34 @@
     "mode": "chat",
     "litellm_provider": "zai"
   },
-  "zai/glm-4.6": {
+  "zai/glm-5": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
+    "input_cost_per_token": 0.000001,
+    "output_cost_per_token": 0.0000032,
     "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 1.1e-7,
+    "cache_read_input_token_cost": 2e-7,
     "mode": "chat",
     "litellm_provider": "zai"
   },
-  "zai/glm-4.5": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "zai/glm-4.5v": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000018,
-    "mode": "chat",
-    "litellm_provider": "zai",
-    "supports_vision": true
-  },
-  "zai/glm-4.5-x": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000089,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "zai/glm-4.5-air": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000011,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "zai/glm-4.5-airx": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0.0000011,
-    "output_cost_per_token": 0.0000045,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "zai/glm-4-32b-0414-128k": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "zai/glm-4.5-flash": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "zai"
-  },
-  "vertex_ai/search_api": {
-    "mode": "vector_store",
-    "litellm_provider": "vertex_ai"
-  },
-  "openai/container": {
-    "mode": "chat",
-    "litellm_provider": "openai"
-  },
-  "openai/sora-2": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "openai/sora-2-pro": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "openai/sora-2-pro-high-res": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "azure/sora-2": {
-    "mode": "video_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/sora-2-pro": {
-    "mode": "video_generation",
-    "litellm_provider": "azure"
-  },
-  "azure/sora-2-pro-high-res": {
-    "mode": "video_generation",
-    "litellm_provider": "azure"
-  },
-  "runwayml/gen4_turbo": {
-    "mode": "video_generation",
-    "litellm_provider": "runwayml"
-  },
-  "runwayml/gen4_aleph": {
-    "mode": "video_generation",
-    "litellm_provider": "runwayml"
-  },
-  "runwayml/gen3a_turbo": {
-    "mode": "video_generation",
-    "litellm_provider": "runwayml"
-  },
-  "runwayml/gen4_image": {
-    "mode": "image_generation",
-    "litellm_provider": "runwayml"
-  },
-  "runwayml/gen4_image_turbo": {
-    "mode": "image_generation",
-    "litellm_provider": "runwayml"
-  },
-  "runwayml/eleven_multilingual_v2": {
-    "mode": "audio_speech",
-    "litellm_provider": "runwayml"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 4.5e-7,
-    "output_cost_per_token": 0.0000018,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-kontext-pro": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 4e-8,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/SSD-1B": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.3e-10,
-    "output_cost_per_token": 1.3e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/chronos-hermes-13b-v2": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-13b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-13b-instruct": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-13b-python": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-34b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-34b-instruct": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-34b-python": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-70b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-70b-instruct": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-70b-python": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-7b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-7b-instruct": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-llama-7b-python": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/code-qwen-1p5-7b": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/codegemma-2b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/codegemma-7b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-671b-v2-p1": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-70b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-llama-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-kontext-max": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 8e-8,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/dbrx-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-1b-base": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-33b-instruct": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-base": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-prover-v2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-v2-lite-chat": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-v2p5": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/devstral-small-2505": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/fare-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/firefunction-v1": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/firellava-13b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/firesearch-ocr-v6": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/fireworks-asr-large": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "audio_transcription",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/fireworks-asr-v2": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "audio_transcription",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-1-dev": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-1-dev-controlnet-union": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-9,
-    "output_cost_per_token": 1e-9,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-1-dev-fp8": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 5e-10,
-    "output_cost_per_token": 5e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-1-schnell": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/flux-1-schnell-fp8": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 3.5e-10,
-    "output_cost_per_token": 3.5e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gemma-2b-it": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gemma-3-27b-it": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gemma-7b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gemma-7b-it": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gemma2-9b-it": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/glm-4p5v": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/gpt-oss-safeguard-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/hermes-2-pro-mistral-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/internvl3-38b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/internvl3-78b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/internvl3-8b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/japanese-stable-diffusion-xl": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.3e-10,
-    "output_cost_per_token": 1.3e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/kat-coder": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/kat-dev-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/kat-dev-72b-exp": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-guard-2-8b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-guard-3-1b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-guard-3-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-13b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-13b-chat": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-70b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-70b-chat": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-7b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v2-7b-chat": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct-hf": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3-8b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3-8b-instruct-hf": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p2-1b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p2-3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llama-v3p3-70b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llamaguard-7b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/llava-yi-34b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/minimax-m1-80k": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/minimax-m2": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/ministral-3-14b-instruct-2512": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/ministral-3-3b-instruct-2512": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/ministral-3-8b-instruct-2512": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-4k": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v0p2": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-7b-instruct-v3": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-7b-v0p2": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-large-3-fp8": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-nemo-base-2407": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-nemo-instruct-2407": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mistral-small-24b-instruct-2501": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mixtral-8x22b": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/mythomax-l2-13b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-capybara-7b-v1p9": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-hermes-2-yi-34b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-13b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-70b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nous-hermes-llama2-7b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/openchat-3p5-0106-7b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/openhermes-2-mistral-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/openhermes-2p5-mistral-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/openorca-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phi-2-3b": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phi-3-mini-128k-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phi-3-vision-128k-instruct": {
-    "max_input_tokens": 32064,
-    "max_output_tokens": 32064,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-python-v1": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v1": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/phind-code-llama-34b-v2": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/playground-v2-1024px-aesthetic": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.3e-10,
-    "output_cost_per_token": 1.3e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/playground-v2-5-1024px-aesthetic": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.3e-10,
-    "output_cost_per_token": 1.3e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/pythia-12b": {
-    "max_input_tokens": 2048,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen-qwq-32b-preview": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen-v2p5-14b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen-v2p5-7b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen1p5-72b-chat": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2-7b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2-vl-2b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2-vl-72b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2-vl-7b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-0p5b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-14b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-1p5b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-32b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-72b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-72b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-7b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-0p5b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-14b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-1p5b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-32k-rope": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-32b-instruct-64k": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-3b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-coder-7b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-math-72b-instruct": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-32b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-3b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-72b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen2p5-vl-7b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-0p6b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-14b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-131072": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-1p7b-fp8-draft-40960": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-instruct-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-4b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-4b-instruct-2507": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-8b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-embedding-0p6b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-embedding-4b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-0p6b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-4b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-reranker-8b": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 40960,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "rerank",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 8.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-32b-instruct": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3-vl-8b-instruct": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3p7-plus": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000016,
-    "cache_read_input_token_cost": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/accounts/fireworks/models/qwq-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/rolm-ocr": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/stable-diffusion-xl-1024-v1-0": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1.3e-10,
-    "output_cost_per_token": 1.3e-10,
-    "mode": "image_generation",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/stablecode-3b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/starcoder-16b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/starcoder-7b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/starcoder2-15b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/starcoder2-3b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/starcoder2-7b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/toppy-m-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/yi-34b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/yi-34b-200k-capybara": {
+  "zai/glm-5-code": {
     "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/yi-34b-chat": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/yi-6b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/models/zephyr-7b-beta": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai"
-  },
-  "fireworks_ai/accounts/fireworks/routers/glm-5p1-fast": {
-    "max_input_tokens": 202800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000028,
-    "output_cost_per_token": 0.0000088,
-    "cache_read_input_token_cost": 5.2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/routers/kimi-k2p6-fast": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/accounts/fireworks/routers/kimi-k2p7-code-fast": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0.0000019,
-    "output_cost_per_token": 0.000008,
-    "cache_read_input_token_cost": 3.8e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "scaleway/qwen/qwen3.5-397b-a17b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000036,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/qwen/qwen3.6-35b-a3b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/qwen/qwen3-235b-a22b-instruct-2507": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.00000225,
-    "mode": "chat",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/qwen/qwen3-embedding-8b": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/qwen/qwen3-coder-30b-a3b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 8e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/openai/gpt-oss-120b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/openai/whisper-large-v3": {
-    "output_cost_per_token": 0,
-    "mode": "audio_transcription",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/google/gemma-4-26b-a4b-it": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/google/gemma-3-27b-it": {
-    "max_input_tokens": 40000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/hcompany/holo2-30b-a3b": {
-    "max_input_tokens": 22000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 7e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/mistralai/mistral-medium-3.5-128b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.0000015,
-    "output_cost_per_token": 0.0000075,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/mistralai/devstral-2-123b-instruct-2512": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.000002,
-    "mode": "chat",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/mistralai/voxtral-small-24b-2507": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 3.5e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_audio_input": true
-  },
-  "scaleway/mistralai/mistral-small-3.2-24b-instruct-2506": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 3.5e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/mistralai/pixtral-12b-2409": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway",
-    "supports_vision": true
-  },
-  "scaleway/BAAI/bge-multilingual-gemma2": {
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "scaleway"
-  },
-  "scaleway/meta/llama-3.3-70b-instruct": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-7,
-    "output_cost_per_token": 9e-7,
-    "mode": "chat",
-    "litellm_provider": "scaleway"
-  },
-  "novita/deepseek/deepseek-v3.2": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.69e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1.345e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/minimax/minimax-m2.1": {
-    "max_input_tokens": 204800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/zai-org/glm-4.7": {
-    "max_input_tokens": 204800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/xiaomimimo/mimo-v2-flash": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 3e-7,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/zai-org/autoglm-phone-9b-multilingual": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3.5e-8,
-    "output_cost_per_token": 1.38e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/moonshotai/kimi-k2-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/minimax/minimax-m2": {
-    "max_input_tokens": 204800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/paddlepaddle/paddleocr-vl": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/deepseek/deepseek-v3.2-exp": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 4.1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-vl-235b-a22b-thinking": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9.8e-7,
-    "output_cost_per_token": 0.00000395,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/zai-org/glm-4.6v": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 9e-7,
-    "cache_read_input_token_cost": 5.5e-8,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/zai-org/glm-4.6": {
-    "max_input_tokens": 204800,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 5.5e-7,
-    "output_cost_per_token": 0.0000022,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/kwaipilot/kat-coder-pro": {
-    "max_input_tokens": 256000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_read_input_token_cost": 6e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-next-80b-a3b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-next-80b-a3b-thinking": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-ocr": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/deepseek/deepseek-v3.1-terminus": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 0.000001,
-    "cache_read_input_token_cost": 1.35e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-vl-235b-a22b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000015,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/qwen/qwen3-max": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 0.00000211,
-    "output_cost_per_token": 0.00000845,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/skywork/r1v4-lite": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/deepseek/deepseek-v3.1": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 0.000001,
-    "cache_read_input_token_cost": 1.35e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/moonshotai/kimi-k2-0905": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-coder-480b-a35b-instruct": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000013,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-coder-30b-a3b-instruct": {
-    "max_input_tokens": 160000,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 2.7e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/openai/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/moonshotai/kimi-k2-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 5.7e-7,
-    "output_cost_per_token": 0.0000023,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-v3-0324": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 0.00000112,
-    "cache_read_input_token_cost": 1.35e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/zai-org/glm-4.5": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 98304,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000022,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-235b-a22b-thinking-2507": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.000003,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-3.1-8b-instruct": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/google/gemma-3-12b-it": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/zai-org/glm-4.5v": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000018,
-    "cache_read_input_token_cost": 1.1e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/openai/gpt-oss-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/qwen/qwen3-235b-a22b-instruct-2507": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 5.8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-distill-qwen-14b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-3.3-70b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 120000,
-    "input_cost_per_token": 1.35e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen-2.5-72b-instruct": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3.8e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/mistralai/mistral-nemo": {
-    "max_input_tokens": 60288,
-    "max_output_tokens": 16000,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 1.7e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/minimaxai/minimax-m1-80k": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 40000,
-    "input_cost_per_token": 5.5e-7,
-    "output_cost_per_token": 0.0000022,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-0528": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 7e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-distill-qwen-32b": {
-    "max_input_tokens": 64000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-3-8b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 4e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/microsoft/wizardlm-2-8x22b": {
-    "max_input_tokens": 65535,
-    "max_output_tokens": 8000,
-    "input_cost_per_token": 6.2e-7,
-    "output_cost_per_token": 6.2e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-0528-qwen3-8b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 9e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-distill-llama-70b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-3-70b-instruct": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8000,
-    "input_cost_per_token": 5.1e-7,
-    "output_cost_per_token": 7.4e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-235b-a22b-fp8": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 20000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-4-maverick-17b-128e-instruct-fp8": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2.7e-7,
-    "output_cost_per_token": 8.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/meta-llama/llama-4-scout-17b-16e-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.8e-7,
-    "output_cost_per_token": 5.9e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/nousresearch/hermes-2-pro-llama-3-8b": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 1.4e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen2.5-vl-72b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 8e-7,
-    "output_cost_per_token": 8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/sao10k/l3-70b-euryale-v2.1": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000148,
-    "output_cost_per_token": 0.00000148,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/baidu/ernie-4.5-21B-a3b-thinking": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/sao10k/l3-8b-lunaris": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/baichuan/baichuan-m2-32b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 7e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/baidu/ernie-4.5-vl-424b-a47b": {
-    "max_input_tokens": 123000,
-    "max_output_tokens": 16000,
-    "input_cost_per_token": 4.2e-7,
-    "output_cost_per_token": 0.00000125,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/baidu/ernie-4.5-300b-a47b-paddle": {
-    "max_input_tokens": 123000,
-    "max_output_tokens": 12000,
-    "input_cost_per_token": 2.8e-7,
-    "output_cost_per_token": 0.0000011,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-prover-v2-671b": {
-    "max_input_tokens": 160000,
-    "max_output_tokens": 160000,
-    "input_cost_per_token": 7e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-32b-fp8": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 20000,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-30b-a3b-fp8": {
-    "max_input_tokens": 40960,
-    "max_output_tokens": 20000,
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/google/gemma-3-27b-it": {
-    "max_input_tokens": 98304,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1.19e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/deepseek/deepseek-v3-turbo": {
-    "max_input_tokens": 64000,
-    "max_output_tokens": 16000,
-    "input_cost_per_token": 4e-7,
-    "output_cost_per_token": 0.0000013,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/deepseek/deepseek-r1-turbo": {
-    "max_input_tokens": 64000,
-    "max_output_tokens": 16000,
-    "input_cost_per_token": 7e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/Sao10K/L3-8B-Stheno-v3.2": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/gryphe/mythomax-l2-13b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 3200,
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 9e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/baidu/ernie-4.5-vl-28b-a3b-thinking": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 3.9e-7,
-    "output_cost_per_token": 3.9e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/qwen/qwen3-vl-8b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/zai-org/glm-4.5-air": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 98304,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 8.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-vl-30b-a3b-instruct": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 7e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/qwen/qwen3-vl-30b-a3b-thinking": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/qwen/qwen3-omni-30b-a3b-thinking": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 9.7e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "novita/qwen/qwen3-omni-30b-a3b-instruct": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 9.7e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "novita/qwen/qwen-mt-plus": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 7.5e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/baidu/ernie-4.5-vl-28b-a3b": {
-    "max_input_tokens": 30000,
-    "max_output_tokens": 8000,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 5.6e-7,
-    "mode": "chat",
-    "litellm_provider": "novita",
-    "supports_vision": true
-  },
-  "novita/baidu/ernie-4.5-21B-a3b": {
-    "max_input_tokens": 120000,
-    "max_output_tokens": 8000,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 2.8e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-8b-fp8": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20000,
-    "input_cost_per_token": 3.5e-8,
-    "output_cost_per_token": 1.38e-7,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-4b-fp8": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 20000,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen2.5-7b-instruct": {
-    "max_input_tokens": 32000,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 7e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/meta-llama/llama-3.2-3b-instruct": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/sao10k/l31-70b-euryale-v2.2": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.00000148,
-    "output_cost_per_token": 0.00000148,
-    "mode": "chat",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-embedding-0.6b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-embedding-8b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "novita"
-  },
-  "novita/baai/bge-m3": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 96000,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 1e-8,
-    "mode": "embedding",
-    "litellm_provider": "novita"
-  },
-  "novita/qwen/qwen3-reranker-8b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "rerank",
-    "litellm_provider": "novita"
-  },
-  "novita/baai/bge-reranker-v2-m3": {
-    "max_input_tokens": 8000,
-    "max_output_tokens": 8000,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 1e-8,
-    "mode": "rerank",
-    "litellm_provider": "novita"
-  },
-  "llamagate/llama-3.1-8b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 5e-8,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/llama-3.2-3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/mistral-7b-v0.3": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/qwen3-8b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 1.4e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/dolphin3-8b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/deepseek-r1-8b": {
-    "max_input_tokens": 65536,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/deepseek-r1-7b-qwen": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/openthinker-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 8e-8,
-    "output_cost_per_token": 1.5e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/qwen2.5-coder-7b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/deepseek-coder-6.7b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/codellama-7b": {
-    "max_input_tokens": 16384,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/qwen3-vl-8b": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate",
-    "supports_vision": true
-  },
-  "llamagate/llava-7b": {
-    "max_input_tokens": 4096,
-    "max_output_tokens": 2048,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "llamagate",
-    "supports_vision": true
-  },
-  "llamagate/gemma3-4b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "llamagate",
-    "supports_vision": true
-  },
-  "llamagate/nomic-embed-text": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "llamagate"
-  },
-  "llamagate/qwen3-embedding-8b": {
-    "max_input_tokens": 40960,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "llamagate"
-  },
-  "libertai/hermes-3-8b-tee": {
-    "max_input_tokens": 16000,
-    "max_output_tokens": 16000,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": false
-  },
-  "libertai/gemma-4-31b-it": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/gemma-4-31b-it-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.6-27b": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.6-27b-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.6-35b-a3b": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.6-35b-a3b-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.5-122b-a10b": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000175,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/qwen3.5-122b-a10b-thinking": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000175,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": true
-  },
-  "libertai/deepseek-v4-flash": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000175,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": false
-  },
-  "libertai/deepseek-v4-flash-thinking": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 200000,
-    "input_cost_per_token": 2.5e-7,
-    "output_cost_per_token": 0.00000175,
-    "mode": "chat",
-    "litellm_provider": "libertai",
-    "supports_vision": false
-  },
-  "libertai/bge-m3": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 1e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "libertai"
-  },
-  "sarvam/sarvam-m": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 32000,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
+    "input_cost_per_token": 0.0000012,
+    "output_cost_per_token": 0.000005,
     "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "sarvam"
-  },
-  "tts-1-1106": {
-    "mode": "audio_speech",
-    "litellm_provider": "openai"
-  },
-  "tts-1-hd-1106": {
-    "mode": "audio_speech",
-    "litellm_provider": "openai"
-  },
-  "gpt-4o-mini-tts-2025-03-20": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "audio_speech",
-    "litellm_provider": "openai"
-  },
-  "gpt-4o-mini-tts-2025-12-15": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.00001,
-    "mode": "audio_speech",
-    "litellm_provider": "openai"
-  },
-  "gpt-4o-mini-transcribe-2025-03-20": {
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.000005,
-    "mode": "audio_transcription",
-    "litellm_provider": "openai"
-  },
-  "gpt-4o-mini-transcribe-2025-12-15": {
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.000005,
-    "mode": "audio_transcription",
-    "litellm_provider": "openai"
-  },
-  "gpt-5-search-api": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-5-search-api-2025-10-14": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "openai",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gpt-realtime-mini-2025-10-06": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 6e-8,
-    "mode": "realtime",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "gpt-realtime-mini-2025-12-15": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 4096,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 6e-8,
-    "mode": "realtime",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "gpt-realtime-whisper": {
-    "mode": "audio_transcription",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "sora-2": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "sora-2-pro": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "sora-2-pro-high-res": {
-    "mode": "video_generation",
-    "litellm_provider": "openai"
-  },
-  "chatgpt-image-latest": {
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_image_token": 0.00004,
-    "cache_read_input_token_cost": 0.00000125,
-    "mode": "image_generation",
-    "litellm_provider": "openai"
-  },
-  "gemini-2.0-flash-exp-image-generation": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-2.0-flash-exp-image-generation": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "image_generation",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini/gemini-2.0-flash-lite-001": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "cache_read_input_token_cost": 1.875e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true
-  },
-  "gemini-2.5-flash-native-audio-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini-2.5-flash-native-audio-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini-2.5-flash-native-audio-preview-12-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini-3.1-flash-live-preview": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "gemini/gemini-2.5-flash-native-audio-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "gemini/gemini-3.1-flash-live-preview": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-7,
-    "output_cost_per_token": 0.0000045,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true
-  },
-  "gemini/gemini-3.1-flash-tts-preview": {
-    "max_input_tokens": 8192,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.00002,
-    "mode": "audio_speech",
-    "litellm_provider": "gemini"
-  },
-  "gemini-2.5-flash-preview-tts": {
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "mode": "audio_speech",
-    "litellm_provider": "gemini"
-  },
-  "gemini-flash-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-flash-lite-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 4e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini-pro-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini/gemini-pro-latest": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000015,
-    "cache_read_input_token_cost": 1.25e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "gemini-exp-1206": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 65535,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 3e-8,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-sonnet-5@default": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "vertex_ai/claude-sonnet-4-6@default": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_creation_input_token_cost": 0.00000375,
     "cache_read_input_token_cost": 3e-7,
     "mode": "chat",
-    "litellm_provider": "vertex_ai-anthropic_models",
-    "supports_pdf_input": true,
-    "supports_vision": true
+    "litellm_provider": "zai"
   },
-  "duckduckgo/search": {
-    "mode": "search",
-    "litellm_provider": "duckduckgo"
-  },
-  "bedrock_mantle/openai.gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle"
-  },
-  "bedrock_mantle/openai.gpt-oss-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle"
-  },
-  "bedrock_mantle/openai.gpt-oss-safeguard-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle"
-  },
-  "bedrock_mantle/openai.gpt-oss-safeguard-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 65536,
-    "input_cost_per_token": 7.5e-8,
-    "output_cost_per_token": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle"
-  },
-  "bedrock_mantle/openai.gpt-5.6-sol": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "responses",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/openai.gpt-5.6-terra": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000132,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "responses",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/openai.gpt-5.6-luna": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.00000132,
-    "cache_creation_input_token_cost": 2.75e-7,
-    "cache_read_input_token_cost": 2.2e-8,
-    "mode": "responses",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "us.openai.gpt-5.6-sol": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_creation_input_token_cost": 0.000006875,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "global.openai.gpt-5.6-sol": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.00003,
-    "cache_creation_input_token_cost": 0.00000625,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "us.openai.gpt-5.6-terra": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000132,
-    "cache_creation_input_token_cost": 0.00000275,
-    "cache_read_input_token_cost": 2.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "global.openai.gpt-5.6-terra": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000012,
-    "cache_creation_input_token_cost": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "us.openai.gpt-5.6-luna": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2.2e-7,
-    "output_cost_per_token": 0.00000132,
-    "cache_creation_input_token_cost": 2.75e-7,
-    "cache_read_input_token_cost": 2.2e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "global.openai.gpt-5.6-luna": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 2e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_creation_input_token_cost": 2.5e-7,
-    "cache_read_input_token_cost": 2e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "bedrock_mantle/openai.gpt-5.5": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.0000055,
-    "output_cost_per_token": 0.000033,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "responses",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/openai.gpt-5.4": {
-    "max_input_tokens": 272000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00000275,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 2.75e-7,
-    "mode": "responses",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/google.gemma-4-31b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/google.gemma-4-26b-a4b": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 1.3e-7,
-    "output_cost_per_token": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/google.gemma-4-e2b": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 4e-8,
-    "output_cost_per_token": 8e-8,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/xai.grok-4.3": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "bedrock_mantle/xai.grok-4.6": {
-    "max_input_tokens": 500000,
-    "max_output_tokens": 500000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_mantle",
-    "supports_vision": true
-  },
-  "us.xai.grok-4.6": {
-    "max_input_tokens": 500000,
-    "max_output_tokens": 500000,
-    "input_cost_per_token": 0.0000022,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "global.xai.grok-4.6": {
-    "max_input_tokens": 500000,
-    "max_output_tokens": 500000,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000006,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock_converse",
-    "supports_vision": true
-  },
-  "volcengine/doubao-seed-2-0-pro-260215": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 128000,
-    "mode": "chat",
-    "litellm_provider": "volcengine",
-    "supports_vision": true
-  },
-  "volcengine/doubao-seed-2-0-lite-260215": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 128000,
-    "mode": "chat",
-    "litellm_provider": "volcengine",
-    "supports_vision": true
-  },
-  "volcengine/doubao-seed-2-0-mini-260215": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 128000,
-    "mode": "chat",
-    "litellm_provider": "volcengine",
-    "supports_vision": true
-  },
-  "volcengine/doubao-seed-2-0-code-preview-260215": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 128000,
-    "mode": "chat",
-    "litellm_provider": "volcengine",
-    "supports_vision": true
-  },
-  "bedrock/us-east-1/zai.glm-5": {
+  "zai/glm-5.1": {
     "max_input_tokens": 200000,
     "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.0000032,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-west-2/zai.glm-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.0000032,
-    "mode": "chat",
-    "litellm_provider": "bedrock"
-  },
-  "bedrock/us-gov-east-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.000006,
-    "cache_creation_input_token_cost": 0.0000015,
-    "cache_read_input_token_cost": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "bedrock/us-gov-west-1/anthropic.claude-haiku-4-5-20251001-v1:0": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 64000,
-    "input_cost_per_token": 0.0000012,
-    "output_cost_per_token": 0.000006,
-    "cache_creation_input_token_cost": 0.0000015,
-    "cache_read_input_token_cost": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "bedrock",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "snowflake/claude-sonnet-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/claude-sonnet-4-6": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/claude-4-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/claude-4-opus": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000005,
-    "output_cost_per_token": 0.000025,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/claude-haiku-4-5": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000005,
-    "cache_read_input_token_cost": 1e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/claude-3-7-sonnet": {
-    "max_input_tokens": 200000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/openai-gpt-4.1": {
-    "max_input_tokens": 300000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000008,
-    "cache_read_input_token_cost": 5e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/openai-gpt-5": {
-    "max_input_tokens": 300000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.00001,
-    "cache_read_input_token_cost": 1.25e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake",
-    "supports_vision": true
-  },
-  "snowflake/openai-gpt-5-mini": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "mode": "chat",
-    "litellm_provider": "snowflake"
-  },
-  "snowflake/openai-gpt-5-nano": {
-    "max_input_tokens": 5000000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake"
-  },
-  "snowflake/llama4-maverick": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 2.4e-7,
-    "output_cost_per_token": 9.7e-7,
-    "mode": "chat",
-    "litellm_provider": "snowflake"
-  },
-  "snowflake/snowflake-arctic-embed-l-v2.0": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "snowflake"
-  },
-  "snowflake/snowflake-arctic-embed-m-v2.0": {
-    "max_input_tokens": 8192,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "snowflake"
-  },
-  "soniox/stt-async-v4": {
-    "max_output_tokens": 8000,
-    "mode": "audio_transcription",
-    "litellm_provider": "soniox",
-    "supports_audio_input": true
-  },
-  "soniox/stt-async-v5": {
-    "max_output_tokens": 8000,
-    "mode": "audio_transcription",
-    "litellm_provider": "soniox",
-    "supports_audio_input": true
-  },
-  "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000036,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 4.5e-7,
-    "output_cost_per_token": 0.0000018,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/Qwen/Qwen3.6-27B-FP8": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 3.2e-7,
-    "output_cost_per_token": 0.0000032,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/lukealonso/GLM-5.1-NVFP4-MTP": {
-    "max_input_tokens": 202752,
-    "max_output_tokens": 202752,
     "input_cost_per_token": 0.0000014,
     "output_cost_per_token": 0.0000044,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/deepseek-ai/DeepSeek-V4-Flash": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 2.8e-7,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/moonshotai/Kimi-K2.6": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 9.6e-7,
-    "output_cost_per_token": 0.000004,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/MiniMaxAI/MiniMax-M2.5": {
-    "max_input_tokens": 196608,
-    "max_output_tokens": 196608,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 0.0000012,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/google/gemma-4-31B-it": {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 5.6e-7,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/openai/gpt-oss-120b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "tensormesh/openai/gpt-oss-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 7e-8,
-    "output_cost_per_token": 2.8e-7,
-    "cache_read_input_token_cost": 0,
-    "mode": "chat",
-    "litellm_provider": "tensormesh"
-  },
-  "deepseek-v4-flash": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 393216,
-    "input_cost_per_token": 4.4e-7,
-    "output_cost_per_token": 0.00000132,
     "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 1.4e-8,
+    "cache_read_input_token_cost": 2.6e-7,
     "mode": "chat",
-    "litellm_provider": "deepseek",
-    "supports_vision": false
-  },
-  "deepseek-v4-pro": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 393216,
-    "input_cost_per_token": 0.00000132,
-    "output_cost_per_token": 0.00000396,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 4.4e-8,
-    "mode": "chat",
-    "litellm_provider": "deepseek",
-    "supports_vision": false
-  },
-  "deepseek/deepseek-v4-flash": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 393216,
-    "input_cost_per_token": 4.4e-7,
-    "output_cost_per_token": 0.00000132,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 1.4e-8,
-    "mode": "chat",
-    "litellm_provider": "deepseek",
-    "supports_vision": false
-  },
-  "deepseek/deepseek-v4-pro": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 393216,
-    "input_cost_per_token": 0.00000132,
-    "output_cost_per_token": 0.00000396,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 4.4e-8,
-    "mode": "chat",
-    "litellm_provider": "deepseek",
-    "supports_vision": false
-  },
-  "tencent/deepseek-v4-pro": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 384000,
-    "input_cost_per_token": 4.35e-7,
-    "output_cost_per_token": 8.7e-7,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 3.625e-9,
-    "mode": "chat",
-    "litellm_provider": "tencent",
-    "supports_vision": false
-  },
-  "tencent/deepseek-v4-flash": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 384000,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 2.8e-7,
-    "cache_creation_input_token_cost": 0,
-    "cache_read_input_token_cost": 2.8e-9,
-    "mode": "chat",
-    "litellm_provider": "tencent",
-    "supports_vision": false
-  },
-  "cognition/swe-1.6": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "cognition"
-  },
-  "cognition/swe-1.7": {
-    "input_cost_per_token": 5e-7,
-    "output_cost_per_token": 0.0000025,
-    "cache_read_input_token_cost": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "cognition"
-  },
-  "cognition/swe-1.7-lightning": {
-    "input_cost_per_token": 0.0000025,
-    "output_cost_per_token": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "cognition"
-  },
-  "pinstripes/ps/glm-4.5-air": {
-    "max_input_tokens": 128000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 1.25e-7,
-    "output_cost_per_token": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "pinstripes/ps/qwen3.6-35b-a3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "pinstripes/ps/qwen3-30b-a3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 9e-8,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "pinstripes/ps/qwen3-coder-30b-a3b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 3e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "pinstripes/ps/deepseek-v4-flash": {
-    "max_input_tokens": 163840,
-    "max_output_tokens": 163840,
-    "input_cost_per_token": 1e-7,
-    "output_cost_per_token": 2e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "pinstripes/ps/minimax-m2.7": {
-    "max_input_tokens": 1000192,
-    "max_output_tokens": 1000192,
-    "input_cost_per_token": 2.55e-7,
-    "output_cost_per_token": 5.5e-7,
-    "mode": "chat",
-    "litellm_provider": "pinstripes"
-  },
-  "darkbloom/gemma-4-26b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 3e-8,
-    "output_cost_per_token": 1.65e-7,
-    "mode": "chat",
-    "litellm_provider": "darkbloom"
-  },
-  "darkbloom/gpt-oss-20b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 1.45e-8,
-    "output_cost_per_token": 7e-8,
-    "mode": "chat",
-    "litellm_provider": "darkbloom"
-  },
-  "xai/grok-4.20-0309-non-reasoning": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.0000025,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000005,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "xai",
-    "supports_vision": true
-  },
-  "xai/grok-4.20-multi-agent-0309": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 1000000,
-    "input_cost_per_token": 0.00000125,
-    "output_cost_per_token": 0.0000025,
-    "input_cost_per_token_above_200k_tokens": 0.0000025,
-    "output_cost_per_token_above_200k_tokens": 0.000005,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "xai",
-    "supports_vision": true
-  },
-  "xai/grok-build-0.1": {
-    "max_input_tokens": 256000,
-    "max_output_tokens": 256000,
-    "input_cost_per_token": 0.000001,
-    "output_cost_per_token": 0.000002,
-    "input_cost_per_token_above_200k_tokens": 0.000002,
-    "output_cost_per_token_above_200k_tokens": 0.000004,
-    "cache_read_input_token_cost": 2e-7,
-    "cache_read_input_token_cost_above_200k_tokens": 4e-7,
-    "mode": "chat",
-    "litellm_provider": "xai",
-    "supports_vision": true
-  },
-  "gpt-transcribe": {
-    "mode": "audio_transcription",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "gpt-live-transcribe": {
-    "mode": "audio_transcription",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "gpt-realtime-translate": {
-    "max_input_tokens": 16000,
-    "max_output_tokens": 2000,
-    "mode": "realtime",
-    "litellm_provider": "openai",
-    "supports_audio_input": true
-  },
-  "claude-mythos-5": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "claude-mythos-preview": {
-    "max_input_tokens": 1000000,
-    "max_output_tokens": 128000,
-    "input_cost_per_token": 0.00001,
-    "output_cost_per_token": 0.00005,
-    "cache_creation_input_token_cost": 0.0000125,
-    "cache_read_input_token_cost": 0.000001,
-    "mode": "chat",
-    "litellm_provider": "anthropic",
-    "supports_pdf_input": true,
-    "supports_vision": true
-  },
-  "gemini/gemini-robotics-er-2-streaming-preview": {
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.00001,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_vision": true,
-    "supports_audio_input": true,
-    "supports_video_input": true
-  },
-  "mistral/mistral-small-2603": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 262144,
-    "input_cost_per_token": 1.5e-7,
-    "output_cost_per_token": 6e-7,
-    "mode": "chat",
-    "litellm_provider": "mistral",
-    "supports_vision": true
-  },
-  "mistral/labs-leanstral-1-5": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "chat",
-    "litellm_provider": "mistral"
-  },
-  "mistral/mistral-moderation-2603": {
-    "max_input_tokens": 131072,
-    "input_cost_per_token": 0,
-    "output_cost_per_token": 0,
-    "mode": "moderation",
-    "litellm_provider": "mistral"
-  },
-  "mistral/voxtral-mini-2602": {
-    "mode": "audio_transcription",
-    "litellm_provider": "mistral",
-    "supports_audio_input": true
-  },
-  "mistral/voxtral-mini-transcribe-realtime-2602": {
-    "mode": "audio_transcription",
-    "litellm_provider": "mistral",
-    "supports_audio_input": true
-  },
-  "mistral/voxtral-mini-tts-2603": {
-    "mode": "audio_speech",
-    "litellm_provider": "mistral"
-  },
-  "fallback_generalizations": {},
-  "gemini/gemini-3.5-live-translate-preview": {
-    "input_cost_per_token": 0.0000035,
-    "output_cost_per_token": 0.000021,
-    "mode": "chat",
-    "litellm_provider": "gemini",
-    "supports_audio_input": true
-  },
-  "perplexity/pplx-embed-context-v1-0.6b": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 8e-9,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "perplexity"
-  },
-  "perplexity/pplx-embed-context-v1-4b": {
-    "max_input_tokens": 32768,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "perplexity"
-  },
-  "voyage/voyage-4-large": {
-    "max_input_tokens": 32000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "voyage/voyage-4": {
-    "max_input_tokens": 32000,
-    "input_cost_per_token": 6e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "voyage/voyage-4-lite": {
-    "max_input_tokens": 32000,
-    "input_cost_per_token": 2e-8,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "voyage/voyage-code-4": {
-    "max_input_tokens": 32000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "voyage/voyage-context-4": {
-    "max_input_tokens": 120000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "voyage/voyage-multimodal-3.5": {
-    "max_input_tokens": 32000,
-    "input_cost_per_token": 1.2e-7,
-    "output_cost_per_token": 0,
-    "mode": "embedding",
-    "litellm_provider": "voyage"
-  },
-  "fireworks_ai/accounts/fireworks/models/deepseek-v4-flash-0731": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 2.8e-7,
-    "cache_read_input_token_cost": 2.8e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/models/kimi-k3": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/deepseek-v4-flash-0731": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 1.4e-7,
-    "output_cost_per_token": 2.8e-7,
-    "cache_read_input_token_cost": 2.8e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/glm-5p2-fast": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000021,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 2.1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/glm-5p2-fast-us": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000021,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 2.1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/kimi-k3": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.000003,
-    "output_cost_per_token": 0.000015,
-    "cache_read_input_token_cost": 3e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/kimi-k3-fast": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000045,
-    "output_cost_per_token": 0.0000225,
-    "cache_read_input_token_cost": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/kimi-k3-us": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/qwen3p8-max": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000006,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/muse-glimmer-30b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 4e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/nemotron-lightning-3p5-30b-a3b": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 2e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/nemotron-3-ultra-nvfp4": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/models/muse-glimmer-30b": {
-    "max_input_tokens": 131072,
-    "max_output_tokens": 16384,
-    "input_cost_per_token": 3.5e-7,
-    "output_cost_per_token": 0.0000015,
-    "cache_read_input_token_cost": 4e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 5e-8,
-    "output_cost_per_token": 2e-7,
-    "cache_read_input_token_cost": 1e-8,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/models/nemotron-3-ultra-nvfp4": {
-    "max_input_tokens": 262144,
-    "max_output_tokens": 32768,
-    "input_cost_per_token": 6e-7,
-    "output_cost_per_token": 0.0000024,
-    "cache_read_input_token_cost": 1.2e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/models/qwen3p8-max": {
-    "max_input_tokens": 262144,
-    "input_cost_per_token": 0.000002,
-    "output_cost_per_token": 0.000006,
-    "cache_read_input_token_cost": 2.5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000021,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 2.1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/routers/glm-5p2-fast-us": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000021,
-    "output_cost_per_token": 0.0000066,
-    "cache_read_input_token_cost": 2.1e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": false
-  },
-  "fireworks_ai/accounts/fireworks/routers/kimi-k3-fast": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000045,
-    "output_cost_per_token": 0.0000225,
-    "cache_read_input_token_cost": 4.5e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
-  },
-  "fireworks_ai/accounts/fireworks/routers/kimi-k3-us": {
-    "max_input_tokens": 1048576,
-    "max_output_tokens": 131072,
-    "input_cost_per_token": 0.0000033,
-    "output_cost_per_token": 0.0000165,
-    "cache_read_input_token_cost": 3.3e-7,
-    "mode": "chat",
-    "litellm_provider": "fireworks_ai",
-    "supports_vision": true
+    "litellm_provider": "zai"
   }
 }

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -2,11 +2,11 @@ import { describe, test, expect } from "@jest/globals";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import modelsJson from "./models.json";
 import {
-  countChatModels,
   findMissingKnownModels,
   pruneModelData,
   sanitizePricing,
   serializeModelData,
+  summarizeCatalog,
   validateModelData,
 } from "./updateModelsData";
 
@@ -115,7 +115,7 @@ describe("validateModelData", () => {
     const vendored = modelsJson as Record<string, Record<string, unknown>>;
     const sanitized = sanitizePricing(vendored);
     expect(sanitized.droppedModelIds).toEqual([]);
-    expect(() => validateModelData(sanitized, countChatModels(vendored))).not.toThrow();
+    expect(() => validateModelData(sanitized, summarizeCatalog(vendored))).not.toThrow();
   });
 
   test("rejects truncated upstream data", () => {
@@ -136,9 +136,35 @@ describe("validateModelData", () => {
       catalog: { ...chatEntries(600), ...curatedCoverage },
       droppedModelIds: [],
     };
-    expect(() => validateModelData(sanitized, 2000)).toThrow(/chat model count shrank from 2000/);
+    expect(() => validateModelData(sanitized, { chatModels: 2000, pricedChatModels: 600 })).toThrow(
+      /chat model count shrank from 2000/
+    );
     // A small decrease within the bound is acceptable (e.g. upstream pruning).
-    expect(() => validateModelData(sanitized, 650)).not.toThrow();
+    expect(() =>
+      validateModelData(sanitized, { chatModels: 650, pricedChatModels: 600 })
+    ).not.toThrow();
+  });
+
+  test("rejects a catalog-wide loss of pricing fields", () => {
+    // Entries keep modes and token limits but lose every cost field, as an
+    // upstream pricing-field rename would produce: nothing is dropped per-entry,
+    // yet priced coverage collapses.
+    const unpriced = Object.fromEntries(
+      Array.from({ length: 700 }, (_, i) => [
+        `provider/unpriced-${i}`,
+        { mode: "chat", max_input_tokens: 128000 },
+      ])
+    );
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = { catalog: { ...unpriced, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() => validateModelData(sanitized, { chatModels: 700, pricedChatModels: 680 })).toThrow(
+      /priced chat model count shrank from 680/
+    );
   });
 
   test("rejects data where too many entries had invalid pricing", () => {

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -338,16 +338,63 @@ describe("validateModelData", () => {
       return { catalog, droppedModelIds: [] };
     };
     // Scaling (or deleting) one row's price moves no count and no median; only
-    // the per-entry magnitude bound can catch it.
+    // the per-identity magnitude bound can catch it.
     expect(() =>
       validateModelData(poison({ input_cost_per_token: 0.000001e-9 }), chatEntries(700))
-    ).toThrow(/provider\/model-3 input_cost_per_token: 0.000001 -> 1e-15/);
+    ).toThrow(/provider:model-3 input_cost_per_token: 0.000001 -> 1e-15/);
     expect(() =>
       validateModelData(poison({ input_cost_per_token: undefined }), chatEntries(700))
-    ).toThrow(/provider\/model-3 input_cost_per_token: 0.000001 -> absent/);
+    ).toThrow(/provider:model-3 input_cost_per_token: 0.000001 -> absent/);
     // Ordinary per-row repricing within the factor is accepted.
     expect(() =>
       validateModelData(poison({ input_cost_per_token: 0.00001 }), chatEntries(700))
+    ).not.toThrow();
+  });
+
+  test("rejects a poisoned higher-precedence alias shadowing a baseline row", () => {
+    // Adding openai/x on top of a baseline bare x (or moving the row there)
+    // leaves every count and median intact, but runtime lookup prefers the
+    // scoped key; comparison must follow resolved identities, not raw keys.
+    const bare = {
+      mode: "chat",
+      max_input_tokens: 128000,
+      input_cost_per_token: 0.000001,
+      output_cost_per_token: 0.000002,
+      litellm_provider: "acme",
+    };
+    const poisonedAlias = { ...bare, input_cost_per_token: 0.000001e-9 };
+    const baseline = { ...chatEntries(700), "acme-chat-1": bare };
+    for (const catalog of [
+      // Attack 1: new alias added while the original row survives.
+      { ...baseline, "acme/acme-chat-1": poisonedAlias },
+      // Attack 2: original key removed, row substituted under the alias.
+      { ...chatEntries(700), "acme/acme-chat-1": poisonedAlias },
+    ]) {
+      const sanitized = { catalog: { ...catalog, ...curatedCoverage }, droppedModelIds: [] };
+      expect(() => validateModelData(sanitized, baseline)).toThrow(
+        /acme:acme-chat-1 input_cost_per_token: 0.000001 -> 1e-15/
+      );
+    }
+  });
+
+  test("rejects a targeted capability-flag flip on a single row", () => {
+    // One true -> false flip is far inside the aggregate 10% allowance, but
+    // runtime would start rejecting valid attachments for that model.
+    const baseline = chatEntries(700, { supports_pdf_input: true });
+    const catalog = { ...baseline, ...curatedCoverage };
+    catalog["provider/model-3"] = { ...catalog["provider/model-3"], supports_pdf_input: false };
+    expect(() => validateModelData({ catalog, droppedModelIds: [] }, baseline)).toThrow(
+      /provider:model-3 supports_pdf_input: true -> false/
+    );
+  });
+
+  test("accepts runtime-parseable numeric strings as equal magnitudes", () => {
+    // getModelStats parses "128000" like 128000, so a representation change
+    // must not read as a >100x collapse and block the refresh.
+    const catalog = { ...chatEntries(700), ...curatedCoverage };
+    catalog["provider/model-3"] = { ...catalog["provider/model-3"], max_input_tokens: "128000" };
+    expect(() =>
+      validateModelData({ catalog, droppedModelIds: [] }, chatEntries(700))
     ).not.toThrow();
   });
 

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -2,9 +2,11 @@ import { describe, test, expect } from "@jest/globals";
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import modelsJson from "./models.json";
 import {
+  countChatModels,
   findMissingKnownModels,
   pruneModelData,
   sanitizePricing,
+  serializeModelData,
   validateModelData,
 } from "./updateModelsData";
 
@@ -65,6 +67,8 @@ describe("sanitizePricing", () => {
 });
 
 describe("findMissingKnownModels", () => {
+  const usable = { max_input_tokens: 256000 };
+
   test("reports all curated models against an empty catalog and no overrides", () => {
     const missing = findMissingKnownModels({}, {});
     expect(missing.sort()).toEqual(
@@ -78,34 +82,63 @@ describe("findMissingKnownModels", () => {
     const grok = Object.values(KNOWN_MODELS).find((model) => model.provider === "xai");
     if (!grok) throw new Error("expected a curated xai model");
 
-    const bareKey = { [grok.providerModelId]: {} };
+    const bareKey = { [grok.providerModelId]: usable };
     expect(findMissingKnownModels(bareKey, {})).toContain(grok.id);
 
-    const prefixedKey = { [`xai/${grok.providerModelId}`]: {} };
+    const prefixedKey = { [`xai/${grok.providerModelId}`]: usable };
     expect(findMissingKnownModels(prefixedKey, {})).not.toContain(grok.id);
+  });
+
+  test("a retained key with unusable token limits still counts as missing", () => {
+    const anthropic = Object.values(KNOWN_MODELS).find((model) => model.provider === "anthropic");
+    if (!anthropic) throw new Error("expected a curated anthropic model");
+
+    // Key presence is not coverage: getModelStats would reject these entries.
+    expect(findMissingKnownModels({ [anthropic.providerModelId]: {} }, {})).toContain(anthropic.id);
+    expect(
+      findMissingKnownModels({ [anthropic.providerModelId]: { max_input_tokens: 0 } }, {})
+    ).toContain(anthropic.id);
   });
 
   test("models-extra overrides satisfy models absent upstream", () => {
     const anthropic = Object.values(KNOWN_MODELS).find((model) => model.provider === "anthropic");
     if (!anthropic) throw new Error("expected a curated anthropic model");
 
-    expect(findMissingKnownModels({}, { [anthropic.providerModelId]: {} })).not.toContain(
+    expect(findMissingKnownModels({}, { [anthropic.providerModelId]: usable })).not.toContain(
       anthropic.id
     );
   });
 });
 
 describe("validateModelData", () => {
-  test("accepts the current vendored models.json", () => {
-    const sanitized = sanitizePricing(modelsJson as Record<string, Record<string, unknown>>);
+  test("accepts the current vendored models.json against its own baseline", () => {
+    const vendored = modelsJson as Record<string, Record<string, unknown>>;
+    const sanitized = sanitizePricing(vendored);
     expect(sanitized.droppedModelIds).toEqual([]);
-    expect(() => validateModelData(sanitized)).not.toThrow();
+    expect(() => validateModelData(sanitized, countChatModels(vendored))).not.toThrow();
   });
 
   test("rejects truncated upstream data", () => {
     expect(() => validateModelData({ catalog: chatEntries(10), droppedModelIds: [] })).toThrow(
       /only 10 chat models found/
     );
+  });
+
+  test("rejects a large shrink below the vendored baseline even above the floor", () => {
+    // Cover every curated model so only the shrink rule is under test.
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = {
+      catalog: { ...chatEntries(600), ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    expect(() => validateModelData(sanitized, 2000)).toThrow(/chat model count shrank from 2000/);
+    // A small decrease within the bound is acceptable (e.g. upstream pruning).
+    expect(() => validateModelData(sanitized, 650)).not.toThrow();
   });
 
   test("rejects data where too many entries had invalid pricing", () => {
@@ -122,5 +155,14 @@ describe("validateModelData", () => {
     expect(() => validateModelData({ catalog: chatEntries(600), droppedModelIds: [] })).toThrow(
       /curated known models missing from upstream/
     );
+  });
+});
+
+describe("serializeModelData", () => {
+  test("sorts keys so upstream reordering produces no diff", () => {
+    const forward = serializeModelData({ b: { mode: "chat" }, a: { mode: "chat" } });
+    const reversed = serializeModelData({ a: { mode: "chat" }, b: { mode: "chat" } });
+    expect(forward).toBe(reversed);
+    expect(forward.indexOf('"a"')).toBeLessThan(forward.indexOf('"b"'));
   });
 });

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -132,7 +132,7 @@ describe("validateModelData", () => {
     const vendored = modelsJson as Record<string, Record<string, unknown>>;
     const sanitized = sanitizePricing(vendored);
     expect(sanitized.droppedModelIds).toEqual([]);
-    expect(() => validateModelData(sanitized, summarizeCatalog(vendored))).not.toThrow();
+    expect(() => validateModelData(sanitized, vendored)).not.toThrow();
   });
 
   test("rejects truncated upstream data", () => {
@@ -146,11 +146,11 @@ describe("validateModelData", () => {
       catalog: { ...chatEntries(600), ...curatedCoverage },
       droppedModelIds: [],
     };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(2000)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(2000))).toThrow(
       /chat usable model count shrank from 2000/
     );
     // A small decrease within the bound is acceptable (e.g. upstream pruning).
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(650)))).not.toThrow();
+    expect(() => validateModelData(sanitized, chatEntries(650))).not.toThrow();
   });
 
   test("rejects the loss of one pricing field even when the other survives", () => {
@@ -158,7 +158,7 @@ describe("validateModelData", () => {
     // input-priced, so aggregated priced coverage would hide the regression.
     const outputless = chatEntries(700, { output_cost_per_token: undefined }, "prov/outputless");
     const sanitized = { catalog: { ...outputless, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(700))).toThrow(
       /chat output_cost_per_token coverage shrank from 700 to 0/
     );
   });
@@ -168,7 +168,7 @@ describe("validateModelData", () => {
     // counts, so each mode compares against its own baseline.
     const responses = (overrides: Record<string, unknown>) =>
       chatEntries(60, { mode: "responses", ...overrides }, "prov/responses");
-    const baseline = summarizeCatalog({ ...chatEntries(700), ...responses({}) });
+    const baseline = { ...chatEntries(700), ...responses({}) };
     const sanitized = {
       catalog: {
         ...chatEntries(700),
@@ -185,10 +185,10 @@ describe("validateModelData", () => {
   test("rejects wholesale omission of a non-mappable mode", () => {
     // A partial payload that keeps chat/responses but drops image_generation
     // rows must trip that mode's own entry-count baseline.
-    const baseline = summarizeCatalog({
+    const baseline = {
       ...chatEntries(700),
       ...chatEntries(300, { mode: "image_generation", max_input_tokens: undefined }, "prov/image"),
-    });
+    };
     const sanitized = {
       catalog: { ...chatEntries(700), ...curatedCoverage },
       droppedModelIds: [],
@@ -203,10 +203,10 @@ describe("validateModelData", () => {
     // runtime would silently fall back to (much lower) generic output rates.
     const image = (overrides: Record<string, unknown>) =>
       chatEntries(300, { mode: "image_generation", ...overrides }, "prov/image");
-    const baseline = summarizeCatalog({
+    const baseline = {
       ...chatEntries(700),
       ...image({ output_cost_per_image_token: 0.00002 }),
-    });
+    };
     const sanitized = {
       catalog: { ...chatEntries(700), ...image({}), ...curatedCoverage },
       droppedModelIds: [],
@@ -219,7 +219,7 @@ describe("validateModelData", () => {
   test("rejects a catalog-wide loss of capability flags", () => {
     // Runtime treats missing/false capability flags as unsupported, so both a
     // field removal and a mass flip to false must register as coverage loss.
-    const baseline = summarizeCatalog(chatEntries(700, { supports_pdf_input: true }));
+    const baseline = chatEntries(700, { supports_pdf_input: true });
     const flipped = {
       catalog: { ...chatEntries(700, { supports_pdf_input: false }), ...curatedCoverage },
       droppedModelIds: [],
@@ -240,7 +240,7 @@ describe("validateModelData", () => {
     // rejects them, so usable coverage must register the collapse.
     const limitless = chatEntries(700, { max_input_tokens: undefined }, "prov/limitless");
     const sanitized = { catalog: { ...limitless, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(700))).toThrow(
       /chat usable model count shrank from 700/
     );
   });
@@ -250,7 +250,7 @@ describe("validateModelData", () => {
     // count, so only the magnitude median can catch mass-shrunk context sizes.
     const tiny = chatEntries(700, { max_input_tokens: 1 }, "prov/tiny");
     const sanitized = { catalog: { ...tiny, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(700))).toThrow(
       /max_input_tokens median shifted/
     );
   });
@@ -311,7 +311,7 @@ describe("validateModelData", () => {
       "prov/scaled"
     );
     const sanitized = { catalog: { ...scaled, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(700))).toThrow(
       /input_cost_per_token median shifted/
     );
   });
@@ -326,9 +326,29 @@ describe("validateModelData", () => {
       "prov/free"
     );
     const sanitized = { catalog: { ...free, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+    expect(() => validateModelData(sanitized, chatEntries(700))).toThrow(
       /input_cost_per_token median shifted from 0.000001 to 0/
     );
+  });
+
+  test("rejects a targeted single-row price shift that no catalog-wide guard sees", () => {
+    const poison = (overrides: Record<string, unknown>) => {
+      const catalog = { ...chatEntries(700), ...curatedCoverage };
+      catalog["provider/model-3"] = { ...catalog["provider/model-3"], ...overrides };
+      return { catalog, droppedModelIds: [] };
+    };
+    // Scaling (or deleting) one row's price moves no count and no median; only
+    // the per-entry magnitude bound can catch it.
+    expect(() =>
+      validateModelData(poison({ input_cost_per_token: 0.000001e-9 }), chatEntries(700))
+    ).toThrow(/provider\/model-3 input_cost_per_token: 0.000001 -> 1e-15/);
+    expect(() =>
+      validateModelData(poison({ input_cost_per_token: undefined }), chatEntries(700))
+    ).toThrow(/provider\/model-3 input_cost_per_token: 0.000001 -> absent/);
+    // Ordinary per-row repricing within the factor is accepted.
+    expect(() =>
+      validateModelData(poison({ input_cost_per_token: 0.00001 }), chatEntries(700))
+    ).not.toThrow();
   });
 
   test("rejects data where too many entries had invalid pricing", () => {

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -10,18 +10,31 @@ import {
   validateModelData,
 } from "./updateModelsData";
 
-function chatEntries(count: number): Record<string, Record<string, unknown>> {
+function chatEntries(
+  count: number,
+  overrides: Record<string, unknown> = {},
+  prefix = "provider/model"
+): Record<string, Record<string, unknown>> {
   const entries: Record<string, Record<string, unknown>> = {};
   for (let i = 0; i < count; i++) {
-    entries[`provider/model-${i}`] = {
+    entries[`${prefix}-${i}`] = {
       mode: "chat",
       max_input_tokens: 128000,
       input_cost_per_token: 0.000001,
       output_cost_per_token: 0.000002,
+      ...overrides,
     };
   }
   return entries;
 }
+
+// Covers every curated model so only the guard under test can fail validation.
+const curatedCoverage = Object.fromEntries(
+  Object.values(KNOWN_MODELS).map((model) => [
+    model.providerModelId,
+    { mode: "chat", max_input_tokens: 200000 },
+  ])
+);
 
 describe("pruneModelData", () => {
   test("rejects non-object payloads", () => {
@@ -129,158 +142,127 @@ describe("validateModelData", () => {
   });
 
   test("rejects a large shrink below the vendored baseline even above the floor", () => {
-    // Cover every curated model so only the shrink rule is under test.
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
-    );
     const sanitized = {
       catalog: { ...chatEntries(600), ...curatedCoverage },
       droppedModelIds: [],
     };
-    const baseline = (usableChat: number) => ({
-      totalEntries: usableChat,
-      medianInputCost: 0.000001,
-      medianOutputCost: 0.000002,
-      modes: { chat: { usable: usableChat, inputPriced: 600, outputPriced: 600 } },
-    });
-    expect(() => validateModelData(sanitized, baseline(2000))).toThrow(
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(2000)))).toThrow(
       /chat usable model count shrank from 2000/
     );
     // A small decrease within the bound is acceptable (e.g. upstream pruning).
-    expect(() => validateModelData(sanitized, baseline(650))).not.toThrow();
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(650)))).not.toThrow();
   });
 
   test("rejects the loss of one pricing field even when the other survives", () => {
     // An upstream rename of just output_cost_per_token keeps every entry
     // input-priced, so aggregated priced coverage would hide the regression.
-    const outputless = Object.fromEntries(
-      Array.from({ length: 700 }, (_, i) => [
-        `provider/outputless-${i}`,
-        { mode: "chat", max_input_tokens: 128000, input_cost_per_token: 0.000001 },
-      ])
-    );
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
-    );
+    const outputless = chatEntries(700, { output_cost_per_token: undefined }, "prov/outputless");
     const sanitized = { catalog: { ...outputless, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() =>
-      validateModelData(sanitized, {
-        totalEntries: 700,
-        medianInputCost: 0.000001,
-        medianOutputCost: 0.000002,
-        modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
-      })
-    ).toThrow(/chat output-priced model count shrank from 680/);
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+      /chat output_cost_per_token coverage shrank from 700 to 0/
+    );
   });
 
   test("rejects pricing loss confined to a smaller mode", () => {
     // Stripping costs from every responses row barely moves aggregate priced
     // counts, so each mode compares against its own baseline.
-    const pricedChat = Object.fromEntries(
-      Array.from({ length: 700 }, (_, i) => [
-        `provider/chat-${i}`,
-        {
-          mode: "chat",
-          max_input_tokens: 128000,
-          input_cost_per_token: 0.000001,
-          output_cost_per_token: 0.000002,
-        },
-      ])
-    );
-    const unpricedResponses = Object.fromEntries(
-      Array.from({ length: 60 }, (_, i) => [
-        `provider/responses-${i}`,
-        { mode: "responses", max_input_tokens: 128000 },
-      ])
-    );
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
-    );
+    const responses = (overrides: Record<string, unknown>) =>
+      chatEntries(60, { mode: "responses", ...overrides }, "prov/responses");
+    const baseline = summarizeCatalog({ ...chatEntries(700), ...responses({}) });
     const sanitized = {
-      catalog: { ...pricedChat, ...unpricedResponses, ...curatedCoverage },
+      catalog: {
+        ...chatEntries(700),
+        ...responses({ input_cost_per_token: undefined, output_cost_per_token: undefined }),
+        ...curatedCoverage,
+      },
       droppedModelIds: [],
     };
-    expect(() =>
-      validateModelData(sanitized, {
-        totalEntries: 760,
-        medianInputCost: 0.000001,
-        medianOutputCost: 0.000002,
-        modes: {
-          chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
-          responses: { usable: 60, inputPriced: 59, outputPriced: 59 },
-        },
-      })
-    ).toThrow(/responses input-priced model count shrank from 59 to 0/);
+    expect(() => validateModelData(sanitized, baseline)).toThrow(
+      /responses input_cost_per_token coverage shrank from 60 to 0/
+    );
   });
 
   test("rejects wholesale omission of a non-mappable mode", () => {
     // A partial payload that keeps chat/responses but drops image_generation
-    // rows must trip that mode's own usable baseline.
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
-    );
+    // rows must trip that mode's own entry-count baseline.
+    const baseline = summarizeCatalog({
+      ...chatEntries(700),
+      ...chatEntries(300, { mode: "image_generation", max_input_tokens: undefined }, "prov/image"),
+    });
     const sanitized = {
       catalog: { ...chatEntries(700), ...curatedCoverage },
       droppedModelIds: [],
     };
-    expect(() =>
-      validateModelData(sanitized, {
-        totalEntries: 760,
-        medianInputCost: 0.000001,
-        medianOutputCost: 0.000002,
-        modes: {
-          chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
-          image_generation: { usable: 300, inputPriced: 250, outputPriced: 0 },
-        },
-      })
-    ).toThrow(/image_generation usable model count shrank from 300 to 0/);
+    expect(() => validateModelData(sanitized, baseline)).toThrow(
+      /image_generation entry count shrank from 300 to 0/
+    );
+  });
+
+  test("rejects removal of a cost field beyond the base input/output pair", () => {
+    // Wiping output_cost_per_image_token leaves the base pair intact; the
+    // runtime would silently fall back to (much lower) generic output rates.
+    const image = (overrides: Record<string, unknown>) =>
+      chatEntries(300, { mode: "image_generation", ...overrides }, "prov/image");
+    const baseline = summarizeCatalog({
+      ...chatEntries(700),
+      ...image({ output_cost_per_image_token: 0.00002 }),
+    });
+    const sanitized = {
+      catalog: { ...chatEntries(700), ...image({}), ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    expect(() => validateModelData(sanitized, baseline)).toThrow(
+      /image_generation output_cost_per_image_token coverage shrank from 300 to 0/
+    );
+  });
+
+  test("rejects a catalog-wide loss of capability flags", () => {
+    // Runtime treats missing/false capability flags as unsupported, so both a
+    // field removal and a mass flip to false must register as coverage loss.
+    const baseline = summarizeCatalog(chatEntries(700, { supports_pdf_input: true }));
+    const flipped = {
+      catalog: { ...chatEntries(700, { supports_pdf_input: false }), ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    const removed = {
+      catalog: { ...chatEntries(700), ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    for (const sanitized of [flipped, removed]) {
+      expect(() => validateModelData(sanitized, baseline)).toThrow(
+        /chat supports_pdf_input coverage shrank from 700 to 0/
+      );
+    }
   });
 
   test("rejects a catalog-wide loss of token limits even when pricing survives", () => {
     // Entries keep mode + pricing but lose max_input_tokens: getModelStats
     // rejects them, so usable coverage must register the collapse.
-    const limitless = Object.fromEntries(
-      Array.from({ length: 700 }, (_, i) => [
-        `provider/limitless-${i}`,
-        { mode: "chat", input_cost_per_token: 0.000001, output_cost_per_token: 0.000002 },
-      ])
-    );
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
-    );
+    const limitless = chatEntries(700, { max_input_tokens: undefined }, "prov/limitless");
     const sanitized = { catalog: { ...limitless, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() =>
-      validateModelData(sanitized, {
-        totalEntries: 700,
-        medianInputCost: 0.000001,
-        medianOutputCost: 0.000002,
-        modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
-      })
-    ).toThrow(/chat usable model count shrank from 700/);
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+      /chat usable model count shrank from 700/
+    );
   });
 
-  test("summarizes coverage per mode with the usability bar applied", () => {
+  test("rejects a catalog-wide token-limit magnitude collapse", () => {
+    // max_input_tokens: 1 still passes the usability bar and every coverage
+    // count, so only the magnitude median can catch mass-shrunk context sizes.
+    const tiny = chatEntries(700, { max_input_tokens: 1 }, "prov/tiny");
+    const sanitized = { catalog: { ...tiny, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+      /max_input_tokens median shifted/
+    );
+  });
+
+  test("summarizes per-mode field coverage and mappable numeric magnitudes", () => {
     expect(
       summarizeCatalog({
         usableChat: {
           mode: "chat",
           max_input_tokens: 128000,
           input_cost_per_token: 0.000001,
+          supports_vision: true,
         },
         usableResponses: {
           mode: "responses",
@@ -288,51 +270,65 @@ describe("validateModelData", () => {
           input_cost_per_token: 0.000002,
           output_cost_per_token: 0.000008,
         },
-        limitlessChat: { mode: "chat", input_cost_per_token: 0.000001 },
+        // supports_vision: false counts as absent (runtime treats it as unsupported).
+        limitlessChat: { mode: "chat", input_cost_per_token: 0.000001, supports_vision: false },
         embedding: { mode: "embedding", max_input_tokens: 8192, input_cost_per_token: 0.0000001 },
       })
     ).toEqual({
       totalEntries: 4,
       modes: {
-        chat: { usable: 1, inputPriced: 2, outputPriced: 0 },
-        responses: { usable: 1, inputPriced: 1, outputPriced: 1 },
-        embedding: { usable: 1, inputPriced: 1, outputPriced: 0 },
+        chat: {
+          entries: 2,
+          usable: 1,
+          fields: { max_input_tokens: 1, input_cost_per_token: 2, supports_vision: 1 },
+        },
+        responses: {
+          entries: 1,
+          usable: 1,
+          fields: { max_input_tokens: 1, input_cost_per_token: 1, output_cost_per_token: 1 },
+        },
+        embedding: {
+          entries: 1,
+          usable: 1,
+          fields: { max_input_tokens: 1, input_cost_per_token: 1 },
+        },
       },
-      // Medians span mappable entries only, so the embedding cost is excluded.
-      medianInputCost: 0.000001,
-      medianOutputCost: 0.000008,
+      // Magnitudes span mappable entries only, so the embedding cost is excluded.
+      numericFields: {
+        max_input_tokens: { samples: 2, median: 128000 },
+        input_cost_per_token: { samples: 3, median: 0.000001 },
+        output_cost_per_token: { samples: 1, median: 0.000008 },
+      },
     });
   });
 
   test("rejects a catalog-wide price magnitude collapse", () => {
     // Every field survives and all counters match, but rates are scaled by
     // 1e-9; only the median magnitude guard can catch this.
-    const scaled = Object.fromEntries(
-      Array.from({ length: 700 }, (_, i) => [
-        `provider/scaled-${i}`,
-        {
-          mode: "chat",
-          max_input_tokens: 128000,
-          input_cost_per_token: 0.000001e-9,
-          output_cost_per_token: 0.000002e-9,
-        },
-      ])
-    );
-    const curatedCoverage = Object.fromEntries(
-      Object.values(KNOWN_MODELS).map((model) => [
-        model.providerModelId,
-        { mode: "chat", max_input_tokens: 200000 },
-      ])
+    const scaled = chatEntries(
+      700,
+      { input_cost_per_token: 0.000001e-9, output_cost_per_token: 0.000002e-9 },
+      "prov/scaled"
     );
     const sanitized = { catalog: { ...scaled, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() =>
-      validateModelData(sanitized, {
-        totalEntries: 721,
-        medianInputCost: 0.000001,
-        medianOutputCost: 0.000002,
-        modes: { chat: { usable: 721, inputPriced: 700, outputPriced: 700 } },
-      })
-    ).toThrow(/median input cost shifted/);
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+      /input_cost_per_token median shifted/
+    );
+  });
+
+  test("rejects a catalog-wide zeroing of prices", () => {
+    // Zero is a valid per-entry price and keeps field coverage intact, but a
+    // catalog-wide zero-out must fail the magnitude check (median collapses to
+    // 0), not slip past it because the ratio guard only ran on positive values.
+    const free = chatEntries(
+      700,
+      { input_cost_per_token: 0, output_cost_per_token: 0 },
+      "prov/free"
+    );
+    const sanitized = { catalog: { ...free, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() => validateModelData(sanitized, summarizeCatalog(chatEntries(700)))).toThrow(
+      /input_cost_per_token median shifted from 0.000001 to 0/
+    );
   });
 
   test("rejects data where too many entries had invalid pricing", () => {

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -142,6 +142,8 @@ describe("validateModelData", () => {
     };
     const baseline = (usableChat: number) => ({
       totalEntries: usableChat,
+      medianInputCost: 0.000001,
+      medianOutputCost: 0.000002,
       modes: { chat: { usable: usableChat, inputPriced: 600, outputPriced: 600 } },
     });
     expect(() => validateModelData(sanitized, baseline(2000))).toThrow(
@@ -170,6 +172,8 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         totalEntries: 700,
+        medianInputCost: 0.000001,
+        medianOutputCost: 0.000002,
         modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
       })
     ).toThrow(/chat output-priced model count shrank from 680/);
@@ -208,6 +212,8 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         totalEntries: 760,
+        medianInputCost: 0.000001,
+        medianOutputCost: 0.000002,
         modes: {
           chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
           responses: { usable: 60, inputPriced: 59, outputPriced: 59 },
@@ -232,6 +238,8 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         totalEntries: 760,
+        medianInputCost: 0.000001,
+        medianOutputCost: 0.000002,
         modes: {
           chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
           image_generation: { usable: 300, inputPriced: 250, outputPriced: 0 },
@@ -259,6 +267,8 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         totalEntries: 700,
+        medianInputCost: 0.000001,
+        medianOutputCost: 0.000002,
         modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
       })
     ).toThrow(/chat usable model count shrank from 700/);
@@ -288,7 +298,41 @@ describe("validateModelData", () => {
         responses: { usable: 1, inputPriced: 1, outputPriced: 1 },
         embedding: { usable: 1, inputPriced: 1, outputPriced: 0 },
       },
+      // Medians span mappable entries only, so the embedding cost is excluded.
+      medianInputCost: 0.000001,
+      medianOutputCost: 0.000008,
     });
+  });
+
+  test("rejects a catalog-wide price magnitude collapse", () => {
+    // Every field survives and all counters match, but rates are scaled by
+    // 1e-9; only the median magnitude guard can catch this.
+    const scaled = Object.fromEntries(
+      Array.from({ length: 700 }, (_, i) => [
+        `provider/scaled-${i}`,
+        {
+          mode: "chat",
+          max_input_tokens: 128000,
+          input_cost_per_token: 0.000001e-9,
+          output_cost_per_token: 0.000002e-9,
+        },
+      ])
+    );
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = { catalog: { ...scaled, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() =>
+      validateModelData(sanitized, {
+        totalEntries: 721,
+        medianInputCost: 0.000001,
+        medianOutputCost: 0.000002,
+        modes: { chat: { usable: 721, inputPriced: 700, outputPriced: 700 } },
+      })
+    ).toThrow(/median input cost shifted/);
   });
 
   test("rejects data where too many entries had invalid pricing", () => {

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -138,8 +138,8 @@ describe("validateModelData", () => {
     };
     const baseline = (usableMappableModels: number) => ({
       usableMappableModels,
-      inputPricedChatModels: 600,
-      outputPricedChatModels: 600,
+      inputPricedModels: 600,
+      outputPricedModels: 600,
     });
     expect(() => validateModelData(sanitized, baseline(2000))).toThrow(
       /usable chat\/responses model count shrank from 2000/
@@ -167,10 +167,10 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         usableMappableModels: 700,
-        inputPricedChatModels: 680,
-        outputPricedChatModels: 680,
+        inputPricedModels: 680,
+        outputPricedModels: 680,
       })
-    ).toThrow(/output-priced chat model count shrank from 680/);
+    ).toThrow(/output-priced model count shrank from 680/);
   });
 
   test("rejects a catalog-wide loss of token limits even when pricing survives", () => {
@@ -192,8 +192,8 @@ describe("validateModelData", () => {
     expect(() =>
       validateModelData(sanitized, {
         usableMappableModels: 700,
-        inputPricedChatModels: 680,
-        outputPricedChatModels: 680,
+        inputPricedModels: 680,
+        outputPricedModels: 680,
       })
     ).toThrow(/usable chat\/responses model count shrank from 700/);
   });
@@ -206,14 +206,19 @@ describe("validateModelData", () => {
           max_input_tokens: 128000,
           input_cost_per_token: 0.000001,
         },
-        usableResponses: { mode: "responses", max_input_tokens: 128000 },
+        usableResponses: {
+          mode: "responses",
+          max_input_tokens: 128000,
+          input_cost_per_token: 0.000002,
+          output_cost_per_token: 0.000008,
+        },
         limitlessChat: { mode: "chat", input_cost_per_token: 0.000001 },
-        embedding: { mode: "embedding", max_input_tokens: 8192 },
+        embedding: { mode: "embedding", max_input_tokens: 8192, input_cost_per_token: 0.0000001 },
       })
     ).toEqual({
       usableMappableModels: 2,
-      inputPricedChatModels: 2,
-      outputPricedChatModels: 0,
+      inputPricedModels: 3,
+      outputPricedModels: 1,
     });
   });
 

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -120,7 +120,7 @@ describe("validateModelData", () => {
 
   test("rejects truncated upstream data", () => {
     expect(() => validateModelData({ catalog: chatEntries(10), droppedModelIds: [] })).toThrow(
-      /only 10 chat models found/
+      /only 10 usable chat\/responses models found/
     );
   });
 
@@ -136,23 +136,25 @@ describe("validateModelData", () => {
       catalog: { ...chatEntries(600), ...curatedCoverage },
       droppedModelIds: [],
     };
-    expect(() => validateModelData(sanitized, { chatModels: 2000, pricedChatModels: 600 })).toThrow(
-      /chat model count shrank from 2000/
+    const baseline = (usableMappableModels: number) => ({
+      usableMappableModels,
+      inputPricedChatModels: 600,
+      outputPricedChatModels: 600,
+    });
+    expect(() => validateModelData(sanitized, baseline(2000))).toThrow(
+      /usable chat\/responses model count shrank from 2000/
     );
     // A small decrease within the bound is acceptable (e.g. upstream pruning).
-    expect(() =>
-      validateModelData(sanitized, { chatModels: 650, pricedChatModels: 600 })
-    ).not.toThrow();
+    expect(() => validateModelData(sanitized, baseline(650))).not.toThrow();
   });
 
-  test("rejects a catalog-wide loss of pricing fields", () => {
-    // Entries keep modes and token limits but lose every cost field, as an
-    // upstream pricing-field rename would produce: nothing is dropped per-entry,
-    // yet priced coverage collapses.
-    const unpriced = Object.fromEntries(
+  test("rejects the loss of one pricing field even when the other survives", () => {
+    // An upstream rename of just output_cost_per_token keeps every entry
+    // input-priced, so aggregated priced coverage would hide the regression.
+    const outputless = Object.fromEntries(
       Array.from({ length: 700 }, (_, i) => [
-        `provider/unpriced-${i}`,
-        { mode: "chat", max_input_tokens: 128000 },
+        `provider/outputless-${i}`,
+        { mode: "chat", max_input_tokens: 128000, input_cost_per_token: 0.000001 },
       ])
     );
     const curatedCoverage = Object.fromEntries(
@@ -161,10 +163,58 @@ describe("validateModelData", () => {
         { mode: "chat", max_input_tokens: 200000 },
       ])
     );
-    const sanitized = { catalog: { ...unpriced, ...curatedCoverage }, droppedModelIds: [] };
-    expect(() => validateModelData(sanitized, { chatModels: 700, pricedChatModels: 680 })).toThrow(
-      /priced chat model count shrank from 680/
+    const sanitized = { catalog: { ...outputless, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() =>
+      validateModelData(sanitized, {
+        usableMappableModels: 700,
+        inputPricedChatModels: 680,
+        outputPricedChatModels: 680,
+      })
+    ).toThrow(/output-priced chat model count shrank from 680/);
+  });
+
+  test("rejects a catalog-wide loss of token limits even when pricing survives", () => {
+    // Entries keep mode + pricing but lose max_input_tokens: getModelStats
+    // rejects them, so usable coverage must register the collapse.
+    const limitless = Object.fromEntries(
+      Array.from({ length: 700 }, (_, i) => [
+        `provider/limitless-${i}`,
+        { mode: "chat", input_cost_per_token: 0.000001, output_cost_per_token: 0.000002 },
+      ])
     );
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = { catalog: { ...limitless, ...curatedCoverage }, droppedModelIds: [] };
+    expect(() =>
+      validateModelData(sanitized, {
+        usableMappableModels: 700,
+        inputPricedChatModels: 680,
+        outputPricedChatModels: 680,
+      })
+    ).toThrow(/usable chat\/responses model count shrank from 700/);
+  });
+
+  test("counts responses-mode entries and applies the usability bar", () => {
+    expect(
+      summarizeCatalog({
+        usableChat: {
+          mode: "chat",
+          max_input_tokens: 128000,
+          input_cost_per_token: 0.000001,
+        },
+        usableResponses: { mode: "responses", max_input_tokens: 128000 },
+        limitlessChat: { mode: "chat", input_cost_per_token: 0.000001 },
+        embedding: { mode: "embedding", max_input_tokens: 8192 },
+      })
+    ).toEqual({
+      usableMappableModels: 2,
+      inputPricedChatModels: 2,
+      outputPricedChatModels: 0,
+    });
   });
 
   test("rejects data where too many entries had invalid pricing", () => {

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -1,0 +1,126 @@
+import { describe, test, expect } from "@jest/globals";
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import modelsJson from "./models.json";
+import {
+  findMissingKnownModels,
+  pruneModelData,
+  sanitizePricing,
+  validateModelData,
+} from "./updateModelsData";
+
+function chatEntries(count: number): Record<string, Record<string, unknown>> {
+  const entries: Record<string, Record<string, unknown>> = {};
+  for (let i = 0; i < count; i++) {
+    entries[`provider/model-${i}`] = {
+      mode: "chat",
+      max_input_tokens: 128000,
+      input_cost_per_token: 0.000001,
+      output_cost_per_token: 0.000002,
+    };
+  }
+  return entries;
+}
+
+describe("pruneModelData", () => {
+  test("rejects non-object payloads", () => {
+    expect(() => pruneModelData(null)).toThrow("Expected LiteLLM model metadata object");
+    expect(() => pruneModelData([1, 2])).toThrow("Expected LiteLLM model metadata object");
+  });
+
+  test("keeps only retained fields and drops non-object entries", () => {
+    const pruned = pruneModelData({
+      "provider/model-a": {
+        max_input_tokens: 1000,
+        input_cost_per_token: 0.001,
+        litellm_provider: "provider",
+        source: "https://example.com",
+        deprecation_date: "2027-01-01",
+      },
+      bogus: "not-an-object",
+    });
+
+    expect(pruned["provider/model-a"]).toEqual({
+      max_input_tokens: 1000,
+      input_cost_per_token: 0.001,
+      litellm_provider: "provider",
+    });
+    expect(pruned.bogus).toBeUndefined();
+  });
+});
+
+describe("sanitizePricing", () => {
+  test("drops entries whose present cost fields are unusable", () => {
+    const { catalog, droppedModelIds } = sanitizePricing({
+      good: { input_cost_per_token: 0.001, output_cost_per_token: 0 },
+      // Subscription providers legitimately omit costs entirely.
+      "no-costs": { max_input_tokens: 1000 },
+      negative: { input_cost_per_token: -0.001 },
+      "not-a-number": { output_cost_per_token: "0.001" },
+      infinite: { cache_read_input_token_cost: Number.POSITIVE_INFINITY },
+    });
+
+    expect(Object.keys(catalog).sort()).toEqual(["good", "no-costs"]);
+    expect(droppedModelIds.sort()).toEqual(["infinite", "negative", "not-a-number"]);
+  });
+});
+
+describe("findMissingKnownModels", () => {
+  test("reports all curated models against an empty catalog and no overrides", () => {
+    const missing = findMissingKnownModels({}, {});
+    expect(missing.sort()).toEqual(
+      Object.values(KNOWN_MODELS)
+        .map((model) => model.id)
+        .sort()
+    );
+  });
+
+  test("provider-prefixed lookups satisfy xai models while bare keys do not", () => {
+    const grok = Object.values(KNOWN_MODELS).find((model) => model.provider === "xai");
+    if (!grok) throw new Error("expected a curated xai model");
+
+    const bareKey = { [grok.providerModelId]: {} };
+    expect(findMissingKnownModels(bareKey, {})).toContain(grok.id);
+
+    const prefixedKey = { [`xai/${grok.providerModelId}`]: {} };
+    expect(findMissingKnownModels(prefixedKey, {})).not.toContain(grok.id);
+  });
+
+  test("models-extra overrides satisfy models absent upstream", () => {
+    const anthropic = Object.values(KNOWN_MODELS).find((model) => model.provider === "anthropic");
+    if (!anthropic) throw new Error("expected a curated anthropic model");
+
+    expect(findMissingKnownModels({}, { [anthropic.providerModelId]: {} })).not.toContain(
+      anthropic.id
+    );
+  });
+});
+
+describe("validateModelData", () => {
+  test("accepts the current vendored models.json", () => {
+    const sanitized = sanitizePricing(modelsJson as Record<string, Record<string, unknown>>);
+    expect(sanitized.droppedModelIds).toEqual([]);
+    expect(() => validateModelData(sanitized)).not.toThrow();
+  });
+
+  test("rejects truncated upstream data", () => {
+    expect(() => validateModelData({ catalog: chatEntries(10), droppedModelIds: [] })).toThrow(
+      /only 10 chat models found/
+    );
+  });
+
+  test("rejects data where too many entries had invalid pricing", () => {
+    // 100 dropped out of 700 total (14%) exceeds the 5% abort threshold.
+    const dropped = Array.from({ length: 100 }, (_, i) => `dropped-${i}`);
+    expect(() =>
+      validateModelData({ catalog: chatEntries(600), droppedModelIds: dropped })
+    ).toThrow(/entries have invalid pricing/);
+  });
+
+  test("rejects data missing curated known models", () => {
+    // A large catalog that satisfies the size floor but carries none of the
+    // curated model keys that models-extra does not already cover.
+    expect(() => validateModelData({ catalog: chatEntries(600), droppedModelIds: [] })).toThrow(
+      /curated known models missing from upstream/
+    );
+  });
+});

--- a/src/common/utils/tokens/updateModelsData.test.ts
+++ b/src/common/utils/tokens/updateModelsData.test.ts
@@ -78,15 +78,19 @@ describe("findMissingKnownModels", () => {
     );
   });
 
-  test("provider-prefixed lookups satisfy xai models while bare keys do not", () => {
+  test("any runtime-resolvable key form satisfies coverage, unrelated keys do not", () => {
     const grok = Object.values(KNOWN_MODELS).find((model) => model.provider === "xai");
     if (!grok) throw new Error("expected a curated xai model");
 
-    const bareKey = { [grok.providerModelId]: usable };
-    expect(findMissingKnownModels(bareKey, {})).toContain(grok.id);
-
-    const prefixedKey = { [`xai/${grok.providerModelId}`]: usable };
-    expect(findMissingKnownModels(prefixedKey, {})).not.toContain(grok.id);
+    // Coverage mirrors getModelStats' lookup keys: both the provider-prefixed
+    // form LiteLLM uses for xAI and the bare fallback resolve at runtime.
+    expect(findMissingKnownModels({ [`xai/${grok.providerModelId}`]: usable }, {})).not.toContain(
+      grok.id
+    );
+    expect(findMissingKnownModels({ [grok.providerModelId]: usable }, {})).not.toContain(grok.id);
+    expect(
+      findMissingKnownModels({ [`unrelated/${grok.providerModelId}x`]: usable }, {})
+    ).toContain(grok.id);
   });
 
   test("a retained key with unusable token limits still counts as missing", () => {
@@ -136,13 +140,12 @@ describe("validateModelData", () => {
       catalog: { ...chatEntries(600), ...curatedCoverage },
       droppedModelIds: [],
     };
-    const baseline = (usableMappableModels: number) => ({
-      usableMappableModels,
-      inputPricedModels: 600,
-      outputPricedModels: 600,
+    const baseline = (usableChat: number) => ({
+      totalEntries: usableChat,
+      modes: { chat: { usable: usableChat, inputPriced: 600, outputPriced: 600 } },
     });
     expect(() => validateModelData(sanitized, baseline(2000))).toThrow(
-      /usable chat\/responses model count shrank from 2000/
+      /chat usable model count shrank from 2000/
     );
     // A small decrease within the bound is acceptable (e.g. upstream pruning).
     expect(() => validateModelData(sanitized, baseline(650))).not.toThrow();
@@ -166,11 +169,75 @@ describe("validateModelData", () => {
     const sanitized = { catalog: { ...outputless, ...curatedCoverage }, droppedModelIds: [] };
     expect(() =>
       validateModelData(sanitized, {
-        usableMappableModels: 700,
-        inputPricedModels: 680,
-        outputPricedModels: 680,
+        totalEntries: 700,
+        modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
       })
-    ).toThrow(/output-priced model count shrank from 680/);
+    ).toThrow(/chat output-priced model count shrank from 680/);
+  });
+
+  test("rejects pricing loss confined to a smaller mode", () => {
+    // Stripping costs from every responses row barely moves aggregate priced
+    // counts, so each mode compares against its own baseline.
+    const pricedChat = Object.fromEntries(
+      Array.from({ length: 700 }, (_, i) => [
+        `provider/chat-${i}`,
+        {
+          mode: "chat",
+          max_input_tokens: 128000,
+          input_cost_per_token: 0.000001,
+          output_cost_per_token: 0.000002,
+        },
+      ])
+    );
+    const unpricedResponses = Object.fromEntries(
+      Array.from({ length: 60 }, (_, i) => [
+        `provider/responses-${i}`,
+        { mode: "responses", max_input_tokens: 128000 },
+      ])
+    );
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = {
+      catalog: { ...pricedChat, ...unpricedResponses, ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    expect(() =>
+      validateModelData(sanitized, {
+        totalEntries: 760,
+        modes: {
+          chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
+          responses: { usable: 60, inputPriced: 59, outputPriced: 59 },
+        },
+      })
+    ).toThrow(/responses input-priced model count shrank from 59 to 0/);
+  });
+
+  test("rejects wholesale omission of a non-mappable mode", () => {
+    // A partial payload that keeps chat/responses but drops image_generation
+    // rows must trip that mode's own usable baseline.
+    const curatedCoverage = Object.fromEntries(
+      Object.values(KNOWN_MODELS).map((model) => [
+        model.providerModelId,
+        { mode: "chat", max_input_tokens: 200000 },
+      ])
+    );
+    const sanitized = {
+      catalog: { ...chatEntries(700), ...curatedCoverage },
+      droppedModelIds: [],
+    };
+    expect(() =>
+      validateModelData(sanitized, {
+        totalEntries: 760,
+        modes: {
+          chat: { usable: 700, inputPriced: 700, outputPriced: 700 },
+          image_generation: { usable: 300, inputPriced: 250, outputPriced: 0 },
+        },
+      })
+    ).toThrow(/image_generation usable model count shrank from 300 to 0/);
   });
 
   test("rejects a catalog-wide loss of token limits even when pricing survives", () => {
@@ -191,14 +258,13 @@ describe("validateModelData", () => {
     const sanitized = { catalog: { ...limitless, ...curatedCoverage }, droppedModelIds: [] };
     expect(() =>
       validateModelData(sanitized, {
-        usableMappableModels: 700,
-        inputPricedModels: 680,
-        outputPricedModels: 680,
+        totalEntries: 700,
+        modes: { chat: { usable: 700, inputPriced: 680, outputPriced: 680 } },
       })
-    ).toThrow(/usable chat\/responses model count shrank from 700/);
+    ).toThrow(/chat usable model count shrank from 700/);
   });
 
-  test("counts responses-mode entries and applies the usability bar", () => {
+  test("summarizes coverage per mode with the usability bar applied", () => {
     expect(
       summarizeCatalog({
         usableChat: {
@@ -216,9 +282,12 @@ describe("validateModelData", () => {
         embedding: { mode: "embedding", max_input_tokens: 8192, input_cost_per_token: 0.0000001 },
       })
     ).toEqual({
-      usableMappableModels: 2,
-      inputPricedModels: 3,
-      outputPricedModels: 1,
+      totalEntries: 4,
+      modes: {
+        chat: { usable: 1, inputPriced: 2, outputPriced: 0 },
+        responses: { usable: 1, inputPriced: 1, outputPriced: 1 },
+        embedding: { usable: 1, inputPriced: 1, outputPriced: 0 },
+      },
     });
   });
 

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -7,7 +7,7 @@
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { modelsExtra } from "./models-extra";
-import { hasUsableTokenLimits } from "./modelStats";
+import { generateModelLookupKeys, hasUsableTokenLimits } from "./modelStats";
 
 const RETAINED_FIELDS = [
   "max_input_tokens",
@@ -48,6 +48,10 @@ const COST_FIELDS = [
 // responses or field renames that would silently degrade thousands of known models.
 const MIN_USABLE_MAPPABLE_MODELS = 500;
 const MAX_BASELINE_SHRINK_FRACTION = 0.1;
+// Relative checks only apply to baselines with enough entries for the fraction
+// to be signal rather than noise (a 3-entry mode legitimately losing 1 entry
+// must not block refreshes forever).
+const MIN_BASELINE_FOR_SHRINK_CHECK = 20;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
 
 /** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
@@ -123,9 +127,9 @@ function providesUsableMetadata(entry: unknown): boolean {
 
 /**
  * Curated models that would lose token/pricing metadata under the given catalog.
- * The models-extra overrides are consulted the same way getModelStats does, and
- * coverage requires usable metadata (not mere key presence), so an upstream entry
- * that loses its token limits still counts as missing.
+ * Coverage uses getModelStats' own lookup keys and usability bar, so any key
+ * form the runtime can resolve (bare, provider-scoped, models-extra override)
+ * counts, and an entry that loses its token limits still counts as missing.
  */
 export function findMissingKnownModels(
   catalog: ModelCatalogData,
@@ -133,68 +137,62 @@ export function findMissingKnownModels(
 ): string[] {
   const missing: string[] = [];
   for (const model of Object.values(KNOWN_MODELS)) {
-    const modelId = model.providerModelId;
-    // xAI and Moonshot models are provider-prefixed in token metadata.
-    const lookupKey =
-      model.provider === "xai" || model.provider === "moonshotai"
-        ? `${model.provider}/${modelId}`
-        : modelId;
-    if (
-      !providesUsableMetadata(catalog[lookupKey]) &&
-      !providesUsableMetadata(extra[lookupKey]) &&
-      !providesUsableMetadata(extra[modelId])
-    ) {
+    const covered = generateModelLookupKeys(model.id).some(
+      (key) => providesUsableMetadata(catalog[key]) || providesUsableMetadata(extra[key])
+    );
+    if (!covered) {
       missing.push(model.id);
     }
   }
   return missing;
 }
 
+export interface ModeCoverage {
+  /** Entries passing getModelStats' usability bar (usable token limits). */
+  usable: number;
+  /** Entries carrying a numeric input cost. */
+  inputPriced: number;
+  /** Entries carrying a numeric output cost. */
+  outputPriced: number;
+}
+
 export interface CatalogSummary {
-  /** Chat/responses entries with usable token limits (what the Treat-as catalog can expose). */
-  usableMappableModels: number;
-  /** Mappable (chat/responses) entries carrying a numeric input cost. */
-  inputPricedModels: number;
-  /** Mappable (chat/responses) entries carrying a numeric output cost. */
-  outputPricedModels: number;
+  totalEntries: number;
+  /** Coverage per mode string, spanning every mode (not just mappable ones). */
+  modes: Record<string, ModeCoverage>;
 }
 
 export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
-  const summary: CatalogSummary = {
-    usableMappableModels: 0,
-    inputPricedModels: 0,
-    outputPricedModels: 0,
-  };
+  const summary: CatalogSummary = { totalEntries: 0, modes: {} };
   for (const metadata of Object.values(catalog)) {
-    if (typeof metadata.mode !== "string" || !MAPPABLE_MODES.has(metadata.mode)) {
-      continue;
-    }
+    summary.totalEntries++;
+    const mode = typeof metadata.mode === "string" ? metadata.mode : "unknown";
+    const coverage = (summary.modes[mode] ??= { usable: 0, inputPriced: 0, outputPriced: 0 });
     // Usability applies getModelStats' bar: entries without usable token limits
     // never resolve, so losing max_input_tokens must register as shrinkage.
     if (hasUsableTokenLimits(metadata)) {
-      summary.usableMappableModels++;
+      coverage.usable++;
     }
-    // Priced coverage spans every mappable mode (getModelStats prices responses
-    // entries identically), and input/output are tracked separately so renaming
-    // just one cost field cannot hide behind the other's coverage.
+    // Input and output pricing are tracked separately per mode so renaming one
+    // cost field, or stripping pricing from a smaller mode like `responses`,
+    // cannot hide behind another field's or a larger mode's coverage.
     if (typeof metadata.input_cost_per_token === "number") {
-      summary.inputPricedModels++;
+      coverage.inputPriced++;
     }
     if (typeof metadata.output_cost_per_token === "number") {
-      summary.outputPricedModels++;
+      coverage.outputPriced++;
     }
   }
   return summary;
 }
 
-const EMPTY_BASELINE: CatalogSummary = {
-  usableMappableModels: 0,
-  inputPricedModels: 0,
-  outputPricedModels: 0,
-};
+const EMPTY_BASELINE: CatalogSummary = { totalEntries: 0, modes: {} };
 
 function belowBaseline(count: number, baseline: number): boolean {
-  return count < Math.ceil(baseline * (1 - MAX_BASELINE_SHRINK_FRACTION));
+  return (
+    baseline >= MIN_BASELINE_FOR_SHRINK_CHECK &&
+    count < Math.ceil(baseline * (1 - MAX_BASELINE_SHRINK_FRACTION))
+  );
 }
 
 /**
@@ -210,25 +208,35 @@ export function validateModelData(
   const errors: string[] = [];
 
   const summary = summarizeCatalog(catalog);
-  if (summary.usableMappableModels < MIN_USABLE_MAPPABLE_MODELS) {
+  const usableMappableModels = [...MAPPABLE_MODES].reduce(
+    (count, mode) => count + (summary.modes[mode]?.usable ?? 0),
+    0
+  );
+  if (usableMappableModels < MIN_USABLE_MAPPABLE_MODELS) {
     errors.push(
-      `only ${summary.usableMappableModels} usable chat/responses models found ` +
+      `only ${usableMappableModels} usable chat/responses models found ` +
         `(expected at least ${MIN_USABLE_MAPPABLE_MODELS})`
     );
   }
+
+  // Costs are optional per entry (subscription providers), so an upstream
+  // pricing-field rename or a wholesale mode omission would sail through the
+  // per-entry checks; comparing every mode's usable and priced coverage against
+  // the vendored baseline (plus the total entry count for modes without usable
+  // limits, like image_generation pricing rows) keeps getModelStats from
+  // silently zero-pricing or dropping whole slices of the catalog.
   const shrinkChecks: Array<[label: string, count: number, baselineCount: number]> = [
-    [
-      "usable chat/responses model count",
-      summary.usableMappableModels,
-      baseline.usableMappableModels,
-    ],
-    // Costs are optional per entry (subscription providers), so an upstream
-    // pricing-field rename would sail through the per-entry checks; catching a
-    // collapse in priced coverage keeps getModelStats from silently zero-pricing
-    // the whole catalog.
-    ["input-priced model count", summary.inputPricedModels, baseline.inputPricedModels],
-    ["output-priced model count", summary.outputPricedModels, baseline.outputPricedModels],
+    ["total entry count", summary.totalEntries, baseline.totalEntries],
   ];
+  const emptyCoverage: ModeCoverage = { usable: 0, inputPriced: 0, outputPriced: 0 };
+  for (const [mode, baselineCoverage] of Object.entries(baseline.modes)) {
+    const coverage = summary.modes[mode] ?? emptyCoverage;
+    shrinkChecks.push(
+      [`${mode} usable model count`, coverage.usable, baselineCoverage.usable],
+      [`${mode} input-priced model count`, coverage.inputPriced, baselineCoverage.inputPriced],
+      [`${mode} output-priced model count`, coverage.outputPriced, baselineCoverage.outputPriced]
+    );
+  }
   for (const [label, count, baselineCount] of shrinkChecks) {
     if (belowBaseline(count, baselineCount)) {
       errors.push(

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -6,8 +6,9 @@
  */
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { normalizeToCanonical } from "../ai/models";
 import { modelsExtra } from "./models-extra";
-import { generateModelLookupKeys, hasUsableTokenLimits } from "./modelStats";
+import { generateModelLookupKeys, hasUsableTokenLimits, parseNum } from "./modelStats";
 
 const RETAINED_FIELDS = [
   "max_input_tokens",
@@ -62,6 +63,24 @@ const MAX_MAGNITUDE_SHIFT_FACTOR = 100;
 
 /** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
 export const MAPPABLE_MODES = new Set(["chat", "responses"]);
+
+/**
+ * Canonical `provider:model` id for a catalog key. LiteLLM keys are either
+ * "provider/model" or a bare model id whose provider lives in litellm_provider;
+ * both forms round-trip through getModelStats' lookup keys. Shared with the
+ * Treat-as catalog so validation and the UI derive identities identically.
+ */
+export function toCanonicalModelId(
+  catalogKey: string,
+  metadata: Record<string, unknown>
+): string | null {
+  const slashIndex = catalogKey.indexOf("/");
+  if (slashIndex > 0) {
+    return `${catalogKey.slice(0, slashIndex)}:${catalogKey.slice(slashIndex + 1)}`;
+  }
+  const provider = metadata.litellm_provider;
+  return typeof provider === "string" && provider.length > 0 ? `${provider}:${catalogKey}` : null;
+}
 
 export type ModelCatalogData = Record<string, Record<string, unknown>>;
 
@@ -224,13 +243,16 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
       if (hasConsumedValue(value)) {
         coverage.fields[field] = (coverage.fields[field] ?? 0) + 1;
       }
-      if (MAPPABLE_MODES.has(mode) && typeof value === "number" && value > 0) {
+      // parseNum mirrors runtime parsing, so a numeric string like "128000"
+      // contributes its real magnitude instead of reading as a collapse.
+      const numeric = parseNum(value);
+      if (MAPPABLE_MODES.has(mode) && numeric !== null && numeric > 0) {
         let samples = numericSamples.get(field);
         if (samples === undefined) {
           samples = [];
           numericSamples.set(field, samples);
         }
-        samples.push(value);
+        samples.push(numeric);
       }
     }
   }
@@ -238,6 +260,24 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
     summary.numericFields[field] = { samples: samples.length, median: median(samples) };
   }
   return summary;
+}
+
+/**
+ * The entry a catalog would serve for a model id, using getModelStats' own
+ * lookup preference and usability bar. Alias-shadowing corruption is only
+ * visible through this resolution, never through raw key comparison.
+ */
+function resolveCatalogEntry(
+  catalog: ModelCatalogData,
+  modelId: string
+): Record<string, unknown> | undefined {
+  for (const key of generateModelLookupKeys(modelId)) {
+    const entry = catalog[key];
+    if (entry !== undefined && hasUsableTokenLimits(entry)) {
+      return entry;
+    }
+  }
+  return undefined;
 }
 
 function belowBaseline(count: number, baseline: number): boolean {
@@ -321,37 +361,58 @@ export function validateModelData(
     }
   }
 
-  // Catalog-wide counts and medians cannot see a targeted repricing of a
-  // single row, so each surviving entry's numeric fields are also bounded
-  // against their own baseline values (a positive value must stay a number
-  // within the factor; vanishing is the same attack as scaling toward zero).
-  // A legitimate per-row correction beyond the factor fails closed: delete
-  // models.json and rerun to deliberately accept a full refresh.
+  // Catalog-wide counts and medians cannot see targeted single-row corruption,
+  // and raw-key comparison cannot see alias shadowing: a poisoned catalog can
+  // add a higher-precedence key (openai/gpt-4o-mini over a baseline
+  // gpt-4o-mini) or move a row to such an alias, leaving every count and
+  // median intact while runtime lookups resolve the poisoned entry. Entries
+  // are therefore compared by runtime identity: for every model id either
+  // catalog can serve, the entry each catalog resolves through getModelStats'
+  // own lookup preference must keep positive numeric fields present and
+  // within the magnitude factor (runtime parseNum semantics, so numeric
+  // strings compare by value) and keep baseline-true capability flags (runtime
+  // treats absent/false as unsupported). Legitimate changes beyond these
+  // bounds fail closed: delete models.json and rerun to deliberately accept a
+  // full refresh.
   const entryShifts: string[] = [];
-  for (const [key, baselineEntry] of Object.entries(baselineCatalog)) {
-    const entry = catalog[key];
+  const identities = new Set<string>();
+  for (const source of [baselineCatalog, catalog]) {
+    for (const [key, metadata] of Object.entries(source)) {
+      identities.add(normalizeToCanonical(toCanonicalModelId(key, metadata) ?? key));
+    }
+  }
+  for (const id of identities) {
+    const baselineEntry = resolveCatalogEntry(baselineCatalog, id);
+    if (baselineEntry === undefined) {
+      continue; // genuinely new identity; nothing vendored to compare against
+    }
+    const entry = resolveCatalogEntry(catalog, id);
     if (entry === undefined) {
-      continue; // removed keys are governed by the coverage baselines above
+      continue; // fully removed identities are governed by the coverage baselines
     }
     for (const field of RETAINED_FIELDS) {
       const baselineValue = baselineEntry[field];
-      if (typeof baselineValue !== "number" || baselineValue <= 0) {
+      if (baselineValue === true) {
+        if (entry[field] !== true) {
+          entryShifts.push(`${id} ${field}: true -> ${JSON.stringify(entry[field]) ?? "absent"}`);
+        }
         continue;
       }
-      const value = entry[field];
-      const ratio = typeof value === "number" ? value / baselineValue : 0;
+      const baselineNum = typeof baselineValue === "boolean" ? null : parseNum(baselineValue);
+      if (baselineNum === null || baselineNum <= 0) {
+        continue;
+      }
+      const candidateNum = parseNum(entry[field]);
+      const ratio = candidateNum === null ? 0 : candidateNum / baselineNum;
       if (ratio > MAX_MAGNITUDE_SHIFT_FACTOR || ratio < 1 / MAX_MAGNITUDE_SHIFT_FACTOR) {
-        entryShifts.push(
-          `${key} ${field}: ${baselineValue} -> ${typeof value === "number" ? value : "absent"}`
-        );
+        entryShifts.push(`${id} ${field}: ${baselineNum} -> ${candidateNum ?? "absent"}`);
       }
     }
   }
   if (entryShifts.length > 0) {
     errors.push(
-      `${entryShifts.length} surviving entries shifted a numeric field more than ` +
-        `${MAX_MAGNITUDE_SHIFT_FACTOR}x from the vendored baseline ` +
-        `(e.g. ${entryShifts.slice(0, 5).join("; ")})`
+      `${entryShifts.length} resolved model identities regressed a retained field beyond the ` +
+        `vendored baseline (e.g. ${entryShifts.slice(0, 5).join("; ")})`
     );
   }
 

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -7,6 +7,7 @@
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { modelsExtra } from "./models-extra";
+import { hasUsableTokenLimits } from "./modelStats";
 
 const RETAINED_FIELDS = [
   "max_input_tokens",
@@ -43,7 +44,10 @@ const COST_FIELDS = [
 ] as const;
 
 // Abort thresholds guarding against truncated or structurally reshaped upstream data.
+// The absolute floor catches degenerate payloads; the relative bound catches partial
+// responses that would silently drop metadata for thousands of currently known models.
 const MIN_CHAT_MODELS = 500;
+const MAX_CHAT_MODEL_SHRINK_FRACTION = 0.1;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
 
 export type ModelCatalogData = Record<string, Record<string, unknown>>;
@@ -106,9 +110,19 @@ export function sanitizePricing(pruned: ModelCatalogData): SanitizedModelData {
   return { catalog, droppedModelIds };
 }
 
+function providesUsableMetadata(entry: unknown): boolean {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    hasUsableTokenLimits(entry as Record<string, unknown>)
+  );
+}
+
 /**
  * Curated models that would lose token/pricing metadata under the given catalog.
- * The models-extra overrides are consulted the same way getModelStats does.
+ * The models-extra overrides are consulted the same way getModelStats does, and
+ * coverage requires usable metadata (not mere key presence), so an upstream entry
+ * that loses its token limits still counts as missing.
  */
 export function findMissingKnownModels(
   catalog: ModelCatalogData,
@@ -122,21 +136,40 @@ export function findMissingKnownModels(
       model.provider === "xai" || model.provider === "moonshotai"
         ? `${model.provider}/${modelId}`
         : modelId;
-    if (!(lookupKey in catalog) && !(lookupKey in extra) && !(modelId in extra)) {
+    if (
+      !providesUsableMetadata(catalog[lookupKey]) &&
+      !providesUsableMetadata(extra[lookupKey]) &&
+      !providesUsableMetadata(extra[modelId])
+    ) {
       missing.push(model.id);
     }
   }
   return missing;
 }
 
-/** Throws when the sanitized upstream data is unfit to replace the vendored models.json. */
-export function validateModelData(sanitized: SanitizedModelData): void {
+export function countChatModels(catalog: ModelCatalogData): number {
+  return Object.values(catalog).filter((metadata) => metadata.mode === "chat").length;
+}
+
+/**
+ * Throws when the sanitized upstream data is unfit to replace the vendored
+ * models.json. `baselineChatCount` is the chat-model count of the currently
+ * vendored catalog (0 when unavailable).
+ */
+export function validateModelData(sanitized: SanitizedModelData, baselineChatCount = 0): void {
   const { catalog, droppedModelIds } = sanitized;
   const errors: string[] = [];
 
-  const chatCount = Object.values(catalog).filter((metadata) => metadata.mode === "chat").length;
+  const chatCount = countChatModels(catalog);
   if (chatCount < MIN_CHAT_MODELS) {
     errors.push(`only ${chatCount} chat models found (expected at least ${MIN_CHAT_MODELS})`);
+  }
+  const minRelativeChatCount = Math.ceil(baselineChatCount * (1 - MAX_CHAT_MODEL_SHRINK_FRACTION));
+  if (chatCount < minRelativeChatCount) {
+    errors.push(
+      `chat model count shrank from ${baselineChatCount} to ${chatCount} ` +
+        `(more than ${MAX_CHAT_MODEL_SHRINK_FRACTION * 100}% below the vendored baseline)`
+    );
   }
 
   const total = Object.keys(catalog).length + droppedModelIds.length;
@@ -158,5 +191,10 @@ export function validateModelData(sanitized: SanitizedModelData): void {
 }
 
 export function serializeModelData(catalog: ModelCatalogData): string {
-  return `${JSON.stringify(catalog, null, 2)}\n`;
+  // Sort keys so upstream object reordering never shows up as a diff (the CLI
+  // and the scheduled workflow treat byte-identical output as "no update").
+  const sorted = Object.fromEntries(
+    Object.entries(catalog).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+  );
+  return `${JSON.stringify(sorted, null, 2)}\n`;
 }

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -53,6 +53,11 @@ const MAX_BASELINE_SHRINK_FRACTION = 0.1;
 // must not block refreshes forever).
 const MIN_BASELINE_FOR_SHRINK_CHECK = 20;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
+// A poisoned upstream could keep every field present but scale prices toward
+// zero (or absurdly high), silently corrupting cost accounting. Legitimate
+// repricing moves few models or small factors, so a catalog-wide median shift
+// beyond this factor is treated as corruption.
+const MAX_MEDIAN_COST_SHIFT_FACTOR = 100;
 
 /** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
 export const MAPPABLE_MODES = new Set(["chat", "responses"]);
@@ -160,10 +165,28 @@ export interface CatalogSummary {
   totalEntries: number;
   /** Coverage per mode string, spanning every mode (not just mappable ones). */
   modes: Record<string, ModeCoverage>;
+  /** Median positive per-token costs across mappable entries (0 when none). */
+  medianInputCost: number;
+  medianOutputCost: number;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
 }
 
 export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
-  const summary: CatalogSummary = { totalEntries: 0, modes: {} };
+  const summary: CatalogSummary = {
+    totalEntries: 0,
+    modes: {},
+    medianInputCost: 0,
+    medianOutputCost: 0,
+  };
+  const inputCosts: number[] = [];
+  const outputCosts: number[] = [];
   for (const metadata of Object.values(catalog)) {
     summary.totalEntries++;
     const mode = typeof metadata.mode === "string" ? metadata.mode : "unknown";
@@ -178,15 +201,28 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
     // cannot hide behind another field's or a larger mode's coverage.
     if (typeof metadata.input_cost_per_token === "number") {
       coverage.inputPriced++;
+      if (MAPPABLE_MODES.has(mode) && metadata.input_cost_per_token > 0) {
+        inputCosts.push(metadata.input_cost_per_token);
+      }
     }
     if (typeof metadata.output_cost_per_token === "number") {
       coverage.outputPriced++;
+      if (MAPPABLE_MODES.has(mode) && metadata.output_cost_per_token > 0) {
+        outputCosts.push(metadata.output_cost_per_token);
+      }
     }
   }
+  summary.medianInputCost = median(inputCosts);
+  summary.medianOutputCost = median(outputCosts);
   return summary;
 }
 
-const EMPTY_BASELINE: CatalogSummary = { totalEntries: 0, modes: {} };
+const EMPTY_BASELINE: CatalogSummary = {
+  totalEntries: 0,
+  modes: {},
+  medianInputCost: 0,
+  medianOutputCost: 0,
+};
 
 function belowBaseline(count: number, baseline: number): boolean {
   return (
@@ -243,6 +279,24 @@ export function validateModelData(
         `${label} shrank from ${baselineCount} to ${count} ` +
           `(more than ${MAX_BASELINE_SHRINK_FRACTION * 100}% below the vendored baseline)`
       );
+    }
+  }
+
+  // Guard price magnitudes, not just field presence: a poisoned catalog could
+  // retain every field while scaling all rates toward zero.
+  const medianChecks: Array<[label: string, value: number, baselineValue: number]> = [
+    ["median input cost", summary.medianInputCost, baseline.medianInputCost],
+    ["median output cost", summary.medianOutputCost, baseline.medianOutputCost],
+  ];
+  for (const [label, value, baselineValue] of medianChecks) {
+    if (value > 0 && baselineValue > 0) {
+      const ratio = value / baselineValue;
+      if (ratio > MAX_MEDIAN_COST_SHIFT_FACTOR || ratio < 1 / MAX_MEDIAN_COST_SHIFT_FACTOR) {
+        errors.push(
+          `${label} shifted from ${baselineValue} to ${value} (more than ` +
+            `${MAX_MEDIAN_COST_SHIFT_FACTOR}x from the vendored baseline; possible price corruption)`
+        );
+      }
     }
   }
 

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -53,11 +53,12 @@ const MAX_BASELINE_SHRINK_FRACTION = 0.1;
 // must not block refreshes forever).
 const MIN_BASELINE_FOR_SHRINK_CHECK = 20;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
-// A poisoned upstream could keep every field present but scale prices toward
-// zero (or absurdly high), silently corrupting cost accounting. Legitimate
-// repricing moves few models or small factors, so a catalog-wide median shift
-// beyond this factor is treated as corruption.
-const MAX_MEDIAN_COST_SHIFT_FACTOR = 100;
+// A poisoned upstream could keep every field present but rescale values
+// (prices toward zero, token limits toward 1), silently corrupting cost
+// accounting or context handling. Legitimate repricing moves few models or
+// small factors, so a catalog-wide median shift beyond this factor is treated
+// as corruption.
+const MAX_MEDIAN_SHIFT_FACTOR = 100;
 
 /** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
 export const MAPPABLE_MODES = new Set(["chat", "responses"]);
@@ -153,21 +154,33 @@ export function findMissingKnownModels(
 }
 
 export interface ModeCoverage {
+  /** Entries in this mode. */
+  entries: number;
   /** Entries passing getModelStats' usability bar (usable token limits). */
   usable: number;
-  /** Entries carrying a numeric input cost. */
-  inputPriced: number;
-  /** Entries carrying a numeric output cost. */
-  outputPriced: number;
+  /**
+   * Per retained field, entries carrying a consumed value. Every retained
+   * field is read somewhere at runtime (stats, pricing, capabilities) and most
+   * are optional per entry, so coverage is tracked per field and per mode:
+   * an upstream removal or rename of any one field registers as shrinkage
+   * instead of hiding behind counts of the surviving fields.
+   */
+  fields: Record<string, number>;
+}
+
+export interface NumericFieldStats {
+  /** Mappable-mode entries carrying a positive value for the field. */
+  samples: number;
+  /** Median of those positive values (0 when none). */
+  median: number;
 }
 
 export interface CatalogSummary {
   totalEntries: number;
   /** Coverage per mode string, spanning every mode (not just mappable ones). */
   modes: Record<string, ModeCoverage>;
-  /** Median positive per-token costs across mappable entries (0 when none). */
-  medianInputCost: number;
-  medianOutputCost: number;
+  /** Magnitude stats per numeric retained field across mappable entries. */
+  numericFields: Record<string, NumericFieldStats>;
 }
 
 function median(values: number[]): number {
@@ -178,51 +191,56 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)];
 }
 
+// Booleans count only when true: capability flags are consumed as "absent ==
+// unsupported", so a catalog-wide flip to false is equivalent to removal.
+function hasConsumedValue(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value);
+  }
+  return typeof value === "string" && value.length > 0;
+}
+
 export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
-  const summary: CatalogSummary = {
-    totalEntries: 0,
-    modes: {},
-    medianInputCost: 0,
-    medianOutputCost: 0,
-  };
-  const inputCosts: number[] = [];
-  const outputCosts: number[] = [];
+  const summary: CatalogSummary = { totalEntries: 0, modes: {}, numericFields: {} };
+  const numericSamples = new Map<string, number[]>();
   for (const metadata of Object.values(catalog)) {
     summary.totalEntries++;
     const mode = typeof metadata.mode === "string" ? metadata.mode : "unknown";
-    const coverage = (summary.modes[mode] ??= { usable: 0, inputPriced: 0, outputPriced: 0 });
+    const coverage = (summary.modes[mode] ??= { entries: 0, usable: 0, fields: {} });
+    coverage.entries++;
     // Usability applies getModelStats' bar: entries without usable token limits
     // never resolve, so losing max_input_tokens must register as shrinkage.
     if (hasUsableTokenLimits(metadata)) {
       coverage.usable++;
     }
-    // Input and output pricing are tracked separately per mode so renaming one
-    // cost field, or stripping pricing from a smaller mode like `responses`,
-    // cannot hide behind another field's or a larger mode's coverage.
-    if (typeof metadata.input_cost_per_token === "number") {
-      coverage.inputPriced++;
-      if (MAPPABLE_MODES.has(mode) && metadata.input_cost_per_token > 0) {
-        inputCosts.push(metadata.input_cost_per_token);
+    for (const field of RETAINED_FIELDS) {
+      if (field === "mode") {
+        continue; // the bucket key itself; `entries` already counts it
       }
-    }
-    if (typeof metadata.output_cost_per_token === "number") {
-      coverage.outputPriced++;
-      if (MAPPABLE_MODES.has(mode) && metadata.output_cost_per_token > 0) {
-        outputCosts.push(metadata.output_cost_per_token);
+      const value = metadata[field];
+      if (hasConsumedValue(value)) {
+        coverage.fields[field] = (coverage.fields[field] ?? 0) + 1;
+      }
+      if (MAPPABLE_MODES.has(mode) && typeof value === "number" && value > 0) {
+        let samples = numericSamples.get(field);
+        if (samples === undefined) {
+          samples = [];
+          numericSamples.set(field, samples);
+        }
+        samples.push(value);
       }
     }
   }
-  summary.medianInputCost = median(inputCosts);
-  summary.medianOutputCost = median(outputCosts);
+  for (const [field, samples] of numericSamples) {
+    summary.numericFields[field] = { samples: samples.length, median: median(samples) };
+  }
   return summary;
 }
 
-const EMPTY_BASELINE: CatalogSummary = {
-  totalEntries: 0,
-  modes: {},
-  medianInputCost: 0,
-  medianOutputCost: 0,
-};
+const EMPTY_BASELINE: CatalogSummary = { totalEntries: 0, modes: {}, numericFields: {} };
 
 function belowBaseline(count: number, baseline: number): boolean {
   return (
@@ -255,23 +273,45 @@ export function validateModelData(
     );
   }
 
-  // Costs are optional per entry (subscription providers), so an upstream
-  // pricing-field rename or a wholesale mode omission would sail through the
-  // per-entry checks; comparing every mode's usable and priced coverage against
-  // the vendored baseline (plus the total entry count for modes without usable
-  // limits, like image_generation pricing rows) keeps getModelStats from
-  // silently zero-pricing or dropping whole slices of the catalog.
+  // Fields are optional per entry (e.g. subscription providers omit costs), so
+  // an upstream rename or wholesale omission of any retained field, or of a
+  // whole mode, would sail through the per-entry checks; comparing every mode's
+  // entry/usable counts and every retained field's per-mode coverage against
+  // the vendored baseline keeps a refresh from silently dropping, zero-pricing,
+  // or de-capability-ing whole slices of the catalog.
   const shrinkChecks: Array<[label: string, count: number, baselineCount: number]> = [
     ["total entry count", summary.totalEntries, baseline.totalEntries],
   ];
-  const emptyCoverage: ModeCoverage = { usable: 0, inputPriced: 0, outputPriced: 0 };
+  const emptyCoverage: ModeCoverage = { entries: 0, usable: 0, fields: {} };
   for (const [mode, baselineCoverage] of Object.entries(baseline.modes)) {
     const coverage = summary.modes[mode] ?? emptyCoverage;
     shrinkChecks.push(
-      [`${mode} usable model count`, coverage.usable, baselineCoverage.usable],
-      [`${mode} input-priced model count`, coverage.inputPriced, baselineCoverage.inputPriced],
-      [`${mode} output-priced model count`, coverage.outputPriced, baselineCoverage.outputPriced]
+      [`${mode} entry count`, coverage.entries, baselineCoverage.entries],
+      [`${mode} usable model count`, coverage.usable, baselineCoverage.usable]
     );
+    for (const [field, baselineCount] of Object.entries(baselineCoverage.fields)) {
+      shrinkChecks.push([`${mode} ${field} coverage`, coverage.fields[field] ?? 0, baselineCount]);
+    }
+  }
+  // Numeric magnitudes are guarded too, not just field presence: a poisoned
+  // catalog could retain every field while rescaling values (prices toward
+  // zero or absurdly high, token limits toward 1). A collapsed sample count
+  // (e.g. every price zeroed) fails both the sample shrink and the median
+  // check, since a zero median is more than MAX_MEDIAN_SHIFT_FACTOR below any
+  // positive baseline.
+  for (const [field, baselineStats] of Object.entries(baseline.numericFields)) {
+    if (baselineStats.samples < MIN_BASELINE_FOR_SHRINK_CHECK || baselineStats.median <= 0) {
+      continue;
+    }
+    const candidate = summary.numericFields[field] ?? { samples: 0, median: 0 };
+    shrinkChecks.push([`${field} positive-value count`, candidate.samples, baselineStats.samples]);
+    const ratio = candidate.median / baselineStats.median;
+    if (ratio > MAX_MEDIAN_SHIFT_FACTOR || ratio < 1 / MAX_MEDIAN_SHIFT_FACTOR) {
+      errors.push(
+        `${field} median shifted from ${baselineStats.median} to ${candidate.median} ` +
+          `(more than ${MAX_MEDIAN_SHIFT_FACTOR}x from the vendored baseline; possible corruption)`
+      );
+    }
   }
   for (const [label, count, baselineCount] of shrinkChecks) {
     if (belowBaseline(count, baselineCount)) {
@@ -279,24 +319,6 @@ export function validateModelData(
         `${label} shrank from ${baselineCount} to ${count} ` +
           `(more than ${MAX_BASELINE_SHRINK_FRACTION * 100}% below the vendored baseline)`
       );
-    }
-  }
-
-  // Guard price magnitudes, not just field presence: a poisoned catalog could
-  // retain every field while scaling all rates toward zero.
-  const medianChecks: Array<[label: string, value: number, baselineValue: number]> = [
-    ["median input cost", summary.medianInputCost, baseline.medianInputCost],
-    ["median output cost", summary.medianOutputCost, baseline.medianOutputCost],
-  ];
-  for (const [label, value, baselineValue] of medianChecks) {
-    if (value > 0 && baselineValue > 0) {
-      const ratio = value / baselineValue;
-      if (ratio > MAX_MEDIAN_COST_SHIFT_FACTOR || ratio < 1 / MAX_MEDIAN_COST_SHIFT_FACTOR) {
-        errors.push(
-          `${label} shifted from ${baselineValue} to ${value} (more than ` +
-            `${MAX_MEDIAN_COST_SHIFT_FACTOR}x from the vendored baseline; possible price corruption)`
-        );
-      }
     }
   }
 

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -147,28 +147,68 @@ export function findMissingKnownModels(
   return missing;
 }
 
-export function countChatModels(catalog: ModelCatalogData): number {
-  return Object.values(catalog).filter((metadata) => metadata.mode === "chat").length;
+export interface CatalogSummary {
+  chatModels: number;
+  /** Chat models carrying a numeric input or output cost. */
+  pricedChatModels: number;
+}
+
+export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
+  let chatModels = 0;
+  let pricedChatModels = 0;
+  for (const metadata of Object.values(catalog)) {
+    if (metadata.mode !== "chat") {
+      continue;
+    }
+    chatModels++;
+    if (
+      typeof metadata.input_cost_per_token === "number" ||
+      typeof metadata.output_cost_per_token === "number"
+    ) {
+      pricedChatModels++;
+    }
+  }
+  return { chatModels, pricedChatModels };
+}
+
+const EMPTY_BASELINE: CatalogSummary = { chatModels: 0, pricedChatModels: 0 };
+
+function belowBaseline(count: number, baseline: number): boolean {
+  return count < Math.ceil(baseline * (1 - MAX_CHAT_MODEL_SHRINK_FRACTION));
 }
 
 /**
  * Throws when the sanitized upstream data is unfit to replace the vendored
- * models.json. `baselineChatCount` is the chat-model count of the currently
- * vendored catalog (0 when unavailable).
+ * models.json. `baseline` summarizes the currently vendored catalog (defaults
+ * to empty when unavailable, disabling the relative checks).
  */
-export function validateModelData(sanitized: SanitizedModelData, baselineChatCount = 0): void {
+export function validateModelData(
+  sanitized: SanitizedModelData,
+  baseline: CatalogSummary = EMPTY_BASELINE
+): void {
   const { catalog, droppedModelIds } = sanitized;
   const errors: string[] = [];
 
-  const chatCount = countChatModels(catalog);
-  if (chatCount < MIN_CHAT_MODELS) {
-    errors.push(`only ${chatCount} chat models found (expected at least ${MIN_CHAT_MODELS})`);
-  }
-  const minRelativeChatCount = Math.ceil(baselineChatCount * (1 - MAX_CHAT_MODEL_SHRINK_FRACTION));
-  if (chatCount < minRelativeChatCount) {
+  const summary = summarizeCatalog(catalog);
+  if (summary.chatModels < MIN_CHAT_MODELS) {
     errors.push(
-      `chat model count shrank from ${baselineChatCount} to ${chatCount} ` +
+      `only ${summary.chatModels} chat models found (expected at least ${MIN_CHAT_MODELS})`
+    );
+  }
+  if (belowBaseline(summary.chatModels, baseline.chatModels)) {
+    errors.push(
+      `chat model count shrank from ${baseline.chatModels} to ${summary.chatModels} ` +
         `(more than ${MAX_CHAT_MODEL_SHRINK_FRACTION * 100}% below the vendored baseline)`
+    );
+  }
+  // Costs are optional per entry (subscription providers), so an upstream
+  // pricing-field rename would sail through the per-entry checks; catching a
+  // collapse in priced coverage keeps getModelStats from silently zero-pricing
+  // the whole catalog.
+  if (belowBaseline(summary.pricedChatModels, baseline.pricedChatModels)) {
+    errors.push(
+      `priced chat model count shrank from ${baseline.pricedChatModels} to ` +
+        `${summary.pricedChatModels} (upstream pricing fields may have been renamed)`
     );
   }
 

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -55,10 +55,10 @@ const MIN_BASELINE_FOR_SHRINK_CHECK = 20;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
 // A poisoned upstream could keep every field present but rescale values
 // (prices toward zero, token limits toward 1), silently corrupting cost
-// accounting or context handling. Legitimate repricing moves few models or
-// small factors, so a catalog-wide median shift beyond this factor is treated
-// as corruption.
-const MAX_MEDIAN_SHIFT_FACTOR = 100;
+// accounting or context handling. Legitimate repricing rarely approaches this
+// factor, so both a catalog-wide median shift and a per-entry value shift
+// beyond it are treated as corruption.
+const MAX_MAGNITUDE_SHIFT_FACTOR = 100;
 
 /** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
 export const MAPPABLE_MODES = new Set(["chat", "responses"]);
@@ -240,8 +240,6 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
   return summary;
 }
 
-const EMPTY_BASELINE: CatalogSummary = { totalEntries: 0, modes: {}, numericFields: {} };
-
 function belowBaseline(count: number, baseline: number): boolean {
   return (
     baseline >= MIN_BASELINE_FOR_SHRINK_CHECK &&
@@ -251,17 +249,18 @@ function belowBaseline(count: number, baseline: number): boolean {
 
 /**
  * Throws when the sanitized upstream data is unfit to replace the vendored
- * models.json. `baseline` summarizes the currently vendored catalog (defaults
+ * models.json. `baselineCatalog` is the currently vendored catalog (defaults
  * to empty when unavailable, disabling the relative checks).
  */
 export function validateModelData(
   sanitized: SanitizedModelData,
-  baseline: CatalogSummary = EMPTY_BASELINE
+  baselineCatalog: ModelCatalogData = {}
 ): void {
   const { catalog, droppedModelIds } = sanitized;
   const errors: string[] = [];
 
   const summary = summarizeCatalog(catalog);
+  const baseline = summarizeCatalog(baselineCatalog);
   const usableMappableModels = [...MAPPABLE_MODES].reduce(
     (count, mode) => count + (summary.modes[mode]?.usable ?? 0),
     0
@@ -306,10 +305,10 @@ export function validateModelData(
     const candidate = summary.numericFields[field] ?? { samples: 0, median: 0 };
     shrinkChecks.push([`${field} positive-value count`, candidate.samples, baselineStats.samples]);
     const ratio = candidate.median / baselineStats.median;
-    if (ratio > MAX_MEDIAN_SHIFT_FACTOR || ratio < 1 / MAX_MEDIAN_SHIFT_FACTOR) {
+    if (ratio > MAX_MAGNITUDE_SHIFT_FACTOR || ratio < 1 / MAX_MAGNITUDE_SHIFT_FACTOR) {
       errors.push(
         `${field} median shifted from ${baselineStats.median} to ${candidate.median} ` +
-          `(more than ${MAX_MEDIAN_SHIFT_FACTOR}x from the vendored baseline; possible corruption)`
+          `(more than ${MAX_MAGNITUDE_SHIFT_FACTOR}x from the vendored baseline; possible corruption)`
       );
     }
   }
@@ -320,6 +319,40 @@ export function validateModelData(
           `(more than ${MAX_BASELINE_SHRINK_FRACTION * 100}% below the vendored baseline)`
       );
     }
+  }
+
+  // Catalog-wide counts and medians cannot see a targeted repricing of a
+  // single row, so each surviving entry's numeric fields are also bounded
+  // against their own baseline values (a positive value must stay a number
+  // within the factor; vanishing is the same attack as scaling toward zero).
+  // A legitimate per-row correction beyond the factor fails closed: delete
+  // models.json and rerun to deliberately accept a full refresh.
+  const entryShifts: string[] = [];
+  for (const [key, baselineEntry] of Object.entries(baselineCatalog)) {
+    const entry = catalog[key];
+    if (entry === undefined) {
+      continue; // removed keys are governed by the coverage baselines above
+    }
+    for (const field of RETAINED_FIELDS) {
+      const baselineValue = baselineEntry[field];
+      if (typeof baselineValue !== "number" || baselineValue <= 0) {
+        continue;
+      }
+      const value = entry[field];
+      const ratio = typeof value === "number" ? value / baselineValue : 0;
+      if (ratio > MAX_MAGNITUDE_SHIFT_FACTOR || ratio < 1 / MAX_MAGNITUDE_SHIFT_FACTOR) {
+        entryShifts.push(
+          `${key} ${field}: ${baselineValue} -> ${typeof value === "number" ? value : "absent"}`
+        );
+      }
+    }
+  }
+  if (entryShifts.length > 0) {
+    errors.push(
+      `${entryShifts.length} surviving entries shifted a numeric field more than ` +
+        `${MAX_MAGNITUDE_SHIFT_FACTOR}x from the vendored baseline ` +
+        `(e.g. ${entryShifts.slice(0, 5).join("; ")})`
+    );
   }
 
   const total = Object.keys(catalog).length + droppedModelIds.length;

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure transform/validation logic for refreshing models.json from LiteLLM's
+ * model_prices_and_context_window.json. The fetch/write CLI wrapper lives in
+ * scripts/update_models.ts (run via `make update-models`); the logic lives here
+ * so `bun test src` covers it (#3727).
+ */
+
+import { KNOWN_MODELS } from "@/common/constants/knownModels";
+import { modelsExtra } from "./models-extra";
+
+const RETAINED_FIELDS = [
+  "max_input_tokens",
+  "max_output_tokens",
+  "input_cost_per_token",
+  "output_cost_per_token",
+  "output_cost_per_image_token",
+  "input_cost_per_token_above_200k_tokens",
+  "output_cost_per_token_above_200k_tokens",
+  "cache_creation_input_token_cost",
+  "cache_creation_input_token_cost_above_200k_tokens",
+  "cache_read_input_token_cost",
+  "cache_read_input_token_cost_above_200k_tokens",
+  "tiered_pricing_threshold_tokens",
+  "mode",
+  "litellm_provider",
+  "supports_pdf_input",
+  "supports_vision",
+  "supports_audio_input",
+  "supports_video_input",
+  "max_pdf_size_mb",
+] as const;
+
+const COST_FIELDS = [
+  "input_cost_per_token",
+  "output_cost_per_token",
+  "output_cost_per_image_token",
+  "input_cost_per_token_above_200k_tokens",
+  "output_cost_per_token_above_200k_tokens",
+  "cache_creation_input_token_cost",
+  "cache_creation_input_token_cost_above_200k_tokens",
+  "cache_read_input_token_cost",
+  "cache_read_input_token_cost_above_200k_tokens",
+] as const;
+
+// Abort thresholds guarding against truncated or structurally reshaped upstream data.
+const MIN_CHAT_MODELS = 500;
+const MAX_INVALID_PRICING_FRACTION = 0.05;
+
+export type ModelCatalogData = Record<string, Record<string, unknown>>;
+
+export interface SanitizedModelData {
+  catalog: ModelCatalogData;
+  /** Catalog keys dropped because a present cost field was not a finite non-negative number. */
+  droppedModelIds: string[];
+}
+
+export function pruneModelData(data: unknown): ModelCatalogData {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("Expected LiteLLM model metadata object");
+  }
+
+  const pruned: ModelCatalogData = {};
+  for (const [modelId, rawMetadata] of Object.entries(data)) {
+    if (!rawMetadata || typeof rawMetadata !== "object" || Array.isArray(rawMetadata)) {
+      continue;
+    }
+
+    const metadata = rawMetadata as Record<string, unknown>;
+    const retained: Record<string, unknown> = {};
+    // Keep models.json small: Xum only reads pricing, token limits, provider, mode, and media
+    // capability fields, while upstream LiteLLM ships many provider-specific fields we never use.
+    for (const field of RETAINED_FIELDS) {
+      if (metadata[field] !== undefined) {
+        retained[field] = metadata[field];
+      }
+    }
+    pruned[modelId] = retained;
+  }
+
+  return pruned;
+}
+
+function hasValidPricing(metadata: Record<string, unknown>): boolean {
+  return COST_FIELDS.every((field) => {
+    const value = metadata[field];
+    // Absent costs are fine (e.g. subscription providers); present costs must be
+    // usable numbers, otherwise cost tracking would silently misprice the model.
+    return (
+      value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0)
+    );
+  });
+}
+
+export function sanitizePricing(pruned: ModelCatalogData): SanitizedModelData {
+  const catalog: ModelCatalogData = {};
+  const droppedModelIds: string[] = [];
+
+  for (const [modelId, metadata] of Object.entries(pruned)) {
+    if (hasValidPricing(metadata)) {
+      catalog[modelId] = metadata;
+    } else {
+      droppedModelIds.push(modelId);
+    }
+  }
+
+  return { catalog, droppedModelIds };
+}
+
+/**
+ * Curated models that would lose token/pricing metadata under the given catalog.
+ * The models-extra overrides are consulted the same way getModelStats does.
+ */
+export function findMissingKnownModels(
+  catalog: ModelCatalogData,
+  extra: Record<string, unknown> = modelsExtra
+): string[] {
+  const missing: string[] = [];
+  for (const model of Object.values(KNOWN_MODELS)) {
+    const modelId = model.providerModelId;
+    // xAI and Moonshot models are provider-prefixed in token metadata.
+    const lookupKey =
+      model.provider === "xai" || model.provider === "moonshotai"
+        ? `${model.provider}/${modelId}`
+        : modelId;
+    if (!(lookupKey in catalog) && !(lookupKey in extra) && !(modelId in extra)) {
+      missing.push(model.id);
+    }
+  }
+  return missing;
+}
+
+/** Throws when the sanitized upstream data is unfit to replace the vendored models.json. */
+export function validateModelData(sanitized: SanitizedModelData): void {
+  const { catalog, droppedModelIds } = sanitized;
+  const errors: string[] = [];
+
+  const chatCount = Object.values(catalog).filter((metadata) => metadata.mode === "chat").length;
+  if (chatCount < MIN_CHAT_MODELS) {
+    errors.push(`only ${chatCount} chat models found (expected at least ${MIN_CHAT_MODELS})`);
+  }
+
+  const total = Object.keys(catalog).length + droppedModelIds.length;
+  if (total > 0 && droppedModelIds.length / total > MAX_INVALID_PRICING_FRACTION) {
+    errors.push(
+      `${droppedModelIds.length}/${total} entries have invalid pricing ` +
+        `(e.g. ${droppedModelIds.slice(0, 5).join(", ")})`
+    );
+  }
+
+  const missingKnownModels = findMissingKnownModels(catalog);
+  if (missingKnownModels.length > 0) {
+    errors.push(`curated known models missing from upstream: ${missingKnownModels.join(", ")}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Refusing to update models.json:\n- ${errors.join("\n- ")}`);
+  }
+}
+
+export function serializeModelData(catalog: ModelCatalogData): string {
+  return `${JSON.stringify(catalog, null, 2)}\n`;
+}

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -153,17 +153,17 @@ export function findMissingKnownModels(
 export interface CatalogSummary {
   /** Chat/responses entries with usable token limits (what the Treat-as catalog can expose). */
   usableMappableModels: number;
-  /** Chat entries carrying a numeric input cost. */
-  inputPricedChatModels: number;
-  /** Chat entries carrying a numeric output cost. */
-  outputPricedChatModels: number;
+  /** Mappable (chat/responses) entries carrying a numeric input cost. */
+  inputPricedModels: number;
+  /** Mappable (chat/responses) entries carrying a numeric output cost. */
+  outputPricedModels: number;
 }
 
 export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
   const summary: CatalogSummary = {
     usableMappableModels: 0,
-    inputPricedChatModels: 0,
-    outputPricedChatModels: 0,
+    inputPricedModels: 0,
+    outputPricedModels: 0,
   };
   for (const metadata of Object.values(catalog)) {
     if (typeof metadata.mode !== "string" || !MAPPABLE_MODES.has(metadata.mode)) {
@@ -174,15 +174,14 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
     if (hasUsableTokenLimits(metadata)) {
       summary.usableMappableModels++;
     }
-    if (metadata.mode === "chat") {
-      // Input and output pricing are tracked separately so renaming just one
-      // cost field cannot hide behind the other's coverage.
-      if (typeof metadata.input_cost_per_token === "number") {
-        summary.inputPricedChatModels++;
-      }
-      if (typeof metadata.output_cost_per_token === "number") {
-        summary.outputPricedChatModels++;
-      }
+    // Priced coverage spans every mappable mode (getModelStats prices responses
+    // entries identically), and input/output are tracked separately so renaming
+    // just one cost field cannot hide behind the other's coverage.
+    if (typeof metadata.input_cost_per_token === "number") {
+      summary.inputPricedModels++;
+    }
+    if (typeof metadata.output_cost_per_token === "number") {
+      summary.outputPricedModels++;
     }
   }
   return summary;
@@ -190,8 +189,8 @@ export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
 
 const EMPTY_BASELINE: CatalogSummary = {
   usableMappableModels: 0,
-  inputPricedChatModels: 0,
-  outputPricedChatModels: 0,
+  inputPricedModels: 0,
+  outputPricedModels: 0,
 };
 
 function belowBaseline(count: number, baseline: number): boolean {
@@ -227,16 +226,8 @@ export function validateModelData(
     // pricing-field rename would sail through the per-entry checks; catching a
     // collapse in priced coverage keeps getModelStats from silently zero-pricing
     // the whole catalog.
-    [
-      "input-priced chat model count",
-      summary.inputPricedChatModels,
-      baseline.inputPricedChatModels,
-    ],
-    [
-      "output-priced chat model count",
-      summary.outputPricedChatModels,
-      baseline.outputPricedChatModels,
-    ],
+    ["input-priced model count", summary.inputPricedModels, baseline.inputPricedModels],
+    ["output-priced model count", summary.outputPricedModels, baseline.outputPricedModels],
   ];
   for (const [label, count, baselineCount] of shrinkChecks) {
     if (belowBaseline(count, baselineCount)) {

--- a/src/common/utils/tokens/updateModelsData.ts
+++ b/src/common/utils/tokens/updateModelsData.ts
@@ -44,11 +44,14 @@ const COST_FIELDS = [
 ] as const;
 
 // Abort thresholds guarding against truncated or structurally reshaped upstream data.
-// The absolute floor catches degenerate payloads; the relative bound catches partial
-// responses that would silently drop metadata for thousands of currently known models.
-const MIN_CHAT_MODELS = 500;
-const MAX_CHAT_MODEL_SHRINK_FRACTION = 0.1;
+// The absolute floor catches degenerate payloads; the relative bounds catch partial
+// responses or field renames that would silently degrade thousands of known models.
+const MIN_USABLE_MAPPABLE_MODELS = 500;
+const MAX_BASELINE_SHRINK_FRACTION = 0.1;
 const MAX_INVALID_PRICING_FRACTION = 0.05;
+
+/** Modes whose metadata applies to chat-style usage; mirrored by the Treat-as catalog. */
+export const MAPPABLE_MODES = new Set(["chat", "responses"]);
 
 export type ModelCatalogData = Record<string, Record<string, unknown>>;
 
@@ -148,33 +151,51 @@ export function findMissingKnownModels(
 }
 
 export interface CatalogSummary {
-  chatModels: number;
-  /** Chat models carrying a numeric input or output cost. */
-  pricedChatModels: number;
+  /** Chat/responses entries with usable token limits (what the Treat-as catalog can expose). */
+  usableMappableModels: number;
+  /** Chat entries carrying a numeric input cost. */
+  inputPricedChatModels: number;
+  /** Chat entries carrying a numeric output cost. */
+  outputPricedChatModels: number;
 }
 
 export function summarizeCatalog(catalog: ModelCatalogData): CatalogSummary {
-  let chatModels = 0;
-  let pricedChatModels = 0;
+  const summary: CatalogSummary = {
+    usableMappableModels: 0,
+    inputPricedChatModels: 0,
+    outputPricedChatModels: 0,
+  };
   for (const metadata of Object.values(catalog)) {
-    if (metadata.mode !== "chat") {
+    if (typeof metadata.mode !== "string" || !MAPPABLE_MODES.has(metadata.mode)) {
       continue;
     }
-    chatModels++;
-    if (
-      typeof metadata.input_cost_per_token === "number" ||
-      typeof metadata.output_cost_per_token === "number"
-    ) {
-      pricedChatModels++;
+    // Usability applies getModelStats' bar: entries without usable token limits
+    // never resolve, so losing max_input_tokens must register as shrinkage.
+    if (hasUsableTokenLimits(metadata)) {
+      summary.usableMappableModels++;
+    }
+    if (metadata.mode === "chat") {
+      // Input and output pricing are tracked separately so renaming just one
+      // cost field cannot hide behind the other's coverage.
+      if (typeof metadata.input_cost_per_token === "number") {
+        summary.inputPricedChatModels++;
+      }
+      if (typeof metadata.output_cost_per_token === "number") {
+        summary.outputPricedChatModels++;
+      }
     }
   }
-  return { chatModels, pricedChatModels };
+  return summary;
 }
 
-const EMPTY_BASELINE: CatalogSummary = { chatModels: 0, pricedChatModels: 0 };
+const EMPTY_BASELINE: CatalogSummary = {
+  usableMappableModels: 0,
+  inputPricedChatModels: 0,
+  outputPricedChatModels: 0,
+};
 
 function belowBaseline(count: number, baseline: number): boolean {
-  return count < Math.ceil(baseline * (1 - MAX_CHAT_MODEL_SHRINK_FRACTION));
+  return count < Math.ceil(baseline * (1 - MAX_BASELINE_SHRINK_FRACTION));
 }
 
 /**
@@ -190,26 +211,40 @@ export function validateModelData(
   const errors: string[] = [];
 
   const summary = summarizeCatalog(catalog);
-  if (summary.chatModels < MIN_CHAT_MODELS) {
+  if (summary.usableMappableModels < MIN_USABLE_MAPPABLE_MODELS) {
     errors.push(
-      `only ${summary.chatModels} chat models found (expected at least ${MIN_CHAT_MODELS})`
+      `only ${summary.usableMappableModels} usable chat/responses models found ` +
+        `(expected at least ${MIN_USABLE_MAPPABLE_MODELS})`
     );
   }
-  if (belowBaseline(summary.chatModels, baseline.chatModels)) {
-    errors.push(
-      `chat model count shrank from ${baseline.chatModels} to ${summary.chatModels} ` +
-        `(more than ${MAX_CHAT_MODEL_SHRINK_FRACTION * 100}% below the vendored baseline)`
-    );
-  }
-  // Costs are optional per entry (subscription providers), so an upstream
-  // pricing-field rename would sail through the per-entry checks; catching a
-  // collapse in priced coverage keeps getModelStats from silently zero-pricing
-  // the whole catalog.
-  if (belowBaseline(summary.pricedChatModels, baseline.pricedChatModels)) {
-    errors.push(
-      `priced chat model count shrank from ${baseline.pricedChatModels} to ` +
-        `${summary.pricedChatModels} (upstream pricing fields may have been renamed)`
-    );
+  const shrinkChecks: Array<[label: string, count: number, baselineCount: number]> = [
+    [
+      "usable chat/responses model count",
+      summary.usableMappableModels,
+      baseline.usableMappableModels,
+    ],
+    // Costs are optional per entry (subscription providers), so an upstream
+    // pricing-field rename would sail through the per-entry checks; catching a
+    // collapse in priced coverage keeps getModelStats from silently zero-pricing
+    // the whole catalog.
+    [
+      "input-priced chat model count",
+      summary.inputPricedChatModels,
+      baseline.inputPricedChatModels,
+    ],
+    [
+      "output-priced chat model count",
+      summary.outputPricedChatModels,
+      baseline.outputPricedChatModels,
+    ],
+  ];
+  for (const [label, count, baselineCount] of shrinkChecks) {
+    if (belowBaseline(count, baselineCount)) {
+      errors.push(
+        `${label} shrank from ${baselineCount} to ${count} ` +
+          `(more than ${MAX_BASELINE_SHRINK_FRACTION * 100}% below the vendored baseline)`
+      );
+    }
   }
 
   const total = Object.keys(catalog).length + droppedModelIds.length;


### PR DESCRIPTION
## Summary

Adds a validated, idempotent `make update-models` flow that refreshes the vendored LiteLLM model catalog, and expands the custom-model "Treat as" dropdown to offer the full models.json catalog instead of only the ~21 curated `KNOWN_MODELS`.

Fixes #3727

## Background

`src/common/utils/tokens/models.json` is a pruned vendor copy of LiteLLM's `model_prices_and_context_window.json`, but `scripts/update_models.ts` was manual-only and unwired, so the data had gone stale (last real refresh around #1103). Meanwhile the "Treat as" mapping (`mappedToModel`) is persisted as a plain string and resolved through `resolveModelForMetadata` -> `getModelStats`, which can already resolve any catalog entry, so restricting the dropdown to curated models was purely a UI limitation. Per the maintainer suggestion on the issue, the refresh is a make-process flag that fetches, validates pricing, and updates only when needed.

## Implementation

Freshness:
- `scripts/update_models.ts` is now a thin CLI over pure logic in `src/common/utils/tokens/updateModelsData.ts` (covered by `bun test src`): prune to retained fields, drop entries whose present cost fields are not finite non-negative numbers, then validate before writing (>= 500 chat entries as a truncation guard, <= 5% invalid-pricing drops, and every `KNOWN_MODELS` entry still resolvable via models.json plus models-extra). Validation also bounds shrinkage to 10% below the vendored catalog's chat-model count, curated coverage requires usable token limits (same bar as getModelStats) rather than key presence, and serialization sorts keys so upstream reordering never diffs. It writes only when the serialized content changed, so reruns are no-ops.
- `make update-models` runs it; `make build UPDATE_MODELS=1` makes the refresh a prerequisite of every catalog-consuming bundle, ordering it under parallel make and forcing those bundles stale (plain `make build` stays network-free).
- `.github/workflows/update-models.yml` runs weekly (plus dispatch) and opens/updates a `bot/update-models` PR only when the data changed, reusing the auto-cleanup GitHub App token pattern so the bot PR triggers CI; the checkout is pinned to main and the job goes through `make update-models`.
- `knownModels.test.ts` now reuses the same `findMissingKnownModels` coverage check instead of duplicating the key logic.
- models.json refreshed in its own commit via the new target (2456 -> 3176 entries). Upstream deleted `max_pdf_size_mb` wholesale, so the capability test for that field now exercises the exported extraction function with injected metadata instead of a retired Gemini 1.5 fixture.

Treat as:
- New `listModelCatalogIds()` (`src/common/utils/tokens/modelCatalog.ts`) returns canonical `provider:model` ids for every chat/responses catalog entry that resolves through `getModelStats`, unioned with the curated ids (~2300 ids on the refreshed data), normalized via normalizeToCanonical and deduped so gateway keys with direct-provider origins collapse into the canonical id whose metadata resolution actually uses. `ModelsSection` feeds it to the dropdown.
- `SearchableModelSelect` caps rendering at 200 rows with a "+N more, keep typing to filter" footer so the popover stays responsive with the full catalog.

## Validation

- `make update-models` run twice: first refreshes, second prints "already up to date" with a clean tree.
- Remote dogfood UAT (Coder Agents) on this exact head passed: full catalog + cap footer verified in the UI, non-curated mapping (`openai:gpt-4o-mini`) saves and inherits 128k context, "None (use own metadata)" clears it, curated Claude mappings still load; `make update-models` idempotency re-verified in the workspace; no console errors. Search latency measured at 4-31 ms per keystroke.
- `make lint-actions` (actionlint + zizmor) clean for the new workflow.

## Risks

- The models.json refresh changes pricing/limits metadata app-wide (costs, context windows, capability gates). Curated models are pinned by models-extra overrides and the coverage validation, and `bun test src` passes on the refreshed data; the main residual risk is upstream metadata quality for non-curated models, which the pricing sanitization bounds.
- The scheduled workflow only opens a PR (never pushes to main) and skips gracefully when app secrets are absent.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->

