### PR TITLE
🤖 fix: forward rlm-mode from the CLI and repair xum api schema clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ESBUILD_HOST_PLATFORM := $(subst Linux,linux,$(subst Darwin,darwin,$(shell uname
 ESBUILD_BIN = $(firstword $(wildcard node_modules/@esbuild/$(ESBUILD_HOST_PLATFORM)/bin/esbuild) $(wildcard node_modules/@esbuild/*/bin/esbuild) node_modules/esbuild/bin/esbuild)
 
 # Common esbuild flags for CLI API bundle (ESM format for trpc-cli)
-ESBUILD_CLI_FLAGS := --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:jsonc-parser --external:@trpc/server --external:ssh2 --external:cpu-features --banner:js="import{createRequire}from'module';globalThis.require=createRequire(import.meta.url);"
+ESBUILD_CLI_FLAGS := --bundle --format=esm --platform=node --target=node20 --outfile=dist/cli/api.mjs --external:zod --external:commander --external:jsonc-parser --external:@trpc/server --external:ssh2 --external:cpu-features --banner:js="import{createRequire}from\"module\";globalThis.require=createRequire(import.meta.url);"
 
 # Common esbuild flags for server runtime Docker bundle.
 # Place runtime bundles under dist/runtime so frontend dist/*.js layers remain stable.

--- a/src/cli/proxifyOrpc.test.ts
+++ b/src/cli/proxifyOrpc.test.ts
@@ -143,6 +143,28 @@ describe("proxifyOrpc CLI help output", () => {
     expect(zodDefOptions?.description).toContain("model: string");
   });
 
+  test("enhanced schema preserves the Standard Schema validator", async () => {
+    const r = router();
+    const proxied = proxifyOrpc(r, { baseUrl: "http://localhost:8080" });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const resumeStream = (proxied as any).workspace?.resumeStream;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const inputSchema = resumeStream?.["~orpc"]?.inputSchema;
+
+    // oRPC validates call inputs via schema["~standard"].validate. Zod keeps
+    // `~standard` non-enumerable, so the enhancement clone used to drop it and
+    // every enhanced procedure crashed at call time ("reading 'validate'").
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const standard = inputSchema?.["~standard"];
+    expect(standard).toBeDefined();
+    // The validator must actually run and flag invalid input.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    const result = await standard.validate({});
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(result.issues).toBeDefined();
+  });
+
   test("JSON Schema for options includes description", () => {
     const r = router();
     const proxied = proxifyOrpc(r, { baseUrl: "http://localhost:8080" });

--- a/src/cli/proxifyOrpc.ts
+++ b/src/cli/proxifyOrpc.ts
@@ -60,6 +60,8 @@ interface Zod4Like {
   _def?: Zod4Def;
   description?: string;
   describe?: (desc: string) => Zod4Like;
+  /** Standard Schema validator (own, non-enumerable on Zod 4 instances). */
+  "~standard"?: unknown;
 }
 
 /**
@@ -497,10 +499,19 @@ function enhanceInputSchema(schema: unknown): unknown {
   // so we explicitly copy it. We also update _zod.def.shape to use our enhanced shape,
   // since toJSONSchema reads from _zod.def, not schema.def.
   const enhancedDef = { ...def, shape: enhancedShape };
+  // Preserve the Standard Schema validator: oRPC validates call inputs via
+  // schema["~standard"].validate, but `~standard` is non-enumerable on Zod 4
+  // instances so object spread drops it — every procedure that took this
+  // enhancement path then crashed at call time with "Cannot read properties
+  // of undefined (reading 'validate')" (e.g. `xum api workspace create`).
+  // Reusing the ORIGINAL schema's validator is deliberate: enhancements only
+  // prettify CLI help text and must not change validation semantics.
+  const originalStandard = schema["~standard"];
   const enhanced = {
     ...schema,
     def: enhancedDef,
     _def: enhancedDef,
+    ...(originalStandard !== undefined ? { "~standard": originalStandard } : {}),
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
   const originalZod = (schema as any)._zod;

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -257,6 +257,15 @@ describe("xum CLI", () => {
       expect(result.output).toContain('Unknown or unsupported experiment "agent-browser"');
     });
 
+    test("Object.prototype property names are rejected as experiments", async () => {
+      // The validity check must be an own-property lookup: `in` would accept
+      // "constructor"/"toString" via the prototype chain and then build a
+      // garbage experiments field from the inherited function.
+      const result = await runRunDirect(["-e", "constructor", "test message"]);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Unknown or unsupported experiment "constructor"');
+    });
+
     test("rlm-mode experiment is accepted", async () => {
       // Regression: rlm-mode parsed fine but was silently dropped when building
       // SendMessageOptions.experiments, so PTC+RLM CLI runs degraded to the

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -248,6 +248,33 @@ describe("xum CLI", () => {
       expect(result.output).toContain("Invalid mode");
     });
 
+    test("app-level experiment without a send-options field shows error", async () => {
+      // agent-browser is a real experiment ID, but it has no
+      // SendMessageOptions.experiments field, so a headless run would silently
+      // ignore it. The CLI must reject it loudly instead.
+      const result = await runRunDirect(["-e", "agent-browser", "test message"]);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).toContain('Unknown or unsupported experiment "agent-browser"');
+    });
+
+    test("rlm-mode experiment is accepted", async () => {
+      // Regression: rlm-mode parsed fine but was silently dropped when building
+      // SendMessageOptions.experiments, so PTC+RLM CLI runs degraded to the
+      // non-kernel PTC toolset. Use a nonexistent dir so the run fails AFTER
+      // experiment parsing without starting a session.
+      const result = await runRunDirect([
+        "-e",
+        "rlm-mode",
+        "-e",
+        "programmatic-tool-calling",
+        "--dir",
+        "/nonexistent/path/that/does/not/exist",
+        "test message",
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.output).not.toContain("Unknown or unsupported experiment");
+    });
+
     test("nonexistent directory shows error", async () => {
       const result = await runRunDirect([
         "--dir",

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -278,7 +278,10 @@ const SEND_MESSAGE_EXPERIMENT_FIELDS = {
   [EXPERIMENT_IDS.ADVISOR_TOOL]: "advisorTool",
   [EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]: "dynamicWorkflows",
   [EXPERIMENT_IDS.MEMORY]: "memory",
-  [EXPERIMENT_IDS.TIMELINE]: "timeline",
+  // TIMELINE is deliberately absent: AIService resolves the timeline
+  // experiment exclusively from the backend ExperimentsService (the schema's
+  // `timeline` request field is never read), and `xum run` wires no timeline
+  // service — accepting `-e timeline` would be a silent no-op.
   [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: "workspaceHeartbeats",
   [EXPERIMENT_IDS.TOOL_SEARCH]: "toolSearch",
 } as const satisfies Partial<
@@ -288,7 +291,10 @@ const SEND_MESSAGE_EXPERIMENT_FIELDS = {
 function isSendMessageExperimentId(
   value: string
 ): value is keyof typeof SEND_MESSAGE_EXPERIMENT_FIELDS {
-  return value in SEND_MESSAGE_EXPERIMENT_FIELDS;
+  // Own-property check: `in` would also accept Object.prototype names like
+  // "constructor" or "toString", which have no mapping and would silently
+  // produce a garbage experiments field.
+  return Object.hasOwn(SEND_MESSAGE_EXPERIMENT_FIELDS, value);
 }
 
 function collectExperiments(value: string, previous: string[]): string[] {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -275,13 +275,18 @@ const SEND_MESSAGE_EXPERIMENT_FIELDS = {
   [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: "programmaticToolCalling",
   [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE]: "programmaticToolCallingExclusive",
   [EXPERIMENT_IDS.RLM]: "rlm",
-  [EXPERIMENT_IDS.ADVISOR_TOOL]: "advisorTool",
   [EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]: "dynamicWorkflows",
-  [EXPERIMENT_IDS.MEMORY]: "memory",
-  // TIMELINE is deliberately absent: AIService resolves the timeline
-  // experiment exclusively from the backend ExperimentsService (the schema's
-  // `timeline` request field is never read), and `xum run` wires no timeline
-  // service — accepting `-e timeline` would be a silent no-op.
+  // Deliberately absent (accepting them would be a silent no-op or worse,
+  // which is exactly what this table exists to prevent):
+  // - TIMELINE: AIService resolves the timeline experiment exclusively from
+  //   the backend ExperimentsService (the schema's `timeline` request field is
+  //   never read), and `xum run` wires no timeline service.
+  // - MEMORY: MemoryService derives its storage from the CLI's ephemeral
+  //   tempDir config root, so persistent memories under the user's Xum home
+  //   would be invisible and new writes deleted on process exit.
+  // - ADVISOR_TOOL: AIService only exposes the advisor tool when the config
+  //   has a non-empty advisorModelString, which the CLI's ephemeral config
+  //   never carries over.
   [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: "workspaceHeartbeats",
   [EXPERIMENT_IDS.TOOL_SEARCH]: "toolSearch",
 } as const satisfies Partial<

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -80,7 +80,7 @@ import { createRuntime, runFullInit } from "../node/runtime/runtimeFactory";
 import type { Runtime } from "../node/runtime/Runtime";
 import { execSync } from "child_process";
 import { getParseOptions } from "./argv";
-import { EXPERIMENT_IDS } from "../common/constants/experiments";
+import { EXPERIMENT_IDS, type ExperimentId } from "../common/constants/experiments";
 import { getErrorMessage } from "@/common/utils/errors";
 import { describeCliGoalStop, driveCliGoalUntilTerminal } from "./goalRunDriver";
 import {
@@ -264,13 +264,42 @@ function renderUnknown(value: unknown): string {
   }
 }
 
-const VALID_EXPERIMENT_IDS = new Set<string>(Object.values(EXPERIMENT_IDS));
+/**
+ * Experiment IDs `xum run` can actually forward, each mapped to its
+ * SendMessageOptions.experiments field. A single table (instead of ad-hoc
+ * `includes` checks) guarantees an ID accepted by `-e` cannot be silently
+ * dropped here — that previously swallowed `rlm-mode`, so PTC+RLM CLI runs
+ * degraded to the flat non-kernel PTC toolset while desktop honored the flag.
+ */
+const SEND_MESSAGE_EXPERIMENT_FIELDS = {
+  [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING]: "programmaticToolCalling",
+  [EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE]: "programmaticToolCallingExclusive",
+  [EXPERIMENT_IDS.RLM]: "rlm",
+  [EXPERIMENT_IDS.ADVISOR_TOOL]: "advisorTool",
+  [EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]: "dynamicWorkflows",
+  [EXPERIMENT_IDS.MEMORY]: "memory",
+  [EXPERIMENT_IDS.TIMELINE]: "timeline",
+  [EXPERIMENT_IDS.WORKSPACE_HEARTBEATS]: "workspaceHeartbeats",
+  [EXPERIMENT_IDS.TOOL_SEARCH]: "toolSearch",
+} as const satisfies Partial<
+  Record<ExperimentId, keyof NonNullable<SendMessageOptions["experiments"]>>
+>;
+
+function isSendMessageExperimentId(
+  value: string
+): value is keyof typeof SEND_MESSAGE_EXPERIMENT_FIELDS {
+  return value in SEND_MESSAGE_EXPERIMENT_FIELDS;
+}
 
 function collectExperiments(value: string, previous: string[]): string[] {
   const experimentId = value.trim().toLowerCase();
-  if (!VALID_EXPERIMENT_IDS.has(experimentId)) {
+  // App-level experiments (e.g. agent-browser) have no send-options field and
+  // would be silent no-ops in a headless run, so reject them loudly.
+  if (!isSendMessageExperimentId(experimentId)) {
     throw new Error(
-      `Unknown experiment "${value}". Valid experiments: ${[...VALID_EXPERIMENT_IDS].join(", ")}`
+      `Unknown or unsupported experiment "${value}". Valid experiments: ${Object.keys(
+        SEND_MESSAGE_EXPERIMENT_FIELDS
+      ).join(", ")}`
     );
   }
   if (previous.includes(experimentId)) {
@@ -281,16 +310,18 @@ function collectExperiments(value: string, previous: string[]): string[] {
 
 /**
  * Convert experiment ID array to the experiments object expected by SendMessageOptions.
+ * Only requested experiments are set (to true); unspecified flags stay undefined so
+ * backend fallbacks apply, mirroring how the desktop renderer sends them.
  */
 function buildExperimentsObject(experimentIds: string[]): SendMessageOptions["experiments"] {
   if (experimentIds.length === 0) return undefined;
 
-  return {
-    programmaticToolCalling: experimentIds.includes("programmatic-tool-calling"),
-    programmaticToolCallingExclusive: experimentIds.includes("programmatic-tool-calling-exclusive"),
-    dynamicWorkflows: experimentIds.includes("dynamic-workflows"),
-    workspaceHeartbeats: experimentIds.includes(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS),
-  };
+  const experiments: NonNullable<SendMessageOptions["experiments"]> = {};
+  for (const experimentId of experimentIds) {
+    assert(isSendMessageExperimentId(experimentId), `Unmapped experiment id: ${experimentId}`);
+    experiments[SEND_MESSAGE_EXPERIMENT_FIELDS[experimentId]] = true;
+  }
+  return experiments;
 }
 
 interface MCPServerEntry {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -321,6 +321,13 @@ function buildExperimentsObject(experimentIds: string[]): SendMessageOptions["ex
     assert(isSendMessageExperimentId(experimentId), `Unmapped experiment id: ${experimentId}`);
     experiments[SEND_MESSAGE_EXPERIMENT_FIELDS[experimentId]] = true;
   }
+  // RLM is a sub-experiment of PTC: tool assembly only builds code_execution
+  // when a PTC flag is set, so rlm-mode alone would be silently inert. Imply
+  // the parent flag, mirroring the desktop where Settings nests RLM under the
+  // PTC toggle (RLM itself then forces the exclusive kernel posture).
+  if (experiments.rlm && experiments.programmaticToolCallingExclusive !== true) {
+    experiments.programmaticToolCalling = true;
+  }
   return experiments;
 }
 

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -230,6 +230,9 @@ function buildExperimentsObject(experimentIds: readonly string[]) {
     programmaticToolCallingExclusive: experimentIds.includes(
       EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE
     ),
+    // RLM rides the PTC parent; without this passthrough `-e rlm-mode` was
+    // silently dropped and workflow sends ran the non-kernel PTC toolset.
+    rlm: experimentIds.includes(EXPERIMENT_IDS.RLM),
     // Invoking `xum workflow` is an explicit opt-in, so the dynamic-workflows
     // experiment is enabled implicitly for this invocation (never persisted).
     dynamicWorkflows: true,

--- a/src/cli/workflow.ts
+++ b/src/cli/workflow.ts
@@ -226,7 +226,12 @@ async function copyPersistentConfig(realConfig: Config, config: Config): Promise
 
 function buildExperimentsObject(experimentIds: readonly string[]) {
   return {
-    programmaticToolCalling: experimentIds.includes(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING),
+    // RLM implies the PTC parent flag: tool assembly only builds
+    // code_execution when a PTC flag is set, so rlm-mode alone would be inert
+    // (the desktop can't express that state — Settings nests RLM under PTC).
+    programmaticToolCalling:
+      experimentIds.includes(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING) ||
+      experimentIds.includes(EXPERIMENT_IDS.RLM),
     programmaticToolCallingExclusive: experimentIds.includes(
       EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING_EXCLUSIVE
     ),


### PR DESCRIPTION
## Summary

Test-driving the PTC+RLM experiment on Terminal-Bench tasks through a dev-server sandbox exposed four CLI-only bugs where `xum run` / `xum workflow` / `xum api` diverged from a normal Mux instance. This PR fixes all four so headless runs honor the same experiment semantics as the desktop and `xum api` works again after any dev-server session.

## Background

Ran three Terminal-Bench 2.0 tasks (`regex-log`, `log-summary-date-ranges`, `multi-source-data-merger`) across Opus 5 (xhigh), Fable 5 (medium), and GPT-5.6-sol (high) against a `dev-server-sandbox` instance with `experiments: {programmaticToolCalling, rlm}`, then compared the CLI path against the server path:

1. **`-e rlm-mode` was silently dropped** — `buildExperimentsObject` in `run.ts` (and `workflow.ts`) never mapped `rlm`, so PTC+RLM CLI runs (including every past Terminal-Bench `rlm-mode` benchmark) actually executed the flat non-kernel PTC toolset. Proven with a kernel-persistence probe: two `code_execution` calls setting/reading `globalThis.probe` returned `undefined` via CLI but `12345` via the server.
2. **`make dev/dev-server` shipped a broken `dist/cli/api.mjs`** — the single-quoted `concurrently` command strings stripped the quotes in the esbuild `--banner:js`, emitting `import{createRequire}frommodule` (SyntaxError). Any `xum api` invocation after a dev session crashed on import.
3. **`xum api` crashed on schema-enhanced procedures** (`workspace create`, etc.) with `Cannot read properties of undefined (reading 'validate')` — the CLI help-text enhancement clones schemas via object spread, which drops Zod 4's own non-enumerable `~standard` Standard Schema validator that oRPC calls at request time.
4. **`-e rlm-mode` alone was inert** — tool assembly only builds `code_execution` when a PTC flag is set; the desktop can't express that state (Settings nests RLM under the PTC toggle), so the CLI now implies the parent flag.

## Implementation

- `run.ts`: experiment IDs map to `SendMessageOptions.experiments` fields through a single `satisfies`-checked table, so an ID accepted by `-e` can never be silently dropped again; app-level experiments without a send-options field (e.g. `agent-browser`) are rejected up front. Only requested experiments are set (`true`), leaving the rest `undefined` so backend fallbacks apply, mirroring the desktop renderer. `rlm` implies `programmaticToolCalling`.
- `workflow.ts`: adds the missing `rlm` passthrough + the same PTC implication, without restructuring its deliberately curated flag object (`dynamicWorkflows`/`agentPlugins` semantics untouched).
- `Makefile`: the banner uses escaped double quotes, which survive both the direct recipe (`sh` double-quote context) and the single-quoted `concurrently` watch strings (literal pass-through, re-parsed by the spawned shell).
- `proxifyOrpc.ts`: the enhancement clone carries the original schema's `~standard` validator over (help-text enhancements must not change validation semantics). Bonus: with `~standard` restored, trpc-cli detects the schema again and generates real per-field flags (`--project-path`, `--runtime-config` with hierarchical union help) instead of the `--input [json]` fallback.

## Validation

- Kernel-persistence probe via `xum run -e programmatic-tool-calling -e rlm-mode` (and `-e rlm-mode` alone post-fix): `probe=undefined` before, `probe=12345`/`probe=4242` after — matching server behavior.
- Restarted `make dev-server` after the Makefile fix: the watch-built `api.mjs` banner is valid and `xum api` works immediately; also emulated the exact `concurrently` invocation standalone.
- Created/listed/removed sandbox workspaces end-to-end through the fixed `xum api workspace` commands (previously crashed).
- Terminal-Bench sanity: 3 tasks × 3 models × {PTC+RLM, flat} = 18 sandbox runs, 18/18 pass against the official task oracles.
- New regression tests: `-e rlm-mode` accepted / app-level ID rejected (run.test.ts), enhanced schema keeps a working Standard Schema validator (proxifyOrpc.test.ts).

## Risks

- Low. `xum run -e` now hard-errors for experiment IDs it previously accepted-and-ignored (e.g. `-e agent-browser`); any automation passing such IDs will fail loudly instead of silently no-oping. Terminal-Bench harness configs pass only send-options experiments, so nightly benchmarks are unaffected.
- The experiments object no longer sends explicit `false` for unrequested flags; in headless runs the backend fallback resolves against an ephemeral config (no persisted overrides), so effective behavior is unchanged.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$44.39`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=44.39 -->
