### PR TITLE
🤖 fix: bundle darwin-x64 sharp runtimes in macOS builds

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -538,6 +538,8 @@ jobs:
       - name: Build macOS distributables
         # Retry for transient Apple timestamp-server failures during code signing.
         run: ./scripts/retry.sh 3 30 make dist-mac
+      - name: Smoke test packaged macOS attach_file runtime
+        run: make check-mac-attach-file-runtime
       - name: Upload x64 artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ include fmt.mk
 .PHONY: build-renderer version build-icons build-static build-docker-runtime verify-docker-runtime-artifacts
 .PHONY: lint lint-fix typecheck static-check static-check-full
 .PHONY: test test-unit test-integration test-watch test-coverage test-e2e test-e2e-perf smoke-test
-.PHONY: dist dist-mac dist-win dist-linux install-mac-arm64 check-appimage-icons check-mac-attach-file-runtime
+.PHONY: dist dist-mac dist-win dist-linux install-mac-arm64 ensure-mac-sharp-runtime-deps check-appimage-icons check-mac-attach-file-runtime
 .PHONY: vscode-ext vscode-ext-install
 .PHONY: docs-server check-docs-links
 .PHONY: storybook storybook-run storybook-build test-storybook
@@ -467,7 +467,24 @@ test-e2e-perf: ## Run automated performance profiling scenarios
 dist: build ## Build distributable packages
 	@bun x electron-builder --publish never
 
+# Issue #3338: bun installs host-only optional deps, but electron-builder packages both mac
+# architectures from one node_modules tree, which otherwise omits the x64 sharp runtime.
+ensure-mac-sharp-runtime-deps: node_modules/.installed
+	@bun install --frozen-lockfile --os=darwin --cpu=x64
+	@bun install --frozen-lockfile --os=darwin --cpu=arm64
+	@for dir in \
+		node_modules/@img/sharp-darwin-x64 \
+		node_modules/@img/sharp-libvips-darwin-x64 \
+		node_modules/@img/sharp-darwin-arm64 \
+		node_modules/@img/sharp-libvips-darwin-arm64; do \
+		if [ ! -d "$$dir" ]; then \
+			echo "Missing $$dir after platform installs. bun >= 1.3 is required because older versions silently ignore --os/--cpu." >&2; \
+			exit 1; \
+		fi; \
+	done
+
 dist-mac: build ## Build macOS distributables (x64 + arm64)
+	@$(MAKE) --no-print-directory ensure-mac-sharp-runtime-deps
 	@if [ -n "$$CSC_LINK" ]; then \
 		echo "🔐 Code signing enabled - using unified build for correct yml..."; \
 		bun x electron-builder --mac --x64 --arm64 --publish never; \
@@ -480,15 +497,18 @@ dist-mac: build ## Build macOS distributables (x64 + arm64)
 	@echo "✅ Both architectures built successfully"
 
 dist-mac-release: build ## Build and publish macOS distributables (x64 + arm64)
+	@$(MAKE) --no-print-directory ensure-mac-sharp-runtime-deps
 	@echo "🔐 Building macOS x64 + arm64 (unified for correct yml)..."
 	@bun x electron-builder --mac --x64 --arm64 --publish always
 	@echo "✅ Both architectures built and published successfully"
 
 dist-mac-x64: build ## Build macOS x64 distributable only
+	@$(MAKE) --no-print-directory ensure-mac-sharp-runtime-deps
 	@echo "Building macOS x64..."
 	@bun x electron-builder --mac --x64 --publish never
 
 dist-mac-arm64: build ## Build macOS arm64 distributable only
+	@$(MAKE) --no-print-directory ensure-mac-sharp-runtime-deps
 	@echo "Building macOS arm64..."
 	@bun x electron-builder --mac --arm64 --publish never
 

--- a/Makefile
+++ b/Makefile
@@ -472,6 +472,9 @@ dist: build ## Build distributable packages
 ensure-mac-sharp-runtime-deps: node_modules/.installed
 	@bun install --frozen-lockfile --os=darwin --cpu=x64
 	@bun install --frozen-lockfile --os=darwin --cpu=arm64
+	@# Cross-arch installs repoint node_modules/.bin at the last-installed platform; a
+	@# host-native install restores them and keeps the darwin packages added above.
+	@bun install --frozen-lockfile
 	@for dir in \
 		node_modules/@img/sharp-darwin-x64 \
 		node_modules/@img/sharp-libvips-darwin-x64 \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ endif
 
 # Issue #3831: macOS may SIGKILL the copied esbuild inode while the platform binary still execs.
 # ESBUILD_BINARY_PATH is not used because only esbuild's JS API honors it, not the Go CLI.
