### PR TITLE
🤖 fix: restore settings backups from the legacy mux/ managed path

### DIFF
--- a/src/common/compat/legacyMux.test.ts
+++ b/src/common/compat/legacyMux.test.ts
@@ -7,6 +7,7 @@ import {
   installLegacyMuxEnvironmentAliases,
   LEGACY_CMUX_HOME_DIR_NAME,
   LEGACY_MUX_HOME_DIR_NAME,
+  listBackupManagedPathSpellings,
   listProjectMetadataRelativePaths,
   normalizeProjectMetadataIdentityPath,
   parseXumHomeLegacyFallbackDirName,
@@ -54,6 +55,23 @@ describe("project metadata compatibility", () => {
     expect(normalizeProjectMetadataIdentityPath(".xum/plugins/demo")).toBe(".mux/plugins/demo");
     expect(normalizeProjectMetadataIdentityPath(".xum\\plugins\\demo")).toBe(".mux\\plugins\\demo");
     expect(getCanonicalProjectMetadataRelativePath("skills/demo")).toBe(".xum/skills/demo");
+  });
+});
+
+describe("backup managed path compatibility", () => {
+  test("falls back from xum segments to the legacy mux spelling", () => {
+    expect(listBackupManagedPathSpellings("xum/")).toEqual(["xum/", "mux/"]);
+    expect(listBackupManagedPathSpellings("dotfiles/xum")).toEqual([
+      "dotfiles/xum",
+      "dotfiles/mux",
+    ]);
+  });
+
+  test("keeps paths without a xum segment as the only spelling", () => {
+    expect(listBackupManagedPathSpellings("mux/")).toEqual(["mux/"]);
+    expect(listBackupManagedPathSpellings("backups")).toEqual(["backups"]);
+    // Only whole segments alias; substrings must not be rewritten.
+    expect(listBackupManagedPathSpellings("xum-settings")).toEqual(["xum-settings"]);
   });
 });
 

--- a/src/common/compat/legacyMux.ts
+++ b/src/common/compat/legacyMux.ts
@@ -1,4 +1,8 @@
-import { XUM_HOME_DIR_NAME, XUM_PROTOCOL_SCHEME } from "@/common/constants/product";
+import {
+  XUM_HOME_DIR_NAME,
+  XUM_PRODUCT_SLUG,
+  XUM_PROTOCOL_SCHEME,
+} from "@/common/constants/product";
 import { type XumEnvironment } from "./xumEnv";
 
 export { assignXumEnvironmentValue, resolveXumEnvironmentValue } from "./xumEnv";
@@ -127,6 +131,20 @@ export function resolveLegacyMuxBuiltInSkillName(name: string): string {
     LEGACY_MUX_BUILT_IN_SKILL_ALIASES[name as keyof typeof LEGACY_MUX_BUILT_IN_SKILL_ALIASES] ??
     name
   );
+}
+
+/**
+ * Settings backups pushed before the rename live under managed paths spelled with the
+ * legacy product slug (default `mux/`). Returns the configured spelling first, then the
+ * legacy spelling when they differ, so restore-side reads can fall back to an old backup
+ * while exports keep writing the configured canonical path.
+ */
+export function listBackupManagedPathSpellings(managedPath: string): readonly string[] {
+  const legacy = managedPath
+    .split("/")
+    .map((segment) => (segment === XUM_PRODUCT_SLUG ? LEGACY_MUX_PRODUCT_SLUG : segment))
+    .join("/");
+  return legacy === managedPath ? [managedPath] : [managedPath, legacy];
 }
 
 const XUM_ENV_PREFIX = "XUM_";

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -565,13 +565,13 @@ describe("backup adapters", () => {
     expect(mode & 0o111).not.toBe(0);
   });
 
