### PR TITLE
🤖 fix: pass MCP jsonSchema tool args through PTC bridge validation

### DIFF
--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -305,6 +305,53 @@ describe("ToolBridge", () => {
       expect(result).toEqual({ echoed: { query: "eng" } });
     });
 
+    it("does not execute after an abort that lands during async validation", async () => {
+      const controller = new AbortController();
+      const mockExecute = mock((_args: unknown) => ({ ok: true }));
+      const tools: Record<string, Tool> = {
+        mcp_slow: {
+          description: "JSON-Schema tool whose validator races an abort",
+          inputSchema: jsonSchema<{ q?: string }>(
+            { type: "object", properties: { q: { type: "string" } } },
+            {
+              validate: (value) => {
+                // Abort lands while validation is outstanding; validation
+                // itself still succeeds.
+                controller.abort();
+                return Promise.resolve({ success: true as const, value: value as { q?: string } });
+              },
+            }
+          ),
+          execute: (args) => Promise.resolve(mockExecute(args)),
+        },
+      };
+
+      const bridge = new ToolBridge(tools);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(
+        createMockRuntime({
+          registerObject: mockRegisterObject,
+          getAbortSignal: mock(() => controller.signal),
+        })
+      );
+
+      const slow = registeredMux.mcp_slow as (...args: unknown[]) => Promise<unknown>;
+      try {
+        await slow({ q: "x" });
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        expect(String(e)).toContain("Execution aborted");
+      }
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
     it("serializes non-JSON values", async () => {
       // Tool that returns a non-plain object (with circular reference)
       const circularObj: Record<string, unknown> = { a: 1 };

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, mock } from "bun:test";
 import { ToolBridge, type KernelBridgeOptions } from "./toolBridge";
-import type { Tool } from "ai";
+import { jsonSchema, type Tool } from "ai";
 import type { IJSRuntime, RuntimeLimits } from "./runtime";
 import type { PTCEvent, PTCExecutionResult } from "./types";
 import { z } from "zod";
@@ -214,6 +214,41 @@ describe("ToolBridge", () => {
       // Call with valid args - should succeed
       await fileRead({ filePath: "test.txt" });
       expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes args through for JSON-Schema (MCP-style) tools", async () => {
+      // MCP tools carry the AI SDK's jsonSchema() wrapper instead of a Zod
+      // schema. Regression: validateArgs called schema.safeParse on it and
+      // every kernel-bridged MCP call died with a TypeError.
+      const mockExecute = mock((args: unknown) => ({ echoed: args }));
+      const tools: Record<string, Tool> = {
+        mcp_search: {
+          description: "MCP-style tool",
+          inputSchema: jsonSchema<{ query?: string }>({
+            type: "object",
+            properties: { query: { type: "string" } },
+          }),
+          execute: (args) => Promise.resolve(mockExecute(args)),
+        },
+      };
+
+      const bridge = new ToolBridge(tools);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(createMockRuntime({ registerObject: mockRegisterObject }));
+
+      const search = registeredMux.mcp_search as (...args: unknown[]) => Promise<unknown>;
+      const result = await search({ query: "eng" });
+
+      // Args flow through untouched — the MCP server is the validator of record.
+      expect(mockExecute).toHaveBeenCalledWith({ query: "eng" });
+      expect(result).toEqual({ echoed: { query: "eng" } });
     });
 
     it("serializes non-JSON values", async () => {

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -352,6 +352,55 @@ describe("ToolBridge", () => {
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
+    it("rejects instead of hanging when an aborted wrapper validator never settles", async () => {
+      const controller = new AbortController();
+      const mockExecute = mock((_args: unknown) => ({ ok: true }));
+      const tools: Record<string, Tool> = {
+        mcp_hang: {
+          description: "JSON-Schema tool whose validator never settles",
+          inputSchema: jsonSchema<{ q?: string }>(
+            { type: "object", properties: { q: { type: "string" } } },
+            {
+              // Hangs forever; only the abort race can settle the call.
+              validate: () => new Promise<never>(() => undefined),
+            }
+          ),
+          execute: (args) => Promise.resolve(mockExecute(args)),
+        },
+      };
+
+      const bridge = new ToolBridge(tools);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(
+        createMockRuntime({
+          registerObject: mockRegisterObject,
+          getAbortSignal: mock(() => controller.signal),
+        })
+      );
+
+      const hang = registeredMux.mcp_hang as (...args: unknown[]) => Promise<unknown>;
+      const pending = hang({ q: "x" });
+      // Flush pending microtasks so the call is suspended on the validator,
+      // then abort mid-validation (exercises the race's listener path rather
+      // than the already-aborted pre-check).
+      await new Promise((r) => setImmediate(r));
+      controller.abort();
+      try {
+        await pending;
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        expect(String(e)).toContain("Execution aborted");
+      }
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
     it("serializes non-JSON values", async () => {
       // Tool that returns a non-plain object (with circular reference)
       const circularObj: Record<string, unknown> = { a: 1 };

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -251,6 +251,60 @@ describe("ToolBridge", () => {
       expect(result).toEqual({ echoed: { query: "eng" } });
     });
 
+    it("honors a jsonSchema wrapper's custom validator (reject + normalize)", async () => {
+      const mockExecute = mock((args: unknown) => ({ echoed: args }));
+      const tools: Record<string, Tool> = {
+        mcp_guarded: {
+          description: "JSON-Schema tool with a wrapper validator",
+          inputSchema: jsonSchema<{ query: string }>(
+            { type: "object", properties: { query: { type: "string" } } },
+            {
+              // Async on purpose: covers the awaited PromiseLike path. Rejects
+              // invalid input and normalizes valid input, like direct AI SDK
+              // calls that honor Schema.validate.
+              validate: (value) => {
+                const query = (value as { query?: unknown }).query;
+                return Promise.resolve(
+                  typeof query === "string"
+                    ? { success: true as const, value: { query: query.trim() } }
+                    : { success: false as const, error: new Error("query must be a string") }
+                );
+              },
+            }
+          ),
+          execute: (args) => Promise.resolve(mockExecute(args)),
+        },
+      };
+
+      const bridge = new ToolBridge(tools);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(createMockRuntime({ registerObject: mockRegisterObject }));
+
+      const guarded = registeredMux.mcp_guarded as (...args: unknown[]) => Promise<unknown>;
+
+      // Rejection surfaces as a readable bridge error and never reaches execute.
+      try {
+        await guarded({ query: 42 });
+        expect.unreachable("Should have thrown");
+      } catch (e) {
+        expect(String(e)).toContain("Invalid arguments for mcp_guarded");
+        expect(String(e)).toContain("query must be a string");
+      }
+      expect(mockExecute).not.toHaveBeenCalled();
+
+      // Valid input reaches execute with the validator's normalized value.
+      const result = await guarded({ query: "  eng  " });
+      expect(mockExecute).toHaveBeenCalledWith({ query: "eng" });
+      expect(result).toEqual({ echoed: { query: "eng" } });
+    });
+
     it("serializes non-JSON values", async () => {
       // Tool that returns a non-plain object (with circular reference)
       const circularObj: Record<string, unknown> = { a: 1 };

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -21,6 +21,12 @@ import {
 } from "@/common/types/capabilityGrants";
 
 /**
+ * Result shape of an AI SDK Schema's optional custom validator
+ * (provider-utils ValidationResult, which the 'ai' package does not re-export).
+ */
+type SchemaValidationResult = { success: true; value: unknown } | { success: false; error: Error };
+
+/**
  * RLM kernel extras for register(): host bindings that only exist on
  * persistent mounts. Presence of this options object is the availability
  * gate — RLM off (no persistent mount) => mux.task_spawn / mux.events /
@@ -252,8 +258,8 @@ export class ToolBridge {
           throw new Error("Execution aborted");
         }
 
-        // Validate args against tool's Zod schema
-        const validatedArgs = this.validateArgs(toolName, boundTool, args);
+        // Validate args against the tool's schema (Zod or AI SDK wrapper)
+        const validatedArgs = await this.validateArgs(toolName, boundTool, args);
 
         // Execute tool with full options (toolCallId and messages are required by type
         // but not used by most tools - generate synthetic values for sandbox context)
@@ -308,7 +314,7 @@ export class ToolBridge {
           throw new Error("Execution aborted");
         }
         const baseArgs = typeof args === "object" && args !== null ? args : {};
-        const validatedArgs = this.validateArgs("task", taskTool, {
+        const validatedArgs = await this.validateArgs("task", taskTool, {
           ...baseArgs,
           run_in_background: true,
         });
@@ -396,28 +402,47 @@ export class ToolBridge {
     return typeof tool.execute === "function";
   }
 
-  private validateArgs(toolName: string, tool: Tool, args: unknown): unknown {
+  private async validateArgs(toolName: string, tool: Tool, args: unknown): Promise<unknown> {
     // AI SDK tools carry their schema on 'inputSchema'; some legacy tools use 'parameters'.
     const toolRecord = tool as { inputSchema?: unknown; parameters?: unknown };
     const schema = toolRecord.inputSchema ?? toolRecord.parameters;
     if (schema == null) return args;
 
     // Built-in tools carry Zod schemas and are validated here for early,
-    // readable errors. MCP tools instead carry the AI SDK's jsonSchema()
-    // wrapper ({ jsonSchema: <raw JSON Schema> }), which has no safeParse:
-    // pass their args through untouched, matching the direct (non-kernel)
-    // call path, where a jsonSchema wrapper without a validate function is
-    // also pass-through. The MCP server validates (and mcpServerManager
-    // sanitizes) on its side. Zod detection mirrors
+    // readable errors. Zod detection mirrors
     // typeGenerator.getInputJsonSchema's "_def" check.
-    if (typeof schema !== "object" || !("_def" in schema)) return args;
-
-    const result = (schema as z.ZodType).safeParse(args);
-    if (!result.success) {
-      const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
-      throw new Error(`Invalid arguments for ${toolName}: ${issues}`);
+    if (typeof schema === "object" && "_def" in schema) {
+      const result = (schema as z.ZodType).safeParse(args);
+      if (!result.success) {
+        const issues = result.error.issues
+          .map((i) => `${i.path.join(".")}: ${i.message}`)
+          .join("; ");
+        throw new Error(`Invalid arguments for ${toolName}: ${issues}`);
+      }
+      return result.data;
     }
-    return result.data;
+
+    // Non-Zod tools carry the AI SDK's jsonSchema() wrapper
+    // ({ jsonSchema: <raw JSON Schema>, validate? }), which has no safeParse.
+    // A wrapper-provided validator must be honored exactly like the direct
+    // (non-kernel) call path does: it may reject invalid input or return a
+    // normalized value, and may be async (ValidationResult | PromiseLike).
+    const validate = (schema as { validate?: unknown }).validate;
+    if (typeof validate === "function") {
+      const result = await (
+        validate as (value: unknown) => SchemaValidationResult | PromiseLike<SchemaValidationResult>
+      )(args);
+      if (!result.success) {
+        const message = result.error instanceof Error ? result.error.message : String(result.error);
+        throw new Error(`Invalid arguments for ${toolName}: ${message}`);
+      }
+      return result.value;
+    }
+
+    // Validator-less JSON Schema (e.g. MCP tools): pass through untouched,
+    // matching the direct call path; the MCP server validates (and
+    // mcpServerManager sanitizes) on its side.
+    return args;
   }
 
   private serializeResult(result: unknown): unknown {

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -2,8 +2,9 @@
  * Tool Bridge for PTC
  *
  * Bridges Xum tools into the QuickJS sandbox, making them callable via `xum.*`
- * (canonical) and `mux.*` (compatibility alias). Handles argument validation via
- * Zod schemas and result serialization.
+ * (canonical) and `mux.*` (compatibility alias). Handles argument validation
+ * (Zod-schema tools validate host-side; JSON-Schema-based tools such as MCP
+ * pass through to server-side validation) and result serialization.
  */
 
 import { randomUUID } from "node:crypto";
@@ -396,12 +397,22 @@ export class ToolBridge {
   }
 
   private validateArgs(toolName: string, tool: Tool, args: unknown): unknown {
-    // Access the tool's Zod schema - AI SDK tools use 'inputSchema', some use 'parameters'
-    const toolRecord = tool as { inputSchema?: z.ZodType; parameters?: z.ZodType };
+    // AI SDK tools carry their schema on 'inputSchema'; some legacy tools use 'parameters'.
+    const toolRecord = tool as { inputSchema?: unknown; parameters?: unknown };
     const schema = toolRecord.inputSchema ?? toolRecord.parameters;
-    if (!schema) return args;
+    if (schema == null) return args;
 
-    const result = schema.safeParse(args);
+    // Built-in tools carry Zod schemas and are validated here for early,
+    // readable errors. MCP tools instead carry the AI SDK's jsonSchema()
+    // wrapper ({ jsonSchema: <raw JSON Schema> }), which has no safeParse:
+    // pass their args through untouched, matching the direct (non-kernel)
+    // call path, where a jsonSchema wrapper without a validate function is
+    // also pass-through. The MCP server validates (and mcpServerManager
+    // sanitizes) on its side. Zod detection mirrors
+    // typeGenerator.getInputJsonSchema's "_def" check.
+    if (typeof schema !== "object" || !("_def" in schema)) return args;
+
+    const result = (schema as z.ZodType).safeParse(args);
     if (!result.success) {
       const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
       throw new Error(`Invalid arguments for ${toolName}: ${issues}`);

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -14,6 +14,7 @@ import type { IJSRuntime } from "./runtime";
 import type { KernelFileLoader } from "@/node/services/tools/kernelFileLoad";
 import { KERNEL_COMPACT_ARGS_CAP_BYTES } from "@/constants/kernelOutput";
 import { RESULT_HANDLE_OFFLOAD_THRESHOLD_BYTES } from "@/constants/resultHandles";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 import {
   FULL_GRANTS,
   isBridgeToolGranted,
@@ -259,11 +260,11 @@ export class ToolBridge {
         }
 
         // Validate args against the tool's schema (Zod or AI SDK wrapper)
-        const validatedArgs = await this.validateArgs(toolName, boundTool, args);
+        const validatedArgs = await this.validateArgs(toolName, boundTool, args, abortSignal);
 
-        // An abort can land while an async wrapper validator is outstanding;
-        // without this recheck the tool would still execute after a timeout or
-        // user interrupt (mirrors the post-await recheck in mux.load).
+        // validateArgs races the validator against the abort signal; this
+        // recheck covers an abort that lands after validation settles but
+        // before execute (mirrors the post-await recheck in mux.load).
         if (abortSignal?.aborted) {
           throw new Error("Execution aborted");
         }
@@ -321,12 +322,14 @@ export class ToolBridge {
           throw new Error("Execution aborted");
         }
         const baseArgs = typeof args === "object" && args !== null ? args : {};
-        const validatedArgs = await this.validateArgs("task", taskTool, {
-          ...baseArgs,
-          run_in_background: true,
-        });
+        const validatedArgs = await this.validateArgs(
+          "task",
+          taskTool,
+          { ...baseArgs, run_in_background: true },
+          abortSignal
+        );
         // Same post-validation recheck as regular bridged tools: an abort that
-        // lands during an async validator must not spawn the child.
+        // lands after validation settles must not spawn the child.
         if (abortSignal?.aborted) {
           throw new Error("Execution aborted");
         }
@@ -414,7 +417,12 @@ export class ToolBridge {
     return typeof tool.execute === "function";
   }
 
-  private async validateArgs(toolName: string, tool: Tool, args: unknown): Promise<unknown> {
+  private async validateArgs(
+    toolName: string,
+    tool: Tool,
+    args: unknown,
+    abortSignal?: AbortSignal
+  ): Promise<unknown> {
     // AI SDK tools carry their schema on 'inputSchema'; some legacy tools use 'parameters'.
     const toolRecord = tool as { inputSchema?: unknown; parameters?: unknown };
     const schema = toolRecord.inputSchema ?? toolRecord.parameters;
@@ -441,9 +449,22 @@ export class ToolBridge {
     // normalized value, and may be async (ValidationResult | PromiseLike).
     const validate = (schema as { validate?: unknown }).validate;
     if (typeof validate === "function") {
-      const result = await (
-        validate as (value: unknown) => SchemaValidationResult | PromiseLike<SchemaValidationResult>
-      )(args);
+      const validation = Promise.resolve(
+        (
+          validate as (
+            value: unknown
+          ) => SchemaValidationResult | PromiseLike<SchemaValidationResult>
+        )(args)
+      );
+      // Race the validator against the runtime abort signal: QuickJS eval
+      // aborts only settle suspended asyncified host calls, so a validator
+      // that never settles would otherwise block this await forever and keep
+      // a persistent kernel locked past timeouts and interrupts.
+      const raced = await raceWithAbortAndTimeout(validation, { signal: abortSignal });
+      if (raced.kind !== "ok") {
+        throw new Error("Execution aborted");
+      }
+      const result = raced.value;
       if (!result.success) {
         const message = result.error instanceof Error ? result.error.message : String(result.error);
         throw new Error(`Invalid arguments for ${toolName}: ${message}`);

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -261,6 +261,13 @@ export class ToolBridge {
         // Validate args against the tool's schema (Zod or AI SDK wrapper)
         const validatedArgs = await this.validateArgs(toolName, boundTool, args);
 
+        // An abort can land while an async wrapper validator is outstanding;
+        // without this recheck the tool would still execute after a timeout or
+        // user interrupt (mirrors the post-await recheck in mux.load).
+        if (abortSignal?.aborted) {
+          throw new Error("Execution aborted");
+        }
+
         // Execute tool with full options (toolCallId and messages are required by type
         // but not used by most tools - generate synthetic values for sandbox context)
         const result: unknown = await boundTool.execute!(validatedArgs, {
@@ -318,6 +325,11 @@ export class ToolBridge {
           ...baseArgs,
           run_in_background: true,
         });
+        // Same post-validation recheck as regular bridged tools: an abort that
+        // lands during an async validator must not spawn the child.
+        if (abortSignal?.aborted) {
+          throw new Error("Execution aborted");
+        }
         const result: unknown = await taskTool.execute!(validatedArgs, {
           abortSignal,
           toolCallId: syntheticToolCallId("task_spawn"),


### PR DESCRIPTION
## Problem

With RLM enabled, **every MCP tool call failed** with `TypeError: schema.safeParse is not a function` — Linear, coder, and Grafana alike, in the main kernel and in fresh sub-agent kernels. The call died synchronously in the bridge (0 bytes, 0 ms) before any server I/O.

## Root cause

`ToolBridge.validateArgs` (`src/node/services/ptc/toolBridge.ts`) cast every bridged tool's `inputSchema` to `z.ZodType` and called `schema.safeParse(args)` unconditionally. Built-in tools carry Zod schemas, but MCP tools carry the AI SDK's `jsonSchema()` wrapper (`mcpClient.ts`), which has no `safeParse`.

Latent since PTC shipped (#1212): in non-exclusive mode models call MCP tools directly and never touch `validateArgs`. RLM forces PTC-exclusive mode (`toolAssembly.ts`), making the kernel the _only_ route to MCP tools — so the latent bug became a total MCP outage.

## Fix

Discriminate schema kind in `validateArgs` using the same `"_def" in schema` check `typeGenerator.getInputJsonSchema` already uses:

- Zod tools keep host-side validation with readable errors (unchanged).
- JSON-Schema-based tools (MCP) pass through untouched — deliberately matching the direct call path, where a `jsonSchema()` wrapper without a `validate` function is also pass-through. The MCP server validates and `mcpServerManager` sanitizes server-side.

## Review hardening (Codex rounds 1–3)

- Honor a `jsonSchema()` wrapper's optional `validate` function (sync or async), matching the direct call path: it may reject invalid input or return a normalized value.
- Recheck the runtime abort signal after async validation so an abort landing mid-validation cannot let the tool (or `task_spawn`) run side effects afterward.
- Race wrapper validators against the runtime abort signal via the existing `raceWithAbortAndTimeout` helper: QuickJS eval aborts only settle suspended asyncified host calls, so a validator that never settles would otherwise block the await forever and lock a persistent kernel past timeouts and interrupts.

## Validation

- New regression tests: MCP-style `jsonSchema()` tool through the bridge (exact TypeError on old code), wrapper-validator honor/reject/normalize behavior, mid-validation abort, and a never-settling validator that must reject instead of hanging
- `bun test src/node/services/ptc/` — 247 pass, 0 fail
- `make static-check` — green

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$30.31`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=30.31 -->