-ESBUILD_BIN = $(firstword $(wildcard node_modules/@esbuild/*/bin/esbuild) node_modules/esbuild/bin/esbuild)
+# Prefer the host platform package: ensure-mac-sharp-runtime-deps adds darwin packages on any
+# host, and a bare wildcard would sort @esbuild/darwin-arm64 first (issue #3338).
+ESBUILD_HOST_PLATFORM := $(subst Linux,linux,$(subst Darwin,darwin,$(shell uname -s)))-$(subst x86_64,x64,$(subst aarch64,arm64,$(shell uname -m)))
+ESBUILD_BIN = $(firstword $(wildcard node_modules/@esbuild/$(ESBUILD_HOST_PLATFORM)/bin/esbuild) $(wildcard node_modules/@esbuild/*/bin/esbuild) node_modules/esbuild/bin/esbuild)
 
 # Common esbuild flags for CLI API bundle (ESM format for trpc-cli)
 ESBUILD_CLI_FLAGS := --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:jsonc-parser --external:@trpc/server --external:ssh2 --external:cpu-features --banner:js="import{createRequire}from'module';globalThis.require=createRequire(import.meta.url);"

--- a/scripts/checkMacAttachFileRuntime.ts
+++ b/scripts/checkMacAttachFileRuntime.ts
@@ -12,6 +12,12 @@ import { resolveMacPackagedAppNames } from "../src/common/compat/macPackagedApp"
 const { productFilename: EXECUTABLE_NAME, appBundleName: APP_NAME } = resolveMacPackagedAppNames(
   packageJson.build
 );
+type MacAppArchitecture = "x64" | "arm64";
+
+const MAC_APP_RUNTIME_PACKAGES: Record<MacAppArchitecture, { binding: string; libvips: string }> = {
+  x64: { binding: "sharp-darwin-x64", libvips: "sharp-libvips-darwin-x64" },
+  arm64: { binding: "sharp-darwin-arm64", libvips: "sharp-libvips-darwin-arm64" },
+};
 const RELEASE_DIR = path.join(process.cwd(), "release");
 const APP_ASAR_UNPACKED_NODE_MODULES = [
   ["node_modules", "sharp"],
@@ -113,7 +119,10 @@ async function findFileMatching(rootDir: string, pattern: RegExp): Promise<strin
   return await walk(rootDir);
 }
 
