### PR TITLE
🤖 fix: return transcript to bottom when canceling a message edit

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -995,7 +995,12 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
 
   const handleCancelEdit = useCallback(() => {
     setEditingMessage(undefined);
-  }, [setEditingMessage]);
+    // handleEditLastUserMessage disabled auto-scroll to keep the view centered
+    // on the edited message. Dismissing the edit hands scroll ownership back to
+    // the transcript tail; without this the view stays scrolled up until the
+    // user manually returns to the bottom.
+    jumpToBottom();
+  }, [jumpToBottom, setEditingMessage]);
 
   const handleMessageSendStarted = useCallback(() => {
     // Re-arm and pin before the send request crosses the IPC boundary. Waiting for


### PR DESCRIPTION
## Summary

Pressing ArrowUp to edit the last user message scrolls that message to the center of the transcript and disables auto-scroll. Sending the edit re-arms auto-scroll, but canceling (Escape) only cleared edit state, so the transcript stayed scrolled up until the user manually returned to the bottom. Canceling an edit now calls `jumpToBottom()`, handing scroll ownership back to the transcript tail.

## Background

`handleEditLastUserMessage` intentionally disables auto-scroll so the edited message stays centered while composing. The send path restores bottom ownership through `handleMessageSent`, but `handleCancelEdit` did not, leaving a one-way scroll state after Escape.

## Implementation

`handleCancelEdit` in `ChatPane.tsx` now invokes `jumpToBottom()` from `useAutoScroll` after clearing edit state. This matches the existing post-send behavior: it re-arms auto-scroll, pins the sentinel to the bottom, and re-engages native CSS scroll anchoring.

## Validation

- Reproduced the stuck-scroll behavior by tracing both exit paths of the edit flow in code.
- `make static-check` passes locally.
- `bun test src/browser/hooks/useAutoScroll.test.tsx`: 24 pass.

---

_Generated with `xum` • Model: `openrouter:stealth/ox-alpha` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openrouter:stealth/ox-alpha thinking=xhigh costs=$0.00 -->
