### PR TITLE
🤖 ci: fix merge-queue flake families (unit segfault double-run, integration oversubscription)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -286,17 +286,19 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           set -euo pipefail
 
-          # --maxWorkers=50%, not 100%: jest integration forks peak at ~4.7GiB each
-          # (scripts/lib/worker_budget.js), so 16 workers on the 16-core/64GB runner
-          # oversubscribe memory (~75GiB peak) and thrash. Under that load, wall clock
-          # inflates ~10-20x: suites that normally finish in seconds pass at 100-135s
-          # while tests with tight explicit timeouts (30-45s) die, which is what made
-          # focus/sendModeDropdown/anthropicCacheStrategy flake in the merge queue.
-          # 8 workers fit in memory with headroom and match the repo's own CPU budget.
+          # No --maxWorkers override: jest.config.js sizes the pool via
+          # workerBudgetFor("jest") (scripts/lib/worker_budget.js), which accounts for
+          # per-fork peak memory (~4.7GiB) and live cgroup usage. The old CLI
+          # --maxWorkers=100% took precedence over that budget and forked 16 workers
+          # on the 16-core/64GB runner (~75GiB peak), thrashing memory. Under that
+          # load, wall clock inflated ~10-20x: suites that normally finish in seconds
+          # passed at 100-135s while tests with tight explicit timeouts (30-45s) died,
+          # which is what made focus/sendModeDropdown/anthropicCacheStrategy flake in
+          # the merge queue.
 
           # Manual override (workflow_dispatch input)
           if [[ -n "${{ github.event.inputs.test_filter }}" ]]; then
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent ${{ github.event.inputs.test_filter }}
+            TEST_INTEGRATION=1 bun x jest --coverage --silent ${{ github.event.inputs.test_filter }}
             exit 0
           fi
 
@@ -309,11 +311,11 @@ jobs:
           # Backend changed: run ALL integration tests (includes tests/ui)
           if [[ "$BACKEND" == "true" ]]; then
             echo "Backend changes detected - running all integration tests"
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent tests/
+            TEST_INTEGRATION=1 bun x jest --coverage --silent tests/
           else
             # Browser-only changes: run tests/ui
             echo "Browser changes detected - running tests/ui"
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent tests/ui/
+            TEST_INTEGRATION=1 bun x jest --coverage --silent tests/ui/
           fi
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -239,18 +239,19 @@ jobs:
             done
           done
 
+          # Derive the exclusions from isolated_unit_tests so the two lists cannot
+          # drift. A hand-maintained duplicate list previously desynced: the QuickJS-heavy
+          # sandboxHostService.test.ts ran a second time inside this shared coverage
+          # process and segfaulted Bun mid-suite (merge-queue runs 32666269009 and
+          # 32667158072), kicking a fully green PR out of the queue.
+          find_excludes=()
+          for isolated_unit_test in "${isolated_unit_tests[@]}"; do
+            find_excludes+=(! -path "$isolated_unit_test")
+          done
+
           mapfile -d '' unit_files < <(
             find src -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) \
-              ! -path 'src/node/orpc/router.test.ts' \
-              ! -path 'src/node/services/workflows/WorkflowRunner.test.ts' \
-              ! -path 'src/node/services/ptc/quickjsRuntime.test.ts' \
-              ! -path 'src/node/services/agentPlugins/hookService.test.ts' \
-              ! -path 'src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx' \
-              ! -path 'src/browser/features/Messages/InlineSkillMarkdown.test.tsx' \
-              ! -path 'src/browser/hooks/useChatTranscriptFullWidth.test.tsx' \
-              ! -path 'src/browser/utils/commands/sources.test.ts' \
-              ! -path 'src/browser/components/CommandPalette/CommandPalette.prompt.test.tsx' \
-              ! -path 'src/browser/features/RightSidebar/Memory/MemoryTab.test.tsx' \
+              "${find_excludes[@]}" \
               -print0
           )
           bun test --max-concurrency=1 --coverage --coverage-reporter=lcov "${unit_files[@]}"
