### PR TITLE
🤖 fix: prevent iOS 26 Liquid Glass blur over PWA header

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     />
     <meta name="description" content="Parallel agentic development with Electron + React" />
     <meta name="theme-color" content="#09090b" />
+    <!-- iOS standalone PWA: with viewport-fit=cover, black-translucent hands the status-bar
+         band to the page (env(safe-area-inset-top)) instead of iOS drawing its own chrome
+         (opaque bar pre-iOS 26, Liquid Glass overlay on iOS/iPadOS 26+). -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials" vite-ignore />
     <link rel="icon" href="favicon.ico" data-theme-icon vite-ignore />
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" vite-ignore />

--- a/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.tsx
+++ b/src/browser/components/ActiveGoalsWarningToast/ActiveGoalsWarningToast.tsx
@@ -3,8 +3,10 @@ import { useActiveGoalCount } from "@/browser/stores/WorkspaceStore";
 
 const ACTIVE_GOAL_WARNING_THRESHOLD = 3;
 const AUTO_DISMISS_MS = 5_000;
+// max() keeps the toast below the iOS standalone status-bar band (black-translucent
+// positions fixed elements against the full screen, including the top safe area).
 const wrapperClassName =
-  "pointer-events-none fixed top-4 right-4 z-[10000] max-w-[min(420px,calc(100vw-2rem))] [&>*]:pointer-events-auto";
+  "pointer-events-none fixed top-[max(1rem,env(safe-area-inset-top,0px))] right-4 z-[10000] max-w-[min(420px,calc(100vw-2rem))] [&>*]:pointer-events-auto";
 
 interface ActiveGoalsWarningToastProps {
   activeGoalCount: number;

--- a/src/browser/components/CommandPalette/CommandPalette.tsx
+++ b/src/browser/components/CommandPalette/CommandPalette.tsx
@@ -559,7 +559,9 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
 
   return (
     <div
-      className="fixed inset-0 z-[2000] flex items-start justify-center bg-black/40 pt-[10vh]"
+      // Dim painted on a pseudo-element so iOS/iPadOS 26 WebKit's status-bar edge
+      // sampler ignores this fixed overlay (same pattern as Dialog/LeftSidebar).
+      className="fixed inset-0 z-[2000] flex items-start justify-center pt-[10vh] before:absolute before:inset-0 before:bg-black/40"
       onMouseDown={dismissPalette}
     >
       <Command

--- a/src/browser/components/CommandPalette/CommandPalette.tsx
+++ b/src/browser/components/CommandPalette/CommandPalette.tsx
@@ -567,7 +567,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ getSlashContext 
       <Command
         label={currentField?.label ?? "Command palette"}
         ref={commandPanelRef}
-        className="font-primary w-[min(720px,92vw)] overflow-hidden rounded-lg border border-[var(--color-command-border)] bg-[var(--color-command-surface)] text-[var(--color-command-foreground)] shadow-[0_10px_40px_rgba(0,0,0,0.4)]"
+        // relative keeps the panel painted above (and hit-tested before) the wrapper's
+        // absolutely positioned ::before backdrop, so clicks land on the palette instead
+        // of the wrapper's dismiss handler.
+        className="font-primary relative w-[min(720px,92vw)] overflow-hidden rounded-lg border border-[var(--color-command-border)] bg-[var(--color-command-surface)] text-[var(--color-command-foreground)] shadow-[0_10px_40px_rgba(0,0,0,0.4)]"
         onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
         onKeyDown={trapPromptFocus}
         shouldFilter={false}

--- a/src/browser/components/Dialog/Dialog.tsx
+++ b/src/browser/components/Dialog/Dialog.tsx
@@ -26,7 +26,10 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[1500] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      // Dim painted on a pseudo-element so iOS/iPadOS 26 WebKit's status-bar edge
+      // sampler ignores this fixed overlay (it samples background-color/backdrop-filter
+      // on fixed elements; pseudo-elements/absolute children are skipped).
+      "fixed inset-0 z-[1500] before:absolute before:inset-0 before:bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/browser/components/LeftSidebar/LeftSidebar.tsx
+++ b/src/browser/components/LeftSidebar/LeftSidebar.tsx
@@ -45,14 +45,16 @@ export function LeftSidebar(props: LeftSidebarProps) {
 
   return (
     <>
-      {/* Overlay backdrop - only visible on mobile when sidebar is open */}
-      <div
-        className={cn(
-          "hidden mobile-overlay fixed inset-0 bg-black/50 z-40 backdrop-blur-sm",
-          collapsed && "!hidden"
-        )}
-        onClick={onToggleCollapsed}
-      />
+      {/* Overlay backdrop - only visible on mobile when sidebar is open. Unmounted (not
+          hidden via opacity/!hidden) when collapsed: iOS/iPadOS 26 WebKit samples any
+          mounted fixed element's backdrop-filter to synthesize a Liquid Glass blur over
+          the status bar, even when the element is visually hidden. */}
+      {!collapsed && (
+        <div
+          className="mobile-overlay fixed inset-0 z-40 hidden bg-black/50 backdrop-blur-sm"
+          onClick={onToggleCollapsed}
+        />
+      )}
 
       {/* Sidebar */}
       <div

--- a/src/browser/components/LeftSidebar/LeftSidebar.tsx
+++ b/src/browser/components/LeftSidebar/LeftSidebar.tsx
@@ -46,12 +46,13 @@ export function LeftSidebar(props: LeftSidebarProps) {
   return (
     <>
       {/* Overlay backdrop - only visible on mobile when sidebar is open. Unmounted (not
-          hidden via opacity/!hidden) when collapsed: iOS/iPadOS 26 WebKit samples any
-          mounted fixed element's backdrop-filter to synthesize a Liquid Glass blur over
-          the status bar, even when the element is visually hidden. */}
+          hidden via opacity/!hidden) when collapsed, and the dim+blur is painted on a
+          pseudo-element: iOS/iPadOS 26 WebKit samples background-color/backdrop-filter on
+          any mounted fixed element (hidden or visible) to synthesize a Liquid Glass blur
+          over the status bar, but ignores pseudo-elements/absolute children. */}
       {!collapsed && (
         <div
-          className="mobile-overlay fixed inset-0 z-40 hidden bg-black/50 backdrop-blur-sm"
+          className="mobile-overlay fixed inset-0 z-40 hidden before:absolute before:inset-0 before:bg-black/50 before:backdrop-blur-sm"
           onClick={onToggleCollapsed}
         />
       )}

--- a/src/browser/components/TutorialTooltip/TutorialTooltip.tsx
+++ b/src/browser/components/TutorialTooltip/TutorialTooltip.tsx
@@ -159,7 +159,9 @@ export const TutorialTooltip: React.FC<TutorialTooltipProps> = ({
     <>
       {/* Backdrop - subtle overlay */}
       <div
-        className="fixed inset-0 z-[9998] bg-black/20"
+        // Dim painted on a pseudo-element so iOS/iPadOS 26 WebKit's status-bar edge
+        // sampler ignores this fixed overlay (same pattern as Dialog/LeftSidebar).
+        className="fixed inset-0 z-[9998] before:absolute before:inset-0 before:bg-black/20"
         data-testid="tutorial-backdrop"
         onClick={onDismiss}
       />

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1180,6 +1180,21 @@ body,
     min-height: 44px !important;
     height: auto !important;
     flex-wrap: wrap !important;
+    /* iOS/iPadOS 26 WebKit samples background-color/backdrop-filter on fixed elements
+       near the viewport edges to synthesize a native Liquid Glass blur over the status
+       bar. Keep the fixed container transparent and paint the surface on a pseudo
+       element instead; the sampler ignores pseudo-elements and absolute children. */
+    background-color: transparent !important;
+  }
+
+  .mobile-sticky-header::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    /* Matches the bg-sidebar utility that these headers use outside this media query. */
+    background-color: var(--color-sidebar);
   }
 
   /* Add padding to content below fixed header so it's not hidden underneath.
@@ -1236,6 +1251,23 @@ body,
     padding-top: env(safe-area-inset-top, 0px) !important;
     padding-bottom: env(safe-area-inset-bottom, 0px) !important;
     padding-left: env(safe-area-inset-left, 0px) !important;
+
+    /* The collapsed drawer stays mounted (translateX(-100%) preserves the slide
+       transition), so iOS/iPadOS 26 WebKit still samples its background-color to
+       synthesize a Liquid Glass blur over the status bar. Keep the fixed container
+       transparent and paint the surface on a pseudo-element, which the sampler
+       ignores (same pattern as .mobile-sticky-header). */
+    background-color: transparent !important;
+  }
+
+  .mobile-sidebar::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    /* Matches the bg-sidebar utility on the sidebar container. */
+    background-color: var(--color-sidebar);
   }
 
   .mobile-sidebar-collapsed {

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -106,6 +106,10 @@
     --color-runtime-devcontainer-text: #34d399; /* emerald-400 */
 
     /* Background & Layout */
+    /* iOS standalone PWA status-bar band backdrop. Deliberately NOT overridden by
+       light themes: black-translucent renders white status-bar glyphs in every
+       theme, so the exposed band needs a constant dark surface behind them. */
+    --color-ios-status-bar-backdrop: hsla(240, 10%, 4%, 1);
     --color-background: hsl(0 0% 12%);
     --color-background-secondary: hsl(60 1% 15%);
     --color-border: #262626; /* neutral-800 */
@@ -1125,6 +1129,27 @@ body,
 #storybook-root {
   overflow: hidden;
   background-color: var(--color-surface-primary);
+}
+
+/* iOS standalone (black-translucent) always renders white status-bar glyphs, and the
+   status-bar-style meta is read at launch, so it cannot follow runtime theme changes.
+   Light themes would expose a light surface behind the white glyphs; back the band
+   with a constant dark strip instead. Absolute pseudo-element (not fixed) so iOS 26's
+   Liquid Glass edge sampler ignores it; height collapses to 0 without top insets. */
+@media (display-mode: standalone) {
+  :root[data-theme$="light"] body::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: env(safe-area-inset-top, 0px);
+    background-color: var(--color-ios-status-bar-backdrop);
+    /* Above the off-canvas drawer (z-index 1000); the band holds no interactive
+       content (layout pads it away), and pointer-events: none keeps taps working. */
+    z-index: 1001;
+    pointer-events: none;
+  }
 }
 
 /* iPadOS reports pointer: coarse even with a trackpad attached, so selection suppression

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -1135,20 +1135,25 @@ body,
    status-bar-style meta is read at launch, so it cannot follow runtime theme changes.
    Light themes would expose a light surface behind the white glyphs; back the band
    with a constant dark strip instead. Absolute pseudo-element (not fixed) so iOS 26's
-   Liquid Glass edge sampler ignores it; height collapses to 0 without top insets. */
+   Liquid Glass edge sampler ignores it; height collapses to 0 without top insets.
+   The @supports gate limits the strip to iOS/iPadOS WebKit: Android standalone PWAs
+   pick dark status glyphs from the light theme-color, so a dark band would invert
+   contrast there. -webkit-touch-callout only exists on iOS-family WebKit. */
 @media (display-mode: standalone) {
-  :root[data-theme$="light"] body::before {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: env(safe-area-inset-top, 0px);
-    background-color: var(--color-ios-status-bar-backdrop);
-    /* Above the off-canvas drawer (z-index 1000); the band holds no interactive
-       content (layout pads it away), and pointer-events: none keeps taps working. */
-    z-index: 1001;
-    pointer-events: none;
+  @supports (-webkit-touch-callout: none) {
+    :root[data-theme$="light"] body::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: env(safe-area-inset-top, 0px);
+      background-color: var(--color-ios-status-bar-backdrop);
+      /* Above the off-canvas drawer (z-index 1000); the band holds no interactive
+         content (layout pads it away), and pointer-events: none keeps taps working. */
+      z-index: 1001;
+      pointer-events: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Eliminates the translucent "Liquid Glass" blur band that iOS/iPadOS 26 WebKit draws over the status bar and top header region when xum runs as a standalone PWA, and keeps status-bar glyphs readable in every theme.

## Background

On iOS/iPadOS 26, WebKit no longer derives standalone-PWA chrome from `theme-color` alone: it samples `background-color` / `backdrop-filter` from mounted `position: fixed` elements near the viewport edges and synthesizes a native blur overlay from them - even for elements that are visually hidden (translated off-screen, `opacity: 0`, etc.). Our fixed mobile headers (`.mobile-sticky-header`), the off-canvas drawer (`.mobile-sidebar`), and the always-mounted sidebar backdrop overlay all qualified, producing a frosted band over the TitleBar/WorkspaceMenuBar on iPad.

## Implementation

- `index.html`: add `apple-mobile-web-app-capable` + `apple-mobile-web-app-status-bar-style: black-translucent` so the page owns the top band via `env(safe-area-inset-top)` (paired with existing `viewport-fit=cover`).
- `globals.css`: fixed mobile headers and the drawer keep `background-color: transparent` and repaint their surface on an absolute `::before` (`z-index: -1`), which WebKit's edge sampler ignores. Centralized in the two classes that make these elements fixed, so desktop rendering is untouched (rules stay scoped to the existing mobile media queries).
- `globals.css`: `black-translucent` always renders white status-bar glyphs and the meta is only read at launch, so light themes back the exposed top band with a constant dark strip (`body::before`, absolute, standalone-only) instead of trying to follow the theme through the meta tag.
- `LeftSidebar.tsx`: the mobile backdrop (`fixed inset-0 backdrop-blur-sm`) unmounts when collapsed instead of relying on a `!hidden` vs `display: block !important` specificity race.

## Validation

- `make static-check` green locally; Storybook smoke suite unchanged (2 snapshot-budget failures reproduce on clean base).
- Not verifiable in this environment: actual iOS/iPadOS 26 rendering (needs a device). Worth checking on-device: blur band gone, and the dark status-bar band on light themes.

## Risks

- Low. CSS changes are scoped to `max-width: 768px` media queries (headers additionally to `pointer: coarse`) or to `display-mode: standalone` with `env(safe-area-inset-top)`-sized geometry (collapses to 0 outside iOS), so desktop/Electron rendering is unaffected. The meta tags only affect iOS standalone installs.

---

_Generated with `mux` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$17.10`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=17.10 -->
