### PR TITLE
🤖 fix: JSON-normalize code_execution output and clamp giant stream errors

### DIFF
--- a/src/common/utils/errors.test.ts
+++ b/src/common/utils/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { getErrorMessage } from "./errors";
+import { clampErrorMessage, getErrorMessage } from "./errors";
 
 describe("getErrorMessage", () => {
   it("returns string representation of non-Error values", () => {
@@ -110,5 +110,29 @@ describe("getErrorMessage", () => {
     const err = new Error("self");
     err.cause = err;
     expect(getErrorMessage(err)).toBe("self");
+  });
+});
+
+describe("clampErrorMessage", () => {
+  it("returns short messages unchanged", () => {
+    expect(clampErrorMessage("boom", 100)).toBe("boom");
+  });
+
+  it("clamps oversized messages while keeping head and tail", () => {
+    const head = "Invalid prompt: schema mismatch. ";
+    const tail = " Error message: expected string, received undefined";
+    const message = head + "x".repeat(100_000) + tail;
+
+    const clamped = clampErrorMessage(message, 1_000);
+
+    expect(clamped.length).toBeLessThan(1_100);
+    expect(clamped.startsWith(head)).toBe(true);
+    expect(clamped.endsWith(tail)).toBe(true);
+    expect(clamped).toContain("chars omitted");
+  });
+
+  it("clamps at the default bound", () => {
+    const clamped = clampErrorMessage("y".repeat(500_000));
+    expect(clamped.length).toBeLessThan(10_000);
   });
 });

--- a/src/common/utils/errors.ts
+++ b/src/common/utils/errors.ts
@@ -1,3 +1,5 @@
+import { ERROR_MESSAGE_CLAMP_MAX_CHARS } from "@/constants/errors";
+
 /**
  * Extract a string message from an unknown error value.
  * Handles Error objects and other thrown values consistently.
@@ -51,15 +53,9 @@ export function getErrorMessage(error: unknown): string {
 }
 
 /**
- * Default bound for clampErrorMessage. Generous for real provider errors,
- * tiny compared to the pathological cases it defends against.
- */
-export const ERROR_MESSAGE_CLAMP_MAX_CHARS = 8_000;
-
-/**
  * Clamp a pathologically long error message before it is persisted, sent over
  * IPC, or rendered. Some AI SDK errors embed entire request payloads in their
- * message — AI_TypeValidationError (surfaced via getErrorMessage's cause walk)
+ * message: AI_TypeValidationError (surfaced via getErrorMessage's cause walk)
  * includes the full JSON-serialized prompt, easily hundreds of KB. Keeps the
  * head (error type + summary) and the tail (the actionable validation detail
  * usually trails the payload dump).

--- a/src/common/utils/errors.ts
+++ b/src/common/utils/errors.ts
@@ -49,3 +49,30 @@ export function getErrorMessage(error: unknown): string {
   }
   return msg;
 }
+
+/**
+ * Default bound for clampErrorMessage. Generous for real provider errors,
+ * tiny compared to the pathological cases it defends against.
+ */
+export const ERROR_MESSAGE_CLAMP_MAX_CHARS = 8_000;
+
+/**
+ * Clamp a pathologically long error message before it is persisted, sent over
+ * IPC, or rendered. Some AI SDK errors embed entire request payloads in their
+ * message — AI_TypeValidationError (surfaced via getErrorMessage's cause walk)
+ * includes the full JSON-serialized prompt, easily hundreds of KB. Keeps the
+ * head (error type + summary) and the tail (the actionable validation detail
+ * usually trails the payload dump).
+ */
+export function clampErrorMessage(
+  message: string,
+  maxChars: number = ERROR_MESSAGE_CLAMP_MAX_CHARS
+): string {
+  if (message.length <= maxChars) {
+    return message;
+  }
+  const tailChars = Math.floor(maxChars / 4);
+  const headChars = maxChars - tailChars;
+  const omitted = message.length - headChars - tailChars;
+  return `${message.slice(0, headChars)}\n… [${omitted} chars omitted] …\n${message.slice(message.length - tailChars)}`;
+}

--- a/src/common/utils/jsonSafeClone.test.ts
+++ b/src/common/utils/jsonSafeClone.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import { jsonSafeClone } from "./jsonSafeClone";
+
+describe("jsonSafeClone", () => {
+  it("passes JSON-safe values through structurally unchanged", () => {
+    const value = { a: 1, b: "x", c: [true, null, { d: 2 }] };
+    expect(jsonSafeClone(value)).toEqual(value);
+  });
+
+  it("normalizes undefined like JSON serialization does", () => {
+    expect(jsonSafeClone({ a: undefined, b: 1 })).toEqual({ b: 1 });
+    expect(jsonSafeClone([undefined, 1, undefined])).toEqual([null, 1, null]);
+    expect(jsonSafeClone(undefined)).toBeUndefined();
+  });
+
+  it("normalizes functions and non-finite numbers like JSON serialization does", () => {
+    expect(jsonSafeClone({ fn: () => 1, n: NaN, i: Infinity, ok: 2 })).toEqual({
+      n: null,
+      i: null,
+      ok: 2,
+    });
+    expect(jsonSafeClone([() => 1])).toEqual([null]);
+  });
+
+  it("honors toJSON", () => {
+    const date = new Date("2026-01-02T03:04:05.000Z");
+    expect(jsonSafeClone({ date })).toEqual({ date: "2026-01-02T03:04:05.000Z" });
+  });
+
+  it("converts BigInt to a decimal string instead of throwing", () => {
+    expect(jsonSafeClone({ big: 123n, keep: [1n] })).toEqual({ big: "123", keep: ["1"] });
+  });
+
+  it("replaces circular references instead of throwing", () => {
+    const cyclic: { self?: unknown; ok: number } = { ok: 1 };
+    cyclic.self = cyclic;
+    expect(jsonSafeClone(cyclic)).toEqual({ ok: 1, self: "[Circular]" });
+  });
+
+  it("preserves shared non-cyclic references in the fallback path", () => {
+    const shared = { v: 1 };
+    // BigInt forces the manual scrub; the DAG must not be treated as a cycle.
+    const value = { a: shared, b: shared, big: 1n };
+    expect(jsonSafeClone(value)).toEqual({ a: { v: 1 }, b: { v: 1 }, big: "1" });
+  });
+
+  it("drops properties whose getters throw, keeping the rest", () => {
+    const value: Record<string, unknown> = { ok: 1 };
+    Object.defineProperty(value, "bad", {
+      enumerable: true,
+      get() {
+        throw new Error("getter boom");
+      },
+    });
+    expect(jsonSafeClone(value)).toEqual({ ok: 1 });
+  });
+
+  it("produces output that is stable under a JSON round-trip", () => {
+    const messy = {
+      arr: [undefined, NaN, { nested: undefined, big: 7n }],
+      fn: () => 1,
+    };
+    const cloned = jsonSafeClone(messy);
+    expect(JSON.parse(JSON.stringify(cloned))).toEqual(cloned);
+  });
+});

--- a/src/common/utils/jsonSafeClone.test.ts
+++ b/src/common/utils/jsonSafeClone.test.ts
@@ -85,6 +85,25 @@ describe("jsonSafeClone", () => {
     expect(jsonSafeClone(value)).toEqual({ keep: "x" });
   });
 
+  it("degrades objects with throwing reflective traps to a placeholder", () => {
+    const throwingOwnKeys = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("ownKeys trap");
+        },
+      }
+    );
+    expect(jsonSafeClone({ keep: 1, evil: throwingOwnKeys })).toEqual({
+      keep: 1,
+      evil: "[Unserializable]",
+    });
+
+    const { proxy, revoke } = Proxy.revocable({}, {});
+    revoke();
+    expect(jsonSafeClone({ p: proxy, big: 1n })).toEqual({ p: "[Unserializable]", big: "1" });
+  });
+
   it("keeps a literal __proto__ key as an own property in the fallback path", () => {
     const nested = JSON.parse('{"__proto__": {"x": 1}}') as Record<string, unknown>;
     const value = { big: 1n, nested };

--- a/src/common/utils/jsonSafeClone.test.ts
+++ b/src/common/utils/jsonSafeClone.test.ts
@@ -63,4 +63,34 @@ describe("jsonSafeClone", () => {
     const cloned = jsonSafeClone(messy);
     expect(JSON.parse(JSON.stringify(cloned))).toEqual(cloned);
   });
+
+  it("fills sparse array holes with null in the fallback path", () => {
+    // BigInt forces the manual scrub; holes must become null (as JSON.stringify
+    // emits), not survive as undefined reads that fail strict JSONValue checks.
+    const value = { sparse: new Array(2) as unknown[], big: 1n };
+    const cloned = jsonSafeClone(value) as { sparse: unknown[]; big: string };
+    expect(cloned.sparse).toEqual([null, null]);
+    expect(Object.hasOwn(cloned.sparse, 0)).toBe(true);
+    expect(Object.hasOwn(cloned.sparse, 1)).toBe(true);
+    expect(JSON.parse(JSON.stringify(cloned))).toEqual(cloned);
+  });
+
+  it("treats a throwing toJSON getter as absent instead of throwing", () => {
+    const value = {
+      keep: "x",
+      get toJSON(): unknown {
+        throw new Error("toJSON getter boom");
+      },
+    };
+    expect(jsonSafeClone(value)).toEqual({ keep: "x" });
+  });
+
+  it("keeps a literal __proto__ key as an own property in the fallback path", () => {
+    const nested = JSON.parse('{"__proto__": {"x": 1}}') as Record<string, unknown>;
+    const value = { big: 1n, nested };
+    const cloned = jsonSafeClone(value) as { big: string; nested: Record<string, unknown> };
+    expect(Object.hasOwn(cloned.nested, "__proto__")).toBe(true);
+    expect(Object.getPrototypeOf(cloned.nested)).toBe(Object.prototype);
+    expect(JSON.stringify(cloned.nested)).toBe('{"__proto__":{"x":1}}');
+  });
 });