-async function verifyUnpackedSharpAssets(appBundlePath: string): Promise<void> {
+async function verifyUnpackedSharpAssets(
+  appBundlePath: string,
+  architectures: readonly MacAppArchitecture[]
+): Promise<void> {
   const unpackedRoot = path.join(appBundlePath, "Contents", "Resources", "app.asar.unpacked");
   for (const segments of APP_ASAR_UNPACKED_NODE_MODULES) {
     const requiredPath = path.join(unpackedRoot, ...segments);
@@ -121,18 +130,36 @@ async function verifyUnpackedSharpAssets(appBundlePath: string): Promise<void> {
     assert(stat?.isDirectory(), `Missing unpacked runtime directory: ${requiredPath}`);
   }
 
-  const unpackedNodeModules = path.join(unpackedRoot, "node_modules");
-  const sharpBinaryPath = await findFileMatching(unpackedNodeModules, /sharp.*\.node$/);
-  assert(
-    sharpBinaryPath != null,
-    `Missing unpacked sharp native binary under ${unpackedNodeModules}`
-  );
+  const unpackedImgDir = path.join(unpackedRoot, "node_modules", "@img");
+  // Issue #3338: checking for any sharp binary let the x64 app ship with only arm64 assets.
+  for (const architecture of architectures) {
+    const runtimePackages = MAC_APP_RUNTIME_PACKAGES[architecture];
+    const bindingDir = path.join(unpackedImgDir, runtimePackages.binding);
+    const bindingStat = await fs.stat(bindingDir).catch(() => null);
+    assert(
+      bindingStat?.isDirectory(),
+      `Missing ${architecture} sharp binding directory: ${bindingDir}`
+    );
 
-  const libvipsPath = await findFileMatching(unpackedNodeModules, /libvips-cpp\..*\.dylib$/);
-  assert(libvipsPath != null, `Missing unpacked libvips dylib under ${unpackedNodeModules}`);
+    const sharpBinaryPath = await findFileMatching(
+      bindingDir,
+      new RegExp(`${runtimePackages.binding}\\.node$`)
+    );
+    assert(
+      sharpBinaryPath != null,
+      `Missing ${architecture} sharp native binary under ${bindingDir}`
+    );
 
-  console.log(`[attach-file-smoke] unpacked sharp binary: ${sharpBinaryPath}`);
-  console.log(`[attach-file-smoke] unpacked libvips dylib: ${libvipsPath}`);
+    const libvipsDir = path.join(unpackedImgDir, runtimePackages.libvips);
+    const libvipsStat = await fs.stat(libvipsDir).catch(() => null);
+    assert(libvipsStat?.isDirectory(), `Missing ${architecture} libvips directory: ${libvipsDir}`);
+
+    const libvipsPath = await findFileMatching(libvipsDir, /libvips-cpp\..*\.dylib$/);
+    assert(libvipsPath != null, `Missing ${architecture} libvips dylib under ${libvipsDir}`);
+
+    console.log(`[attach-file-smoke] ${architecture} sharp binary: ${sharpBinaryPath}`);
+    console.log(`[attach-file-smoke] ${architecture} libvips dylib: ${libvipsPath}`);
+  }
 }
 
 async function createFixtureImages(
@@ -181,6 +208,45 @@ async function resolvePackagedMacExecutable(appBundlePath: string): Promise<stri
   return path.join(macOsDir, match.name);
 }
 
+async function getPackagedAppArchitectures(appBundlePath: string): Promise<MacAppArchitecture[]> {
+  const executablePath = await resolvePackagedMacExecutable(appBundlePath);
+  const result = spawnSync("lipo", ["-archs", executablePath], {
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+
+  if (result.error != null) {
+    throw result.error;
+  }
+  if (result.signal != null) {
+    throw new Error(`lipo was terminated by signal ${result.signal} for ${executablePath}`);
+  }
+  assert(
+    result.status === 0,
+    `lipo failed for ${executablePath} with exit code ${result.status}: ${result.stderr.trim()}`
+  );
+
+  const architectures = result.stdout
+    .trim()
+    .split(/\s+/)
+    .map((architecture): MacAppArchitecture | null => {
+      if (architecture === "x86_64") {
+        return "x64";
+      }
+      if (architecture === "arm64") {
+        return "arm64";
+      }
+      return null;
+    })
+    .filter((architecture): architecture is MacAppArchitecture => architecture != null);
+  const uniqueArchitectures = [...new Set(architectures)];
+  assert(
+    uniqueArchitectures.length > 0,
+    `No supported macOS architecture found in ${executablePath}. lipo reported: ${result.stdout.trim()}`
+  );
+  return uniqueArchitectures;
+}
+
 async function runPackagedSmokeApp(
   appBundlePath: string,
   fixturePaths: { pngPath: string; jpegPath: string }
@@ -224,17 +290,53 @@ async function main(): Promise<void> {
   assert(process.platform === "darwin", "checkMacAttachFileRuntime.ts only runs on macOS");
 
   const requestedAppBundle = process.argv[2];
-  const appBundlePath = requestedAppBundle ?? (await chooseDefaultAppBundle());
-  const appStat = await fs.stat(appBundlePath).catch(() => null);
-  assert(appStat?.isDirectory(), `macOS app bundle not found: ${appBundlePath}`);
+  let appBundles: string[];
+  let smokeAppBundle: string;
+  if (requestedAppBundle != null) {
+    appBundles = [requestedAppBundle];
+    smokeAppBundle = requestedAppBundle;
+  } else {
+    const { matches, seen } = await findAppBundles(RELEASE_DIR);
+    assert(
+      matches.length > 0,
+      `No ${APP_NAME} found under ${RELEASE_DIR}. Run make dist-mac first. Stored .app names: ${
+        seen.length > 0 ? seen.join(", ") : "(none)"
+      }`
+    );
+    appBundles = matches;
+    smokeAppBundle = await chooseDefaultAppBundle();
+  }
 
-  console.log(`[attach-file-smoke] using app bundle ${appBundlePath}`);
-  await verifyUnpackedSharpAssets(appBundlePath);
+  const verifiedArchitectures = new Set<MacAppArchitecture>();
+  for (const appBundlePath of appBundles) {
+    const appStat = await fs.stat(appBundlePath).catch(() => null);
+    assert(appStat?.isDirectory(), `macOS app bundle not found: ${appBundlePath}`);
+
+    const architectures = await getPackagedAppArchitectures(appBundlePath);
+    console.log(
+      `[attach-file-smoke] verifying app bundle ${appBundlePath} (${architectures.join(", ")})`
+    );
+    await verifyUnpackedSharpAssets(appBundlePath, architectures);
+    for (const architecture of architectures) {
+      verifiedArchitectures.add(architecture);
+    }
+  }
+
+  if (requestedAppBundle == null) {
+    for (const requiredArchitecture of ["x64", "arm64"] as const) {
+      assert(
+        verifiedArchitectures.has(requiredArchitecture),
+        `Missing ${requiredArchitecture} macOS app bundle under ${RELEASE_DIR}. Verified architectures: ${
+          verifiedArchitectures.size > 0 ? [...verifiedArchitectures].join(", ") : "(none)"
+        }`
+      );
+    }
+  }
 
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-attach-file-smoke-"));
   try {
     const fixturePaths = await createFixtureImages(tempDir);
-    await runPackagedSmokeApp(appBundlePath, fixturePaths);
+    await runPackagedSmokeApp(smokeAppBundle, fixturePaths);
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
Fixes #3338. Intel (x64) macOS builds shipped without the darwin-x64 sharp native runtime, so `sharp` could not load on Intel Macs. This PR makes macOS packaging install both Darwin sharp runtimes before electron-builder copies `node_modules`, and hardens the packaged-app smoke check so a missing per-arch runtime fails CI instead of shipping.

## Background
macOS release builds run on arm64 runners where bun installs only host-platform optional dependencies, and electron-builder (`npmRebuild: false`) packs the same `node_modules` tree into both arch bundles. Verified against the latest release: `mux-0.28.2-x64.zip` contains only `@img/sharp-darwin-arm64` and `@img/sharp-libvips-darwin-arm64` under `app.asar.unpacked/node_modules/@img`, with no darwin-x64 packages.

In v0.25.0 (the report in #3338) this crashed startup because the since-removed experimental image tools (#3282, removed in #3419) imported sharp eagerly. On current main sharp is lazy-loaded, so the app starts but `attach_file` raster image processing fails at runtime on Intel Macs. The existing smoke test (#3088) only asserted that some sharp binary exists in one bundle, so CI never caught the broken x64 artifact. PR #3434 took the same approach in June but went stale and no longer applies to main.

## Implementation
- `Makefile`: new `ensure-mac-sharp-runtime-deps` target runs `bun install --frozen-lockfile --os=darwin --cpu=x64` and `--cpu=arm64` (additive on bun >= 1.3; `bun.lock` already pins all platform variants), then a host-native install to restore `node_modules/.bin` symlinks, then asserts all four `@img` darwin package dirs exist. The guard matters because bun < 1.3 silently ignores `--os`/`--cpu`. Wired into `dist-mac`, `dist-mac-release`, `dist-mac-x64`, and `dist-mac-arm64`.
- `Makefile`: `ESBUILD_BIN` now prefers `@esbuild/<host-platform>` (derived from `uname`) before the wildcard fallback; with darwin esbuild packages installed on a non-mac host, the old `$(firstword $(wildcard ...))` picked `darwin-arm64` alphabetically and broke every esbuild build step.
- `scripts/checkMacAttachFileRuntime.ts`: verifies every built app bundle instead of one, detects each bundle's architectures via `lipo -archs`, and requires the exact `@img/sharp-darwin-<arch>` binding (`*.node`) and `@img/sharp-libvips-darwin-<arch>` dylib per architecture. In default mode it also fails if either the x64 or arm64 bundle is missing entirely. The runtime attach_file smoke run stays native-arch only.
- `.github/workflows/pr.yml`: Build / macOS now runs `make check-mac-attach-file-runtime` after `make dist-mac`, so PR CI proves both bundles carry their runtimes (previously only release builds ran the check).

## Validation
- Inspected the v0.28.2 x64 release zip to confirm the missing darwin-x64 packages (root cause proof).
- Verified on bun 1.3.5 (CI's pinned version) that the cross-arch installs are additive and leave `bun.lock` untouched, and that bun 1.2.15 silently no-ops (hence the guard).
- Red-green checked the `ESBUILD_BIN` fix: with a fake `@esbuild/darwin-arm64` present, the old expression resolves to the darwin binary, the new one resolves to the host binary.
- Remote dogfood UAT (3 rounds, Linux): ensure target exit 0 with all four darwin packages added and lockfile unchanged; guard fails loudly on old bun; `attach_file` tests 19/19; `make dev-server` boots cleanly after the ensure target; static-check green.
- Not verifiable without darwin-x64 hardware: actually executing the packaged x64 app. The strengthened smoke check in the Build / macOS job is the closest CI proxy (per-arch binary presence plus `lipo` verification plus a native-arch runtime run).

## Risks
Release-pipeline only; no app runtime code changes. The mac dist targets now mutate `node_modules` before packaging, which grows both mac bundles by the extra Darwin sharp/libvips packages (a few MB each). If a future bun regresses `--os`/`--cpu` handling, the explicit directory guard and the CI smoke check fail the build rather than shipping a broken artifact.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