-  it("restores a legacy mux/ backup when the configured path is xum/", async () => {
+  it("selects a legacy mux/ backup when the configured xum/ path has none", async () => {
     // A mux-era client pushed its backup under the pre-rename default path.
     await writeFixtureFile(muxRoot, "AGENTS.md", "legacy instructions\n");
     const gitRepo = createBackupGitRepo({ cacheRoot });
     const payload = createBackupPayloadStore({ config });
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
@@ -580,21 +580,50 @@ describe("backup adapters", () => {
     // After the rename, the same repository is read through the new default path.
     await writeFixtureFile(muxRoot, "AGENTS.md", "post-rename local state\n");
     const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    expect(prepared.managedPath).toBe("mux/");
     const preview = await payload.previewRestore({
       repositoryRoot: prepared.rootDir,
-      managedPath: "xum/",
+      managedPath: prepared.managedPath,
     });
     expect(preview.changes).toEqual([{ status: "M", path: "AGENTS.md" }]);
 
-    await payload.validateRestore({ repositoryRoot: prepared.rootDir, managedPath: "xum/" });
+    await payload.validateRestore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: prepared.managedPath,
+    });
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
-      managedPath: "xum/",
+      managedPath: prepared.managedPath,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
       "legacy instructions\n"
     );
+  });
+
+  it("keeps pushing to a selected legacy mux/ path instead of forking the backup", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "legacy instructions\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await gitRepo.commitAndPush(legacy, {
+      message: "Back up Mux settings",
+      expectedRemoteCommit: legacy.remoteCommit,
+    });
+
+    // A xum-configured push updates the legacy backup in place rather than creating xum/.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "updated instructions\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    await payload.exportTo({ repositoryRoot: prepared.rootDir, managedPath: prepared.managedPath });
+    const pushed = await gitRepo.commitAndPush(prepared, {
+      message: "Back up Xum settings",
+      expectedRemoteCommit: prepared.remoteCommit,
+    });
+    expect(pushed.changed).toBe(true);
+    const tracked = await runGit(["--git-dir", originPath, "ls-tree", "-r", "--name-only", "main"]);
+    expect(tracked.split("\n")).toContain("mux/AGENTS.md");
+    expect(tracked).not.toContain("xum/");
   });
 
   it("prefers the configured xum/ backup over the legacy mux/ spelling", async () => {
@@ -603,26 +632,40 @@ describe("backup adapters", () => {
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "legacy\n");
     const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
-    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
     await gitRepo.commitAndPush(legacy, {
       message: "Back up Mux settings",
       expectedRemoteCommit: legacy.remoteCommit,
     });
 
+    // Seed a canonical xum/ backup through a plain clone: the cache selected the legacy
+    // spelling above, so its own staging is deliberately scoped away from xum/.
     await writeFixtureFile(muxRoot, "AGENTS.md", "canonical\n");
-    const canonical = await gitRepo.prepare({ ...settings, path: "xum/" });
-    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/" });
-    await gitRepo.commitAndPush(canonical, {
-      message: "Back up Xum settings",
-      expectedRemoteCommit: canonical.remoteCommit,
-    });
+    const seed = path.join(tempDir, "canonical-seed");
+    await runGit(["clone", "--quiet", originPath, seed]);
+    await payload.exportTo({ repositoryRoot: seed, managedPath: "xum/" });
+    await runGit(["-C", seed, "add", "-A"]);
+    await runGit([
+      "-C",
+      seed,
+      "-c",
+      "user.email=seed@example.com",
+      "-c",
+      "user.name=Seed",
+      "commit",
+      "--quiet",
+      "-m",
+      "first canonical backup",
+    ]);
+    await runGit(["-C", seed, "push", "--quiet", "origin", "main"]);
 
     // Both spellings now hold a backup; the configured path must win.
     await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
     const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    expect(prepared.managedPath).toBe("xum/");
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
-      managedPath: "xum/",
+      managedPath: prepared.managedPath,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
@@ -669,12 +712,67 @@ describe("backup adapters", () => {
 
     await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
     const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    expect(prepared.managedPath).toBe("xum/");
     const restored = await payload.restore({
       repositoryRoot: prepared.rootDir,
-      managedPath: "xum/",
+      managedPath: prepared.managedPath,
     });
     expect(restored.changedFiles).toEqual(["AGENTS.md"]);
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
+  });
+
+  it("selects a legacy mux/ backup past canonical junk that would fail validation", async () => {
+    // A valid mux-era backup.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "legacy instructions\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await gitRepo.commitAndPush(legacy, {
+      message: "Back up Mux settings",
+      expectedRemoteCommit: legacy.remoteCommit,
+    });
+
+    // Unrelated xum/ content without a real manifest: `manifest.json` is a directory
+    // (which the blob check must reject rather than treat as a manifest) and the tree
+    // holds a gitlink that would fail payload validation were it ever selected.
+    const seed = path.join(tempDir, "junk-seed");
+    await runGit(["clone", "--quiet", originPath, seed]);
+    await writeFixtureFile(seed, "xum/manifest.json/nested.txt", "not a manifest\n");
+    await runGit(["-C", seed, "add", "."]);
+    await runGit([
+      "-C",
+      seed,
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,0123456789012345678901234567890123456789,xum/linked",
+    ]);
+    await runGit([
+      "-C",
+      seed,
+      "-c",
+      "user.email=junk@example.com",
+      "-c",
+      "user.name=Junk",
+      "commit",
+      "--quiet",
+      "-m",
+      "unrelated xum leftovers",
+    ]);
+    await runGit(["-C", seed, "push", "--quiet", "origin", "main"]);
+
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    expect(prepared.managedPath).toBe("mux/");
+    const restored = await payload.restore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: prepared.managedPath,
+    });
+    expect(restored.changedFiles).toEqual(["AGENTS.md"]);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "legacy instructions\n"
+    );
   });
 
   it("reports preferences as changed only when the merge would change them", async () => {
@@ -729,6 +827,7 @@ describe("backup adapters", () => {
       rootDir: path.join(cacheRoot, "missing"),
       credential: "ssh",
       remoteCommit: null,
+      managedPath: settings.path,
     } as const;
     try {
       await gitRepo.getPushChanges(repository);

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -565,6 +565,69 @@ describe("backup adapters", () => {
     expect(mode & 0o111).not.toBe(0);
   });
 
+  it("restores a legacy mux/ backup when the configured path is xum/", async () => {
+    // A mux-era client pushed its backup under the pre-rename default path.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "legacy instructions\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: "mux/" });
+    await gitRepo.commitAndPush(legacy, {
+      message: "Back up Mux settings",
+      expectedRemoteCommit: legacy.remoteCommit,
+    });
+
+    // After the rename, the same repository is read through the new default path.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "post-rename local state\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    const preview = await payload.previewRestore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: "xum/",
+    });
+    expect(preview.changes).toEqual([{ status: "M", path: "AGENTS.md" }]);
+
+    await payload.validateRestore({ repositoryRoot: prepared.rootDir, managedPath: "xum/" });
+    const restored = await payload.restore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: "xum/",
+    });
+    expect(restored.changedFiles).toEqual(["AGENTS.md"]);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "legacy instructions\n"
+    );
+  });
+
+  it("prefers the configured xum/ backup over the legacy mux/ spelling", async () => {
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+
+    await writeFixtureFile(muxRoot, "AGENTS.md", "legacy\n");
+    const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: "mux/" });
+    await gitRepo.commitAndPush(legacy, {
+      message: "Back up Mux settings",
+      expectedRemoteCommit: legacy.remoteCommit,
+    });
+
+    await writeFixtureFile(muxRoot, "AGENTS.md", "canonical\n");
+    const canonical = await gitRepo.prepare({ ...settings, path: "xum/" });
+    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/" });
+    await gitRepo.commitAndPush(canonical, {
+      message: "Back up Xum settings",
+      expectedRemoteCommit: canonical.remoteCommit,
+    });
+
+    // Both spellings now hold a backup; the configured path must win.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    const restored = await payload.restore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: "xum/",
+    });
+    expect(restored.changedFiles).toEqual(["AGENTS.md"]);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
+  });
+
   it("reports preferences as changed only when the merge would change them", async () => {
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "dark" } } };
     const gitRepo = createBackupGitRepo({ cacheRoot });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -775,6 +775,51 @@ describe("backup adapters", () => {
     );
   });
 
+  it("selects a legacy mux/ backup when the canonical manifest is not a real backup", async () => {
+    // A valid mux-era backup.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "legacy instructions\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const legacy = await gitRepo.prepare({ ...settings, path: "mux/" });
+    await payload.exportTo({ repositoryRoot: legacy.rootDir, managedPath: legacy.managedPath });
+    await gitRepo.commitAndPush(legacy, {
+      message: "Back up Mux settings",
+      expectedRemoteCommit: legacy.remoteCommit,
+    });
+
+    // xum/manifest.json exists as a blob but is not a Xum backup manifest — a generic
+    // filename another tool plausibly owns. Presence alone must not win the selection.
+    const seed = path.join(tempDir, "unrelated-seed");
+    await runGit(["clone", "--quiet", originPath, seed]);
+    await writeFixtureFile(seed, "xum/manifest.json", '{ "name": "some other tool" }\n');
+    await runGit(["-C", seed, "add", "."]);
+    await runGit([
+      "-C",
+      seed,
+      "-c",
+      "user.email=other@example.com",
+      "-c",
+      "user.name=Other",
+      "commit",
+      "--quiet",
+      "-m",
+      "unrelated manifest",
+    ]);
+    await runGit(["-C", seed, "push", "--quiet", "origin", "main"]);
+
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    expect(prepared.managedPath).toBe("mux/");
+    const restored = await payload.restore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: prepared.managedPath,
+    });
+    expect(restored.changedFiles).toEqual(["AGENTS.md"]);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "legacy instructions\n"
+    );
+  });
+
   it("reports preferences as changed only when the merge would change them", async () => {
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "dark" } } };
     const gitRepo = createBackupGitRepo({ cacheRoot });

--- a/src/node/services/backup/adapters.test.ts
+++ b/src/node/services/backup/adapters.test.ts
@@ -628,6 +628,55 @@ describe("backup adapters", () => {
     expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
   });
 