@@ -265,7 +266,13 @@ jobs:
     name: Test / Integration
     needs: [changes]
     if: ${{ (needs.changes.outputs.src == 'true' || needs.changes.outputs.config == 'true') && (github.event_name != 'push' || github.actor != 'github-merge-queue[bot]') }}
-    timeout-minutes: 10
+    # Healthy runs finish in ~4-5 min, but jest's integration testTimeout is 10 minutes,
+    # so a single hung test used to collide with a 10-minute job cap: the runner killed
+    # the job ("exceeded the maximum execution time of 10m0s") and destroyed all logs,
+    # repeatedly kicking green PRs from the merge queue (e.g. runs 32632804824,
+    # 32639270365, 32640298486). 20 minutes lets jest fail the hung test with real
+    # diagnostics and still bounds a wedged runner.
+    timeout-minutes: 20
     runs-on: ${{ github.repository_owner == 'coder' && 'depot-ubuntu-22.04-16' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -279,9 +286,17 @@ jobs:
         run: | # zizmor: ignore[template-injection]
           set -euo pipefail
 
+          # --maxWorkers=50%, not 100%: jest integration forks peak at ~4.7GiB each
+          # (scripts/lib/worker_budget.js), so 16 workers on the 16-core/64GB runner
+          # oversubscribe memory (~75GiB peak) and thrash. Under that load, wall clock
+          # inflates ~10-20x: suites that normally finish in seconds pass at 100-135s
+          # while tests with tight explicit timeouts (30-45s) die, which is what made
+          # focus/sendModeDropdown/anthropicCacheStrategy flake in the merge queue.
+          # 8 workers fit in memory with headroom and match the repo's own CPU budget.
+
           # Manual override (workflow_dispatch input)
           if [[ -n "${{ github.event.inputs.test_filter }}" ]]; then
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent ${{ github.event.inputs.test_filter }}
+            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent ${{ github.event.inputs.test_filter }}
             exit 0
           fi
 
@@ -294,11 +309,11 @@ jobs:
           # Backend changed: run ALL integration tests (includes tests/ui)
           if [[ "$BACKEND" == "true" ]]; then
             echo "Backend changes detected - running all integration tests"
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent tests/
+            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent tests/
           else
             # Browser-only changes: run tests/ui
             echo "Browser changes detected - running tests/ui"
-            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=100% --silent tests/ui/
+            TEST_INTEGRATION=1 bun x jest --coverage --maxWorkers=50% --silent tests/ui/
           fi
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/jest.config.js
+++ b/jest.config.js
@@ -44,6 +44,12 @@ module.exports = {
     "node_modules/(?!\\.pnpm)(?!.*)",
   ],
   maxWorkers,
+  // Integration suites leak memory across test files (app harnesses, DuckDB analytics
+  // workers), so a long-lived worker accumulates heap until it dies at V8's ~4GB cap
+  // ("Jest worker ran out of memory and crashed", PR #3939 CI run 32720490232). The
+  // fewer workers the budget selects, the more files each one runs and the sooner it
+  // crashes. Recycle any worker still holding >2GB when idle between test files.
+  workerIdleMemoryLimit: "2GB",
   // Force exit after tests complete to avoid hanging on lingering handles
   forceExit: true,
   // 10 minute timeout for integration tests, 10s for unit tests

--- a/tests/ipc/providers/anthropicCacheStrategy.test.ts
+++ b/tests/ipc/providers/anthropicCacheStrategy.test.ts
@@ -37,7 +37,10 @@ describeIntegration("Anthropic cache strategy integration", () => {
           thinkingLevel: "off",
         });
 
-        await firstCollector.waitForEvent("stream-end", 15000);
+        // Pass the suite budget: waitForEvent resolves null on timeout instead of
+        // throwing, so a shorter inner wait would silently null the end event and
+        // fail the toBeDefined assertions below with no useful diagnostics.
+        await firstCollector.waitForEvent("stream-end", TEST_TIMEOUT_MS);
         firstCollector.stop();
 
         // Send a second message to test cache reuse
@@ -52,7 +55,7 @@ describeIntegration("Anthropic cache strategy integration", () => {
           thinkingLevel: "off",
         });
 
-        await secondCollector.waitForEvent("stream-end", 15000);
+        await secondCollector.waitForEvent("stream-end", TEST_TIMEOUT_MS);
         secondCollector.stop();
 
         // Check that both streams completed successfully

--- a/tests/ipc/providers/anthropicCacheStrategy.test.ts
+++ b/tests/ipc/providers/anthropicCacheStrategy.test.ts
@@ -5,7 +5,11 @@ import { sendMessageWithModel, createStreamCollector, HAIKU_MODEL } from "../hel
 const hasAnthropicKey = Boolean(process.env.ANTHROPIC_API_KEY);
 const shouldRunSuite = shouldRunIntegrationTests() && hasAnthropicKey;
 const describeIntegration = shouldRunSuite ? describe : describe.skip;
-const TEST_TIMEOUT_MS = 45000; // 45s total: setup + 2 messages at 15s each
+// 120s total for setup + 2 live messages: 45s was calibrated for an idle machine, but
+// CI runners under merge-queue load inflate wall clock enough that it was exceeded
+// while sibling suites passed at 100s+ (merge-queue run 32665306160). Peer provider
+// tests already budget 45-150s per live call.
+const TEST_TIMEOUT_MS = 120000;
 
 if (shouldRunIntegrationTests() && !shouldRunSuite) {
   // eslint-disable-next-line no-console

--- a/tests/ui/layout/analyticsEscape.test.ts
+++ b/tests/ui/layout/analyticsEscape.test.ts
@@ -39,7 +39,7 @@ describe("Analytics Escape", () => {
             throw new Error("Workspace chat should be replaced by analytics");
           }
         },
-        { timeout: 10_000 }
+        { timeout: 30_000 }
       );
 
       // Press Escape to close analytics.
@@ -53,10 +53,13 @@ describe("Analytics Escape", () => {
             throw new Error("Workspace chat did not reappear after Escape");
           }
         },
-        { timeout: 10_000 }
+        { timeout: 30_000 }
       );
     } finally {
       await app.dispose();
     }
