### PR TITLE
🤖 feat: scroll-fixed terminal badge overlay (iTerm2-style workspace/tab watermark)

### DIFF
--- a/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
+++ b/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
@@ -44,6 +44,7 @@ const BadgeStory = (props: BadgeStoryProps) => {
           workspaceName={props.workspaceName ?? "fix-3607-terminal-badge"}
           projectName="xum"
           tabName={props.tabName ?? "Terminal"}
+          tabIndex={0}
         />
       </div>
     </div>

--- a/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
+++ b/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 import {
@@ -30,6 +30,16 @@ const BadgeStory = (props: BadgeStoryProps) => {
       ...props.config,
     })
   );
+  // Storybook reuses one browser origin across stories; restore the disabled
+  // default on unmount so later stories with terminals don't inherit the badge.
+  useEffect(() => {
+    return () => {
+      updatePersistedState<TerminalBadgeConfig>(
+        TERMINAL_BADGE_CONFIG_KEY,
+        DEFAULT_TERMINAL_BADGE_CONFIG
+      );
+    };
+  }, []);
 
   return (
     <div className="p-4" style={{ width: props.width, maxWidth: "100%" }}>

--- a/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
+++ b/src/browser/components/TerminalView/TerminalBadgeOverlay.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import { lightweightMeta } from "@/browser/stories/meta.js";
+import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
+  TERMINAL_BADGE_CONFIG_KEY,
+  type TerminalBadgeConfig,
+} from "@/common/constants/storage";
+import { TerminalBadgeOverlay } from "./TerminalBadgeOverlay";
+
+const FAKE_OUTPUT = Array.from(
+  { length: 14 },
+  (_, i) => `$ build step ${i + 1} … ok (${(i + 1) * 137}ms)`
+).join("\n");
+
+interface BadgeStoryProps {
+  config: Partial<TerminalBadgeConfig>;
+  workspaceName?: string;
+  tabName?: string;
+  width?: number;
+}
+
+/** Fake terminal surface: badge config is persisted state, so seed it before the overlay's first read. */
+const BadgeStory = (props: BadgeStoryProps) => {
+  useState(() =>
+    updatePersistedState<TerminalBadgeConfig>(TERMINAL_BADGE_CONFIG_KEY, {
+      ...DEFAULT_TERMINAL_BADGE_CONFIG,
+      enabled: true,
+      ...props.config,
+    })
+  );
+
+  return (
+    <div className="p-4" style={{ width: props.width, maxWidth: "100%" }}>
+      <div
+        className="border-border-medium relative h-64 overflow-hidden rounded border"
+        style={{ backgroundColor: "var(--color-terminal-bg)" }}
+      >
+        <pre className="p-2 text-xs" style={{ color: "var(--color-terminal-fg)" }}>
+          {FAKE_OUTPUT}
+        </pre>
+        <TerminalBadgeOverlay
+          workspaceName={props.workspaceName ?? "fix-3607-terminal-badge"}
+          projectName="xum"
+          tabName={props.tabName ?? "Terminal"}
+        />
+      </div>
+    </div>
+  );
+};
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Terminal/TerminalBadgeOverlay",
+  component: BadgeStory,
+} satisfies Meta<typeof BadgeStory>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TopRightDefault: Story = {
+  args: { config: {} },
+};
+
+export const BottomLeft: Story = {
+  args: { config: { position: "bottom-left" } },
+};
+
+export const HighOpacityLargeFont: Story = {
+  args: { config: { opacity: 0.9, fontSize: 28, template: "{project}/{workspace} · {tab}" } },
+};
+
+export const LongNamesTruncatePhone: Story = {
+  args: {
+    config: {},
+    workspaceName: "extremely-long-workspace-branch-name-that-should-truncate",
+    tabName: "very-long-osc-title-from-a-build-process",
+  },
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: { matrix: { viewports: ["phone"] } },
+    docs: {
+      description: {
+        story:
+          "Pins the phone-width contract: long workspace + tab names truncate with an ellipsis instead of overflowing the terminal surface.",
+      },
+    },
+  },
+};

--- a/src/browser/components/TerminalView/TerminalBadgeOverlay.tsx
+++ b/src/browser/components/TerminalView/TerminalBadgeOverlay.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
+  TERMINAL_BADGE_CONFIG_KEY,
+  normalizeTerminalBadgeConfig,
+  type TerminalBadgeConfig,
+  type TerminalBadgePosition,
+} from "@/common/constants/storage";
+import { formatTerminalBadge } from "@/browser/utils/terminalBadgeTemplate";
+
+const POSITION_CLASSES: Record<TerminalBadgePosition, string> = {
+  "top-left": "top-2 left-2",
+  "top-right": "top-2 right-2",
+  "bottom-left": "bottom-2 left-2",
+  "bottom-right": "bottom-2 right-2",
+};
+
+interface TerminalBadgeOverlayProps {
+  workspaceName: string;
+  projectName: string;
+  tabName: string;
+}
+
+/**
+ * Scroll-fixed workspace/tab watermark rendered above the terminal canvas
+ * (iTerm2-style badge, issue #3607). Prompt markers scroll away with output
+ * and sidebar tab labels aren't visible from inside the viewport, so this
+ * overlay is the persistent identity cue. pointer-events/user-select are
+ * disabled so clicks, drags, and text selection behave as if it were absent.
+ */
+export const TerminalBadgeOverlay: React.FC<TerminalBadgeOverlayProps> = (props) => {
+  const [rawConfig] = usePersistedState<TerminalBadgeConfig>(
+    TERMINAL_BADGE_CONFIG_KEY,
+    DEFAULT_TERMINAL_BADGE_CONFIG,
+    { listener: true }
+  );
+  const config = normalizeTerminalBadgeConfig(rawConfig);
+
+  if (!config.enabled) {
+    return null;
+  }
+
+  const text = formatTerminalBadge(config.template, {
+    workspace: props.workspaceName,
+    project: props.projectName,
+    tab: props.tabName,
+  });
+  if (!text) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`pointer-events-none absolute z-10 max-w-[75%] truncate font-medium select-none ${POSITION_CLASSES[config.position]}`}
+      style={{
+        color: "var(--color-terminal-fg)",
+        opacity: config.opacity,
+        fontSize: config.fontSize,
+      }}
+    >
+      {text}
+    </div>
+  );
+};

--- a/src/browser/components/TerminalView/TerminalBadgeOverlay.tsx
+++ b/src/browser/components/TerminalView/TerminalBadgeOverlay.tsx
@@ -20,6 +20,8 @@ interface TerminalBadgeOverlayProps {
   workspaceName: string;
   projectName: string;
   tabName: string;
+  /** 0-based tab position; undefined when unknown (pop-out windows). */
+  tabIndex?: number;
 }
 
 /**
@@ -45,6 +47,7 @@ export const TerminalBadgeOverlay: React.FC<TerminalBadgeOverlayProps> = (props)
     workspace: props.workspaceName,
     project: props.projectName,
     tab: props.tabName,
+    index: props.tabIndex != null ? String(props.tabIndex + 1) : "",
   });
   if (!text) {
     return null;

--- a/src/browser/components/TerminalView/TerminalView.test.tsx
+++ b/src/browser/components/TerminalView/TerminalView.test.tsx
@@ -121,6 +121,12 @@ void mock.module("@/browser/terminal/TerminalRouterContext", () => ({
 }));
 
 import { TerminalView } from "./TerminalView";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
+  TERMINAL_BADGE_CONFIG_KEY,
+  type TerminalBadgeConfig,
+} from "@/common/constants/storage";
 
 function createRouter(): MockRouter {
   unsubscribeMock = mock(() => undefined);
@@ -203,5 +209,49 @@ describe("TerminalView", () => {
     expect(firstOnExit).toHaveBeenCalledTimes(0);
     expect(secondOnExit).toHaveBeenCalledTimes(1);
     expect(secondOnExit.mock.calls[0]?.[0]).toBe(7);
+  });
+
+  test("renders the badge overlay with substituted template when enabled", async () => {
+    updatePersistedState<TerminalBadgeConfig>(TERMINAL_BADGE_CONFIG_KEY, {
+      ...DEFAULT_TERMINAL_BADGE_CONFIG,
+      enabled: true,
+    });
+
+    const view = render(
+      <TerminalView
+        workspaceId="workspace-1"
+        sessionId="terminal-1"
+        visible
+        setDocumentTitle={false}
+        autoFocus={false}
+        workspaceName="my-feature"
+        projectName="xum"
+        tabName="Terminal 2"
+      />
+    );
+
+    await waitFor(() => {
+      expect(view.container.textContent).toContain("my-feature · Terminal 2");
+    });
+  });
+
+  test("renders no badge overlay by default", async () => {
+    const view = render(
+      <TerminalView
+        workspaceId="workspace-1"
+        sessionId="terminal-1"
+        visible
+        setDocumentTitle={false}
+        autoFocus={false}
+        workspaceName="my-feature"
+        projectName="xum"
+        tabName="Terminal 2"
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockRouter.subscribe).toHaveBeenCalledTimes(1);
+    });
+    expect(view.container.textContent).not.toContain("my-feature");
   });
 });

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -19,6 +19,8 @@ import {
   TERMINAL_ICON_FALLBACK_FAMILY,
 } from "@/browser/terminal/terminalFontFamily";
 import { TERMINAL_CONTAINER_ATTR } from "@/browser/utils/ui/keybinds";
+import { TerminalBadgeOverlay } from "@/browser/components/TerminalView/TerminalBadgeOverlay";
+import { getTerminalTabFallbackName } from "@/browser/types/rightSidebar";
 
 function canLoadFontFamily(primary: string, fontSize: number): boolean {
   const family = stripOuterQuotes(primary).trim();
@@ -129,6 +131,14 @@ interface TerminalViewProps {
   autoFocus?: boolean;
   /** Called when the terminal process exits. */
   onExit?: (exitCode: number) => void;