--- a/src/common/utils/jsonSafeClone.test.ts
+++ b/src/common/utils/jsonSafeClone.test.ts
@@ -31,6 +31,15 @@ describe("jsonSafeClone", () => {
     expect(jsonSafeClone({ big: 123n, keep: [1n] })).toEqual({ big: "123", keep: ["1"] });
   });
 
+  it("replaces oversized BigInts with a placeholder instead of expanding them", () => {
+    const huge = 10n ** 4096n;
+    expect(jsonSafeClone({ huge })).toEqual({ huge: "[BigInt: >4096 digits]" });
+    expect(jsonSafeClone({ huge: -huge })).toEqual({ huge: "[BigInt: >4096 digits]" });
+    // Values inside the bound still convert exactly.
+    const large = 10n ** 4095n;
+    expect(jsonSafeClone({ large })).toEqual({ large: large.toString() });
+  });
+
   it("replaces circular references instead of throwing", () => {
     const cyclic: { self?: unknown; ok: number } = { ok: 1 };
     cyclic.self = cyclic;

--- a/src/common/utils/jsonSafeClone.ts
+++ b/src/common/utils/jsonSafeClone.ts
@@ -1,0 +1,80 @@
+/**
+ * Clone a value into the exact shape `JSON.parse(JSON.stringify(value))` would
+ * produce: `undefined`/function/symbol array elements become `null`, object
+ * properties holding them are dropped, non-finite numbers become `null`, and
+ * `toJSON` is honored. A defensive fallback covers values JSON.stringify
+ * cannot serialize at all (BigInt, circular references, throwing getters).
+ *
+ * Why this exists: tool outputs are persisted as JSON and rehydrated on
+ * reload, but the SAME in-memory object is also embedded in the next step's
+ * tool-result model message, which the AI SDK validates against a strict
+ * JSONValue schema. A non-JSON value that serialization would silently
+ * normalize (e.g. `undefined` inside an array) instead fails that validation
+ * and kills the live stream with AI_InvalidPromptError — while the retry,
+ * rebuilt from rehydrated history, succeeds. Normalizing up front keeps the
+ * live and rehydrated shapes identical.
+ */
+export function jsonSafeClone(value: unknown): unknown {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? undefined : JSON.parse(serialized);
+  } catch {
+    // JSON.stringify throws on BigInt, cycles, and throwing getters/toJSON.
+    return scrubToJsonSafe(value, new WeakSet());
+  }
+}
+
+/**
+ * Best-effort manual walk for values JSON.stringify rejects. Mirrors JSON
+ * semantics where possible; unserializable leaves are replaced instead of
+ * thrown on (BigInt → decimal string, revisited ancestor → "[Circular]").
+ */
+function scrubToJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return value;
+    case "number":
+      return Number.isFinite(value) ? value : null;
+    case "bigint":
+      return value.toString();
+    case "object":
+      break;
+    default:
+      // undefined, function, symbol: dropped by the caller (object property)
+      // or converted to null (array element), matching JSON.stringify.
+      return undefined;
+  }
+  if (value === null) return null;
+  if (ancestors.has(value)) return "[Circular]";
+  ancestors.add(value);
+  try {
+    const withToJson = value as { toJSON?: unknown };
+    if (typeof withToJson.toJSON === "function") {
+      try {
+        return scrubToJsonSafe((withToJson.toJSON as (key?: string) => unknown)(), ancestors);
+      } catch {
+        return undefined;
+      }
+    }
+    if (Array.isArray(value)) {
+      return value.map((element) => scrubToJsonSafe(element, ancestors) ?? null);
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      let element: unknown;
+      try {
+        element = (value as Record<string, unknown>)[key];
+      } catch {
+        continue; // Throwing getter: drop the property, keep the rest.
+      }
+      const scrubbed = scrubToJsonSafe(element, ancestors);
+      if (scrubbed !== undefined) result[key] = scrubbed;
+    }
+    return result;
+  } finally {
+    // Remove on the way out so shared (non-cyclic) references still clone;
+    // only genuine ancestor revisits are treated as cycles.
+    ancestors.delete(value);
+  }
+}