-  }, 60_000);
+    // 120s total (like focus/undo): CI runners under merge-queue load inflate wall
+    // clock enough that the 60s budget covering harness setup + interactions was
+    // exceeded at 66s (merge-queue run 32719185534) on a PR that never touched this area.
+  }, 120_000);
 });

--- a/tests/ui/review/focus.test.ts
+++ b/tests/ui/review/focus.test.ts
@@ -66,11 +66,14 @@ describeIntegration("ReviewPanel focus (UI + ORPC)", () => {
               throw new Error("Review panel not focused");
             }
           },
-          { timeout: 10_000 }
+          { timeout: 30_000 }
         );
       } finally {
         await cleanupView(view, cleanupDom);
       }
     });
-  }, 30_000);
+    // 120s total (like undo.test.ts): CI runners under merge-queue load inflate wall
+    // clock enough that a 30s budget covering workspace setup + render was exceeded
+    // while sibling suites passed at 100s+ (merge-queue run 32715740782).
+  }, 120_000);
 });


### PR DESCRIPTION
## Summary

Fixes the three mechanisms that have been kicking fully validated PRs out of the merge queue: a unit-job Bun segfault caused by a desynced test-file exclusion list, integration-job cancellation caused by the job timeout colliding with jest's own test timeout, and integration test flakes caused by jest worker memory oversubscription on CI runners.

## Background

Recent merge-queue evidence (all on green PRs whose diffs never touched the failing areas):

