### PR TITLE
🤖 Stop AgentStatusService regenerating sidebar statuses on every restart

### DIFF
--- a/src/node/services/ExtensionMetadataService.test.ts
+++ b/src/node/services/ExtensionMetadataService.test.ts
@@ -112,6 +112,40 @@ describe("ExtensionMetadataService", () => {
     expect(snapshots.get("workspace-todos")?.hasTodos).toBe(false);
   });
 
+  test("setSidebarStatus round-trips the dedup input hash and clears it with the status", async () => {
+    const status = { emoji: "🛠️", message: "Editing source" };
+
+    const snapshot = await service.setSidebarStatus("ws-hash", status, { inputHash: "hash-1" });
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBe("hash-1");
+    // Backend-only field: must not leak into the IPC snapshot shape.
+    expect(snapshot).not.toHaveProperty("sidebarStatusInputHash");
+
+    // A status written without a hash invalidates any stale one.
+    await service.setSidebarStatus("ws-hash", status);
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBeNull();
+
+    await service.setSidebarStatus("ws-hash", status, { inputHash: "hash-2" });
+    await service.setSidebarStatus("ws-hash", null);
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBeNull();
+  });
+
+  test("sidebar status input hash survives unrelated metadata mutations", async () => {
+    // Mutators round-trip entries through coerceExtensionMetadata; dropping
+    // the hash there would silently reintroduce regenerate-on-restart after
+    // any recency/streaming/todo write.
+    await service.setSidebarStatus(
+      "ws-hash",
+      { emoji: "🛠️", message: "Editing source" },
+      { inputHash: "hash-1" }
+    );
+
+    await service.updateRecency("ws-hash", 500);
+    await service.setStreaming("ws-hash", true, { model: "anthropic:claude-haiku-4-5" });
+    await service.setTodoStatus("ws-hash", { emoji: "🔄", message: "Running checks" }, true);
+
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBe("hash-1");
+  });
+
   test("concurrent cross-workspace mutations preserve both workspace entries", async () => {
     const restoreLoad = addLoadDelay(service, 20);
     try {

--- a/src/node/services/ExtensionMetadataService.test.ts
+++ b/src/node/services/ExtensionMetadataService.test.ts
@@ -129,6 +129,20 @@ describe("ExtensionMetadataService", () => {
     expect(await service.getSidebarStatusInputHash("ws-hash")).toBeNull();
   });
 
+  test("a todo-path clear orphans the hash and the reader treats it as absent", async () => {
+    await service.setSidebarStatus(
+      "ws-hash",
+      { emoji: "🛠️", message: "Editing source" },
+      { inputHash: "hash-1" }
+    );
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBe("hash-1");
+
+    // setTodoStatus clears the shared todoStatus slot without touching the
+    // hash; the reader must not hand back a hash with no status behind it.
+    await service.setTodoStatus("ws-hash", null, false);
+    expect(await service.getSidebarStatusInputHash("ws-hash")).toBeNull();
+  });
+
   test("sidebar status input hash survives unrelated metadata mutations", async () => {
     // Mutators round-trip entries through coerceExtensionMetadata; dropping
     // the hash there would silently reintroduce regenerate-on-restart after

--- a/src/node/services/ExtensionMetadataService.ts
+++ b/src/node/services/ExtensionMetadataService.ts
@@ -258,11 +258,15 @@ export class ExtensionMetadataService {
    *   exists but no metadata yet) are seeded with `recency=0` until the
    *   next real user interaction.
    * - Doesn't touch `hasTodos`. The todo-derivation path owns that flag.
+   * - Persists `inputHash` (AgentStatusService's dedup key for the input
+   *   that produced `status`) atomically with the status so a restarted
+   *   process can skip regenerating unchanged chats. A skipped write records
+   *   nothing; clearing the status clears the hash.
    */
   async setSidebarStatus(
     workspaceId: string,
     status: ExtensionAgentStatus | null,
-    options: { skipIfRecencyAdvancedSince?: number | null } = {}
+    options: { skipIfRecencyAdvancedSince?: number | null; inputHash?: string | null } = {}
   ): Promise<WorkspaceActivitySnapshot | null> {
     return this.withSerializedMutation(async () => {
       const data = await this.load();
@@ -286,13 +290,28 @@ export class ExtensionMetadataService {
       }
       if (status) {
         workspace.todoStatus = status;
+        // The hash must describe exactly the input that produced the
+        // persisted status; a write without a hash invalidates any stale one.
+        workspace.sidebarStatusInputHash = options.inputHash ?? null;
       } else {
         delete workspace.todoStatus;
+        delete workspace.sidebarStatusInputHash;
       }
       data.workspaces[workspaceId] = workspace;
       await this.save(data);
       return toWorkspaceActivitySnapshot(workspace);
     });
+  }
+
+  /**
+   * Backend-only reader for the dedup hash persisted by setSidebarStatus.
+   * Deliberately not part of getSnapshot()/getAllSnapshots():
+   * WorkspaceActivitySnapshot is an IPC shape and must not grow
+   * backend-only fields.
+   */
+  async getSidebarStatusInputHash(workspaceId: string): Promise<string | null> {
+    const data = await this.load();
+    return coerceExtensionMetadata(data.workspaces[workspaceId])?.sidebarStatusInputHash ?? null;
   }
 
   /**

--- a/src/node/services/ExtensionMetadataService.ts
+++ b/src/node/services/ExtensionMetadataService.ts
@@ -311,7 +311,14 @@ export class ExtensionMetadataService {
    */
   async getSidebarStatusInputHash(workspaceId: string): Promise<string | null> {
     const data = await this.load();
-    return coerceExtensionMetadata(data.workspaces[workspaceId])?.sidebarStatusInputHash ?? null;
+    const entry = coerceExtensionMetadata(data.workspaces[workspaceId]);
+    // Codex review: other writers (setTodoStatus, setStreaming) clear or
+    // replace the shared todoStatus slot without touching the hash. A hash
+    // with no live status behind it is orphaned and must read as absent —
+    // otherwise a restart would dedup an unchanged transcript against a
+    // cleared slot and leave the sidebar blank until the transcript changed.
+    if (!entry?.todoStatus) return null;
+    return entry.sidebarStatusInputHash ?? null;
   }
 
   /**

--- a/src/node/services/agentStatusService.test.ts
+++ b/src/node/services/agentStatusService.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { ProjectsConfig, ProjectConfig, Workspace } from "@/common/types/project";
@@ -51,12 +51,15 @@ describe("AgentStatusService", () => {
       (
         workspaceId: string,
         status: unknown,
-        options?: { skipIfRecencyAdvancedSince?: number | null }
+        options?: { skipIfRecencyAdvancedSince?: number | null; inputHash?: string | null }
       ) => Promise<{ recency: number } | null>
     >
   >;
   let getAllSnapshotsMock: ReturnType<
     typeof mock<() => Promise<Map<string, ActivitySnapshotForTest>>>
+  >;
+  let getSidebarStatusInputHashMock: ReturnType<
+    typeof mock<(workspaceId: string) => Promise<string | null>>
   >;
   let getSnapshotMock: ReturnType<
     typeof mock<(workspaceId: string) => Promise<{ recency: number } | null>>
@@ -130,10 +133,15 @@ describe("AgentStatusService", () => {
     // Tests that exercise the active intervals override this per-test.
     getAllSnapshotsMock = mock(() => Promise.resolve(new Map<string, ActivitySnapshotForTest>()));
     getSnapshotMock = mock((_workspaceId: string) => Promise.resolve(null));
+    // Default: no persisted dedup hash → first consideration behaves as before.
+    getSidebarStatusInputHashMock = mock((_workspaceId: string) =>
+      Promise.resolve<string | null>(null)
+    );
     mockExtensionMetadata = {
       setSidebarStatus: setSidebarStatusMock,
       getAllSnapshots: getAllSnapshotsMock,
       getSnapshot: getSnapshotMock,
+      getSidebarStatusInputHash: getSidebarStatusInputHashMock,
     } as unknown as ExtensionMetadataService;
 
     mockTokenizer = {
@@ -865,7 +873,9 @@ describe("AgentStatusService", () => {
 
     expect(generateSpy).toHaveBeenCalledTimes(1);
     expect(setSidebarStatusMock).toHaveBeenCalledTimes(1);
-    expect(setSidebarStatusMock.mock.calls[0][2]).toEqual({ skipIfRecencyAdvancedSince: 100 });
+    const persistOptions = setSidebarStatusMock.mock.calls[0][2];
+    expect(persistOptions?.skipIfRecencyAdvancedSince).toBe(100);
+    expect(typeof persistOptions?.inputHash).toBe("string");
     expect(emitWorkspaceActivityMock).not.toHaveBeenCalled();
   });
 
@@ -923,16 +933,147 @@ describe("AgentStatusService", () => {
       const skipped = await svc.setSidebarStatus(
         "ws",
         { emoji: "🛠️", message: "Old status" },
-        { skipIfRecencyAdvancedSince: 100 }
+        { skipIfRecencyAdvancedSince: 100, inputHash: "hash-of-stale-input" }
       );
       const after = await svc.getSnapshot("ws");
 
       expect(skipped).toBeNull();
       expect(after?.todoStatus).toBeUndefined();
       expect(after?.recency).toBe(200);
+      // The hash must only record actually-persisted statuses: a skipped
+      // write must not seed a post-restart dedup hit for a status that
+      // never reached the sidebar.
+      expect(await svc.getSidebarStatusInputHash("ws")).toBeNull();
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  // Restart-rehydration tests use a real ExtensionMetadataService on disk so
+  // the dedup hash persisted by one service instance is visible to a
+  // "restarted" one (fresh AgentStatusService + fresh metadata service over
+  // the same file), mirroring a server restart.
+  async function withRestartableMetadata(
+    fn: (ctx: {
+      metadataPath: string;
+      newInstance: () => AgentStatusServiceInternals;
+    }) => Promise<void>
+  ): Promise<void> {
+    const dir = mkdtempSync(join(tmpdir(), "mux-agent-status-restart-"));
+    try {
+      const metadataPath = join(dir, "metadata.json");
+      await fn({
+        metadataPath,
+        newInstance: () => {
+          mockExtensionMetadata = new ExtensionMetadataService(metadataPath);
+          return getInternals(createService());
+        },
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("restart: skips regeneration when the persisted hash matches the unchanged transcript", async () => {
+    // A server restart wipes the in-memory dedup state. Without the persisted
+    // seed, every restart regenerated the status for every non-empty
+    // workspace — even chats idle for months (cost scales as restarts ×
+    // workspaces × users, and churns status wording).
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "Idle workspace")
+    );
+
+    await withRestartableMetadata(async ({ newInstance }) => {
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      // Same history after a restart: the persisted hash must satisfy dedup.
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("restart: regenerates when history changed while down, then settles on the new hash", async () => {
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "Initial request")
+    );
+
+    await withRestartableMetadata(async ({ newInstance }) => {
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      await historyHandle.historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("u2", "user", "Pivot while the server was down")
+      );
+
+      // Stale persisted hash misses dedup → regenerate. observedRecency
+      // matches the on-disk recency (0, seeded by setSidebarStatus) so the
+      // atomic recency-advance check doesn't drop the persist.
+      await newInstance().runForWorkspace(workspaceId, 0);
+      expect(generateSpy).toHaveBeenCalledTimes(2);
+
+      // The regenerated status persisted its own hash: the next restart skips.
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("restart: legacy metadata with a status but no hash regenerates once, then settles", async () => {
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "Chat from an older build")
+    );
+
+    await withRestartableMetadata(async ({ metadataPath, newInstance }) => {
+      // Metadata written by a build that predates sidebarStatusInputHash:
+      // status present, hash absent. Must self-heal without migration.
+      writeFileSync(
+        metadataPath,
+        JSON.stringify({
+          version: 1,
+          workspaces: {
+            [workspaceId]: {
+              recency: 100,
+              streaming: false,
+              lastModel: null,
+              lastThinkingLevel: null,
+              agentStatus: null,
+              todoStatus: { emoji: "🛠️", message: "Pre-upgrade status" },
+            },
+          },
+        })
+      );
+
+      // No persisted hash → falls through to the regenerate path once.
+      await newInstance().runForWorkspace(workspaceId, 100);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      // The regenerated status recorded its hash → the next restart skips.
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("restart: persisted hash folds the streaming bit so an idle restart regenerates", async () => {
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "kick off a long task")
+    );
+
+    await withRestartableMetadata(async ({ newInstance }) => {
+      // Status generated mid-stream: hash covers transcript + streaming=true.
+      await newInstance().runForWorkspace(workspaceId, null, true);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      // Restart with the workspace now idle (ExtensionMetadataService clears
+      // stale streaming flags at startup): same transcript bytes, but the
+      // tense guidance changed, so the persisted hash must not dedup.
+      await newInstance().runForWorkspace(workspaceId, 0, false);
+      expect(generateSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   test("rejects generic placeholder messages and advances dedup so we don't loop", async () => {

--- a/src/node/services/agentStatusService.test.ts
+++ b/src/node/services/agentStatusService.test.ts
@@ -1057,6 +1057,28 @@ describe("AgentStatusService", () => {
     });
   });
 
+  test("restart: does not dedup against a hash orphaned by a todo-path clear", async () => {
+    // Codex review: setTodoStatus(null) clears the shared todoStatus slot
+    // without touching the persisted hash. The orphaned hash must not
+    // suppress regeneration after a restart, or the sidebar stays blank
+    // until the transcript changes.
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "Idle workspace")
+    );
+
+    await withRestartableMetadata(async ({ newInstance }) => {
+      await newInstance().runForWorkspace(workspaceId);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+
+      // Todo path clears the slot (e.g. stream stopped with an empty todo list).
+      await mockExtensionMetadata.setTodoStatus(workspaceId, null, false);
+
+      await newInstance().runForWorkspace(workspaceId, 0);
+      expect(generateSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   test("restart: persisted hash folds the streaming bit so an idle restart regenerates", async () => {
     await historyHandle.historyService.appendToHistory(
       workspaceId,

--- a/src/node/services/agentStatusService.test.ts
+++ b/src/node/services/agentStatusService.test.ts
@@ -24,15 +24,13 @@ interface AgentStatusServiceInternals {
   runForWorkspace(
     workspaceId: string,
     observedRecency?: number | null,
-    streaming?: boolean,
-    hasSidebarStatus?: boolean | null
+    streaming?: boolean
   ): Promise<void>;
 }
 
 interface ActivitySnapshotForTest {
   streaming: boolean;
   recency?: number;
-  todoStatus?: { emoji: string; message: string };
 }
 
 describe("AgentStatusService", () => {
@@ -63,6 +61,8 @@ describe("AgentStatusService", () => {
   let getSidebarStatusInputHashMock: ReturnType<
     typeof mock<(workspaceId: string) => Promise<string | null>>
   >;
+  /** workspaceId → inputHash persisted with the current sidebar status. */
+  let sidebarSlot: Map<string, string | null>;
   let getSnapshotMock: ReturnType<
     typeof mock<(workspaceId: string) => Promise<{ recency: number } | null>>
   >;
@@ -128,16 +128,27 @@ describe("AgentStatusService", () => {
       emitWorkspaceActivity: emitWorkspaceActivityMock,
     } as unknown as WorkspaceService;
 
-    setSidebarStatusMock = mock((_workspaceId: string, _status: unknown, _options?: unknown) =>
-      Promise.resolve({ recency: 0 })
+    // Stateful fake for the shared status slot: mirrors the real service,
+    // where the reader returns a hash only while a live status backs it. The
+    // dedup recheck depends on this coupling, so a plain null-returning mock
+    // would wrongly invalidate every persisted settle.
+    sidebarSlot = new Map();
+    setSidebarStatusMock = mock(
+      (workspaceId: string, status: unknown, options?: { inputHash?: string | null }) => {
+        if (status) {
+          sidebarSlot.set(workspaceId, options?.inputHash ?? null);
+        } else {
+          sidebarSlot.delete(workspaceId);
+        }
+        return Promise.resolve({ recency: 0 });
+      }
     );
     // Default: no snapshots → no workspaces are streaming → idle intervals.
     // Tests that exercise the active intervals override this per-test.
     getAllSnapshotsMock = mock(() => Promise.resolve(new Map<string, ActivitySnapshotForTest>()));
     getSnapshotMock = mock((_workspaceId: string) => Promise.resolve(null));
-    // Default: no persisted dedup hash → first consideration behaves as before.
-    getSidebarStatusInputHashMock = mock((_workspaceId: string) =>
-      Promise.resolve<string | null>(null)
+    getSidebarStatusInputHashMock = mock((workspaceId: string) =>
+      Promise.resolve(sidebarSlot.get(workspaceId) ?? null)
     );
     mockExtensionMetadata = {
       setSidebarStatus: setSidebarStatusMock,
@@ -631,14 +642,7 @@ describe("AgentStatusService", () => {
     getAllSnapshotsMock.mockImplementation(() =>
       Promise.resolve(
         new Map<string, ActivitySnapshotForTest>([
-          // todoStatus present: mirrors production, where the first tick's
-          // successful persist writes the status this scheduler later sees.
-          // Without it the cleared-slot invalidation path would (correctly)
-          // force regeneration and mask the stale-recency behavior under test.
-          [
-            staleWorkspaceId,
-            { streaming: false, recency, todoStatus: { emoji: "🛠️", message: "Editing source" } },
-          ],
+          [staleWorkspaceId, { streaming: false, recency }],
         ])
       )
     );
@@ -1088,11 +1092,12 @@ describe("AgentStatusService", () => {
     });
   });
 
-  test("invalidates the in-memory settled hash when another writer clears the status slot", async () => {
-    // Codex review round 2: within one process, setTodoStatus(null) can clear
-    // the shared todoStatus slot after we settled by persisting. The cached
-    // hash must not keep the dedup branch skipping on the unchanged
-    // transcript, or the sidebar stays blank until the transcript changes.
+  test("regenerates when another writer clears the status slot behind a settled hash", async () => {
+    // Codex review rounds 2-3: setTodoStatus(null) can clear the shared
+    // todoStatus slot at any time after we settled by persisting — including
+    // between the scheduler's snapshot read and the dedup check. The dedup
+    // branch must confirm the persisted hash still exists at the skip
+    // decision, or the sidebar stays blank on an unchanged transcript.
     await historyHandle.historyService.appendToHistory(
       workspaceId,
       createMuxMessage("u1", "user", "Idle workspace")
@@ -1105,19 +1110,20 @@ describe("AgentStatusService", () => {
     expect(setSidebarStatusMock).toHaveBeenCalledTimes(1);
 
     // Status still present: normal dedup skip.
-    await internals.runForWorkspace(workspaceId, null, false, true);
+    await internals.runForWorkspace(workspaceId);
     expect(generateSpy).toHaveBeenCalledTimes(1);
 
     // Slot cleared by the todo path: the settled hash must drop and the
-    // same transcript must regenerate.
-    await internals.runForWorkspace(workspaceId, null, false, false);
+    // same transcript must regenerate on the very next consideration.
+    sidebarSlot.delete(workspaceId);
+    await internals.runForWorkspace(workspaceId);
     expect(generateSpy).toHaveBeenCalledTimes(2);
     expect(setSidebarStatusMock).toHaveBeenCalledTimes(2);
   });
 
-  test("a cleared status slot does not retrigger placeholder-settled transcripts", async () => {
+  test("an empty status slot does not retrigger placeholder-settled transcripts", async () => {
     // Placeholder settles never persisted a status, so "slot has no status"
-    // is their steady state, not an invalidation signal. Dropping their dedup
+    // is their steady state, not an invalidation signal. Rechecking them
     // would re-call the model on the same placeholder-producing transcript
     // every tick and burn provider budget.
     await historyHandle.historyService.appendToHistory(
@@ -1134,11 +1140,11 @@ describe("AgentStatusService", () => {
 
     const service = createService();
     const internals = getInternals(service);
-    await internals.runForWorkspace(workspaceId, null, false, false);
+    await internals.runForWorkspace(workspaceId);
     expect(generateSpy).toHaveBeenCalledTimes(1);
     expect(setSidebarStatusMock).not.toHaveBeenCalled();
 
-    await internals.runForWorkspace(workspaceId, null, false, false);
+    await internals.runForWorkspace(workspaceId);
     expect(generateSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/src/node/services/agentStatusService.test.ts
+++ b/src/node/services/agentStatusService.test.ts
@@ -24,13 +24,15 @@ interface AgentStatusServiceInternals {
   runForWorkspace(
     workspaceId: string,
     observedRecency?: number | null,
-    streaming?: boolean
+    streaming?: boolean,
+    hasSidebarStatus?: boolean | null
   ): Promise<void>;
 }
 
 interface ActivitySnapshotForTest {
   streaming: boolean;
   recency?: number;
+  todoStatus?: { emoji: string; message: string };
 }
 
 describe("AgentStatusService", () => {
@@ -629,7 +631,14 @@ describe("AgentStatusService", () => {
     getAllSnapshotsMock.mockImplementation(() =>
       Promise.resolve(
         new Map<string, ActivitySnapshotForTest>([
-          [staleWorkspaceId, { streaming: false, recency }],
+          // todoStatus present: mirrors production, where the first tick's
+          // successful persist writes the status this scheduler later sees.
+          // Without it the cleared-slot invalidation path would (correctly)
+          // force regeneration and mask the stale-recency behavior under test.
+          [
+            staleWorkspaceId,
+            { streaming: false, recency, todoStatus: { emoji: "🛠️", message: "Editing source" } },
+          ],
         ])
       )
     );
@@ -1077,6 +1086,60 @@ describe("AgentStatusService", () => {
       await newInstance().runForWorkspace(workspaceId, 0);
       expect(generateSpy).toHaveBeenCalledTimes(2);
     });
+  });
+
+  test("invalidates the in-memory settled hash when another writer clears the status slot", async () => {
+    // Codex review round 2: within one process, setTodoStatus(null) can clear
+    // the shared todoStatus slot after we settled by persisting. The cached
+    // hash must not keep the dedup branch skipping on the unchanged
+    // transcript, or the sidebar stays blank until the transcript changes.
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "Idle workspace")
+    );
+
+    const service = createService();
+    const internals = getInternals(service);
+    await internals.runForWorkspace(workspaceId);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(setSidebarStatusMock).toHaveBeenCalledTimes(1);
+
+    // Status still present: normal dedup skip.
+    await internals.runForWorkspace(workspaceId, null, false, true);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+
+    // Slot cleared by the todo path: the settled hash must drop and the
+    // same transcript must regenerate.
+    await internals.runForWorkspace(workspaceId, null, false, false);
+    expect(generateSpy).toHaveBeenCalledTimes(2);
+    expect(setSidebarStatusMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a cleared status slot does not retrigger placeholder-settled transcripts", async () => {
+    // Placeholder settles never persisted a status, so "slot has no status"
+    // is their steady state, not an invalidation signal. Dropping their dedup
+    // would re-call the model on the same placeholder-producing transcript
+    // every tick and burn provider budget.
+    await historyHandle.historyService.appendToHistory(
+      workspaceId,
+      createMuxMessage("u1", "user", "kick off a task")
+    );
+
+    generateSpy.mockResolvedValueOnce(
+      Ok({
+        status: { emoji: "💤", message: "Awaiting next task" },
+        modelUsed: "anthropic:claude-haiku-4-5",
+      })
+    );
+
+    const service = createService();
+    const internals = getInternals(service);
+    await internals.runForWorkspace(workspaceId, null, false, false);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(setSidebarStatusMock).not.toHaveBeenCalled();
+
+    await internals.runForWorkspace(workspaceId, null, false, false);
+    expect(generateSpy).toHaveBeenCalledTimes(1);
   });
 
   test("restart: persisted hash folds the streaming bit so an idle restart regenerates", async () => {

--- a/src/node/services/agentStatusService.ts
+++ b/src/node/services/agentStatusService.ts
@@ -247,11 +247,7 @@ export class AgentStatusService {
       // present-progressive tense when the assistant is mid-response.
       // Snapshots were already read once per tick above.
       const streaming = snapshots.get(id)?.streaming === true;
-      // Whether a live sidebar status still backs the shared todoStatus slot;
-      // runForWorkspace uses the false case to drop a settled hash whose
-      // status another writer has since cleared.
-      const hasSidebarStatus = snapshots.get(id)?.todoStatus != null;
-      const promise = this.runForWorkspace(id, recency, streaming, hasSidebarStatus).finally(() => {
+      const promise = this.runForWorkspace(id, recency, streaming).finally(() => {
         state.inFlight = false;
         this.inFlightPromises.delete(promise);
       });
@@ -262,9 +258,7 @@ export class AgentStatusService {
   private async runForWorkspace(
     workspaceId: string,
     observedRecency: number | null = null,
-    streaming = false,
-    // null = caller has no signal about the persisted status slot.
-    hasSidebarStatus: boolean | null = null
+    streaming = false
   ): Promise<void> {
     try {
       const transcript = await this.buildTrailingTranscript(workspaceId);
@@ -308,16 +302,6 @@ export class AgentStatusService {
           }
         }
       }
-      // Codex review: another writer (the todo path) can clear the shared
-      // status slot after we settled by persisting. Keeping the settled hash
-      // would let the dedup branch skip regeneration and leave the sidebar
-      // blank until the transcript changes, so drop it. Placeholder settles
-      // (lastInputHashPersisted=false) keep their dedup — see the field doc.
-      if (hasSidebarStatus === false && state.lastInputHashPersisted) {
-        state.lastInputHash = null;
-        state.lastInputHashPersisted = false;
-      }
-
       const markRecencyObserved = () => {
         if (observedRecency !== null) {
           state.lastObservedRecency = observedRecency;
@@ -378,8 +362,24 @@ export class AgentStatusService {
       // the streaming bit must force a re-generation so the new liveness
       // hint actually applies.
       if (state.lastInputHash === dedupHash) {
-        markRecencyObserved();
-        return;
+        // Codex review: another writer (the todo path) can clear the shared
+        // status slot at any time, including between scheduler reads, so a
+        // dispatch-time snapshot would be stale here. Confirm at the skip
+        // decision itself: the authoritative reader returns null once the
+        // slot is cleared. Placeholder settles skip the recheck — they never
+        // persisted a status, so an empty slot is their steady state, and
+        // rechecking would retry the same placeholder transcript every tick.
+        const stillBacked =
+          !state.lastInputHashPersisted ||
+          (await this.extensionMetadata.getSidebarStatusInputHash(workspaceId)) === dedupHash;
+        if (stillBacked) {
+          markRecencyObserved();
+          return;
+        }
+        // Slot cleared (or rewritten) since we settled: drop the stale
+        // settle and regenerate now instead of leaving the sidebar blank.
+        state.lastInputHash = null;
+        state.lastInputHashPersisted = false;
       }
       if (isWaitingForProviderFailureCooldown(state, dedupHash, this.clock())) {
         // Provider-side failures are not permanently settled: after the
@@ -672,14 +672,25 @@ function computeTranscriptHash(transcript: string): string {
 }
 
 /**
+ * Codex review: the dedup hash is persisted across restarts, so unlike the
+ * old process-local cache it is no longer naturally invalidated by upgrades.
+ * Bump this when status-generation semantics change without changing
+ * transcript bytes (prompt guidance, placeholder rules, tool-summary
+ * interpretation) so persisted hashes from older builds miss once and
+ * stale statuses regenerate predictably.
+ */
+const STATUS_GENERATION_VERSION = "G1";
+
+/**
  * Dedup key for generation: combines the transcript hash with the
  * streaming bit, because `streaming` changes the prompt's tense guidance
  * (and therefore the generated status). Same transcript + different
- * streaming → must regenerate. Cheap: hashes a 3-byte prefix + the
+ * streaming → must regenerate. Cheap: hashes a short prefix + the
  * already-computed transcript hash.
  */
 function computeDedupHash(transcriptHash: string, streaming: boolean): string {
   return createHash("sha256")
+    .update(STATUS_GENERATION_VERSION + "\n")
     .update(streaming ? "S1\n" : "S0\n")
     .update(transcriptHash)
     .digest("hex");

--- a/src/node/services/agentStatusService.ts
+++ b/src/node/services/agentStatusService.ts
@@ -68,8 +68,17 @@ interface State {
    * `runForWorkspace`.
    *
    * null if we have never settled on a transcript for this workspace.
+   * On the first run after process start it is seeded from the hash
+   * persisted next to the sidebar status (see persistedHashChecked).
    */
   lastInputHash: string | null;
+  /**
+   * Whether we already tried seeding lastInputHash from the hash persisted
+   * alongside the sidebar status (ExtensionMetadataService). Done lazily on
+   * the first runForWorkspace per process so a server restart doesn't
+   * regenerate statuses for chats whose transcript hasn't changed.
+   */
+  persistedHashChecked: boolean;
   /**
    * Hash of the transcript the scheduler last examined, even if that input
    * did not settle into a sidebar status (for example, a pre-provider config
@@ -269,6 +278,15 @@ export class AgentStatusService {
       // chat pivoted again.
       const state = this.ensureState(workspaceId);
 
+      // First look at this workspace since process start: seed the dedup
+      // hash persisted alongside the sidebar status so a restart doesn't
+      // regenerate every idle chat. A stale or missing persisted hash simply
+      // misses the dedup branch below and regenerates as before.
+      if (!state.persistedHashChecked) {
+        state.persistedHashChecked = true;
+        state.lastInputHash ??= await this.extensionMetadata.getSidebarStatusInputHash(workspaceId);
+      }
+
       const markRecencyObserved = () => {
         if (observedRecency !== null) {
           state.lastObservedRecency = observedRecency;
@@ -443,7 +461,9 @@ export class AgentStatusService {
         const snapshot = await this.extensionMetadata.setSidebarStatus(
           workspaceId,
           result.data.status,
-          { skipIfRecencyAdvancedSince: observedRecency }
+          // inputHash persists atomically with the status so a restarted
+          // process can skip regenerating this exact input.
+          { inputHash: dedupHash, skipIfRecencyAdvancedSince: observedRecency }
         );
         if (this.stopped) return;
         if (!snapshot) {
@@ -480,6 +500,7 @@ export class AgentStatusService {
       state = {
         lastRanAt: 0,
         lastInputHash: null,
+        persistedHashChecked: false,
         lastSeenInputHash: null,
         lastObservedRecency: null,
         lastProviderFailureHash: null,

--- a/src/node/services/agentStatusService.ts
+++ b/src/node/services/agentStatusService.ts
@@ -80,6 +80,14 @@ interface State {
    */
   persistedHashChecked: boolean;
   /**
+   * Whether lastInputHash settled by persisting a sidebar status (true) or
+   * without one, e.g. placeholder rejection (false). Only persisted settles
+   * are invalidated when another writer clears the shared status slot;
+   * invalidating placeholder settles would retry the same
+   * placeholder-producing transcript on every tick.
+   */
+  lastInputHashPersisted: boolean;
+  /**
    * Hash of the transcript the scheduler last examined, even if that input
    * did not settle into a sidebar status (for example, a pre-provider config
    * failure). Used to avoid consuming a recency bump while history is still
@@ -239,7 +247,11 @@ export class AgentStatusService {
       // present-progressive tense when the assistant is mid-response.
       // Snapshots were already read once per tick above.
       const streaming = snapshots.get(id)?.streaming === true;
-      const promise = this.runForWorkspace(id, recency, streaming).finally(() => {
+      // Whether a live sidebar status still backs the shared todoStatus slot;
+      // runForWorkspace uses the false case to drop a settled hash whose
+      // status another writer has since cleared.
+      const hasSidebarStatus = snapshots.get(id)?.todoStatus != null;
+      const promise = this.runForWorkspace(id, recency, streaming, hasSidebarStatus).finally(() => {
         state.inFlight = false;
         this.inFlightPromises.delete(promise);
       });
@@ -250,7 +262,9 @@ export class AgentStatusService {
   private async runForWorkspace(
     workspaceId: string,
     observedRecency: number | null = null,
-    streaming = false
+    streaming = false,
+    // null = caller has no signal about the persisted status slot.
+    hasSidebarStatus: boolean | null = null
   ): Promise<void> {
     try {
       const transcript = await this.buildTrailingTranscript(workspaceId);
@@ -284,7 +298,24 @@ export class AgentStatusService {
       // misses the dedup branch below and regenerates as before.
       if (!state.persistedHashChecked) {
         state.persistedHashChecked = true;
-        state.lastInputHash ??= await this.extensionMetadata.getSidebarStatusInputHash(workspaceId);
+        if (state.lastInputHash === null) {
+          const persisted = await this.extensionMetadata.getSidebarStatusInputHash(workspaceId);
+          if (persisted !== null) {
+            // The reader only returns hashes backed by a live status, so a
+            // seeded hash is by definition a persisted settle.
+            state.lastInputHash = persisted;
+            state.lastInputHashPersisted = true;
+          }
+        }
+      }
+      // Codex review: another writer (the todo path) can clear the shared
+      // status slot after we settled by persisting. Keeping the settled hash
+      // would let the dedup branch skip regeneration and leave the sidebar
+      // blank until the transcript changes, so drop it. Placeholder settles
+      // (lastInputHashPersisted=false) keep their dedup — see the field doc.
+      if (hasSidebarStatus === false && state.lastInputHashPersisted) {
+        state.lastInputHash = null;
+        state.lastInputHashPersisted = false;
       }
 
       const markRecencyObserved = () => {
@@ -299,9 +330,10 @@ export class AgentStatusService {
       // Pre-provider failures and the empty/dedup-hit branches use bare
       // `markRecencyObserved()` because they should still retry on the same
       // transcript when conditions change.
-      const settleOnTranscript = () => {
+      const settleOnTranscript = (persistedStatus: boolean) => {
         markRecencyObserved();
         state.lastInputHash = dedupHash;
+        state.lastInputHashPersisted = persistedStatus;
         resetProviderFailureTracking(state);
       };
 
@@ -450,7 +482,7 @@ export class AgentStatusService {
           workspaceId,
           message: result.data.status.message,
         });
-        settleOnTranscript();
+        settleOnTranscript(false);
         return;
       }
 
@@ -478,7 +510,7 @@ export class AgentStatusService {
           });
           return;
         }
-        settleOnTranscript();
+        settleOnTranscript(true);
         this.workspaceService.emitWorkspaceActivity(workspaceId, snapshot);
       } catch (error) {
         log.error("AgentStatusService: failed to persist generated status", {
@@ -501,6 +533,7 @@ export class AgentStatusService {
         lastRanAt: 0,
         lastInputHash: null,
         persistedHashChecked: false,
+        lastInputHashPersisted: false,
         lastSeenInputHash: null,
         lastObservedRecency: null,
         lastProviderFailureHash: null,

--- a/src/node/utils/extensionMetadata.ts
+++ b/src/node/utils/extensionMetadata.ts
@@ -30,6 +30,11 @@ export interface ExtensionMetadata {
   // Persists the latest display-status URL so later updates without a URL
   // can still carry the last deep link even after displayStatus is cleared.
   lastStatusUrl?: string | null;
+  // Backend-only dedup state for AgentStatusService: hash of the input that
+  // produced the persisted AI sidebar status. Seeds the in-memory dedup after
+  // a restart so unchanged chats are not regenerated. Never exposed on
+  // WorkspaceActivitySnapshot (IPC shape).
+  sidebarStatusInputHash?: string | null;
   goal?: GoalSnapshot | null;
 }
 
@@ -121,6 +126,9 @@ export function coerceExtensionMetadata(value: unknown): ExtensionMetadata | nul
     ...(todoStatus !== undefined ? { todoStatus } : {}),
     ...(typeof record.hasTodos === "boolean" ? { hasTodos: record.hasTodos } : {}),
     lastStatusUrl: coerceStatusUrl(record.lastStatusUrl),
+    ...(typeof record.sidebarStatusInputHash === "string"
+      ? { sidebarStatusInputHash: record.sidebarStatusInputHash }
+      : {}),
     ...(goal !== undefined ? { goal } : {}),
   };
 }


### PR DESCRIPTION
## Problem

`AgentStatusService` generates the AI sidebar status via a small-model call (Haiku-first, `propose_status`). Its "already settled on this input" dedup state (`State.lastInputHash`) was in-memory only, so **every server restart regenerated the status for every non-empty workspace**, even chats idle for months.

Verified on dogfood: 3 workspace restarts in 24h × 3 idle chats = 9 orphan Haiku gateway sessions, each rewording an unchanged status. Cost is small per call (~$0.003) but scales as restarts × workspaces × users, and churns status text.

## Fix

Persist the settled `dedupHash` as a **backend-only** field (`sidebarStatusInputHash`) in `~/.xum/extensionMetadata.json`, written atomically in the same `setSidebarStatus` mutation that persists the status. On the first post-restart consideration of a workspace, lazily seed `State.lastInputHash` from the persisted hash; the **existing** dedup branch then skips the model call with all current guards (recency-ahead-of-history wait, empty-transcript, cooldowns) unchanged.

Safety properties:

- `buildTrailingTranscript` is deterministic across restarts (same history + streaming bit ⇒ same hash); any mismatch simply falls through to the existing regenerate path — self-healing, no migration.
- The hash only records actually-persisted statuses: recency-advanced persist skips write nothing, clearing the status clears the hash, and placeholder-rejection / provider-failure settles stay in-memory only (they retry once per restart, preserving today's self-healing).
- The dedup hash folds the streaming bit, so a status generated mid-stream regenerates after an idle restart.
- Field is deliberately **not** projected into `toWorkspaceActivitySnapshot`; the IPC shape is untouched (follows the `lastStatusUrl` precedent for backend-only fields).

## Tests

- Restart skip (persisted hash + unchanged transcript ⇒ no generator call)
- Restart with changed history ⇒ regenerates, settles the new hash
- Legacy metadata without a hash ⇒ regenerates once, then settles
- Recency-advanced persist skip ⇒ hash not written
- Streaming-bit flip across restart ⇒ regenerates
- Hash round-trip/clear semantics + survival across unrelated metadata mutations + IPC-leak guard (ExtensionMetadataService suite)

## Validation

- `bun test agentStatusService.test.ts ExtensionMetadataService.test.ts`: 48 pass / 0 fail
- `make static-check` green locally (post-rebase onto main)

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$21.70`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=21.70 -->
