### PR TITLE
🤖 fix: clamp model selector dropdown height to stay below the top bar

### DIFF
--- a/src/browser/components/ModelSelector/ModelSelector.tsx
+++ b/src/browser/components/ModelSelector/ModelSelector.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useImperativeHandle,
   forwardRef,
@@ -36,6 +37,15 @@ import {
 } from "@/common/utils/ai/models";
 import { Button } from "../Button/Button";
 import { modelMatchesQuery } from "./modelFilter";
+import { DESKTOP_TITLEBAR_HEIGHT_PX } from "@/browser/hooks/useDesktopTitlebar";
+
+// The dropdown opens upward, so in short windows it can extend past the top of
+// the viewport and under the title/menu bar (a window-drag region in desktop
+// mode that swallows clicks). Clamp its height to the space above the trigger,
+// keeping clear of the bar.
+const PANEL_TOP_CLEARANCE_PX = DESKTOP_TITLEBAR_HEIGHT_PX + 8;
+// Below this the panel is unusable; prefer slight bar overlap in pathological layouts.
+const PANEL_MIN_HEIGHT_PX = 150;
 
 interface ModelSelectorProps {
   value: string;
@@ -101,6 +111,22 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
       setShowAllModels(false);
       setHighlightedIndex(0);
     }, []);
+
+    // Clamp the panel to the space above the trigger so it stays fully visible.
+    const [panelMaxHeight, setPanelMaxHeight] = useState<number | null>(null);
+    useLayoutEffect(() => {
+      if (!isOpen) return;
+
+      const updatePanelMaxHeight = () => {
+        const triggerTop = containerRef.current?.getBoundingClientRect().top;
+        if (triggerTop === undefined) return;
+        setPanelMaxHeight(Math.max(triggerTop - PANEL_TOP_CLEARANCE_PX, PANEL_MIN_HEIGHT_PX));
+      };
+
+      updatePanelMaxHeight();
+      window.addEventListener("resize", updatePanelMaxHeight);
+      return () => window.removeEventListener("resize", updatePanelMaxHeight);
+    }, [isOpen]);
 
     // Close dropdown on outside click
     useEffect(() => {
@@ -377,13 +403,14 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
         {/* Dropdown content - rendered inline for testability */}
         {isOpen && (
           <div
+            style={panelMaxHeight != null ? { maxHeight: panelMaxHeight } : undefined}
             className={cn(
-              "absolute bottom-full left-0 z-[1020] mb-1 w-82",
+              "absolute bottom-full left-0 z-[1020] mb-1 flex w-82 flex-col",
               COMPOSER_PICKER_PANEL_CLASS
             )}
           >
             {/* Search input */}
-            <div className="border-border-light border-b px-2.5 py-1.5">
+            <div className="border-border-light shrink-0 border-b px-2.5 py-1.5">
               <input
                 ref={inputRef}
                 type="text"
@@ -397,7 +424,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
             </div>
 
             {/* Scrollable list */}
-            <div ref={listRef} className="max-h-[280px] overflow-y-auto py-1">
+            <div ref={listRef} className="max-h-[280px] min-h-0 overflow-y-auto py-1">
               {filteredModels.length === 0 ? (
                 <div className="text-muted py-2 text-center text-[10px]">No matching models</div>
               ) : (
@@ -540,7 +567,7 @@ export const ModelSelector = forwardRef<ModelSelectorRef, ModelSelectorProps>(
 
             {/* Footer actions (last row in dropdown) */}
             {(hiddenModels.length > 0 || onOpenSettings) && (
-              <div className="border-border-light flex flex-col gap-1 border-t py-1">
+              <div className="border-border-light flex shrink-0 flex-col gap-1 border-t py-1">
                 {hiddenModels.length > 0 && (
                   <button
                     type="button"

--- a/src/browser/hooks/useDesktopTitlebar.ts
+++ b/src/browser/hooks/useDesktopTitlebar.ts
@@ -51,11 +51,16 @@ export const MAC_TRAFFIC_LIGHTS_INSET = 80;
 export const WIN_LINUX_OVERLAY_INSET = 138;
 
 /**
+ * Desktop titlebar height in pixels. Keep in sync with the Tailwind classes below.
+ */
+export const DESKTOP_TITLEBAR_HEIGHT_PX = 36;
+
+/**
  * Tailwind height classes for the desktop titlebar.
  * Use these in components that need to align with the titlebar height.
  */
-export const DESKTOP_TITLEBAR_HEIGHT_CLASS = "h-9"; // 36px
-export const DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS = "min-h-9"; // 36px
+export const DESKTOP_TITLEBAR_HEIGHT_CLASS = "h-9";
+export const DESKTOP_TITLEBAR_MIN_HEIGHT_CLASS = "min-h-9";
 
 /**
  * Returns the left inset needed for macOS traffic lights.


### PR DESCRIPTION
## Summary

The model selector dropdown could render partially or fully under the top bar, hiding its search input and top items. The panel now measures the space above its trigger when it opens and clamps its height so it always fits below the bar, with only the model list shrinking and scrolling.

## Background

The dropdown opens upward (`absolute bottom-full`) with a fixed 280px list plus a search header and footer, and nothing constrained it to the viewport. In short windows, or wherever the composer sits high (for example the new-workspace page), the panel top extended past the window top and under the title/menu bar. The auto-focused search input became invisible, and in desktop mode the bar is a window-drag region, so the overlapped part could not even receive clicks.

## Implementation

- `ModelSelector` runs a layout effect when the dropdown opens: it reads the trigger's viewport position and caps the panel `max-height` to the space above it, keeping clear of the titlebar height plus a small gap. It re-measures on window resize.
- The panel is now a flex column; the search header and footer are `shrink-0`, so only the model list shrinks and scrolls. The existing 280px list cap still applies when space allows.
- A 150px floor keeps the panel usable in pathological layouts (slight bar overlap is preferred over an unusably short panel).
- `useDesktopTitlebar.ts` exports the titlebar height as a numeric constant alongside the existing Tailwind classes.

The sibling pickers (`AgentModePicker`, `ThinkingSelector`) share the upward-opening pattern but are short enough not to hit this in practice; they are left unchanged to keep the diff minimal.

## Validation

Reproduced and verified visually in Storybook (`ModelSelectorDropdownOpen` story) at a 900x400 viewport, where the old code placed the panel top ~38px above the window: the full panel (search input, scrollable list, footer) now fits between the top bar and the trigger.

No unit test added: happy-dom cannot do layout, so the only possible assertion would restate the clamp arithmetic against a mocked rect.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