1. **Test / Unit segfault** (mq runs 32666269009, 32667158072, both kicked PR #3937): every test passes, then Bun 1.3.5 panics with `Segmentation fault` (exit 132). The logs show the crash is not teardown noise: it happens mid-`SandboxHostService` suite inside the monolithic coverage run. `src/node/services/sandbox/sandboxHostService.test.ts` was added to the `isolated_unit_tests` list in #3865 (QuickJS-heavy suites are known to crash Bun under coverage in a shared process) but was never added to the hand-maintained duplicate `find` exclusion list, so the suite ran a **second time** inside the shared process, where it segfaults intermittently.
2. **Test / Integration cancelled at the job cap** (mq runs 32632804824, 32639270365, 32640298486, kicking PRs #3931/#3930): the check-run annotation reads "The job has exceeded the maximum execution time of 10m0s". Healthy runs finish in ~4-5 min, but jest's integration `testTimeout` is 10 minutes (`jest.config.js`), so any single hung test makes jest wait right through the 10-minute job cap; the runner then kills the job and destroys all diagnostics.
3. **Recurring integration flakes** (`focus.test.ts` in run 32715740782 kicking PR #3932, `sendModeDropdown.test.ts` in run 32666269009, `anthropicCacheStrategy.test.ts` in run 32665306160, plus `analyticsEscape.test.ts` at 66s of its 60s budget in run 32719185534 kicking PR #3932's attempt 5, plus earlier `undo.test.ts`/`analyticsHeader.test.ts` kicks): all share one mechanism. CI runs jest with `--maxWorkers=100%`: 16 forked workers on the 16-core/64GB runner at ~4.7GiB peak each (per `scripts/lib/worker_budget.js`) oversubscribes memory (~75GiB peak) and thrashes. In the failing logs, suites that normally finish in seconds *pass* at 100-135s wall time while the only tests that *fail* are the ones with tight explicit timeouts (30s/45s), timing out in setup. The `--maxWorkers=100%` flag predates the repo's memory-aware worker budget (#1326 vs #3760), so CI never got the sizing fix that local runs already use.

## Implementation

- **Unit job**: derive the `find` exclusions from the `isolated_unit_tests` array instead of maintaining a duplicate list, so the two can never drift again. This removes the double-run of the crashing suite (and fixes the whole desync class rather than one instance). No exit-code masking anywhere: a genuinely failing test still fails the job exactly as before.
- **Integration job**: dropped the CLI `--maxWorkers` override so `jest.config.js`'s memory- and cgroup-aware `workerBudgetFor("jest")` sizes the pool (per Codex review; CLI flags take precedence over config), and `timeout-minutes: 10` → `20` so a hung test hits jest's 10-minute `testTimeout` and produces a real failure with logs instead of a log-destroying job cancellation.
- **Worker recycling**: the first PR CI run under the bounded budget surfaced the complementary failure mode: integration suites leak memory across test files, so with fewer workers each one accumulates heap until it dies at V8's ~4GB cap (“Jest worker ran out of memory and crashed”, run 32720490232). `workerIdleMemoryLimit: "2GB"` recycles leaky workers between files.
- **Tightest observed-killed test timeouts**: `focus.test.ts` 30s → 120s (aligned with its sibling `undo.test.ts`) `anthropicCacheStrategy.test.ts` 45s → 120s (peer provider tests already budget 45-150s per live call), and `analyticsEscape.test.ts` 60s → 120s after it died at 66s in run 32719185534. Other flagged tests already use the harness's 30s windows and should recover via the worker fix; they were left untouched to avoid churn.

Live-API tests (e.g. `anthropicCacheStrategy`) are deliberately **not** excluded from `merge_group`: the mq run is the last gate that executes tests for the merged combination (main-push runs skip test jobs for the merge-queue bot), so quarantining them there would remove real coverage. The single observed kick was timeout-tuning, not provider outage.

## Validation

- Red-green proof of the file-selection change: reproduced the old `find` invocation and the new derived one side by side; the old list contains `sandboxHostService.test.ts` (the double-run), the new list differs by exactly that one file (759 → 758, no other adds/removes).
- `TEST_INTEGRATION=1 bun x jest tests/ui/review/focus.test.ts tests/ipc/providers/anthropicCacheStrategy.test.ts` passes locally (2/2, including the live Anthropic call).
- `make lint-actions` (actionlint + zizmor) and `make static-check` pass.

## Risks

CI-config only plus two test-timeout constants; no production code. The main tradeoff is failure-detection latency: a genuinely hung integration run is now killed at 20 min instead of 10 (but now with jest diagnostics at the 10-minute testTimeout), and the two touched tests take up to 120s before reporting a real hang. Suite wall time at 8 workers may shift slightly in either direction (less thrash, fewer lanes); healthy runs have ample headroom against the 20-minute cap either way.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->


