### PR TITLE
🤖 perf: exclude archived workspaces from projects.list response

### DIFF
--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -639,11 +639,15 @@ function installProjectSidebarTestDoubles() {
     ((props: {
       isOpen: boolean;
       projectName: string;
+      activeCount: number;
+      archivedCount: number;
       onConfirm: () => void;
       onCancel: () => void;
     }) =>
       props.isOpen ? (
-        <div data-testid="project-delete-confirmation-modal">{props.projectName}</div>
+        <div data-testid="project-delete-confirmation-modal">
+          {`${props.projectName}:${props.activeCount}:${props.archivedCount}`}
+        </div>
       ) : null) as unknown as typeof ProjectDeleteConfirmationModalModule.ProjectDeleteConfirmationModal
   );
   installProviderIconSvgMocks();
@@ -2368,11 +2372,21 @@ describe("ProjectSidebar project actions menu", () => {
     expect(view.getByRole("button", { name: "Edit name" })).toBeTruthy();
   });
 
-  test("menu actions route to settings and delete confirmation", () => {
+  test("menu actions route to settings and delete confirmation", async () => {
+    const removeProjectCalls: Array<{ path: string; options?: { force?: boolean } }> = [];
     projectContextValue = createProjectContextValue({
       userProjects: new Map([
         [demoProjectPath, { workspaces: [{ path: `${demoProjectPath}/ws-1` }] }],
       ]),
+      removeProject: (path, options) => {
+        removeProjectCalls.push({ path, options });
+        // projects.list excludes archived workspaces, so the delete flow gets
+        // blocker counts from the backend's non-forced rejection.
+        return Promise.resolve({
+          success: false,
+          error: { type: "workspace_blockers", activeCount: 2, archivedCount: 3 },
+        });
+      },
     });
 
     const view = renderSidebar();
@@ -2394,7 +2408,34 @@ describe("ProjectSidebar project actions menu", () => {
     fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));
     fireEvent.click(view.getByRole("button", { name: "Delete..." }));
 
-    expect(view.getByTestId("project-delete-confirmation-modal").textContent).toBe("demo-project");
+    // The confirmation dialog shows the backend-reported counts.
+    await waitFor(() => {
+      expect(view.getByTestId("project-delete-confirmation-modal").textContent).toBe(
+        "demo-project:2:3"
+      );
+    });
+    expect(removeProjectCalls).toEqual([{ path: demoProjectPath, options: undefined }]);
+  });
+
+  test("delete removes an empty project immediately without a confirmation dialog", async () => {
+    const removeProjectCalls: Array<{ path: string; options?: { force?: boolean } }> = [];
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([[demoProjectPath, { workspaces: [] }]]),
+      removeProject: (path, options) => {
+        removeProjectCalls.push({ path, options });
+        return Promise.resolve({ success: true });
+      },
+    });
+
+    const view = renderSidebar();
+
+    fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete..." }));
+
+    await waitFor(() => {
+      expect(removeProjectCalls).toEqual([{ path: demoProjectPath, options: undefined }]);
+    });
+    expect(view.queryByTestId("project-delete-confirmation-modal")).toBeNull();
   });
 
   test("reopening the color picker does not apply stale pending color", async () => {

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.test.tsx
@@ -249,6 +249,7 @@ function createProjectContextValue(
     refreshProjects: () => Promise.resolve(),
     addProject: () => undefined,
     removeProject: () => Promise.resolve({ success: true }),
+    getRemovalBlockers: () => Promise.resolve({ activeCount: 0, archivedCount: 0 }),
     isProjectCreateModalOpen: false,
     openProjectCreateModal: () => undefined,
     closeProjectCreateModal: () => undefined,
@@ -1319,6 +1320,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       refreshProjects: () => Promise.resolve(),
       addProject: () => undefined,
       removeProject: () => Promise.resolve({ success: true }),
+      getRemovalBlockers: () => Promise.resolve({ activeCount: 0, archivedCount: 0 }),
       isProjectCreateModalOpen: false,
       openProjectCreateModal: () => undefined,
       closeProjectCreateModal: () => undefined,
@@ -1911,6 +1913,7 @@ describe("ProjectSidebar multi-project completed-subagent toggles", () => {
       refreshProjects: () => Promise.resolve(),
       addProject: () => undefined,
       removeProject: () => Promise.resolve({ success: true }),
+      getRemovalBlockers: () => Promise.resolve({ activeCount: 0, archivedCount: 0 }),
       isProjectCreateModalOpen: false,
       openProjectCreateModal: () => undefined,
       closeProjectCreateModal: () => undefined,
@@ -2380,13 +2383,11 @@ describe("ProjectSidebar project actions menu", () => {
       ]),
       removeProject: (path, options) => {
         removeProjectCalls.push({ path, options });
-        // projects.list excludes archived workspaces, so the delete flow gets
-        // blocker counts from the backend's non-forced rejection.
-        return Promise.resolve({
-          success: false,
-          error: { type: "workspace_blockers", activeCount: 2, archivedCount: 3 },
-        });
+        return Promise.resolve({ success: true });
       },
+      // projects.list excludes archived workspaces, so the delete flow gets
+      // blocker counts from the read-only backend preflight.
+      getRemovalBlockers: () => Promise.resolve({ activeCount: 2, archivedCount: 3 }),
     });
 
     const view = renderSidebar();
@@ -2408,13 +2409,58 @@ describe("ProjectSidebar project actions menu", () => {
     fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));
     fireEvent.click(view.getByRole("button", { name: "Delete..." }));
 
-    // The confirmation dialog shows the backend-reported counts.
+    // The confirmation dialog shows the backend-reported counts, and nothing
+    // is removed before the user confirms.
     await waitFor(() => {
       expect(view.getByTestId("project-delete-confirmation-modal").textContent).toBe(
         "demo-project:2:3"
       );
     });
-    expect(removeProjectCalls).toEqual([{ path: demoProjectPath, options: undefined }]);
+    expect(removeProjectCalls).toEqual([]);
+  });
+
+  test("a stale removal preflight cannot overwrite the newer confirmation dialog", async () => {
+    const zetaProjectPath = "/projects/zeta-project";
+    const resolvers = new Map<
+      string,
+      (counts: { activeCount: number; archivedCount: number }) => void
+    >();
+    projectContextValue = createProjectContextValue({
+      userProjects: new Map([
+        [demoProjectPath, { workspaces: [{ path: `${demoProjectPath}/ws-1` }] }],
+        [zetaProjectPath, { workspaces: [{ path: `${zetaProjectPath}/ws-1` }] }],
+      ]),
+      getRemovalBlockers: (path) =>
+        new Promise((resolve) => {
+          resolvers.set(path, resolve);
+        }),
+    });
+
+    const view = renderSidebar();
+
+    fireEvent.click(view.getByRole("button", { name: "Project options for demo-project" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete..." }));
+    fireEvent.click(view.getByRole("button", { name: "Project options for zeta-project" }));
+    fireEvent.click(view.getByRole("button", { name: "Delete..." }));
+
+    await waitFor(() => {
+      expect(resolvers.size).toBe(2);
+    });
+
+    // The newer preflight resolves first and opens its dialog.
+    resolvers.get(zetaProjectPath)!({ activeCount: 1, archivedCount: 0 });
+    await waitFor(() => {
+      expect(view.getByTestId("project-delete-confirmation-modal").textContent).toBe(
+        "zeta-project:1:0"
+      );
+    });
+
+    // The slower, earlier preflight must be discarded, not overwrite the dialog.
+    resolvers.get(demoProjectPath)!({ activeCount: 2, archivedCount: 3 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(view.getByTestId("project-delete-confirmation-modal").textContent).toBe(
+      "zeta-project:1:0"
+    );
   });
 
   test("delete removes an empty project immediately without a confirmation dialog", async () => {

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -140,7 +140,6 @@ import { isMultiProject } from "@/common/utils/multiProject";
 import { isWorkspacePinnable, isWorkspacePinned } from "@/common/utils/pin";
 import { SCRATCH_PROJECT_CONFIG_KEY, SCRATCH_SIDEBAR_SECTION_ID } from "@/common/constants/scratch";
 import { MULTI_PROJECT_SIDEBAR_SECTION_ID } from "@/common/constants/multiProject";
-import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { HexColorPicker } from "react-colorful";
@@ -1390,6 +1389,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         : undefined;
 
     // Removing a sub-project unregisters it and clears the cwd pointer from its workspaces.
+    // projects.list excludes archived workspaces, so this count covers live ones only;
+    // that matches the sidebar view this dialog describes, and the action itself is
+    // non-destructive (workspaces just move back to the parent project).
     const workspacesInSection = (userProjects.get(projectPath)?.workspaces ?? []).filter(
       (workspace) => workspace.subProjectPath === subProjectPath
     );
@@ -1480,28 +1482,35 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
   );
 
   const handleRequestProjectRemoval = useCallback(
-    (projectPath: string, buttonElement?: HTMLElement) => {
+    async (projectPath: string, buttonElement?: HTMLElement) => {
       const projectConfig = userProjects.get(projectPath);
       if (!projectConfig) {
         return;
       }
 
       const projectName = projectConfig.displayName ?? getProjectNameFromPath(projectPath);
-      const counts = getProjectWorkspaceCounts(projectConfig.workspaces);
-      const total = counts.activeCount + counts.archivedCount;
-      if (total > 0) {
+      // projects.list excludes archived workspaces (read-side projection), so
+      // blocker counts can't be derived from the embedded workspace arrays.
+      // Attempt a non-forced removal instead: empty projects are removed
+      // immediately (same as before), and the backend's workspace_blockers
+      // rejection carries authoritative active/archived counts (including
+      // cross-project references) for the confirmation dialog.
+      const result = await onRemoveProject(projectPath);
+      if (result.success) {
+        return;
+      }
+      if (result.error.type === "workspace_blockers") {
         setDeleteConfirmation({
           projectPath,
           projectName,
-          activeCount: counts.activeCount,
-          archivedCount: counts.archivedCount,
+          activeCount: result.error.activeCount,
+          archivedCount: result.error.archivedCount,
         });
         return;
       }
-
-      void removeProjectWithFeedback(projectPath, undefined, buttonElement);
+      showProjectRemoveError(projectPath, result.error, buttonElement);
     },
-    [removeProjectWithFeedback, userProjects]
+    [onRemoveProject, showProjectRemoveError, userProjects]
   );
 
   const cancelProjectDisplayNameEditing = useCallback(() => {
@@ -1573,7 +1582,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         return;
       }
 
-      handleRequestProjectRemoval(projectMenuTargetPath, buttonElement);
+      void handleRequestProjectRemoval(projectMenuTargetPath, buttonElement);
       closeProjectContextMenu();
     },
     [closeProjectContextMenu, handleRequestProjectRemoval, projectMenuTargetPath]

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -1285,7 +1285,9 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         activeCount?: number;
         archivedCount?: number;
       },
-      buttonElement?: HTMLElement
+      // Callers pass precomputed coordinates because the triggering button may
+      // already be unmounted by the time an awaited removal/preflight settles.
+      anchor?: { top: number; left: number }
     ) => {
       let message: string;
       if (error.type === "workspace_blockers") {
@@ -1306,25 +1308,20 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         message = error.message ?? "Failed to remove project";
       }
 
-      let anchor: { top: number; left: number } | undefined;
-      if (buttonElement) {
-        const rect = buttonElement.getBoundingClientRect();
-        anchor = {
-          top: rect.top + window.scrollY,
-          left: rect.right + 10,
-        };
-      }
-
       projectRemoveError.showError(projectPath, message, anchor);
     },
     [projectRemoveError]
   );
 
   const removeProjectWithFeedback = useCallback(
-    async (projectPath: string, options?: { force?: boolean }, buttonElement?: HTMLElement) => {
+    async (
+      projectPath: string,
+      options?: { force?: boolean },
+      anchor?: { top: number; left: number }
+    ) => {
       const result = await onRemoveProject(projectPath, options);
       if (!result.success) {
-        showProjectRemoveError(projectPath, result.error, buttonElement);
+        showProjectRemoveError(projectPath, result.error, anchor);
       }
       return result;
     },
@@ -1495,6 +1492,16 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
       }
 
       const projectName = projectConfig.displayName ?? getProjectNameFromPath(projectPath);
+      // Capture the anchor up front: the context menu closes (unmounting the
+      // button) while the preflight below is awaited, and a disconnected
+      // element would resolve to zero coordinates.
+      const anchor =
+        buttonElement != null
+          ? (() => {
+              const rect = buttonElement.getBoundingClientRect();
+              return { top: rect.top + window.scrollY, left: rect.right + 10 };
+            })()
+          : undefined;
       // projects.list excludes archived workspaces (read-side projection), so
       // blocker counts come from a read-only backend preflight instead of the
       // embedded workspace arrays. remove() is deliberately NOT used as the
@@ -1509,7 +1516,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
           showProjectRemoveError(
             projectPath,
             { type: "unknown", message: getErrorMessage(error) },
-            buttonElement
+            anchor
           );
         }
         return;
@@ -1527,7 +1534,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
         return;
       }
 
-      void removeProjectWithFeedback(projectPath, undefined, buttonElement);
+      void removeProjectWithFeedback(projectPath, undefined, anchor);
     },
     [getRemovalBlockers, removeProjectWithFeedback, showProjectRemoveError, userProjects]
   );

--- a/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/browser/components/ProjectSidebar/ProjectSidebar.tsx
@@ -716,6 +716,7 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     userProjects,
     openProjectCreateModal: onAddProject,
     removeProject: onRemoveProject,
+    getRemovalBlockers,
     updateDisplayName,
     updateColor: updateProjectColor,
     assignWorkspaceToSubProject,
@@ -1481,6 +1482,11 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
     [projectContextMenu]
   );
 
+  // Monotonic token so a slower earlier removal preflight can never overwrite
+  // the confirmation dialog (or trigger removal) for a project the user
+  // selected afterwards.
+  const removalPreflightSeq = useRef(0);
+
   const handleRequestProjectRemoval = useCallback(
     async (projectPath: string, buttonElement?: HTMLElement) => {
       const projectConfig = userProjects.get(projectPath);
@@ -1490,27 +1496,40 @@ const ProjectSidebarInner: React.FC<ProjectSidebarProps> = ({
 
       const projectName = projectConfig.displayName ?? getProjectNameFromPath(projectPath);
       // projects.list excludes archived workspaces (read-side projection), so
-      // blocker counts can't be derived from the embedded workspace arrays.
-      // Attempt a non-forced removal instead: empty projects are removed
-      // immediately (same as before), and the backend's workspace_blockers
-      // rejection carries authoritative active/archived counts (including
-      // cross-project references) for the confirmation dialog.
-      const result = await onRemoveProject(projectPath);
-      if (result.success) {
+      // blocker counts come from a read-only backend preflight instead of the
+      // embedded workspace arrays. remove() is deliberately NOT used as the
+      // probe: it prunes stale workspace entries and deletes the project when
+      // nothing remains, which must not happen before the user confirms.
+      const seq = ++removalPreflightSeq.current;
+      let counts: { activeCount: number; archivedCount: number };
+      try {
+        counts = await getRemovalBlockers(projectPath);
+      } catch (error) {
+        if (seq === removalPreflightSeq.current) {
+          showProjectRemoveError(
+            projectPath,
+            { type: "unknown", message: getErrorMessage(error) },
+            buttonElement
+          );
+        }
         return;
       }
-      if (result.error.type === "workspace_blockers") {
+      if (seq !== removalPreflightSeq.current) {
+        return;
+      }
+      if (counts.activeCount + counts.archivedCount > 0) {
         setDeleteConfirmation({
           projectPath,
           projectName,
-          activeCount: result.error.activeCount,
-          archivedCount: result.error.archivedCount,
+          activeCount: counts.activeCount,
+          archivedCount: counts.archivedCount,
         });
         return;
       }
-      showProjectRemoveError(projectPath, result.error, buttonElement);
+
+      void removeProjectWithFeedback(projectPath, undefined, buttonElement);
     },
-    [onRemoveProject, showProjectRemoveError, userProjects]
+    [getRemovalBlockers, removeProjectWithFeedback, showProjectRemoveError, userProjects]
   );
 
   const cancelProjectDisplayNameEditing = useCallback(() => {

--- a/src/browser/contexts/ProjectContext.tsx
+++ b/src/browser/contexts/ProjectContext.tsx
@@ -22,6 +22,7 @@ import {
   getDraftScopeId,
 } from "@/common/constants/storage";
 import { getErrorMessage } from "@/common/utils/errors";
+import type { ProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 import { getProjectRouteId } from "@/common/utils/projectRouteId";
 import { SCRATCH_PROJECT_CONFIG_KEY } from "@/common/constants/scratch";
 import { getFirstTopLevelProjectPath } from "@/common/utils/subProjects";
@@ -79,6 +80,11 @@ export interface ProjectContext {
   refreshProjects: () => Promise<void>;
   addProject: (normalizedPath: string, projectConfig: ProjectConfig) => void;
   removeProject: (path: string, options?: { force?: boolean }) => Promise<ProjectRemoveResult>;
+  /**
+   * Read-only removal preflight (no pruning/deletion side effects). Needed by
+   * the delete confirmation because projects.list excludes archived workspaces.
+   */
+  getRemovalBlockers: (path: string) => Promise<ProjectWorkspaceCounts>;
 
   // Project creation modal
   projectCreateInitialPath?: string;
@@ -348,6 +354,16 @@ export function ProjectProvider(props: { children: ReactNode }) {
     [api, refreshProjects]
   );
 
+  const getRemovalBlockers = useCallback(
+    async (path: string): Promise<ProjectWorkspaceCounts> => {
+      if (!api) {
+        throw new Error("API not connected");
+      }
+      return api.projects.getRemovalBlockers({ projectPath: path });
+    },
+    [api]
+  );
+
   const resolveProjectPath = useCallback(
     (query: ProjectQuery): string | null => {
       // The scratch sentinel is not a configured project until the first
@@ -606,6 +622,7 @@ export function ProjectProvider(props: { children: ReactNode }) {
       refreshProjects,
       addProject,
       removeProject,
+      getRemovalBlockers,
       projectCreateInitialPath,
       isProjectCreateModalOpen,
       openProjectCreateModal: (options?: { initialPath?: string }) => {
@@ -655,6 +672,7 @@ export function ProjectProvider(props: { children: ReactNode }) {
       refreshProjects,
       addProject,
       removeProject,
+      getRemovalBlockers,
       projectCreateInitialPath,
       isProjectCreateModalOpen,
       workspaceModalState,

--- a/src/browser/contexts/ProjectContext.tsx
+++ b/src/browser/contexts/ProjectContext.tsx
@@ -354,16 +354,6 @@ export function ProjectProvider(props: { children: ReactNode }) {
     [api, refreshProjects]
   );
 
-  const getRemovalBlockers = useCallback(
-    async (path: string): Promise<ProjectWorkspaceCounts> => {
-      if (!api) {
-        throw new Error("API not connected");
-      }
-      return api.projects.getRemovalBlockers({ projectPath: path });
-    },
-    [api]
-  );
-
   const resolveProjectPath = useCallback(
     (query: ProjectQuery): string | null => {
       // The scratch sentinel is not a configured project until the first
@@ -622,7 +612,14 @@ export function ProjectProvider(props: { children: ReactNode }) {
       refreshProjects,
       addProject,
       removeProject,
-      getRemovalBlockers,
+      // Inline (not useCallback-wrapped): `api` is already a dependency of
+      // this provider value memo, mirroring the other inline actions below.
+      getRemovalBlockers: async (path: string): Promise<ProjectWorkspaceCounts> => {
+        if (!api) {
+          throw new Error("API not connected");
+        }
+        return api.projects.getRemovalBlockers({ projectPath: path });
+      },
       projectCreateInitialPath,
       isProjectCreateModalOpen,
       openProjectCreateModal: (options?: { initialPath?: string }) => {
@@ -672,7 +669,6 @@ export function ProjectProvider(props: { children: ReactNode }) {
       refreshProjects,
       addProject,
       removeProject,
-      getRemovalBlockers,
       projectCreateInitialPath,
       isProjectCreateModalOpen,
       workspaceModalState,

--- a/src/browser/contexts/WorkspaceContext.tsx
+++ b/src/browser/contexts/WorkspaceContext.tsx
@@ -1271,9 +1271,9 @@ export function WorkspaceProvider(props: WorkspaceProviderProps) {
               updated.set(event.workspaceId, meta);
             }
 
-            // Reload projects when archive state changes so that
-            // getProjectWorkspaceCounts (used for removal eligibility) sees
-            // up-to-date archivedAt timestamps in the project config.
+            // Reload projects when archive state changes so the sidebar's
+            // embedded workspace arrays stay in sync (projects.list excludes
+            // archived workspaces, so archiving/unarchiving changes them).
             const wasInActiveMap = prev.has(event.workspaceId);
             const archiveStateChanged = isNowArchived
               ? wasInActiveMap // was active, now archived

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -78,6 +78,7 @@ import {
 import type { z } from "zod";
 import type { ProjectRemoveErrorSchema } from "@/common/orpc/schemas/errors";
 import { isWorkspaceArchived } from "@/common/utils/archive";
+import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
 
 /** Session usage data structure matching SessionUsageFileSchema */
 export interface MockSessionUsage {
@@ -1325,7 +1326,20 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
       },
     },
     projects: {
-      list: () => Promise.resolve(Array.from(projects.entries())),
+      // Mirror the server-side read projection: projects.list excludes archived
+      // workspaces (the UI loads them on demand via workspace.list({archived:true})).
+      list: () =>
+        Promise.resolve(
+          Array.from(projects.entries()).map(([projectPath, project]): [string, ProjectConfig] => [
+            projectPath,
+            {
+              ...project,
+              workspaces: project.workspaces.filter(
+                (workspace) => !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)
+              ),
+            },
+          ])
+        ),
       create: () =>
         Promise.resolve({
           success: true,
@@ -1373,9 +1387,20 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         }
         return Promise.resolve({ success: true as const });
       },
-      remove: (input: { projectPath: string }) => {
+      remove: (input: { projectPath: string; force?: boolean | null }) => {
         if (onProjectRemove) {
           return Promise.resolve(onProjectRemove(input.projectPath));
+        }
+        // Mirror the real backend: a non-forced removal of a project that still
+        // has workspaces is rejected with authoritative blocker counts, which
+        // the sidebar uses to populate the delete confirmation dialog.
+        const project = projects.get(input.projectPath);
+        const counts = getProjectWorkspaceCounts(project?.workspaces ?? []);
+        if (input.force !== true && counts.activeCount + counts.archivedCount > 0) {
+          return Promise.resolve({
+            success: false,
+            error: { type: "workspace_blockers", ...counts },
+          });
         }
         return Promise.resolve({ success: true, data: undefined });
       },

--- a/src/browser/stories/mocks/orpc.ts
+++ b/src/browser/stories/mocks/orpc.ts
@@ -1387,6 +1387,11 @@ export function createMockORPCClient(options: MockORPCClientOptions = {}): APICl
         }
         return Promise.resolve({ success: true as const });
       },
+      // Read-only preflight used by the delete confirmation dialog.
+      getRemovalBlockers: (input: { projectPath: string }) => {
+        const project = projects.get(input.projectPath);
+        return Promise.resolve(getProjectWorkspaceCounts(project?.workspaces ?? []));
+      },
       remove: (input: { projectPath: string; force?: boolean | null }) => {
         if (onProjectRemove) {
           return Promise.resolve(onProjectRemove(input.projectPath));

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -35,6 +35,7 @@ import {
   GoalSetInputSchema,
 } from "./goal";
 import { ProjectConfigSchema } from "./project";
+import { ProjectWorkspaceCountsSchema } from "@/common/utils/projectRemoval";
 import {
   MemoryChangeEventSchema,
   MemoryConsolidationRecordSchema,
@@ -759,10 +760,7 @@ export const projects = {
   // longer embeds archived workspaces, so blocker counts come from the backend.
   getRemovalBlockers: {
     input: z.object({ projectPath: z.string() }),
-    output: z.object({
-      activeCount: z.number().int().nonnegative(),
-      archivedCount: z.number().int().nonnegative(),
-    }),
+    output: ProjectWorkspaceCountsSchema,
   },
   list: {
     input: z.void(),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -755,6 +755,15 @@ export const projects = {
     input: z.object({ projectPath: z.string(), force: z.boolean().nullish() }).passthrough(),
     output: ResultSchema(z.void(), ProjectRemoveErrorSchema),
   },
+  // Read-only preflight for the delete confirmation dialog: projects.list no
+  // longer embeds archived workspaces, so blocker counts come from the backend.
+  getRemovalBlockers: {
+    input: z.object({ projectPath: z.string() }),
+    output: z.object({
+      activeCount: z.number().int().nonnegative(),
+      archivedCount: z.number().int().nonnegative(),
+    }),
+  },
   list: {
     input: z.void(),
     output: z.array(z.tuple([z.string(), ProjectConfigSchema])),

--- a/src/common/utils/projectRemoval.ts
+++ b/src/common/utils/projectRemoval.ts
@@ -1,9 +1,17 @@
+import { z } from "zod";
 import { isWorkspaceArchived } from "./archive";
 
-export interface ProjectWorkspaceCounts {
-  activeCount: number;
-  archivedCount: number;
-}
+/**
+ * Single source of truth for removal blocker counts: the projects.getRemovalBlockers
+ * IPC output validates against this schema, so service return type and runtime
+ * validation cannot drift.
+ */
+export const ProjectWorkspaceCountsSchema = z.object({
+  activeCount: z.number().int().nonnegative(),
+  archivedCount: z.number().int().nonnegative(),
+});
+
+export type ProjectWorkspaceCounts = z.infer<typeof ProjectWorkspaceCountsSchema>;
 
 /**
  * Compute active vs archived workspace counts from a project's workspace config entries.

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -3619,6 +3619,12 @@ export const router = (authToken?: string) => {
           }
           return Ok(undefined);
         }),
+      getRemovalBlockers: t
+        .input(schemas.projects.getRemovalBlockers.input)
+        .output(schemas.projects.getRemovalBlockers.output)
+        .handler(({ context, input }) => {
+          return context.projectService.getRemovalBlockers(input.projectPath);
+        }),
       secrets: {
         get: t
           .input(schemas.projects.secrets.get.input)

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2364,6 +2364,94 @@ exit 1
     });
   });
 
+  describe("list", () => {
+    it("excludes archived workspaces while preserving live ones", async () => {
+      const projectPath = "/fake/project";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          { id: "live-1", path: "/fake/project/ws-live" },
+          { id: "archived-1", path: "/fake/project/ws-archived", archivedAt: ARCHIVED_AT },
+          {
+            id: "unarchived-1",
+            path: "/fake/project/ws-unarchived",
+            archivedAt: ARCHIVED_AT,
+            unarchivedAt: "2026-01-02T00:00:00.000Z",
+          },
+        ],
+      });
+      await config.editConfig(() => cfg);
+
+      const listed = service.list();
+
+      const project = listed.find(([listedPath]) => listedPath === projectPath)?.[1];
+      expect(project).toBeDefined();
+      expect(project?.workspaces.map((workspace) => workspace.id)).toEqual([
+        "live-1",
+        "unarchived-1",
+      ]);
+    });
+
+    it("keeps live multi-project workspaces in their bucket", async () => {
+      const projectPath = "/fake/project";
+      const otherProjectPath = "/fake/other";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          {
+            id: "multi-live",
+            path: "/fake/project/ws-multi",
+            projects: [
+              { projectPath, projectName: "project" },
+              { projectPath: otherProjectPath, projectName: "other" },
+            ],
+          },
+          {
+            id: "multi-archived",
+            path: "/fake/project/ws-multi-archived",
+            archivedAt: ARCHIVED_AT,
+            projects: [
+              { projectPath, projectName: "project" },
+              { projectPath: otherProjectPath, projectName: "other" },
+            ],
+          },
+        ],
+      });
+      await config.editConfig(() => cfg);
+
+      const listed = service.list();
+
+      const project = listed.find(([listedPath]) => listedPath === projectPath)?.[1];
+      expect(project?.workspaces.map((workspace) => workspace.id)).toEqual(["multi-live"]);
+      expect(project?.workspaces[0]?.projects?.map((ref) => ref.projectPath)).toEqual([
+        projectPath,
+        otherProjectPath,
+      ]);
+    });
+
+    it("does not modify archived entries in persisted config", async () => {
+      const projectPath = "/fake/project";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          { id: "live-1", path: "/fake/project/ws-live" },
+          { id: "archived-1", path: "/fake/project/ws-archived", archivedAt: ARCHIVED_AT },
+        ],
+      });
+      await config.editConfig(() => cfg);
+
+      service.list();
+
+      // The projection must not leak into the in-memory or persisted config:
+      // archived entries stay on disk for older builds (downgrade safety).
+      const after = config.loadConfigOrDefault();
+      expect(after.projects.get(projectPath)?.workspaces.map((workspace) => workspace.id)).toEqual([
+        "live-1",
+        "archived-1",
+      ]);
+    });
+  });
+
   describe("remove", () => {
     it("removes project with no workspaces", async () => {
       const projectPath = "/fake/project";

--- a/src/node/services/projectService.test.ts
+++ b/src/node/services/projectService.test.ts
@@ -2452,7 +2452,100 @@ exit 1
     });
   });
 
+  describe("getRemovalBlockers", () => {
+    it("counts own-bucket and cross-project blockers without mutating config", async () => {
+      const projectPath = "/fake/project";
+      const otherPath = "/fake/other";
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, {
+        workspaces: [
+          // Missing checkout directory on purpose: unlike remove(), the
+          // preflight must not prune stale entries (or delete the project).
+          { id: "stale-live", path: path.join(tempDir, "missing-checkout") },
+          { id: "own-archived", path: path.join(tempDir, "archived"), archivedAt: ARCHIVED_AT },
+        ],
+      });
+      cfg.projects.set(otherPath, {
+        workspaces: [
+          {
+            id: "cross-ref",
+            path: path.join(tempDir, "cross"),
+            projects: [
+              { projectPath: otherPath, projectName: "other" },
+              { projectPath, projectName: "project" },
+            ],
+          },
+        ],
+      });
+      await config.editConfig(() => cfg);
+
+      const counts = service.getRemovalBlockers(projectPath);
+
+      expect(counts).toEqual({ activeCount: 2, archivedCount: 1 });
+      const after = config.loadConfigOrDefault();
+      expect(after.projects.get(projectPath)?.workspaces.map((ws) => ws.id)).toEqual([
+        "stale-live",
+        "own-archived",
+      ]);
+    });
+
+    it("returns zero counts for unknown projects", () => {
+      expect(service.getRemovalBlockers("/no/such/project")).toEqual({
+        activeCount: 0,
+        archivedCount: 0,
+      });
+    });
+  });
+
   describe("remove", () => {
+    it("force removal fails fast on cross-project references without deleting owned workspaces", async () => {
+      const projectPath = "/fake/project";
+      const otherPath = "/fake/other";
+      const ownWorkspaceDir = path.join(tempDir, "owned-workspace");
+      await fs.mkdir(ownWorkspaceDir, { recursive: true });
+      const cfg = config.loadConfigOrDefault();
+      cfg.projects.set(projectPath, {
+        workspaces: [{ id: "owned-1", path: ownWorkspaceDir }],
+      });
+      cfg.projects.set(otherPath, {
+        workspaces: [
+          {
+            id: "cross-ref",
+            path: path.join(tempDir, "cross"),
+            projects: [
+              { projectPath: otherPath, projectName: "other" },
+              { projectPath, projectName: "project" },
+            ],
+          },
+        ],
+      });
+      await config.editConfig(() => cfg);
+
+      const removedWorkspaceIds: string[] = [];
+      service.setWorkspaceService({
+        remove: async (workspaceId) => {
+          removedWorkspaceIds.push(workspaceId);
+          await config.removeWorkspace(workspaceId);
+          return Ok(undefined);
+        },
+      });
+
+      const result = await service.remove(projectPath, true);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error("Expected failure");
+      expect(result.error).toEqual({
+        type: "workspace_blockers",
+        activeCount: 2,
+        archivedCount: 0,
+      });
+      // The cascade must not have started: a partial deletion would destroy
+      // owned workspaces and still leave the project registered.
+      expect(removedWorkspaceIds).toEqual([]);
+      const after = config.loadConfigOrDefault();
+      expect(after.projects.get(projectPath)?.workspaces.map((ws) => ws.id)).toEqual(["owned-1"]);
+    });
+
     it("removes project with no workspaces", async () => {
       const projectPath = "/fake/project";
       const cfg = config.loadConfigOrDefault();

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -41,7 +41,10 @@ import { getXumProjectsDir } from "@/common/constants/paths";
 import { expandTilde } from "@/node/runtime/tildeExpansion";
 import { getErrorMessage } from "@/common/utils/errors";
 import { deriveProjectHierarchy, isPathDescendant } from "@/common/utils/subProjects";
-import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
+import {
+  getProjectWorkspaceCounts,
+  type ProjectWorkspaceCounts,
+} from "@/common/utils/projectRemoval";
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import type { z } from "zod";
 
@@ -1290,6 +1293,19 @@ export class ProjectService {
 
       const totalWorkspaces = counts.activeCount + counts.archivedCount;
       if (force && totalWorkspaces > 0) {
+        // Fail fast on cross-project references BEFORE the cascade: the force
+        // loop below only deletes this project's own bucket, so proceeding
+        // would permanently delete owned workspaces and then still fail on the
+        // external references, leaving a partially-deleted project behind.
+        const crossCounts = this.countCrossProjectReferences(config, normalizedPath);
+        if (crossCounts.activeCount + crossCounts.archivedCount > 0) {
+          return Err({
+            type: "workspace_blockers" as const,
+            activeCount: counts.activeCount + crossCounts.activeCount,
+            archivedCount: counts.archivedCount + crossCounts.archivedCount,
+          });
+        }
+
         if (!this.workspaceService) {
           return Err({
             type: "unknown" as const,
@@ -1337,35 +1353,12 @@ export class ProjectService {
         counts = getProjectWorkspaceCounts(projectConfig.workspaces);
       }
 
-      // Also count multi-project workspace references to this project from OTHER project buckets.
-      // Multi-project workspaces can be stored under _multi (interactive creation) or under
-      // any project bucket (task/fork creation via taskService).
-      let crossProjectActiveCount = 0;
-      let crossProjectArchivedCount = 0;
-      for (const [configKey, otherConfig] of config.projects) {
-        if (configKey === normalizedPath) {
-          // Project workspaces in this bucket are already counted above.
-          continue;
-        }
-
-        const referencingWorkspaces = otherConfig.workspaces.filter((workspace) =>
-          workspace.projects?.some(
-            (project) => stripTrailingSlashes(project.projectPath) === normalizedPath
-          )
-        );
-
-        if (referencingWorkspaces.length === 0) {
-          continue;
-        }
-
-        const referencingWorkspaceCounts = getProjectWorkspaceCounts(referencingWorkspaces);
-        crossProjectActiveCount += referencingWorkspaceCounts.activeCount;
-        crossProjectArchivedCount += referencingWorkspaceCounts.archivedCount;
-      }
-
+      // Also count multi-project workspace references to this project from OTHER
+      // project buckets (recomputed from the post-cascade config snapshot).
+      const crossProjectCounts = this.countCrossProjectReferences(config, normalizedPath);
       counts = {
-        activeCount: counts.activeCount + crossProjectActiveCount,
-        archivedCount: counts.archivedCount + crossProjectArchivedCount,
+        activeCount: counts.activeCount + crossProjectCounts.activeCount,
+        archivedCount: counts.archivedCount + crossProjectCounts.archivedCount,
       };
 
       if (counts.activeCount + counts.archivedCount > 0) {
@@ -1407,6 +1400,62 @@ export class ProjectService {
       const message = getErrorMessage(error);
       return Err({ type: "unknown" as const, message: `Failed to remove project: ${message}` });
     }
+  }
+
+  /**
+   * Count multi-project workspace references to this project stored in OTHER
+   * project buckets. Multi-project workspaces can live under _multi
+   * (interactive creation) or any project bucket (task/fork creation).
+   */
+  private countCrossProjectReferences(
+    config: { projects: Map<string, ProjectConfig> },
+    normalizedPath: string
+  ): ProjectWorkspaceCounts {
+    let activeCount = 0;
+    let archivedCount = 0;
+    for (const [configKey, otherConfig] of config.projects) {
+      if (configKey === normalizedPath) {
+        // Project workspaces in this bucket are counted by the caller.
+        continue;
+      }
+
+      const referencingWorkspaces = otherConfig.workspaces.filter((workspace) =>
+        workspace.projects?.some(
+          (project) => stripTrailingSlashes(project.projectPath) === normalizedPath
+        )
+      );
+
+      if (referencingWorkspaces.length === 0) {
+        continue;
+      }
+
+      const referencingWorkspaceCounts = getProjectWorkspaceCounts(referencingWorkspaces);
+      activeCount += referencingWorkspaceCounts.activeCount;
+      archivedCount += referencingWorkspaceCounts.archivedCount;
+    }
+    return { activeCount, archivedCount };
+  }
+
+  /**
+   * Read-only removal preflight: reports the same blocker counts remove()
+   * enforces (own bucket + cross-project references) WITHOUT remove()'s side
+   * effects (stale-entry pruning, deletion of empty projects). The delete
+   * confirmation dialog needs this because projects.list no longer carries
+   * archived workspaces to count client-side.
+   */
+  getRemovalBlockers(projectPath: string): ProjectWorkspaceCounts {
+    const normalizedPath = stripTrailingSlashes(projectPath);
+    const config = this.config.loadConfigOrDefault();
+    const projectConfig = config.projects.get(normalizedPath);
+    if (!projectConfig) {
+      return { activeCount: 0, archivedCount: 0 };
+    }
+    const ownCounts = getProjectWorkspaceCounts(projectConfig.workspaces);
+    const crossCounts = this.countCrossProjectReferences(config, normalizedPath);
+    return {
+      activeCount: ownCounts.activeCount + crossCounts.activeCount,
+      archivedCount: ownCounts.archivedCount + crossCounts.archivedCount,
+    };
   }
 
   list(): Array<[string, ProjectConfig]> {

--- a/src/node/services/projectService.ts
+++ b/src/node/services/projectService.ts
@@ -42,6 +42,7 @@ import { expandTilde } from "@/node/runtime/tildeExpansion";
 import { getErrorMessage } from "@/common/utils/errors";
 import { deriveProjectHierarchy, isPathDescendant } from "@/common/utils/subProjects";
 import { getProjectWorkspaceCounts } from "@/common/utils/projectRemoval";
+import { isWorkspaceArchived } from "@/common/utils/archive";
 import type { z } from "zod";
 
 function orderWorkspacesForCascadeRemoval(
@@ -1411,7 +1412,24 @@ export class ProjectService {
   list(): Array<[string, ProjectConfig]> {
     try {
       const config = this.config.loadConfigOrDefault();
-      return Array.from(deriveProjectHierarchy(config.projects).entries());
+      // Read-side projection: exclude archived workspaces from the listing. On
+      // archive-heavy configs they dominate the payload (measured 84% of a
+      // 1.1 MB projects.list response re-fetched on every config change), and
+      // the UI loads archived workspaces on demand via
+      // workspace.list({ archived: true }). Build new arrays instead of
+      // mutating the loaded config: persisted config.json must keep archived
+      // entries (upgrade/downgrade safety).
+      return Array.from(deriveProjectHierarchy(config.projects).entries()).map(
+        ([projectPath, project]): [string, ProjectConfig] => [
+          projectPath,
+          {
+            ...project,
+            workspaces: project.workspaces.filter(
+              (workspace) => !isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)
+            ),
+          },
+        ]
+      );
     } catch (error) {
       log.error("Failed to list projects:", error);
       return [];


### PR DESCRIPTION
Part (a) of #3960.

## Summary

`projects.list` no longer serializes archived workspaces. This is a read-side/API projection only: archived entries remain untouched in `config.json` (upgrade↔downgrade safe), they are simply excluded from the response that `ProjectContext` re-fetches on every `config.onConfigChanged` signal. On the reference deployment (1,513 embedded workspaces, 84% archived, 1.12 MB per call, re-fetched 8× in a 4-minute session) this removes the top byte source on the frontend WebSocket.

## Audit: who consumes the embedded `workspaces` arrays?

Exactly three frontend read sites consume `project.workspaces` from `projects.list`:

| Consumer                                                                        | Needs archived entries?                                                                                                        | Outcome               |
| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
| `buildSortedWorkspacesByProject` (`src/browser/utils/ui/workspaceFiltering.ts`) | No — looks up `ws.id` against live metadata from `workspace.list`, which already excludes archived; archived IDs never matched | unchanged             |
| Sub-project removal confirmation (`ProjectSidebar.handleRemoveSection`)         | No — informational count for a non-destructive action; now counts live workspaces only (matches the sidebar view it describes) | comment added         |
| Project delete confirmation (`ProjectSidebar.handleRequestProjectRemoval`)      | **Yes** — derived active/archived counts locally to build the type-to-confirm dialog                                           | **converted** (below) |

The archived-workspace UI (project page “Archived Workspaces” section, restore/delete flows) was already on-demand via `workspace.list({ archived: true })` and is unaffected.

Dropping the embedded bodies entirely was considered but rejected for now: the sidebar’s first-pass grouping still uses the live arrays (incl. multi-project workspace buckets), and live entries are a small fraction of the payload.

## Implementation

- **`ProjectService.list()`**: projects each project to a copy whose `workspaces` array is filtered through the existing `isWorkspaceArchived` helper. New arrays are built (never mutating the loaded config), so persisted state keeps archived entries.
- **Project delete flow**: since blocker counts can no longer be derived client-side, the sidebar calls a new **read-only** `projects.getRemovalBlockers` preflight, which reports the same blocker counts `remove()` enforces (own bucket + cross-project references) without `remove()`’s side effects (stale-entry pruning, deletion of empty projects). The dialog therefore shows authoritative counts — _more_ accurate than the old local count, which missed cross-project references. A monotonic sequence guard discards stale preflight responses so rapid Delete clicks on different projects can’t cross wires. Empty projects are still removed immediately (same as before).
- **`remove(force)` hardening** (from review): the force cascade now fails fast on cross-project references _before_ deleting anything, so a mixed project can no longer have its directly-owned workspaces deleted only for the operation to fail on external references afterwards.

Not touched (per #3959 coordination): `getActivityList()` / extension-metadata store.

## Validation

- Unit tests: projection filters archived, preserves live + re-unarchived entries, keeps multi-project workspaces in their bucket, and leaves persisted config unmodified (`projectService.test.ts`); delete flow shows backend counts in the dialog and removes empty projects without a dialog (`ProjectSidebar.test.tsx`).
- `make static-check` green locally.

### Dogfood (dev-server sandbox, seeded config: 1 project, 100 workspaces = 10 live + 90 archived)

Payload of one `projects.list` response (uncompressed JSON, same seed config):

|                        |     bytes | embedded workspaces |
| ---------------------- | --------: | ------------------: |
| before (parent commit) |    60,613 |                 100 |
| after (this PR)        |     5,713 |                  10 |
| **reduction**          | **10.6×** |                     |

Extrapolated to the reference deployment (84% archived + per-entry overhead): ~1.12 MB → ~0.1 MB per call, ~9.3 MB → ~0.9 MB for the measured 4-minute session.

UI flows verified in the browser against the patched sandbox:

- Sidebar lists the 10 live workspaces; project page shows “Archived Workspaces (90)” loaded on demand.
- Restore: archived workspace moves to sidebar, count 10 → 11.
- Archive: workspace leaves sidebar, count 11 → 10.
- Delete project: the backend blocker counts resolve to `{activeCount: 10, archivedCount: 90}` and the type-to-confirm dialog renders “This will permanently delete 100 workspaces (10 active, 90 archived)” — correct counts despite `projects.list` containing no archived entries. (Dogfooded pre-review via the non-forced `projects.remove` probe; the flow now uses the read-only `getRemovalBlockers` preflight covered by unit + story tests.)

| Archived section (90) + sidebar (10)                                                                             | Delete dialog with backend counts                                                                                              | Restored workspace in sidebar (11)                                                                                        |
| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
| ![archived](https://raw.githubusercontent.com/coder/xum/assets/projects-list-projection-evidence/df-06-menu.png) | ![delete-dialog](https://raw.githubusercontent.com/coder/xum/assets/projects-list-projection-evidence/df-09-delete-dialog.png) | ![restored](https://raw.githubusercontent.com/coder/xum/assets/projects-list-projection-evidence/df-04-after-restore.png) |

Screen recording of the full flow (restore → archive → delete dialog → cancel): [dogfood-flow.webm](https://raw.githubusercontent.com/coder/xum/assets/projects-list-projection-evidence/dogfood-flow-fixed.webm)

_(Evidence lives on the temporary `assets/projects-list-projection-evidence` branch because attachment upload requires an interactive SSO session; safe to delete after merge.)_

## Risks

- **Delete-project UX**: clicking “Delete…” now issues a read-only `projects.getRemovalBlockers` RPC before the dialog (no destructive effects, no pruning). Severity: low.
- **`remove(force)` behavior change**: projects with cross-project references now fail before (rather than after) cascade deletion; previously such removals destroyed owned workspaces and then failed anyway, so this strictly reduces damage. Severity: low.
- **Sub-project removal dialog** counts only live workspaces now; the action itself is non-destructive.
- Any external API consumer reading archived workspaces out of `projects.list` must use `workspace.list({ archived: true })` instead (the UI already did).

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=0.00 -->