+  it("ignores a broken legacy mux/ tree when the configured xum/ backup exists", async () => {
+    await writeFixtureFile(muxRoot, "AGENTS.md", "canonical\n");
+    const gitRepo = createBackupGitRepo({ cacheRoot });
+    const payload = createBackupPayloadStore({ config });
+    const canonical = await gitRepo.prepare({ ...settings, path: "xum/" });
+    await payload.exportTo({ repositoryRoot: canonical.rootDir, managedPath: "xum/" });
+    await gitRepo.commitAndPush(canonical, {
+      message: "Back up Xum settings",
+      expectedRemoteCommit: canonical.remoteCommit,
+    });
+
+    // A leftover legacy tree that would fail payload validation (a gitlink here) must not
+    // block the canonical backup: unused, it is neither validated nor materialized.
+    const seed = path.join(tempDir, "legacy-seed");
+    await runGit(["clone", "--quiet", originPath, seed]);
+    await writeFixtureFile(seed, "mux/manifest.json", "not a real backup\n");
+    await runGit(["-C", seed, "add", "."]);
+    await runGit([
+      "-C",
+      seed,
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,0123456789012345678901234567890123456789,mux/linked",
+    ]);
+    await runGit([
+      "-C",
+      seed,
+      "-c",
+      "user.email=legacy@example.com",
+      "-c",
+      "user.name=Legacy",
+      "commit",
+      "--quiet",
+      "-m",
+      "legacy leftovers",
+    ]);
+    await runGit(["-C", seed, "push", "--quiet", "origin", "main"]);
+
+    await writeFixtureFile(muxRoot, "AGENTS.md", "local edit\n");
+    const prepared = await gitRepo.prepare({ ...settings, path: "xum/" });
+    const restored = await payload.restore({
+      repositoryRoot: prepared.rootDir,
+      managedPath: "xum/",
+    });
+    expect(restored.changedFiles).toEqual(["AGENTS.md"]);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe("canonical\n");
+  });
+
   it("reports preferences as changed only when the merge would change them", async () => {
     config.state = { projects: new Map(), userPreferences: { appearance: { theme: "dark" } } };
     const gitRepo = createBackupGitRepo({ cacheRoot });

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { listBackupManagedPathSpellings } from "@/common/compat/legacyMux";
 import { VERSION } from "@/version";
 import type { Config } from "@/node/config";
 import type { BackupFileChange } from "@/common/orpc/schemas/backup";
@@ -146,6 +147,15 @@ function sameMode(a: BackupFile, b: BackupFile): boolean {
   return (a.executable === true) === (b.executable === true);
 }
 
+/** Names every spelling a restore looked in, so the error explains the legacy fallback. */
+function describeMissingBackup(managedPath: string): string {
+  const [, ...legacySpellings] = listBackupManagedPathSpellings(managedPath);
+  const fallbacks = legacySpellings.map((spelling) => `'${spelling}'`).join(" or ");
+  return fallbacks === ""
+    ? `No Xum backup found in '${managedPath}' on this branch`
+    : `No Xum backup found in '${managedPath}' or legacy ${fallbacks} on this branch`;
+}
+
 export function createBackupPayloadStore(options: { config: Config }): BackupPayloadStore {
   const muxRoot = options.config.rootDir;
 
@@ -154,6 +164,21 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   async function managedDir(repositoryRoot: string, managedPath: string): Promise<string> {
     const segments = managedPath.split("/").filter((segment) => segment !== "");
     return await resolveContainedPath(repositoryRoot, segments.join("/"));
+  }
+
+  // Backups pushed before the product rename live under the legacy `mux` spelling, which
+  // BackupRepoCache materializes alongside the configured path. Restore-side reads fall
+  // back to it when the configured path holds no payload; exports keep writing the
+  // configured path so the backup migrates forward on the next push.
+  async function findRestoreSourceDir(
+    repositoryRoot: string,
+    managedPath: string
+  ): Promise<string | null> {
+    for (const spelling of listBackupManagedPathSpellings(managedPath)) {
+      const dir = await managedDir(repositoryRoot, spelling);
+      if (await backupPayloadExists(dir)) return dir;
+    }
+    return null;
   }
 
   function localPreferences() {
@@ -201,11 +226,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async previewRestore(previewOptions) {
-      const sourceDir = await managedDir(previewOptions.repositoryRoot, previewOptions.managedPath);
+      const sourceDir = await findRestoreSourceDir(
+        previewOptions.repositoryRoot,
+        previewOptions.managedPath
+      );
       const local = await localFilesByPath();
       // A repository with no backup yet is a normal first-run state, not an error:
       // nothing would be restored, and every local file is local-only.
-      if (!(await backupPayloadExists(sourceDir))) {
+      if (sourceDir === null) {
         return { changes: [], localOnlyFiles: [...local.keys()].sort(), commandApprovals: [] };
       }
 
@@ -266,14 +294,14 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async validateRestore(validateOptions) {
-      const sourceDir = await managedDir(
+      const sourceDir = await findRestoreSourceDir(
         validateOptions.repositoryRoot,
         validateOptions.managedPath
       );
-      if (!(await backupPayloadExists(sourceDir))) {
+      if (sourceDir === null) {
         throw new BackupServiceError(
           "INVALID_BACKUP",
-          `No Xum backup found in '${validateOptions.managedPath}' on this branch`
+          describeMissingBackup(validateOptions.managedPath)
         );
       }
       const payload = await readBackupPayload(sourceDir);
@@ -296,9 +324,18 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async restore(restoreOptions) {
-      const payload = await readBackupPayload(
-        await managedDir(restoreOptions.repositoryRoot, restoreOptions.managedPath)
+      const sourceDir = await findRestoreSourceDir(
+        restoreOptions.repositoryRoot,
+        restoreOptions.managedPath
       );
+      // The service validates before restoring, so this only guards direct callers.
+      if (sourceDir === null) {
+        throw new BackupServiceError(
+          "INVALID_BACKUP",
+          describeMissingBackup(restoreOptions.managedPath)
+        );
+      }
+      const payload = await readBackupPayload(sourceDir);
       const before = await localFilesByPath();
       const result = await restoreBackupPayload({
         muxRoot,

--- a/src/node/services/backup/adapters.ts
+++ b/src/node/services/backup/adapters.ts
@@ -96,6 +96,7 @@ export function createBackupGitRepo(options: {
         rootDir: cache.cachePath,
         credential: cache.credential ?? "ambient",
         remoteCommit,
+        managedPath: cache.effectiveManagedPath,
       };
       prepared.set(repository, cache);
       return repository;
@@ -147,7 +148,12 @@ function sameMode(a: BackupFile, b: BackupFile): boolean {
   return (a.executable === true) === (b.executable === true);
 }
 
-/** Names every spelling a restore looked in, so the error explains the legacy fallback. */
+/**
+ * Names every spelling that was considered, so the error explains the legacy fallback.
+ * The repository preparation selects the legacy `mux` spelling whenever it holds a
+ * manifest and the configured spelling does not, so reaching this with the configured
+ * path means the legacy spelling was checked and held no backup either.
+ */
 function describeMissingBackup(managedPath: string): string {
   const [, ...legacySpellings] = listBackupManagedPathSpellings(managedPath);
   const fallbacks = legacySpellings.map((spelling) => `'${spelling}'`).join(" or ");
@@ -164,21 +170,6 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
   async function managedDir(repositoryRoot: string, managedPath: string): Promise<string> {
     const segments = managedPath.split("/").filter((segment) => segment !== "");
     return await resolveContainedPath(repositoryRoot, segments.join("/"));
-  }
-
-  // Backups pushed before the product rename live under the legacy `mux` spelling, which
-  // BackupRepoCache materializes alongside the configured path. Restore-side reads fall
-  // back to it when the configured path holds no payload; exports keep writing the
-  // configured path so the backup migrates forward on the next push.
-  async function findRestoreSourceDir(
-    repositoryRoot: string,
-    managedPath: string
-  ): Promise<string | null> {
-    for (const spelling of listBackupManagedPathSpellings(managedPath)) {
-      const dir = await managedDir(repositoryRoot, spelling);
-      if (await backupPayloadExists(dir)) return dir;
-    }
-    return null;
   }
 
   function localPreferences() {
@@ -226,14 +217,11 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async previewRestore(previewOptions) {
-      const sourceDir = await findRestoreSourceDir(
-        previewOptions.repositoryRoot,
-        previewOptions.managedPath
-      );
+      const sourceDir = await managedDir(previewOptions.repositoryRoot, previewOptions.managedPath);
       const local = await localFilesByPath();
       // A repository with no backup yet is a normal first-run state, not an error:
       // nothing would be restored, and every local file is local-only.
-      if (sourceDir === null) {
+      if (!(await backupPayloadExists(sourceDir))) {
         return { changes: [], localOnlyFiles: [...local.keys()].sort(), commandApprovals: [] };
       }
 
@@ -294,11 +282,11 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async validateRestore(validateOptions) {
-      const sourceDir = await findRestoreSourceDir(
+      const sourceDir = await managedDir(
         validateOptions.repositoryRoot,
         validateOptions.managedPath
       );
-      if (sourceDir === null) {
+      if (!(await backupPayloadExists(sourceDir))) {
         throw new BackupServiceError(
           "INVALID_BACKUP",
           describeMissingBackup(validateOptions.managedPath)
@@ -324,18 +312,9 @@ export function createBackupPayloadStore(options: { config: Config }): BackupPay
     },
 
     async restore(restoreOptions) {
-      const sourceDir = await findRestoreSourceDir(
-        restoreOptions.repositoryRoot,
-        restoreOptions.managedPath
+      const payload = await readBackupPayload(
+        await managedDir(restoreOptions.repositoryRoot, restoreOptions.managedPath)
       );
-      // The service validates before restoring, so this only guards direct callers.
-      if (sourceDir === null) {
-        throw new BackupServiceError(
-          "INVALID_BACKUP",
-          describeMissingBackup(restoreOptions.managedPath)
-        );
-      }
-      const payload = await readBackupPayload(sourceDir);
       const before = await localFilesByPath();
       const result = await restoreBackupPayload({
         muxRoot,

--- a/src/node/services/backup/backupService.integration.test.ts
+++ b/src/node/services/backup/backupService.integration.test.ts
@@ -341,6 +341,32 @@ describe("BackupService against a real repository", () => {
     expect(service.getSettings()?.lastRestoredCommit).toBe(pushed.data.commit);
   });
 
+  it("restores and re-pushes a pre-rename mux/ backup through xum/ settings", async () => {
+    // The backup was pushed while the default managed path was still `mux/`.
+    const pushed = await pushOrThrow();
+
+    // A post-rename client points the default `xum/` path at the same repository.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "locally diverged\n");
+    settings = { ...settings, path: "xum/" };
+    const restored = await service.restore(settings);
+    if (!restored.success) throw new Error(restored.error.message);
+    expect(restored.data.commit).toBe(pushed.data.commit);
+    expect(await fs.readFile(path.join(muxRoot, "AGENTS.md"), "utf-8")).toBe(
+      "global instructions\n"
+    );
+
+    // Pushing through the renamed settings updates mux/ in place instead of forking xum/.
+    await writeFixtureFile(muxRoot, "AGENTS.md", "updated after rename\n");
+    await pushOrThrow();
+    const clone = await cloneOrigin("after-rename");
+    const files = await listFiles(clone);
+    expect(files).toContain("mux/AGENTS.md");
+    expect(files.some((file) => file.startsWith("xum/"))).toBe(false);
+    expect(await fs.readFile(path.join(clone, "mux/AGENTS.md"), "utf-8")).toBe(
+      "updated after rename\n"
+    );
+  });
+
   it("reports an empty repository as reachable and bootstraps its first commit", async () => {
     const validated = await service.validate(settings);
     if (!validated.success) throw new Error(validated.error.message);

--- a/src/node/services/backup/backupService.test.ts
+++ b/src/node/services/backup/backupService.test.ts
@@ -59,6 +59,7 @@ function createRepository(
     rootDir: "/cache/repository",
     credential: "ssh",
     remoteCommit: "remote-commit",
+    managedPath: SETTINGS.path,
     ...overrides,
   };
 }
@@ -480,6 +481,45 @@ describe("BackupService", () => {
 
     expect(result.success).toBe(true);
     expect(events).toEqual(["restore-preview", "export", "push-preview"]);
+  });
+
+  test("addresses payload operations to the prepared repository's managed path", async () => {
+    // prepare() may select the legacy `mux` spelling of the configured path (backups
+    // pushed before the product rename); every payload call must follow that selection
+    // rather than the configured settings path.
+    const managedPaths: string[] = [];
+    const recordManagedPath = (options: { managedPath: string }) => {
+      managedPaths.push(options.managedPath);
+    };
+    const service = createService(tempDir, {
+      gitRepo: createGitRepo({
+        prepare: () => Promise.resolve(createRepository({ managedPath: "legacy-spelling" })),
+      }),
+      payload: createPayload({
+        previewRestore: (options) => {
+          recordManagedPath(options);
+          return Promise.resolve({ changes: [], localOnlyFiles: [], commandApprovals: [] });
+        },
+        exportTo: (options) => {
+          recordManagedPath(options);
+          return Promise.resolve({ redactions: [], secretFiles: [], secretApproval: "" });
+        },
+        validateRestore: (options) => {
+          recordManagedPath(options);
+          return Promise.resolve();
+        },
+        restore: (options) => {
+          recordManagedPath(options);
+          return Promise.resolve({ changedFiles: [], localOnlyFiles: [] });
+        },
+      }),
+    });
+
+    expect((await service.preview(SETTINGS)).success).toBe(true);
+    expect((await service.push(SETTINGS)).success).toBe(true);
+    expect((await service.restore(SETTINGS)).success).toBe(true);
+    expect(managedPaths).not.toContain(SETTINGS.path);
+    expect(new Set(managedPaths)).toEqual(new Set(["legacy-spelling"]));
   });
 
   test("returns repository drift as expected Result data without updating settings", async () => {

--- a/src/node/services/backup/backupService.ts
+++ b/src/node/services/backup/backupService.ts
@@ -29,6 +29,13 @@ export interface PreparedBackupRepository {
   rootDir: string;
   credential: BackupCredentialKind;
   remoteCommit: string | null;
+  /**
+   * The managed path the prepared cache actually holds: the configured spelling, or its
+   * legacy `mux` spelling when only that tree carries a backup manifest (backups pushed
+   * before the product rename). Payload reads and writes must use this path — only this
+   * tree is materialized, validated, and staged.
+   */
+  managedPath: string;
 }
 
 export interface BackupGitRepo {
@@ -304,11 +311,11 @@ export class BackupService {
       const { restorePreview, exported } = await this.withLocalPayload(async () => ({
         restorePreview: await this.dependencies.payload.previewRestore({
           repositoryRoot: repository.rootDir,
-          managedPath: normalized.path,
+          managedPath: repository.managedPath,
         }),
         exported: await this.dependencies.payload.exportTo({
           repositoryRoot: repository.rootDir,
-          managedPath: normalized.path,
+          managedPath: repository.managedPath,
         }),
       }));
       const pushChanges = await this.dependencies.gitRepo.getPushChanges(repository);
@@ -342,7 +349,7 @@ export class BackupService {
       const exported = await this.withLocalPayload(() =>
         this.dependencies.payload.exportTo({
           repositoryRoot: repository.rootDir,
-          managedPath: normalized.path,
+          managedPath: repository.managedPath,
         })
       );
       // Approval is bound to the exact flagged bytes, so an override the user granted for
@@ -396,7 +403,7 @@ export class BackupService {
         // unredacted copy of the local settings on disk.
         await this.dependencies.payload.validateRestore({
           repositoryRoot: repository.rootDir,
-          managedPath: normalized.path,
+          managedPath: repository.managedPath,
           approvedCommandTokens,
         });
         const snapshotPath = await this.createSnapshotPath();
@@ -411,7 +418,7 @@ export class BackupService {
         try {
           const restored = await this.dependencies.payload.restore({
             repositoryRoot: repository.rootDir,
-            managedPath: normalized.path,
+            managedPath: repository.managedPath,
             approvedCommandTokens,
           });
           await this.persistSettings(normalized, { lastRestoredCommit: remoteCommit });

--- a/src/node/services/backup/gitRepo.ts
+++ b/src/node/services/backup/gitRepo.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { listBackupManagedPathSpellings } from "@/common/compat/legacyMux";
 import { execFileAsync, type ExecFileAsyncOptions } from "@/node/utils/disposableExec";
 import { isErrnoWithCode } from "@/node/utils/fs";
 import {
@@ -1033,6 +1034,22 @@ export class BackupRepoCache {
     }
   }
 
+  /**
+   * The trees this cache materializes and reads: the configured managed path first, then
+   * the legacy `mux` spelling when it differs. Backups pushed before the product rename
+   * live under the legacy spelling, and a restore can only read what the sparse checkout
+   * materialized. Writes (stage, commit, status) stay scoped to the configured path.
+   */
+  private managedReadPaths(): readonly string[] {
+    return [
+      ...new Set(
+        listBackupManagedPathSpellings(this.options.managedPath).map((spelling) =>
+          safeRelativePath(spelling)
+        )
+      ),
+    ];
+  }
+
   private async listManagedBlobs(remoteCommit: string): Promise<ManagedBlobEntry[]> {
     let stdout: string;
     try {
@@ -1044,7 +1061,7 @@ export class BackupRepoCache {
           "-z",
           remoteCommit,
           "--",
-          `:(top,literal)${safeRelativePath(this.options.managedPath)}`,
+          ...this.managedReadPaths().map((readPath) => `:(top,literal)${readPath}`),
         ],
         {
           env: { GIT_NO_LAZY_FETCH: "1" },
@@ -1132,13 +1149,14 @@ export class BackupRepoCache {
       );
     }
 
-    const managedPrefix = `${safeRelativePath(this.options.managedPath)}/`;
+    const managedPrefixes = this.managedReadPaths().map((readPath) => `${readPath}/`);
     try {
       const payloadPaths = entries.map((entry) => {
-        if (!entry.path.startsWith(managedPrefix)) {
+        const prefix = managedPrefixes.find((candidate) => entry.path.startsWith(candidate));
+        if (prefix === undefined) {
           throw new Error(`Backup tree contains invalid path '${entry.path}'`);
         }
-        return entry.path.slice(managedPrefix.length);
+        return entry.path.slice(prefix.length);
       });
       assertBackupPathComplexity(payloadPaths);
     } catch (error) {
@@ -1212,7 +1230,9 @@ export class BackupRepoCache {
     await writeOwnedGitInfoFile(
       this.cachePath,
       "sparse-checkout",
-      `/${escapeSparsePattern(safeRelativePath(this.options.managedPath))}/*\n`
+      this.managedReadPaths()
+        .map((readPath) => `/${escapeSparsePattern(readPath)}/*\n`)
+        .join("")
     );
   }
 

--- a/src/node/services/backup/gitRepo.ts
+++ b/src/node/services/backup/gitRepo.ts
@@ -15,6 +15,7 @@ import {
 } from "./credentials";
 import {
   assertBackupPathComplexity,
+  BACKUP_MANIFEST_FILE,
   BackupInvalidPayloadError,
   MAX_BACKUP_FILE_BYTES,
   MAX_BACKUP_FILE_COUNT,
@@ -1035,22 +1036,47 @@ export class BackupRepoCache {
   }
 
   /**
-   * The trees this cache materializes and reads: the configured managed path first, then
-   * the legacy `mux` spelling when it differs. Backups pushed before the product rename
-   * live under the legacy spelling, and a restore can only read what the sparse checkout
-   * materialized. Writes (stage, commit, status) stay scoped to the configured path.
+   * The trees this cache materializes and reads: the configured managed path, plus the
+   * legacy `mux` spelling only when the configured path holds no backup manifest at the
+   * fetched commit. Backups pushed before the product rename live under the legacy
+   * spelling, and a restore can only read what the sparse checkout materialized. Scoping
+   * the fallback to the missing-manifest case keeps an unused legacy tree out of
+   * validation and the checkout, so a broken or oversized leftover cannot block a valid
+   * canonical backup. Writes (stage, commit, status) stay scoped to the configured path.
    */
-  private managedReadPaths(): readonly string[] {
-    return [
+  private async resolveManagedReadPaths(remoteCommit: string | null): Promise<readonly string[]> {
+    const [configured, ...legacySpellings] = [
       ...new Set(
         listBackupManagedPathSpellings(this.options.managedPath).map((spelling) =>
           safeRelativePath(spelling)
         )
       ),
     ];
+    if (remoteCommit !== null && !(await this.treeHasBackupManifest(remoteCommit, configured))) {
+      for (const legacy of legacySpellings) {
+        if (await this.treeHasBackupManifest(remoteCommit, legacy)) return [configured, legacy];
+      }
+    }
+    return [configured];
   }
 
-  private async listManagedBlobs(remoteCommit: string): Promise<ManagedBlobEntry[]> {
+  /** Reads only tree objects, which a blob-filtered fetch always transfers. */
+  private async treeHasBackupManifest(remoteCommit: string, readPath: string): Promise<boolean> {
+    const { stdout } = await this.localGit([
+      "ls-tree",
+      "-r",
+      "-z",
+      remoteCommit,
+      "--",
+      `:(top,literal)${readPath}/${BACKUP_MANIFEST_FILE}`,
+    ]);
+    return stdout.length > 0;
+  }
+
+  private async listManagedBlobs(
+    remoteCommit: string,
+    readPaths: readonly string[]
+  ): Promise<ManagedBlobEntry[]> {
     let stdout: string;
     try {
       ({ stdout } = await this.localGit(
@@ -1061,7 +1087,7 @@ export class BackupRepoCache {
           "-z",
           remoteCommit,
           "--",
-          ...this.managedReadPaths().map((readPath) => `:(top,literal)${readPath}`),
+          ...readPaths.map((readPath) => `:(top,literal)${readPath}`),
         ],
         {
           env: { GIT_NO_LAZY_FETCH: "1" },
@@ -1141,15 +1167,18 @@ export class BackupRepoCache {
     return nextUsedBytes;
   }
 
-  private async validateManagedTreeBeforeCheckout(remoteCommit: string): Promise<void> {
-    const entries = await this.listManagedBlobs(remoteCommit);
+  private async validateManagedTreeBeforeCheckout(
+    remoteCommit: string,
+    readPaths: readonly string[]
+  ): Promise<void> {
+    const entries = await this.listManagedBlobs(remoteCommit, readPaths);
     if (entries.length > this.materializationLimits.maxFileCount) {
       throw new BackupInvalidPayloadError(
         new Error(`Backup has more than ${this.materializationLimits.maxFileCount} files`)
       );
     }
 
-    const managedPrefixes = this.managedReadPaths().map((readPath) => `${readPath}/`);
+    const managedPrefixes = readPaths.map((readPath) => `${readPath}/`);
     try {
       const payloadPaths = entries.map((entry) => {
         const prefix = managedPrefixes.find((candidate) => entry.path.startsWith(candidate));
@@ -1193,7 +1222,7 @@ export class BackupRepoCache {
 
       const fetchedSizes = new Map<string, number>();
       const fetchedObjectIds = new Set(objectIds);
-      for (const entry of await this.listManagedBlobs(remoteCommit)) {
+      for (const entry of await this.listManagedBlobs(remoteCommit, readPaths)) {
         if (entry.size !== null && fetchedObjectIds.has(entry.objectId)) {
           fetchedSizes.set(entry.objectId, entry.size);
         }
@@ -1226,21 +1255,22 @@ export class BackupRepoCache {
    * and the checkout that follows is what applies it. Pre-checkout size validation fetches any
    * missing managed blobs through the credential ladder.
    */
-  private async applySparseCheckout(): Promise<void> {
+  private async applySparseCheckout(readPaths: readonly string[]): Promise<void> {
     await writeOwnedGitInfoFile(
       this.cachePath,
       "sparse-checkout",
-      this.managedReadPaths()
-        .map((readPath) => `/${escapeSparsePattern(readPath)}/*\n`)
-        .join("")
+      readPaths.map((readPath) => `/${escapeSparsePattern(readPath)}/*\n`).join("")
     );
   }
 
   async resetHardToRemote(): Promise<string | null> {
-    await this.applySparseCheckout();
+    // The read paths depend on the fetched commit's tree, so resolve them before the
+    // sparse patterns are written and the checkout materializes anything.
     const remoteCommit = await this.remoteBranchCommit();
+    const readPaths = await this.resolveManagedReadPaths(remoteCommit);
+    await this.applySparseCheckout(readPaths);
     if (remoteCommit) {
-      await this.validateManagedTreeBeforeCheckout(remoteCommit);
+      await this.validateManagedTreeBeforeCheckout(remoteCommit, readPaths);
       // -f because a previous preview leaves modified tracked files in this cache. Without
       // it the checkout keeps them and the next preview reads the local export as if it
       // were the remote's backup.

--- a/src/node/services/backup/gitRepo.ts
+++ b/src/node/services/backup/gitRepo.ts
@@ -17,6 +17,7 @@ import {
   assertBackupPathComplexity,
   BACKUP_MANIFEST_FILE,
   BackupInvalidPayloadError,
+  isParseableBackupManifest,
   MAX_BACKUP_FILE_BYTES,
   MAX_BACKUP_FILE_COUNT,
   MAX_BACKUP_TOTAL_BYTES,
@@ -1064,23 +1065,30 @@ export class BackupRepoCache {
     const [configured, ...legacySpellings] = listBackupManagedPathSpellings(
       this.options.managedPath
     );
-    if (remoteCommit === null) return configured;
-    if (await this.treeHasBackupManifest(remoteCommit, safeRelativePath(configured))) {
+    if (remoteCommit === null || legacySpellings.length === 0) return configured;
+    if (await this.treeHasReadableBackupManifest(remoteCommit, safeRelativePath(configured))) {
       return configured;
     }
     for (const legacy of legacySpellings) {
-      if (await this.treeHasBackupManifest(remoteCommit, safeRelativePath(legacy))) return legacy;
+      if (await this.treeHasReadableBackupManifest(remoteCommit, safeRelativePath(legacy))) {
+        return legacy;
+      }
     }
     return configured;
   }
 
   /**
-   * True only when `<readPath>/manifest.json` is a blob at the given commit. Deliberately
-   * non-recursive: a directory spelled like the manifest is then a single `tree` record the
-   * type check rejects, rather than an unbounded listing of its descendants. Reads only
-   * tree objects, which a blob-filtered fetch always transfers.
+   * True only when `<readPath>/manifest.json` is a blob at the given commit that parses as
+   * a backup manifest. Deliberately non-recursive: a directory spelled like the manifest is
+   * then a single `tree` record the type check rejects, rather than an unbounded listing of
+   * its descendants. Parsing matters because `manifest.json` is a generic filename: an
+   * unrelated or corrupt file under the configured spelling must not win the selection over
+   * a valid legacy backup that would then never be consulted.
    */
-  private async treeHasBackupManifest(remoteCommit: string, readPath: string): Promise<boolean> {
+  private async treeHasReadableBackupManifest(
+    remoteCommit: string,
+    readPath: string
+  ): Promise<boolean> {
     const { stdout } = await this.localGit(
       ["ls-tree", "-z", remoteCommit, "--", `:(top,literal)${readPath}/${BACKUP_MANIFEST_FILE}`],
       { env: { GIT_NO_LAZY_FETCH: "1" }, maxOutputBytes: MANIFEST_LOOKUP_MAX_OUTPUT_BYTES }
@@ -1088,7 +1096,49 @@ export class BackupRepoCache {
     const record = stdout.split("\0")[0] ?? "";
     const separator = record.indexOf("\t");
     if (separator < 0) return false;
-    return record.slice(0, separator).trim().split(/\s+/)[1] === "blob";
+    const [, objectType, objectId] = record.slice(0, separator).trim().split(/\s+/);
+    if (objectType !== "blob" || objectId === undefined || !/^[0-9a-f]{40,64}$/.test(objectId)) {
+      return false;
+    }
+    const manifest = await this.readProbedBlob(objectId);
+    return manifest !== null && isParseableBackupManifest(manifest);
+  }
+
+  /**
+   * Reads a probed blob's bytes, fetching it once through the credential ladder when the
+   * blob-filtered clone has only promised it. Returns null for a blob that still cannot be
+   * read afterwards (including one larger than any legitimate payload), so the probe treats
+   * it as "not a usable manifest" rather than failing the whole preparation.
+   */
+  private async readProbedBlob(objectId: string): Promise<string | null> {
+    const read = () =>
+      this.localGit(["cat-file", "blob", objectId], {
+        env: { GIT_NO_LAZY_FETCH: "1" },
+        maxOutputBytes: MAX_BACKUP_TOTAL_BYTES,
+      });
+    try {
+      return (await read()).stdout;
+    } catch {
+      // The blob is missing from the partial clone; fetch exactly it, like the
+      // pre-checkout size validation does for payload blobs.
+      await this.networkGit([
+        "-C",
+        this.cachePath,
+        "fetch",
+        "--refetch",
+        "--no-tags",
+        "--no-write-fetch-head",
+        ...localUploadPackArgs(this.repoUrl),
+        "origin",
+        objectId,
+      ]);
+      await this.assertObjectStoreWithinBudget();
+    }
+    try {
+      return (await read()).stdout;
+    } catch {
+      return null;
+    }
   }
 
   private async listManagedBlobs(

--- a/src/node/services/backup/gitRepo.ts
+++ b/src/node/services/backup/gitRepo.ts
@@ -1107,19 +1107,27 @@ export class BackupRepoCache {
   /**
    * Reads a probed blob's bytes, fetching it once through the credential ladder when the
    * blob-filtered clone has only promised it. Returns null for a blob that still cannot be
-   * read afterwards (including one larger than any legitimate payload), so the probe treats
-   * it as "not a usable manifest" rather than failing the whole preparation.
+   * read afterwards, so the probe treats it as "not a usable manifest" rather than failing
+   * the whole preparation. Capped at the per-file payload limit before parsing: a manifest
+   * the restore path could never read must not be buffered whole in the main process, and
+   * the streaming cap kills the read as soon as it passes the limit.
    */
   private async readProbedBlob(objectId: string): Promise<string | null> {
     const read = () =>
       this.localGit(["cat-file", "blob", objectId], {
         env: { GIT_NO_LAZY_FETCH: "1" },
-        maxOutputBytes: MAX_BACKUP_TOTAL_BYTES,
+        maxOutputBytes: MAX_BACKUP_FILE_BYTES,
       });
+    const isOverLimit = (error: unknown) =>
+      error instanceof Error &&
+      error.message === `Command produced more than ${MAX_BACKUP_FILE_BYTES} bytes of output`;
     try {
       return (await read()).stdout;
-    } catch {
-      // The blob is missing from the partial clone; fetch exactly it, like the
+    } catch (error) {
+      // Over-limit is definitive: the blob exists locally and is too large, so fetching
+      // it again could only re-buffer the same oversized bytes.
+      if (isOverLimit(error)) return null;
+      // Otherwise the blob is missing from the partial clone; fetch exactly it, like the
       // pre-checkout size validation does for payload blobs.
       await this.networkGit([
         "-C",

--- a/src/node/services/backup/gitRepo.ts
+++ b/src/node/services/backup/gitRepo.ts
@@ -157,7 +157,10 @@ export interface BackupRepoCacheOptions extends Omit<GitCredentialOptions, "repo
   repoUrl: string;
   branch: string;
   cacheRoot: string;
-  /** Scopes the sparse checkout, so nothing outside it is ever materialized. */
+  /**
+   * Scopes the sparse checkout, so nothing outside it is ever materialized. materialize()
+   * may swap in the legacy `mux` spelling of this path; see `effectiveManagedPath`.
+   */
   managedPath: string;
   materializationLimits?: {
     maxFileBytes?: number;
@@ -210,6 +213,9 @@ interface ManagedBlobEntry {
 }
 
 const BLOB_PREFETCH_BATCH_SIZE = 16;
+
+/** One non-recursive ls-tree record for a bounded-length path; anything larger is hostile. */
+const MANIFEST_LOOKUP_MAX_OUTPUT_BYTES = 16384;
 
 export interface RemoteRefs {
   credential: BackupCredential;
@@ -677,6 +683,7 @@ export class BackupRepoCache {
   private readonly maxCacheObjectKib: number;
   private baseRemoteCommit: string | null | undefined;
   private usedCredential: BackupCredential | undefined;
+  private selectedManagedPath: string | undefined;
 
   constructor(private readonly options: BackupRepoCacheOptions) {
     this.cachePath = backupCachePath(options.cacheRoot, options.repoUrl, options.branch);
@@ -707,6 +714,16 @@ export class BackupRepoCache {
 
   get credential(): BackupCredential | undefined {
     return this.usedCredential;
+  }
+
+  /**
+   * The managed path this cache actually uses, resolved by materialize(). It is the
+   * configured spelling unless that tree has no backup manifest while the legacy `mux`
+   * spelling from before the product rename does — then reads and writes both follow the
+   * legacy spelling, so a pre-rename backup keeps working and pushes update it in place.
+   */
+  get effectiveManagedPath(): string {
+    return this.selectedManagedPath ?? this.options.managedPath;
   }
 
   private credentialOptions(): GitCredentialOptions {
@@ -1036,59 +1053,52 @@ export class BackupRepoCache {
   }
 
   /**
-   * The trees this cache materializes and reads: the configured managed path, plus the
-   * legacy `mux` spelling only when the configured path holds no backup manifest at the
-   * fetched commit. Backups pushed before the product rename live under the legacy
-   * spelling, and a restore can only read what the sparse checkout materialized. Scoping
-   * the fallback to the missing-manifest case keeps an unused legacy tree out of
-   * validation and the checkout, so a broken or oversized leftover cannot block a valid
-   * canonical backup. Writes (stage, commit, status) stay scoped to the configured path.
+   * The one managed path this cache materializes, reads, and writes: the configured
+   * spelling, unless it holds no backup manifest at the fetched commit while a legacy
+   * spelling (`mux/`, from before the product rename) does. Selecting a single tree keeps
+   * every unselected spelling out of validation, the sparse checkout, and staging, so a
+   * broken or oversized tree under the other spelling can never block the backup that is
+   * actually in use, and pushes update the backup where it lives instead of forking it.
    */
-  private async resolveManagedReadPaths(remoteCommit: string | null): Promise<readonly string[]> {
-    const [configured, ...legacySpellings] = [
-      ...new Set(
-        listBackupManagedPathSpellings(this.options.managedPath).map((spelling) =>
-          safeRelativePath(spelling)
-        )
-      ),
-    ];
-    if (remoteCommit !== null && !(await this.treeHasBackupManifest(remoteCommit, configured))) {
-      for (const legacy of legacySpellings) {
-        if (await this.treeHasBackupManifest(remoteCommit, legacy)) return [configured, legacy];
-      }
+  private async resolveEffectiveManagedPath(remoteCommit: string | null): Promise<string> {
+    const [configured, ...legacySpellings] = listBackupManagedPathSpellings(
+      this.options.managedPath
+    );
+    if (remoteCommit === null) return configured;
+    if (await this.treeHasBackupManifest(remoteCommit, safeRelativePath(configured))) {
+      return configured;
     }
-    return [configured];
+    for (const legacy of legacySpellings) {
+      if (await this.treeHasBackupManifest(remoteCommit, safeRelativePath(legacy))) return legacy;
+    }
+    return configured;
   }
 
-  /** Reads only tree objects, which a blob-filtered fetch always transfers. */
+  /**
+   * True only when `<readPath>/manifest.json` is a blob at the given commit. Deliberately
+   * non-recursive: a directory spelled like the manifest is then a single `tree` record the
+   * type check rejects, rather than an unbounded listing of its descendants. Reads only
+   * tree objects, which a blob-filtered fetch always transfers.
+   */
   private async treeHasBackupManifest(remoteCommit: string, readPath: string): Promise<boolean> {
-    const { stdout } = await this.localGit([
-      "ls-tree",
-      "-r",
-      "-z",
-      remoteCommit,
-      "--",
-      `:(top,literal)${readPath}/${BACKUP_MANIFEST_FILE}`,
-    ]);
-    return stdout.length > 0;
+    const { stdout } = await this.localGit(
+      ["ls-tree", "-z", remoteCommit, "--", `:(top,literal)${readPath}/${BACKUP_MANIFEST_FILE}`],
+      { env: { GIT_NO_LAZY_FETCH: "1" }, maxOutputBytes: MANIFEST_LOOKUP_MAX_OUTPUT_BYTES }
+    );
+    const record = stdout.split("\0")[0] ?? "";
+    const separator = record.indexOf("\t");
+    if (separator < 0) return false;
+    return record.slice(0, separator).trim().split(/\s+/)[1] === "blob";
   }
 
   private async listManagedBlobs(
     remoteCommit: string,
-    readPaths: readonly string[]
+    managedPath: string
   ): Promise<ManagedBlobEntry[]> {
     let stdout: string;
     try {
       ({ stdout } = await this.localGit(
-        [
-          "ls-tree",
-          "-r",
-          "-l",
-          "-z",
-          remoteCommit,
-          "--",
-          ...readPaths.map((readPath) => `:(top,literal)${readPath}`),
-        ],
+        ["ls-tree", "-r", "-l", "-z", remoteCommit, "--", `:(top,literal)${managedPath}`],
         {
           env: { GIT_NO_LAZY_FETCH: "1" },
           maxOutputBytes: MAX_BACKUP_TOTAL_BYTES,
@@ -1169,23 +1179,22 @@ export class BackupRepoCache {
 
   private async validateManagedTreeBeforeCheckout(
     remoteCommit: string,
-    readPaths: readonly string[]
+    managedPath: string
   ): Promise<void> {
-    const entries = await this.listManagedBlobs(remoteCommit, readPaths);
+    const entries = await this.listManagedBlobs(remoteCommit, managedPath);
     if (entries.length > this.materializationLimits.maxFileCount) {
       throw new BackupInvalidPayloadError(
         new Error(`Backup has more than ${this.materializationLimits.maxFileCount} files`)
       );
     }
 
-    const managedPrefixes = readPaths.map((readPath) => `${readPath}/`);
+    const managedPrefix = `${managedPath}/`;
     try {
       const payloadPaths = entries.map((entry) => {
-        const prefix = managedPrefixes.find((candidate) => entry.path.startsWith(candidate));
-        if (prefix === undefined) {
+        if (!entry.path.startsWith(managedPrefix)) {
           throw new Error(`Backup tree contains invalid path '${entry.path}'`);
         }
-        return entry.path.slice(prefix.length);
+        return entry.path.slice(managedPrefix.length);
       });
       assertBackupPathComplexity(payloadPaths);
     } catch (error) {
@@ -1222,7 +1231,7 @@ export class BackupRepoCache {
 
       const fetchedSizes = new Map<string, number>();
       const fetchedObjectIds = new Set(objectIds);
-      for (const entry of await this.listManagedBlobs(remoteCommit, readPaths)) {
+      for (const entry of await this.listManagedBlobs(remoteCommit, managedPath)) {
         if (entry.size !== null && fetchedObjectIds.has(entry.objectId)) {
           fetchedSizes.set(entry.objectId, entry.size);
         }
@@ -1255,22 +1264,23 @@ export class BackupRepoCache {
    * and the checkout that follows is what applies it. Pre-checkout size validation fetches any
    * missing managed blobs through the credential ladder.
    */
-  private async applySparseCheckout(readPaths: readonly string[]): Promise<void> {
+  private async applySparseCheckout(managedPath: string): Promise<void> {
     await writeOwnedGitInfoFile(
       this.cachePath,
       "sparse-checkout",
-      readPaths.map((readPath) => `/${escapeSparsePattern(readPath)}/*\n`).join("")
+      `/${escapeSparsePattern(managedPath)}/*\n`
     );
   }
 
   async resetHardToRemote(): Promise<string | null> {
-    // The read paths depend on the fetched commit's tree, so resolve them before the
-    // sparse patterns are written and the checkout materializes anything.
+    // The managed path selection depends on the fetched commit's tree, so resolve it
+    // before the sparse pattern is written and the checkout materializes anything.
     const remoteCommit = await this.remoteBranchCommit();
-    const readPaths = await this.resolveManagedReadPaths(remoteCommit);
-    await this.applySparseCheckout(readPaths);
+    this.selectedManagedPath = await this.resolveEffectiveManagedPath(remoteCommit);
+    const managedPath = safeRelativePath(this.selectedManagedPath);
+    await this.applySparseCheckout(managedPath);
     if (remoteCommit) {
-      await this.validateManagedTreeBeforeCheckout(remoteCommit, readPaths);
+      await this.validateManagedTreeBeforeCheckout(remoteCommit, managedPath);
       // -f because a previous preview leaves modified tracked files in this cache. Without
       // it the checkout keeps them and the next preview reads the local export as if it
       // were the remote's backup.
@@ -1350,7 +1360,7 @@ export class BackupRepoCache {
   }
 
   async stageAndCommit(message: string): Promise<string | null> {
-    const target = safeRelativePath(this.options.managedPath);
+    const target = safeRelativePath(this.effectiveManagedPath);
     // -f because the target may be a dotfiles repo whose ignore rules match payload
     // names. Skipping one file would push a manifest that references missing content.
     await this.localGit(["add", "-A", "-f", "--", target]);
@@ -1415,7 +1425,7 @@ export class BackupRepoCache {
         "-z",
         "--untracked-files=all",
         "--",
-        safeRelativePath(this.options.managedPath),
+        safeRelativePath(this.effectiveManagedPath),
       ])
     ).stdout;
   }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -1615,6 +1615,20 @@ function parseManifest(raw: string, portable: boolean): BackupManifest {
   return manifest as BackupManifest;
 }
 
+/**
+ * True when the bytes parse as a portable backup manifest. Managed-path selection probes
+ * with this rather than mere existence: `manifest.json` is a generic filename, so an
+ * unrelated or corrupt file under one spelling must not beat a valid backup under another.
+ */
+export function isParseableBackupManifest(raw: string): boolean {
+  try {
+    parseManifest(raw, true);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function backupPayloadExists(sourceDir: string): Promise<boolean> {
   return await fileExists(path.join(sourceDir, BACKUP_MANIFEST_FILE));
 }

--- a/src/node/services/backup/payload.ts
+++ b/src/node/services/backup/payload.ts
@@ -18,7 +18,7 @@ import { isErrnoWithCode } from "@/node/utils/fs";
 import type { BackupCommandApproval } from "@/common/orpc/schemas/backup";
 
 export const BACKUP_SCHEMA_VERSION = 1;
-const BACKUP_MANIFEST_FILE = "manifest.json";
+export const BACKUP_MANIFEST_FILE = "manifest.json";
 /**
  * A payload is read wholly into memory on both sides, and the repository side is written by
  * whoever can push to the branch, so an oversized entry would crash the main process during


### PR DESCRIPTION
## Summary

Settings backups pushed before the product rename live under the legacy `mux/` managed path, so a fresh Xum install pointed at the same repository failed with `No Xum backup found in 'xum/' on this branch`. The backup cache now selects one **effective managed path** per prepare: the configured spelling, or its legacy `mux` spelling when only that tree carries a backup manifest. Reads *and* writes follow the selection, so pre-rename backups restore correctly and pushes update them in place instead of forking a second `xum/` copy.

## Background

The Backup settings default managed path moved `mux/` → `xum/` across the rename, but the backup cache only ever materialized (sparse checkout), validated, and read the configured directory. Rename compatibility is centralized in `src/common/compat/legacyMux.ts`, so the alias lives there rather than as a scattered fallback.

## Implementation

- `legacyMux.ts`: `listBackupManagedPathSpellings()` returns the configured spelling first, then the legacy spelling produced by replacing whole `xum` path segments with `mux` (substrings like `xum-settings` are untouched).
- `gitRepo.ts`: before checkout, `resolveEffectiveManagedPath` probes the fetched commit for `<spelling>/manifest.json` with a bounded, non-recursive `ls-tree` that requires the entry to be a **blob** (a directory spelled like the manifest is rejected). Only the selected tree is validated, sparse-checked-out, staged, and diffed — junk under the unselected spelling can never block or bloat the backup in use.
- The selection is exposed as `PreparedBackupRepository.managedPath`; `BackupService` addresses every payload operation (export, preview, validate, restore) to it. The payload store itself stays single-path.
- The missing-backup error now names the legacy spelling that was also considered.

## Validation

New tests:
- adapters: select + restore a `mux/`-era backup via `xum/` config; push updates `mux/` in place (no `xum/` fork); configured `xum/` wins when both spellings hold backups; canonical junk (gitlink + directory `manifest.json`) doesn't block selecting a valid legacy backup.
- service unit: every payload call follows the prepared repository's managed path, not the configured settings path.
- service integration: full push(mux-era) → restore(xum settings) → re-push round trip against a real bare repo.

Pre-existing local failures unrelated to this change (case-insensitive APFS + a SIGTERM-flaky 200-commit transfer test) fail identically on the base commit.

## Risks

Low-moderate: the managed-path selection sits in the cache-materialization path all backup operations share. If selection ever picked the wrong spelling, pushes would write to that spelling — mitigated by the blob-manifest probe, configured-path precedence, and the in-place-push/no-fork tests. Behavior for repositories without any legacy spelling is unchanged (selection short-circuits to the configured path).

---

_Generated with `xum` • Model: `coder:anthropic-wif/claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=coder:anthropic-wif/claude-fable-5 thinking=xhigh -->