--- a/src/common/utils/jsonSafeClone.ts
+++ b/src/common/utils/jsonSafeClone.ts
@@ -10,7 +10,7 @@
  * tool-result model message, which the AI SDK validates against a strict
  * JSONValue schema. A non-JSON value that serialization would silently
  * normalize (e.g. `undefined` inside an array) instead fails that validation
- * and kills the live stream with AI_InvalidPromptError — while the retry,
+ * and kills the live stream with AI_InvalidPromptError, while the retry,
  * rebuilt from rehydrated history, succeeds. Normalizing up front keeps the
  * live and rehydrated shapes identical.
  */
@@ -49,18 +49,40 @@ function scrubToJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
   if (ancestors.has(value)) return "[Circular]";
   ancestors.add(value);
   try {
-    const withToJson = value as { toJSON?: unknown };
-    if (typeof withToJson.toJSON === "function") {
+    // Read toJSON once, guarded: the property itself may be a throwing
+    // getter, which must degrade to "no toJSON" instead of throwing here.
+    let toJson: unknown;
+    try {
+      toJson = (value as { toJSON?: unknown }).toJSON;
+    } catch {
+      toJson = undefined;
+    }
+    if (typeof toJson === "function") {
       try {
-        return scrubToJsonSafe((withToJson.toJSON as (key?: string) => unknown)(), ancestors);
+        return scrubToJsonSafe((toJson as (this: unknown) => unknown).call(value), ancestors);
       } catch {
         return undefined;
       }
     }
     if (Array.isArray(value)) {
-      return value.map((element) => scrubToJsonSafe(element, ancestors) ?? null);
+      // Index loop instead of .map: .map skips holes in sparse arrays, which
+      // would survive the clone as `undefined` reads: the exact non-JSON
+      // shape this helper exists to eliminate. JSON.stringify emits null for
+      // holes; do the same, and for throwing index getters too (array length
+      // must be preserved, so dropping is not an option).
+      const items: unknown[] = new Array(value.length);
+      for (let i = 0; i < value.length; i++) {
+        let element: unknown;
+        try {
+          element = value[i];
+        } catch {
+          element = null;
+        }
+        items[i] = scrubToJsonSafe(element, ancestors) ?? null;
+      }
+      return items;
     }
-    const result: Record<string, unknown> = {};
+    const entries: Array<[string, unknown]> = [];
     for (const key of Object.keys(value)) {
       let element: unknown;
       try {
@@ -69,9 +91,12 @@ function scrubToJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
         continue; // Throwing getter: drop the property, keep the rest.
       }
       const scrubbed = scrubToJsonSafe(element, ancestors);
-      if (scrubbed !== undefined) result[key] = scrubbed;
+      if (scrubbed !== undefined) entries.push([key, scrubbed]);
     }
-    return result;
+    // fromEntries defines own data properties, so a literal "__proto__" key
+    // stays a plain property instead of silently mutating the clone's
+    // prototype (and vanishing from the JSON shape).
+    return Object.fromEntries(entries);
   } finally {
     // Remove on the way out so shared (non-cyclic) references still clone;
     // only genuine ancestor revisits are treated as cycles.

--- a/src/common/utils/jsonSafeClone.ts
+++ b/src/common/utils/jsonSafeClone.ts
@@ -3,7 +3,8 @@
  * produce: `undefined`/function/symbol array elements become `null`, object
  * properties holding them are dropped, non-finite numbers become `null`, and
  * `toJSON` is honored. A defensive fallback covers values JSON.stringify
- * cannot serialize at all (BigInt, circular references, throwing getters).
+ * cannot serialize at all (BigInt, circular references, throwing getters,
+ * proxies with throwing traps).
  *
  * Why this exists: tool outputs are persisted as JSON and rehydrated on
  * reload, but the SAME in-memory object is also embedded in the next step's
@@ -97,6 +98,12 @@ function scrubToJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
     // stays a plain property instead of silently mutating the clone's
     // prototype (and vanishing from the JSON shape).
     return Object.fromEntries(entries);
+  } catch {
+    // Reflective operations outside the per-property guards can throw for
+    // hostile exotic objects (Proxy ownKeys/length traps, revoked proxies).
+    // Children handle their own failures via recursion, so this only fires
+    // for THIS value being uninspectable: degrade it to a placeholder leaf.
+    return "[Unserializable]";
   } finally {
     // Remove on the way out so shared (non-cyclic) references still clone;
     // only genuine ancestor revisits are treated as cycles.

--- a/src/common/utils/jsonSafeClone.ts
+++ b/src/common/utils/jsonSafeClone.ts
@@ -1,3 +1,9 @@
+import { JSON_SAFE_CLONE_MAX_BIGINT_DIGITS } from "@/constants/json";
+
+// Precomputed so the per-value magnitude gate is a cheap comparison (BigInt
+// comparison short-circuits on digit-count mismatch).
+const BIGINT_ABS_LIMIT = 10n ** BigInt(JSON_SAFE_CLONE_MAX_BIGINT_DIGITS);
+
 /**
  * Clone a value into the exact shape `JSON.parse(JSON.stringify(value))` would
  * produce: `undefined`/function/symbol array elements become `null`, object
@@ -38,6 +44,13 @@ function scrubToJsonSafe(value: unknown, ancestors: WeakSet<object>): unknown {
     case "number":
       return Number.isFinite(value) ? value : null;
     case "bigint":
+      // The sandbox's memory/time caps end at runtime.eval(); a hostile guest
+      // can still hand the host a huge BigInt whose decimal expansion is
+      // superlinear and would block the event loop. Gate magnitude BEFORE
+      // converting.
+      if (value >= BIGINT_ABS_LIMIT || value <= -BIGINT_ABS_LIMIT) {
+        return `[BigInt: >${JSON_SAFE_CLONE_MAX_BIGINT_DIGITS} digits]`;
+      }
       return value.toString();
     case "object":
       break;

--- a/src/constants/errors.ts
+++ b/src/constants/errors.ts
@@ -1,0 +1,6 @@
+/**
+ * Default bound for clampErrorMessage. Generous for real provider errors,
+ * tiny compared to the pathological cases it defends against (AI SDK errors
+ * that embed entire serialized request payloads in their message).
+ */
+export const ERROR_MESSAGE_CLAMP_MAX_CHARS = 8_000;

--- a/src/constants/json.ts
+++ b/src/constants/json.ts
@@ -1,0 +1,7 @@
+/**
+ * Maximum decimal digits jsonSafeClone will expand a BigInt into. Generous
+ * for real values (a 4096-bit RSA modulus is ~1,234 digits) while bounding
+ * the superlinear BigInt#toString() cost a hostile sandbox value could
+ * otherwise impose on the host event loop.
+ */
+export const JSON_SAFE_CLONE_MAX_BIGINT_DIGITS = 4_096;

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -3846,11 +3846,7 @@ export class StreamManager extends EventEmitter {
 
     return {
       messageId: streamInfo.messageId,
-      // Clamp AFTER categorization/enhancement: some SDK errors embed the
-      // entire serialized prompt in their message (AI_TypeValidationError via
-      // the cause walk), and an unbounded message would be persisted to
-      // history metadata, shipped over IPC, and rendered in the chat.
-      error: clampErrorMessage(errorMessage),
+      error: errorMessage,
       errorType,
       acpPromptId: streamInfo.initialMetadata?.acpPromptId,
     };
@@ -3864,6 +3860,14 @@ export class StreamManager extends EventEmitter {
     streamInfo: WorkspaceStreamInfo,
     payload: StreamErrorPayload & { errorType: StreamErrorType }
   ): Promise<void> {
+    // Clamp at the single choke point every stream error payload passes
+    // through before persist/emit, including buildStreamErrorPayload's
+    // early-return branches (e.g. ModelRefusalError, whose fallbackNote can
+    // embed another error's message). Some SDK errors embed the entire
+    // serialized prompt in their message (AI_TypeValidationError via the
+    // cause walk); unbounded, that would be persisted to history metadata,
+    // shipped over IPC, and rendered in the chat.
+    payload = { ...payload, error: clampErrorMessage(payload.error) };
     const refusalFinishReason =
       payload.errorType === "model_refusal"
         ? ([streamInfo.terminalFinishReason, streamInfo.terminalRawFinishReason].find(

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -93,7 +93,7 @@ import {
   normalizeUsageModelKey,
   resolveModelForMetadata,
 } from "@/common/utils/providers/modelEntries";
-import { getErrorMessage } from "@/common/utils/errors";
+import { clampErrorMessage, getErrorMessage } from "@/common/utils/errors";
 import { runLanguageModelCleanup } from "./languageModelCleanup";
 import { shellQuote } from "@/common/utils/shell";
 import { classify429Capacity } from "@/common/utils/errors/classify429Capacity";
@@ -3846,7 +3846,11 @@ export class StreamManager extends EventEmitter {
 
     return {
       messageId: streamInfo.messageId,
-      error: errorMessage,
+      // Clamp AFTER categorization/enhancement: some SDK errors embed the
+      // entire serialized prompt in their message (AI_TypeValidationError via
+      // the cause walk), and an unbounded message would be persisted to
+      // history metadata, shipped over IPC, and rendered in the chat.
+      error: clampErrorMessage(errorMessage),
       errorType,
       acpPromptId: streamInfo.initialMetadata?.acpPromptId,
     };

--- a/src/node/services/tools/code_execution.test.ts
+++ b/src/node/services/tools/code_execution.test.ts
@@ -353,6 +353,29 @@ describe("createCodeExecutionTool", () => {
       expect(result.result).toBe(3);
     });
 
+    it("normalizes non-JSON guest values so the output survives strict JSONValue validation", async () => {
+      // Regression: console.log(undefined) / returned undefined fields used to
+      // reach the AI SDK verbatim, failing ModelMessage validation on the next
+      // step and killing the live stream (AI_InvalidPromptError) — while the
+      // retry, rebuilt from JSON-rehydrated history, succeeded.
+      const tool = await createCodeExecutionTool(runtimeFactory, new ToolBridge({}));
+
+      const result = (await tool.execute!(
+        {
+          code: "console.log(undefined); return { a: undefined, arr: [undefined, 1], nan: NaN };",
+        },
+        mockToolCallOptions
+      )) as PTCExecutionResult;
+
+      expect(result.success).toBe(true);
+      // The live object must equal its own JSON round-trip (what a reloaded
+      // history would contain), so first-run and retry behavior are identical.
+      const roundTripped = JSON.parse(JSON.stringify(result)) as PTCExecutionResult;
+      expect(result).toEqual(roundTripped);
+      expect(result.result).toEqual({ arr: [null, 1], nan: null });
+      expect(result.consoleOutput[0]?.args).toEqual([null]);
+    });
+
     it("captures console.log output", async () => {
       const tool = await createCodeExecutionTool(runtimeFactory, new ToolBridge({}));
 

--- a/src/node/services/tools/code_execution.ts
+++ b/src/node/services/tools/code_execution.ts
@@ -32,6 +32,7 @@ import {
 } from "@/constants/resultHandles";
 import { KERNEL_COMPACT_ARGS_CAP_BYTES, KERNEL_CONSOLE_CAP_BYTES } from "@/constants/kernelOutput";
 import { sliceUtf8Bytes } from "@/common/utils/sliceUtf8Bytes";
+import { jsonSafeClone } from "@/common/utils/jsonSafeClone";
 
 // Default limits
 const DEFAULT_MEMORY_BYTES = 64 * 1024 * 1024; // 64MB
@@ -848,7 +849,17 @@ ${xumTypes}
               }
             }
           }
-          return result;
+          // Guest values arrive via ctx.dump() and can contain undefined (e.g.
+          // console.log(undefined) or a returned {a: undefined}) or other
+          // non-JSON values. Persistence JSON-normalizes them on reload, but
+          // the LIVE object is embedded verbatim in the next step's
+          // tool-result message, where the AI SDK's ModelMessage validation
+          // rejects it and kills the stream (AI_InvalidPromptError) — while
+          // the retry, rebuilt from rehydrated history, succeeds. Clone into
+          // the exact JSON shape persistence produces so live and rehydrated
+          // behavior are identical. Must stay the LAST step: the snapshot-
+          // conflict rewrites above reintroduce undefined fields.
+          return jsonSafeClone(result) as PTCExecutionResult;
         } finally {
           // A late abort of THIS call's signal must not poison a reused runtime.
           abortSignal?.removeEventListener("abort", onAbort);


### PR DESCRIPTION
## Summary

Fixes a mid-stream crash (`AI_InvalidPromptError: messages do not match the ModelMessage[] schema`) caused by `code_execution` tool results containing non-JSON values (`undefined`), and clamps the resulting multi-hundred-KB error payloads that were persisted, shipped over IPC, and rendered in chat.

## Background

A workspace stream died mid-turn with a schema validation error. Forensics from session logs:

1. A `code_execution` script logged an expression that evaluated to `undefined` in the QuickJS guest.
2. `ctx.dump()` marshals that as a real in-memory `undefined` inside the tool result (`consoleOutput[0].args = [undefined]`).
3. On the next step of the same stream, the AI SDK embeds that live object verbatim into a tool-result message and validates it against its strict `JSONValue` schema. `undefined` is not a JSON value, so the stream is killed.
4. Automatic retry succeeded because it rebuilt messages from JSON-rehydrated history where `undefined` had been normalized to `null`: a heisenbug that crashes live but works after reload.

Separately, the `InvalidPromptError`'s cause chain embeds the entire serialized prompt (~150KB+), which `getErrorMessage()`'s cause walk appended to the persisted/rendered error.

## Implementation

- **Root cause:** `code_execution` output is cloned through `jsonSafeClone()` into the exact JSON shape persistence produces (`undefined` in arrays → `null`, `undefined` object values → dropped, `toJSON` honored) before crossing into the AI SDK, so live and rehydrated behavior are identical.
- **New `jsonSafeClone()` util** (`src/common/utils/jsonSafeClone.ts`) with a hardened fallback for values `JSON.stringify` outright rejects: BigInt → decimal string (magnitude-gated at 10^4096 with an O(1) comparison so hostile sandbox values cannot block the host on `toString()`), cycles → `"[Circular]"`, throwing getters dropped, throwing `toJSON` getters treated as absent, sparse-array holes filled with `null`, literal `__proto__` keys kept as own data properties (`Object.fromEntries`), and objects with throwing reflective traps (Proxy `ownKeys`/revoked proxies) degraded to `"[Unserializable]"`.
- **Error inflation:** stream error payloads are clamped to 8KB (head + tail preserved so the actionable validation detail after the payload dump survives) inside `persistStreamError()`, the single choke point every payload passes through before persist/IPC/render, covering early-return branches like `ModelRefusalError` whose `fallbackNote` can embed another error's message.
- Limits centralized in `src/constants/errors.ts` and `src/constants/json.ts`.

## Validation

- Regression test reproducing the exact crash vector (`console.log(undefined)` plus a returned `{a: undefined, arr: [undefined, 1], nan: NaN}`) asserting the tool output equals its own JSON round-trip.
- Fallback-hardening regression tests: oversized/boundary BigInts, sparse arrays, throwing `toJSON` getters, `__proto__` prototype integrity, throwing Proxy traps, revoked proxies.
- `code_execution`, `streamManager`, `errors`, and `jsonSafeClone` suites pass; full `make static-check` green.

## Risks

Low-to-moderate, scoped to `code_execution` result shape and stream error formatting:

- `jsonSafeClone` runs on every `code_execution` result; a behavior difference vs. raw output would surface as subtly different tool results. Mitigated by matching `JSON.stringify` semantics exactly (the shape every result already assumed after rehydration).
- Error clamping truncates the middle of giant messages; worst case is losing detail in a >8KB error body, which was previously unreadable in chat anyway.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$23.08`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=23.08 -->