+  /**
+   * Workspace/tab identity for the badge overlay. When omitted (pop-out
+   * window), workspace names are resolved via the API and the tab name
+   * falls back to the latest OSC title.
+   */
+  workspaceName?: string;
+  projectName?: string;
+  tabName?: string;
 }
 
 export function TerminalView({
@@ -140,6 +150,9 @@ export function TerminalView({
   onAutoFocusConsumed,
   autoFocus = true,
   onExit,
+  workspaceName,
+  projectName,
+  tabName,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -171,6 +184,16 @@ export function TerminalView({
   routerRef.current = router;
   sessionIdRef.current = sessionId;
 
+  // Pop-out windows have no WorkspaceProvider, so the badge overlay's
+  // workspace identity is resolved here alongside the window title.
+  const [resolvedNames, setResolvedNames] = useState<{
+    workspaceName: string;
+    projectName: string;
+  } | null>(null);
+  // Latest OSC 0/1/2 title; badge fallback for pop-out windows where the
+  // sidebar's per-tab title map is unavailable.
+  const [oscTitle, setOscTitle] = useState<string | null>(null);
+
   // Set window title (dedicated terminal window only)
   useEffect(() => {
     if (!api || !setDocumentTitle) return;
@@ -180,6 +203,7 @@ export function TerminalView({
         const workspace = workspaces.find((ws) => ws.id === workspaceId);
         if (workspace) {
           document.title = `Terminal — ${workspace.projectName}/${workspace.name}`;
+          setResolvedNames({ workspaceName: workspace.name, projectName: workspace.projectName });
         } else {
           document.title = `Terminal — ${workspaceId}`;
         }
@@ -556,6 +580,7 @@ export function TerminalView({
         // Terminal title changes (from OSC escape sequences like "echo -ne '\033]0;Title\007'")
         // Use ref to always get latest callback
         disposeOnTitleChange = terminal.onTitleChange((title: string) => {
+          setOscTitle(title);
           onTitleChangeRef.current?.(title);
         });
 
@@ -887,6 +912,13 @@ export function TerminalView({
         >
           <span className="text-muted animate-pulse text-sm">Connecting...</span>
         </div>
+      )}
+      {!showLoading && (
+        <TerminalBadgeOverlay
+          workspaceName={workspaceName ?? resolvedNames?.workspaceName ?? ""}
+          projectName={projectName ?? resolvedNames?.projectName ?? ""}
+          tabName={tabName ?? oscTitle ?? getTerminalTabFallbackName(0)}
+        />
       )}
     </div>
   );

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -139,6 +139,8 @@ interface TerminalViewProps {
   workspaceName?: string;
   projectName?: string;
   tabName?: string;
+  /** 0-based tab position for the badge's {index} token; unknown in pop-out windows. */
+  tabIndex?: number;
 }
 
 export function TerminalView({
@@ -153,6 +155,7 @@ export function TerminalView({
   workspaceName,
   projectName,
   tabName,
+  tabIndex,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -918,6 +921,7 @@ export function TerminalView({
           workspaceName={workspaceName ?? resolvedNames?.workspaceName ?? ""}
           projectName={projectName ?? resolvedNames?.projectName ?? ""}
           tabName={tabName ?? oscTitle ?? getTerminalTabFallbackName(0)}
+          tabIndex={tabIndex}
         />
       )}
     </div>

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -918,7 +918,7 @@ export function TerminalView({
       )}
       {!showLoading && (
         <TerminalBadgeOverlay
-          workspaceName={workspaceName ?? resolvedNames?.workspaceName ?? ""}
+          workspaceName={workspaceName ?? resolvedNames?.workspaceName ?? workspaceId}
           projectName={projectName ?? resolvedNames?.projectName ?? ""}
           tabName={tabName ?? oscTitle ?? getTerminalTabFallbackName(0)}
           tabIndex={tabIndex}

--- a/src/browser/components/TerminalView/TerminalView.tsx
+++ b/src/browser/components/TerminalView/TerminalView.tsx
@@ -141,6 +141,11 @@ interface TerminalViewProps {
   tabName?: string;
   /** 0-based tab position for the badge's {index} token; unknown in pop-out windows. */
   tabIndex?: number;
+  /**
+   * OSC title carried over from before a pop-out handoff, so the badge doesn't
+   * reset to "Terminal" until the shell emits another title.
+   */
+  initialTitle?: string;
 }
 
 export function TerminalView({
@@ -156,6 +161,7 @@ export function TerminalView({
   projectName,
   tabName,
   tabIndex,
+  initialTitle,
 }: TerminalViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -195,7 +201,7 @@ export function TerminalView({
   } | null>(null);
   // Latest OSC 0/1/2 title; badge fallback for pop-out windows where the
   // sidebar's per-tab title map is unavailable.
-  const [oscTitle, setOscTitle] = useState<string | null>(null);
+  const [oscTitle, setOscTitle] = useState<string | null>(initialTitle ?? null);
 
   // Set window title (dedicated terminal window only)
   useEffect(() => {

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -58,6 +58,7 @@ import {
   isTabType,
   isTerminalTab,
   getTerminalSessionId,
+  getTerminalTabFallbackName,
   makeTerminalTabType,
   type TabType,
 } from "@/browser/types/rightSidebar";
@@ -548,13 +549,15 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
         )}
 
         {/* Render all terminal tabs (keep-alive: hidden but mounted) */}
-        {terminalTabs.map((terminalTab) => {
+        {terminalTabs.map((terminalTab, terminalIndex) => {
           const terminalTabId = `${tabsetBaseId}-tab-${terminalTab}`;
           const terminalPanelId = `${tabsetBaseId}-panel-${terminalTab}`;
           const isActive = props.node.activeTab === terminalTab;
           // Check if this terminal should be auto-focused (was just opened via keybind)
           const terminalSessionId = getTerminalSessionId(terminalTab);
           const shouldAutoFocus = isActive && terminalSessionId === props.autoFocusTerminalSession;
+          const tabName =
+            props.terminalTitles.get(terminalTab) ?? getTerminalTabFallbackName(terminalIndex);
 
           return (
             <div
@@ -569,6 +572,7 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
                 workspaceId={props.workspaceId}
                 tabType={terminalTab}
                 visible={isActive}
+                tabName={tabName}
                 onTitleChange={(title) => props.onTerminalTitleChange(terminalTab, title)}
                 autoFocus={shouldAutoFocus}
                 onAutoFocusConsumed={shouldAutoFocus ? props.onAutoFocusConsumed : undefined}

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -287,6 +287,8 @@ interface RightSidebarTabsetNodeProps {
   onTerminalExit: (tab: TabType) => void;
   /** Map of terminal tab types to their current titles (from OSC sequences) */
   terminalTitles: Map<TabType, string>;
+  /** Workspace-wide 0-based ordering of terminal tabs across all splits */
+  terminalTabOrder: Map<TabType, number>;
   /** Handler to update a terminal's title */
   onTerminalTitleChange: (tab: TabType, title: string) => void;
   /** Map of tab → global position index (0-based) for keybind tooltips */
@@ -412,7 +414,7 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
       const Label = TAB_REGISTRY[tab].Label;
       label = <Label workspaceId={props.workspaceId} reviewStats={props.reviewStats} />;
     } else if (isTerminal) {
-      const terminalIndex = terminalTabs.indexOf(tab);
+      const terminalIndex = props.terminalTabOrder.get(tab) ?? 0;
       label = (
         <TerminalTabLabel
           dynamicTitle={props.terminalTitles.get(tab)}
@@ -549,13 +551,14 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
         )}
 
         {/* Render all terminal tabs (keep-alive: hidden but mounted) */}
-        {terminalTabs.map((terminalTab, terminalIndex) => {
+        {terminalTabs.map((terminalTab) => {
           const terminalTabId = `${tabsetBaseId}-tab-${terminalTab}`;
           const terminalPanelId = `${tabsetBaseId}-panel-${terminalTab}`;
           const isActive = props.node.activeTab === terminalTab;
           // Check if this terminal should be auto-focused (was just opened via keybind)
           const terminalSessionId = getTerminalSessionId(terminalTab);
           const shouldAutoFocus = isActive && terminalSessionId === props.autoFocusTerminalSession;
+          const terminalIndex = props.terminalTabOrder.get(terminalTab) ?? 0;
           const tabName =
             props.terminalTitles.get(terminalTab) ?? getTerminalTabFallbackName(terminalIndex);
 
@@ -1323,6 +1326,13 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
     return positions;
   }, [layout.root]);
 
+  // Workspace-wide terminal ordering. Numbering per tabset would restart at
+  // "Terminal"/#1 in every split, defeating the badge's per-tab identity.
+  const terminalTabOrder = new Map<TabType, number>();
+  collectAllTabs(layout.root)
+    .filter(isTerminalTab)
+    .forEach((tab, index) => terminalTabOrder.set(tab, index));
+
   // @dnd-kit state for tracking active drag
   const [activeDragData, setActiveDragData] = React.useState<TabDragData | null>(null);
 
@@ -1700,6 +1710,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
         onCloseTerminal={handleCloseTerminal}
         onTerminalExit={removeTerminalTab}
         terminalTitles={terminalTitles}
+        terminalTabOrder={terminalTabOrder}
         onTerminalTitleChange={handleTerminalTitleChange}
         tabPositions={tabPositions}
         onRequestTerminalFocus={setAutoFocusTerminalSession}

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -573,6 +573,7 @@ const RightSidebarTabsetNode: React.FC<RightSidebarTabsetNodeProps> = (props) =>
                 tabType={terminalTab}
                 visible={isActive}
                 tabName={tabName}
+                tabIndex={terminalIndex}
                 onTitleChange={(title) => props.onTerminalTitleChange(terminalTab, title)}
                 autoFocus={shouldAutoFocus}
                 onAutoFocusConsumed={shouldAutoFocus ? props.onAutoFocusConsumed : undefined}

--- a/src/browser/features/RightSidebar/RightSidebar.tsx
+++ b/src/browser/features/RightSidebar/RightSidebar.tsx
@@ -1540,10 +1540,14 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
       // an unhandled promise rejection. We surface it via the same PopoverError used by
       // handleAddTerminal — the user already paid the cost of removing the tab below, so
       // they need to know if the pop-out itself failed.
-      void openTerminalPopout(api, workspaceId, sessionId).catch((err: unknown) => {
-        console.error("[RightSidebar] Failed to open terminal pop-out:", err);
-        terminalCreateError.showError("terminal-popout", getErrorMessage(err));
-      });
+      // Carry the known OSC title into the pop-out; it is deleted from the
+      // sidebar map below and the new window only sees future title changes.
+      void openTerminalPopout(api, workspaceId, sessionId, terminalTitles.get(tab)).catch(
+        (err: unknown) => {
+          console.error("[RightSidebar] Failed to open terminal pop-out:", err);
+          terminalCreateError.showError("terminal-popout", getErrorMessage(err));
+        }
+      );
 
       // Remove the tab from the sidebar (terminal now lives in its own window)
       // Don't close the session - the pop-out window takes over
@@ -1557,7 +1561,7 @@ const RightSidebarComponent: React.FC<RightSidebarProps> = ({
         return next;
       });
     },
-    [workspaceId, api, setLayout, terminalTitlesKey, terminalCreateError]
+    [workspaceId, api, setLayout, terminalTitlesKey, terminalCreateError, terminalTitles]
   );
 
   // Configure sensors with distance threshold for click vs drag disambiguation

--- a/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
+++ b/src/browser/features/RightSidebar/Tabs/TabLabels.tsx
@@ -21,6 +21,7 @@ import {
   X,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { getTerminalTabFallbackName } from "@/browser/types/rightSidebar";
 import { type ReviewStats } from "./registry";
 import { useAPI } from "@/browser/contexts/API";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
@@ -347,8 +348,7 @@ export const TerminalTabLabel: React.FC<TerminalTabLabelProps> = ({
   onPopOut,
   onClose,
 }) => {
-  const fallbackName = terminalIndex === 0 ? "Terminal" : `Terminal ${terminalIndex + 1}`;
-  const displayName = dynamicTitle ?? fallbackName;
+  const displayName = dynamicTitle ?? getTerminalTabFallbackName(terminalIndex);
 
   return (
     <span className="inline-flex items-center gap-1">

--- a/src/browser/features/RightSidebar/TerminalTab.tsx
+++ b/src/browser/features/RightSidebar/TerminalTab.tsx
@@ -11,6 +11,8 @@ interface TerminalTabProps {
   visible: boolean;
   /** Display name for this tab (OSC title or "Terminal N" fallback), shown by the badge overlay. */
   tabName: string;
+  /** 0-based position among the tabset's terminal tabs, for the badge's {index} token. */
+  tabIndex: number;
   /** Called when terminal title changes (from shell OSC sequences) */
   onTitleChange?: (title: string) => void;
   /** Whether to auto-focus the terminal when it becomes visible (e.g., when opened via keybind) */
@@ -55,6 +57,7 @@ export const TerminalTab: React.FC<TerminalTabProps> = (props) => {
       workspaceName={metadata?.name ?? ""}
       projectName={metadata?.projectName ?? ""}
       tabName={props.tabName}
+      tabIndex={props.tabIndex}
     />
   );
 };

--- a/src/browser/features/RightSidebar/TerminalTab.tsx
+++ b/src/browser/features/RightSidebar/TerminalTab.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { TerminalView } from "@/browser/components/TerminalView/TerminalView";
+import { useWorkspaceMetadata } from "@/browser/contexts/WorkspaceContext";
 import type { TabType } from "@/browser/types/rightSidebar";
 import { getTerminalSessionId } from "@/browser/types/rightSidebar";
 
@@ -8,6 +9,8 @@ interface TerminalTabProps {
   /** The tab type (e.g., "terminal:ws-123-1704567890") */
   tabType: TabType;
   visible: boolean;
+  /** Display name for this tab (OSC title or "Terminal N" fallback), shown by the badge overlay. */
+  tabName: string;
   /** Called when terminal title changes (from shell OSC sequences) */
   onTitleChange?: (title: string) => void;
   /** Whether to auto-focus the terminal when it becomes visible (e.g., when opened via keybind) */
@@ -28,6 +31,7 @@ interface TerminalTabProps {
 export const TerminalTab: React.FC<TerminalTabProps> = (props) => {
   // Extract session ID from tab type - must exist (sessions created before tab added)
   const sessionId = getTerminalSessionId(props.tabType);
+  const metadata = useWorkspaceMetadata().workspaceMetadata.get(props.workspaceId);
 
   if (!sessionId) {
     // This should never happen - RightSidebar creates session before adding tab
@@ -48,6 +52,9 @@ export const TerminalTab: React.FC<TerminalTabProps> = (props) => {
       onAutoFocusConsumed={props.onAutoFocusConsumed}
       autoFocus={props.autoFocus ?? false}
       onExit={props.onExit}
+      workspaceName={metadata?.name ?? ""}
+      projectName={metadata?.projectName ?? ""}
+      tabName={props.tabName}
     />
   );
 };

--- a/src/browser/features/Settings/Sections/GeneralSection.stories.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.stories.tsx
@@ -1,4 +1,10 @@
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { lightweightMeta } from "@/browser/stories/meta.js";
+import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
+  TERMINAL_BADGE_CONFIG_KEY,
+  type TerminalBadgeConfig,
+} from "@/common/constants/storage";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { within } from "@storybook/test";
 import { GeneralSection } from "./GeneralSection.js";
@@ -25,5 +31,45 @@ export const General: Story = {
     await canvas.findByText(/^Theme$/i);
     await canvas.findByText(/^Terminal Font$/i);
     await canvas.findByText(/^Terminal Font Size$/i);
+  },
+};
+
+export const TerminalBadgeEnabledPhone: Story = {
+  render: () => (
+    <SettingsSectionStory
+      setup={() => {
+        const client = setupSettingsStory({});
+        // Seed after the story reset so the enabled-only badge rows render;
+        // the phone Pixel snapshot guards their narrow-width wrapping.
+        updatePersistedState<TerminalBadgeConfig>(TERMINAL_BADGE_CONFIG_KEY, {
+          ...DEFAULT_TERMINAL_BADGE_CONFIG,
+          enabled: true,
+        });
+        return client;
+      }}
+    >
+      <GeneralSection />
+    </SettingsSectionStory>
+  ),
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: { matrix: { viewports: ["phone"] } },
+    docs: {
+      description: {
+        story:
+          "Pins the phone-width contract for the enabled badge settings rows (template/position/opacity/font size), which only render when the badge is on.",
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Static contract: the enabled-only rows must be present, otherwise the
+    // phone snapshot would silently capture the collapsed (disabled) UI.
+    await canvas.findByLabelText("Terminal Badge Template");
+    await canvas.findByLabelText("Terminal Badge Opacity");
+    await canvas.findByLabelText("Terminal Badge Font Size");
   },
 };

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -751,7 +751,11 @@ export function GeneralSection() {
                 <div className="flex-1">
                   <div className="text-foreground text-sm">Terminal Badge Template</div>
                   <div className="text-muted text-xs">
-                    Tokens: {"{workspace}"}, {"{tab}"}, {"{project}"}
+                    Tokens: {"{workspace}"}, {"{tab}"}, {"{project}"}, {"{index}"}
+                  </div>
+                  <div className="text-muted text-xs">
+                    {"{tab}"} follows the tab label (shell titles); {"{index}"} is the stable tab
+                    number
                   </div>
                 </div>
                 <Input

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -18,6 +18,9 @@ import {
   DEFAULT_EDITOR_CONFIG,
   TERMINAL_FONT_CONFIG_KEY,
   DEFAULT_TERMINAL_FONT_CONFIG,
+  TERMINAL_BADGE_CONFIG_KEY,
+  TERMINAL_BADGE_POSITIONS,
+  DEFAULT_TERMINAL_BADGE_CONFIG,
   LAUNCH_BEHAVIOR_KEY,
   BASH_COLLAPSED_SUMMARY_MODE_KEY,
   BASH_COLLAPSED_SUMMARY_MODES,
@@ -28,6 +31,7 @@ import {
   TRANSCRIPT_DENSITIES,
   normalizeBashCollapsedSummaryMode,
   normalizeEditorConfig,
+  normalizeTerminalBadgeConfig,
   normalizeTerminalFontConfig,
   normalizeTranscriptDensity,
   type BashCollapsedSummaryMode,
@@ -35,6 +39,8 @@ import {
   type EditorConfig,
   type EditorType,
   type LaunchBehavior,
+  type TerminalBadgeConfig,
+  type TerminalBadgePosition,
   type TerminalFontConfig,
 } from "@/common/constants/storage";
 import {
@@ -126,6 +132,16 @@ const TRANSCRIPT_DENSITY_OPTIONS = TRANSCRIPT_DENSITIES.map((value) => ({
   value,
   label: TRANSCRIPT_DENSITY_LABELS[value],
 }));
+const TERMINAL_BADGE_POSITION_LABELS: Record<TerminalBadgePosition, string> = {
+  "top-left": "Top left",
+  "top-right": "Top right",
+  "bottom-left": "Bottom left",
+  "bottom-right": "Bottom right",
+};
+const TERMINAL_BADGE_POSITION_OPTIONS = TERMINAL_BADGE_POSITIONS.map((value) => ({
+  value,
+  label: TERMINAL_BADGE_POSITION_LABELS[value],
+}));
 const ARCHIVE_BEHAVIOR_OPTIONS = [
   { value: "keep", label: "Keep running" },
   { value: "stop", label: "Stop workspace" },
@@ -183,6 +199,12 @@ export function GeneralSection() {
     String.fromCodePoint(0xe725), // dev-git_branch
     String.fromCodePoint(0xf135), // fa-rocket
   ].join(" ");
+
+  const [rawTerminalBadgeConfig, setTerminalBadgeConfig] = usePersistedState<TerminalBadgeConfig>(
+    TERMINAL_BADGE_CONFIG_KEY,
+    DEFAULT_TERMINAL_BADGE_CONFIG
+  );
+  const terminalBadgeConfig = normalizeTerminalBadgeConfig(rawTerminalBadgeConfig);
 
   const [rawEditorConfig, setEditorConfig] = usePersistedState<EditorConfig>(
     EDITOR_CONFIG_KEY,
@@ -455,6 +477,39 @@ export function GeneralSection() {
     setEditorConfig((prev) => ({ ...normalizeEditorConfig(prev), customCommand }));
   };
 
+  const handleTerminalBadgeEnabledChange = (enabled: boolean) => {
+    setTerminalBadgeConfig((prev) => ({ ...normalizeTerminalBadgeConfig(prev), enabled }));
+  };
+
+  const handleTerminalBadgeTemplateChange = (template: string) => {
+    setTerminalBadgeConfig((prev) => ({ ...normalizeTerminalBadgeConfig(prev), template }));
+  };
+
+  const handleTerminalBadgePositionChange = (position: TerminalBadgePosition) => {
+    setTerminalBadgeConfig((prev) => ({ ...normalizeTerminalBadgeConfig(prev), position }));
+  };
+
+  const handleTerminalBadgeOpacityChange = (rawValue: string) => {
+    const parsed = Number(rawValue);
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 100) {
+      return;
+    }
+
+    setTerminalBadgeConfig((prev) => ({
+      ...normalizeTerminalBadgeConfig(prev),
+      opacity: parsed / 100,
+    }));
+  };
+
+  const handleTerminalBadgeFontSizeChange = (rawValue: string) => {
+    const parsed = Number(rawValue);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return;
+    }
+
+    setTerminalBadgeConfig((prev) => ({ ...normalizeTerminalBadgeConfig(prev), fontSize: parsed }));
+  };
+
   const handleSshHostChange = useCallback(
     (value: string) => {
       setSshHost(value);
@@ -675,6 +730,103 @@ export function GeneralSection() {
               className="border-border-medium bg-background-secondary h-9 w-28"
             />
           </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex-1">
+              <div className="text-foreground text-sm">Terminal Badge</div>
+              <div className="text-muted text-xs">
+                Show a scroll-fixed workspace/tab watermark over the terminal
+              </div>
+            </div>
+            <Switch
+              checked={terminalBadgeConfig.enabled}
+              onCheckedChange={handleTerminalBadgeEnabledChange}
+              aria-label="Toggle Terminal Badge"
+            />
+          </div>
+
+          {terminalBadgeConfig.enabled && (
+            <>
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-foreground text-sm">Terminal Badge Template</div>
+                  <div className="text-muted text-xs">
+                    Tokens: {"{workspace}"}, {"{tab}"}, {"{project}"}
+                  </div>
+                </div>
+                <Input
+                  value={terminalBadgeConfig.template}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleTerminalBadgeTemplateChange(e.target.value)
+                  }
+                  placeholder={DEFAULT_TERMINAL_BADGE_CONFIG.template}
+                  aria-label="Terminal Badge Template"
+                  className="border-border-medium bg-background-secondary h-9 w-80"
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-foreground text-sm">Terminal Badge Position</div>
+                  <div className="text-muted text-xs">
+                    Corner of the terminal to pin the badge to
+                  </div>
+                </div>
+                <Select
+                  value={terminalBadgeConfig.position}
+                  onValueChange={(value) =>
+                    handleTerminalBadgePositionChange(value as TerminalBadgePosition)
+                  }
+                >
+                  <SelectTrigger className="border-border-medium bg-background-secondary hover:bg-hover h-9 w-auto cursor-pointer rounded-md border px-3 text-sm transition-colors">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TERMINAL_BADGE_POSITION_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-foreground text-sm">Terminal Badge Opacity</div>
+                  <div className="text-muted text-xs">Percent (1-100)</div>
+                </div>
+                <Input
+                  type="number"
+                  value={Math.round(terminalBadgeConfig.opacity * 100)}
+                  min={1}
+                  max={100}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleTerminalBadgeOpacityChange(e.target.value)
+                  }
+                  aria-label="Terminal Badge Opacity"
+                  className="border-border-medium bg-background-secondary h-9 w-28"
+                />
+              </div>
+
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-foreground text-sm">Terminal Badge Font Size</div>
+                  <div className="text-muted text-xs">Font size for the badge text</div>
+                </div>
+                <Input
+                  type="number"
+                  value={terminalBadgeConfig.fontSize}
+                  min={6}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    handleTerminalBadgeFontSizeChange(e.target.value)
+                  }
+                  aria-label="Terminal Badge Font Size"
+                  className="border-border-medium bg-background-secondary h-9 w-28"
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -200,9 +200,12 @@ export function GeneralSection() {
     String.fromCodePoint(0xf135), // fa-rocket
   ].join(" ");
 
+  // The command palette also toggles this key, so stay subscribed to
+  // external updates while Settings is mounted.
   const [rawTerminalBadgeConfig, setTerminalBadgeConfig] = usePersistedState<TerminalBadgeConfig>(
     TERMINAL_BADGE_CONFIG_KEY,
-    DEFAULT_TERMINAL_BADGE_CONFIG
+    DEFAULT_TERMINAL_BADGE_CONFIG,
+    { listener: true }
   );
   const terminalBadgeConfig = normalizeTerminalBadgeConfig(rawTerminalBadgeConfig);
 

--- a/src/browser/features/Settings/Sections/GeneralSection.tsx
+++ b/src/browser/features/Settings/Sections/GeneralSection.tsx
@@ -747,7 +747,7 @@ export function GeneralSection() {
 
           {terminalBadgeConfig.enabled && (
             <>
-              <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-4">
                 <div className="flex-1">
                   <div className="text-foreground text-sm">Terminal Badge Template</div>
                   <div className="text-muted text-xs">
@@ -765,7 +765,7 @@ export function GeneralSection() {
                   }
                   placeholder={DEFAULT_TERMINAL_BADGE_CONFIG.template}
                   aria-label="Terminal Badge Template"
-                  className="border-border-medium bg-background-secondary h-9 w-80"
+                  className="border-border-medium bg-background-secondary h-9 w-80 max-w-full"
                 />
               </div>
 

--- a/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
+++ b/src/browser/features/Settings/Sections/settingsStoryUtils.tsx
@@ -23,6 +23,7 @@ import {
 import {
   SELECTED_WORKSPACE_KEY,
   SIDEBAR_AGE_GROUPING_KEY,
+  TERMINAL_BADGE_CONFIG_KEY,
   UI_THEME_KEY,
 } from "@/common/constants/storage";
 import type { ServiceTier } from "@/common/config/schemas/providersConfig";
@@ -54,6 +55,10 @@ export function resetStorybookPersistedStateForStory(): void {
     // Sidebar stories can write sidebarAgeGrouping=false into the shared
     // origin; clear it so the GeneralSection switch snapshots its default.
     localStorage.removeItem(SIDEBAR_AGE_GROUPING_KEY);
+
+    // Terminal badge stories seed an enabled badge config; clear it so the
+    // default GeneralSection story snapshots the disabled (collapsed) rows.
+    localStorage.removeItem(TERMINAL_BADGE_CONFIG_KEY);
   }
 }
 

--- a/src/browser/stories/meta.tsx
+++ b/src/browser/stories/meta.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import {
   SELECTED_WORKSPACE_KEY,
   SIDEBAR_AGE_GROUPING_KEY,
+  TERMINAL_BADGE_CONFIG_KEY,
   UI_THEME_KEY,
 } from "@/common/constants/storage";
 
@@ -88,6 +89,9 @@ function resetStorybookPersistedStateForStory(): void {
     // Stories that disable sidebar age grouping must not leak the setting
     // into later stories via the shared localStorage origin.
     localStorage.removeItem(SIDEBAR_AGE_GROUPING_KEY);
+    // Terminal badge stories seed an enabled badge config; clear it so other
+    // stories with terminals don't render order-dependent badge overlays.
+    localStorage.removeItem(TERMINAL_BADGE_CONFIG_KEY);
   }
 }
 function getStorybookRenderKey(): string | null {

--- a/src/browser/terminal-window.tsx
+++ b/src/browser/terminal-window.tsx
@@ -13,13 +13,18 @@ import { TerminalRouterProvider } from "@/browser/terminal/TerminalRouterContext
 import { installWindowOpenLocalhostProxyNormalization } from "@/browser/utils/windowOpenLocalhostProxy";
 import "./styles/globals.css";
 
-function TerminalWindowContent(props: { workspaceId: string; sessionId: string }) {
+function TerminalWindowContent(props: {
+  workspaceId: string;
+  sessionId: string;
+  initialTitle?: string;
+}) {
   const { api } = useAPI();
 
   return (
     <TerminalView
       workspaceId={props.workspaceId}
       sessionId={props.sessionId}
+      initialTitle={props.initialTitle}
       visible={true}
       onExit={() => {
         api?.terminal.closeWindow({ workspaceId: props.workspaceId }).catch((err) => {
@@ -42,6 +47,7 @@ installWindowOpenLocalhostProxyNormalization();
 const params = new URLSearchParams(window.location.search);
 const workspaceId = params.get("workspaceId");
 const sessionId = params.get("sessionId");
+const initialTitle = params.get("title") ?? undefined;
 
 if (!workspaceId || !sessionId) {
   document.body.innerHTML = `
@@ -58,7 +64,11 @@ if (!workspaceId || !sessionId) {
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <APIProvider>
       <TerminalRouterProvider>
-        <TerminalWindowContent workspaceId={workspaceId} sessionId={sessionId} />
+        <TerminalWindowContent
+          workspaceId={workspaceId}
+          sessionId={sessionId}
+          initialTitle={initialTitle}
+        />
       </TerminalRouterProvider>
     </APIProvider>
   );

--- a/src/browser/types/rightSidebar.ts
+++ b/src/browser/types/rightSidebar.ts
@@ -50,3 +50,8 @@ export function getTerminalSessionId(tab: TabType): string | undefined {
 export function makeTerminalTabType(sessionId?: string): TabType {
   return sessionId ? `terminal:${sessionId}` : "terminal";
 }
+
+/** Default terminal tab name when no OSC title has been set (0-based index). */
+export function getTerminalTabFallbackName(terminalIndex: number): string {
+  return terminalIndex === 0 ? "Terminal" : `Terminal ${terminalIndex + 1}`;
+}

--- a/src/browser/utils/commandIds.ts
+++ b/src/browser/utils/commandIds.ts
@@ -41,6 +41,7 @@ export const CommandIds = {
   navPrev: () => "nav:prev" as const,
   navToggleSidebar: () => "nav:toggleSidebar" as const,
   navToggleHideSubAgents: () => "nav:toggle-hide-subagents" as const,
+  navToggleTerminalBadge: () => "nav:toggle-terminal-badge" as const,
   navRightSidebarFocusTerminal: () => "nav:rightSidebar:focusTerminal" as const,
   navRightSidebarSplitHorizontal: () => "nav:rightSidebar:splitHorizontal" as const,
   navRightSidebarSplitVertical: () => "nav:rightSidebar:splitVertical" as const,

--- a/src/browser/utils/commands/sources.ts
+++ b/src/browser/utils/commands/sources.ts
@@ -24,8 +24,12 @@ import assert from "@/common/utils/assert";
 import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
   RIGHT_SIDEBAR_COLLAPSED_KEY,
   SIDEBAR_HIDE_SUBAGENTS_KEY,
+  TERMINAL_BADGE_CONFIG_KEY,
+  normalizeTerminalBadgeConfig,
+  type TerminalBadgeConfig,
 } from "@/common/constants/storage";
 import { readPersistedState, updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { CommandIds } from "@/browser/utils/commandIds";
@@ -715,6 +719,29 @@ export function buildCoreSources(p: BuildSourcesParams): Array<() => CommandActi
         keywords: ["sub-agents", "subagents", "hide", "show", "sidebar"],
         run: () => {
           updatePersistedState<boolean>(SIDEBAR_HIDE_SUBAGENTS_KEY, (prev) => !prev, false);
+        },
+      },
+      {
+        id: CommandIds.navToggleTerminalBadge(),
+        title: "Toggle Terminal Badge",
+        subtitle: `Current: ${
+          normalizeTerminalBadgeConfig(
+            readPersistedState(TERMINAL_BADGE_CONFIG_KEY, DEFAULT_TERMINAL_BADGE_CONFIG)
+          ).enabled
+            ? "Shown"
+            : "Hidden"
+        }`,
+        section: section.navigation,
+        keywords: ["terminal", "badge", "watermark", "overlay", "workspace", "tab"],
+        run: () => {
+          updatePersistedState<TerminalBadgeConfig>(
+            TERMINAL_BADGE_CONFIG_KEY,
+            (prev) => {
+              const config = normalizeTerminalBadgeConfig(prev);
+              return { ...config, enabled: !config.enabled };
+            },
+            DEFAULT_TERMINAL_BADGE_CONFIG
+          );
         },
       },
     ];

--- a/src/browser/utils/terminal.ts
+++ b/src/browser/utils/terminal.ts
@@ -40,7 +40,8 @@ export const DEFAULT_TERMINAL_SIZE = { cols: 80, rows: 24 };
 export function openTerminalPopout(
   api: APIClient,
   workspaceId: string,
-  sessionId: string
+  sessionId: string,
+  initialTitle?: string
 ): Promise<void> {
   const isBrowser = !window.api;
 
@@ -48,6 +49,9 @@ export function openTerminalPopout(
     // In browser mode, we must open the window client-side
     // The backend cannot open a window on the user's client
     const params = new URLSearchParams({ workspaceId, sessionId });
+    if (initialTitle) {
+      params.set("title", initialTitle);
+    }
     const terminalUrl = resolveBrowserAssetUrl(`terminal.html?${params.toString()}`);
     window.open(
       terminalUrl,
@@ -59,7 +63,7 @@ export function openTerminalPopout(
   // Open via backend (Electron pops up BrowserWindow, browser already opened above).
   // Returned to the caller so a backend rejection can be observed instead of vanishing
   // into an unhandled promise rejection.
-  return api.terminal.openWindow({ workspaceId, sessionId });
+  return api.terminal.openWindow({ workspaceId, sessionId, initialTitle });
 }
 
 /**

--- a/src/browser/utils/terminalBadgeTemplate.test.ts
+++ b/src/browser/utils/terminalBadgeTemplate.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { formatTerminalBadge } from "./terminalBadgeTemplate";
 
-const vars = { workspace: "fix-badge", project: "xum", tab: "Terminal 2" };
+const vars = { workspace: "fix-badge", project: "xum", tab: "Terminal 2", index: "2" };
 
 describe("formatTerminalBadge", () => {
-  test("substitutes workspace, project, and tab tokens", () => {
+  test("substitutes workspace, project, tab, and index tokens", () => {
     expect(formatTerminalBadge("{workspace} · {tab}", vars)).toBe("fix-badge · Terminal 2");
     expect(formatTerminalBadge("{project}/{workspace}", vars)).toBe("xum/fix-badge");
+    expect(formatTerminalBadge("{workspace} #{index}", vars)).toBe("fix-badge #2");
+  });
+
+  test("unknown index expands to empty and trims away", () => {
+    expect(formatTerminalBadge("{workspace} {index}", { ...vars, index: "" })).toBe("fix-badge");
   });
 
   test("substitutes repeated tokens", () => {

--- a/src/browser/utils/terminalBadgeTemplate.test.ts
+++ b/src/browser/utils/terminalBadgeTemplate.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { formatTerminalBadge } from "./terminalBadgeTemplate";
+
+const vars = { workspace: "fix-badge", project: "xum", tab: "Terminal 2" };
+
+describe("formatTerminalBadge", () => {
+  test("substitutes workspace, project, and tab tokens", () => {
+    expect(formatTerminalBadge("{workspace} · {tab}", vars)).toBe("fix-badge · Terminal 2");
+    expect(formatTerminalBadge("{project}/{workspace}", vars)).toBe("xum/fix-badge");
+  });
+
+  test("substitutes repeated tokens", () => {
+    expect(formatTerminalBadge("{tab} {tab}", vars)).toBe("Terminal 2 Terminal 2");
+  });
+
+  test("preserves unknown tokens", () => {
+    expect(formatTerminalBadge("{workspace} {nope}", vars)).toBe("fix-badge {nope}");
+  });
+
+  test("trims surrounding whitespace so empty expansions collapse", () => {
+    expect(formatTerminalBadge("  {tab}  ", vars)).toBe("Terminal 2");
+    expect(formatTerminalBadge(" {workspace} ", { ...vars, workspace: "" })).toBe("");
+  });
+
+  test("empty template yields empty string", () => {
+    expect(formatTerminalBadge("", vars)).toBe("");
+  });
+});

--- a/src/browser/utils/terminalBadgeTemplate.ts
+++ b/src/browser/utils/terminalBadgeTemplate.ts
@@ -1,0 +1,19 @@
+export interface TerminalBadgeVariables {
+  workspace: string;
+  project: string;
+  tab: string;
+}
+
+/**
+ * Expand a terminal badge template. Only {workspace}, {project}, and {tab}
+ * are substituted; unknown {tokens} pass through unchanged so typos stay
+ * visible instead of silently vanishing.
+ */
+export function formatTerminalBadge(template: string, vars: TerminalBadgeVariables): string {
+  return template
+    .replace(
+      /\{(workspace|project|tab)\}/g,
+      (_match, token: keyof TerminalBadgeVariables) => vars[token]
+    )
+    .trim();
+}

--- a/src/browser/utils/terminalBadgeTemplate.ts
+++ b/src/browser/utils/terminalBadgeTemplate.ts
@@ -2,17 +2,23 @@ export interface TerminalBadgeVariables {
   workspace: string;
   project: string;
   tab: string;
+  /**
+   * Stable 1-based tab position, unlike {tab} which follows the live OSC
+   * title (interactive shells typically overwrite it on every prompt).
+   * Empty in pop-out windows, where the sidebar tab order is unknown.
+   */
+  index: string;
 }
 
 /**
- * Expand a terminal badge template. Only {workspace}, {project}, and {tab}
- * are substituted; unknown {tokens} pass through unchanged so typos stay
- * visible instead of silently vanishing.
+ * Expand a terminal badge template. Only {workspace}, {project}, {tab}, and
+ * {index} are substituted; unknown {tokens} pass through unchanged so typos
+ * stay visible instead of silently vanishing.
  */
 export function formatTerminalBadge(template: string, vars: TerminalBadgeVariables): string {
   return template
     .replace(
-      /\{(workspace|project|tab)\}/g,
+      /\{(workspace|project|tab|index)\}/g,
       (_match, token: keyof TerminalBadgeVariables) => vars[token]
     )
     .trim();

--- a/src/common/config/schemas/userPreferences.ts
+++ b/src/common/config/schemas/userPreferences.ts
@@ -7,12 +7,15 @@ import {
 import {
   BASH_COLLAPSED_SUMMARY_MODES,
   EDITOR_TYPES,
+  TERMINAL_BADGE_POSITIONS,
   TRANSCRIPT_DENSITIES,
   normalizeEditorConfig,
+  normalizeTerminalBadgeConfig,
   normalizeTerminalFontConfig,
   type BashCollapsedSummaryMode,
   type EditorConfig,
   type LaunchBehavior,
+  type TerminalBadgeConfig,
   type TerminalFontConfig,
   type TranscriptDensity,
 } from "@/common/constants/storage";
@@ -49,6 +52,15 @@ export const UserPreferencesSchema = z.object({
       terminalFontConfig: z
         .object({
           fontFamily: z.string().min(1),
+          fontSize: z.number().positive(),
+        })
+        .optional(),
+      terminalBadgeConfig: z
+        .object({
+          enabled: z.boolean(),
+          template: z.string(),
+          position: z.enum(TERMINAL_BADGE_POSITIONS),
+          opacity: z.number().min(0).max(1),
           fontSize: z.number().positive(),
         })
         .optional(),
@@ -151,6 +163,14 @@ function parseTerminalFontConfig(value: unknown): TerminalFontConfig | undefined
   }
 
   return normalizeTerminalFontConfig(value);
+}
+
+function parseTerminalBadgeConfig(value: unknown): TerminalBadgeConfig | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return normalizeTerminalBadgeConfig(value);
 }
 
 function parseEditorConfig(value: unknown): EditorConfig | undefined {
@@ -379,6 +399,11 @@ export function normalizeUserPreferences(value: unknown): UserPreferences | unde
     const terminalFontConfig = parseTerminalFontConfig(value.appearance.terminalFontConfig);
     if (terminalFontConfig) {
       appearance.terminalFontConfig = terminalFontConfig;
+    }
+
+    const terminalBadgeConfig = parseTerminalBadgeConfig(value.appearance.terminalBadgeConfig);
+    if (terminalBadgeConfig) {
+      appearance.terminalBadgeConfig = terminalBadgeConfig;
     }
 
     const editorConfig = parseEditorConfig(value.appearance.editorConfig);

--- a/src/common/constants/storage.test.ts
+++ b/src/common/constants/storage.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  DEFAULT_TERMINAL_BADGE_CONFIG,
   copyWorkspaceStorage,
   deleteWorkspaceStorage,
   getDraftScopeId,
   getInputAttachmentsKey,
+  normalizeTerminalBadgeConfig,
   normalizeTranscriptDensity,
+  type TerminalBadgeConfig,
 } from "@/common/constants/storage";
 
 class MemoryStorage implements Storage {
@@ -122,5 +125,41 @@ describe("storage workspace-scoped keys", () => {
     deleteWorkspaceStorage(workspaceId);
 
     expect(localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe("normalizeTerminalBadgeConfig", () => {
+  test("returns defaults for non-object input", () => {
+    expect(normalizeTerminalBadgeConfig(undefined)).toEqual(DEFAULT_TERMINAL_BADGE_CONFIG);
+    expect(normalizeTerminalBadgeConfig("nope")).toEqual(DEFAULT_TERMINAL_BADGE_CONFIG);
+    expect(normalizeTerminalBadgeConfig([])).toEqual(DEFAULT_TERMINAL_BADGE_CONFIG);
+  });
+
+  test("passes through a valid config", () => {
+    const config: TerminalBadgeConfig = {
+      enabled: true,
+      template: "{tab}",
+      position: "bottom-left",
+      opacity: 0.75,
+      fontSize: 24,
+    };
+    expect(normalizeTerminalBadgeConfig(config)).toEqual(config);
+  });
+
+  test("falls back per field on invalid values", () => {
+    const normalized = normalizeTerminalBadgeConfig({
+      enabled: "yes",
+      template: 7,
+      position: "middle",
+      opacity: 3,
+      fontSize: -2,
+    });
+    expect(normalized).toEqual({ ...DEFAULT_TERMINAL_BADGE_CONFIG, enabled: false });
+  });
+
+  test("rejects zero opacity and keeps the default", () => {
+    expect(normalizeTerminalBadgeConfig({ opacity: 0 }).opacity).toBe(
+      DEFAULT_TERMINAL_BADGE_CONFIG.opacity
+    );
   });
 });

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -525,6 +525,77 @@ export function normalizeTerminalFontConfig(value: unknown): TerminalFontConfig 
 }
 
 /**
+ * Terminal badge overlay configuration (global)
+ * Scroll-fixed workspace/tab watermark rendered above the terminal canvas,
+ * similar to iTerm2 badges. Stores: { enabled, template, position, opacity, fontSize }
+ */
+export const TERMINAL_BADGE_CONFIG_KEY = "terminalBadgeConfig";
+
+export const TERMINAL_BADGE_POSITIONS = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+] as const;
+export type TerminalBadgePosition = (typeof TERMINAL_BADGE_POSITIONS)[number];
+
+export interface TerminalBadgeConfig {
+  enabled: boolean;
+  /** Supports {workspace}, {tab}, and {project} tokens. */
+  template: string;
+  position: TerminalBadgePosition;
+  /** 0-1 */
+  opacity: number;
+  fontSize: number;
+}
+
+export const DEFAULT_TERMINAL_BADGE_CONFIG: TerminalBadgeConfig = {
+  enabled: false,
+  template: "{workspace} · {tab}",
+  position: "top-right",
+  opacity: 0.4,
+  fontSize: 16,
+};
+
+function isTerminalBadgePosition(value: unknown): value is TerminalBadgePosition {
+  return (
+    typeof value === "string" && TERMINAL_BADGE_POSITIONS.includes(value as TerminalBadgePosition)
+  );
+}
+
+export function normalizeTerminalBadgeConfig(value: unknown): TerminalBadgeConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return DEFAULT_TERMINAL_BADGE_CONFIG;
+  }
+
+  const record = value as {
+    enabled?: unknown;
+    template?: unknown;
+    position?: unknown;
+    opacity?: unknown;
+    fontSize?: unknown;
+  };
+  const enabled = record.enabled === true;
+  const template =
+    typeof record.template === "string" ? record.template : DEFAULT_TERMINAL_BADGE_CONFIG.template;
+  const position = isTerminalBadgePosition(record.position)
+    ? record.position
+    : DEFAULT_TERMINAL_BADGE_CONFIG.position;
+  const opacityNumber = Number(record.opacity);
+  const opacity =
+    Number.isFinite(opacityNumber) && opacityNumber > 0 && opacityNumber <= 1
+      ? opacityNumber
+      : DEFAULT_TERMINAL_BADGE_CONFIG.opacity;
+  const fontSizeNumber = Number(record.fontSize);
+  const fontSize =
+    Number.isFinite(fontSizeNumber) && fontSizeNumber > 0
+      ? fontSizeNumber
+      : DEFAULT_TERMINAL_BADGE_CONFIG.fontSize;
+
+  return { enabled, template, position, opacity, fontSize };
+}
+
+/**
  * Tutorial state storage key (global)
  * Stores: { disabled: boolean, completed: { creation?: true, workspace?: true, review?: true } }
  */

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -2194,6 +2194,8 @@ export const terminal = {
       workspaceId: z.string(),
       /** Optional session ID to reattach to an existing terminal session (for pop-out handoff) */
       sessionId: z.string().optional(),
+      /** Last known OSC title, so the pop-out badge doesn't reset to "Terminal" */
+      initialTitle: z.string().optional(),
     }),
     output: z.void(),
   },

--- a/src/common/preferences/userPreferencesStorage.ts
+++ b/src/common/preferences/userPreferencesStorage.ts
@@ -18,6 +18,7 @@ import {
   PROVIDER_OPTIONS_ANTHROPIC_KEY,
   PROVIDER_OPTIONS_GOOGLE_KEY,
   REVIEW_INCLUDE_UNCOMMITTED_KEY,
+  TERMINAL_BADGE_CONFIG_KEY,
   TERMINAL_FONT_CONFIG_KEY,
   TRANSCRIPT_DENSITIES,
   TRANSCRIPT_DENSITY_KEY,
@@ -34,6 +35,7 @@ import {
   getThinkingLevelKey,
   getTrunkBranchKey,
   normalizeEditorConfig,
+  normalizeTerminalBadgeConfig,
   normalizeTerminalFontConfig,
   type BashCollapsedSummaryMode,
   type LaunchBehavior,
@@ -68,6 +70,7 @@ const STATIC_USER_PREFERENCE_KEYS = new Set<string>([
   UI_THEME_KEY,
   TRANSCRIPT_DENSITY_KEY,
   BASH_COLLAPSED_SUMMARY_MODE_KEY,
+  TERMINAL_BADGE_CONFIG_KEY,
   TERMINAL_FONT_CONFIG_KEY,
   EDITOR_CONFIG_KEY,
   VIM_ENABLED_KEY,
@@ -262,6 +265,14 @@ export function applyStoredUserPreference(
     return pruneUserPreferences(next);
   }
 
+  if (key === TERMINAL_BADGE_CONFIG_KEY) {
+    if (!isRecord(value)) {
+      return removeStoredUserPreference(next, key);
+    }
+    ensureAppearance(next).terminalBadgeConfig = normalizeTerminalBadgeConfig(value);
+    return pruneUserPreferences(next);
+  }
+
   if (key === EDITOR_CONFIG_KEY) {
     if (!isRecord(value)) {
       return removeStoredUserPreference(next, key);
@@ -452,6 +463,7 @@ export function removeStoredUserPreference(
   else if (key === BASH_COLLAPSED_SUMMARY_MODE_KEY)
     delete next.appearance?.bashCollapsedSummaryMode;
   else if (key === TERMINAL_FONT_CONFIG_KEY) delete next.appearance?.terminalFontConfig;
+  else if (key === TERMINAL_BADGE_CONFIG_KEY) delete next.appearance?.terminalBadgeConfig;
   else if (key === EDITOR_CONFIG_KEY) delete next.appearance?.editorConfig;
   else if (key === VIM_ENABLED_KEY) delete next.appearance?.vimEnabled;
   else if (key === LAUNCH_BEHAVIOR_KEY) delete next.navigation?.launchBehavior;
@@ -512,6 +524,8 @@ export function entriesFromUserPreferences(
     });
   if (appearance?.terminalFontConfig !== undefined)
     entries.push({ key: TERMINAL_FONT_CONFIG_KEY, value: appearance.terminalFontConfig });
+  if (appearance?.terminalBadgeConfig !== undefined)
+    entries.push({ key: TERMINAL_BADGE_CONFIG_KEY, value: appearance.terminalBadgeConfig });
   if (appearance?.editorConfig !== undefined)
     entries.push({ key: EDITOR_CONFIG_KEY, value: appearance.editorConfig });
   if (appearance?.vimEnabled !== undefined)

--- a/src/desktop/terminalWindowManager.ts
+++ b/src/desktop/terminalWindowManager.ts
@@ -32,7 +32,11 @@ export class TerminalWindowManager {
    * Multiple windows can be open for the same workspace
    * @param sessionId Optional session ID to reattach to (for pop-out handoff from embedded terminal)
    */
-  async openTerminalWindow(workspaceId: string, sessionId?: string): Promise<void> {
+  async openTerminalWindow(
+    workspaceId: string,
+    sessionId?: string,
+    initialTitle?: string
+  ): Promise<void> {
     this.windowCount++;
     const windowId = this.windowCount;
 
@@ -116,6 +120,9 @@ export class TerminalWindowManager {
     const queryParams: Record<string, string> = { workspaceId };
     if (sessionId) {
       queryParams.sessionId = sessionId;
+    }
+    if (initialTitle) {
+      queryParams.title = initialTitle;
     }
 
     if (useDevServer) {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -6195,7 +6195,11 @@ export const router = (authToken?: string) => {
         .input(schemas.terminal.openWindow.input)
         .output(schemas.terminal.openWindow.output)
         .handler(async ({ context, input }) => {
-          return context.terminalService.openWindow(input.workspaceId, input.sessionId);
+          return context.terminalService.openWindow(
+            input.workspaceId,
+            input.sessionId,
+            input.initialTitle
+          );
         }),
       closeWindow: t
         .input(schemas.terminal.closeWindow.input)

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -777,6 +777,7 @@ const BACKED_UP_APPEARANCE_FIELDS = [
   "transcriptDensity",
   "bashCollapsedSummaryMode",
   "terminalFontConfig",
+  "terminalBadgeConfig",
   "vimEnabled",
 ] as const satisfies ReadonlyArray<keyof Appearance>;
 

--- a/src/node/services/terminalService.test.ts
+++ b/src/node/services/terminalService.test.ts
@@ -494,8 +494,8 @@ describe("TerminalService", () => {
 
   it("should open terminal window via manager", async () => {
     await service.openWindow("ws-1");
-    // openWindow(workspaceId, sessionId?) passes sessionId as undefined when not provided
-    expect(openTerminalWindowMock).toHaveBeenCalledWith("ws-1", undefined);
+    // openWindow(workspaceId, sessionId?, initialTitle?) passes undefined when not provided
+    expect(openTerminalWindowMock).toHaveBeenCalledWith("ws-1", undefined, undefined);
   });
 
   it("should handle session exit", async () => {

--- a/src/node/services/terminalService.ts
+++ b/src/node/services/terminalService.ts
@@ -345,7 +345,7 @@ export class TerminalService {
     }
   }
 
-  async openWindow(workspaceId: string, sessionId?: string): Promise<void> {
+  async openWindow(workspaceId: string, sessionId?: string, initialTitle?: string): Promise<void> {
     try {
       const allMetadata = await this.config.getAllWorkspaceMetadata();
       const workspace = allMetadata.find((w) => w.id === workspaceId);
@@ -362,7 +362,7 @@ export class TerminalService {
         log.info(
           `Opening terminal window for workspace: ${workspaceId}${sessionId ? ` (session: ${sessionId})` : ""}`
         );
-        await this.terminalWindowManager!.openTerminalWindow(workspaceId, sessionId);
+        await this.terminalWindowManager!.openTerminalWindow(workspaceId, sessionId, initialTitle);
       } else {
         log.info(
           `Browser mode: terminal UI handled by browser for ${isSSH ? "SSH" : "local"} workspace: ${workspaceId}`


### PR DESCRIPTION
Fixes #3607

## Summary

Adds an iTerm2-style "Terminal Badge": a configurable, scroll-fixed watermark overlay above every ghostty-web terminal surface (right-sidebar tabs and pop-out windows) that shows templated workspace/tab identity. Default OFF.

## Background

When working across multiple workspaces and multiple terminal tabs, nothing inside the terminal viewport identifies which workspace/tab you are in: prompt markers scroll away, the sidebar tab label is not visible while scrolling output, and ghostty's `background-image` is global. The badge is a DOM overlay (not scrollback content), so it stays fixed regardless of output volume or scroll position.

## Implementation

- `TerminalBadgeOverlay` renders as a sibling of the ghostty container inside the already-`position: relative` `.terminal-view`, with `pointer-events: none` + `user-select: none` so clicks, drags, and selection pass through to the canvas. Color comes from `var(--color-terminal-fg)`; opacity/position/size from config.
- Config (`terminalBadgeConfig`) follows the `terminalFontConfig` pattern end to end: storage key + normalizer in `src/common/constants/storage.ts`, zod schema in `userPreferences.ts`, preference sync in `userPreferencesStorage.ts`, backup projection in `payload.ts`.
- Template tokens: `{workspace}`, `{tab}`, `{project}`, `{index}`. `{tab}` mirrors the sidebar tab label (OSC 0/1/2 title, falling back to "Terminal N"); `{index}` is the stable 1-based tab position because interactive shells overwrite the OSC title on every prompt (dogfood UAT finding). Unknown `{tokens}` pass through so typos stay visible.
- Embedded path: RightSidebar passes the tab name/index it already computes; pop-out windows resolve workspace names via the existing `api.workspace.list()` document-title path and track the OSC title locally (`{index}` is empty there: the sidebar tab order is unknown to a pop-out).
- Settings UI in General (below Terminal Font Size): enable switch, template input, corner-position select, opacity (percent), font size. Also a command palette action "Toggle Terminal Badge".
- Stories: corner/opacity/truncation variants incl. a pinned phone-viewport truncation story.

## Validation

- `make static-check` green; targeted suites pass (badge template, storage normalizer, TerminalView badge rendering with mocked ghostty-web, commands sources, GeneralSection, preference storage, backup payload).
- Remote dogfood UAT on dev.coder.com (real workspace, real model): **PASS**. All nine acceptance scenarios verified through the UI, including DOM-rect-stable positioning during scrollback, `elementFromPoint` hit-testing returning the terminal canvas under the badge, live restyle without reload, per-tab OSC title isolation, pop-out rendering, and 375px truncation. The `{index}` token addresses the UAT finding that OSC titles make same-cwd tabs indistinguishable.
- Note: `tests/ui/storybook/budget.test.ts` (local-only, not in CI) was already failing on clean main (378 estimated snapshots vs cap 305, 88 files vs cap 79); this PR adds 1 story file / 4 snapshots on top of that pre-existing drift.

## Risks

Low. The overlay renders `null` unless explicitly enabled, so default behavior is unchanged. The riskiest touchpoint is `TerminalView` (shared by all terminal surfaces); changes there are additive props, a state-captured workspace-name resolution on the existing pop-out fetch, and an OSC-title state update that piggybacks on the existing `onTitleChange` subscription.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
