### PR TITLE
🤖 feat: mobile timeline dialog for small viewports

### DIFF
--- a/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
+++ b/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
@@ -3,6 +3,7 @@ import { ArchiveIcon } from "../icons/ArchiveIcon/ArchiveIcon";
 import {
   GitBranch,
   HeartPulse,
+  History,
   Maximize2,
   Pencil,
   Pin,
@@ -52,6 +53,8 @@ interface WorkspaceActionsMenuContentProps {
   /** Mobile workspace-header action: open immersive review in full-screen touch mode. */
   onOpenTouchFullscreenReview?: (() => void) | null;
   onEnterImmersiveReview?: (() => void) | null;
+  /** Small-viewport action: open the timeline dialog (the right sidebar hosting the tab is hidden there). */
+  onOpenTimeline?: (() => void) | null;
   onStopRuntime?: (() => void) | null;
   onForkChat?: ((anchorEl: HTMLElement) => void) | null;
   /** Pin/unpin toggle; pass null on sub-agent rows (only root chats are pinnable). */
@@ -132,6 +135,18 @@ export const WorkspaceActionsMenuContent: React.FC<WorkspaceActionsMenuContentPr
             props.onCloseMenu();
             props.onEnterImmersiveReview?.();
           }}
+        />
+      )}
+      {props.onOpenTimeline && (
+        <WorkspaceActionButton
+          label="Timeline"
+          icon={<History className="h-3 w-3 shrink-0" />}
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onCloseMenu();
+            props.onOpenTimeline?.();
+          }}
+          testId="workspace-timeline-button"
         />
       )}
       {props.onStopRuntime && (

--- a/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
+++ b/src/browser/components/WorkspaceActionsMenuContent/WorkspaceActionsMenuContent.tsx
@@ -140,6 +140,8 @@ export const WorkspaceActionsMenuContent: React.FC<WorkspaceActionsMenuContentPr
       {props.onOpenTimeline && (
         <WorkspaceActionButton
           label="Timeline"
+          shortcut={formatKeybind(KEYBINDS.OPEN_TIMELINE_DIALOG)}
+          shortcutClassName={props.shortcutClassName}
           icon={<History className="h-3 w-3 shrink-0" />}
           onClick={(e) => {
             e.stopPropagation();

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -31,8 +31,8 @@ import * as SkillIndicatorModule from "../SkillIndicator/SkillIndicator";
 import * as TimelineDialogModule from "@/browser/features/RightSidebar/Timeline/TimelineDialog";
 
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
-import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
-import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import type * as ExperimentsModuleType from "@/browser/hooks/useExperiments";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import {
   NARROW_VIEWPORT_MAX_WIDTH_PX,
   WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX,
@@ -112,7 +112,21 @@ let archiveWorkspaceMock = mock(
 );
 let archiveShowErrorMock = mock(() => undefined);
 
+// Timeline gate control. useExperimentValue must be module-mocked, not driven through
+// localStorage: bun module mocks are process-global, so another test file's leaked
+// useExperiments mock would otherwise override the real hook and poison these gates.
+let mockTimelineExperimentEnabled = false;
+
 function installWorkspaceMenuBarTestDoubles() {
+  const actualExperiments =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("@/browser/hooks/useExperiments?real=1") as typeof ExperimentsModuleType;
+  void mock.module("@/browser/hooks/useExperiments", () => ({
+    ...actualExperiments,
+    useExperimentValue: (experimentId: string) =>
+      experimentId === EXPERIMENT_IDS.TIMELINE && mockTimelineExperimentEnabled,
+  }));
+
   preflightArchiveWorkspaceMock = mock(
     (_workspaceId: string): Promise<ArchivePreflightActionResult> => resolveArchivePreflight()
   );
@@ -324,6 +338,7 @@ const defaultProps: ComponentProps<typeof WorkspaceMenuBarComponent> = {
 describe("WorkspaceMenuBar archive confirmations", () => {
   beforeEach(() => {
     workspaceMetadata = new Map();
+    mockTimelineExperimentEnabled = false;
     cleanupDom = installDom();
     installWorkspaceMenuBarTestDoubles();
     /* eslint-disable @typescript-eslint/no-require-imports */
@@ -413,7 +428,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("offers the Timeline action on narrow viewports and opens the dialog", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
 
     render(<WorkspaceMenuBar {...defaultProps} />);
@@ -431,7 +446,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("hides the Timeline action on wide viewports", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     stubMatchMedia(() => false);
 
     render(<WorkspaceMenuBar {...defaultProps} />);
@@ -448,7 +463,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("offers the Timeline action when the shell container hides the sidebar at wide viewports", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     stubMatchMedia(() => false);
 
     // Mimic WorkspaceShell: the shell wraps the menu bar and a CSS-hidden right sidebar
@@ -470,7 +485,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("re-gates the Timeline action when the viewport crosses the narrow breakpoint", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     let narrow = false;
     const media = stubMatchMedia(
       (query) => narrow && query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`
@@ -488,7 +503,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("opens the timeline dialog with the keyboard shortcut on narrow viewports", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
 
     render(<WorkspaceMenuBar {...defaultProps} />);
@@ -502,7 +517,7 @@ describe("WorkspaceMenuBar archive confirmations", () => {
   });
 
   it("ignores the timeline shortcut while the sidebar is visible", () => {
-    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    mockTimelineExperimentEnabled = true;
     stubMatchMedia(() => false);
 
     render(<WorkspaceMenuBar {...defaultProps} />);

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -529,6 +529,71 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     expect(getLastTimelineDialogProps()?.open).toBe(false);
   });
 
+  it("ignores the timeline shortcut while another modal is open", () => {
+    mockTimelineExperimentEnabled = true;
+    stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+
+    const modal = document.createElement("div");
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
+    document.body.appendChild(modal);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "T", shiftKey: true });
+    });
+
+    expect(getLastTimelineDialogProps()?.open).toBe(false);
+    modal.remove();
+  });
+
+  it("closes the timeline dialog when switching workspaces", () => {
+    mockTimelineExperimentEnabled = true;
+    stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+
+    const view = render(<WorkspaceMenuBar {...defaultProps} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "T", shiftKey: true });
+    });
+    expect(getLastTimelineDialogProps()?.open).toBe(true);
+
+    // The timeline's "Open child workspace" action swaps the selected workspace while
+    // App reuses this menu bar instance; the dialog must not cover the new workspace.
+    view.rerender(<WorkspaceMenuBar {...defaultProps} workspaceId="workspace-2" />);
+
+    expect(getLastTimelineDialogProps()?.open).toBe(false);
+  });
+
+  it("keeps the Timeline action hidden when immersive review hides the sidebar", () => {
+    mockTimelineExperimentEnabled = true;
+    stubMatchMedia(() => false);
+
+    // Immersive review hides the sidebar via the same display:none but marks it
+    // aria-hidden; the gate must not treat that as a responsive (narrow) layout.
+    const shell = document.createElement("div");
+    shell.setAttribute("data-workspace-shell", "");
+    document.body.appendChild(shell);
+    const sidebar = document.createElement("div");
+    sidebar.className = "mobile-hide-right-sidebar";
+    sidebar.style.display = "none";
+    sidebar.setAttribute("aria-hidden", "true");
+    shell.appendChild(sidebar);
+    const mount = document.createElement("div");
+    shell.appendChild(mount);
+
+    render(<WorkspaceMenuBar {...defaultProps} />, { container: mount });
+
+    expect(getLastMenuContentProps()?.onOpenTimeline).toBeNull();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "T", shiftKey: true });
+    });
+    expect(getLastTimelineDialogProps()?.open).toBe(false);
+    shell.remove();
+  });
+
   it("applies the collapsed-left-sidebar inset immediately from props", () => {
     const view = render(<WorkspaceMenuBar {...defaultProps} leftSidebarCollapsed />);
 

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -278,19 +278,35 @@ function getLastTimelineDialogProps() {
   return spy.mock.calls.at(-1)?.[0];
 }
 
-/** Replace window.matchMedia so viewport-gated actions can be exercised per test. */
+/**
+ * Replace window.matchMedia so viewport-gated actions can be exercised per test.
+ * `matches` is re-read on every access and registered change listeners are returned
+ * so tests can simulate live viewport transitions.
+ */
 function stubMatchMedia(matches: (query: string) => boolean) {
+  const changeListeners: Array<() => void> = [];
   window.matchMedia = ((query: string) =>
     ({
-      matches: matches(query),
+      get matches() {
+        return matches(query);
+      },
       media: query,
       onchange: null,
       addListener: () => undefined,
       removeListener: () => undefined,
-      addEventListener: () => undefined,
+      addEventListener: (_type: string, listener: () => void) => {
+        changeListeners.push(listener);
+      },
       removeEventListener: () => undefined,
       dispatchEvent: () => false,
     }) as unknown as MediaQueryList) as typeof window.matchMedia;
+  return {
+    fireChange: () => {
+      for (const listener of changeListeners) {
+        listener();
+      }
+    },
+  };
 }
 
 const defaultProps: ComponentProps<typeof WorkspaceMenuBarComponent> = {
@@ -447,13 +463,28 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     const mount = document.createElement("div");
     shell.appendChild(mount);
 
-    const view = render(<WorkspaceMenuBar {...defaultProps} />, { container: mount });
-    // First render computes the gate before the menu bar ref attaches; any re-render
-    // (opening the More menu in production) re-evaluates it against the shell.
-    view.rerender(<WorkspaceMenuBar {...defaultProps} />);
+    render(<WorkspaceMenuBar {...defaultProps} />, { container: mount });
 
     expect(typeof getLastMenuContentProps()?.onOpenTimeline).toBe("function");
     shell.remove();
+  });
+
+  it("re-gates the Timeline action when the viewport crosses the narrow breakpoint", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    let narrow = false;
+    const media = stubMatchMedia(
+      (query) => narrow && query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`
+    );
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+    expect(getLastMenuContentProps()?.onOpenTimeline).toBeNull();
+
+    narrow = true;
+    act(() => {
+      media.fireChange();
+    });
+
+    expect(typeof getLastMenuContentProps()?.onOpenTimeline).toBe("function");
   });
 
   it("opens the timeline dialog with the keyboard shortcut on narrow viewports", () => {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -564,6 +564,12 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     view.rerender(<WorkspaceMenuBar {...defaultProps} workspaceId="workspace-2" />);
 
     expect(getLastTimelineDialogProps()?.open).toBe(false);
+
+    // Returning to the original workspace must not resurrect the dialog: the
+    // retained id is cleared on leave, not merely masked by the comparison.
+    view.rerender(<WorkspaceMenuBar {...defaultProps} />);
+
+    expect(getLastTimelineDialogProps()?.open).toBe(false);
   });
 
   it("keeps the Timeline action hidden when immersive review hides the sidebar", () => {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -431,6 +431,58 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     expect(getLastMenuContentProps()?.onOpenTimeline).toBeNull();
   });
 
+  it("offers the Timeline action when the shell container hides the sidebar at wide viewports", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    stubMatchMedia(() => false);
+
+    // Mimic WorkspaceShell: the shell wraps the menu bar and a CSS-hidden right sidebar
+    // (the <=684px container query), which the gate reads via computed style.
+    const shell = document.createElement("div");
+    shell.setAttribute("data-workspace-shell", "");
+    document.body.appendChild(shell);
+    const sidebar = document.createElement("div");
+    sidebar.className = "mobile-hide-right-sidebar";
+    sidebar.style.display = "none";
+    shell.appendChild(sidebar);
+    const mount = document.createElement("div");
+    shell.appendChild(mount);
+
+    const view = render(<WorkspaceMenuBar {...defaultProps} />, { container: mount });
+    // First render computes the gate before the menu bar ref attaches; any re-render
+    // (opening the More menu in production) re-evaluates it against the shell.
+    view.rerender(<WorkspaceMenuBar {...defaultProps} />);
+
+    expect(typeof getLastMenuContentProps()?.onOpenTimeline).toBe("function");
+    shell.remove();
+  });
+
+  it("opens the timeline dialog with the keyboard shortcut on narrow viewports", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "T", shiftKey: true });
+    });
+
+    const dialogProps = getLastTimelineDialogProps();
+    expect(dialogProps?.open).toBe(true);
+  });
+
+  it("ignores the timeline shortcut while the sidebar is visible", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    stubMatchMedia(() => false);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "T", shiftKey: true });
+    });
+
+    expect(getLastTimelineDialogProps()?.open).toBe(false);
+  });
+
   it("applies the collapsed-left-sidebar inset immediately from props", () => {
     const view = render(<WorkspaceMenuBar {...defaultProps} leftSidebarCollapsed />);
 

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.test.tsx
@@ -28,9 +28,15 @@ import * as PopoverErrorModule from "../PopoverError/PopoverError";
 import * as WorkspaceActionsMenuContentModule from "../WorkspaceActionsMenuContent/WorkspaceActionsMenuContent";
 import * as WorkspaceTerminalIconModule from "../icons/WorkspaceTerminalIcon/WorkspaceTerminalIcon";
 import * as SkillIndicatorModule from "../SkillIndicator/SkillIndicator";
+import * as TimelineDialogModule from "@/browser/features/RightSidebar/Timeline/TimelineDialog";
 
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
-import { WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX } from "@/constants/layout";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
+import {
+  NARROW_VIEWPORT_MAX_WIDTH_PX,
+  WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX,
+} from "@/constants/layout";
 
 let WorkspaceMenuBar!: typeof WorkspaceMenuBarComponent;
 
@@ -53,6 +59,7 @@ function getLastMenuContentProps() {
             onForkChat?: ((anchorEl: HTMLElement) => void) | null;
             onEnterImmersiveReview?: (() => void) | null;
             onOpenTouchFullscreenReview?: (() => void) | null;
+            onOpenTimeline?: (() => void) | null;
           },
         ]
       >;
@@ -257,6 +264,33 @@ function installWorkspaceMenuBarTestDoubles() {
   spyOn(SkillIndicatorModule, "SkillIndicator").mockImplementation(
     (() => null) as unknown as typeof SkillIndicatorModule.SkillIndicator
   );
+  spyOn(TimelineDialogModule, "TimelineDialog").mockImplementation(
+    (() => null) as unknown as typeof TimelineDialogModule.TimelineDialog
+  );
+}
+
+// Records render props like the WorkspaceActionsMenuContent double, so tests can
+// assert the dialog opened without rendering the real timeline panel.
+function getLastTimelineDialogProps() {
+  const spy = TimelineDialogModule.TimelineDialog as unknown as {
+    mock: { calls: Array<[{ workspaceId: string; open: boolean }]> };
+  };
+  return spy.mock.calls.at(-1)?.[0];
+}
+
+/** Replace window.matchMedia so viewport-gated actions can be exercised per test. */
+function stubMatchMedia(matches: (query: string) => boolean) {
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: matches(query),
+      media: query,
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
 }
 
 const defaultProps: ComponentProps<typeof WorkspaceMenuBarComponent> = {
@@ -360,6 +394,41 @@ describe("WorkspaceMenuBar archive confirmations", () => {
     const menuProps = getLastMenuContentProps();
     expect(typeof menuProps?.onForkChat).toBe("function");
     expect(typeof menuProps?.onEnterImmersiveReview).toBe("function");
+  });
+
+  it("offers the Timeline action on narrow viewports and opens the dialog", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    const menuProps = getLastMenuContentProps();
+    expect(typeof menuProps?.onOpenTimeline).toBe("function");
+
+    act(() => {
+      menuProps?.onOpenTimeline?.();
+    });
+
+    const dialogProps = getLastTimelineDialogProps();
+    expect(dialogProps?.open).toBe(true);
+    expect(dialogProps?.workspaceId).toBe(workspaceId);
+  });
+
+  it("hides the Timeline action on wide viewports", () => {
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+    stubMatchMedia(() => false);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    expect(getLastMenuContentProps()?.onOpenTimeline).toBeNull();
+  });
+
+  it("hides the Timeline action when the timeline experiment is disabled", () => {
+    stubMatchMedia((query) => query === `(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+
+    render(<WorkspaceMenuBar {...defaultProps} />);
+
+    expect(getLastMenuContentProps()?.onOpenTimeline).toBeNull();
   });
 
   it("applies the collapsed-left-sidebar inset immediately from props", () => {

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -48,7 +48,11 @@ import { forkWorkspace } from "@/browser/utils/chatCommands";
 import { SCRATCH_PROJECT_CONFIG_KEY, SCRATCH_PROJECT_NAME } from "@/common/constants/scratch";
 import { hasWorkspaceRepository } from "@/browser/utils/workspaceCapabilities";
 import { stopKeyboardPropagation } from "@/browser/utils/events";
-import { WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX } from "@/constants/layout";
+import {
+  NARROW_VIEWPORT_MAX_WIDTH_PX,
+  WORKSPACE_MENU_BAR_LEFT_SIDEBAR_COLLAPSED_PADDING_PX,
+} from "@/constants/layout";
+import { TimelineDialog } from "@/browser/features/RightSidebar/Timeline/TimelineDialog";
 import type { AgentSkillDescriptor, AgentSkillIssue } from "@/common/types/agentSkill";
 
 interface WorkspaceMenuBarProps {
@@ -91,6 +95,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const { preflightArchiveWorkspace, archiveWorkspace, setWorkspacePinned } = useWorkspaceActions();
   const { workspaceMetadata } = useWorkspaceContext();
   const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
+  const timelineExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.TIMELINE);
   const openTerminalPopout = useOpenTerminal();
   const openInEditor = useOpenInEditor();
   const runtimeStatus = useRuntimeStatus(workspaceId);
@@ -117,6 +122,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const [debugLlmRequestOpen, setDebugLlmRequestOpen] = useState(false);
   const [mcpModalOpen, setMcpModalOpen] = useState(false);
   const [heartbeatModalOpen, setHeartbeatModalOpen] = useState(false);
+  const [timelineDialogOpen, setTimelineDialogOpen] = useState(false);
   const [availableSkills, setAvailableSkills] = useState<AgentSkillDescriptor[]>([]);
   const [invalidSkills, setInvalidSkills] = useState<AgentSkillIssue[]>([]);
   const isSkillsMountedRef = useRef(true);
@@ -175,6 +181,12 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const isTouchMobileScreen =
     typeof window !== "undefined" &&
     window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
+
+  // Any pointer type: the right sidebar (home of the Timeline tab) is CSS-hidden
+  // at this width, so the timeline needs a dialog entry point instead.
+  const isNarrowScreen =
+    typeof window !== "undefined" &&
+    window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
 
   const isDevcontainerWorkspace = isDevcontainerRuntime(runtimeConfig);
   const isRuntimeRunning = isDevcontainerWorkspace && runtimeStatus === "running";
@@ -749,6 +761,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               onEnterImmersiveReview={
                 hasRepository && !isTouchMobileScreen ? handleEnterImmersiveReview : null
               }
+              onOpenTimeline={
+                timelineExperimentEnabled && isNarrowScreen
+                  ? () => setTimelineDialogOpen(true)
+                  : null
+              }
               onStopRuntime={isRuntimeRunning ? () => void handleStopRuntime() : null}
               // Scratch chats have no repo: review events are ignored by
               // RightSidebar and fork is unsupported on the backend, so hide
@@ -796,6 +813,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
         projectPath={projectPath}
         open={mcpModalOpen}
         onOpenChange={setMcpModalOpen}
+      />
+      <TimelineDialog
+        workspaceId={workspaceId}
+        open={timelineDialogOpen}
+        onOpenChange={setTimelineDialogOpen}
       />
       <DebugLlmRequestModal
         workspaceId={workspaceId}

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -207,6 +207,28 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
     return window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
   }, []);
 
+  // Keep the gate reactive: resizing re-evaluates CSS instantly, but a render-time read
+  // would leave the More menu stale until an unrelated state update. The media-query
+  // listener covers viewport transitions and the ResizeObserver covers the shell
+  // container query (e.g. expanding the left sidebar squeezes the shell under 684px).
+  const [timelineSidebarHidden, setTimelineSidebarHidden] = useState(false);
+  useEffect(() => {
+    const compute = () => setTimelineSidebarHidden(isTimelineSidebarHidden());
+    compute();
+    const mql = window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`);
+    mql.addEventListener("change", compute);
+    const shell = menuBarRef.current?.closest("[data-workspace-shell]");
+    let resizeObserver: ResizeObserver | undefined;
+    if (shell instanceof HTMLElement && typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(compute);
+      resizeObserver.observe(shell);
+    }
+    return () => {
+      mql.removeEventListener("change", compute);
+      resizeObserver?.disconnect();
+    };
+  }, [isTimelineSidebarHidden]);
+
   // The dialog is the only timeline entry point while the sidebar is hidden, and every
   // operation needs a keyboard shortcut. Evaluated at keydown time so the gate tracks
   // live viewport/layout changes without a resize subscription.
@@ -804,7 +826,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
                 hasRepository && !isTouchMobileScreen ? handleEnterImmersiveReview : null
               }
               onOpenTimeline={
-                timelineExperimentEnabled && isTimelineSidebarHidden()
+                timelineExperimentEnabled && timelineSidebarHidden
                   ? () => setTimelineDialogOpen(true)
                   : null
               }

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -131,6 +131,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   // Keyed by workspace so switching workspaces (e.g. the timeline's "Open child
   // workspace" action) implicitly closes the dialog instead of covering the new view.
   const [timelineDialogWorkspaceId, setTimelineDialogWorkspaceId] = useState<string | null>(null);
+  if (timelineDialogWorkspaceId !== null && timelineDialogWorkspaceId !== workspaceId) {
+    // Render-time adjustment (not an effect): leaving the dialog's workspace closes it
+    // for good; merely deriving open=false would reopen it when navigating back.
+    setTimelineDialogWorkspaceId(null);
+  }
   const timelineDialogOpen = timelineDialogWorkspaceId === workspaceId;
   const [availableSkills, setAvailableSkills] = useState<AgentSkillDescriptor[]>([]);
   const [invalidSkills, setInvalidSkills] = useState<AgentSkillIssue[]>([]);

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -16,7 +16,12 @@ import { WorkspaceMCPModal } from "../WorkspaceMCPModal/WorkspaceMCPModal";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip/Tooltip";
 import { Popover, PopoverTrigger, PopoverContent } from "../Popover/Popover";
 import { Checkbox } from "../Checkbox/Checkbox";
-import { formatKeybind, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
+import {
+  formatKeybind,
+  isEditableElement,
+  KEYBINDS,
+  matchesKeybind,
+} from "@/browser/utils/ui/keybinds";
 import { useRuntimeStatus, useRuntimeStatusStoreRaw } from "@/browser/stores/RuntimeStatusStore";
 import { useWorkspaceSidebarState } from "@/browser/stores/WorkspaceStore";
 import { Button } from "@/browser/components/Button/Button";
@@ -127,6 +132,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const [invalidSkills, setInvalidSkills] = useState<AgentSkillIssue[]>([]);
   const isSkillsMountedRef = useRef(true);
   const moreActionsButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuBarRef = useRef<HTMLDivElement | null>(null);
 
   const skillsRequestIdRef = useRef(0);
   const [moreMenuOpen, setMoreMenuOpen] = useState(false);
@@ -182,11 +188,46 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
     typeof window !== "undefined" &&
     window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
 
-  // Any pointer type: the right sidebar (home of the Timeline tab) is CSS-hidden
-  // at this width, so the timeline needs a dialog entry point instead.
-  const isNarrowScreen =
-    typeof window !== "undefined" &&
-    window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
+  // The right sidebar (home of the Timeline tab) is CSS-hidden by two independent
+  // rules: a viewport media query (<=768px, any pointer) and the workspace-shell
+  // container query (<=684px shell, e.g. a ~900px window with the left sidebar
+  // expanded). Read the sidebar's actual computed visibility so the timeline dialog
+  // gate matches the CSS truth; fall back to the media query when no shell is in
+  // the DOM (scratch pages, first render before refs attach, tests).
+  const isTimelineSidebarHidden = useCallback((): boolean => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    const sidebar = menuBarRef.current
+      ?.closest("[data-workspace-shell]")
+      ?.querySelector(".mobile-hide-right-sidebar");
+    if (sidebar instanceof HTMLElement) {
+      return window.getComputedStyle(sidebar).display === "none";
+    }
+    return window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
+  }, []);
+
+  // The dialog is the only timeline entry point while the sidebar is hidden, and every
+  // operation needs a keyboard shortcut. Evaluated at keydown time so the gate tracks
+  // live viewport/layout changes without a resize subscription.
+  useEffect(() => {
+    if (!timelineExperimentEnabled) {
+      return;
+    }
+    const handler = (e: KeyboardEvent) => {
+      if (
+        !matchesKeybind(e, KEYBINDS.OPEN_TIMELINE_DIALOG) ||
+        isEditableElement(e.target) ||
+        !isTimelineSidebarHidden()
+      ) {
+        return;
+      }
+      e.preventDefault();
+      setTimelineDialogOpen(true);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [timelineExperimentEnabled, isTimelineSidebarHidden]);
 
   const isDevcontainerWorkspace = isDevcontainerRuntime(runtimeConfig);
   const isRuntimeRunning = isDevcontainerWorkspace && runtimeStatus === "running";
@@ -500,6 +541,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
 
   return (
     <div
+      ref={menuBarRef}
       data-testid="workspace-menu-bar"
       className={cn(
         "bg-sidebar border-border-light flex items-center justify-between border-b px-2",
@@ -762,7 +804,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
                 hasRepository && !isTouchMobileScreen ? handleEnterImmersiveReview : null
               }
               onOpenTimeline={
-                timelineExperimentEnabled && isNarrowScreen
+                timelineExperimentEnabled && isTimelineSidebarHidden()
                   ? () => setTimelineDialogOpen(true)
                   : null
               }

--- a/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
+++ b/src/browser/components/WorkspaceMenuBar/WorkspaceMenuBar.tsx
@@ -18,6 +18,7 @@ import { Popover, PopoverTrigger, PopoverContent } from "../Popover/Popover";
 import { Checkbox } from "../Checkbox/Checkbox";
 import {
   formatKeybind,
+  isDialogOpen,
   isEditableElement,
   KEYBINDS,
   matchesKeybind,
@@ -127,7 +128,10 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
   const [debugLlmRequestOpen, setDebugLlmRequestOpen] = useState(false);
   const [mcpModalOpen, setMcpModalOpen] = useState(false);
   const [heartbeatModalOpen, setHeartbeatModalOpen] = useState(false);
-  const [timelineDialogOpen, setTimelineDialogOpen] = useState(false);
+  // Keyed by workspace so switching workspaces (e.g. the timeline's "Open child
+  // workspace" action) implicitly closes the dialog instead of covering the new view.
+  const [timelineDialogWorkspaceId, setTimelineDialogWorkspaceId] = useState<string | null>(null);
+  const timelineDialogOpen = timelineDialogWorkspaceId === workspaceId;
   const [availableSkills, setAvailableSkills] = useState<AgentSkillDescriptor[]>([]);
   const [invalidSkills, setInvalidSkills] = useState<AgentSkillIssue[]>([]);
   const isSkillsMountedRef = useRef(true);
@@ -202,6 +206,11 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
       ?.closest("[data-workspace-shell]")
       ?.querySelector(".mobile-hide-right-sidebar");
     if (sidebar instanceof HTMLElement) {
+      // Immersive review hides the sidebar on any viewport (marked aria-hidden);
+      // only a responsive hide should surface the dialog entry points.
+      if (sidebar.getAttribute("aria-hidden") === "true") {
+        return false;
+      }
       return window.getComputedStyle(sidebar).display === "none";
     }
     return window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches;
@@ -239,17 +248,18 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
     const handler = (e: KeyboardEvent) => {
       if (
         !matchesKeybind(e, KEYBINDS.OPEN_TIMELINE_DIALOG) ||
+        isDialogOpen() ||
         isEditableElement(e.target) ||
         !isTimelineSidebarHidden()
       ) {
         return;
       }
       e.preventDefault();
-      setTimelineDialogOpen(true);
+      setTimelineDialogWorkspaceId(workspaceId);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [timelineExperimentEnabled, isTimelineSidebarHidden]);
+  }, [timelineExperimentEnabled, isTimelineSidebarHidden, workspaceId]);
 
   const isDevcontainerWorkspace = isDevcontainerRuntime(runtimeConfig);
   const isRuntimeRunning = isDevcontainerWorkspace && runtimeStatus === "running";
@@ -827,7 +837,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
               }
               onOpenTimeline={
                 timelineExperimentEnabled && timelineSidebarHidden
-                  ? () => setTimelineDialogOpen(true)
+                  ? () => setTimelineDialogWorkspaceId(workspaceId)
                   : null
               }
               onStopRuntime={isRuntimeRunning ? () => void handleStopRuntime() : null}
@@ -881,7 +891,7 @@ export const WorkspaceMenuBar: React.FC<WorkspaceMenuBarProps> = ({
       <TimelineDialog
         workspaceId={workspaceId}
         open={timelineDialogOpen}
-        onOpenChange={setTimelineDialogOpen}
+        onOpenChange={(open) => setTimelineDialogWorkspaceId(open ? workspaceId : null)}
       />
       <DebugLlmRequestModal
         workspaceId={workspaceId}

--- a/src/browser/components/WorkspaceShell/WorkspaceShell.tsx
+++ b/src/browser/components/WorkspaceShell/WorkspaceShell.tsx
@@ -218,6 +218,9 @@ export const WorkspaceShell: React.FC<WorkspaceShellProps> = (props) => {
   return (
     <div
       ref={shellRef}
+      // Lets descendants (WorkspaceMenuBar's timeline gate) locate the shell that
+      // owns the right-sidebar container query without prop-drilling layout state.
+      data-workspace-shell=""
       className={cn(
         "relative flex flex-1 flex-row bg-surface-primary text-light overflow-x-auto overflow-y-hidden [@media(max-width:768px)]:flex-col",
         props.className

--- a/src/browser/features/RightSidebar/Timeline/TimelineDialog.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelineDialog.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/browser/components/Dialog/Dialog";
+import { CUSTOM_EVENTS } from "@/common/constants/events";
+
+import { TimelinePanel } from "./TimelinePanel";
+
+interface TimelineDialogProps {
+  workspaceId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Timeline in a dialog for small viewports, where the right sidebar (the
+ * timeline's usual home) is CSS-hidden and its tabs are unreachable.
+ */
+export function TimelineDialog(props: TimelineDialogProps) {
+  const { open, onOpenChange, workspaceId } = props;
+
+  // "Reveal in transcript" scrolls/highlights the chat pane underneath this modal,
+  // so close it once a reveal for this workspace dispatches to make the result visible.
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleReveal = (event: Event) => {
+      const detail = (event as CustomEvent<{ workspaceId: string }>).detail;
+      if (detail?.workspaceId !== workspaceId) {
+        return;
+      }
+      onOpenChange(false);
+    };
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, handleReveal);
+    return () => window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, handleReveal);
+  }, [open, onOpenChange, workspaceId]);
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent
+        className="flex h-[85dvh] w-[95%] flex-col gap-0 overflow-hidden p-0"
+        data-testid="timeline-dialog"
+      >
+        <DialogHeader className="border-border shrink-0 border-b px-4 py-3">
+          <DialogTitle className="text-base">Timeline</DialogTitle>
+        </DialogHeader>
+        <div className="min-h-0 flex-1">
+          <TimelinePanel workspaceId={props.workspaceId} />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/browser/features/RightSidebar/Timeline/TimelineDialog.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelineDialog.tsx
@@ -1,7 +1,9 @@
+import { X } from "lucide-react";
 import { useEffect } from "react";
 
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -45,9 +47,17 @@ export function TimelineDialog(props: TimelineDialogProps) {
       <DialogContent
         className="flex h-[85dvh] w-[95%] flex-col gap-0 overflow-hidden p-0"
         data-testid="timeline-dialog"
+        showCloseButton={false}
       >
-        <DialogHeader className="border-border shrink-0 border-b px-4 py-3">
+        {/* Own the close button inside a flex row instead of using DialogContent's
+            absolutely-positioned overlay: flex centering keeps the title and X aligned
+            regardless of font metrics, which skewed the floating button on some devices. */}
+        <DialogHeader className="border-border shrink-0 flex-row items-center justify-between space-y-0 border-b px-4 py-3">
           <DialogTitle className="text-base">Timeline</DialogTitle>
+          <DialogClose className="text-muted hover:text-foreground flex shrink-0 items-center rounded-sm transition-colors focus:outline-none">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
         </DialogHeader>
         <div className="min-h-0 flex-1">
           <TimelinePanel workspaceId={props.workspaceId} />

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -663,6 +663,14 @@ function TimelinePreviewCard(props: {
       ) {
         return;
       }
+      // Duplicate panels can be mounted at once: narrow viewports CSS-hide the right
+      // sidebar without unmounting its Timeline tab while the mobile dialog mounts a
+      // second panel. Only the visible panel may act on this window-level shortcut:
+      // offsetParent is null inside display:none subtrees, and content outside an open
+      // modal dialog (or an inert-hidden sidebar) is marked aria-hidden/inert.
+      if (button.offsetParent === null || button.closest("[inert], [aria-hidden='true']") != null) {
+        return;
+      }
       event.preventDefault();
       button.click();
     };

--- a/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
+++ b/src/browser/features/RightSidebar/Timeline/TimelinePanel.tsx
@@ -775,9 +775,12 @@ interface TimelinePanelViewProps extends TimelinePanelProps {
 export function TimelinePanelView(props: TimelinePanelViewProps) {
   const timeline = props.timeline;
   const workspaceStore = props.workspaceStore;
+  // listener keeps duplicate mounts in sync: a CSS-hidden sidebar tab and the mobile
+  // timeline dialog can both be mounted, sharing this persisted filter.
   const [storedFilter, setStoredFilter] = usePersistedState<string>(
     `timeline-filter:${props.workspaceId}`,
-    "all"
+    "all",
+    { listener: true }
   );
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [expandedRuns, setExpandedRuns] = useState<Record<string, boolean>>({});

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -48,6 +48,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   FOCUS_CHAT: "Focus chat input",
   CLOSE_TAB: "Close tab",
   REVEAL_TIMELINE_EVENT: "Reveal selected timeline event in transcript",
+  OPEN_TIMELINE_DIALOG: "Open timeline dialog (small viewports)",
   REVEAL_LAST_PROMPT: "Reveal last prompt in transcript",
   SIDEBAR_TAB_1: "Tab 1",
   SIDEBAR_TAB_2: "Tab 2",
@@ -188,6 +189,7 @@ const KEYBIND_GROUPS: Array<{
       "SIDEBAR_TAB_9",
       "CLOSE_TAB",
       "REVEAL_TIMELINE_EVENT",
+      "OPEN_TIMELINE_DIALOG",
     ],
   },
   {

--- a/src/browser/stories/App.phoneViewports.stories.tsx
+++ b/src/browser/stories/App.phoneViewports.stories.tsx
@@ -9,6 +9,8 @@ import { userEvent, within, waitFor } from "@storybook/test";
 import type { ComponentType } from "react";
 
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+import type { TimelineEvent } from "@/common/orpc/schemas/timeline";
 
 import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import { LEFT_SIDEBAR_COLLAPSED_KEY } from "@/common/constants/storage";
@@ -414,6 +416,109 @@ export const IPhone17ProMaxTouchReviewImmersive: AppStory = {
         if (document.querySelectorAll("[data-bottom-inset-owner]").length > 0) {
           throw new Error("Immersive review left the bottom safe-area inset unowned.");
         }
+      },
+      { timeout: 10_000 }
+    );
+
+    blurActiveElement();
+  },
+};
+
+const TIMELINE_DIALOG_WORKSPACE_ID = "ws-iphone-16e-timeline";
+const TIMELINE_DIALOG_BASE_TS = Date.UTC(2020, 0, 15, 15, 0, 0);
+const TIMELINE_DIALOG_EVENTS: TimelineEvent[] = [
+  {
+    v: 1,
+    id: "turn-completed",
+    kind: "turn.completed",
+    seq: 3,
+    ts: TIMELINE_DIALOG_BASE_TS,
+    source: { system: "chat" },
+    status: "completed",
+    data: { model: "anthropic/claude-sonnet-4", mode: "exec", durationMs: 84_000 },
+    anchor: { messageId: "msg-2" },
+  },
+  {
+    v: 1,
+    id: "agent-milestone",
+    kind: "agent.event",
+    seq: 2,
+    ts: TIMELINE_DIALOG_BASE_TS - 45_000,
+    source: { system: "agent", key: "timeline-event:milestone" },
+    data: {
+      description: "Wired the mobile timeline dialog behind the workspace actions menu",
+      category: "milestone",
+    },
+  },
+  {
+    v: 1,
+    id: "goal-set",
+    kind: "goal.set",
+    seq: 1,
+    ts: TIMELINE_DIALOG_BASE_TS - 90_000,
+    source: { system: "goal" },
+    status: "started",
+    data: { digest: "Make the timeline reachable at phone widths" },
+  },
+];
+
+/**
+ * Timeline on small viewports: the right sidebar (the timeline's usual home) is
+ * hidden at phone widths, so the workspace actions menu offers a Timeline entry
+ * that opens the panel in a dialog instead.
+ */
+export const IPhone16eTimelineDialog: AppStory = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        const client = setupSimpleChatStory({
+          workspaceId: TIMELINE_DIALOG_WORKSPACE_ID,
+          workspaceName: "mobile-timeline",
+          projectName: "mux",
+          messages: [...MESSAGES],
+          timelineEvents: TIMELINE_DIALOG_EVENTS,
+        });
+        updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), true);
+        return client;
+      }}
+    />
+  ),
+  decorators: [IPhone16eDecorator],
+  parameters: {
+    ...appMeta.parameters,
+    pixel: {
+      matrix: { themes: ["dark", "light"], viewports: ["phone"] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    await stabilizePhoneViewportStory(canvasElement);
+
+    // The Timeline menu action is gated on `window.matchMedia`, which the fixed-width
+    // decorator cannot move; only assert where the viewport is genuinely narrow (Pixel's
+    // phone viewport). The test-runner executes at desktop window size and skips here.
+    if (!window.matchMedia(`(max-width: ${NARROW_VIEWPORT_MAX_WIDTH_PX}px)`).matches) {
+      return;
+    }
+
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByTestId("workspace-more-actions"));
+    await userEvent.click(
+      await waitFor(() => within(document.body).getByTestId("workspace-timeline-button"))
+    );
+
+    // The dialog portals to document.body, outside the story canvas.
+    await waitFor(
+      () => {
+        const dialog = document.querySelector('[data-testid="timeline-dialog"]');
+        if (!dialog) {
+          throw new Error("Timeline dialog did not open");
+        }
+        within(dialog as HTMLElement).getByText(
+          "Wired the mobile timeline dialog behind the workspace actions menu"
+        );
       },
       { timeout: 10_000 }
     );

--- a/src/browser/stories/helpers/chatSetup.ts
+++ b/src/browser/stories/helpers/chatSetup.ts
@@ -9,6 +9,7 @@ import type { MuxMessage } from "@/common/types/message";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import type { BackgroundProcessInfo } from "@/common/orpc/schemas/api";
+import type { TimelineEvent } from "@/common/orpc/schemas/timeline";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import type { APIClient } from "@/browser/contexts/API";
 import { DEFAULT_MODEL } from "@/common/constants/knownModels";
@@ -93,6 +94,8 @@ export interface SimpleChatSetupOptions {
   clearLogsResult?: { success: boolean; error?: string | null };
   /** Full-width transcript preference returned by the mock config API. */
   chatTranscriptFullWidth?: boolean;
+  /** Timeline events served by the mock workspace.timeline endpoints. */
+  timelineEvents?: TimelineEvent[];
 }
 
 /**
@@ -184,6 +187,7 @@ export function setupSimpleChatStory(opts: SimpleChatSetupOptions): APIClient {
     logEntries: opts.logEntries,
     clearLogsResult: opts.clearLogsResult,
     chatTranscriptFullWidth: opts.chatTranscriptFullWidth,
+    timelineEvents: opts.timelineEvents,
   });
 }
 

--- a/src/browser/stories/meta.tsx
+++ b/src/browser/stories/meta.tsx
@@ -12,6 +12,7 @@ import { AppLoader } from "../components/AppLoader/AppLoader";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import type { APIClient } from "@/browser/contexts/API";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
 import {
   SELECTED_WORKSPACE_KEY,
   SIDEBAR_AGE_GROUPING_KEY,
@@ -92,6 +93,9 @@ function resetStorybookPersistedStateForStory(): void {
     // Terminal badge stories seed an enabled badge config; clear it so other
     // stories with terminals don't render order-dependent badge overlays.
     localStorage.removeItem(TERMINAL_BADGE_CONFIG_KEY);
+    // The timeline dialog story enables the timeline experiment; clear it so
+    // other stories' right-sidebar layouts don't gain an order-dependent tab.
+    localStorage.removeItem(getExperimentKey(EXPERIMENT_IDS.TIMELINE));
   }
 }
 function getStorybookRenderKey(): string | null {

--- a/src/browser/stories/meta.tsx
+++ b/src/browser/stories/meta.tsx
@@ -13,6 +13,7 @@ import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import type { APIClient } from "@/browser/contexts/API";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
+import { updatePersistedState } from "@/browser/hooks/usePersistedState";
 import {
   SELECTED_WORKSPACE_KEY,
   SIDEBAR_AGE_GROUPING_KEY,
@@ -95,7 +96,9 @@ function resetStorybookPersistedStateForStory(): void {
     localStorage.removeItem(TERMINAL_BADGE_CONFIG_KEY);
     // The timeline dialog story enables the timeline experiment; clear it so
     // other stories' right-sidebar layouts don't gain an order-dependent tab.
-    localStorage.removeItem(getExperimentKey(EXPERIMENT_IDS.TIMELINE));
+    // Cleared via the persisted-state helper so mounted experiment subscribers
+    // observe the reset instead of holding a stale snapshot.
+    updatePersistedState(getExperimentKey(EXPERIMENT_IDS.TIMELINE), undefined);
   }
 }
 function getStorybookRenderKey(): string | null {

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -5,6 +5,7 @@
  */
 import { DEFAULT_GOAL_DEFAULTS, normalizeGoalDefaults, type GoalDefaults } from "@/constants/goals";
 import type { GoalBoardSnapshot } from "@/common/types/goal";
+import type { TimelineEvent } from "@/common/orpc/schemas/timeline";
 import type {
   MemoryConsolidationRecordPayload,
   MemoryConsolidationStatusPayload,
@@ -176,6 +177,8 @@ export interface MockORPCClientOptions {
    * keyed by the workspace ID the story uses.
    */
   goalBoardSnapshots?: Map<string, GoalBoardSnapshot>;
+  /** Pre-seeded timeline events served to workspace.timeline.list/subscribe for every workspace. */
+  timelineEvents?: TimelineEvent[];
   /**
    * Pre-seeded memory files for memory.list (Memory tab / Settings → Memory
    * stories). read/save/delete/setPinned operate on this in-memory set.
@@ -408,6 +411,7 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
     heartbeatDefaultIntervalMs: initialHeartbeatDefaultIntervalMs,
     goalDefaults: initialGoalDefaults,
     goalBoardSnapshots = new Map<string, GoalBoardSnapshot>(),
+    timelineEvents = [],
     memoryFiles = [],
     memoryConsolidationStatus,
     memoryFileContents = new Map<string, string>(),
@@ -1518,11 +1522,16 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         set: () => Promise.resolve({ success: true, data: undefined }),
       },
       timeline: {
-        list: () => Promise.resolve({ events: [], nextCursor: null, hasOlder: false }),
+        list: () => Promise.resolve({ events: timelineEvents, nextCursor: null, hasOlder: false }),
         subscribe: () =>
           Promise.resolve(
             (function* () {
-              yield { type: "snapshot" as const, events: [], nextCursor: null, hasOlder: false };
+              yield {
+                type: "snapshot" as const,
+                events: timelineEvents,
+                nextCursor: null,
+                hasOlder: false,
+              };
             })()
           ),
         preview: () => Promise.resolve(null),

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -443,6 +443,9 @@ export const KEYBINDS = {
   /** Reveal the selected timeline event in the transcript */
   REVEAL_TIMELINE_EVENT: { key: "Enter", ctrl: true, shift: true },
 
+  /** Open the timeline dialog on small viewports where the right sidebar is hidden */
+  OPEN_TIMELINE_DIALOG: { key: "t", shift: true },
+
   /** Reveal the last prompt in the transcript while its popup is open */
   REVEAL_LAST_PROMPT: { key: "Enter", ctrl: true, alt: true },
 

--- a/tests/ui/rightSidebar/timeline.test.ts
+++ b/tests/ui/rightSidebar/timeline.test.ts
@@ -829,6 +829,35 @@ describe("TimelinePanel", () => {
     }
   });
 
+  test("ignores the reveal shortcut in a panel hidden behind an open modal", async () => {
+    // A CSS-hidden sidebar keeps its panel mounted while the mobile timeline dialog mounts a
+    // second one; Radix marks content outside the open modal aria-hidden. The hidden panel's
+    // window-level shortcut listener must not fire a competing reveal.
+    const event = makeEvent("anchored", "turn.completed", 1, {
+      anchor: { messageId: "loaded-message" },
+    });
+    const view = renderTimeline({ events: [event] });
+    view.workspaceState.messages = [{ historyId: "loaded-message" }];
+    const revealed: unknown[] = [];
+    const listener = (revealEvent: Event) => revealed.push(revealEvent);
+    window.addEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+
+    try {
+      fireEvent.click(view.container.querySelector('[data-timeline-event-id="anchored"]')!);
+      const revealButton = await waitFor(() => view.getByTestId("timeline-reveal"));
+
+      view.container.setAttribute("aria-hidden", "true");
+      fireEvent.keyDown(window, { key: "Enter", ctrlKey: true, shiftKey: true });
+
+      // The guard rejects synchronously, so the button never enters the revealing state.
+      expect(revealButton.textContent).toBe("Reveal in transcript");
+      await Promise.resolve();
+      expect(revealed).toHaveLength(0);
+    } finally {
+      window.removeEventListener(CUSTOM_EVENTS.REVEAL_TIMELINE_ANCHOR, listener);
+    }
+  });
+
   test("keeps pagination reachable when the active filter has no matches", () => {
     const view = renderTimeline({
       events: [makeEvent("task", "task.created", 1, { source: { system: "task" } })],


### PR DESCRIPTION
## Summary

Makes the workspace Timeline reachable on mobile/small viewports. The right sidebar (the Timeline tab's home) is CSS-hidden at widths <= 768px, so this adds a "Timeline" entry to the workspace header's More-actions menu that opens the existing `TimelinePanel` in a dialog. The entry is gated on the Timeline experiment plus a <= 768px viewport.

## Background

The Timeline experiment tab only existed inside the right sidebar, which `mobile-hide-right-sidebar` hides on phones and narrow windows, leaving no way to see the timeline there. The More-actions menu is the established mobile surface for sidebar-locked functionality (it already hosts mobile full-screen review).

## Implementation

- `TimelineDialog` wraps `TimelinePanel` in a near-full-screen dialog and listens for the reveal-in-transcript event to close itself so the highlighted message is visible underneath.
- The dialog header owns its close button inside a flex row (title and X centered by layout) instead of using `DialogContent`'s absolutely-positioned overlay, whose inline icon drifted with fallback font metrics on some devices.
- `WorkspaceMenuBar` gates the menu callback on `useExperimentValue(TIMELINE)` plus the right sidebar's actual computed visibility (read through the workspace shell, covering both the <=768px media query and the <=684px shell container query), falling back to the media query when no shell is in the DOM. `Shift+T` opens the dialog under the same gate (hint hidden on mobile); it ignores keypresses while another modal is open, and an `aria-hidden` sidebar (immersive review) does not count as a responsive hide. The dialog's open state is keyed by workspace id, so switching workspaces (e.g. the timeline's Open child workspace action) closes it.
- The timeline reveal shortcut only fires from a visible panel: a CSS-hidden sidebar keeps its panel mounted while the dialog mounts a second one, so `display:none`/`aria-hidden`/`inert` subtrees are ignored.
- Storybook: `IPhone16eTimelineDialog` phone-viewport story clicks through the real menu (guarded on `matchMedia` for the desktop-width test-runner); the orpc mock and `setupSimpleChatStory` gained `timelineEvents` fixtures; `meta.tsx` clears the experiment override between stories to prevent layout bleed.

## Validation

- Unit tests: 3 new `WorkspaceMenuBar` gating tests (narrow+experiment opens the dialog; wide viewport hides it; experiment off hides it).
- Two remote UAT rounds on dev.coder.com (real dev server, real Opus 5 prompts, 390x844): round 1 PASS for the full flow including the 768/769 boundary, live-resize reactivity, and negative cases; round 2 PASS confirming the header alignment fix (title/X midY delta 0px). Zero console errors in both rounds.

## Risks

Low. The dialog is additive and double-gated (experiment + narrow viewport); desktop behavior is unchanged. The only shared-surface edits are the new optional menu prop and story-mock plumbing.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->


