### PR TITLE
🤖 feat: surface pending bash-monitor wake delivery in background process UI

### DIFF
--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
@@ -134,7 +134,7 @@ export const MonitorWakePendingAfterExit: AppStory = {
                 droppedLines: 0,
                 lastLines: ["WAKE: all checks green"],
                 stopped: true,
-                wakePending: true,
+                pendingWakeKind: "match",
               },
               status: "exited",
               exitCode: 0,
@@ -149,6 +149,54 @@ export const MonitorWakePendingAfterExit: AppStory = {
       description: {
         story:
           "A one-shot watcher matched and exited while its monitor wake is still pending delivery. The banner stays visible with a 'waking agent' indicator, no live duration, and no terminate button.",
+      },
+    },
+  },
+};
+
+export const MonitorLostWakePendingAfterRestart: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          messages: [
+            createUserMessage("msg-1", "Watch the PR checks and wake me when they finish", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 60000,
+            }),
+          ],
+          backgroundProcesses: [
+            // Synthesized from a durable pending monitor-lost wake after restart: no live
+            // process (pid 0), so no pid line, no output action, and "monitor lost" wording
+            // instead of claiming a match.
+            {
+              id: "bash_watcher",
+              pid: 0,
+              script: "./watch_pr_checks.sh",
+              displayName: "PR Checks Watcher",
+              startTime: Date.now() - 90000,
+              monitor: {
+                filter: "WAKE:",
+                filter_exclude: false,
+                cooldown_ms: 0,
+                totalMatches: 0,
+                droppedLines: 0,
+                lastLines: [],
+                stopped: true,
+                pendingWakeKind: "monitor-lost",
+              },
+              status: "exited",
+            },
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An app restart terminated an armed watcher; its durable monitor-lost wake is still pending delivery. The synthesized row shows 'monitor lost' wording with no pid, duration, output, or terminate affordances.",
       },
     },
   },

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
@@ -144,7 +144,16 @@ export const MonitorWakePendingAfterExit: AppStory = {
       }
     />
   ),
+  // The waking indicator sits on its own non-truncating line specifically so narrow
+  // rows cannot ellipsize it away; snapshot the phone width (alongside desktop) so the
+  // guarded condition is actually exercised.
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
   parameters: {
+    pixel: {
+      matrix: { viewports: ["phone", "desktop"] },
+    },
     docs: {
       description: {
         story:
@@ -193,7 +202,15 @@ export const MonitorLostWakePendingAfterRestart: AppStory = {
       }
     />
   ),
+  // Same phone-width coverage as MonitorWakePendingAfterExit: the lost-monitor label
+  // must stay visible on narrow rows too.
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
   parameters: {
+    pixel: {
+      matrix: { viewports: ["phone", "desktop"] },
+    },
     docs: {
       description: {
         story:

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
@@ -174,6 +174,7 @@ export const MonitorLostWakePendingAfterRestart: AppStory = {
               pid: 0,
               script: "./watch_pr_checks.sh",
               displayName: "PR Checks Watcher",
+              synthesized: true,
               startTime: Date.now() - 90000,
               monitor: {
                 filter: "WAKE:",

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.stories.tsx
@@ -91,3 +91,65 @@ export const BackgroundProcesses: AppStory = {
     },
   },
 };
+
+/**
+ * A one-shot watcher matched its monitor filter and exited, but the synthetic wake turn
+ * has not been delivered yet. The banner must keep the process visible with a pending
+ * indicator instead of vanishing (which previously looked like a lost wake).
+ */
+export const MonitorWakePendingAfterExit: AppStory = {
+  render: () => (
+    <AppWithMocks
+      setup={() =>
+        setupSimpleChatStory({
+          messages: [
+            createUserMessage("msg-1", "Watch the PR checks and wake me when they finish", {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 60000,
+            }),
+            createAssistantMessage(
+              "msg-2",
+              "I've started a background watcher that prints WAKE: when the checks finish.",
+              {
+                historySequence: 2,
+                timestamp: STABLE_TIMESTAMP - 50000,
+                toolCalls: [
+                  createTerminalTool("call-1", "./watch_pr_checks.sh", "Watching PR checks..."),
+                ],
+              }
+            ),
+          ],
+          backgroundProcesses: [
+            {
+              id: "bash_watcher",
+              pid: 22345,
+              script: "./watch_pr_checks.sh",
+              displayName: "PR Checks Watcher",
+              startTime: Date.now() - 90000,
+              monitor: {
+                filter: "WAKE:",
+                filter_exclude: false,
+                cooldown_ms: 1000,
+                totalMatches: 1,
+                droppedLines: 0,
+                lastLines: ["WAKE: all checks green"],
+                stopped: true,
+                wakePending: true,
+              },
+              status: "exited",
+              exitCode: 0,
+            },
+          ],
+        })
+      }
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A one-shot watcher matched and exited while its monitor wake is still pending delivery. The banner stays visible with a 'waking agent' indicator, no live duration, and no terminate button.",
+      },
+    },
+  },
+};

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -43,7 +43,7 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
   // wake has not been delivered yet — otherwise a one-shot watcher that matched and exited
   // vanishes from the banner and looks like a lost wake.
   const visibleProcesses = processes.filter(
-    (p) => p.status === "running" || p.monitor?.wakePending === true
+    (p) => p.status === "running" || p.monitor?.pendingWakeKind != null
   );
   const viewingProcess = processes.find((p) => p.id === viewingProcessId) ?? null;
   const count = visibleProcesses.length;
@@ -116,8 +116,13 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                         watching /{proc.monitor.filter}/ · {proc.monitor.totalMatches} match
                         {proc.monitor.totalMatches === 1 ? "" : "es"}
                         {proc.monitor.stopped ? " · stopped" : ""}
-                        {proc.monitor.wakePending && (
-                          <span className="text-secondary"> · match found — waking agent…</span>
+                        {proc.monitor.pendingWakeKind != null && (
+                          <span className="text-secondary">
+                            {/* monitor-lost wakes report a terminated watcher, not a match */}
+                            {proc.monitor.pendingWakeKind === "match"
+                              ? " · match found — waking agent…"
+                              : " · monitor lost — waking agent…"}
+                          </span>
                         )}
                       </div>
                     )}
@@ -134,22 +139,26 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                         {formatDuration(Date.now() - proc.startTime)}
                       </span>
                     )}
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          disabled={isTerminating}
-                          onClick={(e) => handleViewOutput(proc.id, e)}
-                          className={cn(
-                            "text-muted hover:text-secondary rounded p-1 transition-colors",
-                            isTerminating && "cursor-not-allowed"
-                          )}
-                        >
-                          <FileText size={14} />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>View output</TooltipContent>
-                    </Tooltip>
+                    {/* Rows synthesized from a durable pending wake (pid 0) have no manager
+                        entry behind them, so fetching output is guaranteed to fail. */}
+                    {proc.pid > 0 && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            disabled={isTerminating}
+                            onClick={(e) => handleViewOutput(proc.id, e)}
+                            className={cn(
+                              "text-muted hover:text-secondary rounded p-1 transition-colors",
+                              isTerminating && "cursor-not-allowed"
+                            )}
+                          >
+                            <FileText size={14} />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>View output</TooltipContent>
+                      </Tooltip>
+                    )}
                     {/* Nothing to terminate once the process has exited */}
                     {proc.status === "running" && (
                       <Tooltip>

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -39,17 +39,22 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
   const terminatingIds = useBackgroundBashTerminatingIds(props.workspaceId);
   const { terminate } = useBackgroundBashActions();
 
-  // Filter to only running processes
-  const runningProcesses = processes.filter((p) => p.status === "running");
+  // Keep running processes visible, plus exited processes whose monitor matched but whose
+  // wake has not been delivered yet — otherwise a one-shot watcher that matched and exited
+  // vanishes from the banner and looks like a lost wake.
+  const visibleProcesses = processes.filter(
+    (p) => p.status === "running" || p.monitor?.wakePending === true
+  );
   const viewingProcess = processes.find((p) => p.id === viewingProcessId) ?? null;
-  const count = runningProcesses.length;
+  const count = visibleProcesses.length;
+  const hasRunning = visibleProcesses.some((p) => p.status === "running");
 
-  // Update duration display every second when expanded
+  // Update duration display every second when expanded (exited processes show no duration)
   useEffect(() => {
-    if (!isExpanded || count === 0) return;
+    if (!isExpanded || !hasRunning) return;
     const interval = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(interval);
-  }, [isExpanded, count]);
+  }, [isExpanded, hasRunning]);
 
   const handleViewOutput = useCallback((processId: string, event: React.MouseEvent) => {
     event.stopPropagation();
@@ -91,7 +96,7 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
             </>
           }
           renderExpanded={() =>
-            runningProcesses.map((proc) => {
+            visibleProcesses.map((proc) => {
               const isTerminating = terminatingIds.has(proc.id);
               return (
                 <div
@@ -111,14 +116,20 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                         watching /{proc.monitor.filter}/ · {proc.monitor.totalMatches} match
                         {proc.monitor.totalMatches === 1 ? "" : "es"}
                         {proc.monitor.stopped ? " · stopped" : ""}
+                        {proc.monitor.wakePending && (
+                          <span className="text-secondary"> · match found — waking agent…</span>
+                        )}
                       </div>
                     )}
                     <div className="text-muted font-mono text-[10px]">pid {proc.pid}</div>
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
-                    <span className="text-muted text-[10px] tabular-nums">
-                      {formatDuration(Date.now() - proc.startTime)}
-                    </span>
+                    {/* Exited-but-wake-pending rows have no live duration to increment */}
+                    {proc.status === "running" && (
+                      <span className="text-muted text-[10px] tabular-nums">
+                        {formatDuration(Date.now() - proc.startTime)}
+                      </span>
+                    )}
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
@@ -135,26 +146,29 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                       </TooltipTrigger>
                       <TooltipContent>View output</TooltipContent>
                     </Tooltip>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          disabled={isTerminating}
-                          onClick={(e) => handleTerminate(proc.id, e)}
-                          className={cn(
-                            "text-muted hover:text-error rounded p-1 transition-colors",
-                            isTerminating && "cursor-not-allowed"
-                          )}
-                        >
-                          {isTerminating ? (
-                            <Loader2 size={14} className="animate-spin" />
-                          ) : (
-                            <X size={14} />
-                          )}
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent>Terminate process</TooltipContent>
-                    </Tooltip>
+                    {/* Nothing to terminate once the process has exited */}
+                    {proc.status === "running" && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            disabled={isTerminating}
+                            onClick={(e) => handleTerminate(proc.id, e)}
+                            className={cn(
+                              "text-muted hover:text-error rounded p-1 transition-colors",
+                              isTerminating && "cursor-not-allowed"
+                            )}
+                          >
+                            {isTerminating ? (
+                              <Loader2 size={14} className="animate-spin" />
+                            ) : (
+                              <X size={14} />
+                            )}
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Terminate process</TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
               );

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -121,7 +121,11 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                         )}
                       </div>
                     )}
-                    <div className="text-muted font-mono text-[10px]">pid {proc.pid}</div>
+                    {/* Rows synthesized from a durable pending wake (process gone after
+                        restart) carry no real pid. */}
+                    {proc.pid > 0 && (
+                      <div className="text-muted font-mono text-[10px]">pid {proc.pid}</div>
+                    )}
                   </div>
                   <div className="flex shrink-0 items-center gap-2">
                     {/* Exited-but-wake-pending rows have no live duration to increment */}

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -123,10 +123,13 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                             widths — hiding the only explanation for an exited row. */}
                         {proc.monitor.pendingWakeKind != null && (
                           <div className="text-secondary text-[10px]">
-                            {/* monitor-lost wakes report a terminated watcher, not a match */}
+                            {/* settled wakes report a process exit without any filter match;
+                                monitor-lost wakes report a terminated watcher, not a match */}
                             {proc.monitor.pendingWakeKind === "match"
                               ? "match found — waking agent…"
-                              : "monitor lost — waking agent…"}
+                              : proc.monitor.pendingWakeKind === "settled"
+                                ? "process settled — waking agent…"
+                                : "monitor lost — waking agent…"}
                           </div>
                         )}
                       </>

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -139,9 +139,11 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                         {formatDuration(Date.now() - proc.startTime)}
                       </span>
                     )}
-                    {/* Rows synthesized from a durable pending wake (pid 0) have no manager
-                        entry behind them, so fetching output is guaranteed to fail. */}
-                    {proc.pid > 0 && (
+                    {/* Rows synthesized from a durable pending wake have no manager entry
+                        behind them, so fetching output is guaranteed to fail. Keyed on the
+                        explicit marker, not the pid: migrated processes also use pid 0 but
+                        remain fully queryable. */}
+                    {proc.synthesized !== true && (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button

--- a/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
+++ b/src/browser/components/BackgroundProcessesBanner/BackgroundProcessesBanner.tsx
@@ -112,19 +112,24 @@ export const BackgroundProcessesBanner: React.FC<BackgroundProcessesBannerProps>
                       {proc.displayName ?? truncateScript(proc.script)}
                     </div>
                     {proc.monitor && (
-                      <div className="text-muted truncate text-[10px]">
-                        watching /{proc.monitor.filter}/ · {proc.monitor.totalMatches} match
-                        {proc.monitor.totalMatches === 1 ? "" : "es"}
-                        {proc.monitor.stopped ? " · stopped" : ""}
+                      <>
+                        <div className="text-muted truncate text-[10px]">
+                          watching /{proc.monitor.filter}/ · {proc.monitor.totalMatches} match
+                          {proc.monitor.totalMatches === 1 ? "" : "es"}
+                          {proc.monitor.stopped ? " · stopped" : ""}
+                        </div>
+                        {/* Own non-truncating line: appended to the watching line above,
+                            a long filter would right-ellipsize this away on narrow
+                            widths — hiding the only explanation for an exited row. */}
                         {proc.monitor.pendingWakeKind != null && (
-                          <span className="text-secondary">
+                          <div className="text-secondary text-[10px]">
                             {/* monitor-lost wakes report a terminated watcher, not a match */}
                             {proc.monitor.pendingWakeKind === "match"
-                              ? " · match found — waking agent…"
-                              : " · monitor lost — waking agent…"}
-                          </span>
+                              ? "match found — waking agent…"
+                              : "monitor lost — waking agent…"}
+                          </div>
                         )}
-                      </div>
+                      </>
                     )}
                     {/* Rows synthesized from a durable pending wake (process gone after
                         restart) carry no real pid. */}

--- a/src/browser/stores/BackgroundBashStore.ts
+++ b/src/browser/stores/BackgroundBashStore.ts
@@ -23,6 +23,7 @@ function areMonitorSnapshotsEqual(
     a.totalMatches === b.totalMatches &&
     a.droppedLines === b.droppedLines &&
     a.stopped === b.stopped &&
+    a.wakePending === b.wakePending &&
     a.lastLines.length === b.lastLines.length &&
     a.lastLines.every((line, index) => line === b.lastLines[index])
   );

--- a/src/browser/stores/BackgroundBashStore.ts
+++ b/src/browser/stores/BackgroundBashStore.ts
@@ -23,7 +23,7 @@ function areMonitorSnapshotsEqual(
     a.totalMatches === b.totalMatches &&
     a.droppedLines === b.droppedLines &&
     a.stopped === b.stopped &&
-    a.wakePending === b.wakePending &&
+    a.pendingWakeKind === b.pendingWakeKind &&
     a.lastLines.length === b.lastLines.length &&
     a.lastLines.every((line, index) => line === b.lastLines[index])
   );

--- a/src/browser/stores/BackgroundBashStore.ts
+++ b/src/browser/stores/BackgroundBashStore.ts
@@ -39,6 +39,9 @@ function areProcessesEqual(a: BackgroundProcessInfo[], b: BackgroundProcessInfo[
       proc.pid === other.pid &&
       proc.script === other.script &&
       proc.displayName === other.displayName &&
+      // A synthesized wake-only row and a manager-backed row can otherwise compare equal,
+      // deduping the transition that restores (or removes) the View output action.
+      proc.synthesized === other.synthesized &&
       proc.startTime === other.startTime &&
       proc.status === other.status &&
       areMonitorSnapshotsEqual(proc.monitor, other.monitor) &&

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -189,6 +189,12 @@ export const BackgroundProcessMonitorInfoSchema = z.object({
   droppedLines: z.number(),
   lastLines: z.array(z.string()),
   stopped: z.boolean(),
+  /**
+   * True when a monitor match is durably queued but its synthetic wake turn has not been
+   * delivered yet. Without this, a one-shot watcher that matched and exited looks like a
+   * lost wake in the UI (nothing running, no visible pending delivery).
+   */
+  wakePending: z.boolean().optional(),
 });
 
 // Background process info (for UI display)

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -190,11 +190,12 @@ export const BackgroundProcessMonitorInfoSchema = z.object({
   lastLines: z.array(z.string()),
   stopped: z.boolean(),
   /**
-   * True when a monitor match is durably queued but its synthetic wake turn has not been
+   * Set when a monitor wake is durably queued but its synthetic wake turn has not been
    * delivered yet. Without this, a one-shot watcher that matched and exited looks like a
-   * lost wake in the UI (nothing running, no visible pending delivery).
+   * lost wake in the UI (nothing running, no visible pending delivery). Carries the wake
+   * kind so the UI does not claim a "match" for monitor-lost restart notices.
    */
-  wakePending: z.boolean().optional(),
+  pendingWakeKind: z.enum(["match", "monitor-lost"]).optional(),
 });
 
 // Background process info (for UI display)

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -204,6 +204,12 @@ export const BackgroundProcessInfoSchema = z.object({
   pid: z.number(),
   script: z.string(),
   displayName: z.string().optional(),
+  /**
+   * True for rows synthesized from a durable pending wake with no manager entry behind
+   * them (e.g. after an app restart). Such rows have no queryable output or live process.
+   * Deliberately not inferred from pid: migrated manager-backed processes also use pid 0.
+   */
+  synthesized: z.boolean().optional(),
   startTime: z.number(),
   status: BackgroundProcessStatusSchema,
   monitor: BackgroundProcessMonitorInfoSchema.optional(),

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -195,7 +195,10 @@ export const BackgroundProcessMonitorInfoSchema = z.object({
    * lost wake in the UI (nothing running, no visible pending delivery). Carries the wake
    * kind so the UI does not claim a "match" for monitor-lost restart notices.
    */
-  pendingWakeKind: z.enum(["match", "monitor-lost"]).optional(),
+  // "settled": the wake reports only process settlement (a monitored process that
+  // exited without ever matching, or an earlier run's preserved settlement) — never
+  // labeled as a match the filter did not produce.
+  pendingWakeKind: z.enum(["match", "monitor-lost", "settled"]).optional(),
 });
 
 // Background process info (for UI display)

--- a/src/common/utils/asyncEventIterator.test.ts
+++ b/src/common/utils/asyncEventIterator.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLatestValueQueue } from "./asyncEventIterator";
+
+describe("createLatestValueQueue", () => {
+  test("an unconsumed value is replaced, not queued", async () => {
+    const queue = createLatestValueQueue<number>();
+    // A consumer slower than the producer must never accumulate a backlog: pushes
+    // while nothing is waiting coalesce into the single latest value.
+    queue.push(1);
+    queue.push(2);
+    queue.push(3);
+    const iterator = queue.iterate();
+    expect((await iterator.next()).value).toBe(3);
+    queue.push(4);
+    expect((await iterator.next()).value).toBe(4);
+    queue.end();
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  test("a waiting consumer receives the next pushed value immediately", async () => {
+    const queue = createLatestValueQueue<string>();
+    const iterator = queue.iterate();
+    const next = iterator.next();
+    queue.push("a");
+    expect((await next).value).toBe("a");
+    queue.end();
+  });
+
+  test("end wakes a waiting consumer without yielding a value", async () => {
+    const queue = createLatestValueQueue<string>();
+    const iterator = queue.iterate();
+    const next = iterator.next();
+    queue.end();
+    expect((await next).done).toBe(true);
+    // Pushes after end are ignored.
+    queue.push("late");
+    expect((await iterator.next()).done).toBe(true);
+  });
+});

--- a/src/common/utils/asyncEventIterator.ts
+++ b/src/common/utils/asyncEventIterator.ts
@@ -72,3 +72,66 @@ export function createAsyncEventQueue<T>(): {
 
   return { push, iterate, end };
 }
+
+/**
+ * Latest-value variant of createAsyncEventQueue: pushing replaces any unconsumed value
+ * instead of appending. Use it for full-state snapshots where only the newest state
+ * matters — a consumer slower than the producer then never accumulates an unbounded
+ * backlog and never replays stale intermediate states; it simply sees the latest
+ * snapshot on its next read.
+ */
+export function createLatestValueQueue<T>(): {
+  push: (value: T) => void;
+  iterate: () => AsyncGenerator<T>;
+  end: () => void;
+} {
+  let slot: { value: T } | null = null;
+  let resolveNext: ((value: T) => void) | null = null;
+  let ended = false;
+
+  const push = (value: T) => {
+    if (ended) return;
+    if (resolveNext) {
+      const resolve = resolveNext;
+      resolveNext = null;
+      resolve(value);
+    } else {
+      // Replace, never append: an unconsumed older snapshot is disposable.
+      slot = { value };
+    }
+  };
+
+  async function* iterate(): AsyncGenerator<T> {
+    while (!ended) {
+      if (slot != null) {
+        const { value } = slot;
+        slot = null;
+        yield value;
+        continue;
+      }
+
+      const value = await new Promise<T>((resolve) => {
+        resolveNext = resolve;
+      });
+
+      // end() may have been called while we were waiting. Ensure we don't yield
+      // a sentinel/invalid value back to consumers.
+      if (ended) {
+        return;
+      }
+
+      yield value;
+    }
+  }
+
+  const end = () => {
+    ended = true;
+    // Wake up the iterator if it's waiting
+    if (resolveNext) {
+      // This will never be yielded since ended=true stops the loop
+      resolveNext(undefined as T);
+    }
+  };
+
+  return { push, iterate, end };
+}

--- a/src/common/utils/coalescedReader.test.ts
+++ b/src/common/utils/coalescedReader.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCoalescedReader } from "@/common/utils/coalescedReader";
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 50 && !predicate(); i++) await tick();
+  expect(predicate()).toBe(true);
+}
+
+describe("createCoalescedReader", () => {
+  test("coalesces a burst of triggers into at most one trailing read", async () => {
+    let started = 0;
+    const releases: Array<() => void> = [];
+    const reader = createCoalescedReader({
+      read: () =>
+        new Promise<void>((resolve) => {
+          started += 1;
+          releases.push(resolve);
+        }),
+      retryDelayMs: 0,
+    });
+
+    reader.trigger();
+    expect(started).toBe(1);
+    // A burst while the first read is in flight coalesces into one trailing read
+    // instead of queueing one read per event.
+    for (let i = 0; i < 1000; i++) reader.trigger();
+    expect(started).toBe(1);
+    releases.shift()?.();
+    await waitFor(() => started === 2);
+    releases.shift()?.();
+    await tick();
+    expect(started).toBe(2); // nothing further queued
+  });
+
+  test("retries a failed read instead of discarding the trigger", async () => {
+    let calls = 0;
+    let succeeded = false;
+    const reader = createCoalescedReader({
+      read: () => {
+        calls += 1;
+        if (calls === 1) return Promise.reject(new Error("transient"));
+        succeeded = true;
+        return Promise.resolve();
+      },
+      retryDelayMs: 0,
+    });
+    reader.trigger();
+    await waitFor(() => succeeded);
+    expect(calls).toBe(2);
+  });
+
+  test("stop ends the retry loop and ignores later triggers", async () => {
+    let calls = 0;
+    const reader = createCoalescedReader({
+      read: () => {
+        calls += 1;
+        return Promise.reject(new Error("always failing"));
+      },
+      retryDelayMs: 0,
+    });
+    reader.trigger();
+    await waitFor(() => calls >= 1);
+    reader.stop();
+    await tick();
+    const after = calls;
+    for (let i = 0; i < 5; i++) await tick();
+    expect(calls).toBe(after); // retry loop exited
+    reader.trigger();
+    for (let i = 0; i < 5; i++) await tick();
+    expect(calls).toBe(after); // post-stop triggers are ignored
+  });
+});

--- a/src/common/utils/coalescedReader.ts
+++ b/src/common/utils/coalescedReader.ts
@@ -1,0 +1,59 @@
+import assert from "@/common/utils/assert";
+
+/**
+ * Runs an async `read` at most once at a time, coalescing bursts of triggers into at
+ * most one trailing read: trigger() marks state dirty, and a single reader loop keeps
+ * reading until a read completes with no trigger landing during it. Because only the
+ * latest state matters to callers, a burst of N triggers costs at most 2 reads instead
+ * of queueing N, and serialized reads cannot resolve out of order (a stale snapshot can
+ * never overwrite a newer one).
+ *
+ * A failed read re-marks dirty and retries after `retryDelayMs` instead of discarding
+ * the trigger — a trigger may be the only signal an event source ever emits (e.g. a
+ * process exit), so dropping it on a transient failure would leave consumers stale
+ * forever. stop() ends the loop; triggers after stop() are ignored.
+ */
+export function createCoalescedReader(options: {
+  read: () => Promise<void>;
+  retryDelayMs: number;
+}): {
+  trigger: () => void;
+  stop: () => void;
+} {
+  assert(
+    Number.isFinite(options.retryDelayMs) && options.retryDelayMs >= 0,
+    "createCoalescedReader requires a non-negative retryDelayMs"
+  );
+  let dirty = false;
+  let running = false;
+  let stopped = false;
+
+  const run = async (): Promise<void> => {
+    running = true;
+    try {
+      while (dirty && !stopped) {
+        dirty = false;
+        try {
+          await options.read();
+        } catch {
+          dirty = true;
+          await new Promise((resolve) => setTimeout(resolve, options.retryDelayMs));
+        }
+      }
+    } finally {
+      running = false;
+    }
+  };
+
+  return {
+    trigger: () => {
+      if (stopped) return;
+      dirty = true;
+      // Fire-and-forget is safe: run() catches read failures internally and cannot reject.
+      if (!running) void run();
+    },
+    stop: () => {
+      stopped = true;
+    },
+  };
+}

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -76,6 +76,7 @@ import { isMultiProject } from "@/common/utils/multiProject";
 import { mergeMultiProjectSecrets } from "@/node/services/utils/multiProjectSecrets";
 import { roundToBase2 } from "@/common/telemetry/utils";
 import { createAsyncEventQueue } from "@/common/utils/asyncEventIterator";
+import { createCoalescedReader } from "@/common/utils/coalescedReader";
 import { withQueueHeartbeat } from "@/common/utils/withQueueHeartbeat";
 import {
   DEFAULT_LAYOUT_PRESETS_CONFIG,
@@ -5513,20 +5514,22 @@ export const router = (authToken?: string) => {
               signal.addEventListener("abort", onAbort, { once: true });
             }
 
-            // Serialize event-driven reads: consecutive change events (e.g. spawn's emit
-            // followed by the post-persistence wake-state emit) would otherwise start
-            // overlapping getState() calls whose resolution order can invert, letting a
-            // stale pre-persistence snapshot overwrite the newer one.
-            let readTail: Promise<void> = Promise.resolve();
+            // Coalesce event-driven reads: a monitor with cooldown_ms 0 can emit one
+            // change per matching output line, and reading full state once per event
+            // would queue an unbounded backlog of manager refreshes while only the
+            // latest state matters. The reader also serializes reads (overlapping
+            // getState() calls could resolve out of order and publish a stale
+            // pre-persistence snapshot over a newer one) and retries failed reads —
+            // a change event may be the only signal an exited process ever emits, so
+            // dropping it would leave the renderer stale with no reconnect.
+            const reader = createCoalescedReader({
+              read: async () => {
+                queue.push(await getState());
+              },
+              retryDelayMs: 1_000,
+            });
             const onChange = (changedWorkspaceId: string) => {
-              if (changedWorkspaceId === workspaceId) {
-                readTail = readTail
-                  .then(async () => {
-                    queue.push(await getState());
-                  })
-                  // Keep the chain alive after a failed read; the next event retries.
-                  .catch(() => undefined);
-              }
+              if (changedWorkspaceId === workspaceId) reader.trigger();
             };
 
             service.onBackgroundBashChange(onChange);
@@ -5538,6 +5541,7 @@ export const router = (authToken?: string) => {
             } finally {
               signal?.removeEventListener("abort", onAbort);
               queue.end();
+              reader.stop();
               service.offBackgroundBashChange(onChange);
             }
           }),

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5513,9 +5513,19 @@ export const router = (authToken?: string) => {
               signal.addEventListener("abort", onAbort, { once: true });
             }
 
+            // Serialize event-driven reads: consecutive change events (e.g. spawn's emit
+            // followed by the post-persistence wake-state emit) would otherwise start
+            // overlapping getState() calls whose resolution order can invert, letting a
+            // stale pre-persistence snapshot overwrite the newer one.
+            let readTail: Promise<void> = Promise.resolve();
             const onChange = (changedWorkspaceId: string) => {
               if (changedWorkspaceId === workspaceId) {
-                void getState().then(queue.push);
+                readTail = readTail
+                  .then(async () => {
+                    queue.push(await getState());
+                  })
+                  // Keep the chain alive after a failed read; the next event retries.
+                  .catch(() => undefined);
               }
             };
 

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -75,7 +75,7 @@ import { secretsToRecord } from "@/common/types/secrets";
 import { isMultiProject } from "@/common/utils/multiProject";
 import { mergeMultiProjectSecrets } from "@/node/services/utils/multiProjectSecrets";
 import { roundToBase2 } from "@/common/telemetry/utils";
-import { createAsyncEventQueue } from "@/common/utils/asyncEventIterator";
+import { createAsyncEventQueue, createLatestValueQueue } from "@/common/utils/asyncEventIterator";
 import { createCoalescedReader } from "@/common/utils/coalescedReader";
 import { withQueueHeartbeat } from "@/common/utils/withQueueHeartbeat";
 import {
@@ -5504,7 +5504,11 @@ export const router = (authToken?: string) => {
               foregroundToolCallIds: service.getForegroundToolCallIds(workspaceId),
             });
 
-            const queue = createAsyncEventQueue<Awaited<ReturnType<typeof getState>>>();
+            // Latest-value queue, not FIFO: each pushed value is a FULL state snapshot,
+            // so an unconsumed older snapshot is disposable. A FIFO would retain every
+            // snapshot a slow ORPC consumer has not yet serialized — unbounded memory
+            // and stale intermediate UI replays under sustained monitor output.
+            const queue = createLatestValueQueue<Awaited<ReturnType<typeof getState>>>();
 
             const onAbort = () => {
               queue.end();
@@ -5516,7 +5520,7 @@ export const router = (authToken?: string) => {
 
             // Coalesce event-driven reads: a monitor with cooldown_ms 0 can emit one
             // change per matching output line, and reading full state once per event
-            // would queue an unbounded backlog of manager refreshes while only the
+            // would launch an unbounded backlog of manager refreshes while only the
             // latest state matters. The reader also serializes reads (overlapping
             // getState() calls could resolve out of order and publish a stale
             // pre-persistence snapshot over a newer one) and retries failed reads —

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5539,8 +5539,12 @@ export const router = (authToken?: string) => {
             service.onBackgroundBashChange(onChange);
 
             try {
-              // Emit initial state immediately
-              yield await getState();
+              // Bootstrap through the SAME serialized reader as event-driven reads. A
+              // separate `yield await getState()` can race an onChange-triggered read:
+              // the event read's snapshot waits in the queue while the slower bootstrap
+              // yields a NEWER snapshot first, and consuming the queued older value then
+              // regresses the renderer with no later event to repair it.
+              reader.trigger();
               yield* queue.iterate();
             } finally {
               signal?.removeEventListener("abort", onAbort);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -5526,9 +5526,34 @@ export const router = (authToken?: string) => {
             // pre-persistence snapshot over a newer one) and retries failed reads —
             // a change event may be the only signal an exited process ever emits, so
             // dropping it would leave the renderer stale with no reconnect.
+            // Bootstrap failures FAIL OPEN: if the very first read keeps failing (e.g.
+            // a remote status probe is down), endless silent retries would leave the
+            // subscriber without any signal — BackgroundBashStore could never run its
+            // error path that marks workspace state known, blocking the chat view's
+            // first-paint barrier indefinitely. Surface the first pre-snapshot failure
+            // as a subscription error instead; once a snapshot has been delivered the
+            // reader's silent retry loop takes over (the renderer has state to show).
+            // Boxed (not bare `let`s) so the reader closure's writes stay visible to
+            // the generator body: TS flow analysis keeps a captured let narrowed to
+            // its initial null in this scope, so `throw bootstrap.error` would be
+            // rejected as throwing a non-Error.
+            const bootstrap = { delivered: false, error: null as Error | null };
             const reader = createCoalescedReader({
               read: async () => {
-                queue.push(await getState());
+                let state: Awaited<ReturnType<typeof getState>>;
+                try {
+                  state = await getState();
+                } catch (error) {
+                  if (!bootstrap.delivered) {
+                    bootstrap.error =
+                      error instanceof Error ? error : new Error(getErrorMessage(error));
+                    queue.end();
+                    return;
+                  }
+                  throw error;
+                }
+                bootstrap.delivered = true;
+                queue.push(state);
               },
               retryDelayMs: 1_000,
             });
@@ -5546,6 +5571,7 @@ export const router = (authToken?: string) => {
               // regresses the renderer with no later event to repair it.
               reader.trigger();
               yield* queue.iterate();
+              if (bootstrap.error != null) throw bootstrap.error;
             } finally {
               signal?.removeEventListener("abort", onAbort);
               queue.end();

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -411,6 +411,18 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     this.emit("change", workspaceId);
   }
 
+  /**
+   * Nudge background-bash subscribers after a monitor wake-state transition (pending
+   * enqueued, delivered, or superseded). Wake records live in BashMonitorWakeStore
+   * (owned by WorkspaceService), but subscribers observe them through this manager's
+   * "change" stream, so the owner needs a way to request an emit when only wake state
+   * — not process state — changed.
+   */
+  notifyMonitorWakeStateChanged(workspaceId: string): void {
+    assert(workspaceId.length > 0, "notifyMonitorWakeStateChanged requires a workspaceId");
+    this.emitChange(workspaceId);
+  }
+
   private createMonitorState(
     config: BackgroundProcessMonitorConfig,
     options: { pollIntervalMs: number }

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2894,6 +2894,45 @@ describe("BashMonitorWakeStore", () => {
     expect(await fsPromises.readdir(dir)).toContain("%70roc-1.json");
   });
 
+  test("the pre-cutoff fence sees a clear published during the record pass", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired mid-pass"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // A concurrent instance COMMITS a clear while this scan is inside its record
+    // loop (injected on the record pass's classification lstat): tombstone discovery
+    // pinned before the loop would never see it, serve the pre-cutoff record, and
+    // let a drain deliver output that clear just retired.
+    const realLstat = fsPromises.lstat;
+    const injected = { fired: false };
+    const lstatSpy = spyOn(fsPromises, "lstat").mockImplementation((async (
+      target: Parameters<typeof realLstat>[0]
+    ) => {
+      if (!injected.fired && String(target).endsWith("proc-1.json")) {
+        injected.fired = true;
+        await fsPromises.writeFile(
+          tombPath,
+          JSON.stringify({
+            clearedAt: new Date().toISOString(),
+            clearId: "clear-mid-pass",
+            phase: "committed",
+          }),
+          "utf-8"
+        );
+      }
+      return realLstat(target);
+    }) as typeof fsPromises.lstat);
+    try {
+      expect(await store.listPending("owner-1")).toEqual([]);
+    } finally {
+      lstatSpy.mockRestore();
+    }
+    expect(injected.fired).toBe(true);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -8,6 +8,7 @@ import {
   BashMonitorWakeStore,
   buildBashMonitorWakeMetadata,
   buildBashMonitorWakePrompt,
+  deferredTempRecoveryDelayMs,
   TEMP_RECOVERY_MIN_AGE_MS,
   TERMINAL_WAKE_RETENTION_MS,
   type BashMonitorWakePayload,
@@ -502,6 +503,84 @@ describe("BashMonitorWakeStore", () => {
     expect(pending.map((r) => r.lines)).toEqual([["ERROR fresh only copy"]]);
     expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR fresh only copy"]);
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
+    const now = Date.now();
+    // Near the gate: fires just past it (epsilon), no spurious full-interval wait.
+    expect(deferredTempRecoveryDelayMs(now - TEMP_RECOVERY_MIN_AGE_MS + 100, now)).toBe(350);
+    // Already past the gate: only the epsilon remains.
+    expect(deferredTempRecoveryDelayMs(now - TEMP_RECOVERY_MIN_AGE_MS - 5_000, now)).toBe(250);
+    // Far-future mtime (clock rollback / corrupted timestamps): the raw remaining time
+    // would exceed Node's max timer delay (clamped to ~1ms — a tight rescan loop);
+    // instead the delay caps at one bounded recheck interval.
+    expect(deferredTempRecoveryDelayMs(now + 2 ** 40, now)).toBe(TEMP_RECOVERY_MIN_AGE_MS + 250);
+  });
+
+  test("a transient stat failure during temp recovery propagates", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR only copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+
+    // The artifact guard's first stat succeeds; the recovery-internal second stat
+    // fails transiently. Swallowing it would turn the scan into a successful empty
+    // result that schedules neither a drain nor the deferred-recovery timer.
+    const realStat = fsPromises.stat;
+    let tempStats = 0;
+    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
+      p: Parameters<typeof realStat>[0]
+    ) =>
+      String(p) === temp && ++tempStats === 2
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realStat(p)) as typeof fsPromises.stat);
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the stat failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      statSpy.mockRestore();
+    }
+    // The temp was untouched; the next scan restores it.
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR only copy"]]);
+  });
+
+  test("a stale crashed temp cannot resurrect a superseded wake across canonical pruning", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    // The wake was then re-enqueued and deliberately superseded (e.g. a history
+    // clear); by now BOTH files are past the terminal retention window.
+    const record = JSON.parse(await fsPromises.readFile(temp, "utf-8")) as {
+      updatedAt: string;
+    };
+    const superseded = {
+      ...record,
+      status: "superseded",
+      updatedAt: new Date(Date.parse(record.updatedAt) + 1_000).toISOString(),
+    };
+    await fsPromises.writeFile(file, JSON.stringify(superseded, null, 2), "utf-8");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 120_000);
+    await fsPromises.utimes(temp, past, past);
+    await fsPromises.utimes(file, past, past);
+
+    // One scan must both prune the terminal canonical AND discard the stale temp —
+    // in no order may the pruned canonical make the stale pending temp look like the
+    // only durable copy and resurrect the canceled wake.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect(await fresh.get("owner-1", "proc-1")).toBeNull();
+    const entries = await fsPromises.readdir(dir).catch(() => [] as string[]);
+    expect(entries.filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    expect(await fresh.listPending("owner-1")).toEqual([]);
   });
 
   test("a transient orphan-temp placement failure propagates instead of hiding the wake", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -299,6 +299,53 @@ describe("BashMonitorWakeStore", () => {
     expect(later[0].lines).toEqual(["ERROR rearmed"]);
   });
 
+  test("listPending restores a pending wake stranded in a crashed prune file", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    // Simulate a crash between the prune's capture rename and its verify/restore: the
+    // captured pending inode is stranded under the trash name.
+    const stranded = `${file}.prune-crashed`;
+    await fsPromises.rename(file, stranded);
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.id)).toEqual(["proc-1"]);
+    // Restored to the canonical path (visible to delivery reads) and the leftover is gone.
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("pending");
+    let strandedGone = false;
+    try {
+      await fsPromises.access(stranded);
+    } catch {
+      strandedGone = true;
+    }
+    expect(strandedGone).toBe(true);
+  });
+
+  test("a stranded prune file never clobbers a newer record at the original path", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR old generation"] }));
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const stranded = `${file}.prune-crashed`;
+    await fsPromises.rename(file, stranded);
+    // A newer wake claims the original path after the crash.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR new generation"] }));
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR new generation"]);
+    // The stranded leftover is dropped, not restored over the newer record.
+    let strandedGone = false;
+    try {
+      await fsPromises.access(stranded);
+    } catch {
+      strandedGone = true;
+    }
+    expect(strandedGone).toBe(true);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR new generation"]);
+  });
+
   test("listPending keeps serving a cached pending wake when stat transiently fails", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -1122,6 +1122,214 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
+  test("an unknown tombstone phase reads as malformed instead of condemning wakes", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR nearly condemned"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // Corruption (or a newer build's state) produced a phase outside the supported
+    // enum. Only the exact "staged" value enters the hold path, so an unvalidated
+    // unknown phase would take the COMMITTED path and permanently delete the
+    // pre-clear wake.
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at"),
+      JSON.stringify({
+        clearedAt: new Date(Date.now() + 60_000).toISOString(),
+        clearId: "clear-x",
+        phase: "staging",
+        stagedAt: new Date().toISOString(),
+      }),
+      "utf-8"
+    );
+
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR nearly condemned"]]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("equal-cutoff healing prefers the committed generation over its staged capture", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired by commit"] }));
+    // The clear stages (the record is stamped superseded)...
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    const staged = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    // ...and its COMMIT crashes between publishing the committed value and consuming
+    // the staged capture: BOTH generations of one clear survive as leftovers with
+    // identical clearedAt values, the staging old enough for the grace rollback.
+    await fsPromises.writeFile(
+      `${tombPath}.cas-a-staged`,
+      JSON.stringify({
+        ...staged,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await fsPromises.writeFile(
+      `${tombPath}.cas-b-committed`,
+      JSON.stringify({ clearedAt: clear.clearedAt, clearId: clear.clearId, phase: "committed" }),
+      "utf-8"
+    );
+    await fsPromises.rm(tombPath, { force: true });
+
+    // Force enumeration to present the STAGED capture first: the tie must be decided
+    // by phase rank, never by directory order.
+    const rank = (e: string) =>
+      e.endsWith(".cas-a-staged") ? 0 : e.endsWith(".cas-b-committed") ? 1 : 2;
+    const realReaddir = fsPromises.readdir;
+    const readdirSpy = spyOn(fsPromises, "readdir").mockImplementation(((
+      p: Parameters<typeof realReaddir>[0]
+    ) =>
+      realReaddir(p).then((entries) =>
+        [...entries].sort((a, b) => rank(String(a)) - rank(String(b)))
+      )) as typeof fsPromises.readdir);
+    try {
+      // A fresh instance (the restarted app) heals the leftovers: selecting the
+      // staged generation would roll the clear back and resurrect the retired wake.
+      const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+      expect(await fresh.listPending("owner-1")).toEqual([]);
+      expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
+  test("a failing promotion keeps the clear active so scans do not roll it back", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // The staging is old enough that a CRASHED clear would be rolled back...
+    const staged = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...staged,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    // ...but this clear is NOT crashed: its history clear succeeded and only its
+    // tombstone promotion keeps failing (e.g. ENOSPC).
+    const realWriteFile = fsPromises.writeFile;
+    const writeSpy = spyOn(fsPromises, "writeFile").mockImplementation(((
+      target: Parameters<typeof realWriteFile>[0],
+      data: Parameters<typeof realWriteFile>[1]
+    ) =>
+      typeof target === "string" && target.includes("cleared-at.tmp-")
+        ? Promise.reject(Object.assign(new Error("ENOSPC: no space"), { code: "ENOSPC" }))
+        : realWriteFile(target, data, "utf-8")) as typeof fsPromises.writeFile);
+    try {
+      await store.commitClear("owner-1", clear);
+      expect.unreachable("expected commitClear to propagate the promotion failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("ENOSPC");
+    } finally {
+      writeSpy.mockRestore();
+    }
+    // The clear stays ACTIVE while its promotion is being retried: scans must not
+    // treat the locally known successful clear as crashed and restore its wakes.
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    // The retried promotion then lands durably.
+    await store.commitClear("owner-1", clear);
+    expect(await store.listPending("owner-1")).toEqual([]);
+    const tomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as { phase?: string };
+    expect(tomb.phase).toBe("committed");
+  });
+
+  test("a committed clear survives a newer staged generation's rollback", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // A wake crashes into a deferred temp inside the freshness gate...
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre-clear"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 5_000);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // Clear A captures its cutoff (past the wake) but stalls before its staging
+    // lands...
+    const clearA = await store.supersedeAllPending("owner-1");
+    // ...so clear B (another instance) stages a NEWER cutoff having never seen A's:
+    // B's tombstone records NO predecessor.
+    const clearB = {
+      clearId: "clear-b",
+      clearedAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at"),
+      JSON.stringify({
+        clearedAt: clearB.clearedAt,
+        clearId: clearB.clearId,
+        phase: "staged",
+        stagedAt: new Date().toISOString(),
+      }),
+      "utf-8"
+    );
+    // A's history clear SUCCEEDS and promotes; B's later fails and rolls back.
+    await store.commitClear("owner-1", clearA);
+    await store.restorePendingSnapshots("owner-1", [], clearB);
+
+    // B's rollback must demote to A's committed cutoff — not erase the tombstone —
+    // so the deferred pre-A wake stays condemned once past the gate.
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("recovering a divergent match temp keeps the lost notice's undelivered lines", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // A pending match generation crashes into a consumable temp...
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR matched output"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // ...while restart recovery already wrote a monitor-lost notice for the same id
+    // from a DIFFERENT lineage (offset subsumption unprovable) that still carries
+    // its OWN undelivered matched lines from an earlier generation.
+    const parsedTemp = JSON.parse(await fsPromises.readFile(temp, "utf-8")) as Record<
+      string,
+      unknown
+    > & { createdAt: string; updatedAt: string };
+    await fsPromises.writeFile(
+      file,
+      JSON.stringify({
+        ...parsedTemp,
+        kind: "monitor-lost",
+        script: "echo relaunch",
+        lines: ["ERROR earlier undelivered"],
+        createdAt: new Date(Date.parse(parsedTemp.createdAt) - 60_000).toISOString(),
+        updatedAt: new Date(Date.parse(parsedTemp.updatedAt) + 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // The merge must carry BOTH pending payloads: replacing the notice with the temp
+    // alone would permanently drop already-matched output from the wake prompt.
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].kind).toBe("monitor-lost");
+    expect(pending[0].script).toBe("echo relaunch");
+    expect(pending[0].lines).toEqual(["ERROR matched output", "ERROR earlier undelivered"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
     const now = Date.now();
     // Near the gate: fires just past it (epsilon), no spurious full-interval wait.

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -8,6 +8,7 @@ import {
   BashMonitorWakeStore,
   buildBashMonitorWakeMetadata,
   buildBashMonitorWakePrompt,
+  TERMINAL_WAKE_RETENTION_MS,
   type BashMonitorWakePayload,
   type BashMonitorWakeRecord,
 } from "@/node/services/bashMonitorWakeStore";
@@ -229,6 +230,36 @@ describe("BashMonitorWakeStore", () => {
     const pending = await store.listPending("owner-1");
     expect(pending).toHaveLength(1);
     expect(pending[0].lines).toEqual(["ERROR rearmed"]);
+  });
+
+  test("listPending prunes terminal wake files past the retention window", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ processId: "proc-old", taskId: "bash:proc-old" }));
+    await store.markDelivered("owner-1", "proc-old");
+    await store.enqueueOrMergePending(
+      payload({ processId: "proc-live", taskId: "bash:proc-live" })
+    );
+
+    // Backdate the terminal file beyond the retention window (fresh terminal files stay).
+    const oldFile = path.join(
+      rootDir,
+      "sessions",
+      "owner-1",
+      "bash-monitor-wakes",
+      "proc-old.json"
+    );
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(oldFile, past, past);
+
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-live"]);
+    // The old terminal record is gone from disk so future scans stay bounded.
+    let pruned = false;
+    try {
+      await fsPromises.access(oldFile);
+    } catch {
+      pruned = true;
+    }
+    expect(pruned).toBe(true);
   });
 
   test("listPending discovers wakes written by another store instance after seeding", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2100,6 +2100,150 @@ describe("BashMonitorWakeStore", () => {
     ]);
   });
 
+  test("a promotion that loses the tombstone no-clobber race fails instead of leaving the clear silently staged", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired by clear"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    const stagedRaw = await fsPromises.readFile(tombPath, "utf-8");
+    // A foreign instance republishes this SAME staged tombstone (a heal restoring a
+    // stranded capture) between the promotion's capture rename and its no-clobber
+    // placement: the placement loses (EEXIST) and the promotion never lands.
+    const realRename = fsPromises.rename;
+    const injected = { fired: false };
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((async (
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) => {
+      const result = await realRename(from, to);
+      if (!injected.fired && String(from).endsWith("cleared-at") && String(to).includes(".cas-")) {
+        injected.fired = true;
+        await fsPromises.writeFile(tombPath, stagedRaw, "utf-8");
+      }
+      return result;
+    }) as typeof fsPromises.rename);
+    try {
+      // Reporting success would disarm the heartbeat and drop the active-clear marker
+      // while the clear is durably STAGED with no retry left: the grace scan would
+      // roll it back and restore retired wakes into the cleared transcript.
+      await store.commitClear("owner-1", clear);
+      expect.unreachable("expected the lost promotion race to fail the commit");
+    } catch (error) {
+      expect((error as Error).message).toContain("no-clobber");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // The clear stays ACTIVE: even a staging aged past its grace window must not be
+    // rolled back by the owning instance while its promotion retry is still due.
+    const staged = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(staged.phase).toBe("staged");
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...staged,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    // The caller's retry re-drives the promotion against the standing generation and
+    // converges: the retired wake never resurfaces.
+    await store.commitClear("owner-1", clear);
+    const committed = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(committed.phase).toBe("committed");
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+  });
+
+  test("a committed capture stranded behind a malformed tombstone still condemns pre-clear temps", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre-clear"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // The wake crashes into a deferred temp inside the freshness gate: invisible to
+    // the clear below.
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 5_000);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+    expect(clear.snapshots).toEqual([]);
+    await store.commitClear("owner-1", clear);
+
+    // A tombstone mutation crashes mid-dance (its capture stranded) while persisted
+    // corruption leaves garbage at the canonical path: the committed cutoff's ONLY
+    // copy is the .cas- capture behind the malformed file.
+    const tombPath = path.join(dir, "cleared-at");
+    await fsPromises.rename(tombPath, `${tombPath}.cas-stranded`);
+    await fsPromises.writeFile(tombPath, "not json {{{", "utf-8");
+    // The temp ages past the gate: consumable on the next scan.
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+
+    // Judging only the malformed canonical would read as "no clear" and RESTORE the
+    // pre-clear temp into the cleared transcript. The scan must quarantine the
+    // malformed file, heal the committed capture back, and condemn the temp.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    // The healed committed cutoff stands at the canonical path again, durably.
+    const healed = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(healed.phase).toBe("committed");
+    expect(healed.clearId).toBe(clear.clearId);
+  });
+
+  test("a staged capture stranded behind a malformed tombstone still reaches its crash rollback", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stamped by clear"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // The owner crashes with the STAGED value stranded in a mutation capture, aged
+    // past its rollback grace window, while corruption leaves garbage at the
+    // canonical path.
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      `${tombPath}.cas-stranded`,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await fsPromises.writeFile(tombPath, "not json {{{", "utf-8");
+
+    // Ignoring the malformed canonical would report "no clear": the crash rollback
+    // never finds the staging, and the clear-stamped record stays superseded forever
+    // — a wake permanently lost for a history clear that never committed. The scan
+    // must heal the staged capture back and run the overdue rollback.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await fresh.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR stamped by clear"],
+    ]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("pending");
+    // Stop the abandoned owner's staged-clear heartbeat (its clear never settles).
+    await store.abandonWorkspaceClears("owner-1");
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -1459,6 +1460,40 @@ describe("BashMonitorWakeStore", () => {
     await store.commitClear("owner-1", clear);
   });
 
+  test("abandoning a workspace's clears stops its heartbeat from recreating the directory", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir), {
+      stagedClearRefreshIntervalMs: 25,
+    });
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    // The promotion fails (ENOSPC): commitClear intentionally leaves the heartbeat
+    // armed for cross-instance liveness while promotion retries continue.
+    const realWriteFile = fsPromises.writeFile;
+    const writeSpy = spyOn(fsPromises, "writeFile").mockImplementation(((
+      target: Parameters<typeof realWriteFile>[0],
+      data: Parameters<typeof realWriteFile>[1]
+    ) =>
+      typeof target === "string" && target.includes("cleared-at.tmp-")
+        ? Promise.reject(Object.assign(new Error("ENOSPC: no space"), { code: "ENOSPC" }))
+        : realWriteFile(target, data, "utf-8")) as typeof fsPromises.writeFile);
+    try {
+      await store.commitClear("owner-1", clear);
+      expect.unreachable("expected commitClear to propagate the promotion failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("ENOSPC");
+    } finally {
+      writeSpy.mockRestore();
+    }
+    // Workspace removal abandons the clear writers, then deletes the session
+    // directory. Without the abandon, the still-armed heartbeat's mutateClearedAt
+    // would mkdir the directory straight back into existence.
+    store.abandonWorkspaceClears("owner-1");
+    const sessionDir = path.join(rootDir, "sessions", "owner-1");
+    await fsPromises.rm(sessionDir, { recursive: true, force: true });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(existsSync(sessionDir)).toBe(false);
+  });
+
   test("a newer re-armed match replaces a stale canonical lost notice", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     const notice = await store.enqueueMonitorLost(
@@ -1585,6 +1620,144 @@ describe("BashMonitorWakeStore", () => {
     // Committing the clear still leaves the merged record deliverable.
     await store.commitClear("owner-1", clear);
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("a same-millisecond merge with an unchanged updatedAt survives the supersede", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR before cutoff"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Another instance merges NEW matched output between the clear's snapshot and its
+    // per-record stamp — landing in the SAME millisecond, so updatedAt stays
+    // byte-identical while lines and counters differ (the CAS replacement documents
+    // identical timestamps with different content as possible).
+    const getSpy = spyOn(store, "get").mockImplementation(async (owner: string, id: string) => {
+      getSpy.mockRestore();
+      const raw = JSON.parse(await fsPromises.readFile(file, "utf-8")) as Record<
+        string,
+        unknown
+      > & { lines: string[] };
+      await fsPromises.writeFile(
+        file,
+        JSON.stringify({
+          ...raw,
+          lines: [...raw.lines, "ERROR same instant"],
+          totalMatches: 2,
+          matchedThroughOffset: 20,
+        }),
+        "utf-8"
+      );
+      return store.get(owner, id);
+    });
+
+    const clear = await store.supersedeAllPending("owner-1");
+    // A timestamp-only generation check misses this merge and would retire the
+    // record, permanently discarding output the clear never saw.
+    expect(clear.snapshots).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR before cutoff", "ERROR same instant"],
+    ]);
+    await store.commitClear("owner-1", clear);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("the staged tombstone lands durably before any record is stamped for the clear", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR first"] }));
+    await store.enqueueOrMergePending(
+      payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR second"] })
+    );
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // Observe the on-disk tombstone at the instant each record stamp is written: a
+    // hard crash immediately after ANY stamp leaves restart recovery only the
+    // tombstone to discover stamped records through (rollbackCrashedClearStaging).
+    // Stamping before the staging lands would make a crash in that window
+    // permanently lose wakes for a history clear that never ran.
+    const observed: Array<string | null> = [];
+    const realWriteFile = fsPromises.writeFile;
+    const writeSpy = spyOn(fsPromises, "writeFile").mockImplementation((async (
+      target: Parameters<typeof realWriteFile>[0],
+      data: Parameters<typeof realWriteFile>[1]
+    ) => {
+      if (typeof data === "string" && data.includes("supersededByClearId")) {
+        observed.push(await fsPromises.readFile(tombPath, "utf-8").catch(() => null));
+      }
+      return realWriteFile(target, data, "utf-8");
+    }) as typeof fsPromises.writeFile);
+    let clearId: string;
+    try {
+      const clear = await store.supersedeAllPending("owner-1");
+      clearId = clear.clearId;
+      await store.commitClear("owner-1", clear);
+    } finally {
+      writeSpy.mockRestore();
+    }
+    expect(observed).toHaveLength(2);
+    for (const tombRaw of observed) {
+      expect(tombRaw).not.toBeNull();
+      const tomb = JSON.parse(tombRaw!) as { clearId?: string; phase?: string };
+      expect(tomb.clearId).toBe(clearId);
+      expect(tomb.phase).toBe("staged");
+    }
+  });
+
+  test("a stamping failure after staging rolls the staged tombstone back", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR survives abort"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // The record stamp fails (EIO) AFTER the staged tombstone landed: the aborted
+    // clear must demote its own staging — leaving it standing would hold deferred
+    // pre-clear temps for a clear that already failed until the grace scan.
+    const realWriteFile = fsPromises.writeFile;
+    const writeSpy = spyOn(fsPromises, "writeFile").mockImplementation(((
+      target: Parameters<typeof realWriteFile>[0],
+      data: Parameters<typeof realWriteFile>[1]
+    ) =>
+      typeof data === "string" && data.includes("supersededByClearId")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realWriteFile(target, data, "utf-8")) as typeof fsPromises.writeFile);
+    try {
+      await store.supersedeAllPending("owner-1");
+      expect.unreachable("expected the record stamp failure to propagate");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      writeSpy.mockRestore();
+    }
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR survives abort"],
+    ]);
+    expect((await fsPromises.readdir(dir)).some((e) => e.startsWith("cleared-at"))).toBe(false);
+  });
+
+  test("terminal pruning spares records owned by an unresolved staged clear", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR long clear"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // The clear outlives the retention window (a long history clear, or a promotion
+    // retrying past transient failures): the stamped record ages past
+    // TERMINAL_WAKE_RETENTION_MS while the tombstone stays staged.
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // ANOTHER instance's scan (no in-memory active-clear marker) must not prune the
+    // record: it is the staged clear's ONLY rollback source — restore rewrites the
+    // canonical record, so pruning it here would permanently lose the wake if the
+    // clear subsequently fails.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+
+    // The clear then fails and rolls back: the held record restores and delivers.
+    await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR long clear"],
+    ]);
   });
 
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -8,6 +8,7 @@ import {
   BashMonitorWakeStore,
   buildBashMonitorWakeMetadata,
   buildBashMonitorWakePrompt,
+  TEMP_RECOVERY_MIN_AGE_MS,
   TERMINAL_WAKE_RETENTION_MS,
   type BashMonitorWakePayload,
   type BashMonitorWakeRecord,
@@ -473,23 +474,160 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
-  test("a fresh orphaned temp with no canonical record is placed immediately", async () => {
+  test("a fresh orphan temp is deferred, then re-driven once the live-writer gate elapses", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR fresh only copy"] }));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
-    // Crash before the commit rename, restart WITHIN the temp freshness gate: waiting
-    // for the gate would leave the only durable copy invisible with no re-drive.
+    // A temp within the freshness gate may equally be a crash orphan or a LIVE writer
+    // between writeFile and its commit rename. Recovery must not place it (a failed
+    // live write would silently become durable), but the deferral must not be terminal
+    // either — startup discovery alone would never retry.
     const temp = `${file}.tmp-crashed`;
     await fsPromises.rename(file, temp);
+    // Nearly past the gate so the deferred re-drive fires quickly in tests.
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
 
     const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const due = new Promise<string>((resolve) => {
+      fresh.onDeferredTempRecoveryDue = resolve;
+    });
+    // Within the gate: nothing is placed or published, but a re-drive is armed.
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect(await fresh.get("owner-1", "proc-1")).toBeNull();
+    expect(await due).toBe("owner-1");
+    // The re-driven scan places and publishes the only durable copy.
     const pending = await fresh.listPending("owner-1");
     expect(pending.map((r) => r.lines)).toEqual([["ERROR fresh only copy"]]);
     expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR fresh only copy"]);
-    // The temp itself stays (a possible live writer's commit rename of the same inode
-    // is a POSIX no-op); the age-gated sweep consumes it later.
-    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a transient orphan-temp placement failure propagates instead of hiding the wake", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR only copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past); // consumable orphan
+
+    // The temp is the ONLY durable copy; a swallowed EIO would turn recovery into a
+    // successful empty scan that schedules neither a drain nor a read retry.
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation(() =>
+      Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+    );
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the placement failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      linkSpy.mockRestore();
+    }
+    // The temp was kept, so the next scan restores it.
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR only copy"]]);
+  });
+
+  test("quarantine never displaces a valid record regenerated over a malformed canonical", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR temp copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    await fsPromises.writeFile(file, "{not json", "utf-8");
+
+    // Between recovery classifying the canonical file as malformed and the quarantine
+    // rename, another instance replaces it with a valid NEWER wake. A blind rename
+    // would move that live record to a .malformed- path scans intentionally ignore.
+    const regenerated = JSON.stringify(
+      {
+        ...(JSON.parse(await fsPromises.readFile(temp, "utf-8")) as object),
+        lines: ["ERROR regenerated"],
+        updatedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    );
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (String(from) === file && String(to).includes(".prune-")) {
+        renameSpy.mockRestore(); // interpose only on the quarantine capture
+        await fsPromises.writeFile(file, regenerated, "utf-8");
+      }
+      return realRename(from, to);
+    });
+    try {
+      const pending = await store.listPending("owner-1");
+      // The regenerated record is authoritative and published.
+      expect(pending.map((r) => r.lines)).toEqual([["ERROR regenerated"]]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR regenerated"]);
+    const entries = await fsPromises.readdir(dir);
+    // Nothing valid was quarantined; the temp stays for re-reconciliation.
+    expect(entries.filter((e) => e.includes(".malformed-"))).toHaveLength(0);
+    expect(entries.filter((e) => e.includes(".prune-"))).toHaveLength(0);
+    expect(entries.filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+  });
+
+  test("the match/notice merge backs off when the canonical record changes mid-merge", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR matched pre-crash"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    const notice = await store.enqueueMonitorLost(
+      {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        ownerWorkspaceId: "owner-1",
+        filter: "ERROR",
+        filterExclude: false,
+        script: "./watch.sh",
+      },
+      TREAT_ALL_AS_STALE()
+    );
+    if (notice == null) throw new Error("expected a pending monitor-lost notice");
+
+    // Between the merge reading the pending notice and committing the merged record,
+    // another instance supersedes the wake (a deliberate cancel). A blind write would
+    // resurrect it with the crashed matched lines attached.
+    const superseded = JSON.stringify(
+      { ...notice, status: "superseded", updatedAt: new Date().toISOString() },
+      null,
+      2
+    );
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (String(from) === file && String(to).includes(".prune-")) {
+        renameSpy.mockRestore(); // interpose only on the CAS capture
+        await fsPromises.writeFile(file, superseded, "utf-8");
+      }
+      return realRename(from, to);
+    });
+    try {
+      await store.listPending("owner-1");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // The cancel survives — the merge was never committed over it.
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual([]);
+    // The merged draft was discarded; the match temp stays for re-reconciliation.
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toEqual([
+      "proc-1.json.tmp-crashed",
+    ]);
+    expect(await store.listPending("owner-1")).toEqual([]);
   });
 
   test("a crashed match temp merges into a pending restart notice", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -715,7 +715,7 @@ describe("BashMonitorWakeStore", () => {
     });
     // The clear cannot see the deferred temp (freshness gate), so nothing pending is
     // retired — but its durable tombstone condemns the invisible pre-clear wake.
-    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
     expect(await due).toBe("owner-1");
     // The re-driven scan discards the pre-clear temp instead of restoring and
     // delivering it into the freshly cleared transcript.
@@ -739,11 +739,11 @@ describe("BashMonitorWakeStore", () => {
     const due = new Promise<string>((resolve) => {
       store.onDeferredTempRecoveryDue = resolve;
     });
-    const snapshots = await store.supersedeAllPending("owner-1");
+    const { snapshots, clearedAt } = await store.supersedeAllPending("owner-1");
     expect(snapshots.map((r) => r.id)).toEqual(["proc-1"]);
     // The clear later fails and is rolled back: the tombstone must not keep
     // condemning the deferred temp's wake after its siblings return to pending.
-    await store.restorePendingSnapshots("owner-1", snapshots);
+    await store.restorePendingSnapshots("owner-1", snapshots, clearedAt);
     expect(await due).toBe("owner-1");
     const pending = await store.listPending("owner-1");
     expect(pending.map((r) => r.lines).sort()).toEqual([["ERROR deferred"], ["ERROR visible"]]);
@@ -759,7 +759,7 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
     // Clear #1 commits, permanently retiring the deferred wake via its tombstone.
-    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
 
     // Clear #2 supersedes new output but then fails and is rolled back. The rollback
     // must demote to clear #1's tombstone, not delete the file wholesale — otherwise
@@ -767,9 +767,9 @@ describe("BashMonitorWakeStore", () => {
     await store.enqueueOrMergePending(
       payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR second"] })
     );
-    const snapshots = await store.supersedeAllPending("owner-1");
+    const { snapshots, clearedAt } = await store.supersedeAllPending("owner-1");
     expect(snapshots.map((r) => r.id)).toEqual(["proc-2"]);
-    await store.restorePendingSnapshots("owner-1", snapshots);
+    await store.restorePendingSnapshots("owner-1", snapshots, clearedAt);
 
     // Past the gate, recovery must still condemn the pre-clear-#1 temp.
     const past = new Date(Date.now() - 10 * 60 * 1000);
@@ -789,7 +789,7 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
     // Clear #1 commits its tombstone.
-    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
 
     // Clear #2 fails DURING the supersede loop — before its own tombstone was ever
     // written. Its internal rollback must not demote clear #1's standing tombstone.
@@ -818,6 +818,98 @@ describe("BashMonitorWakeStore", () => {
     const pending = await store.listPending("owner-1");
     expect(pending.map((r) => r.lines)).toEqual([["ERROR second"]]);
     expect(await store.get("owner-1", "proc-1")).toBeNull();
+  });
+
+  test("a subsuming leftover replaces the canonical record instead of duplicating lines", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Canonical is an OLDER committed generation; the captured leftover is the same
+    // lineage with a frontier past it (a crashed later merge). Merging would report
+    // the older line twice; the leftover must replace the canonical record instead.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR one"], matchedThroughOffset: 100 }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    await fsPromises.writeFile(
+      `${file}.prune-crashed`,
+      JSON.stringify({
+        ...canonicalRecord,
+        lines: ["ERROR one", "ERROR two"],
+        matchedThroughOffset: 150,
+        totalMatches: 2,
+        updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR one", "ERROR two"]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR one", "ERROR two"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("a match record never subsumes its monitor-lost upgrade", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // The canonical path holds the OLDER match generation; the captured leftover is
+    // its later same-lineage monitor-lost upgrade (same offsets). Offset evidence
+    // alone would call the match a superset — dropping the termination notice and
+    // relaunch script the agent needs.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR out"], matchedThroughOffset: 100 }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+    };
+    await fsPromises.writeFile(
+      `${file}.prune-crashed`,
+      JSON.stringify({
+        ...canonicalRecord,
+        kind: "monitor-lost",
+        script: "./watch.sh",
+        updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].kind).toBe("monitor-lost");
+    expect(pending[0].script).toBe("./watch.sh");
+    // Replaced, not merged: the shared lines appear once.
+    expect(pending[0].lines).toEqual(["ERROR out"]);
+    const settled = await fresh.get("owner-1", "proc-1");
+    expect(settled?.kind).toBe("monitor-lost");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("a stale rollback leaves a newer clear's tombstone untouched", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Clear A publishes its tombstone first.
+    const clearA = await store.supersedeAllPending("owner-1");
+    // A wake arrives AFTER clear A and crashes into a deferred temp...
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR between clears"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // ...and clear B then commits, retiring it via B's tombstone.
+    await store.supersedeAllPending("owner-1");
+
+    // Clear A's history operation later fails and rolls back. It must not demote B's
+    // tombstone — the wake between the two clears was retired by B, not A.
+    await store.restorePendingSnapshots("owner-1", clearA.snapshots, clearA.clearedAt);
+
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
@@ -1476,7 +1568,7 @@ describe("BashMonitorWakeStore", () => {
     expect(current?.lines).toEqual(["ERROR fresh"]);
     // The record is still restorable: a failed history clear can roll it back to pending.
     expect(freshPending).not.toBeNull();
-    await store.restorePendingSnapshots("owner-1", [freshPending!]);
+    await store.restorePendingSnapshots("owner-1", [freshPending!], new Date().toISOString());
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
   });
 

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -665,11 +665,14 @@ describe("BashMonitorWakeStore", () => {
     expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
   });
 
-  test("listPending keeps serving a cached pending wake when stat transiently fails", async () => {
+  test("a transient stat failure propagates even with a cached classification", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());
     expect(await store.listPending("owner-1")).toHaveLength(1); // classify into the cache
 
+    // Even a warm cache must not answer through a stat failure: the failure may hide a
+    // concurrent supersession by another instance, and drains treat this listing as
+    // delivery authority — a served stale pending could deliver a canceled wake.
     const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
     const realStat = fsPromises.stat;
     const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
@@ -679,12 +682,106 @@ describe("BashMonitorWakeStore", () => {
         ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
         : realStat(target)) as unknown as typeof fsPromises.stat);
     try {
-      // A transient stat failure must not silently drop the durable pending record from
-      // an otherwise-successful (authoritative-looking) result.
-      expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the stat failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
     } finally {
       statSpy.mockRestore();
     }
+    // Once the failure clears, the durable record is served again.
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+  });
+
+  test("non-regular *.json entries are skipped, not fatal", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // A directory named like a record (corruption or a foreign tool) must not fail
+    // every scan and block delivery of the valid wake next to it.
+    await fsPromises.mkdir(path.join(dir, "not-a-file.json"));
+
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+  });
+
+  test("temp files of ids containing the prune marker are never misparsed as trash", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Wake ids are arbitrary process ids; encodeURIComponent escapes neither dots nor
+    // hyphens, so this id's own files embed the literal prune marker.
+    await store.enqueueOrMergePending(payload({ processId: "x.json.prune-y", taskId: "bash:x" }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonical = path.join(dir, "x.json.prune-y.json");
+    // Crashed write: the temp file leaks next to the canonical record.
+    const temp = path.join(dir, "x.json.prune-y.json.tmp-abc123");
+    await fsPromises.copyFile(canonical, temp);
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    // The temp file must not be treated as prune trash for the truncated id "x": that
+    // would link the record to x.json (undeliverable at its real id) and eat the temp.
+    expect(pending.map((r) => r.id)).toEqual(["x.json.prune-y"]);
+    const entries = await fsPromises.readdir(dir);
+    expect(entries).not.toContain("x.json");
+    expect(entries).toContain("x.json.prune-y.json.tmp-abc123"); // swept only once old
+  });
+
+  test("reconciliation never overwrites a canonical record changed mid-swap", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Pre-classify the canonical file so the scan below serves it from cache: the only
+    // canonical read is then recovery's compare-read, making the injection point
+    // deterministic regardless of readdir order.
+    expect(await store.listPending("owner-1")).toHaveLength(1);
+    // Craft a stranded leftover STRICTLY NEWER than the canonical record, as left by an
+    // interrupted prune race on another instance.
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    const leftover = {
+      ...canonicalRecord,
+      lines: ["ERROR crafted"],
+      updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+    };
+    const leftoverPath = `${file}.prune-crashed`;
+    await fsPromises.writeFile(leftoverPath, JSON.stringify(leftover), "utf-8");
+
+    // Between recovery's canonical compare-read and its replacement, another instance
+    // merges even newer output into the canonical record. A blind rename would
+    // overwrite it with the crafted leftover, losing that output.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realReadFile = fsPromises.readFile;
+    let injected = false;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation((async (
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) => {
+      const result = await realReadFile(target, options);
+      if (!injected && target === file) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR newest"], totalMatches: 2 }));
+      }
+      return result;
+    }) as unknown as typeof fsPromises.readFile);
+    try {
+      await store.listPending("owner-1");
+    } finally {
+      readSpy.mockRestore();
+    }
+    // The mid-swap write survived — a blind rename would have replaced it with the
+    // crafted leftover, losing "ERROR newest".
+    const current = await store.get("owner-1", "proc-1");
+    expect(current?.lines).toEqual(["ERROR stale", "ERROR newest"]);
+    // The leftover backed off (kept) rather than being consumed against a moved target.
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toEqual([
+      "proc-1.json.prune-crashed",
+    ]);
+    await fsPromises.rm(leftoverPath, { force: true });
+    const settled = await store.listPending("owner-1");
+    expect(settled).toHaveLength(1);
+    expect(settled[0].lines).toEqual(["ERROR stale", "ERROR newest"]);
   });
 
   test("listPending propagates a transient stat failure it has no cached answer for", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -299,6 +299,77 @@ describe("BashMonitorWakeStore", () => {
     expect(later[0].lines).toEqual(["ERROR rearmed"]);
   });
 
+  test("a transient prune capture failure propagates instead of hiding records", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // The path may hold a concurrently rewritten pending wake by capture time, so a
+    // transient capture failure must not silently produce a successful partial snapshot.
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((from, to) =>
+      String(from) === file && String(to).includes(".prune-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realRename(from, to)
+    );
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the capture failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // The record was untouched; the next scan prunes it normally.
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+  });
+
+  test("an EEXIST-superseded capture publishes the canonical record, not the capture", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    let renameInjected = false;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (!renameInjected && String(from) === file && String(to).includes(".prune-")) {
+        renameInjected = true;
+        // The capture grabs this concurrently rewritten pending wake…
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR captured"] }));
+      }
+      return realRename(from, to);
+    });
+    const realLink = fsPromises.link;
+    let linkInjected = false;
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation(async (from, to) => {
+      if (!linkInjected && String(to) === file) {
+        linkInjected = true;
+        // …but before the restore lands, an even newer wake claims the canonical path
+        // and is immediately canceled. The restore must fail EEXIST and the canceled
+        // durable state must win: publishing the discarded capture would hand a drain
+        // durably-retired content.
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR newer"] }));
+        await other.markSuperseded("owner-1", "proc-1");
+      }
+      return realLink(from, to);
+    });
+    try {
+      expect(await store.listPending("owner-1")).toHaveLength(0);
+    } finally {
+      renameSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+  });
+
   test("owner discovery fails open when a stranded leftover cannot be read", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -377,7 +377,9 @@ describe("BashMonitorWakeStore", () => {
     await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
-    expect(await store.listPending("owner-1")).toHaveLength(1); // pre-classify canonical
+    // Terminal canonical: a strictly newer PENDING leftover takes the direct CAS path.
+    await store.markSuperseded("owner-1", "proc-1");
+    expect(await store.listPending("owner-1")).toEqual([]); // pre-classify canonical
     const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
       updatedAt: string;
       lines: string[];
@@ -388,6 +390,7 @@ describe("BashMonitorWakeStore", () => {
       JSON.stringify({
         ...canonicalRecord,
         lines: ["ERROR crafted"],
+        status: "pending",
         updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
       }),
       "utf-8"
@@ -432,7 +435,7 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rm(leftoverPath, { force: true });
     const settled = await store.listPending("owner-1");
     expect(settled).toHaveLength(1);
-    expect(settled[0].lines).toEqual(["ERROR stale", "ERROR merged"]);
+    expect(settled[0].lines).toEqual(["ERROR merged"]);
   });
 
   test("a valid stranded wake displaces a malformed canonical file", async () => {
@@ -502,6 +505,103 @@ describe("BashMonitorWakeStore", () => {
     const pending = await fresh.listPending("owner-1");
     expect(pending.map((r) => r.lines)).toEqual([["ERROR fresh only copy"]]);
     expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR fresh only copy"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a surviving match temp cannot replay an already-delivered merged wake", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR matched pre-crash"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    const notice = await store.enqueueMonitorLost(
+      {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        ownerWorkspaceId: "owner-1",
+        filter: "ERROR",
+        filterExclude: false,
+        script: "./watch.sh",
+      },
+      TREAT_ALL_AS_STALE()
+    );
+    expect(notice).not.toBeNull();
+
+    // The merge commits but the match-temp cleanup fails transiently, leaving the
+    // source temp on disk beside the committed merged canonical record.
+    const realRm = fsPromises.rm;
+    const rmSpy = spyOn(fsPromises, "rm").mockImplementation(((
+      target: Parameters<typeof realRm>[0],
+      options: Parameters<typeof realRm>[1]
+    ) =>
+      String(target) === temp
+        ? Promise.reject(Object.assign(new Error("EBUSY: busy"), { code: "EBUSY" }))
+        : realRm(target, options)) as typeof fsPromises.rm);
+    try {
+      const merged = await store.listPending("owner-1");
+      expect(merged.map((r) => r.lines)).toEqual([["ERROR matched pre-crash"]]);
+    } finally {
+      rmSpy.mockRestore();
+    }
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+    await store.markDelivered("owner-1", "proc-1");
+
+    // Re-scan: the canonical record subsumes the surviving temp — no fresh pending
+    // wake may be minted for already-delivered output.
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("delivered");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a failed stale-temp discard blocks canonical pruning in the same scan", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const record = JSON.parse(await fsPromises.readFile(temp, "utf-8")) as {
+      updatedAt: string;
+    };
+    const superseded = {
+      ...record,
+      status: "superseded",
+      updatedAt: new Date(Date.parse(record.updatedAt) + 1_000).toISOString(),
+    };
+    await fsPromises.writeFile(file, JSON.stringify(superseded, null, 2), "utf-8");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 120_000);
+    await fsPromises.utimes(temp, past, past);
+    await fsPromises.utimes(file, past, past);
+
+    // The stale-temp discard fails transiently. Swallowing it would let this same
+    // scan's record pass prune the terminal canonical; the next scan would then
+    // restore the surviving pending temp as the only durable copy — resurrection.
+    const realRm = fsPromises.rm;
+    const rmSpy = spyOn(fsPromises, "rm").mockImplementation(((
+      target: Parameters<typeof realRm>[0],
+      options: Parameters<typeof realRm>[1]
+    ) =>
+      String(target) === temp
+        ? Promise.reject(Object.assign(new Error("EBUSY: busy"), { code: "EBUSY" }))
+        : realRm(target, options)) as typeof fsPromises.rm);
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    try {
+      await fresh.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the discard failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EBUSY");
+    } finally {
+      rmSpy.mockRestore();
+    }
+    // The canonical terminal record survived the aborted scan alongside the temp.
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+    // The retry discards the temp first; only then is pruning safe.
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect(await fresh.get("owner-1", "proc-1")).toBeNull();
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
@@ -782,7 +882,9 @@ describe("BashMonitorWakeStore", () => {
     await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
-    expect(await store.listPending("owner-1")).toHaveLength(1); // pre-classify canonical
+    // Terminal canonical: a strictly newer PENDING leftover takes the direct CAS path.
+    await store.markSuperseded("owner-1", "proc-1");
+    expect(await store.listPending("owner-1")).toEqual([]); // pre-classify canonical
     const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
       updatedAt: string;
       lines: string[];
@@ -793,6 +895,7 @@ describe("BashMonitorWakeStore", () => {
       JSON.stringify({
         ...canonicalRecord,
         lines: ["ERROR crafted"],
+        status: "pending",
         updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
       }),
       "utf-8"
@@ -856,7 +959,11 @@ describe("BashMonitorWakeStore", () => {
 
   test("stranded recovery publishes a canonical winner created mid-scan", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
-    await store.enqueueOrMergePending(payload({ lines: ["ERROR older"] }));
+    // The captured generation's offset exceeds the winner's so no subsumption check
+    // can mistake the divergent winner for a superset of it.
+    await store.enqueueOrMergePending(
+      payload({ lines: ["ERROR older"], matchedThroughOffset: 500 })
+    );
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
     const leftoverPath = `${file}.prune-crashed`;
@@ -872,24 +979,31 @@ describe("BashMonitorWakeStore", () => {
     const linkSpy = spyOn(fsPromises, "link").mockImplementation(async (from, to) => {
       if (!injected && String(from) === leftoverPath) {
         injected = true;
-        await other.enqueueOrMergePending(payload({ lines: ["ERROR winner"], totalMatches: 2 }));
+        await other.enqueueOrMergePending(
+          payload({ lines: ["ERROR winner"], totalMatches: 2, matchedThroughOffset: 10 })
+        );
       }
       return realLink(from, to);
     });
     try {
+      // The mid-scan winner never saw the captured generation, so recovery merges
+      // both pending payloads instead of letting the newer timestamp win.
       const pending = await store.listPending("owner-1");
-      expect(pending.map((r) => r.lines)).toEqual([["ERROR winner"]]);
+      expect(pending.map((r) => r.lines)).toEqual([["ERROR older", "ERROR winner"]]);
     } finally {
       linkSpy.mockRestore();
     }
-    // The older leftover was dropped as superseded.
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
-    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR winner"]);
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR older", "ERROR winner"]);
+    expect((await store.get("owner-1", "proc-1"))?.totalMatches).toBe(3);
   });
 
   test("a failed CAS capture propagates instead of hiding the stranded generation", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old"] }));
+    // Terminal canonical: a strictly newer PENDING leftover takes the direct CAS path
+    // (divergent pending generations merge instead — covered elsewhere).
+    await store.markSuperseded("owner-1", "proc-1");
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
     const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
@@ -899,6 +1013,7 @@ describe("BashMonitorWakeStore", () => {
     const leftover = {
       ...canonicalRecord,
       lines: ["ERROR newer"],
+      status: "pending",
       updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
     };
     await fsPromises.writeFile(`${file}.prune-crashed`, JSON.stringify(leftover), "utf-8");
@@ -929,6 +1044,8 @@ describe("BashMonitorWakeStore", () => {
   test("a failed CAS placement restores the canonical record and propagates", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old"] }));
+    // Terminal canonical: a strictly newer PENDING leftover takes the direct CAS path.
+    await store.markSuperseded("owner-1", "proc-1");
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
     const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
@@ -941,6 +1058,7 @@ describe("BashMonitorWakeStore", () => {
       JSON.stringify({
         ...canonicalRecord,
         lines: ["ERROR newer"],
+        status: "pending",
         updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
       }),
       "utf-8"
@@ -1168,17 +1286,17 @@ describe("BashMonitorWakeStore", () => {
     expect(strandedGone).toBe(true);
   });
 
-  test("recovery keeps the newest of multiple stranded pending generations", async () => {
+  test("stranded pending generations of one id merge instead of newest-wins", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const file = path.join(dir, "proc-1.json");
     // Two interrupted prune races stranded two distinct pending generations of the same
-    // reused id with no canonical file. Whichever leftover recovery visits first, the
-    // NEWER generation must end up canonical — a first-restored older generation must
-    // not make the newer one look EEXIST-superseded.
+    // reused id with no canonical file. Neither generation ever saw the other, so
+    // whichever leftover recovery visits first, ONE merged record must carry both
+    // outputs — a newest-wins pick would permanently lose the other generation.
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old gen"] }));
     await fsPromises.rename(file, `${file}.prune-gen-old`);
-    // Distinct updatedAt millisecond so the reconciliation comparison is strict.
+    // Distinct timestamps so ordering inside the merged record is deterministic.
     await new Promise((resolve) => setTimeout(resolve, 5));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR new gen"] }));
     await fsPromises.rename(file, `${file}.prune-gen-new`);
@@ -1186,25 +1304,30 @@ describe("BashMonitorWakeStore", () => {
     const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
     const pending = await fresh.listPending("owner-1");
     expect(pending).toHaveLength(1);
-    expect(pending[0].lines).toEqual(["ERROR new gen"]);
-    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR new gen"]);
+    expect(pending[0].lines).toEqual(["ERROR old gen", "ERROR new gen"]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual([
+      "ERROR old gen",
+      "ERROR new gen",
+    ]);
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
   });
 
-  test("a stranded prune file never clobbers a newer record at the original path", async () => {
+  test("a stranded pending generation merges into a newer canonical record", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old generation"] }));
     const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
     const stranded = `${file}.prune-crashed`;
     await fsPromises.rename(file, stranded);
-    // A newer wake claims the original path after the crash.
+    // A newer wake claims the original path after the crash — written from scratch, so
+    // it cannot have merged (or even seen) the captured generation's output.
+    await new Promise((resolve) => setTimeout(resolve, 5));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR new generation"] }));
 
     const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
     const pending = await fresh.listPending("owner-1");
     expect(pending).toHaveLength(1);
-    expect(pending[0].lines).toEqual(["ERROR new generation"]);
-    // The stranded leftover is dropped, not restored over the newer record.
+    expect(pending[0].lines).toEqual(["ERROR old generation", "ERROR new generation"]);
+    // The stranded leftover was consumed by the merge, not restored over the record.
     let strandedGone = false;
     try {
       await fsPromises.access(stranded);
@@ -1212,7 +1335,10 @@ describe("BashMonitorWakeStore", () => {
       strandedGone = true;
     }
     expect(strandedGone).toBe(true);
-    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR new generation"]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual([
+      "ERROR old generation",
+      "ERROR new generation",
+    ]);
   });
 
   test("a read failure after a generation change propagates instead of serving stale cache", async () => {
@@ -1342,7 +1468,9 @@ describe("BashMonitorWakeStore", () => {
     // Pre-classify the canonical file so the scan below serves it from cache: the only
     // canonical read is then recovery's compare-read, making the injection point
     // deterministic regardless of readdir order.
-    expect(await store.listPending("owner-1")).toHaveLength(1);
+    // Terminal canonical: a strictly newer PENDING leftover takes the direct CAS path.
+    await store.markSuperseded("owner-1", "proc-1");
+    expect(await store.listPending("owner-1")).toEqual([]);
     // Craft a stranded leftover STRICTLY NEWER than the canonical record, as left by an
     // interrupted prune race on another instance.
     const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
@@ -1352,6 +1480,7 @@ describe("BashMonitorWakeStore", () => {
     const leftover = {
       ...canonicalRecord,
       lines: ["ERROR crafted"],
+      status: "pending",
       updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
     };
     const leftoverPath = `${file}.prune-crashed`;
@@ -1382,7 +1511,7 @@ describe("BashMonitorWakeStore", () => {
     // The mid-swap write survived — a blind rename would have replaced it with the
     // crafted leftover, losing "ERROR newest".
     const current = await store.get("owner-1", "proc-1");
-    expect(current?.lines).toEqual(["ERROR stale", "ERROR newest"]);
+    expect(current?.lines).toEqual(["ERROR newest"]);
     // The leftover backed off (kept) rather than being consumed against a moved target.
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toEqual([
       "proc-1.json.prune-crashed",
@@ -1390,7 +1519,7 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rm(leftoverPath, { force: true });
     const settled = await store.listPending("owner-1");
     expect(settled).toHaveLength(1);
-    expect(settled[0].lines).toEqual(["ERROR stale", "ERROR newest"]);
+    expect(settled[0].lines).toEqual(["ERROR newest"]);
   });
 
   test("listPending propagates a transient stat failure it has no cached answer for", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -749,6 +749,77 @@ describe("BashMonitorWakeStore", () => {
     expect(pending.map((r) => r.lines).sort()).toEqual([["ERROR deferred"], ["ERROR visible"]]);
   });
 
+  test("a failed clear's rollback preserves the previous clear's tombstone", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // A deferred pre-clear temp, invisible to the first clear's scan.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // Clear #1 commits, permanently retiring the deferred wake via its tombstone.
+    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+
+    // Clear #2 supersedes new output but then fails and is rolled back. The rollback
+    // must demote to clear #1's tombstone, not delete the file wholesale — otherwise
+    // the wake clear #1 permanently retired becomes deliverable again.
+    await store.enqueueOrMergePending(
+      payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR second"] })
+    );
+    const snapshots = await store.supersedeAllPending("owner-1");
+    expect(snapshots.map((r) => r.id)).toEqual(["proc-2"]);
+    await store.restorePendingSnapshots("owner-1", snapshots);
+
+    // Past the gate, recovery must still condemn the pre-clear-#1 temp.
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR second"]]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a failed supersede loop never demotes the standing tombstone", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // Clear #1 commits its tombstone.
+    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+
+    // Clear #2 fails DURING the supersede loop — before its own tombstone was ever
+    // written. Its internal rollback must not demote clear #1's standing tombstone.
+    await store.enqueueOrMergePending(
+      payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR second"] })
+    );
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((from, to) =>
+      String(to).endsWith("proc-2.json")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realRename(from, to)
+    );
+    try {
+      await store.supersedeAllPending("owner-1");
+      expect.unreachable("expected supersedeAllPending to propagate the loop failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    // Clear #1's protection survived: the pre-clear-#1 temp stays condemned while the
+    // never-retired new wake stays pending.
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR second"]]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+  });
+
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
     const now = Date.now();
     // Near the gate: fires just past it (epsilon), no spurious full-interval wait.

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2,7 +2,7 @@ import * as fsPromises from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import {
   BashMonitorWakeStore,
@@ -187,6 +187,41 @@ describe("BashMonitorWakeStore", () => {
 
     const superseded = await store.markSupersededSnapshot("owner-1", snapshot);
     expect(superseded).toBe(true);
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+  });
+
+  test("listPending stays correct across transitions on both the seeded and indexed paths", async () => {
+    // Records written by a previous process (fresh store instance = cold index).
+    const writer = new BashMonitorWakeStore(makeConfig(rootDir));
+    await writer.enqueueOrMergePending(payload({ processId: "proc-a", taskId: "bash:proc-a" }));
+    await writer.enqueueOrMergePending(payload({ processId: "proc-b", taskId: "bash:proc-b" }));
+    await writer.markDelivered("owner-1", "proc-a");
+
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Cold path: seeds the index from a full directory scan.
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-b"]);
+
+    // Warm path: transitions and new enqueues must be reflected without a rescan.
+    const readdirSpy = spyOn(fsPromises, "readdir");
+    await store.markSuperseded("owner-1", "proc-b");
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+    await store.enqueueOrMergePending(payload({ processId: "proc-c", taskId: "bash:proc-c" }));
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-c"]);
+    // The hot UI path must not rescan the (unpruned, ever-growing) wake directory.
+    expect(readdirSpy).not.toHaveBeenCalled();
+    readdirSpy.mockRestore();
+  });
+
+  test("listPending self-heals index entries retired by another store instance", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    expect(await store.listPending("owner-1")).toHaveLength(1);
+
+    // A second instance (e.g. another service handle) retires the record on disk.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    await other.markSuperseded("owner-1", "proc-1");
+
+    // The first instance's index still lists the id; the read-verify drops it.
     expect(await store.listPending("owner-1")).toHaveLength(0);
   });
 

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2667,6 +2667,82 @@ describe("BashMonitorWakeStore", () => {
     }
   });
 
+  test("an identity-mismatched canonical is quarantined so a valid crash temp still restores", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR only durable copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonicalPath = path.join(dir, "proc-1.json");
+    // The wake's ONLY durable copy crashes into a temp (aged past the freshness
+    // gate)...
+    const temp = `${canonicalPath}.tmp-crashed`;
+    await fsPromises.rename(canonicalPath, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // ...while corruption leaves a syntactically valid record with a FOREIGN
+    // identity and a newer updatedAt at the canonical path.
+    const tempParsed = JSON.parse(
+      await fsPromises.readFile(temp, "utf-8")
+    ) as BashMonitorWakeRecord;
+    const imposter = { ...tempParsed, id: "proc-9", updatedAt: new Date().toISOString() };
+    await fsPromises.writeFile(canonicalPath, JSON.stringify(imposter), "utf-8");
+
+    // Classifying the imposter as a real record would discard the valid temp as
+    // stale (the canonical updatedAt is newer), after which the record pass rejects
+    // the imposter too — no wake left anywhere. The imposter must read as MALFORMED:
+    // quarantined aside, the temp restores to the canonical path.
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR only durable copy"],
+    ]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("healing sweeps captures superseded by the standing winner", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR survives twin stale captures"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await store.abandonWorkspaceClears("owner-1");
+    // Crashed heartbeat mutations strand TWO captures of the same crashed clear,
+    // BOTH past the rollback grace window, with distinct liveness generations. The
+    // canonical path is empty.
+    await fsPromises.rm(tombPath);
+    await fsPromises.writeFile(
+      `${tombPath}.cas-older`,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 120_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await fsPromises.writeFile(
+      `${tombPath}.cas-newer`,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    // The heal links the freshest capture and must SWEEP the superseded one: left
+    // behind, it would resurrect protection for the rolled-back clear the moment the
+    // grace rollback demotes the healed staging — the restored records would be held
+    // again, this scan would return empty, and startup owner discovery would
+    // schedule no drain for a wake stranded indefinitely.
+    const scan = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await scan.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR survives twin stale captures"],
+    ]);
+    expect((await scan.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.startsWith("cleared-at"))).toEqual([]);
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -559,6 +559,29 @@ describe("BashMonitorWakeStore", () => {
     expect(strandedGone).toBe(true);
   });
 
+  test("recovery keeps the newest of multiple stranded pending generations", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Two interrupted prune races stranded two distinct pending generations of the same
+    // reused id with no canonical file. Whichever leftover recovery visits first, the
+    // NEWER generation must end up canonical — a first-restored older generation must
+    // not make the newer one look EEXIST-superseded.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR old gen"] }));
+    await fsPromises.rename(file, `${file}.prune-gen-old`);
+    // Distinct updatedAt millisecond so the reconciliation comparison is strict.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR new gen"] }));
+    await fsPromises.rename(file, `${file}.prune-gen-new`);
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR new gen"]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR new gen"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
   test("a stranded prune file never clobbers a newer record at the original path", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old generation"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2244,6 +2244,180 @@ describe("BashMonitorWakeStore", () => {
     await store.abandonWorkspaceClears("owner-1");
   });
 
+  test("a crash rollback whose pinned CAS declines re-supersedes the records it restored", async () => {
+    const owner = new BashMonitorWakeStore(makeConfig(rootDir));
+    await owner.enqueueOrMergePending(payload({ lines: ["ERROR retired mid-clear"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await owner.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // The owner stalls (e.g. laptop sleep) long enough for the staging to age past
+    // its grace window on disk.
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    // A foreign scan judges the staging crashed — but the owner RESUMES and its
+    // heartbeat refreshes the staging between the scan's tombstone read and its
+    // pinned rollback CAS. Injected on the scan's record-restore rename, which sits
+    // exactly inside that window.
+    const foreign = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    const injected = { fired: false };
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((async (
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) => {
+      const result = await realRename(from, to);
+      if (
+        !injected.fired &&
+        String(from).includes("proc-1.json.tmp-") &&
+        String(to).endsWith("proc-1.json")
+      ) {
+        injected.fired = true;
+        await fsPromises.writeFile(
+          tombPath,
+          JSON.stringify({ ...stagedTomb, stagedAt: new Date().toISOString() }),
+          "utf-8"
+        );
+      }
+      return result;
+    }) as typeof fsPromises.rename);
+    try {
+      // The refreshed staging means the clear is LIVE, not crashed: the scan must not
+      // leave its stamped records pending (delivery during a live clear, and — when a
+      // pre-clear updatedAt equals the cutoff — past the strict pre-cutoff fence into
+      // an already-cleared transcript).
+      expect(await foreign.listPending("owner-1")).toEqual([]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    expect(injected.fired).toBe(true);
+    expect((await foreign.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    // The refreshed staging survives the declined rollback.
+    const standing = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(standing.phase).toBe("staged");
+    // The owner never settles the clear and the staging ages out AGAIN: the next scan
+    // completes the rollback (re-superseded records restore idempotently).
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    expect((await foreign.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR retired mid-clear"],
+    ]);
+    expect((await foreign.get("owner-1", "proc-1"))?.status).toBe("pending");
+    await owner.abandonWorkspaceClears("owner-1");
+  });
+
+  test("a supersede stamp stranded in a temp is recovered before the crash rollback demotes the tombstone", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stamped into temp"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonicalPath = path.join(dir, "proc-1.json");
+    const pendingRaw = await fsPromises.readFile(canonicalPath, "utf-8");
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.supersedeAllPending("owner-1");
+    // Reconstruct a crash inside supersedeForClear's write: the SUPERSEDED generation
+    // reached only the temp (aged past the freshness gate) while the canonical path
+    // still holds the pre-clear PENDING generation.
+    const supersededRaw = await fsPromises.readFile(canonicalPath, "utf-8");
+    const temp = `${canonicalPath}.tmp-crashed`;
+    await fsPromises.writeFile(temp, supersededRaw, "utf-8");
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    await fsPromises.writeFile(canonicalPath, pendingRaw, "utf-8");
+    // The owner crashed: its staging ages past the grace window.
+    const tombPath = path.join(dir, "cleared-at");
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await store.abandonWorkspaceClears("owner-1");
+
+    // Rolling back BEFORE artifact reconciliation would demote the tombstone while
+    // the canonical record still reads pending; the newer superseded temp then
+    // commits with no tombstone left to restore it — a wake permanently lost for a
+    // history clear that never completed. Artifacts must reconcile first so the
+    // rollback sees the stamped generation.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await fresh.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR stamped into temp"],
+    ]);
+    const restored = await fresh.get("owner-1", "proc-1");
+    expect(restored?.status).toBe("pending");
+    // The pre-clear updatedAt survives the stamp → rollback round trip.
+    expect(restored?.updatedAt).toBe((JSON.parse(pendingRaw) as BashMonitorWakeRecord).updatedAt);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    expect(existsSync(tombPath)).toBe(false);
+  });
+
+  test("a supersede stamp stranded in prune trash is restored and listed in the same scan as the rollback", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stamped into prune trash"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonicalPath = path.join(dir, "proc-1.json");
+    // An interrupted prune strands the ONLY stamped generation in trash: the canonical
+    // path is empty.
+    await fsPromises.rename(canonicalPath, `${canonicalPath}.prune-crashed`);
+    // The owner crashed: its staging ages past the grace window.
+    const tombPath = path.join(dir, "cleared-at");
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await store.abandonWorkspaceClears("owner-1");
+
+    // Rolling back first would demote the tombstone with nothing at the canonical
+    // path; prune recovery then restores the record as plain TERMINAL content (its
+    // staged-clear hold reads the already-demoted tombstone) and nothing ever flips
+    // it back — a wake permanently lost. Artifacts must reconcile first, and the
+    // rollback's restored records must reach this very scan's listing.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await fresh.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR stamped into prune trash"],
+    ]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+    expect(existsSync(tombPath)).toBe(false);
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -1096,9 +1096,9 @@ describe("BashMonitorWakeStore", () => {
     // Another instance's clear B begins a tombstone mutation mid-scan: by the time
     // the temp is inspected, B has CAPTURED the canonical (cleared-at is absent; only
     // B's .cas- capture of the OLD generation remains on disk)...
-    const realStat = fsPromises.stat;
+    const realStat = fsPromises.lstat;
     let capturedByB = false;
-    const statSpy = spyOn(fsPromises, "stat").mockImplementation((async (
+    const statSpy = spyOn(fsPromises, "lstat").mockImplementation((async (
       p: Parameters<typeof realStat>[0]
     ) => {
       if (!capturedByB && String(p) === temp) {
@@ -1106,7 +1106,7 @@ describe("BashMonitorWakeStore", () => {
         await fsPromises.rename(tombPath, `${tombPath}.cas-instance-b`);
       }
       return realStat(p);
-    }) as typeof fsPromises.stat);
+    }) as typeof fsPromises.lstat);
     // ...and B publishes its NEWER cutoff exactly when the healing read tries to link
     // the stale capture back, losing the race.
     const realLink = fsPromises.link;
@@ -2805,6 +2805,95 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.stat(canonicalPath)).isFile()).toBe(true);
   });
 
+  test("a dangling canonical symlink cannot wedge artifact recovery", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR behind a dangling symlink"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonicalPath = path.join(dir, "proc-1.json");
+    // The wake's ONLY durable copy crashes into a temp (aged past the freshness
+    // gate)...
+    const temp = `${canonicalPath}.tmp-crashed`;
+    await fsPromises.rename(canonicalPath, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // ...while corruption leaves a DANGLING SYMLINK at the canonical path. A
+    // following stat reports ENOENT ("absent"), the recovery link then hits EEXIST
+    // against the occupied pathname, and every scan repeats that dead end — the sole
+    // pending artifact never delivers.
+    await fsPromises.symlink(path.join(dir, "does-not-exist"), canonicalPath);
+
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR behind a dangling symlink"],
+    ]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    // The symlink is parked as evidence; a regular record file stands at the
+    // canonical path again.
+    expect((await fsPromises.lstat(canonicalPath)).isFile()).toBe(true);
+  });
+
+  test("the pre-cutoff fence reads the tombstone beyond the scan's directory snapshot", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired by mid-scan clear"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        clearedAt: new Date().toISOString(),
+        clearId: "clear-mid-scan",
+        phase: "committed",
+      }),
+      "utf-8"
+    );
+    // A clear commits AFTER this scan's readdir snapshot: simulated by filtering the
+    // tombstone out of readdir results, exactly what a scan that raced the clear's
+    // publish would have seen. Tombstone discovery must not be tied to that stale
+    // snapshot — served anyway, the pre-cutoff pending record would let a drain
+    // deliver output the clear retired.
+    const realReaddir = fsPromises.readdir;
+    const readdirSpy = spyOn(fsPromises, "readdir").mockImplementation((async (
+      target: Parameters<typeof realReaddir>[0],
+      options?: unknown
+    ) => {
+      const result = await (realReaddir as (t: unknown, o?: unknown) => Promise<unknown>)(
+        target,
+        options
+      );
+      if (Array.isArray(result)) {
+        return (result as unknown[]).filter(
+          (e) => typeof e !== "string" || !e.startsWith("cleared-at")
+        );
+      }
+      return result;
+    }) as typeof fsPromises.readdir);
+    try {
+      expect(await store.listPending("owner-1")).toEqual([]);
+    } finally {
+      readdirSpy.mockRestore();
+    }
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+  });
+
+  test("noncanonical percent-encoded filename aliases are not published", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR aliased"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const raw = await fsPromises.readFile(path.join(dir, "proc-1.json"), "utf-8");
+    await fsPromises.rm(path.join(dir, "proc-1.json"));
+    // Corruption re-names the valid record with an ALTERNATE percent encoding of the
+    // same ID: decoding the stem matches, but every later transition (get/write
+    // build paths via encodeURIComponent) targets the canonical proc-1.json name —
+    // published, the alias would stay pending forever with nothing able to settle it.
+    await fsPromises.writeFile(path.join(dir, "%70roc-1.json"), raw, "utf-8");
+
+    expect(await store.listPending("owner-1")).toEqual([]);
+    // Kept as evidence, never served.
+    expect(await fsPromises.readdir(dir)).toContain("%70roc-1.json");
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));
@@ -2861,14 +2950,14 @@ describe("BashMonitorWakeStore", () => {
     // The artifact guard's first stat succeeds; the recovery-internal second stat
     // fails transiently. Swallowing it would turn the scan into a successful empty
     // result that schedules neither a drain nor the deferred-recovery timer.
-    const realStat = fsPromises.stat;
+    const realStat = fsPromises.lstat;
     let tempStats = 0;
-    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
+    const statSpy = spyOn(fsPromises, "lstat").mockImplementation(((
       p: Parameters<typeof realStat>[0]
     ) =>
       String(p) === temp && ++tempStats === 2
         ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
-        : realStat(p)) as typeof fsPromises.stat);
+        : realStat(p)) as typeof fsPromises.lstat);
     try {
       await store.listPending("owner-1");
       expect.unreachable("expected listPending to propagate the stat failure");
@@ -3662,13 +3751,13 @@ describe("BashMonitorWakeStore", () => {
     // concurrent supersession by another instance, and drains treat this listing as
     // delivery authority — a served stale pending could deliver a canceled wake.
     const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
-    const realStat = fsPromises.stat;
-    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
-      target: Parameters<typeof fsPromises.stat>[0]
+    const realStat = fsPromises.lstat;
+    const statSpy = spyOn(fsPromises, "lstat").mockImplementation(((
+      target: Parameters<typeof fsPromises.lstat>[0]
     ) =>
       String(target) === file
         ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
-        : realStat(target)) as unknown as typeof fsPromises.stat);
+        : realStat(target)) as unknown as typeof fsPromises.lstat);
     try {
       await store.listPending("owner-1");
       expect.unreachable("expected listPending to propagate the stat failure");
@@ -3782,13 +3871,13 @@ describe("BashMonitorWakeStore", () => {
     // Cold cache: this instance has never classified the file, so a partial result would
     // silently omit a pending wake. Callers keep their last good snapshot on a throw.
     const coldStore = new BashMonitorWakeStore(makeConfig(rootDir));
-    const realStat = fsPromises.stat;
-    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
-      target: Parameters<typeof fsPromises.stat>[0]
+    const realStat = fsPromises.lstat;
+    const statSpy = spyOn(fsPromises, "lstat").mockImplementation(((
+      target: Parameters<typeof fsPromises.lstat>[0]
     ) =>
       String(target).endsWith("proc-1.json")
         ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
-        : realStat(target)) as unknown as typeof fsPromises.stat);
+        : realStat(target)) as unknown as typeof fsPromises.lstat);
     try {
       await coldStore.listPending("owner-1");
       expect.unreachable("expected listPending to propagate the stat failure");

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -370,6 +370,142 @@ describe("BashMonitorWakeStore", () => {
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
   });
 
+  test("a failed CAS rollback keeps the captured record and propagates", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    expect(await store.listPending("owner-1")).toHaveLength(1); // pre-classify canonical
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    const leftoverPath = `${file}.prune-crashed`;
+    await fsPromises.writeFile(
+      leftoverPath,
+      JSON.stringify({
+        ...canonicalRecord,
+        lines: ["ERROR crafted"],
+        updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // The canonical record changes between the compare-read and the CAS capture, and
+    // then the rollback link fails. The captured record — at that point the only
+    // durable copy — must be kept, and the failure must propagate.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realReadFile = fsPromises.readFile;
+    let injected = false;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation((async (
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) => {
+      const result = await realReadFile(target, options);
+      if (!injected && target === file) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR merged"], totalMatches: 2 }));
+      }
+      return result;
+    }) as unknown as typeof fsPromises.readFile);
+    const realLink = fsPromises.link;
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation((from, to) =>
+      String(from) !== leftoverPath && String(from).includes(".prune-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realLink(from, to)
+    );
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the rollback failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      readSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+    // The changed capture was NOT deleted: it survives as prune trash beside the
+    // crafted leftover, and once the crafted leftover is gone, recovery restores it.
+    const leftovers = (await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"));
+    expect(leftovers).toHaveLength(2);
+    await fsPromises.rm(leftoverPath, { force: true });
+    const settled = await store.listPending("owner-1");
+    expect(settled).toHaveLength(1);
+    expect(settled[0].lines).toEqual(["ERROR stale", "ERROR merged"]);
+  });
+
+  test("a valid stranded wake displaces a malformed canonical file", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stranded"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    await fsPromises.rename(file, `${file}.prune-crashed`);
+    // A malformed canonical file appears (corruption); without quarantining it, every
+    // scan would hit the same dead end and the valid durable wake would never deliver.
+    await fsPromises.writeFile(file, "{not json", "utf-8");
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR stranded"]]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR stranded"]);
+    const entries = await fsPromises.readdir(dir);
+    // The malformed content is quarantined as evidence, not deleted.
+    expect(entries.filter((e) => e.includes(".malformed-"))).toHaveLength(1);
+    expect(entries.filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("a complete orphaned temp write is restored, not swept", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR only copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Crash between writeFile and the commit rename of a brand-new wake: the temp file
+    // is the ONLY durable copy (no canonical file exists).
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000); // orphaned, but within retention
+    await fsPromises.utimes(temp, past, past);
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR only copy"]]);
+    // Restored to the canonical path (visible to delivery) and the temp is consumed.
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR only copy"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("stranded recovery publishes a canonical winner created mid-scan", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR older"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const leftoverPath = `${file}.prune-crashed`;
+    await fsPromises.rename(file, leftoverPath);
+
+    // The canonical record is created AFTER this scan's readdir snapshot (so the scan
+    // never visits its entry) but before recovery's restore link. The canonical winner
+    // must still be published — otherwise the scan reports empty and startup discovery
+    // misses a wake whose writer already exited.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realLink = fsPromises.link;
+    let injected = false;
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation(async (from, to) => {
+      if (!injected && String(from) === leftoverPath) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR winner"], totalMatches: 2 }));
+      }
+      return realLink(from, to);
+    });
+    try {
+      const pending = await store.listPending("owner-1");
+      expect(pending.map((r) => r.lines)).toEqual([["ERROR winner"]]);
+    } finally {
+      linkSpy.mockRestore();
+    }
+    // The older leftover was dropped as superseded.
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR winner"]);
+  });
+
   test("a failed CAS capture propagates instead of hiding the stranded generation", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR old"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -299,6 +299,39 @@ describe("BashMonitorWakeStore", () => {
     expect(later[0].lines).toEqual(["ERROR rearmed"]);
   });
 
+  test("owner discovery fails open when a stranded leftover cannot be read", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const stranded = `${file}.prune-crashed`;
+    await fsPromises.rename(file, stranded);
+
+    const realReadFile = fsPromises.readFile;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation(((
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) =>
+      target === stranded
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realReadFile(target, options)) as unknown as typeof fsPromises.readFile);
+    try {
+      // The leftover read failure propagates instead of producing an empty scan…
+      try {
+        await store.listPending("owner-1");
+        expect.unreachable("expected listPending to propagate the leftover read failure");
+      } catch (error) {
+        expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+      }
+      // …and startup owner discovery still schedules this owner rather than skipping it.
+      expect(await store.listPendingOwnerWorkspaceIds()).toEqual(["owner-1"]);
+    } finally {
+      readSpy.mockRestore();
+    }
+    // Once the transient failure clears, the stranded wake is recovered.
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+  });
+
   test("a failed restore keeps the captured wake for a later recovery scan", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -473,6 +473,170 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
+  test("a fresh orphaned temp with no canonical record is placed immediately", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR fresh only copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Crash before the commit rename, restart WITHIN the temp freshness gate: waiting
+    // for the gate would leave the only durable copy invisible with no re-drive.
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR fresh only copy"]]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR fresh only copy"]);
+    // The temp itself stays (a possible live writer's commit rename of the same inode
+    // is a POSIX no-op); the age-gated sweep consumes it later.
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+  });
+
+  test("a crashed match temp merges into a pending restart notice", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR matched pre-crash"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past); // consumable orphan
+
+    // Restart recovery writes the monitor-lost notice BEFORE any temp scan, so the
+    // notice always carries the later updatedAt; a plain newest-wins comparison would
+    // discard the crashed matched lines forever.
+    const notice = await store.enqueueMonitorLost(
+      {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        ownerWorkspaceId: "owner-1",
+        filter: "ERROR",
+        filterExclude: false,
+        script: "./watch.sh",
+      },
+      TREAT_ALL_AS_STALE()
+    );
+    expect(notice).not.toBeNull();
+
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    // One record carries BOTH the undelivered matched lines and the lost-monitor notice.
+    expect(pending[0].kind).toBe("monitor-lost");
+    expect(pending[0].lines).toEqual(["ERROR matched pre-crash"]);
+    expect(pending[0].script).toBe("./watch.sh");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a valid orphan temp displaces a malformed canonical file", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR temp copy"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // Corruption leaves a malformed canonical; without quarantining it the valid temp
+    // record would be blocked at every scan.
+    await fsPromises.writeFile(file, "{not json", "utf-8");
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR temp copy"]]);
+    expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR temp copy"]);
+    const entries = await fsPromises.readdir(dir);
+    expect(entries.filter((e) => e.includes(".malformed-"))).toHaveLength(1);
+    expect(entries.filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("non-regular artifact entries are skipped, not fatal", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // A directory named like prune trash (corruption or a foreign tool) must not fail
+    // every scan; readFile on such entries would throw EISDIR (or block on a FIFO).
+    await fsPromises.mkdir(path.join(dir, "ghost.json.prune-x"));
+
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+  });
+
+  test("the CAS detects a same-millisecond generation change", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    expect(await store.listPending("owner-1")).toHaveLength(1); // pre-classify canonical
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    const leftoverPath = `${file}.prune-crashed`;
+    await fsPromises.writeFile(
+      leftoverPath,
+      JSON.stringify({
+        ...canonicalRecord,
+        lines: ["ERROR crafted"],
+        updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // Between the compare-read and the CAS capture, another instance rewrites the
+    // canonical record with MORE lines but the SAME updatedAt millisecond and status.
+    // A timestamp+status predicate would call that capture "unchanged" and destroy it.
+    const realReadFile = fsPromises.readFile;
+    let injected = false;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation((async (
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) => {
+      const result = await realReadFile(target, options);
+      if (!injected && target === file) {
+        injected = true;
+        await fsPromises.writeFile(
+          file,
+          JSON.stringify({ ...canonicalRecord, lines: ["ERROR stale", "ERROR extra"] }),
+          "utf-8"
+        );
+      }
+      return result;
+    }) as unknown as typeof fsPromises.readFile);
+    try {
+      await store.listPending("owner-1");
+    } finally {
+      readSpy.mockRestore();
+    }
+    // The same-millisecond rewrite survived; the crafted leftover backed off.
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR stale", "ERROR extra"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toEqual([
+      "proc-1.json.prune-crashed",
+    ]);
+    await fsPromises.rm(leftoverPath, { force: true });
+  });
+
+  test("a failed commit rename does not leave a committable temp behind", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+
+    // The caller observes this failure (e.g. a history clear reports an error and the
+    // wake stays pending); the temp must not later masquerade as a crashed-but-intended
+    // write that recovery would "commit", silently canceling the wake.
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+    );
+    try {
+      await store.markSuperseded("owner-1", "proc-1");
+      expect.unreachable("expected markSuperseded to propagate the rename failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
   test("stranded recovery publishes a canonical winner created mid-scan", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR older"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -605,6 +605,150 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
+  test("identical line text never proves subsumption across divergent generations", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Generation A is captured by a prune; generation B is then written from scratch
+    // with IDENTICAL line text (two distinct real events can read the same). B never
+    // carried A's event, so content must not be treated as proof of subsumption.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR boom"] }));
+    await fsPromises.rename(file, `${file}.prune-crashed`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR boom"] }));
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    // Both events survive as separate lines; a content-containment shortcut would
+    // have deleted the captured generation and lost its event.
+    expect(pending[0].lines).toEqual(["ERROR boom", "ERROR boom"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("an incomplete fresh temp arms the deferred re-drive", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    await fsPromises.mkdir(dir, { recursive: true });
+    const file = path.join(dir, "proc-1.json");
+    // A live writer's writeFile is still in flight at scan time. Its process may yet
+    // complete the write and crash before the rename — leaving a complete orphan with
+    // no event, pending owner, or timer to trigger another scan unless armed here.
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.writeFile(temp, '{"id": "proc-1", "trunc', "utf-8");
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+
+    const due = new Promise<string>((resolve) => {
+      store.onDeferredTempRecoveryDue = resolve;
+    });
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await due).toBe("owner-1");
+    // Simulate the crash having completed the write after that scan: the re-driven
+    // scan restores the now-complete record.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR completed"] }));
+    const completed = await fsPromises.readFile(file, "utf-8");
+    await fsPromises.rm(file, { force: true });
+    await fsPromises.writeFile(temp, completed, "utf-8");
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR completed"]]);
+  });
+
+  test("a doubly-failed write cleanup leaves no committable temp", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR keep pending"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+
+    // The commit rename fails AND the best-effort temp removal fails. The rejected
+    // supersede must not survive in committable form, or recovery would later make
+    // durable an operation the caller was told never happened.
+    const realRename = fsPromises.rename;
+    const realRm = fsPromises.rm;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((from, to) =>
+      String(from).includes(".json.tmp-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realRename(from, to)
+    );
+    const rmSpy = spyOn(fsPromises, "rm").mockImplementation(((
+      target: Parameters<typeof realRm>[0],
+      options: Parameters<typeof realRm>[1]
+    ) =>
+      String(target).includes(".json.tmp-")
+        ? Promise.reject(Object.assign(new Error("EBUSY: busy"), { code: "EBUSY" }))
+        : realRm(target, options)) as typeof fsPromises.rm);
+    try {
+      await store.markSuperseded("owner-1", "proc-1");
+      expect.unreachable("expected markSuperseded to propagate the commit failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+      rmSpy.mockRestore();
+    }
+    // The surviving temp was truncated to unparseable garbage: scans never commit the
+    // rejected supersede, and the wake stays pending.
+    const temps = (await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"));
+    expect(temps).toHaveLength(1);
+    expect((await fsPromises.stat(path.join(dir, temps[0]))).size).toBe(0);
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(path.join(dir, temps[0]), past, past);
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR keep pending"],
+    ]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a history clear condemns wakes stranded in deferred temps", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre-clear"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const temp = `${file}.tmp-crashed`;
+    await fsPromises.rename(file, temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+
+    const due = new Promise<string>((resolve) => {
+      store.onDeferredTempRecoveryDue = resolve;
+    });
+    // The clear cannot see the deferred temp (freshness gate), so nothing pending is
+    // retired — but its durable tombstone condemns the invisible pre-clear wake.
+    expect(await store.supersedeAllPending("owner-1")).toEqual([]);
+    expect(await due).toBe("owner-1");
+    // The re-driven scan discards the pre-clear temp instead of restoring and
+    // delivering it into the freshly cleared transcript.
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("rolling back a failed clear also revives deferred temps", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR visible"] }));
+    await store.enqueueOrMergePending(
+      payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR deferred"] })
+    );
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-2.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-2.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+
+    const due = new Promise<string>((resolve) => {
+      store.onDeferredTempRecoveryDue = resolve;
+    });
+    const snapshots = await store.supersedeAllPending("owner-1");
+    expect(snapshots.map((r) => r.id)).toEqual(["proc-1"]);
+    // The clear later fails and is rolled back: the tombstone must not keep
+    // condemning the deferred temp's wake after its siblings return to pending.
+    await store.restorePendingSnapshots("owner-1", snapshots);
+    expect(await due).toBe("owner-1");
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines).sort()).toEqual([["ERROR deferred"], ["ERROR visible"]]);
+  });
+
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
     const now = Date.now();
     // Near the gate: fires just past it (epsilon), no spurious full-interval wait.
@@ -995,7 +1139,9 @@ describe("BashMonitorWakeStore", () => {
     }
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
     expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR older", "ERROR winner"]);
-    expect((await store.get("owner-1", "proc-1"))?.totalMatches).toBe(3);
+    // totalMatches is a CUMULATIVE monitor counter, so the merge takes the max
+    // (summing would double count same-process split generations).
+    expect((await store.get("owner-1", "proc-1"))?.totalMatches).toBe(2);
   });
 
   test("a failed CAS capture propagates instead of hiding the stranded generation", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -9,6 +9,7 @@ import {
   buildBashMonitorWakeMetadata,
   buildBashMonitorWakePrompt,
   deferredTempRecoveryDelayMs,
+  STAGED_CLEAR_ROLLBACK_GRACE_MS,
   TEMP_RECOVERY_MIN_AGE_MS,
   TERMINAL_WAKE_RETENTION_MS,
   type BashMonitorWakePayload,
@@ -714,8 +715,11 @@ describe("BashMonitorWakeStore", () => {
       store.onDeferredTempRecoveryDue = resolve;
     });
     // The clear cannot see the deferred temp (freshness gate), so nothing pending is
-    // retired — but its durable tombstone condemns the invisible pre-clear wake.
-    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
+    // retired — but once COMMITTED, its durable tombstone condemns the invisible
+    // pre-clear wake.
+    const clear = await store.supersedeAllPending("owner-1");
+    expect(clear.snapshots).toEqual([]);
+    await store.commitClear("owner-1", clear);
     expect(await due).toBe("owner-1");
     // The re-driven scan discards the pre-clear temp instead of restoring and
     // delivering it into the freshly cleared transcript.
@@ -739,11 +743,12 @@ describe("BashMonitorWakeStore", () => {
     const due = new Promise<string>((resolve) => {
       store.onDeferredTempRecoveryDue = resolve;
     });
-    const { snapshots, clearedAt } = await store.supersedeAllPending("owner-1");
-    expect(snapshots.map((r) => r.id)).toEqual(["proc-1"]);
+    const clear = await store.supersedeAllPending("owner-1");
+    expect(clear.snapshots.map((r) => r.id)).toEqual(["proc-1"]);
     // The clear later fails and is rolled back: the tombstone must not keep
-    // condemning the deferred temp's wake after its siblings return to pending.
-    await store.restorePendingSnapshots("owner-1", snapshots, clearedAt);
+    // holding or condemning the deferred temp's wake after its siblings return to
+    // pending.
+    await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
     expect(await due).toBe("owner-1");
     const pending = await store.listPending("owner-1");
     expect(pending.map((r) => r.lines).sort()).toEqual([["ERROR deferred"], ["ERROR visible"]]);
@@ -759,7 +764,9 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
     // Clear #1 commits, permanently retiring the deferred wake via its tombstone.
-    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
+    const clearOne = await store.supersedeAllPending("owner-1");
+    expect(clearOne.snapshots).toEqual([]);
+    await store.commitClear("owner-1", clearOne);
 
     // Clear #2 supersedes new output but then fails and is rolled back. The rollback
     // must demote to clear #1's tombstone, not delete the file wholesale — otherwise
@@ -767,9 +774,9 @@ describe("BashMonitorWakeStore", () => {
     await store.enqueueOrMergePending(
       payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR second"] })
     );
-    const { snapshots, clearedAt } = await store.supersedeAllPending("owner-1");
-    expect(snapshots.map((r) => r.id)).toEqual(["proc-2"]);
-    await store.restorePendingSnapshots("owner-1", snapshots, clearedAt);
+    const clearTwo = await store.supersedeAllPending("owner-1");
+    expect(clearTwo.snapshots.map((r) => r.id)).toEqual(["proc-2"]);
+    await store.restorePendingSnapshots("owner-1", clearTwo.snapshots, clearTwo);
 
     // Past the gate, recovery must still condemn the pre-clear-#1 temp.
     const past = new Date(Date.now() - 10 * 60 * 1000);
@@ -789,7 +796,9 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
     // Clear #1 commits its tombstone.
-    expect((await store.supersedeAllPending("owner-1")).snapshots).toEqual([]);
+    const clearOne = await store.supersedeAllPending("owner-1");
+    expect(clearOne.snapshots).toEqual([]);
+    await store.commitClear("owner-1", clearOne);
 
     // Clear #2 fails DURING the supersede loop — before its own tombstone was ever
     // written. Its internal rollback must not demote clear #1's standing tombstone.
@@ -889,8 +898,9 @@ describe("BashMonitorWakeStore", () => {
 
   test("a stale rollback leaves a newer clear's tombstone untouched", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
-    // Clear A publishes its tombstone first.
+    // Clear A publishes and commits its tombstone first.
     const clearA = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clearA);
     // A wake arrives AFTER clear A and crashes into a deferred temp...
     await store.enqueueOrMergePending(payload({ lines: ["ERROR between clears"] }));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
@@ -899,14 +909,129 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
     // ...and clear B then commits, retiring it via B's tombstone.
-    await store.supersedeAllPending("owner-1");
+    const clearB = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clearB);
 
     // Clear A's history operation later fails and rolls back. It must not demote B's
     // tombstone — the wake between the two clears was retired by B, not A.
-    await store.restorePendingSnapshots("owner-1", clearA.snapshots, clearA.clearedAt);
+    await store.restorePendingSnapshots("owner-1", clearA.snapshots, clearA);
 
     const past = new Date(Date.now() - 10 * 60 * 1000);
     await fsPromises.utimes(temp, past, past);
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a resumed older clear cannot lower a newer committed cutoff", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Clear A stages, then stalls before its outcome.
+    const clearA = await store.supersedeAllPending("owner-1");
+    // A wake arrives after A's cutoff and crashes into a deferred temp...
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR between clears"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+    // ...and clear B commits with the newer cutoff.
+    const clearB = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clearB);
+
+    // Clear A finally resumes and commits: it must not lower B's committed cutoff —
+    // the wake between the two cutoffs was retired by B.
+    await store.commitClear("owner-1", clearA);
+
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("a crash-stranded tombstone capture still protects retired wakes", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // A tombstone mutation crashed between its capture rename and final placement:
+    // the only durable copy of the committed cutoff is the stranded capture.
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at.cas-crashed"),
+      JSON.stringify({
+        clearedAt: new Date().toISOString(),
+        clearId: "crashed-clear",
+        phase: "committed",
+      }),
+      "utf-8"
+    );
+
+    // Reads heal the capture: the pre-clear temp stays condemned, never restored.
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect(await store.get("owner-1", "proc-1")).toBeNull();
+    const entries = await fsPromises.readdir(dir);
+    expect(entries.filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    expect(entries).toContain("cleared-at");
+    expect(entries.filter((e) => e.includes(".cas-"))).toHaveLength(0);
+  });
+
+  test("a crashed clear staging rolls back after the grace window", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR staged"] }));
+    const originalUpdatedAt = (await store.listPending("owner-1"))[0].updatedAt;
+    // The clear stages (records superseded + staged tombstone) and then Xum crashes
+    // before the history clear's outcome is known.
+    await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    const tomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as {
+      stagedAt: string;
+    };
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...tomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // A fresh instance (the restarted app) rolls the orphaned staging back: the
+    // transcript was never cleared, so losing these wakes would be the worse failure.
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    const pending = await fresh.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR staged"]]);
+    const restored = await fresh.get("owner-1", "proc-1");
+    expect(restored?.status).toBe("pending");
+    // The pre-clear updatedAt survives the round trip (snapshot keys depend on it).
+    expect(restored?.updatedAt).toBe(originalUpdatedAt);
+    expect(await fsPromises.readdir(dir)).not.toContain("cleared-at");
+  });
+
+  test("an in-flight staged clear holds deferred temps until its outcome", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR held"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    // Inside the freshness gate at staging time, so the clear's own scan cannot see
+    // (and properly retire) it — the held-temp case under test.
+    const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 5_000);
+    await fsPromises.utimes(temp, nearGate, nearGate);
+
+    const clear = await store.supersedeAllPending("owner-1");
+    // The temp ages past the gate while the clear's outcome is still unknown.
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // Staged, outcome unknown: the temp is HELD — neither restored (a committed
+    // clear must not see it delivered) nor discarded (a rollback must revive it).
+    expect(await store.listPending("owner-1")).toEqual([]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(1);
+    // Commit resolves the hold into condemnation.
+    await store.commitClear("owner-1", clear);
     expect(await store.listPending("owner-1")).toEqual([]);
     expect(await store.get("owner-1", "proc-1")).toBeNull();
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
@@ -1568,7 +1693,10 @@ describe("BashMonitorWakeStore", () => {
     expect(current?.lines).toEqual(["ERROR fresh"]);
     // The record is still restorable: a failed history clear can roll it back to pending.
     expect(freshPending).not.toBeNull();
-    await store.restorePendingSnapshots("owner-1", [freshPending!], new Date().toISOString());
+    await store.restorePendingSnapshots("owner-1", [freshPending!], {
+      clearId: "unrelated-clear",
+      clearedAt: new Date().toISOString(),
+    });
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
   });
 

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2743,6 +2743,68 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.startsWith("cleared-at"))).toEqual([]);
   });
 
+  test("healing sweeps duplicate captures of the identical generation", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR survives duplicate captures"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await store.abandonWorkspaceClears("owner-1");
+    // A crash (or failed cleanup) strands TWO captures holding the EXACT same
+    // crashed staged generation, aged past the rollback grace. The canonical path is
+    // empty.
+    const staleRaw = JSON.stringify({
+      ...stagedTomb,
+      stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+    });
+    await fsPromises.rm(tombPath);
+    await fsPromises.writeFile(`${tombPath}.cas-dup1`, staleRaw, "utf-8");
+    await fsPromises.writeFile(`${tombPath}.cas-dup2`, staleRaw, "utf-8");
+    // The heal links one duplicate and must sweep the IDENTICAL other: left behind,
+    // it would resurrect the staging the moment the grace rollback demotes the
+    // healed one — the restored record would be held again, this scan would return
+    // empty, and startup owner discovery would schedule no drain.
+    const scan = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await scan.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR survives duplicate captures"],
+    ]);
+    expect((await scan.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.startsWith("cleared-at"))).toEqual([]);
+  });
+
+  test("a non-regular canonical path cannot wedge artifact recovery", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR behind a directory"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const canonicalPath = path.join(dir, "proc-1.json");
+    // The wake's ONLY durable copy crashes into a temp (aged past the freshness
+    // gate)...
+    const temp = `${canonicalPath}.tmp-crashed`;
+    await fsPromises.rename(canonicalPath, temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // ...while corruption leaves a DIRECTORY at the canonical path. Artifacts-first
+    // recovery reads the canonical state BEFORE the record pass's non-regular skip:
+    // unguarded, every scan fails with EISDIR (a FIFO would block forever),
+    // stranding every wake in the workspace.
+    await fsPromises.mkdir(canonicalPath);
+
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR behind a directory"],
+    ]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    // The imposter directory is parked as evidence; a regular record file stands at
+    // the canonical path again.
+    expect((await fsPromises.stat(canonicalPath)).isFile()).toBe(true);
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -716,6 +716,9 @@ describe("BashMonitorWakeStore", () => {
     const due = new Promise<string>((resolve) => {
       store.onDeferredTempRecoveryDue = resolve;
     });
+    // Strictly order wake < cutoff: a same-millisecond stamp is deliberately
+    // ambiguous and fails toward delivery, which is not the case under test.
+    await new Promise((resolve) => setTimeout(resolve, 5));
     // The clear cannot see the deferred temp (freshness gate), so nothing pending is
     // retired — but once COMMITTED, its durable tombstone condemns the invisible
     // pre-clear wake.
@@ -765,6 +768,8 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
     // Clear #1 commits, permanently retiring the deferred wake via its tombstone.
     const clearOne = await store.supersedeAllPending("owner-1");
     expect(clearOne.snapshots).toEqual([]);
@@ -797,6 +802,8 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
     // Clear #1 commits its tombstone.
     const clearOne = await store.supersedeAllPending("owner-1");
     expect(clearOne.snapshots).toEqual([]);
@@ -910,7 +917,9 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 100);
     await fsPromises.utimes(temp, nearGate, nearGate);
-    // ...and clear B then commits, retiring it via B's tombstone.
+    // ...and clear B then commits, retiring it via B's tombstone. Strictly order
+    // wake < B's cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
     const clearB = await store.supersedeAllPending("owner-1");
     await store.commitClear("owner-1", clearB);
 
@@ -983,6 +992,8 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.utimes(temp, past, past);
     // A tombstone mutation crashed between its capture rename and final placement:
     // the only durable copy of the committed cutoff is the stranded capture.
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
     await fsPromises.writeFile(
       path.join(dir, "cleared-at.cas-crashed"),
       JSON.stringify({
@@ -1046,6 +1057,8 @@ describe("BashMonitorWakeStore", () => {
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 5_000);
     await fsPromises.utimes(temp, nearGate, nearGate);
 
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
     const clear = await store.supersedeAllPending("owner-1");
     // The temp ages past the gate while the clear's outcome is still unknown.
     const past = new Date(Date.now() - 10 * 60 * 1000);
@@ -1282,8 +1295,10 @@ describe("BashMonitorWakeStore", () => {
     await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
     const nearGate = new Date(Date.now() - TEMP_RECOVERY_MIN_AGE_MS + 5_000);
     await fsPromises.utimes(temp, nearGate, nearGate);
-    // Clear A captures its cutoff (past the wake) but stalls before its staging
+    // Clear A captures its cutoff (past the wake — strictly ordered, since
+    // same-millisecond stamps fail toward delivery) but stalls before its staging
     // lands...
+    await new Promise((resolve) => setTimeout(resolve, 5));
     const clearA = await store.supersedeAllPending("owner-1");
     // ...so clear B (another instance) stages a NEWER cutoff having never seen A's:
     // B's tombstone records NO predecessor.
@@ -1357,6 +1372,9 @@ describe("BashMonitorWakeStore", () => {
   test("an interrupted clear rollback restores records before demoting the tombstone", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR restored first"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery),
+    // so the mid-rollback hold below is deterministic.
+    await new Promise((resolve) => setTimeout(resolve, 5));
     const clear = await store.supersedeAllPending("owner-1");
     // The rollback's tombstone demotion fails (crash-equivalent) mid-rollback: the
     // records must ALREADY be pending again — with the demotion first, a crash in
@@ -1528,7 +1546,7 @@ describe("BashMonitorWakeStore", () => {
     // Workspace removal abandons the clear writers, then deletes the session
     // directory. Without the abandon, the still-armed heartbeat's mutateClearedAt
     // would mkdir the directory straight back into existence.
-    store.abandonWorkspaceClears("owner-1");
+    await store.abandonWorkspaceClears("owner-1");
     const sessionDir = path.join(rootDir, "sessions", "owner-1");
     await fsPromises.rm(sessionDir, { recursive: true, force: true });
     await new Promise((resolve) => setTimeout(resolve, 150));
@@ -1851,6 +1869,208 @@ describe("BashMonitorWakeStore", () => {
     // The clear rolls back: the held record delivers again.
     await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
     expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR pre-clear"]]);
+  });
+
+  test("abandoning drains heartbeat ticks that already fired", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir), {
+      stagedClearRefreshIntervalMs: 25,
+    });
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    await store.supersedeAllPending("owner-1");
+    // Park the heartbeat's tombstone write so one tick is mid-mutation (holding the
+    // tombstone lock) while the next tick queues behind it — the queued tick has not
+    // yet run its mkdir.
+    const realWriteFile = fsPromises.writeFile;
+    const writeCalls = { count: 0 };
+    const writeSpy = spyOn(fsPromises, "writeFile").mockImplementation((async (
+      target: Parameters<typeof realWriteFile>[0],
+      data: Parameters<typeof realWriteFile>[1]
+    ) => {
+      if (typeof target === "string" && target.includes("cleared-at.tmp-")) {
+        writeCalls.count += 1;
+        await new Promise((resolve) => setTimeout(resolve, 300));
+      }
+      return realWriteFile(target, data, "utf-8");
+    }) as typeof fsPromises.writeFile);
+    try {
+      const start = Date.now();
+      while (writeCalls.count === 0 && Date.now() - start < 2_000) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(writeCalls.count).toBeGreaterThan(0);
+      // Let a second tick fire and queue behind the parked mutation.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      // Removal-time abandon must DRAIN the fired ticks, not merely disarm the
+      // interval: a queued tick's mutateClearedAt runs its recursive mkdir only
+      // after the parked one releases the lock — which, without the drain, is after
+      // removal already deleted the session directory.
+      await store.abandonWorkspaceClears("owner-1");
+    } finally {
+      writeSpy.mockRestore();
+    }
+    const sessionDir = path.join(rootDir, "sessions", "owner-1");
+    await fsPromises.rm(sessionDir, { recursive: true, force: true });
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(existsSync(sessionDir)).toBe(false);
+  });
+
+  test("the clear never retires a snapshot stamped after its cutoff", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre"] }));
+    // Another instance's wake lands AFTER the clear captured its cutoff but before
+    // its snapshot scan, so it appears in the snapshot with an unambiguously
+    // post-cutoff timestamp.
+    const listSpy = spyOn(store, "listPending").mockImplementation(async (owner: string) => {
+      listSpy.mockRestore();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await store.enqueueOrMergePending(
+        payload({ processId: "proc-late", taskId: "bash:proc-late", lines: ["ERROR after cutoff"] })
+      );
+      return store.listPending(owner);
+    });
+
+    const clear = await store.supersedeAllPending("owner-1");
+    expect(clear.snapshots.map((r) => r.id)).toEqual(["proc-1"]);
+    expect((await store.get("owner-1", "proc-late"))?.status).toBe("pending");
+    await store.commitClear("owner-1", clear);
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-late"]);
+  });
+
+  test("a record stamped in the cutoff millisecond survives canonical reconciliation", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR cutoff instant"] }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clear);
+
+    // Another instance's mid-clear wake lands stamped in the cutoff's own
+    // millisecond: the timestamp cannot order it before the clear, and the
+    // transaction's invariant is that mid-clear output survives.
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const raw = JSON.parse(await fsPromises.readFile(file, "utf-8")) as Record<string, unknown>;
+    delete raw.supersededByClearId;
+    delete raw.pendingUpdatedAtBeforeClear;
+    await fsPromises.writeFile(
+      file,
+      JSON.stringify({
+        ...raw,
+        status: "pending",
+        lines: ["ERROR mid-clear"],
+        updatedAt: clear.clearedAt,
+      }),
+      "utf-8"
+    );
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect((await fresh.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR mid-clear"]]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("a stranded leftover that is the canonical inode is dropped, not merged", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Offset-less record (legacy, or a terminal-only settlement): the subsumption
+    // guards cannot prove same-generation identity for it.
+    await store.enqueueOrMergePending(
+      payload({ lines: ["ERROR only once"], matchedThroughOffset: undefined })
+    );
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // A prior recovery linked the captured inode back to the canonical path but
+    // crashed (or failed) before removing the leftover name: two names, one inode.
+    await fsPromises.link(
+      path.join(dir, "proc-1.json"),
+      path.join(dir, "proc-1.json.prune-stranded")
+    );
+
+    const pending = await store.listPending("owner-1");
+    // Merging the record against itself would double its lines and counters.
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR only once"]]);
+    expect(pending[0].totalMatches).toBe(1);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("a refreshed staging is not demoted by a stale crash rollback", async () => {
+    const storeA = new BashMonitorWakeStore(makeConfig(rootDir));
+    await storeA.enqueueOrMergePending(payload({ lines: ["ERROR held"] }));
+    const clear = await storeA.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // Another instance's scan reads a staging aged past the grace window...
+    const staged = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const staleStagedAt = new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000);
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({ ...staged, stagedAt: staleStagedAt.toISOString() }),
+      "utf-8"
+    );
+    // ...but the owner's heartbeat refresh lands between that read and the demote's
+    // CAS capture. clearId alone cannot tell a refreshed (live) staging from the
+    // crashed one the scan judged.
+    const refreshedStagedAt = new Date().toISOString();
+    const writeRefreshedTombstone = () =>
+      fsPromises.writeFile(
+        tombPath,
+        JSON.stringify({ ...staged, stagedAt: refreshedStagedAt }),
+        "utf-8"
+      );
+    const realRename = fsPromises.rename;
+    const injected = { fired: false };
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((async (
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) => {
+      if (!injected.fired && String(from).endsWith("cleared-at") && String(to).includes(".cas-")) {
+        injected.fired = true;
+        await writeRefreshedTombstone();
+      }
+      return realRename(from, to);
+    }) as typeof fsPromises.rename);
+    try {
+      const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+      await fresh.listPending("owner-1");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // The demote captured a refreshed generation (live clear): the tombstone stands.
+    expect(existsSync(tombPath)).toBe(true);
+    const after = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(after.phase).toBe("staged");
+    expect(after.stagedAt).toBe(refreshedStagedAt);
+    // The owner can still settle its clear normally afterwards.
+    await storeA.restorePendingSnapshots("owner-1", clear.snapshots, clear);
+    expect((await storeA.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR held"]]);
+  });
+
+  test("an aged stranded prune capture owned by a staged clear is restored, not swept", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR staged capture"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // A terminal prune captured the stamped record and crashed before verifying;
+    // the stranded copy then ages past the retention window while the clear is
+    // still staged (long clear, or promotion retries).
+    const leftover = path.join(dir, "proc-1.json.prune-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), leftover);
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(leftover, past, past);
+
+    // Another instance's scan must restore the clear's only rollback source, not
+    // sweep it by age (rollbackCrashedClearStaging restores canonical files only).
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+
+    // The clear then fails and rolls back: the held record restores and delivers.
+    await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR staged capture"],
+    ]);
   });
 
   test("terminal pruning spares records owned by an unresolved staged clear", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -429,7 +429,15 @@ describe("BashMonitorWakeStore", () => {
       Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
     );
     try {
-      expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR rearmed"]]);
+      // The failed restore propagates (caller retries engage) instead of publishing a
+      // record whose canonical path is absent — a drain delivering it could no-op its
+      // delivered-transition and cause a duplicate delivery after the later restore.
+      try {
+        await store.listPending("owner-1");
+        expect.unreachable("expected listPending to propagate the restore failure");
+      } catch (error) {
+        expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+      }
     } finally {
       renameSpy.mockRestore();
       linkSpy.mockRestore();
@@ -528,6 +536,65 @@ describe("BashMonitorWakeStore", () => {
     }
     expect(strandedGone).toBe(true);
     expect((await fresh.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR new generation"]);
+  });
+
+  test("a read failure after a generation change propagates instead of serving stale cache", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    expect(await store.listPending("owner-1")).toHaveLength(1); // classify as pending
+
+    // Another instance retires the wake: the file changes generations, so the cached
+    // pending classification is known stale. A failed re-read must not resurface it —
+    // a drain could deliver the canceled wake.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    await other.markSuperseded("owner-1", "proc-1");
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const realReadFile = fsPromises.readFile;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation(((
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) =>
+      target === file
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realReadFile(target, options)) as unknown as typeof fsPromises.readFile);
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the changed-file read failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      readSpy.mockRestore();
+    }
+    // Once readable again, the retired state wins.
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+  });
+
+  test("a stranded-wake restore failure propagates so owner discovery fails open", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const stranded = `${file}.prune-crashed`;
+    await fsPromises.rename(file, stranded);
+
+    // Startup scenario: the stranded pending wake is found but its restore fails
+    // transiently. The scan must not look successfully empty — discovery would then
+    // never schedule this owner's drain and the wake would sit undelivered all session.
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation(() =>
+      Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+    );
+    try {
+      try {
+        await store.listPending("owner-1");
+        expect.unreachable("expected listPending to propagate the stranded restore failure");
+      } catch (error) {
+        expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+      }
+      expect(await store.listPendingOwnerWorkspaceIds()).toEqual(["owner-1"]);
+    } finally {
+      linkSpy.mockRestore();
+    }
+    // Once the failure clears, the stranded wake is restored and listed.
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
   });
 
   test("listPending keeps serving a cached pending wake when stat transiently fails", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -927,12 +927,28 @@ describe("BashMonitorWakeStore", () => {
 
   test("a resumed older clear cannot lower a newer committed cutoff", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
-    // Clear A stages, then stalls before its outcome.
+    // Clear A stages, then stalls past the grace window; another instance's scan
+    // rolls its staging back as crashed (indistinguishable from a crash), freeing
+    // the tombstone for later clears while A still holds its token.
     const clearA = await store.supersedeAllPending("owner-1");
+    const dirForRollback = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dirForRollback, "cleared-at");
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await new BashMonitorWakeStore(makeConfig(rootDir)).listPending("owner-1");
     // Strictly order A < wake < B: cutoffs have millisecond granularity, and a fast
     // machine can otherwise run all three inside one millisecond — B's staging over
-    // A's still-staged equal cutoff then correctly aborts as a concurrent clear,
-    // which is not the interleaving under test.
+    // A's equal cutoff would then abort, which is not the interleaving under test.
     await new Promise((resolve) => setTimeout(resolve, 5));
     // A wake arrives after A's cutoff and crashes into a deferred temp...
     await store.enqueueOrMergePending(payload({ lines: ["ERROR between clears"] }));
@@ -1362,9 +1378,16 @@ describe("BashMonitorWakeStore", () => {
     } finally {
       renameSpy.mockRestore();
     }
+    // Mid-rollback (the staged tombstone still standing) the restored record is
+    // durably pending on disk but HELD from delivery: its pre-cutoff timestamp is
+    // indistinguishable from a stray pre-clear write until the staging resolves.
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect(await store.listPending("owner-1")).toEqual([]);
+    // Resuming the rollback (as the grace scan would) is idempotent: the tombstone
+    // demotes and the held record delivers.
+    await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
     const pending = await store.listPending("owner-1");
     expect(pending.map((r) => r.lines)).toEqual([["ERROR restored first"]]);
-    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
   });
 
   test("an implausibly future tombstone reads as malformed instead of standing forever", async () => {
@@ -1421,7 +1444,25 @@ describe("BashMonitorWakeStore", () => {
     } catch (error) {
       expect((error as Error).message).toContain("concurrent history clear");
     }
+    // The record is durably pending but HELD while the foreign staging (whose
+    // cutoff covers it) stands: B may still commit and retire it.
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect(await store.listPending("owner-1")).toEqual([]);
+    // Once that staging resolves (here: rolled back as crashed after its grace
+    // window), the held record delivers.
+    const tombPath = path.join(dir, "cleared-at");
+    const foreignTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...foreignTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
     expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
       ["ERROR must survive"],
     ]);
@@ -1731,6 +1772,85 @@ describe("BashMonitorWakeStore", () => {
       ["ERROR survives abort"],
     ]);
     expect((await fsPromises.readdir(dir)).some((e) => e.startsWith("cleared-at"))).toBe(false);
+  });
+
+  test("a newer clear never replaces another instance's unresolved staged tombstone", async () => {
+    const storeA = new BashMonitorWakeStore(makeConfig(rootDir));
+    await storeA.enqueueOrMergePending(payload({ lines: ["ERROR staged by A"] }));
+    const clearA = await storeA.supersedeAllPending("owner-1");
+    // Ensure B's cutoff is strictly newer than A's, so only the staged-phase guard
+    // (not the equal-cutoff tie rule) can block it.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Another instance starts its own clear while A's outcome is unknown. Replacing
+    // A's staged tombstone would strand A-stamped records: if both processes then
+    // crashed, restart rollback would only discover records stamped with the
+    // standing tombstone's clearId, leaving A's superseded until pruning — wakes
+    // permanently lost for a history clear that never ran.
+    const storeB = new BashMonitorWakeStore(makeConfig(rootDir));
+    await storeB.enqueueOrMergePending(
+      payload({ processId: "proc-2", taskId: "bash:proc-2", lines: ["ERROR new for B"] })
+    );
+    try {
+      await storeB.supersedeAllPending("owner-1");
+      expect.unreachable("expected B's staging to abort while A's staging stands");
+    } catch (error) {
+      expect((error as Error).message).toContain("concurrent history clear");
+    }
+    // B's abort touched nothing: its record stays pending and A's staging stands.
+    expect((await storeB.get("owner-1", "proc-2"))?.status).toBe("pending");
+    expect((await storeA.get("owner-1", "proc-1"))?.status).toBe("superseded");
+
+    // A's transaction still rolls back losslessly.
+    await storeA.restorePendingSnapshots("owner-1", clearA.snapshots, clearA);
+    const pending = await storeA.listPending("owner-1");
+    expect(pending.map((r) => r.id).sort()).toEqual(["proc-1", "proc-2"]);
+  });
+
+  test("a pre-cutoff record surfacing as canonical after a committed clear is retired, not delivered", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre-clear"] }));
+    const preClear = await store.get("owner-1", "proc-1");
+    expect(preClear).not.toBeNull();
+    // Strictly order the record's updatedAt before the clear's cutoff.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clear);
+
+    // A crash-stalled writer's rename (or a cross-instance recovery) re-publishes
+    // the PRE-CUTOFF pending generation over the canonical path after the clear
+    // settled. The staged/committed tombstones fence only orphan-temp recovery, so
+    // without a canonical-pass check this record would deliver pre-clear output
+    // into the freshly cleared transcript.
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    await fsPromises.writeFile(file, JSON.stringify(preClear), "utf-8");
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    // Retirement is durable and self-healing, not a per-scan suppression.
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+  });
+
+  test("a pre-cutoff record surfacing mid-clear is held while staged, then restored by rollback", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR pre-clear"] }));
+    const preClear = await store.get("owner-1", "proc-1");
+    expect(preClear).not.toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+
+    // The pre-cutoff generation re-surfaces as canonical while the clear's outcome
+    // is unknown: neither deliver (a committing clear must retire it) nor retire
+    // durably (a rollback must still deliver it) — hold it.
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    await fsPromises.writeFile(file, JSON.stringify(preClear), "utf-8");
+
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("pending");
+
+    // The clear rolls back: the held record delivers again.
+    await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR pre-clear"]]);
   });
 
   test("terminal pruning spares records owned by an unresolved staged clear", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -201,15 +201,33 @@ describe("BashMonitorWakeStore", () => {
     // Cold path: seeds the index from a full directory scan.
     expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-b"]);
 
-    // Warm path: transitions and new enqueues must be reflected without a rescan.
-    const readdirSpy = spyOn(fsPromises, "readdir");
+    // Warm path: transitions and new enqueues must be reflected correctly.
     await store.markSuperseded("owner-1", "proc-b");
     expect(await store.listPending("owner-1")).toHaveLength(0);
     await store.enqueueOrMergePending(payload({ processId: "proc-c", taskId: "bash:proc-c" }));
+
+    // The hot UI path may re-list the directory (cross-instance discovery) but must not
+    // re-read the contents of already-classified terminal files (proc-a, proc-b).
+    const readFileSpy = spyOn(fsPromises, "readFile");
     expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-c"]);
-    // The hot UI path must not rescan the (unpruned, ever-growing) wake directory.
-    expect(readdirSpy).not.toHaveBeenCalled();
-    readdirSpy.mockRestore();
+    expect(readFileSpy).toHaveBeenCalledTimes(1);
+    readFileSpy.mockRestore();
+  });
+
+  test("listPending discovers wakes written by another store instance after seeding", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ processId: "proc-a", taskId: "bash:proc-a" }));
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-a"]);
+
+    // A second instance (another service handle or app process sharing the session dir)
+    // durably enqueues a wake under a process ID this instance has never seen.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    await other.enqueueOrMergePending(payload({ processId: "proc-b", taskId: "bash:proc-b" }));
+
+    expect((await store.listPending("owner-1")).map((r) => r.id).sort()).toEqual([
+      "proc-a",
+      "proc-b",
+    ]);
   });
 
   test("listPending self-heals index entries retired by another store instance", async () => {

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -10,6 +10,7 @@ import {
   buildBashMonitorWakePrompt,
   deferredTempRecoveryDelayMs,
   STAGED_CLEAR_ROLLBACK_GRACE_MS,
+  MAX_TOMBSTONE_FUTURE_SKEW_MS,
   TEMP_RECOVERY_MIN_AGE_MS,
   TERMINAL_WAKE_RETENTION_MS,
   type BashMonitorWakePayload,
@@ -1327,6 +1328,62 @@ describe("BashMonitorWakeStore", () => {
     expect(pending[0].kind).toBe("monitor-lost");
     expect(pending[0].script).toBe("echo relaunch");
     expect(pending[0].lines).toEqual(["ERROR matched output", "ERROR earlier undelivered"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
+  test("an interrupted clear rollback restores records before demoting the tombstone", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR restored first"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    // The rollback's tombstone demotion fails (crash-equivalent) mid-rollback: the
+    // records must ALREADY be pending again — with the demotion first, a crash in
+    // this window would leave them permanently stamped superseded with no staged
+    // tombstone left on disk to resume their recovery from.
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(((
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) =>
+      String(to).includes("cleared-at.cas-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realRename(from, to)) as typeof fsPromises.rename);
+    try {
+      await store.restorePendingSnapshots("owner-1", clear.snapshots, clear);
+      expect.unreachable("expected the tombstone demotion failure to propagate");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR restored first"]]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("an implausibly future tombstone reads as malformed instead of standing forever", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR outlives the glitch"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // A clock rollback (or corruption) persisted a committed cutoff FAR in the
+    // future: accepted, it would condemn every subsequently orphaned temp while the
+    // monotonic clear logic never replaces it with a normal current-time cutoff.
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at"),
+      JSON.stringify({
+        clearedAt: new Date(Date.now() + 2 * MAX_TOMBSTONE_FUTURE_SKEW_MS).toISOString(),
+        clearId: "clear-future",
+        phase: "committed",
+      }),
+      "utf-8"
+    );
+
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR outlives the glitch"]]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -214,6 +214,23 @@ describe("BashMonitorWakeStore", () => {
     readFileSpy.mockRestore();
   });
 
+  test("listPending reclassifies a filename rewritten by another store instance", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+
+    // Another instance retires the wake, then the re-armed process ID produces a NEW
+    // pending wake under the same filename. The filename is not immutable content.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    await other.markSuperseded("owner-1", "proc-1");
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+    await other.enqueueOrMergePending(payload({ lines: ["ERROR rearmed"] }));
+
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR rearmed"]);
+  });
+
   test("listPending discovers wakes written by another store instance after seeding", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ processId: "proc-a", taskId: "bash:proc-a" }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2523,6 +2523,150 @@ describe("BashMonitorWakeStore", () => {
     expect(existsSync(sessionDir)).toBe(false);
   });
 
+  test("a tombstone removal resurrected by a concurrent heal reports the lost race", async () => {
+    const owner = new BashMonitorWakeStore(makeConfig(rootDir));
+    await owner.enqueueOrMergePending(payload({ lines: ["ERROR retired then resurrected"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await owner.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // The owner crashed: its staging ages past the grace window.
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await owner.abandonWorkspaceClears("owner-1");
+    // A concurrent instance's heal consumes the rollback demotion's capture and
+    // republishes it at the canonical path between the capture rename and the
+    // removal's rm: unlike replacements, the removal branch has no no-clobber
+    // placement to lose, so it must VERIFY the removal stands.
+    const scan = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRm = fsPromises.rm;
+    const injected = { fired: false };
+    const rmSpy = spyOn(fsPromises, "rm").mockImplementation((async (
+      target: Parameters<typeof realRm>[0],
+      options?: Parameters<typeof realRm>[1]
+    ) => {
+      if (!injected.fired && String(target).includes("cleared-at.cas-")) {
+        injected.fired = true;
+        await fsPromises.link(String(target), tombPath);
+      }
+      return realRm(target, options);
+    }) as typeof fsPromises.rm);
+    try {
+      // Accepting the rollback would leave restored records pending under a standing
+      // staging: a record whose pre-clear updatedAt equals the cutoff would pass the
+      // strict pre-cutoff fence and deliver during the clear.
+      expect(await scan.listPending("owner-1")).toEqual([]);
+    } finally {
+      rmSpy.mockRestore();
+    }
+    expect(injected.fired).toBe(true);
+    expect((await scan.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    const standing = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(standing.phase).toBe("staged");
+    // The resurrected staging is still beyond its grace window: the next scan
+    // completes the rollback cleanly (compensation and restore are idempotent).
+    expect((await scan.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR retired then resurrected"],
+    ]);
+    expect((await scan.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect(existsSync(tombPath)).toBe(false);
+  });
+
+  test("records whose identity disagrees with their path are not published", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR real"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const realRaw = await fsPromises.readFile(path.join(dir, "proc-1.json"), "utf-8");
+    // A copied or moved artifact: syntactically valid record content whose id
+    // disagrees with the canonical path it sits at. Later transitions address the
+    // PARSED identity, so publishing it would leave THIS file pending forever while
+    // deliveries and writes target a different record.
+    const imposter = { ...(JSON.parse(realRaw) as BashMonitorWakeRecord), id: "proc-9" };
+    await fsPromises.writeFile(path.join(dir, "proc-2.json"), JSON.stringify(imposter), "utf-8");
+    // A record claiming a DIFFERENT workspace at this workspace's path: writes built
+    // from its fields would land in the foreign workspace's store.
+    const foreign = {
+      ...(JSON.parse(realRaw) as BashMonitorWakeRecord),
+      id: "proc-3",
+      ownerWorkspaceId: "owner-2",
+    };
+    await fsPromises.writeFile(path.join(dir, "proc-3.json"), JSON.stringify(foreign), "utf-8");
+
+    expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+    // Kept as evidence (like malformed canonicals), never served or deleted here.
+    const entries = await fsPromises.readdir(dir);
+    expect(entries).toContain("proc-2.json");
+    expect(entries).toContain("proc-3.json");
+  });
+
+  test("healing prefers the freshest staged capture at equal cutoffs", async () => {
+    // Two name pairs so that on any filesystem's directory iteration order at least
+    // one arm encounters the STALE capture first — the selection must be
+    // order-independent either way.
+    const arms = [
+      { owner: "owner-1", staleName: "cleared-at.cas-older", freshName: "cleared-at.cas-newer" },
+      { owner: "owner-2", staleName: "cleared-at.cas-stale", freshName: "cleared-at.cas-live" },
+    ];
+    for (const arm of arms) {
+      const store = new BashMonitorWakeStore(makeConfig(rootDir));
+      await store.enqueueOrMergePending(
+        payload({ workspaceId: arm.owner, lines: ["ERROR retired by live clear"] })
+      );
+      // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await store.supersedeAllPending(arm.owner);
+      const dir = path.join(rootDir, "sessions", arm.owner, "bash-monitor-wakes");
+      const tombPath = path.join(dir, "cleared-at");
+      const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      await store.abandonWorkspaceClears(arm.owner);
+      // Concurrent heartbeat mutations crash and strand TWO captures of the SAME
+      // staged clear: equal cutoff, different liveness generations. The canonical
+      // path is empty. Directory iteration order must not decide which one heals
+      // back: the older capture sits beyond the rollback grace, so selecting it
+      // would let this scan roll back a clear whose owner is still live.
+      const staleStagedAt = new Date(
+        Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000
+      ).toISOString();
+      const freshStagedAt = new Date().toISOString();
+      await fsPromises.rm(tombPath);
+      await fsPromises.writeFile(
+        path.join(dir, arm.staleName),
+        JSON.stringify({ ...stagedTomb, stagedAt: staleStagedAt }),
+        "utf-8"
+      );
+      await fsPromises.writeFile(
+        path.join(dir, arm.freshName),
+        JSON.stringify({ ...stagedTomb, stagedAt: freshStagedAt }),
+        "utf-8"
+      );
+      const scan = new BashMonitorWakeStore(makeConfig(rootDir));
+      expect(await scan.listPending(arm.owner)).toEqual([]);
+      expect((await scan.get(arm.owner, "proc-1"))?.status).toBe("superseded");
+      const healed = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      expect(healed.stagedAt).toBe(freshStagedAt);
+    }
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -1387,6 +1387,174 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
+  test("staging that cannot land durably aborts the clear and restores its records", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR must survive"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // Another instance's clear B already owns the tombstone with a NEWER staged
+    // cutoff, so OUR staging can never land under the monotonic rule.
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at"),
+      JSON.stringify({
+        clearedAt: new Date(Date.now() + 60_000).toISOString(),
+        clearId: "clear-b",
+        phase: "staged",
+        stagedAt: new Date().toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // Reporting success would leave no durable trace of OUR clear's identity: after
+    // a double crash, restart rollback only restores records stamped with the
+    // standing tombstone's clearId, stranding ours superseded forever. The clear
+    // must abort and restore its stamped records instead.
+    try {
+      await store.supersedeAllPending("owner-1");
+      expect.unreachable("expected supersedeAllPending to abort under a foreign staging");
+    } catch (error) {
+      expect((error as Error).message).toContain("concurrent history clear");
+    }
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR must survive"],
+    ]);
+  });
+
+  test("a live clear's heartbeat keeps its staging inside the rollback grace", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir), {
+      stagedClearRefreshIntervalMs: 25,
+    });
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR retired"] }));
+    const clear = await store.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // Age the staging past the grace window (as wall-clock time would during a long
+    // history clear).
+    const staged = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...staged,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    // The owner's heartbeat refreshes stagedAt, so ANOTHER instance (which cannot
+    // see the in-memory active marker) keeps holding instead of misreading the
+    // still-running clear as crashed and resurrecting its retired wakes.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const fresh = new BashMonitorWakeStore(makeConfig(rootDir));
+    expect(await fresh.listPending("owner-1")).toEqual([]);
+    expect((await fresh.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    // Settle the clear so the heartbeat stops.
+    await store.commitClear("owner-1", clear);
+  });
+
+  test("a newer re-armed match replaces a stale canonical lost notice", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    const notice = await store.enqueueMonitorLost(
+      {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        ownerWorkspaceId: "owner-1",
+        filter: "ERROR",
+        filterExclude: false,
+        script: "./watch.sh",
+      },
+      TREAT_ALL_AS_STALE()
+    );
+    expect(notice).not.toBeNull();
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // A stranded prune capture holds a NEWER re-armed match generation of the same
+    // id (different lineage, so offset subsumption is unprovable).
+    const reArmed: Record<string, unknown> = {
+      ...notice,
+      kind: "match",
+      lines: ["ERROR re-armed output"],
+      totalMatches: 1,
+      matchedThroughOffset: 10,
+      createdAt: new Date(Date.parse(notice!.createdAt) + 1_000).toISOString(),
+      updatedAt: new Date(Date.parse(notice!.updatedAt) + 5_000).toISOString(),
+    };
+    delete reArmed.script;
+    await fsPromises.writeFile(
+      path.join(dir, "proc-1.json.prune-crashed"),
+      JSON.stringify(reArmed),
+      "utf-8"
+    );
+
+    // The strictly newer match proves the id was re-armed AFTER the notice was
+    // written: the stale notice is replaced, not merged — merging would keep
+    // claiming the newly running task was terminated.
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].kind).toBe("match");
+    expect(pending[0].script).toBeUndefined();
+    expect(pending[0].lines).toEqual(["ERROR re-armed output"]);
+  });
+
+  test("a rescued pending generation is revalidated against later artifacts in the same scan", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR stale rescue"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // A crashed prune stranded the PENDING generation aside...
+    const raw = JSON.parse(await fsPromises.readFile(file, "utf-8")) as Record<string, unknown> & {
+      updatedAt: string;
+    };
+    await fsPromises.rename(file, path.join(dir, "proc-1.json.prune-a"));
+    // ...and a crashed write stranded a NEWER TERMINAL generation (the wake was
+    // superseded after the prune capture) with no canonical file left at all.
+    await fsPromises.writeFile(
+      path.join(dir, "proc-1.json.tmp-b"),
+      JSON.stringify({
+        ...raw,
+        status: "superseded",
+        updatedAt: new Date(Date.parse(raw.updatedAt) + 5_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(path.join(dir, "proc-1.json.tmp-b"), past, past);
+
+    // Force the pending rescue to be processed FIRST so the terminal generation
+    // supersedes it later within the SAME scan.
+    const rank = (e: string) => (e.endsWith(".prune-a") ? 0 : e.endsWith(".tmp-b") ? 1 : 2);
+    const realReaddir = fsPromises.readdir;
+    const readdirSpy = spyOn(fsPromises, "readdir").mockImplementation(((
+      p: Parameters<typeof realReaddir>[0]
+    ) =>
+      realReaddir(p).then((entries) =>
+        [...entries].sort((a, b) => rank(String(a)) - rank(String(b)))
+      )) as typeof fsPromises.readdir);
+    try {
+      // The scan must serve the FINAL canonical generation (terminal), never the
+      // obsolete pending intermediate it rescued earlier in the same pass.
+      expect(await store.listPending("owner-1")).toEqual([]);
+      expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
+    } finally {
+      readdirSpy.mockRestore();
+    }
+  });
+
+  test("a directory squatting on the tombstone path is quarantined instead of failing scans", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR still delivered"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // Corruption left a DIRECTORY at the tombstone path: readFile would fail every
+    // scan with EISDIR, permanently blocking valid pending wakes.
+    await fsPromises.mkdir(path.join(dir, "cleared-at"));
+
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR still delivered"]]);
+    const entries = await fsPromises.readdir(dir);
+    expect(entries).not.toContain("cleared-at");
+    expect(entries.some((e) => e.startsWith("cleared-at.malformed-"))).toBe(true);
+  });
+
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
     const now = Date.now();
     // Near the gate: fires just past it (epsilon), no spurious full-interval wait.

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -928,8 +928,14 @@ describe("BashMonitorWakeStore", () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     // Clear A stages, then stalls before its outcome.
     const clearA = await store.supersedeAllPending("owner-1");
+    // Strictly order A < wake < B: cutoffs have millisecond granularity, and a fast
+    // machine can otherwise run all three inside one millisecond — B's staging over
+    // A's still-staged equal cutoff then correctly aborts as a concurrent clear,
+    // which is not the interleaving under test.
+    await new Promise((resolve) => setTimeout(resolve, 5));
     // A wake arrives after A's cutoff and crashes into a deferred temp...
     await store.enqueueOrMergePending(payload({ lines: ["ERROR between clears"] }));
+    await new Promise((resolve) => setTimeout(resolve, 5));
     const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
     const temp = path.join(dir, "proc-1.json.tmp-crashed");
     await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
@@ -1540,6 +1546,63 @@ describe("BashMonitorWakeStore", () => {
     }
   });
 
+  test("a record merged after the clear's snapshot survives the supersede", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR before cutoff"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    // Another instance merges NEW matched output into the record between the clear's
+    // snapshot and its per-record stamp (injected inside the stamp's own re-read).
+    const getSpy = spyOn(store, "get").mockImplementation(async (owner: string, id: string) => {
+      getSpy.mockRestore();
+      const raw = JSON.parse(await fsPromises.readFile(file, "utf-8")) as Record<
+        string,
+        unknown
+      > & { lines: string[]; updatedAt: string };
+      await fsPromises.writeFile(
+        file,
+        JSON.stringify({
+          ...raw,
+          lines: [...raw.lines, "ERROR after cutoff"],
+          totalMatches: 2,
+          matchedThroughOffset: 20,
+          updatedAt: new Date(Date.parse(raw.updatedAt) + 5_000).toISOString(),
+        }),
+        "utf-8"
+      );
+      return store.get(owner, id);
+    });
+
+    const clear = await store.supersedeAllPending("owner-1");
+    // The clear retires nothing: its only candidate changed past the cutoff, and the
+    // transaction explicitly intends mid-clear output to survive — superseding the
+    // merged record would permanently discard output the clear never saw.
+    expect(clear.snapshots).toEqual([]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([
+      ["ERROR before cutoff", "ERROR after cutoff"],
+    ]);
+    // Committing the clear still leaves the merged record deliverable.
+    await store.commitClear("owner-1", clear);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    // Corruption left a DIRECTORY under a .cas- capture name with no canonical
+    // tombstone: every heal — and with it every readClearedAt and listPending —
+    // would fail with EISDIR, permanently blocking the workspace's wakes.
+    await fsPromises.mkdir(path.join(dir, "cleared-at.cas-bad"));
+
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR heals anyway"]]);
+    const entries = await fsPromises.readdir(dir);
+    expect(entries).not.toContain("cleared-at.cas-bad");
+    expect(entries.some((e) => e.startsWith("cleared-at.malformed-"))).toBe(true);
+  });
+
   test("a directory squatting on the tombstone path is quarantined instead of failing scans", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR still delivered"] }));
@@ -1918,6 +1981,23 @@ describe("BashMonitorWakeStore", () => {
     const file = path.join(dir, "proc-1.json");
     const leftoverPath = `${file}.prune-crashed`;
     await fsPromises.rename(file, leftoverPath);
+    // Backdate the captured generation: divergent generations in production come from
+    // different instants, but on a fast machine both test enqueues can share one
+    // millisecond — a createdAt collision that makes reverse subsumption mistake the
+    // divergent winner for the captured generation's own lineage.
+    const captured = JSON.parse(await fsPromises.readFile(leftoverPath, "utf-8")) as Record<
+      string,
+      unknown
+    > & { createdAt: string; updatedAt: string };
+    await fsPromises.writeFile(
+      leftoverPath,
+      JSON.stringify({
+        ...captured,
+        createdAt: new Date(Date.parse(captured.createdAt) - 60_000).toISOString(),
+        updatedAt: new Date(Date.parse(captured.updatedAt) - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
 
     // The canonical record is created AFTER this scan's readdir snapshot (so the scan
     // never visits its entry) but before recovery's restore link. The canonical winner

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -451,6 +451,51 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
   });
 
+  test("an unverifiable prune capture is restored and the failure propagates", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // A concurrent rewrite lands during the capture rename, and then the captured inode
+    // cannot be read. The helper must not report a successful empty scan: startup owner
+    // discovery would skip scheduling this owner's drain for a possibly-pending wake.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    let injected = false;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (!injected && String(from) === file && String(to).includes(".prune-")) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR rearmed"] }));
+      }
+      return realRename(from, to);
+    });
+    const realReadFile = fsPromises.readFile;
+    const readSpy = spyOn(fsPromises, "readFile").mockImplementation(((
+      target: Parameters<typeof fsPromises.readFile>[0],
+      options: Parameters<typeof fsPromises.readFile>[1]
+    ) =>
+      typeof target === "string" && target.includes(".json.prune-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realReadFile(target, options)) as unknown as typeof fsPromises.readFile);
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the capture read failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+      readSpy.mockRestore();
+    }
+    // The unverifiable capture was restored to the canonical path fail-safe, so the
+    // concurrently rewritten pending wake was never lost or stranded.
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR rearmed"]]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
   test("pruning keeps a freshly superseded record captured from a concurrent rewrite", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -2418,6 +2418,111 @@ describe("BashMonitorWakeStore", () => {
     expect(existsSync(tombPath)).toBe(false);
   });
 
+  test("a declined rollback leaves records pending when a twin scan already demoted the tombstone", async () => {
+    const owner = new BashMonitorWakeStore(makeConfig(rootDir));
+    await owner.enqueueOrMergePending(payload({ lines: ["ERROR restored by twin scans"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await owner.supersedeAllPending("owner-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // The owner crashed: its staging ages past the grace window.
+    const stagedTomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    await fsPromises.writeFile(
+      tombPath,
+      JSON.stringify({
+        ...stagedTomb,
+        stagedAt: new Date(Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS - 60_000).toISOString(),
+      }),
+      "utf-8"
+    );
+    await owner.abandonWorkspaceClears("owner-1");
+    // A TWIN scan completes the same rollback between this scan's record restore and
+    // its pinned CAS: record restores are idempotent, and the twin's demotion removes
+    // the tombstone (this clear had no predecessor). Injected on the scan's
+    // record-restore rename, which sits exactly inside that window.
+    const scan = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    const injected = { fired: false };
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((async (
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) => {
+      const result = await realRename(from, to);
+      if (
+        !injected.fired &&
+        String(from).includes("proc-1.json.tmp-") &&
+        String(to).endsWith("proc-1.json")
+      ) {
+        injected.fired = true;
+        await fsPromises.rm(tombPath, { force: true });
+      }
+      return result;
+    }) as typeof fsPromises.rename);
+    try {
+      // The declined CAS here means "already rolled back", not "owner alive":
+      // re-superseding would strand the record with NO staged tombstone left on disk
+      // for any recovery to find — a permanently lost wake.
+      expect((await scan.listPending("owner-1")).map((r) => r.lines)).toEqual([
+        ["ERROR restored by twin scans"],
+      ]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    expect(injected.fired).toBe(true);
+    expect((await scan.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
+  test("a heartbeat tick disarmed mid-flight is still drained by abandonWorkspaceClears", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir), {
+      stagedClearRefreshIntervalMs: 30,
+    });
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR cleared"] }));
+    // Strictly order wake < cutoff (same-millisecond stamps fail toward delivery).
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const clear = await store.supersedeAllPending("owner-1");
+    const sessionDir = path.join(rootDir, "sessions", "owner-1");
+    const dir = path.join(sessionDir, "bash-monitor-wakes");
+    const tombPath = path.join(dir, "cleared-at");
+    // Stall the first tombstone capture long enough for heartbeat ticks to fire and
+    // queue on the tombstone lock behind it: commitClear then disarms the heartbeat
+    // TIMER while those fired ticks are still pending.
+    const realRename = fsPromises.rename;
+    let release = (): void => undefined;
+    const gateOpen = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const gate = { blocked: false };
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((async (
+      from: Parameters<typeof realRename>[0],
+      to: Parameters<typeof realRename>[1]
+    ) => {
+      if (!gate.blocked && String(from) === tombPath && String(to).includes(".cas-")) {
+        gate.blocked = true;
+        await gateOpen;
+      }
+      return realRename(from, to);
+    }) as typeof fsPromises.rename);
+    try {
+      const commit = store.commitClear("owner-1", clear);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      release();
+      await commit;
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // Removal's teardown: the timer entry is already gone (commitClear disarmed it),
+    // but the fired-and-queued ticks must still be drained — an undrained tick's
+    // recursive mkdir would recreate the session directory after removal deletes it.
+    await store.abandonWorkspaceClears("owner-1");
+    await fsPromises.rm(sessionDir, { recursive: true, force: true });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(existsSync(sessionDir)).toBe(false);
+  });
+
   test("a directory squatting on a tombstone capture is quarantined instead of failing heals", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ lines: ["ERROR heals anyway"] }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -299,6 +299,46 @@ describe("BashMonitorWakeStore", () => {
     expect(later[0].lines).toEqual(["ERROR rearmed"]);
   });
 
+  test("a failed restore keeps the captured wake for a later recovery scan", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // Prune captures a concurrently rewritten pending wake, but restoring it to the
+    // canonical path fails (EIO / ENOSPC / link-unsupported filesystem). The capture is
+    // then the only durable copy and must not be deleted.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    let injected = false;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (!injected && String(from) === file && String(to).includes(".prune-")) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR rearmed"] }));
+      }
+      return realRename(from, to);
+    });
+    const linkSpy = spyOn(fsPromises, "link").mockImplementationOnce(() =>
+      Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+    );
+    try {
+      expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR rearmed"]]);
+    } finally {
+      renameSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+    // The capture survived as a prune leftover…
+    const leftovers = (await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"));
+    expect(leftovers).toHaveLength(1);
+    // …and the next scan's stranded-leftover recovery restores it to the canonical path.
+    expect((await store.listPending("owner-1")).map((r) => r.lines)).toEqual([["ERROR rearmed"]]);
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR rearmed"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
   test("pruning keeps a freshly superseded record captured from a concurrent rewrite", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -299,6 +299,46 @@ describe("BashMonitorWakeStore", () => {
     expect(later[0].lines).toEqual(["ERROR rearmed"]);
   });
 
+  test("pruning keeps a freshly superseded record captured from a concurrent rewrite", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // Between this instance's old-terminal classification and its capture rename,
+    // another instance enqueues a new pending wake and a history clear supersedes it —
+    // leaving a FRESH terminal record at the same path that restorePendingSnapshots may
+    // still need to flip back to pending.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    let injected = false;
+    let freshPending: Awaited<ReturnType<BashMonitorWakeStore["enqueueOrMergePending"]>> | null =
+      null;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (!injected && String(from) === file && String(to).includes(".prune-")) {
+        injected = true;
+        freshPending = await other.enqueueOrMergePending(payload({ lines: ["ERROR fresh"] }));
+        await other.markSuperseded("owner-1", "proc-1");
+      }
+      return realRename(from, to);
+    });
+    try {
+      // Not pending, so nothing is listed — but the fresh terminal record must survive.
+      expect(await store.listPending("owner-1")).toHaveLength(0);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    const current = await store.get("owner-1", "proc-1");
+    expect(current?.status).toBe("superseded");
+    expect(current?.lines).toEqual(["ERROR fresh"]);
+    // The record is still restorable: a failed history clear can roll it back to pending.
+    expect(freshPending).not.toBeNull();
+    await store.restorePendingSnapshots("owner-1", [freshPending!]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+  });
+
   test("listPending restores a pending wake stranded in a crashed prune file", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -1037,6 +1037,91 @@ describe("BashMonitorWakeStore", () => {
     expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
   });
 
+  test("healing defers to a tombstone that wins the canonical link race", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    // Clear #1 commits an old cutoff.
+    const clearOne = await store.supersedeAllPending("owner-1");
+    await store.commitClear("owner-1", clearOne);
+    // A wake arrives after that cutoff and crashes into a consumable deferred temp.
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR between cutoffs"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+
+    const tombPath = path.join(dir, "cleared-at");
+    const newerTombstone = JSON.stringify({
+      clearedAt: new Date(Date.now() + 60_000).toISOString(),
+      clearId: "clear-b",
+      phase: "committed",
+    });
+    // Another instance's clear B begins a tombstone mutation mid-scan: by the time
+    // the temp is inspected, B has CAPTURED the canonical (cleared-at is absent; only
+    // B's .cas- capture of the OLD generation remains on disk)...
+    const realStat = fsPromises.stat;
+    let capturedByB = false;
+    const statSpy = spyOn(fsPromises, "stat").mockImplementation((async (
+      p: Parameters<typeof realStat>[0]
+    ) => {
+      if (!capturedByB && String(p) === temp) {
+        capturedByB = true;
+        await fsPromises.rename(tombPath, `${tombPath}.cas-instance-b`);
+      }
+      return realStat(p);
+    }) as typeof fsPromises.stat);
+    // ...and B publishes its NEWER cutoff exactly when the healing read tries to link
+    // the stale capture back, losing the race.
+    const realLink = fsPromises.link;
+    let publishedByB = false;
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation((async (
+      from: Parameters<typeof realLink>[0],
+      to: Parameters<typeof realLink>[1]
+    ) => {
+      if (!publishedByB && String(to) === tombPath && String(from).includes(".cas-")) {
+        publishedByB = true;
+        await fsPromises.writeFile(tombPath, newerTombstone, "utf-8");
+      }
+      return realLink(from, to);
+    }) as typeof fsPromises.link);
+    try {
+      // The heal must report B's winning cutoff, not the stale capture it selected:
+      // the deferred wake between the two cutoffs was retired by B's clear, so
+      // restoring it would deliver retired output into B's cleared transcript.
+      expect(await store.listPending("owner-1")).toEqual([]);
+      expect(await store.get("owner-1", "proc-1")).toBeNull();
+      expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+    } finally {
+      statSpy.mockRestore();
+      linkSpy.mockRestore();
+    }
+  });
+
+  test("an incomplete staged tombstone reads as malformed instead of holding wakes forever", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR held hostage"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const temp = path.join(dir, "proc-1.json.tmp-crashed");
+    await fsPromises.rename(path.join(dir, "proc-1.json"), temp);
+    const past = new Date(Date.now() - 10 * 60 * 1000);
+    await fsPromises.utimes(temp, past, past);
+    // Corruption left a staged tombstone WITHOUT its transaction fields: no clearId
+    // for any rollback to ever claim, no stagedAt for the grace window to expire —
+    // every scan would hold the pre-clear temp for an outcome that cannot arrive.
+    await fsPromises.writeFile(
+      path.join(dir, "cleared-at"),
+      JSON.stringify({ clearedAt: new Date(Date.now() + 60_000).toISOString(), phase: "staged" }),
+      "utf-8"
+    );
+
+    // The invalid staged shape reads as malformed (fail toward delivery): the wake
+    // recovers and delivers instead of being deferred indefinitely.
+    const pending = await store.listPending("owner-1");
+    expect(pending.map((r) => r.lines)).toEqual([["ERROR held hostage"]]);
+    expect((await store.get("owner-1", "proc-1"))?.status).toBe("pending");
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".tmp-"))).toHaveLength(0);
+  });
+
   test("deferred recovery delays are bounded for corrupt or future mtimes", () => {
     const now = Date.now();
     // Near the gate: fires just past it (epsilon), no spurious full-interval wait.

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -262,6 +262,89 @@ describe("BashMonitorWakeStore", () => {
     expect(pruned).toBe(true);
   });
 
+  test("pruning rescues a pending wake concurrently rewritten over a terminal filename", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    await store.markDelivered("owner-1", "proc-1");
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const past = new Date(Date.now() - TERMINAL_WAKE_RETENTION_MS - 60_000);
+    await fsPromises.utimes(file, past, past);
+
+    // Another store instance renames a NEW pending wake over the path in the window
+    // between this instance classifying the file as old-terminal and deleting it. The
+    // injection point (the prune's own rename-to-trash) is exactly that window.
+    const other = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realRename = fsPromises.rename;
+    let injected = false;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation(async (from, to) => {
+      if (!injected && String(from) === file && String(to).includes(".prune-")) {
+        injected = true;
+        await other.enqueueOrMergePending(payload({ lines: ["ERROR rearmed"] }));
+      }
+      return realRename(from, to);
+    });
+    try {
+      // The prune must capture-and-verify rather than rm-by-path: the new pending wake
+      // is rescued and still part of this listing.
+      const pending = await store.listPending("owner-1");
+      expect(pending).toHaveLength(1);
+      expect(pending[0].status).toBe("pending");
+      expect(pending[0].lines).toEqual(["ERROR rearmed"]);
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // The rescued record survived on disk for future scans and eventual delivery.
+    const later = await store.listPending("owner-1");
+    expect(later).toHaveLength(1);
+    expect(later[0].lines).toEqual(["ERROR rearmed"]);
+  });
+
+  test("listPending keeps serving a cached pending wake when stat transiently fails", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload());
+    expect(await store.listPending("owner-1")).toHaveLength(1); // classify into the cache
+
+    const file = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes", "proc-1.json");
+    const realStat = fsPromises.stat;
+    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
+      target: Parameters<typeof fsPromises.stat>[0]
+    ) =>
+      String(target) === file
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realStat(target)) as unknown as typeof fsPromises.stat);
+    try {
+      // A transient stat failure must not silently drop the durable pending record from
+      // an otherwise-successful (authoritative-looking) result.
+      expect((await store.listPending("owner-1")).map((r) => r.id)).toEqual(["proc-1"]);
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  test("listPending propagates a transient stat failure it has no cached answer for", async () => {
+    const seedStore = new BashMonitorWakeStore(makeConfig(rootDir));
+    await seedStore.enqueueOrMergePending(payload());
+
+    // Cold cache: this instance has never classified the file, so a partial result would
+    // silently omit a pending wake. Callers keep their last good snapshot on a throw.
+    const coldStore = new BashMonitorWakeStore(makeConfig(rootDir));
+    const realStat = fsPromises.stat;
+    const statSpy = spyOn(fsPromises, "stat").mockImplementation(((
+      target: Parameters<typeof fsPromises.stat>[0]
+    ) =>
+      String(target).endsWith("proc-1.json")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realStat(target)) as unknown as typeof fsPromises.stat);
+    try {
+      await coldStore.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the stat failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
   test("listPending discovers wakes written by another store instance after seeding", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ processId: "proc-a", taskId: "bash:proc-a" }));

--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -370,6 +370,98 @@ describe("BashMonitorWakeStore", () => {
     expect((await store.get("owner-1", "proc-1"))?.status).toBe("superseded");
   });
 
+  test("a failed CAS capture propagates instead of hiding the stranded generation", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR old"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    const leftover = {
+      ...canonicalRecord,
+      lines: ["ERROR newer"],
+      updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+    };
+    await fsPromises.writeFile(`${file}.prune-crashed`, JSON.stringify(leftover), "utf-8");
+
+    // The CAS capture rename fails transiently: the scan must reject (engaging caller
+    // retries), not report a successful result that hides the stranded generation.
+    const realRename = fsPromises.rename;
+    const renameSpy = spyOn(fsPromises, "rename").mockImplementation((from, to) =>
+      String(from) === file && String(to).includes(".prune-")
+        ? Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }))
+        : realRename(from, to)
+    );
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the CAS capture failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      renameSpy.mockRestore();
+    }
+    // Nothing was lost; the next scan completes the swap and the newer generation wins.
+    const settled = await store.listPending("owner-1");
+    expect(settled).toHaveLength(1);
+    expect(settled[0].lines).toEqual(["ERROR newer"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
+  test("a failed CAS placement restores the canonical record and propagates", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR old"] }));
+    const dir = path.join(rootDir, "sessions", "owner-1", "bash-monitor-wakes");
+    const file = path.join(dir, "proc-1.json");
+    const canonicalRecord = JSON.parse(await fsPromises.readFile(file, "utf-8")) as {
+      updatedAt: string;
+      lines: string[];
+    };
+    const leftoverPath = `${file}.prune-crashed`;
+    await fsPromises.writeFile(
+      leftoverPath,
+      JSON.stringify({
+        ...canonicalRecord,
+        lines: ["ERROR newer"],
+        updatedAt: new Date(Date.parse(canonicalRecord.updatedAt) + 1_000).toISOString(),
+      }),
+      "utf-8"
+    );
+
+    // The CAS verified its capture but placing the leftover fails transiently. The
+    // captured canonical record must be restored (the id would otherwise have NO
+    // canonical file at all) and the failure must propagate.
+    const realLink = fsPromises.link;
+    let leftoverLinkCalls = 0;
+    const linkSpy = spyOn(fsPromises, "link").mockImplementation((from, to) => {
+      if (String(from) === leftoverPath) {
+        leftoverLinkCalls += 1;
+        // Call 1 is recovery's optimistic restore (real EEXIST); call 2 is the CAS
+        // placement after capture — fail that one.
+        if (leftoverLinkCalls === 2) {
+          return Promise.reject(Object.assign(new Error("EIO: i/o error"), { code: "EIO" }));
+        }
+      }
+      return realLink(from, to);
+    });
+    try {
+      await store.listPending("owner-1");
+      expect.unreachable("expected listPending to propagate the CAS placement failure");
+    } catch (error) {
+      expect((error as NodeJS.ErrnoException).code).toBe("EIO");
+    } finally {
+      linkSpy.mockRestore();
+    }
+    // The canonical record was restored, not deleted with the cas file.
+    expect((await store.get("owner-1", "proc-1"))?.lines).toEqual(["ERROR old"]);
+    // The next scan completes the swap.
+    const settled = await store.listPending("owner-1");
+    expect(settled).toHaveLength(1);
+    expect(settled[0].lines).toEqual(["ERROR newer"]);
+    expect((await fsPromises.readdir(dir)).filter((e) => e.includes(".prune-"))).toHaveLength(0);
+  });
+
   test("owner discovery fails open when a stranded leftover cannot be read", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload());

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -39,6 +39,13 @@ const TMP_WRITE_SUFFIX_RE = /\.json\.tmp-[^.]+$/;
 // older is an orphan from a crash. Exported for tests.
 export const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
 
+// A STAGED clear tombstone older than this is a crashed clear staging: the owning
+// instance promotes or rolls back within its own request, so nothing else ever
+// resolves it. Scans roll it back after this grace — failing toward delivery, per the
+// store's documented bias — while the grace keeps another instance's scans from
+// rolling back a clear that is merely in flight. Exported for tests.
+export const STAGED_CLEAR_ROLLBACK_GRACE_MS = 5 * 60 * 1000;
+
 /**
  * Delay until a deferred fresh temp should be rechecked: an epsilon past the gate so
  * the re-driven scan's own freshness check cannot lose a same-millisecond race against
@@ -192,6 +199,35 @@ export interface BashMonitorWakeRecord {
   createdAt: string;
   updatedAt: string;
   deliveredAt?: string;
+  /**
+   * Set when a history clear superseded this record (see supersedeAllPending): the
+   * clear's identity plus the pre-clear updatedAt let a CRASHED clear staging be
+   * rolled back losslessly at scan time — snapshot keys and acceptance logic key on
+   * the original updatedAt, so it must survive the round trip.
+   */
+  supersededByClearId?: string;
+  pendingUpdatedAtBeforeClear?: string;
+}
+
+/** Identifies one history-clear transaction (see supersedeAllPending / commitClear). */
+export interface BashMonitorClearToken {
+  clearId: string;
+  clearedAt: string;
+}
+
+/**
+ * Durable history-clear tombstone contents. `phase` distinguishes a STAGED clear
+ * (visible wakes retired, outcome unknown — deferred temps are held, not condemned)
+ * from a COMMITTED one (retirement is final — pre-clear temps are condemned). A
+ * missing phase reads as committed: demoted previous-generation values carry no
+ * staging state, and committed is the protective default.
+ */
+interface ClearTombstone {
+  clearedAt: string;
+  clearId?: string;
+  phase?: "staged" | "committed";
+  stagedAt?: string;
+  previousClearedAt?: string;
 }
 
 /**
@@ -251,6 +287,8 @@ const BashMonitorWakeRecordSchema = z
     createdAt: z.string().min(1),
     updatedAt: z.string().min(1),
     deliveredAt: z.string().optional(),
+    supersededByClearId: z.string().optional(),
+    pendingUpdatedAtBeforeClear: z.string().optional(),
   })
   // Strip (not reject) unknown keys: this is a persisted, evolving record, so a record written by
   // a newer build that added a field must still parse here and deliver rather than be dropped as
@@ -567,6 +605,12 @@ export class BashMonitorWakeStore {
   onDeferredTempRecoveryDue: ((ownerWorkspaceId: string) => void) | null = null;
   // One unref'd timer per deferred temp path, fired just past the freshness gate.
   private readonly deferredTempRecoveryTimers = new Map<string, NodeJS.Timeout>();
+  // Dedicated lock map for tombstone mutations (record locks key on `${owner}:${id}`
+  // where id is an arbitrary process id, so sharing them risks collisions).
+  private readonly clearedAtLocks = new MutexMap<string>();
+  // Clears begun by THIS instance that have not yet committed or rolled back; scans
+  // must never treat their staged tombstones as crashed.
+  private readonly activeClearIds = new Set<string>();
 
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
 
@@ -602,111 +646,285 @@ export class BashMonitorWakeStore {
     return path.join(this.dir(ownerWorkspaceId), "cleared-at");
   }
 
-  private async writeClearedAt(ownerWorkspaceId: string, clearedAt: string): Promise<void> {
+  /**
+   * Atomically mutate the clear tombstone under a CAS: the current generation is
+   * CAPTURED (renamed aside) before `decide` runs, so the decision applies to exactly
+   * the generation being replaced — a plain read-then-write could demote or clobber a
+   * NEWER tombstone published by another instance between the read and the write.
+   * `decide` returns the next generation, "keep" to restore the capture untouched, or
+   * null to remove the tombstone. The final placement uses a no-clobber link, so a
+   * generation claimed by another instance mid-mutation wins and ours backs off. A
+   * crash mid-dance strands the capture under a .cas- name, which reads heal (see
+   * readClearedAt), so protection is never silently lost. In-process mutations are
+   * serialized by a dedicated lock.
+   */
+  private async mutateClearedAt(
+    ownerWorkspaceId: string,
+    decide: (current: ClearTombstone | null) => ClearTombstone | "keep" | null
+  ): Promise<void> {
     const target = this.clearedAtFile(ownerWorkspaceId);
-    await fsPromises.mkdir(path.dirname(target), { recursive: true });
-    // Carry the value being replaced: a ROLLBACK of this clear must restore the prior
-    // tombstone rather than deleting the file wholesale, or an older successful
-    // clear's protection would die with a newer failed one and let a pre-old-clear
-    // temp deliver permanently retired output. Only one level is needed — a clear
-    // becomes "previous" only after committing, and committed clears are never
-    // rolled back.
-    const previousClearedAtMs = await this.readClearedAtMs(ownerWorkspaceId);
-    await this.writeClearedAtFile(target, {
-      clearedAt,
-      ...(previousClearedAtMs != null
-        ? { previousClearedAt: new Date(previousClearedAtMs).toISOString() }
-        : {}),
+    await this.clearedAtLocks.withLock(ownerWorkspaceId, async () => {
+      await fsPromises.mkdir(path.dirname(target), { recursive: true });
+      const capture = `${target}.cas-${randomUUID()}`;
+      let captured = false;
+      try {
+        await fsPromises.rename(target, capture);
+        captured = true;
+      } catch (error) {
+        if (!isErrnoWithCode(error, "ENOENT")) throw error;
+        // Absent: heal a crash-stranded capture back first so its protection joins
+        // the decision, then retry the capture once.
+        if ((await this.healClearedAtFromLeftovers(ownerWorkspaceId)) != null) {
+          try {
+            await fsPromises.rename(target, capture);
+            captured = true;
+          } catch (retryError) {
+            if (!isErrnoWithCode(retryError, "ENOENT")) throw retryError;
+          }
+        }
+      }
+      let current: ClearTombstone | null = null;
+      if (captured) {
+        let raw: string | null;
+        try {
+          raw = await fsPromises.readFile(capture, "utf-8");
+        } catch (error) {
+          // Cannot verify what we captured: put it back (no-clobber) and propagate.
+          try {
+            await fsPromises.link(capture, target);
+            await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+          } catch {
+            // A newer write claimed the path; the capture heals as a leftover later.
+          }
+          throw error;
+        }
+        current = BashMonitorWakeStore.parseTombstone(raw);
+      }
+      const next = decide(current);
+      if (next === "keep") {
+        if (captured) {
+          try {
+            await fsPromises.link(capture, target);
+          } catch (error) {
+            if (!isErrnoWithCode(error, "EEXIST")) throw error; // capture heals later
+          }
+          await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+        }
+        return;
+      }
+      if (next == null) {
+        // Removal failures PROPAGATE: a stranded capture would heal back as standing
+        // protection (the safe direction), and the caller must know removal failed.
+        if (captured) await fsPromises.rm(capture, { force: true });
+        return;
+      }
+      const temp = `${target}.tmp-${randomUUID()}`;
+      await fsPromises.writeFile(temp, JSON.stringify(next), "utf-8");
+      try {
+        await fsPromises.link(temp, target);
+      } catch (error) {
+        await fsPromises.rm(temp, { force: true }).catch(() => undefined);
+        if (!isErrnoWithCode(error, "EEXIST")) {
+          if (captured) {
+            try {
+              await fsPromises.link(capture, target);
+              await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+            } catch {
+              // A newer write claimed the path; the capture heals as a leftover later.
+            }
+          }
+          throw error;
+        }
+        // EEXIST: another instance claimed the path mid-mutation. Its generation
+        // wins this race and supersedes both our decision and our capture.
+        if (captured) await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+        return;
+      }
+      await fsPromises.rm(temp, { force: true }).catch(() => undefined);
+      if (captured) await fsPromises.rm(capture, { force: true }).catch(() => undefined);
     });
   }
 
-  private async writeClearedAtFile(
-    target: string,
-    record: { clearedAt: string; previousClearedAt?: string }
-  ): Promise<void> {
-    // Atomic like write(): a torn tombstone must never be a file's settled content.
-    // The temp name matches no artifact pattern either, so scans skip it too.
-    const temp = `${target}.tmp-${randomUUID()}`;
-    await fsPromises.writeFile(temp, JSON.stringify(record), "utf-8");
+  /**
+   * Restore the newest crash-stranded tombstone capture (a .cas- leftover from a
+   * mutation interrupted between its capture rename and final placement) back to the
+   * canonical path, and report it. Stale older leftovers are swept once a newer value
+   * stands. Returns the tombstone now effective, or null when none exists.
+   */
+  private async healClearedAtFromLeftovers(
+    ownerWorkspaceId: string
+  ): Promise<ClearTombstone | null> {
+    const target = this.clearedAtFile(ownerWorkspaceId);
+    const dir = path.dirname(target);
+    const base = path.basename(target);
+    let entries: string[];
     try {
-      await fsPromises.rename(temp, target);
+      entries = await fsPromises.readdir(dir);
     } catch (error) {
-      await fsPromises.rm(temp, { force: true }).catch(() => undefined);
+      if (isErrnoWithCode(error, "ENOENT")) return null;
       throw error;
+    }
+    let newest: ClearTombstone | null = null;
+    let newestPath: string | null = null;
+    for (const entry of entries) {
+      if (!entry.startsWith(`${base}.cas-`)) continue;
+      const leftoverPath = path.join(dir, entry);
+      let raw: string;
+      try {
+        raw = await fsPromises.readFile(leftoverPath, "utf-8");
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) continue; // concurrently consumed
+        throw error;
+      }
+      const parsed = BashMonitorWakeStore.parseTombstone(raw);
+      if (parsed == null) {
+        await fsPromises.rm(leftoverPath, { force: true }).catch(() => undefined);
+        continue;
+      }
+      if (newest == null || Date.parse(parsed.clearedAt) > Date.parse(newest.clearedAt)) {
+        newest = parsed;
+        newestPath = leftoverPath;
+      }
+    }
+    if (newest == null || newestPath == null) return null;
+    try {
+      await fsPromises.link(newestPath, target);
+      await fsPromises.rm(newestPath, { force: true }).catch(() => undefined);
+    } catch {
+      // EEXIST (a concurrent writer re-established the path) or transient: the
+      // leftover stays for a later heal; the newest protection is still reported.
+    }
+    return newest;
+  }
+
+  private static parseTombstone(raw: string): ClearTombstone | null {
+    try {
+      const parsed = JSON.parse(raw) as Partial<ClearTombstone>;
+      if (typeof parsed.clearedAt !== "string" || Number.isNaN(Date.parse(parsed.clearedAt))) {
+        return null;
+      }
+      return parsed as ClearTombstone;
+    } catch {
+      // Corrupted tombstone: fail toward DELIVERY (a lost wake is worse than a rare
+      // resurrected one); the next clear rewrites it.
+      return null;
     }
   }
 
   /**
-   * Roll back exactly ONE clear's tombstone, identified by the clearedAt it wrote:
-   * restore the previous clear's value when one exists, otherwise remove the file. The
-   * identity check matters with multiple instances — another instance may have
-   * committed a NEWER clear since, and demoting its tombstone would revive deferred
-   * wakes that newer clear legitimately retired; a current generation that is not the
-   * one being rolled back is left untouched. (supersedeAllPending writes its tombstone
-   * last, so its own failure path never promotes one and never calls this.) Failures
-   * PROPAGATE — a stale surviving tombstone would silently discard a revived wake's
-   * deferred temp.
+   * The effective clear tombstone, or null when none applies (absent or malformed).
+   * Transient failures PROPAGATE: guessing "no clear happened" could restore and
+   * deliver a retired wake. An absent canonical path falls back to crash-stranded
+   * captures so an interrupted mutation never silently drops protection.
    */
-  private async rollbackClearedAt(
-    ownerWorkspaceId: string,
-    expectedClearedAt: string
-  ): Promise<void> {
-    const target = this.clearedAtFile(ownerWorkspaceId);
-    let raw: string;
-    try {
-      raw = await fsPromises.readFile(target, "utf-8");
-    } catch (error) {
-      if (isErrnoWithCode(error, "ENOENT")) return; // nothing to roll back
-      throw error;
-    }
-    let current: string | null = null;
-    let previous: string | null = null;
-    try {
-      const parsed = JSON.parse(raw) as { clearedAt?: unknown; previousClearedAt?: unknown };
-      current = typeof parsed.clearedAt === "string" ? parsed.clearedAt : null;
-      previous =
-        typeof parsed.previousClearedAt === "string" &&
-        !Number.isNaN(Date.parse(parsed.previousClearedAt))
-          ? parsed.previousClearedAt
-          : null;
-    } catch {
-      // Malformed tombstones already provide no protection to preserve.
-      current = null;
-      previous = null;
-    }
-    if (current != null && current !== expectedClearedAt) {
-      // A different clear owns the current tombstone: not ours to roll back.
-      return;
-    }
-    if (previous != null) {
-      await this.writeClearedAtFile(target, { clearedAt: previous });
-      return;
-    }
-    await fsPromises.rm(target, { force: true });
-  }
-
-  /** Epoch ms of the latest history clear, or null when none applies (absent or malformed). */
-  private async readClearedAtMs(ownerWorkspaceId: string): Promise<number | null> {
+  private async readClearedAt(ownerWorkspaceId: string): Promise<ClearTombstone | null> {
     let raw: string;
     try {
       raw = await fsPromises.readFile(this.clearedAtFile(ownerWorkspaceId), "utf-8");
     } catch (error) {
-      if (isErrnoWithCode(error, "ENOENT")) return null;
-      // Transient failures PROPAGATE: guessing "no clear happened" here could restore
-      // and deliver a retired wake; caller retries re-read instead.
+      if (!isErrnoWithCode(error, "ENOENT")) throw error;
+      return this.healClearedAtFromLeftovers(ownerWorkspaceId);
+    }
+    const tomb = BashMonitorWakeStore.parseTombstone(raw);
+    if (tomb == null) {
+      log.debug("Ignoring malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
+    }
+    return tomb;
+  }
+
+  /**
+   * Promote a clear's tombstone to COMMITTED after the history clear durably
+   * succeeded: pre-clear deferred temps stop being held and become condemned. The
+   * update is monotonic — a newer cutoff published since is never lowered — and
+   * re-establishes the committed cutoff if a foreign rollback removed the staging.
+   */
+  async commitClear(ownerWorkspaceId: string, token: BashMonitorClearToken): Promise<void> {
+    this.activeClearIds.delete(token.clearId);
+    await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+      if (current == null) {
+        return { clearedAt: token.clearedAt, clearId: token.clearId, phase: "committed" };
+      }
+      if (current.clearId === token.clearId) {
+        if (current.phase === "committed") return "keep";
+        const { stagedAt: _stagedAt, ...rest } = current;
+        return { ...rest, phase: "committed" };
+      }
+      // Monotonic: a newer (or equal) cutoff subsumes ours; never lower it.
+      if (Date.parse(current.clearedAt) >= Date.parse(token.clearedAt)) return "keep";
+      return {
+        clearedAt: token.clearedAt,
+        clearId: token.clearId,
+        phase: "committed",
+        previousClearedAt: current.clearedAt,
+      };
+    });
+  }
+
+  /**
+   * Roll back exactly ONE clear's tombstone, identified by its clear id: restore the
+   * previous clear's cutoff when one exists, otherwise remove the file. A current
+   * generation owned by a DIFFERENT clear (another instance committed a newer one) is
+   * left untouched — demoting it would revive wakes that clear legitimately retired.
+   */
+  private async rollbackClearTombstone(ownerWorkspaceId: string, clearId: string): Promise<void> {
+    await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+      if (current?.clearId !== clearId) return "keep";
+      if (current.previousClearedAt != null) {
+        // Demoted values carry no staging state: the previous clear committed long
+        // ago (a clear only becomes "previous" after committing).
+        return { clearedAt: current.previousClearedAt, phase: "committed" };
+      }
+      return null;
+    });
+  }
+
+  /**
+   * Roll back a clear staging orphaned by a crash: the owning instance promotes or
+   * rolls back within its own request, so a STAGED tombstone past the grace window
+   * with no in-process active clear can only be a crash between staging and the
+   * history clear's outcome. Failing toward DELIVERY (the store's documented bias):
+   * stamped records flip back to pending with their original updatedAt, then the
+   * tombstone demotes — in that order, so a crash mid-rollback leaves the staged
+   * tombstone in place and the next scan resumes (record restores are idempotent).
+   * The rare symmetric window (crash AFTER the history clear durably succeeded but
+   * before commitClear) resurrects those wakes into the cleared transcript — a
+   * duplicate delivery, accepted as strictly better than silently losing wakes for a
+   * transcript that was never cleared.
+   */
+  private async rollbackCrashedClearStaging(ownerWorkspaceId: string): Promise<void> {
+    const tomb = await this.readClearedAt(ownerWorkspaceId);
+    if (tomb?.phase !== "staged" || tomb.clearId == null) return;
+    if (this.activeClearIds.has(tomb.clearId)) return; // in flight, not crashed
+    const stagedAtMs = tomb.stagedAt != null ? Date.parse(tomb.stagedAt) : NaN;
+    if (Number.isNaN(stagedAtMs)) return; // unreadable staging age: leave it held
+    if (stagedAtMs > Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS) return;
+    const clearId = tomb.clearId;
+    const dir = this.dir(ownerWorkspaceId);
+    let entries: string[];
+    try {
+      entries = await fsPromises.readdir(dir);
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return;
       throw error;
     }
-    try {
-      const parsed = JSON.parse(raw) as { clearedAt?: unknown };
-      const ms = typeof parsed.clearedAt === "string" ? Date.parse(parsed.clearedAt) : NaN;
-      if (Number.isNaN(ms)) throw new Error("invalid clearedAt");
-      return ms;
-    } catch {
-      // Corrupted tombstone: fail toward DELIVERY (a lost wake is worse than a rare
-      // resurrected one) and keep the file as evidence until the next clear rewrites it.
-      log.debug("Ignoring malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
-      return null;
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      const id = BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length));
+      const filePath = path.join(dir, entry);
+      await this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+        const record = await this.readRecordAt(filePath);
+        if (record?.status !== "superseded" || record.supersededByClearId !== clearId) return;
+        const { supersededByClearId: _clearStamp, pendingUpdatedAtBeforeClear, ...rest } = record;
+        await this.write({
+          ...rest,
+          status: "pending",
+          // The pre-clear updatedAt survives the round trip: snapshot keys and
+          // acceptance logic key on it.
+          updatedAt: pendingUpdatedAtBeforeClear ?? record.updatedAt,
+        });
+      });
     }
+    await this.rollbackClearTombstone(ownerWorkspaceId, clearId);
   }
 
   static wakeId(processId: string): string {
@@ -946,6 +1164,13 @@ export class BashMonitorWakeStore {
     if (classified == null) {
       classified = new Map();
       this.classifiedFilesByOwner.set(ownerWorkspaceId, classified);
+    }
+    // A staged clear tombstone abandoned past its grace window is a CRASHED clear
+    // staging (see rollbackCrashedClearStaging); resolve it before anything below
+    // consults the tombstone or the stamped records. The entries check keeps this off
+    // the hot path — tombstone artifacts exist only around clears and crashes.
+    if (entries.some((e) => e === "cleared-at" || e.startsWith("cleared-at.cas-"))) {
+      await this.rollbackCrashedClearStaging(ownerWorkspaceId);
     }
     const records: BashMonitorWakeRecord[] = [];
     const seen = new Set<string>();
@@ -1527,15 +1752,26 @@ export class BashMonitorWakeStore {
         return null;
       }
       if (parsed.status === "pending") {
-        const clearedAtMs = await this.readClearedAtMs(ownerWorkspaceId);
-        if (clearedAtMs != null && Date.parse(parsed.updatedAt) <= clearedAtMs) {
-          // A history clear retired every wake stamped before it, but this temp was
-          // INVISIBLE to that clear's scan (the freshness gate deferred it). Restoring
-          // it would deliver a pre-clear wake into the freshly cleared transcript —
-          // condemn it instead. A fresh temp may still belong to a live writer, so
-          // only consumable ones are removed (failures PROPAGATE, matching the
-          // stale-discard discipline below); fresh ones are left unrestored, with no
-          // re-drive, for a later scan's consumable sweep.
+        const tomb = await this.readClearedAt(ownerWorkspaceId);
+        if (tomb != null && Date.parse(parsed.updatedAt) <= Date.parse(tomb.clearedAt)) {
+          if (tomb.phase === "staged") {
+            // The owning clear's outcome is UNKNOWN: hold the temp — neither restore
+            // (a committed clear must not see this wake delivered) nor discard (a
+            // rolled-back clear must still deliver it). Promotion condemns it;
+            // rollback demotes the tombstone so the next scan restores it; a crashed
+            // staging is rolled back by scans after the grace window. The re-drive
+            // timer (armed from now, one full recheck interval) keeps resolution
+            // independent of external scans.
+            this.scheduleDeferredTempRecovery(ownerWorkspaceId, filePath, Date.now());
+            return null;
+          }
+          // COMMITTED: the clear retired every wake stamped before it, but this temp
+          // was INVISIBLE to that clear's scan (the freshness gate deferred it).
+          // Restoring it would deliver a pre-clear wake into the freshly cleared
+          // transcript — condemn it instead. A fresh temp may still belong to a live
+          // writer, so only consumable ones are removed (failures PROPAGATE, matching
+          // the stale-discard discipline below); fresh ones are left unrestored, with
+          // no re-drive, for a later scan's consumable sweep.
           if (consumable) await fsPromises.rm(filePath, { force: true });
           return null;
         }
@@ -1906,49 +2142,91 @@ export class BashMonitorWakeStore {
     return ownerWorkspaceIds;
   }
 
+  /**
+   * Stage a history clear: retire every visible pending wake (stamped with this
+   * clear's identity for lossless crash rollback) and publish a STAGED tombstone that
+   * holds — never yet condemns — deferred pre-clear temps. The caller must complete
+   * the transaction: commitClear once the history clear durably succeeded, or
+   * restorePendingSnapshots to roll back. A staging orphaned by a crash is rolled
+   * back by scans after STAGED_CLEAR_ROLLBACK_GRACE_MS.
+   */
   async supersedeAllPending(
     ownerWorkspaceId: string
-  ): Promise<{ snapshots: BashMonitorWakeRecord[]; clearedAt: string }> {
+  ): Promise<{ snapshots: BashMonitorWakeRecord[] } & BashMonitorClearToken> {
     // Captured BEFORE the scan: the tombstone below retires only wakes stamped before
     // the clear began, so output enqueued mid-clear survives it. Returned so a later
-    // rollback can identify exactly this clear's tombstone (see rollbackClearedAt).
+    // commit or rollback can identify exactly this clear's tombstone.
     const clearedAt = new Date().toISOString();
+    const clearId = randomUUID();
+    this.activeClearIds.add(clearId);
     const pending = await this.listPending(ownerWorkspaceId);
     const staged: BashMonitorWakeRecord[] = [];
     try {
       for (const record of pending) {
-        await this.markSuperseded(ownerWorkspaceId, record.id);
+        await this.supersedeForClear(ownerWorkspaceId, record.id, clearId);
         staged.push(record);
       }
-      // Durable tombstone for wakes this clear could NOT see: a crash-orphaned temp
-      // inside the freshness gate is invisible to the listPending above, and without
-      // the tombstone its deferred re-drive would later restore and deliver a
+      // Durable STAGED tombstone for wakes this clear could NOT see: a crash-orphaned
+      // temp inside the freshness gate is invisible to the listPending above, and
+      // without the tombstone its deferred re-drive would later restore and deliver a
       // pre-clear wake into the cleared transcript. Written only after every visible
       // wake retired; a failure here fails the clear (snapshots restored below).
-      await this.writeClearedAt(ownerWorkspaceId, clearedAt);
-      return { snapshots: pending, clearedAt };
+      // Monotonic: a newer concurrent cutoff is never lowered — this clear's own
+      // rollback then finds a foreign identity and correctly leaves it alone.
+      await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+        if (current != null && Date.parse(current.clearedAt) >= Date.parse(clearedAt)) {
+          return "keep";
+        }
+        return {
+          clearedAt,
+          clearId,
+          phase: "staged",
+          stagedAt: new Date().toISOString(),
+          ...(current != null ? { previousClearedAt: current.clearedAt } : {}),
+        };
+      });
+      return { snapshots: pending, clearedAt, clearId };
     } catch (error) {
       // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
       // tombstone write above is the try block's last step, so on this path it was
       // never promoted, and demoting here would strip the PREVIOUS clear's
       // protection instead.
+      this.activeClearIds.delete(clearId);
       await this.restoreSnapshotRecords(ownerWorkspaceId, staged);
       throw error;
     }
   }
 
+  /** Supersede one pending record on behalf of a clear, stamping rollback metadata. */
+  private async supersedeForClear(
+    ownerWorkspaceId: string,
+    id: string,
+    clearId: string
+  ): Promise<void> {
+    await this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+      const record = await this.get(ownerWorkspaceId, id);
+      if (record?.status !== "pending") return;
+      await this.write({
+        ...this.withTerminalStatus(record, "superseded"),
+        supersededByClearId: clearId,
+        pendingUpdatedAtBeforeClear: record.updatedAt,
+      });
+    });
+  }
+
   async restorePendingSnapshots(
     ownerWorkspaceId: string,
     snapshots: readonly BashMonitorWakeRecord[],
-    clearedAt: string
+    token: BashMonitorClearToken
   ): Promise<void> {
-    // Rolling back a clear also rolls back ITS tombstone (identified by the clearedAt
+    // Rolling back a clear also rolls back ITS tombstone (identified by the token
     // that supersedeAllPending returned) — restoring the previous clear's value, never
-    // deleting the file wholesale, and never touching a newer clear's tombstone: the
-    // wakes below return to pending, so a sibling deferred temp must not stay
+    // deleting the file wholesale, and never touching a different clear's tombstone:
+    // the wakes below return to pending, so a sibling deferred temp must not stay
     // condemned by the rolled-back clear, while temps retired by OTHER clears must
     // stay condemned.
-    await this.rollbackClearedAt(ownerWorkspaceId, clearedAt);
+    this.activeClearIds.delete(token.clearId);
+    await this.rollbackClearTombstone(ownerWorkspaceId, token.clearId);
     await this.restoreSnapshotRecords(ownerWorkspaceId, snapshots);
   }
 

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -789,11 +789,29 @@ export class BashMonitorWakeStore {
     if (newest == null || newestPath == null) return null;
     try {
       await fsPromises.link(newestPath, target);
-      await fsPromises.rm(newestPath, { force: true }).catch(() => undefined);
-    } catch {
-      // EEXIST (a concurrent writer re-established the path) or transient: the
-      // leftover stays for a later heal; the newest protection is still reported.
+    } catch (error) {
+      // Non-EEXIST placement failures PROPAGATE: reporting a capture that never
+      // durably won could hand the caller a cutoff no later read reproduces.
+      if (!isErrnoWithCode(error, "EEXIST")) throw error;
+      // EEXIST: a concurrent mutation re-established the canonical path after we
+      // selected the capture — ITS generation won and may carry a NEWER cutoff (a
+      // mid-dance mutation's capture holds the PREVIOUS generation, not the one it
+      // is publishing). Report the winner, not our stale selection: a caller judging
+      // a wake between the two cutoffs would otherwise restore what the newer clear
+      // retired. The leftover stays behind for a later heal, so its protection is
+      // never silently lost.
+      let raw: string;
+      try {
+        raw = await fsPromises.readFile(target, "utf-8");
+      } catch (readError) {
+        if (!isErrnoWithCode(readError, "ENOENT")) throw readError;
+        // The winner was removed again before we could read it: the capture remains
+        // the newest standing protection.
+        return newest;
+      }
+      return BashMonitorWakeStore.parseTombstone(raw) ?? newest;
     }
+    await fsPromises.rm(newestPath, { force: true }).catch(() => undefined);
     return newest;
   }
 
@@ -802,6 +820,18 @@ export class BashMonitorWakeStore {
       const parsed = JSON.parse(raw) as Partial<ClearTombstone>;
       if (typeof parsed.clearedAt !== "string" || Number.isNaN(Date.parse(parsed.clearedAt))) {
         return null;
+      }
+      if (parsed.phase === "staged") {
+        // A staged tombstone is only actionable through its transaction fields:
+        // without clearId no rollback (crashed-stage or owner) can ever claim it, and
+        // without a readable stagedAt the grace window never expires — while temp
+        // recovery keeps holding pre-clear temps for an outcome that cannot arrive,
+        // leaving those wakes undeliverable forever. Treat the corrupt shape as
+        // malformed (fail toward delivery); the next clear rewrites the file.
+        if (typeof parsed.clearId !== "string" || parsed.clearId.length === 0) return null;
+        if (typeof parsed.stagedAt !== "string" || Number.isNaN(Date.parse(parsed.stagedAt))) {
+          return null;
+        }
       }
       return parsed as ClearTombstone;
     } catch {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -835,7 +835,12 @@ export class BashMonitorWakeStore {
           // Old terminal record: delete it so the directory (and this scan) stays
           // bounded. Deletion re-verifies the captured inode (see the helper) because a
           // concurrent writer may have renamed a new pending wake over this path.
-          const rescued = await this.pruneTerminalWakeFile(ownerWorkspaceId, entry, filePath);
+          const rescued = await this.pruneTerminalWakeFile(
+            ownerWorkspaceId,
+            entry,
+            filePath,
+            pruneBeforeMs
+          );
           classified.delete(entry);
           if (rescued != null) records.push(rescued);
         }
@@ -861,7 +866,12 @@ export class BashMonitorWakeStore {
       const pending = parsed?.status === "pending" ? parsed : null;
       const prunable = parsed != null && parsed.status !== "pending";
       if (prunable && stat.mtimeMs < pruneBeforeMs) {
-        const rescued = await this.pruneTerminalWakeFile(ownerWorkspaceId, entry, filePath);
+        const rescued = await this.pruneTerminalWakeFile(
+          ownerWorkspaceId,
+          entry,
+          filePath,
+          pruneBeforeMs
+        );
         classified.delete(entry);
         if (rescued != null) records.push(rescued);
         continue;
@@ -899,7 +909,9 @@ export class BashMonitorWakeStore {
    * record at the path, which then supersedes the stranded one and lets it be removed)
    * and the leftover deleted; a leftover that cannot be read or restored right now is
    * KEPT so a later scan retries rather than ever deleting an unrecovered pending wake.
-   * Non-pending leftovers are swept once old. Returns the restored pending record.
+   * Fresh terminal content is restored too — a freshly superseded record must stay
+   * visible at its path for restorePendingSnapshots rollback — while old or malformed
+   * leftovers are swept once past retention. Returns the restored pending record.
    */
   private async recoverStrandedPruneFile(
     ownerWorkspaceId: string,
@@ -918,17 +930,22 @@ export class BashMonitorWakeStore {
       // Unreadable (vanished via a concurrent recover, or transiently failing): keep
       // whatever may exist for a later retry.
       const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
-      const parsed = raw == null ? null : this.parse(raw);
+      if (raw == null) return null;
+      const parsed = this.parse(raw);
       if (parsed?.status !== "pending") {
-        // Terminal or malformed content was already destined for pruning; sweep it once
-        // old (the age gate keeps a live prune's in-flight trash out of reach).
-        if (raw != null) {
-          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
-          if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
-            await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-          }
+        // Old terminal and malformed content was already destined for pruning; sweep it
+        // once old (the age gate keeps a live prune's in-flight trash out of reach).
+        const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+        if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          return null;
         }
-        return null;
+        // Malformed-but-fresh content cannot be meaningfully restored; keep the
+        // leftover as evidence until the age gate sweeps it.
+        if (parsed == null) return null;
+        // Fresh terminal content falls through to the restore below: a freshly
+        // superseded record must stay visible at its path or restorePendingSnapshots
+        // cannot flip it back to pending after a failed history clear.
       }
       let restored = false;
       try {
@@ -937,13 +954,13 @@ export class BashMonitorWakeStore {
       } catch (error) {
         if (!isErrnoWithCode(error, "EEXIST")) {
           // Transient link failure: keep the leftover so a later scan retries the
-          // restore instead of deleting a never-recovered pending wake.
+          // restore instead of deleting a never-recovered record.
           return null;
         }
         // EEXIST: a newer record owns the original path and supersedes the stranded one.
       }
       await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-      return restored ? parsed : null;
+      return restored && parsed.status === "pending" ? parsed : null;
     });
   }
 
@@ -961,7 +978,8 @@ export class BashMonitorWakeStore {
   private async pruneTerminalWakeFile(
     ownerWorkspaceId: string,
     entry: string,
-    filePath: string
+    filePath: string,
+    pruneBeforeMs: number
   ): Promise<BashMonitorWakeRecord | null> {
     const id = BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length));
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
@@ -973,10 +991,22 @@ export class BashMonitorWakeStore {
       }
       const raw = await fsPromises.readFile(trash, "utf-8").catch(() => null);
       const parsed = raw == null ? null : this.parse(raw);
+      let restore: boolean;
       if (parsed == null || parsed.status === "pending") {
-        // Not verifiably terminal (raced rewrite, or a read/parse hiccup just now):
-        // restore it. link() refuses to clobber an even newer write that claimed the
-        // path since, in which case that newer record simply supersedes this one.
+        // Not verifiably terminal (raced rewrite, or a read/parse hiccup just now).
+        restore = true;
+      } else {
+        // Terminal content still needs its age re-verified against the CAPTURED inode:
+        // the prune decision came from an earlier stat, and a concurrent writer may have
+        // replaced the path with a freshly superseded record (e.g. a history clear's
+        // supersedeAllPending) that restorePendingSnapshots may still flip back to
+        // pending. A fresh mtime keeps it; an unreadable stat fails safe to restore.
+        const trashStat = await fsPromises.stat(trash).catch(() => null);
+        restore = trashStat == null || trashStat.mtimeMs >= pruneBeforeMs;
+      }
+      if (restore) {
+        // link() refuses to clobber an even newer write that claimed the path since, in
+        // which case that newer record simply supersedes this one.
         try {
           await fsPromises.link(trash, filePath);
         } catch {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -17,6 +17,12 @@ import { stripAnsiControlChars } from "@/node/utils/ansi";
 export const BASH_MONITOR_WAKE_DIR = "bash-monitor-wakes";
 const MAX_WAKE_LINES = 50;
 const MAX_WAKE_LINE_BYTES = 8_192;
+// Terminal (delivered/superseded) wake files are pruned once they are older than this.
+// Without pruning the directory grows forever and every listPending — invoked per
+// background-bash UI snapshot — pays a stat for each historical file. The retention
+// window must comfortably exceed the only post-terminal read: restorePendingSnapshots
+// re-checks records superseded seconds earlier within one history-clear operation.
+export const TERMINAL_WAKE_RETENTION_MS = 60 * 60 * 1000;
 
 // Single-source the wake status enum so the exported TS type and the runtime
 // Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
@@ -514,9 +520,11 @@ export class BashMonitorWakeStore {
   // a torn in-progress write can never persist as the final content of a file.
   // `pending` caches the parsed record for pending files (few, bounded) so unchanged
   // pending wakes need no re-read either; terminal/malformed files cache null.
+  // `prunable` marks parsed terminal records (never malformed files, which are kept as
+  // evidence) so old ones can be deleted without re-reading their contents.
   private readonly classifiedFilesByOwner = new Map<
     string,
-    Map<string, { sig: string; pending: BashMonitorWakeRecord | null }>
+    Map<string, { sig: string; pending: BashMonitorWakeRecord | null; prunable: boolean }>
   >();
 
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
@@ -766,6 +774,7 @@ export class BashMonitorWakeStore {
     }
     const records: BashMonitorWakeRecord[] = [];
     const seen = new Set<string>();
+    const pruneBeforeMs = Date.now() - TERMINAL_WAKE_RETENTION_MS;
     for (const entry of entries) {
       if (!entry.endsWith(".json")) continue;
       seen.add(entry);
@@ -782,7 +791,14 @@ export class BashMonitorWakeStore {
       const sig = `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
       const cached = classified.get(entry);
       if (cached?.sig === sig) {
-        if (cached.pending != null) records.push(cached.pending);
+        if (cached.pending != null) {
+          records.push(cached.pending);
+        } else if (cached.prunable && stat.mtimeMs < pruneBeforeMs) {
+          // Old terminal record: delete it so the directory (and this scan) stays bounded.
+          // Best-effort; concurrent transitions re-check current status themselves.
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          classified.delete(entry);
+        }
         continue;
       }
       const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
@@ -793,7 +809,13 @@ export class BashMonitorWakeStore {
       }
       const parsed = this.parse(raw);
       const pending = parsed?.status === "pending" ? parsed : null;
-      classified.set(entry, { sig, pending });
+      const prunable = parsed != null && parsed.status !== "pending";
+      if (prunable && stat.mtimeMs < pruneBeforeMs) {
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        classified.delete(entry);
+        continue;
+      }
+      classified.set(entry, { sig, pending, prunable });
       if (pending != null) records.push(pending);
     }
     // Forget cache entries whose files vanished so the map cannot grow past the directory.

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -776,17 +776,39 @@ export class BashMonitorWakeStore {
     const seen = new Set<string>();
     const pruneBeforeMs = Date.now() - TERMINAL_WAKE_RETENTION_MS;
     for (const entry of entries) {
-      if (!entry.endsWith(".json")) continue;
-      seen.add(entry);
       const filePath = path.join(dir, entry);
+      if (!entry.endsWith(".json")) {
+        // write()/pruning leave *.json.tmp-* / *.json.prune-* files behind only when the
+        // process crashed mid-operation; sweep old ones so crash leaks stay bounded.
+        if (/\.json\.(?:tmp|prune)-/.test(entry)) {
+          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+          if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
+            await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          }
+        }
+        continue;
+      }
+      seen.add(entry);
       let stat: Stats;
       try {
         stat = await fsPromises.stat(filePath);
-      } catch {
-        // Deleted between readdir and stat (or transiently unreadable): drop the cache
-        // entry so the next call reclassifies from scratch.
-        classified.delete(entry);
-        continue;
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) {
+          // Deleted between readdir and stat: legitimately gone.
+          classified.delete(entry);
+          continue;
+        }
+        // Transient stat failure. Returning a partial result would look authoritative to
+        // callers (listBackgroundProcesses caches it as the last good pending set),
+        // silently dropping a durable pending wake. Serve the cached pending
+        // classification when we have one; otherwise propagate so the caller keeps its
+        // previous snapshot instead.
+        const cachedOnError = classified.get(entry);
+        if (cachedOnError != null) {
+          if (cachedOnError.pending != null) records.push(cachedOnError.pending);
+          continue;
+        }
+        throw error;
       }
       const sig = `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
       const cached = classified.get(entry);
@@ -794,25 +816,38 @@ export class BashMonitorWakeStore {
         if (cached.pending != null) {
           records.push(cached.pending);
         } else if (cached.prunable && stat.mtimeMs < pruneBeforeMs) {
-          // Old terminal record: delete it so the directory (and this scan) stays bounded.
-          // Best-effort; concurrent transitions re-check current status themselves.
-          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          // Old terminal record: delete it so the directory (and this scan) stays
+          // bounded. Deletion re-verifies the captured inode (see the helper) because a
+          // concurrent writer may have renamed a new pending wake over this path.
+          const rescued = await this.pruneTerminalWakeFile(ownerWorkspaceId, entry, filePath);
           classified.delete(entry);
+          if (rescued != null) records.push(rescued);
         }
         continue;
       }
-      const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
-      if (raw == null) {
-        // Transient read failure: leave unclassified so the next call retries.
-        classified.delete(entry);
-        continue;
+      let raw: string;
+      try {
+        raw = await fsPromises.readFile(filePath, "utf-8");
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) {
+          classified.delete(entry);
+          continue;
+        }
+        // Same policy as the stat failure above: never let a transient error silently
+        // reclassify a pending wake out of the returned set.
+        if (cached != null) {
+          if (cached.pending != null) records.push(cached.pending);
+          continue;
+        }
+        throw error;
       }
       const parsed = this.parse(raw);
       const pending = parsed?.status === "pending" ? parsed : null;
       const prunable = parsed != null && parsed.status !== "pending";
       if (prunable && stat.mtimeMs < pruneBeforeMs) {
-        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        const rescued = await this.pruneTerminalWakeFile(ownerWorkspaceId, entry, filePath);
         classified.delete(entry);
+        if (rescued != null) records.push(rescued);
         continue;
       }
       classified.set(entry, { sig, pending, prunable });
@@ -824,6 +859,55 @@ export class BashMonitorWakeStore {
     }
     records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
     return records;
+  }
+
+  /**
+   * Delete a terminal wake file that is past its retention window. The prune decision is
+   * check-then-act against an earlier stat/read, and wake ids are reused process ids, so
+   * a concurrent writer (another store instance, or an enqueue in this process) may have
+   * renamed a NEW pending wake over the path in between — a plain rm-by-path would unlink
+   * that record and its synthetic turn would never deliver. Instead, atomically capture
+   * whatever inode currently owns the path under a unique trash name, verify it, and
+   * restore anything that is not a positively verified terminal record. Returns the
+   * rescued pending record when the capture raced a rewrite so the in-flight listing can
+   * still include it. The per-record lock serializes against same-process writers.
+   */
+  private async pruneTerminalWakeFile(
+    ownerWorkspaceId: string,
+    entry: string,
+    filePath: string
+  ): Promise<BashMonitorWakeRecord | null> {
+    const stem = entry.slice(0, -".json".length);
+    // Filenames are encodeURIComponent(id); fall back to the raw stem for foreign files
+    // that do not round-trip (no writer contends on those ids anyway).
+    let id = stem;
+    try {
+      id = decodeURIComponent(stem);
+    } catch {
+      // keep the raw stem
+    }
+    return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+      const trash = `${filePath}.prune-${randomUUID()}`;
+      try {
+        await fsPromises.rename(filePath, trash);
+      } catch {
+        return null; // already gone (concurrent prune or external cleanup)
+      }
+      const raw = await fsPromises.readFile(trash, "utf-8").catch(() => null);
+      const parsed = raw == null ? null : this.parse(raw);
+      if (parsed == null || parsed.status === "pending") {
+        // Not verifiably terminal (raced rewrite, or a read/parse hiccup just now):
+        // restore it. link() refuses to clobber an even newer write that claimed the
+        // path since, in which case that newer record simply supersedes this one.
+        try {
+          await fsPromises.link(trash, filePath);
+        } catch {
+          // EEXIST (or transient failure): leave whatever owns the path in place.
+        }
+      }
+      await fsPromises.rm(trash, { force: true }).catch(() => undefined);
+      return parsed?.status === "pending" ? parsed : null;
+    });
   }
 
   async listPendingOwnerWorkspaceIds(): Promise<string[]> {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -882,8 +882,36 @@ export class BashMonitorWakeStore {
     for (const entry of [...classified.keys()]) {
       if (!seen.has(entry)) classified.delete(entry);
     }
-    records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
-    return records;
+    // Dedupe by id keeping the newest updatedAt: recovering multiple stranded
+    // generations of one reused id in a single scan can surface the id twice (an older
+    // leftover restored first, then replaced by a newer one).
+    const newestById = new Map<string, BashMonitorWakeRecord>();
+    for (const record of records) {
+      const existing = newestById.get(record.id);
+      if (existing == null || Date.parse(record.updatedAt) >= Date.parse(existing.updatedAt)) {
+        newestById.set(record.id, record);
+      }
+    }
+    const deduped = [...newestById.values()];
+    deduped.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+    return deduped;
+  }
+
+  /**
+   * Read and parse the wake record at a path. Returns null when the file is missing
+   * (ENOENT) or its content is malformed; any other read failure PROPAGATES — callers
+   * publish these reads as authoritative pending state, and converting a transient
+   * error into "no record" would hide a durable wake from every retry path.
+   */
+  private async readRecordAt(filePath: string): Promise<BashMonitorWakeRecord | null> {
+    let raw: string;
+    try {
+      raw = await fsPromises.readFile(filePath, "utf-8");
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return null;
+      throw error;
+    }
+    return this.parse(raw);
   }
 
   /**
@@ -966,7 +994,26 @@ export class BashMonitorWakeStore {
           // a silent null would leave a stranded pending wake undelivered all session.
           throw error;
         }
-        // EEXIST: a newer record owns the original path and supersedes the stranded one.
+        // EEXIST: something owns the canonical path — but with multiple instances, two
+        // interrupted prune races can strand DISTINCT pending generations of the same
+        // reused id, and a previously restored older generation may be what occupies
+        // the path. Reconcile deterministically by updatedAt instead of assuming
+        // supersession: a strictly newer pending leftover atomically replaces the
+        // canonical record; otherwise the canonical record wins and the leftover is
+        // dropped below as superseded.
+        const canonical = await this.readRecordAt(originalPath);
+        if (canonical == null) {
+          // Vanished (or unparseable) between the failed link and this read: keep the
+          // leftover so a later scan retries with a settled canonical state.
+          return null;
+        }
+        if (
+          parsed.status === "pending" &&
+          Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)
+        ) {
+          await fsPromises.rename(filePath, originalPath);
+          return parsed;
+        }
       }
       await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
       return restored && parsed.status === "pending" ? parsed : null;
@@ -1009,9 +1056,9 @@ export class BashMonitorWakeStore {
       } catch (error) {
         if (isErrnoWithCode(error, "ENOENT")) {
           // A concurrent recoverStrandedPruneFile consumed the trash (restored or swept
-          // it). Publish the canonical path's current state, mirroring the EEXIST branch.
-          const currentRaw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
-          const current = currentRaw == null ? null : this.parse(currentRaw);
+          // it). Publish the canonical path's current state, mirroring the EEXIST
+          // branch; readRecordAt propagates transient failures into caller retries.
+          const current = await this.readRecordAt(filePath);
           return current?.status === "pending" ? current : null;
         }
         // Cannot verify the captured inode — it may be a concurrently rewritten pending
@@ -1062,10 +1109,11 @@ export class BashMonitorWakeStore {
           // EEXIST: a newer record owns the canonical path and supersedes this capture.
           // Publish the canonical record's CURRENT pending state, never the discarded
           // capture — the newer write may carry newer output or even have canceled the
-          // wake, and a drain must not deliver durably-retired content.
+          // wake, and a drain must not deliver durably-retired content. readRecordAt
+          // propagates transient reread failures into caller retries rather than
+          // reporting a successful scan without the newer pending wake.
           await fsPromises.rm(trash, { force: true }).catch(() => undefined);
-          const currentRaw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
-          const current = currentRaw == null ? null : this.parse(currentRaw);
+          const current = await this.readRecordAt(filePath);
           return current?.status === "pending" ? current : null;
         }
       }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1141,13 +1141,19 @@ export class BashMonitorWakeStore {
    * previous clear's cutoff when one exists, otherwise remove the file. A current
    * generation owned by a DIFFERENT clear (another instance committed a newer one) is
    * left untouched — demoting it would revive wakes that clear legitimately retired.
+   * Returns whether the pinned demotion durably landed: false means the standing
+   * generation declined it (foreign, refreshed, or committed) or the CAS lost its
+   * no-clobber race — callers restoring records on the crashed-staging path must
+   * treat that as "the clear is not rolled back" (see rollbackCrashedClearStaging).
    */
   private async rollbackClearTombstone(
     ownerWorkspaceId: string,
     clearId: string,
     onlyIfStagedAt?: string
-  ): Promise<void> {
-    await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+  ): Promise<boolean> {
+    let demoted = false;
+    const applied = await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+      demoted = false;
       if (current?.clearId !== clearId) return "keep";
       // Crash-rollback callers pin the exact staging generation they judged crashed:
       // between their read and this CAS, the owning instance may have refreshed
@@ -1161,6 +1167,7 @@ export class BashMonitorWakeStore {
       ) {
         return "keep";
       }
+      demoted = true;
       if (current.previousClearedAt != null) {
         // Demoted values carry no staging state: the previous clear committed long
         // ago (a clear only becomes "previous" after committing).
@@ -1168,6 +1175,7 @@ export class BashMonitorWakeStore {
       }
       return null;
     });
+    return applied && demoted;
   }
 
   /**
@@ -1182,23 +1190,35 @@ export class BashMonitorWakeStore {
    * before commitClear) resurrects those wakes into the cleared transcript — a
    * duplicate delivery, accepted as strictly better than silently losing wakes for a
    * transcript that was never cleared.
+   *
+   * Returns the canonical entry names left PENDING by this rollback so the calling
+   * scan can serve them: a record restored from an artifact rescued in the same scan
+   * (e.g. a stamped generation stranded in prune trash) has no canonical entry in the
+   * caller's readdir snapshot and would otherwise wait for the next scan.
    */
-  private async rollbackCrashedClearStaging(ownerWorkspaceId: string): Promise<void> {
+  private async rollbackCrashedClearStaging(ownerWorkspaceId: string): Promise<string[]> {
     const tomb = await this.readClearedAt(ownerWorkspaceId);
-    if (tomb?.phase !== "staged" || tomb.clearId == null) return;
-    if (this.activeClearIds.has(tomb.clearId)) return; // in flight, not crashed
+    if (tomb?.phase !== "staged" || tomb.clearId == null) return [];
+    if (this.activeClearIds.has(tomb.clearId)) return []; // in flight, not crashed
     const stagedAtMs = tomb.stagedAt != null ? Date.parse(tomb.stagedAt) : NaN;
-    if (Number.isNaN(stagedAtMs)) return; // unreadable staging age: leave it held
-    if (stagedAtMs > Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS) return;
+    if (Number.isNaN(stagedAtMs)) return []; // unreadable staging age: leave it held
+    if (stagedAtMs > Date.now() - STAGED_CLEAR_ROLLBACK_GRACE_MS) return [];
     const clearId = tomb.clearId;
     const dir = this.dir(ownerWorkspaceId);
     let entries: string[];
     try {
       entries = await fsPromises.readdir(dir);
     } catch (error) {
-      if (isErrnoWithCode(error, "ENOENT")) return;
+      if (isErrnoWithCode(error, "ENOENT")) return [];
       throw error;
     }
+    const restored: Array<{
+      entry: string;
+      id: string;
+      filePath: string;
+      original: BashMonitorWakeRecord;
+      written: BashMonitorWakeRecord;
+    }> = [];
     for (const entry of entries) {
       if (!entry.endsWith(".json")) continue;
       const id = BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length));
@@ -1207,18 +1227,40 @@ export class BashMonitorWakeStore {
         const record = await this.readRecordAt(filePath);
         if (record?.status !== "superseded" || record.supersededByClearId !== clearId) return;
         const { supersededByClearId: _clearStamp, pendingUpdatedAtBeforeClear, ...rest } = record;
-        await this.write({
+        const written: BashMonitorWakeRecord = {
           ...rest,
           status: "pending",
           // The pre-clear updatedAt survives the round trip: snapshot keys and
           // acceptance logic key on it.
           updatedAt: pendingUpdatedAtBeforeClear ?? record.updatedAt,
-        });
+        };
+        await this.write(written);
+        restored.push({ entry, id, filePath, original: record, written });
       });
     }
     // Pinned to the staging generation read above: only the exact stagedAt judged
     // crashed may be demoted (see rollbackClearTombstone).
-    await this.rollbackClearTombstone(ownerWorkspaceId, clearId, tomb.stagedAt);
+    if (await this.rollbackClearTombstone(ownerWorkspaceId, clearId, tomb.stagedAt)) {
+      return restored.map((r) => r.entry);
+    }
+    // The pinned CAS DECLINED: between the tombstone read above and this
+    // authorization, the owning instance (resumed from a long stall) refreshed the
+    // staging (live, not crashed) or committed it (retirement final) — restoring its
+    // stamped records above was premature. Left pending, a record whose pre-clear
+    // updatedAt equals the cutoff would pass the strict pre-cutoff fence and deliver
+    // during a live clear or into an already-cleared transcript. Re-supersede exactly
+    // the generations restored above; a record that changed since (a live monitor
+    // merged new output) stays pending — mid-clear output must survive, and its
+    // pre-cutoff lines redelivering is the documented lesser failure.
+    for (const r of restored) {
+      await this.locks.withLock(`${ownerWorkspaceId}:${r.id}`, async () => {
+        const current = await this.readRecordAt(r.filePath);
+        if (current == null) return;
+        if (JSON.stringify(current) !== JSON.stringify(r.written)) return;
+        await this.write(r.original);
+      });
+    }
+    return [];
   }
 
   static wakeId(processId: string): string {
@@ -1459,17 +1501,6 @@ export class BashMonitorWakeStore {
       classified = new Map();
       this.classifiedFilesByOwner.set(ownerWorkspaceId, classified);
     }
-    // A staged clear tombstone abandoned past its grace window is a CRASHED clear
-    // staging (see rollbackCrashedClearStaging); resolve it before anything below
-    // consults the tombstone or the stamped records. The entries check keeps this off
-    // the hot path — tombstone artifacts exist only around clears and crashes. The
-    // effective tombstone is then read (post-rollback) for the pre-cutoff canonical
-    // check at the end of this scan.
-    let tomb: ClearTombstone | null = null;
-    if (entries.some((e) => e === "cleared-at" || e.startsWith("cleared-at.cas-"))) {
-      await this.rollbackCrashedClearStaging(ownerWorkspaceId);
-      tomb = await this.readClearedAt(ownerWorkspaceId);
-    }
     const records: BashMonitorWakeRecord[] = [];
     const seen = new Set<string>();
     const pruneBeforeMs = Date.now() - TERMINAL_WAKE_RETENTION_MS;
@@ -1536,6 +1567,28 @@ export class BashMonitorWakeStore {
     // generation is what gets served.
     for (const entry of recoveredEntries) {
       if (!recordEntries.includes(entry)) recordEntries.push(entry);
+    }
+    // A staged clear tombstone abandoned past its grace window is a CRASHED clear
+    // staging (see rollbackCrashedClearStaging); resolve it AFTER the artifact rescue
+    // above — a crash inside supersedeForClear's write (or an interrupted prune) can
+    // leave the only clear-stamped generation in a *.tmp-*/*.prune-* artifact, and
+    // the rollback restores canonical .json files only. Rolling back first would
+    // demote the tombstone while the stamped generation is still stranded; the rescue
+    // would then commit it as plain terminal content with no tombstone left to flip
+    // it back — a wake permanently lost for a history clear that never completed.
+    // (While the stale staging still stands, the rescue HOLDS pre-cutoff artifacts
+    // instead of consuming them — a bounded deferral, never a loss.) Records the
+    // rollback leaves pending are folded into the record pass: one restored from an
+    // artifact rescued this very scan has no canonical entry in the readdir snapshot
+    // above. The entries check keeps this off the hot path — tombstone artifacts
+    // exist only around clears and crashes. The effective tombstone is then read
+    // (post-rollback) for the pre-cutoff canonical check at the end of this scan.
+    let tomb: ClearTombstone | null = null;
+    if (entries.some((e) => e === "cleared-at" || e.startsWith("cleared-at.cas-"))) {
+      for (const entry of await this.rollbackCrashedClearStaging(ownerWorkspaceId)) {
+        if (!recordEntries.includes(entry)) recordEntries.push(entry);
+      }
+      tomb = await this.readClearedAt(ownerWorkspaceId);
     }
     for (const entry of recordEntries) {
       const filePath = path.join(dir, entry);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -32,9 +32,12 @@ export const TERMINAL_WAKE_RETENTION_MS = 60 * 60 * 1000;
 const PRUNE_TRASH_SUFFIX_RE = /\.json\.prune-[^.]+$/;
 const TMP_WRITE_SUFFIX_RE = /\.json\.tmp-[^.]+$/;
 // A temp file younger than this may belong to a LIVE write (writeFile done, commit
-// rename imminent in another process); recovery must not race that rename by consuming
-// the temp. Anything older is an orphan from a crash.
-const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
+// rename imminent in another process); recovery must neither consume the temp nor
+// place it at the canonical path — placement would make a FAILED write durable (the
+// writer deletes only its temp name and reports the failure, while the placed link
+// silently commits the very operation the caller was told never happened). Anything
+// older is an orphan from a crash. Exported for tests.
+export const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
 
 // Single-source the wake status enum so the exported TS type and the runtime
 // Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
@@ -539,7 +542,36 @@ export class BashMonitorWakeStore {
     Map<string, { sig: string; pending: BashMonitorWakeRecord | null; prunable: boolean }>
   >();
 
+  /**
+   * Invoked when a COMPLETE fresh temp file was deferred by the live-writer freshness
+   * gate (see recoverOrphanTempFile). That deferral can otherwise be terminal: startup
+   * owner discovery runs once, sees nothing pending, and schedules no drain — so a
+   * crash-orphaned wake would stay invisible for the whole session. WorkspaceService
+   * points this at its delivery scheduler so a scan re-runs once the gate has elapsed.
+   */
+  onDeferredTempRecoveryDue: ((ownerWorkspaceId: string) => void) | null = null;
+  // One unref'd timer per deferred temp path, fired just past the freshness gate.
+  private readonly deferredTempRecoveryTimers = new Map<string, NodeJS.Timeout>();
+
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
+
+  private scheduleDeferredTempRecovery(
+    ownerWorkspaceId: string,
+    filePath: string,
+    mtimeMs: number
+  ): void {
+    if (this.deferredTempRecoveryTimers.has(filePath)) return;
+    // Epsilon past the gate so the re-driven scan's own freshness check cannot lose a
+    // same-millisecond race against the gate arithmetic.
+    const delayMs = Math.max(0, mtimeMs + TEMP_RECOVERY_MIN_AGE_MS - Date.now()) + 250;
+    const timer = setTimeout(() => {
+      this.deferredTempRecoveryTimers.delete(filePath);
+      this.onDeferredTempRecoveryDue?.(ownerWorkspaceId);
+    }, delayMs);
+    // Never hold process shutdown open for a recovery re-drive.
+    timer.unref();
+    this.deferredTempRecoveryTimers.set(filePath, timer);
+  }
 
   private dir(ownerWorkspaceId: string): string {
     assert(ownerWorkspaceId.trim().length > 0, "BashMonitorWakeStore requires ownerWorkspaceId");
@@ -963,12 +995,70 @@ export class BashMonitorWakeStore {
   }
 
   /**
-   * Move a malformed canonical file aside as evidence. The suffix matches neither
-   * record nor trash/temp patterns, so quarantined files are never re-parsed or swept —
-   * the same keep-as-evidence policy applied to malformed files elsewhere.
+   * Move a malformed canonical file aside as evidence — but only after re-verifying
+   * that the generation being moved IS the malformed one. The caller's classification
+   * is check-then-act: between its read and this rename, another instance can
+   * atomically replace the malformed file with a valid newer wake, and blindly
+   * renaming would move live wake state to a suffix scans intentionally ignore
+   * (permanently losing or resurrecting it). So: atomically capture the path's current
+   * inode under the standard prune-trash name (a crash mid-swap then heals via
+   * recoverStrandedPruneFile), verify it is still malformed, and only then park it
+   * under the .malformed- evidence suffix, which is never re-parsed or swept.
+   *
+   * Returns "cleared" when the canonical path is now free for the caller to place a
+   * record at, or "occupied" with the path's current record when a valid generation
+   * was found (restored fail-safe) — the caller must back off and treat that record
+   * as authoritative. Caller must hold the per-record lock.
    */
-  private async quarantineMalformedCanonical(originalPath: string): Promise<void> {
-    await fsPromises.rename(originalPath, `${originalPath}.malformed-${randomUUID()}`);
+  private async quarantineMalformedCanonical(
+    originalPath: string
+  ): Promise<{ kind: "cleared" } | { kind: "occupied"; record: BashMonitorWakeRecord | null }> {
+    const capture = `${originalPath}.prune-${randomUUID()}`;
+    try {
+      await fsPromises.rename(originalPath, capture);
+    } catch (error) {
+      // Vanished: a concurrent recover/prune consumed it, so the path is free. Any
+      // other failure propagates into caller retries.
+      if (isErrnoWithCode(error, "ENOENT")) return { kind: "cleared" };
+      throw error;
+    }
+    let captured: BashMonitorWakeRecord | null;
+    try {
+      captured = await this.readRecordAt(capture);
+    } catch (error) {
+      // Cannot verify what we captured: put it back (no-clobber) and propagate. A
+      // failed restore keeps the capture healing as ordinary prune trash.
+      try {
+        await fsPromises.link(capture, originalPath);
+        await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+      } catch {
+        // A newer write claimed the path; the capture heals as prune trash later.
+      }
+      throw error;
+    }
+    if (captured == null) {
+      // Verified malformed: park it as evidence. A failed rename leaves it as prune
+      // trash, where the age-gated sweep eventually removes it.
+      await fsPromises
+        .rename(capture, `${originalPath}.malformed-${randomUUID()}`)
+        .catch(() => undefined);
+      return { kind: "cleared" };
+    }
+    // A valid record replaced the malformed generation between the caller's
+    // classification and our capture: restore it (link never clobbers an even newer
+    // write, which then supersedes the capture).
+    try {
+      await fsPromises.link(capture, originalPath);
+    } catch (error) {
+      if (!isErrnoWithCode(error, "EEXIST")) {
+        // The capture may be the only durable copy; keep it (heals as prune trash)
+        // and propagate so caller retries engage.
+        throw error;
+      }
+    }
+    await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+    // Publish the path's CURRENT state (an even newer write may have claimed it).
+    return { kind: "occupied", record: await this.readRecordAt(originalPath) };
   }
 
   /**
@@ -1073,12 +1163,23 @@ export class BashMonitorWakeStore {
             // wait for the age-gated sweep.
             return null;
           }
-          await this.quarantineMalformedCanonical(originalPath);
+          const quarantined = await this.quarantineMalformedCanonical(originalPath);
+          if (quarantined.kind === "occupied") {
+            // A valid record regenerated over the malformed one mid-quarantine: it is
+            // authoritative; the leftover stays for re-reconciliation against it.
+            return quarantined.record?.status === "pending" ? quarantined.record : null;
+          }
           try {
             await fsPromises.link(filePath, originalPath);
-          } catch {
-            // Someone claimed the path mid-quarantine; re-reconcile next scan.
-            return null;
+          } catch (error) {
+            if (!isErrnoWithCode(error, "EEXIST")) {
+              // Transient placement failure: the leftover (kept) still holds an
+              // unrestored pending record, so propagate into caller retries.
+              throw error;
+            }
+            // EEXIST: someone claimed the path mid-quarantine; publish ITS state.
+            const current = await this.readRecordAt(originalPath);
+            return current?.status === "pending" ? current : null;
           }
           await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
           return parsed;
@@ -1108,9 +1209,10 @@ export class BashMonitorWakeStore {
    * in the temp file — for a brand-new wake there is no canonical file at all, so
    * treating the temp as disposable would lose the matched output permanently and
    * startup discovery would never schedule delivery. Fresh temps are left untouched
-   * (they may belong to a live writer about to commit); orphaned ones are restored when
-   * no same-or-newer canonical record exists, and stale or incomplete ones sweep once
-   * past retention. Returns the record now visible at the canonical path when pending.
+   * (they may belong to a live writer about to commit) with a timed re-drive armed;
+   * orphaned ones are restored when no same-or-newer canonical record exists, and
+   * stale or incomplete ones sweep once past retention. Returns the record now visible
+   * at the canonical path when pending.
    */
   private async recoverOrphanTempFile(
     ownerWorkspaceId: string,
@@ -1126,9 +1228,6 @@ export class BashMonitorWakeStore {
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
       const stat = await fsPromises.stat(filePath).catch(() => null);
       if (!stat?.isFile()) return null; // vanished (live writer committed) or non-regular
-      // Consuming (deleting) a fresh temp could break a LIVE writer whose commit rename
-      // is imminent; deletion therefore waits for this gate. Placement via link is safe
-      // at any age (see below), so freshness never delays making a wake visible.
       const consumable = stat.mtimeMs < Date.now() - TEMP_RECOVERY_MIN_AGE_MS;
       const old = stat.mtimeMs < pruneBeforeMs;
       const parsed = await this.readRecordAt(filePath);
@@ -1138,37 +1237,55 @@ export class BashMonitorWakeStore {
         if (old) await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
         return null;
       }
+      if (!consumable) {
+        // A COMPLETE fresh temp may still belong to a LIVE writer between writeFile
+        // and its commit rename. Touching it now — even a hard link at the canonical
+        // path — would make a FAILED write durable: the writer deletes only its temp
+        // name and reports the failure, while the placed link silently commits the
+        // very operation the caller was told never happened (e.g. a rejected
+        // supersedeAllPending canceling a wake behind a history clear's rollback).
+        // Defer — but arm a timed re-drive, because this deferral may otherwise be
+        // terminal: startup discovery sees nothing pending and schedules no drain,
+        // leaving a crash-orphaned wake invisible for the whole session.
+        this.scheduleDeferredTempRecovery(ownerWorkspaceId, filePath, stat.mtimeMs);
+        return null;
+      }
       const canonicalState = await this.readCanonicalState(originalPath);
       if (canonicalState.kind !== "record") {
-        // The complete temp record may be the ONLY durable copy of this wake, and a
-        // restart within the freshness gate would otherwise leave it invisible with no
-        // re-drive (startup discovery succeeds empty and schedules nothing). Placing
-        // the SAME inode at the canonical path is exactly what the crashed commit
-        // rename would have done — and if the writer is alive after all, its rename of
-        // this inode onto the path becomes a harmless POSIX no-op. Fresh temp files are
-        // left in place for that possible live writer; consumable orphans are removed
-        // after placement. A malformed canonical is quarantined first (as evidence),
-        // or a valid pending temp would be blocked forever.
+        // The complete temp record may be the ONLY durable copy of this wake (a
+        // brand-new wake has no canonical file at all): place the SAME inode at the
+        // canonical path — exactly what the crashed commit rename would have done. A
+        // malformed canonical is quarantined first (as evidence), or a valid pending
+        // temp would be blocked forever.
         if (canonicalState.kind === "malformed") {
           if (parsed.status !== "pending") return null; // evidence outranks stale terminals
-          await this.quarantineMalformedCanonical(originalPath);
+          const quarantined = await this.quarantineMalformedCanonical(originalPath);
+          if (quarantined.kind === "occupied") {
+            // A valid record regenerated over the malformed one mid-quarantine: it is
+            // authoritative; the temp stays for re-reconciliation against it.
+            return quarantined.record?.status === "pending" ? quarantined.record : null;
+          }
         }
         try {
           await fsPromises.link(filePath, originalPath);
-        } catch {
-          return null; // claimed concurrently; re-reconcile next scan
+        } catch (error) {
+          if (!isErrnoWithCode(error, "EEXIST")) {
+            // Transient placement failure (EIO, ENOSPC, unsupported links): the temp
+            // may hold the ONLY durable copy of this wake. Keep it and PROPAGATE so
+            // caller retries and fail-open owner discovery engage — a silent null is
+            // a successful empty scan that schedules no drain and no retry, stranding
+            // the wake for the session.
+            throw error;
+          }
+          // EEXIST: a concurrent writer claimed the path; publish ITS current state,
+          // never the superseded temp.
+          const current = await this.readRecordAt(originalPath);
+          return current?.status === "pending" ? current : null;
         }
-        if (consumable) {
-          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-        }
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
         return parsed.status === "pending" ? parsed : null;
       }
       const canonical = canonicalState.record;
-      if (!consumable) {
-        // Canonical record present and the temp may belong to a live in-flight write:
-        // the canonical record is authoritative until the temp ages past the gate.
-        return null;
-      }
       if (
         parsed.kind === "match" &&
         parsed.status === "pending" &&
@@ -1195,9 +1312,28 @@ export class BashMonitorWakeStore {
                 ...parsed,
                 updatedAt: new Date().toISOString(),
               };
-        await this.write(merged);
+        // Commit through the CAS, never a blind write: between reading `canonical`
+        // above and this commit, another instance can replace or supersede the record
+        // (new output, or a deliberate cancel), and overwriting that generation would
+        // lose it or resurrect a canceled wake. The merged draft is written to its own
+        // temp first so the CAS places a durable inode; a crash mid-commit then heals
+        // through this very recovery path (the draft postdates the canonical record).
+        const mergedTemp = `${originalPath}.tmp-${randomUUID()}`;
+        await fsPromises.writeFile(mergedTemp, JSON.stringify(merged, null, 2), "utf-8");
+        const committed = await this.replaceCanonicalIfUnchanged(
+          mergedTemp,
+          originalPath,
+          merged,
+          canonical
+        );
+        if (committed == null) {
+          // The canonical record changed under the merge: the draft is stale. Discard
+          // it and keep the original match temp for re-reconciliation next scan.
+          await fsPromises.rm(mergedTemp, { force: true }).catch(() => undefined);
+          return null;
+        }
         await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-        return merged;
+        return committed.status === "pending" ? committed : null;
       }
       if (Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)) {
         // The crashed write postdates the canonical record (an uncommitted merge or

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -293,6 +293,21 @@ function relabelStaleSettleLine(line: string): string {
   return `[monitor] an earlier run of this process ID settled:${line.slice(BASH_MONITOR_SETTLE_LINE_PREFIX.length)}; the ID has since been re-armed by a new process`;
 }
 
+/** True when `needle` appears as one contiguous run inside `haystack` (or is empty). */
+function containsContiguousSubsequence(
+  haystack: readonly string[],
+  needle: readonly string[]
+): boolean {
+  if (needle.length === 0) return true;
+  outer: for (let start = 0; start + needle.length <= haystack.length; start++) {
+    for (let index = 0; index < needle.length; index++) {
+      if (haystack[start + index] !== needle[index]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}
+
 function removeDeliveredLineOverlap(
   currentLines: readonly string[],
   deliveredLines: readonly string[]
@@ -1099,6 +1114,68 @@ export class BashMonitorWakeStore {
   }
 
   /**
+   * Whether the canonical record already carries everything `other` offers, so `other`
+   * can be discarded without losing output. Within one process instance (equal
+   * createdAt — the instance token, see matchedThroughOffset) the offsets are
+   * comparable and only grow. Across instances (or with legacy records missing
+   * offsets), only a visible contiguous copy of the other record's lines proves
+   * subsumption; line caps can defeat that check, in which case the failure mode is a
+   * rare duplicated merge — never lost output.
+   */
+  private static pendingSubsumes(
+    canonical: BashMonitorWakeRecord,
+    other: BashMonitorWakeRecord
+  ): boolean {
+    if (
+      canonical.createdAt === other.createdAt &&
+      canonical.matchedThroughOffset != null &&
+      other.matchedThroughOffset != null &&
+      canonical.matchedThroughOffset >= other.matchedThroughOffset
+    ) {
+      return true;
+    }
+    return containsContiguousSubsequence(canonical.lines, other.lines);
+  }
+
+  /**
+   * Merge two DIVERGENT pending generations of one wake id. With multiple store
+   * instances, a prune can capture pending generation A while the canonical path is
+   * briefly absent, letting another instance's enqueue write generation B from
+   * scratch — B never saw A, so neither timestamp order proves subsumption and
+   * newest-wins would permanently lose the other generation's matched output. Older
+   * lines come first (delivery reads top-down); counters are summed; a lost-monitor
+   * notice outranks a match so the termination context and relaunch script survive
+   * the merge. Offsets are only comparable within one process instance, so a
+   * divergent same-instance split takes the max frontier while cross-instance merges
+   * keep the newer record's own frontier.
+   */
+  private static mergeDivergentPending(
+    a: BashMonitorWakeRecord,
+    b: BashMonitorWakeRecord
+  ): BashMonitorWakeRecord {
+    const [older, newer] = Date.parse(a.updatedAt) <= Date.parse(b.updatedAt) ? [a, b] : [b, a];
+    const bounded = boundLines([...older.lines, ...newer.lines]);
+    const merged: BashMonitorWakeRecord = {
+      ...newer,
+      lines: bounded.lines,
+      totalMatches: older.totalMatches + newer.totalMatches,
+      droppedLines: older.droppedLines + newer.droppedLines + bounded.droppedLines,
+      updatedAt: new Date().toISOString(),
+    };
+    if (older.kind === "monitor-lost" && newer.kind !== "monitor-lost") {
+      merged.kind = "monitor-lost";
+      if (merged.script == null && older.script != null) merged.script = older.script;
+    }
+    if (older.createdAt === newer.createdAt) {
+      merged.matchedThroughOffset = Math.max(
+        older.matchedThroughOffset ?? 0,
+        newer.matchedThroughOffset ?? 0
+      );
+    }
+    return merged;
+  }
+
+  /**
    * Handle a *.json.prune-* leftover. pruneTerminalWakeFile renames the path's current
    * inode aside before verifying it; a crash in that window strands the captured inode
    * under the trash name, where neither scans nor delivery (both address the original
@@ -1209,17 +1286,60 @@ export class BashMonitorWakeStore {
           return parsed;
         }
         const canonical = canonicalState.record;
+        if (parsed.status === "pending" && canonical.status === "pending") {
+          // DIVERGENT pending generations: the canonical record may have been written
+          // from scratch while a prune held this generation captured, so a newer
+          // timestamp is NOT proof it merged (or even saw) the captured output.
+          if (BashMonitorWakeStore.pendingSubsumes(canonical, parsed)) {
+            // rm(force) ignores ENOENT, so any failure here is real — PROPAGATE it:
+            // a silently surviving leftover could be restored as the only durable
+            // copy after the canonical record is later pruned or superseded.
+            await fsPromises.rm(filePath, { force: true });
+            return canonical;
+          }
+          if (parsed.kind === "monitor-lost" && canonical.kind === "match") {
+            // A fresh match proves this id was re-armed by a LIVE monitor, so the
+            // captured lost notice is stale (mirrors enqueueOrMergePending's rule of
+            // replacing stale notices rather than mislabeling live output).
+            await fsPromises.rm(filePath, { force: true });
+            return canonical;
+          }
+          const merged = BashMonitorWakeStore.mergeDivergentPending(parsed, canonical);
+          const mergedTemp = `${originalPath}.tmp-${randomUUID()}`;
+          await fsPromises.writeFile(mergedTemp, JSON.stringify(merged, null, 2), "utf-8");
+          const committed = await this.replaceCanonicalIfUnchanged(
+            mergedTemp,
+            originalPath,
+            merged,
+            canonical
+          );
+          if (committed == null) {
+            // The canonical record changed under the merge: discard the stale draft
+            // and keep the leftover for re-reconciliation next scan.
+            await fsPromises.rm(mergedTemp, { force: true }).catch(() => undefined);
+            return null;
+          }
+          // Consumed: the merged canonical now carries this generation's output. A
+          // failed removal PROPAGATES — the surviving leftover would merge again
+          // (duplicating lines) or resurrect after the canonical is retired.
+          await fsPromises.rm(filePath, { force: true });
+          return committed;
+        }
         if (
           parsed.status === "pending" &&
           Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)
         ) {
+          // Strictly newer pending leftover vs a TERMINAL canonical record: matches
+          // enqueued after delivery/supersession are legitimately new output.
           return this.replaceCanonicalIfUnchanged(filePath, originalPath, parsed, canonical);
         }
         // The canonical record wins: drop the superseded leftover and PUBLISH the
         // winner's pending state. Its file may postdate this scan's readdir snapshot
         // (created between our failed link and now), so returning null here could
-        // report a successful empty scan for a wake whose writer already exited.
-        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        // report a successful empty scan for a wake whose writer already exited. The
+        // removal PROPAGATES failures so the leftover can never outlive the canonical
+        // record and be restored as a resurrected copy.
+        await fsPromises.rm(filePath, { force: true });
         return canonical.status === "pending" ? canonical : null;
       }
       await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
@@ -1326,6 +1446,17 @@ export class BashMonitorWakeStore {
         canonical.kind === "monitor-lost" &&
         canonical.status !== "superseded"
       ) {
+        // REPLAY guard: a previous scan's merge of THIS temp may have committed while
+        // its cleanup below failed, leaving the source temp eligible for another
+        // merge. Once the merged canonical delivers, re-merging would mint a fresh
+        // pending wake for already-delivered output. A canonical that provably
+        // carries this temp's payload subsumes it: discard the temp instead. The
+        // removal PROPAGATES failures — a silently surviving temp would replay after
+        // the canonical is delivered and pruned.
+        if (BashMonitorWakeStore.pendingSubsumes(canonical, parsed)) {
+          await fsPromises.rm(filePath, { force: true });
+          return canonical.status === "pending" ? canonical : null;
+        }
         // A crash stranded matched output, and restart recovery already wrote the
         // monitor-lost notice for the same id BEFORE this temp was scanned — so the
         // notice always carries the later updatedAt and a plain comparison would
@@ -1387,7 +1518,11 @@ export class BashMonitorWakeStore {
       // ages past retention and is pruned, a later scan would see no canonical record
       // and restore this stale pending temp, redelivering a deliberately superseded
       // wake. The freshness gate already passed, so no live writer can still own it.
-      await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+      // A failed removal PROPAGATES (rm with force ignores ENOENT, so any error is
+      // real): aborting the scan here keeps the record pass from pruning the terminal
+      // canonical while the stale temp survives — the same resurrection, one fault
+      // later. The retry re-attempts both in artifact-first order.
+      await fsPromises.rm(filePath, { force: true });
       return null;
     });
   }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -831,6 +831,25 @@ export class BashMonitorWakeStore {
     for (const entry of entries) {
       if (!entry.startsWith(`${base}.cas-`)) continue;
       const leftoverPath = path.join(dir, entry);
+      // Non-regular guard (matching readClearedAt's canonical-path behavior): a
+      // directory here would fail every heal with EISDIR — and, with the canonical
+      // absent, every readClearedAt and listPending with it — while a FIFO would
+      // block forever. Quarantine the imposter under a name outside the .cas-
+      // namespace so scans stop tripping over it.
+      let leftoverStat: Stats;
+      try {
+        leftoverStat = await fsPromises.stat(leftoverPath);
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) continue; // concurrently consumed
+        throw error;
+      }
+      if (!leftoverStat.isFile()) {
+        log.debug("Quarantining non-regular bash monitor wake tombstone capture", {
+          ownerWorkspaceId,
+        });
+        await fsPromises.rename(leftoverPath, `${target}.malformed-${randomUUID()}`);
+        continue;
+      }
       let raw: string;
       try {
         raw = await fsPromises.readFile(leftoverPath, "utf-8");
@@ -2362,8 +2381,12 @@ export class BashMonitorWakeStore {
     const staged: BashMonitorWakeRecord[] = [];
     try {
       for (const record of pending) {
-        await this.supersedeForClear(ownerWorkspaceId, record.id, clearId);
-        staged.push(record);
+        // Snapshots list only what was ACTUALLY retired: a record that changed past
+        // the cutoff stays pending, and restoring it on rollback would be wrong (its
+        // restore would clobber the newer merged generation back to the snapshot).
+        if (await this.supersedeForClear(ownerWorkspaceId, record, clearId)) {
+          staged.push(record);
+        }
       }
       // Durable STAGED tombstone for wakes this clear could NOT see: a crash-orphaned
       // temp inside the freshness gate is invisible to the listPending above, and
@@ -2421,7 +2444,10 @@ export class BashMonitorWakeStore {
         );
       }
       this.armStagedClearRefresh(ownerWorkspaceId, clearId);
-      return { snapshots: pending, clearedAt, clearId };
+      // Snapshots are the records ACTUALLY retired (see the loop above) — a record
+      // that changed past the cutoff stayed pending and must not be reported as
+      // retired, restored on rollback, or counted by acceptance bookkeeping.
+      return { snapshots: staged, clearedAt, clearId };
     } catch (error) {
       // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
       // tombstone write above is the try block's last step, so on this path it was
@@ -2434,20 +2460,31 @@ export class BashMonitorWakeStore {
     }
   }
 
-  /** Supersede one pending record on behalf of a clear, stamping rollback metadata. */
+  /**
+   * Supersede one pending record on behalf of a clear, stamping rollback metadata.
+   * Returns whether the record was actually retired.
+   */
   private async supersedeForClear(
     ownerWorkspaceId: string,
-    id: string,
+    snapshot: BashMonitorWakeRecord,
     clearId: string
-  ): Promise<void> {
-    await this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
-      const record = await this.get(ownerWorkspaceId, id);
-      if (record?.status !== "pending") return;
+  ): Promise<boolean> {
+    return this.locks.withLock(`${ownerWorkspaceId}:${snapshot.id}`, async () => {
+      const record = await this.get(ownerWorkspaceId, snapshot.id);
+      if (record?.status !== "pending") return false;
+      // Only the SNAPSHOTTED generation is retired: another store instance can merge
+      // NEW matched output into this record between the clear's snapshot and this
+      // lock, and the clear's cutoff explicitly intends mid-clear output to survive.
+      // A changed generation stays pending — its pre-cutoff lines may then redeliver
+      // (the documented lesser failure) instead of the post-cutoff output being
+      // permanently discarded by a clear that never saw it.
+      if (record.updatedAt !== snapshot.updatedAt) return false;
       await this.write({
         ...this.withTerminalStatus(record, "superseded"),
         supersededByClearId: clearId,
         pendingUpdatedAtBeforeClear: record.updatedAt,
       });
+      return true;
     });
   }
 

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -854,12 +854,11 @@ export class BashMonitorWakeStore {
           classified.delete(entry);
           continue;
         }
-        // Same policy as the stat failure above: never let a transient error silently
-        // reclassify a pending wake out of the returned set.
-        if (cached != null) {
-          if (cached.pending != null) records.push(cached.pending);
-          continue;
-        }
+        // Unlike the stat failure above, reaching this read means the stat signature
+        // DIFFERED from the cached one — the cached classification is known stale (the
+        // file changed generations, e.g. another instance superseded a pending wake or
+        // re-enqueued over a terminal one). Serving it could deliver a canceled wake or
+        // hide a new one, so propagate and let caller retries re-read instead.
         throw error;
       }
       const parsed = this.parse(raw);
@@ -960,9 +959,12 @@ export class BashMonitorWakeStore {
         restored = true;
       } catch (error) {
         if (!isErrnoWithCode(error, "EEXIST")) {
-          // Transient link failure: keep the leftover so a later scan retries the
-          // restore instead of deleting a never-recovered record.
-          return null;
+          // Transient link failure: the leftover (kept — never deleted unrecovered)
+          // still holds an unrestored record, so PROPAGATE rather than let this scan
+          // look successfully empty. Startup owner discovery then fails open and
+          // schedules this owner's drain, and the UI read path schedules its retry;
+          // a silent null would leave a stranded pending wake undelivered all session.
+          throw error;
         }
         // EEXIST: a newer record owns the original path and supersedes the stranded one.
       }
@@ -1025,9 +1027,12 @@ export class BashMonitorWakeStore {
           if (!isErrnoWithCode(error, "EEXIST")) {
             // Hard-link failure (EIO, ENOSPC, unsupported filesystem): the trash file
             // is now the only durable copy of this record. Keep it — a later scan's
-            // recoverStrandedPruneFile retries the restore — instead of deleting it in
-            // the removal below.
-            return parsed?.status === "pending" ? parsed : null;
+            // recoverStrandedPruneFile retries the restore — and PROPAGATE so caller
+            // retries engage. Publishing the record instead would let a drain deliver
+            // it while its canonical path is absent: the delivered-transition would
+            // no-op against ENOENT and the still-pending trash copy would later be
+            // restored and delivered again.
+            throw error;
           }
           // EEXIST: a newer record owns the canonical path and supersedes this capture.
           // Publish the canonical record's CURRENT pending state, never the discarded

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -648,42 +648,52 @@ export class BashMonitorWakeStore {
   // abandonWorkspaceClears).
   private readonly stagedClearRefreshTimers = new Map<
     string,
-    { timer: NodeJS.Timeout; ownerWorkspaceId: string; inFlight: Promise<void> | null }
+    { timer: NodeJS.Timeout; ownerWorkspaceId: string }
   >();
+
+  // In-flight heartbeat tick mutations, keyed by owner and tracked INDEPENDENTLY of
+  // the timer entries above: commitClear (and rollback) disarm a clear's timer while
+  // a fired tick can still be queued on the tombstone lock behind their own mutation,
+  // and abandonWorkspaceClears must be able to drain those orphaned ticks too — an
+  // undrained tick's recursive mkdir would recreate the session directory after
+  // removal deletes it. Ticks remove themselves once settled.
+  private readonly heartbeatTicksByOwner = new Map<string, Set<Promise<void>>>();
 
   private armStagedClearRefresh(ownerWorkspaceId: string, clearId: string): void {
     this.disarmStagedClearRefresh(clearId);
-    const entry: {
-      timer: NodeJS.Timeout;
-      ownerWorkspaceId: string;
-      inFlight: Promise<void> | null;
-    } = {
-      timer: setInterval(() => {
-        // Best-effort: a missed refresh only narrows the liveness window and the next
-        // tick tries again — refresh failures must never break the clear itself. The
-        // guard on clearId keeps a heartbeat that outlives its generation (raced away
-        // by a newer clear) from resurrecting or touching a foreign tombstone.
-        // Tracked (not fire-and-forget) so abandonWorkspaceClears can DRAIN a tick
-        // that already fired: even a "keep" no-op re-creates the wake directory
-        // (mutateClearedAt mkdirs before capturing), which removal must never race.
-        // Ticks serialize on the per-owner tombstone lock, so the latest assignment
-        // settles last and awaiting it covers every earlier queued tick.
-        entry.inFlight = this.mutateClearedAt(ownerWorkspaceId, (current) =>
-          current?.clearId === clearId && current.phase === "staged"
-            ? { ...current, stagedAt: new Date().toISOString() }
-            : "keep"
-        ).then(
-          () => undefined,
-          () => undefined
-        );
-      }, this.stagedClearRefreshIntervalMs),
-      ownerWorkspaceId,
-      inFlight: null,
-    };
+    const timer = setInterval(() => {
+      // Best-effort: a missed refresh only narrows the liveness window and the next
+      // tick tries again — refresh failures must never break the clear itself. The
+      // guard on clearId keeps a heartbeat that outlives its generation (raced away
+      // by a newer clear) from resurrecting or touching a foreign tombstone.
+      // Tracked (not fire-and-forget) in heartbeatTicksByOwner so
+      // abandonWorkspaceClears can DRAIN a tick that already fired, even after this
+      // timer is disarmed: even a "keep" no-op re-creates the wake directory
+      // (mutateClearedAt mkdirs before capturing), which removal must never race.
+      let ticks = this.heartbeatTicksByOwner.get(ownerWorkspaceId);
+      if (ticks == null) {
+        ticks = new Set();
+        this.heartbeatTicksByOwner.set(ownerWorkspaceId, ticks);
+      }
+      const trackedTicks = ticks;
+      const tick: Promise<void> = this.mutateClearedAt(ownerWorkspaceId, (current) =>
+        current?.clearId === clearId && current.phase === "staged"
+          ? { ...current, stagedAt: new Date().toISOString() }
+          : "keep"
+      ).then(
+        () => {
+          trackedTicks.delete(tick);
+        },
+        () => {
+          trackedTicks.delete(tick);
+        }
+      );
+      trackedTicks.add(tick);
+    }, this.stagedClearRefreshIntervalMs);
     // Never hold process shutdown open: a staging orphaned by shutdown is exactly
     // what the grace scan reconciles.
-    entry.timer.unref();
-    this.stagedClearRefreshTimers.set(clearId, entry);
+    timer.unref();
+    this.stagedClearRefreshTimers.set(clearId, { timer, ownerWorkspaceId });
   }
 
   private disarmStagedClearRefresh(clearId: string): void {
@@ -703,19 +713,25 @@ export class BashMonitorWakeStore {
    * instead of being held forever by a marker whose owner will never settle it.
    */
   async abandonWorkspaceClears(ownerWorkspaceId: string): Promise<void> {
-    const drains: Array<Promise<void>> = [];
     for (const [clearId, entry] of this.stagedClearRefreshTimers) {
       if (entry.ownerWorkspaceId !== ownerWorkspaceId) continue;
       clearInterval(entry.timer);
       this.stagedClearRefreshTimers.delete(clearId);
       this.activeClearIds.delete(clearId);
-      // clearInterval cancels ticks that have not fired, but a tick that already
-      // fired holds a live mutateClearedAt promise outside any caller-visible lock;
-      // its recursive mkdir would recreate the session directory if removal deleted
-      // it mid-mutation. Collect and drain those before the caller proceeds.
-      if (entry.inFlight != null) drains.push(entry.inFlight);
     }
-    await Promise.all(drains);
+    // clearInterval cancels ticks that have not fired, but a tick that already fired
+    // holds a live mutateClearedAt promise outside any caller-visible lock; its
+    // recursive mkdir would recreate the session directory if removal deleted it
+    // mid-mutation. Drained from the owner-keyed tick set rather than the timer
+    // entries above, because a tick can outlive its timer: commitClear disarms the
+    // timer while the tick is still queued on the tombstone lock behind the commit's
+    // own mutation. The snapshot is complete — fired ticks register synchronously and
+    // the timers above are already cleared, so no new tick can appear.
+    const ticks = this.heartbeatTicksByOwner.get(ownerWorkspaceId);
+    if (ticks != null) {
+      await Promise.all([...ticks]);
+      this.heartbeatTicksByOwner.delete(ownerWorkspaceId);
+    }
   }
 
   private scheduleDeferredTempRecovery(
@@ -1243,15 +1259,28 @@ export class BashMonitorWakeStore {
     if (await this.rollbackClearTombstone(ownerWorkspaceId, clearId, tomb.stagedAt)) {
       return restored.map((r) => r.entry);
     }
-    // The pinned CAS DECLINED: between the tombstone read above and this
-    // authorization, the owning instance (resumed from a long stall) refreshed the
-    // staging (live, not crashed) or committed it (retirement final) — restoring its
-    // stamped records above was premature. Left pending, a record whose pre-clear
-    // updatedAt equals the cutoff would pass the strict pre-cutoff fence and deliver
-    // during a live clear or into an already-cleared transcript. Re-supersede exactly
-    // the generations restored above; a record that changed since (a live monitor
-    // merged new output) stays pending — mid-clear output must survive, and its
-    // pre-cutoff lines redelivering is the documented lesser failure.
+    // The pinned CAS DECLINED. Adjudicate WHY before compensating: a TWIN scan racing
+    // this same crashed staging can restore the records in parallel and demote the
+    // tombstone between our read and our CAS. Its rollback COMPLETED — the records
+    // restored above are legitimately pending, and re-superseding them with no staged
+    // tombstone left on disk would strand them beyond any recovery, permanently
+    // losing wakes for a history clear that never ran. Only a standing generation
+    // still owned by THIS clear proves otherwise; a foreign or absent generation
+    // also needs no compensation — its committed cutoff (when one stands) retires
+    // pre-cutoff records through the canonical fence on its own.
+    const standing = await this.readClearedAt(ownerWorkspaceId);
+    if (standing?.clearId !== clearId) {
+      return restored.map((r) => r.entry);
+    }
+    // This clear still owns the tombstone: the owning instance (resumed from a long
+    // stall) refreshed the staging (live, not crashed) or committed it (retirement
+    // final) — restoring its stamped records above was premature. Left pending, a
+    // record whose pre-clear updatedAt equals the cutoff would pass the strict
+    // pre-cutoff fence and deliver during a live clear or into an already-cleared
+    // transcript. Re-supersede exactly the generations restored above; a record that
+    // changed since (a live monitor merged new output) stays pending — mid-clear
+    // output must survive, and its pre-cutoff lines redelivering is the documented
+    // lesser failure.
     for (const r of restored) {
       await this.locks.withLock(`${ownerWorkspaceId}:${r.id}`, async () => {
         const current = await this.readRecordAt(r.filePath);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -57,6 +57,15 @@ export const STAGED_CLEAR_ROLLBACK_GRACE_MS = 5 * 60 * 1000;
 export const MAX_TOMBSTONE_FUTURE_SKEW_MS = 60 * 60 * 1000;
 
 /**
+ * How often an in-flight clear refreshes its staged tombstone's stagedAt.
+ * activeClearIds is process-local, so OTHER store instances can only judge staging
+ * liveness by stagedAt age: without a heartbeat, a legitimate history clear outliving
+ * STAGED_CLEAR_ROLLBACK_GRACE_MS would be misread as crashed and rolled back. A real
+ * crash stops the refresh and lets the grace expire as designed.
+ */
+export const STAGED_CLEAR_REFRESH_INTERVAL_MS = 60 * 1000;
+
+/**
  * Delay until a deferred fresh temp should be rechecked: an epsilon past the gate so
  * the re-driven scan's own freshness check cannot lose a same-millisecond race against
  * the gate arithmetic. The delay is CAPPED to one bounded recheck interval: a far-future
@@ -622,7 +631,45 @@ export class BashMonitorWakeStore {
   // must never treat their staged tombstones as crashed.
   private readonly activeClearIds = new Set<string>();
 
-  constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
+  constructor(
+    private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">,
+    options?: { stagedClearRefreshIntervalMs?: number }
+  ) {
+    this.stagedClearRefreshIntervalMs =
+      options?.stagedClearRefreshIntervalMs ?? STAGED_CLEAR_REFRESH_INTERVAL_MS;
+  }
+
+  // Injectable for tests only; production uses STAGED_CLEAR_REFRESH_INTERVAL_MS.
+  private readonly stagedClearRefreshIntervalMs: number;
+
+  // Liveness heartbeats for in-flight staged clears (see
+  // STAGED_CLEAR_REFRESH_INTERVAL_MS), keyed by clearId.
+  private readonly stagedClearRefreshTimers = new Map<string, NodeJS.Timeout>();
+
+  private armStagedClearRefresh(ownerWorkspaceId: string, clearId: string): void {
+    this.disarmStagedClearRefresh(clearId);
+    const timer = setInterval(() => {
+      // Best-effort: a missed refresh only narrows the liveness window and the next
+      // tick tries again — refresh failures must never break the clear itself. The
+      // guard on clearId keeps a heartbeat that outlives its generation (raced away
+      // by a newer clear) from resurrecting or touching a foreign tombstone.
+      void this.mutateClearedAt(ownerWorkspaceId, (current) =>
+        current?.clearId === clearId && current.phase === "staged"
+          ? { ...current, stagedAt: new Date().toISOString() }
+          : "keep"
+      ).catch(() => undefined);
+    }, this.stagedClearRefreshIntervalMs);
+    // Never hold process shutdown open: a staging orphaned by shutdown is exactly
+    // what the grace scan reconciles.
+    timer.unref();
+    this.stagedClearRefreshTimers.set(clearId, timer);
+  }
+
+  private disarmStagedClearRefresh(clearId: string): void {
+    const timer = this.stagedClearRefreshTimers.get(clearId);
+    if (timer != null) clearInterval(timer);
+    this.stagedClearRefreshTimers.delete(clearId);
+  }
 
   private scheduleDeferredTempRecovery(
     ownerWorkspaceId: string,
@@ -671,9 +718,9 @@ export class BashMonitorWakeStore {
   private async mutateClearedAt(
     ownerWorkspaceId: string,
     decide: (current: ClearTombstone | null) => ClearTombstone | "keep" | null
-  ): Promise<void> {
+  ): Promise<boolean> {
     const target = this.clearedAtFile(ownerWorkspaceId);
-    await this.clearedAtLocks.withLock(ownerWorkspaceId, async () => {
+    return this.clearedAtLocks.withLock(ownerWorkspaceId, async () => {
       await fsPromises.mkdir(path.dirname(target), { recursive: true });
       const capture = `${target}.cas-${randomUUID()}`;
       let captured = false;
@@ -716,17 +763,21 @@ export class BashMonitorWakeStore {
           try {
             await fsPromises.link(capture, target);
           } catch (error) {
-            if (!isErrnoWithCode(error, "EEXIST")) throw error; // capture heals later
+            if (!isErrnoWithCode(error, "EEXIST")) throw error;
+            // Another generation claimed the path mid-mutation: the kept value is no
+            // longer what stands. The capture stays behind as a healable leftover so
+            // its protection is never silently lost; report the lost race.
+            return false;
           }
           await fsPromises.rm(capture, { force: true }).catch(() => undefined);
         }
-        return;
+        return true;
       }
       if (next == null) {
         // Removal failures PROPAGATE: a stranded capture would heal back as standing
         // protection (the safe direction), and the caller must know removal failed.
         if (captured) await fsPromises.rm(capture, { force: true });
-        return;
+        return true;
       }
       const temp = `${target}.tmp-${randomUUID()}`;
       await fsPromises.writeFile(temp, JSON.stringify(next), "utf-8");
@@ -748,10 +799,11 @@ export class BashMonitorWakeStore {
         // EEXIST: another instance claimed the path mid-mutation. Its generation
         // wins this race and supersedes both our decision and our capture.
         if (captured) await fsPromises.rm(capture, { force: true }).catch(() => undefined);
-        return;
+        return false;
       }
       await fsPromises.rm(temp, { force: true }).catch(() => undefined);
       if (captured) await fsPromises.rm(capture, { force: true }).catch(() => undefined);
+      return true;
     });
   }
 
@@ -887,9 +939,28 @@ export class BashMonitorWakeStore {
    * captures so an interrupted mutation never silently drops protection.
    */
   private async readClearedAt(ownerWorkspaceId: string): Promise<ClearTombstone | null> {
+    const target = this.clearedAtFile(ownerWorkspaceId);
+    // Non-regular guard: a directory (or FIFO) left at the tombstone path by
+    // corruption would fail (or block) EVERY scan that consults the tombstone,
+    // permanently blocking otherwise valid pending wakes. Quarantine the imposter
+    // aside as evidence and continue as if the tombstone were malformed.
+    let stat: Stats;
+    try {
+      stat = await fsPromises.stat(target);
+    } catch (error) {
+      if (!isErrnoWithCode(error, "ENOENT")) throw error;
+      return this.healClearedAtFromLeftovers(ownerWorkspaceId);
+    }
+    if (!stat.isFile()) {
+      log.debug("Quarantining non-regular bash monitor wake clear tombstone", {
+        ownerWorkspaceId,
+      });
+      await fsPromises.rename(target, `${target}.malformed-${randomUUID()}`);
+      return this.healClearedAtFromLeftovers(ownerWorkspaceId);
+    }
     let raw: string;
     try {
-      raw = await fsPromises.readFile(this.clearedAtFile(ownerWorkspaceId), "utf-8");
+      raw = await fsPromises.readFile(target, "utf-8");
     } catch (error) {
       if (!isErrnoWithCode(error, "ENOENT")) throw error;
       return this.healClearedAtFromLeftovers(ownerWorkspaceId);
@@ -943,9 +1014,11 @@ export class BashMonitorWakeStore {
     });
     // Deactivated only AFTER the promotion durably landed: this marker is what stops
     // the staged-clear grace scan from treating a slow-to-commit SUCCESSFUL clear as
-    // crashed and restoring the wakes it retired. On failure it stays active — the
-    // caller's retry (see WorkspaceService.scheduleBashMonitorClearCommitRetry)
-    // re-drives the promotion, and a process crash hands over to the grace scan.
+    // crashed and restoring the wakes it retired. On failure it stays active (and the
+    // staged heartbeat keeps running for cross-instance liveness) — the caller's
+    // retry (see WorkspaceService.scheduleBashMonitorClearCommitRetry) re-drives the
+    // promotion, and a process crash hands over to the grace scan.
+    this.disarmStagedClearRefresh(token.clearId);
     this.activeClearIds.delete(token.clearId);
   }
 
@@ -1271,6 +1344,12 @@ export class BashMonitorWakeStore {
     // resurrecting and redelivering a deliberately superseded wake. Artifacts-first
     // guarantees every temp is judged against the still-present canonical record.
     const recordEntries: string[] = [];
+    // Wake ids whose artifacts were reconciled this scan. Their state is re-read from
+    // the FINAL canonical generation in the record pass below instead of accumulating
+    // each recovery's return value: a later artifact for the same wake (e.g. a newer
+    // terminal temp) may supersede an earlier rescue within this very scan, and
+    // serving the obsolete intermediate would redeliver superseded output.
+    const recoveredEntries = new Set<string>();
     for (const entry of entries) {
       if (entry.endsWith(".json")) {
         recordEntries.push(entry);
@@ -1297,13 +1376,14 @@ export class BashMonitorWakeStore {
       // concurrently rewritten pending wake that neither scans nor delivery (both
       // address the original path) can see. Inspect stranded prune files and restore
       // pending content before any sweeping can touch it.
+      const originalEntry = entry.slice(0, entry.lastIndexOf(".json") + ".json".length);
       if (isPruneTrash) {
         const rescued = await this.recoverStrandedPruneFile(
           ownerWorkspaceId,
           filePath,
           pruneBeforeMs
         );
-        if (rescued != null) records.push(rescued);
+        if (rescued != null) recoveredEntries.add(originalEntry);
         continue;
       }
       // write() leaves *.json.tmp-* files behind only when the process crashed
@@ -1313,7 +1393,13 @@ export class BashMonitorWakeStore {
       // temps are parsed and restored rather than treated as disposable; incomplete
       // ones sweep once old so crash leaks stay bounded.
       const rescued = await this.recoverOrphanTempFile(ownerWorkspaceId, filePath, pruneBeforeMs);
-      if (rescued != null) records.push(rescued);
+      if (rescued != null) recoveredEntries.add(originalEntry);
+    }
+    // A rescue may have (re)created a canonical file that postdates this scan's
+    // readdir snapshot; fold those into the record pass so the final canonical
+    // generation is what gets served.
+    for (const entry of recoveredEntries) {
+      if (!recordEntries.includes(entry)) recordEntries.push(entry);
     }
     for (const entry of recordEntries) {
       const filePath = path.join(dir, entry);
@@ -1742,6 +1828,18 @@ export class BashMonitorWakeStore {
             // falls through to the merge, which preserves the notice and script.
             await fsPromises.rm(filePath, { force: true });
             return canonical;
+          }
+          if (
+            parsed.kind === "match" &&
+            canonical.kind === "monitor-lost" &&
+            Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)
+          ) {
+            // The SAME stale-notice rule in the reversed storage orientation: an
+            // older lost record was restored as canonical before this newer re-armed
+            // match generation was recovered. Merging would keep claiming the newly
+            // running task was terminated (and offer its stale relaunch script);
+            // replace the obsolete notice with the live match instead.
+            return this.replaceCanonicalIfUnchanged(filePath, originalPath, parsed, canonical);
           }
           const merged = BashMonitorWakeStore.mergeDivergentPending(parsed, canonical);
           const mergedTemp = `${originalPath}.tmp-${randomUUID()}`;
@@ -2274,9 +2372,19 @@ export class BashMonitorWakeStore {
       // wake retired; a failure here fails the clear (snapshots restored below).
       // Monotonic: a newer concurrent cutoff is never lowered — this clear's own
       // rollback then finds a foreign identity and correctly leaves it alone.
-      await this.mutateClearedAt(ownerWorkspaceId, (current) => {
-        if (current != null && Date.parse(current.clearedAt) >= Date.parse(clearedAt)) {
-          return "keep";
+      let decidedToStage = false;
+      const applied = await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+        if (current != null) {
+          const currentMs = Date.parse(current.clearedAt);
+          const ourMs = Date.parse(clearedAt);
+          // A strictly newer cutoff always wins; an EQUAL cutoff blocks us only while
+          // it is another clear's in-flight STAGING (same-millisecond concurrent
+          // clears). An equal COMMITTED cutoff retires exactly what ours would, so
+          // staging over it (with it as rollback predecessor) loses nothing — and
+          // same-millisecond sequential clears in one process keep working.
+          if (currentMs > ourMs || (currentMs === ourMs && current.phase === "staged")) {
+            return "keep";
+          }
         }
         // The rollback predecessor must be a COMMITTED cutoff: inheriting a staged
         // current's own cutoff would let OUR later rollback materialize it as
@@ -2290,6 +2398,7 @@ export class BashMonitorWakeStore {
             : current.phase === "staged"
               ? (current.previousClearedAt ?? null)
               : current.clearedAt;
+        decidedToStage = true;
         return {
           clearedAt,
           clearId,
@@ -2298,12 +2407,27 @@ export class BashMonitorWakeStore {
           ...(committedPredecessor != null ? { previousClearedAt: committedPredecessor } : {}),
         };
       });
+      if (!decidedToStage || !applied) {
+        // This clear's staging did NOT land durably — a concurrent clear's newer (or
+        // equal) generation owns the tombstone. Proceeding would report successful
+        // staging while the durable transaction state carries no trace of THIS
+        // clear's identity: if both instances then crashed, restart rollback would
+        // only restore records stamped with the standing tombstone's clearId,
+        // stranding ours superseded forever. Abort instead (the catch below restores
+        // our stamped records) and let the caller retry after the other clear
+        // settles.
+        throw new Error(
+          "A concurrent history clear owns the wake tombstone; retry after it settles"
+        );
+      }
+      this.armStagedClearRefresh(ownerWorkspaceId, clearId);
       return { snapshots: pending, clearedAt, clearId };
     } catch (error) {
       // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
       // tombstone write above is the try block's last step, so on this path it was
-      // never promoted, and demoting here would strip the PREVIOUS clear's
-      // protection instead.
+      // never promoted (or never landed at all), and demoting here would strip the
+      // PREVIOUS clear's protection instead.
+      this.disarmStagedClearRefresh(clearId);
       this.activeClearIds.delete(clearId);
       await this.restoreSnapshotRecords(ownerWorkspaceId, staged);
       throw error;
@@ -2344,6 +2468,7 @@ export class BashMonitorWakeStore {
     // standing, so the grace scan can resume the rollback (record restores are
     // idempotent). Demoting the tombstone first would strand still-stamped records
     // with nothing left on disk to trigger their recovery.
+    this.disarmStagedClearRefresh(token.clearId);
     this.activeClearIds.delete(token.clearId);
     await this.restoreSnapshotRecords(ownerWorkspaceId, snapshots);
     await this.rollbackClearTombstone(ownerWorkspaceId, token.clearId);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -919,6 +919,9 @@ export class BashMonitorWakeStore {
     }
     let newest: ClearTombstone | null = null;
     let newestPath: string | null = null;
+    // Every valid capture seen this pass, retained so captures SUPERSEDED by the
+    // standing winner can be swept below.
+    const candidates: Array<{ path: string; tomb: ClearTombstone }> = [];
     for (const entry of entries) {
       if (!entry.startsWith(`${base}.cas-`)) continue;
       const leftoverPath = path.join(dir, entry);
@@ -953,6 +956,7 @@ export class BashMonitorWakeStore {
         await fsPromises.rm(leftoverPath, { force: true }).catch(() => undefined);
         continue;
       }
+      candidates.push({ path: leftoverPath, tomb: parsed });
       if (
         newest == null ||
         Date.parse(parsed.clearedAt) > Date.parse(newest.clearedAt) ||
@@ -977,6 +981,21 @@ export class BashMonitorWakeStore {
       }
     }
     if (newest == null || newestPath == null) return null;
+    // Sweep captures the DURABLY STANDING generation strictly outranks: a superseded
+    // capture left behind can resurrect protection for a clear that was just settled
+    // — after the grace rollback demotes a healed staging, the very next
+    // readClearedAt would heal the older capture straight back, re-holding the
+    // records the rollback restored; the scan then lists nothing and startup owner
+    // discovery schedules no drain, stranding the wake indefinitely. Only run once a
+    // standing canonical is verified (linked by us or read back below): subsumption
+    // is provable only against durable protection. Best-effort — a capture that
+    // survives re-enters this same reconciliation later.
+    const sweepSuperseded = async (standing: ClearTombstone): Promise<void> => {
+      for (const candidate of candidates) {
+        if (!BashMonitorWakeStore.tombstoneStrictlyOutranks(standing, candidate.tomb)) continue;
+        await fsPromises.rm(candidate.path, { force: true }).catch(() => undefined);
+      }
+    };
     try {
       await fsPromises.link(newestPath, target);
     } catch (error) {
@@ -988,21 +1007,47 @@ export class BashMonitorWakeStore {
       // mid-dance mutation's capture holds the PREVIOUS generation, not the one it
       // is publishing). Report the winner, not our stale selection: a caller judging
       // a wake between the two cutoffs would otherwise restore what the newer clear
-      // retired. The leftover stays behind for a later heal, so its protection is
-      // never silently lost.
+      // retired. A leftover the standing generation does not strictly outrank stays
+      // behind for a later heal, so its protection is never silently lost.
       let raw: string;
       try {
         raw = await fsPromises.readFile(target, "utf-8");
       } catch (readError) {
         if (!isErrnoWithCode(readError, "ENOENT")) throw readError;
         // The winner was removed again before we could read it: the capture remains
-        // the newest standing protection.
+        // the newest standing protection. Nothing durably stands, so sweep nothing.
         return newest;
       }
-      return BashMonitorWakeStore.parseTombstone(raw) ?? newest;
+      const standing = BashMonitorWakeStore.parseTombstone(raw);
+      // A malformed canonical is not standing protection: sweep nothing.
+      if (standing == null) return newest;
+      await sweepSuperseded(standing);
+      return standing;
     }
     await fsPromises.rm(newestPath, { force: true }).catch(() => undefined);
+    await sweepSuperseded(newest);
     return newest;
+  }
+
+  /**
+   * Whether `standing` strictly outranks `candidate` under the heal selection
+   * ordering (newer cutoff; committed over staged at an equal cutoff; fresher
+   * stagedAt when both are staged at an equal cutoff). Used to sweep captures that a
+   * durably standing generation supersedes — exact ties are NOT outranked and are
+   * kept, because sweeping requires proof the candidate can never matter again.
+   */
+  private static tombstoneStrictlyOutranks(
+    standing: ClearTombstone,
+    candidate: ClearTombstone
+  ): boolean {
+    const standingMs = Date.parse(standing.clearedAt);
+    const candidateMs = Date.parse(candidate.clearedAt);
+    if (standingMs !== candidateMs) return standingMs > candidateMs;
+    if (candidate.phase === "staged" && standing.phase !== "staged") return true;
+    if (candidate.phase === "staged" && standing.phase === "staged") {
+      return Date.parse(standing.stagedAt ?? "") > Date.parse(candidate.stagedAt ?? "");
+    }
+    return false;
   }
 
   private static parseTombstone(raw: string): ClearTombstone | null {
@@ -1860,10 +1905,17 @@ export class BashMonitorWakeStore {
   /**
    * Like readRecordAt, but distinguishes an absent canonical file from a malformed one:
    * recovery paths must quarantine malformed canonicals (or a valid stranded record is
-   * blocked forever) while treating absence as "safe to place". Transient errors throw.
+   * blocked forever) while treating absence as "safe to place". A syntactically valid
+   * record whose identity disagrees with the path classifies as MALFORMED too (see
+   * recordIdentityMatches): treating the imposter as a real record would let its
+   * equal-or-newer updatedAt condemn a valid crash artifact as stale — deleting the
+   * wake's only durable copy while the record pass rejects the imposter anyway.
+   * Transient errors throw.
    */
   private async readCanonicalState(
-    originalPath: string
+    originalPath: string,
+    ownerWorkspaceId: string,
+    id: string
   ): Promise<
     { kind: "absent" } | { kind: "malformed" } | { kind: "record"; record: BashMonitorWakeRecord }
   > {
@@ -1875,7 +1927,13 @@ export class BashMonitorWakeStore {
       throw error;
     }
     const record = this.parse(raw);
-    return record == null ? { kind: "malformed" } : { kind: "record", record };
+    if (
+      record == null ||
+      !BashMonitorWakeStore.recordIdentityMatches(record, ownerWorkspaceId, id)
+    ) {
+      return { kind: "malformed" };
+    }
+    return { kind: "record", record };
   }
 
   /**
@@ -1895,7 +1953,9 @@ export class BashMonitorWakeStore {
    * as authoritative. Caller must hold the per-record lock.
    */
   private async quarantineMalformedCanonical(
-    originalPath: string
+    originalPath: string,
+    ownerWorkspaceId: string,
+    id: string
   ): Promise<{ kind: "cleared" } | { kind: "occupied"; record: BashMonitorWakeRecord | null }> {
     const capture = `${originalPath}.prune-${randomUUID()}`;
     try {
@@ -1920,9 +1980,14 @@ export class BashMonitorWakeStore {
       }
       throw error;
     }
-    if (captured == null) {
-      // Verified malformed: park it as evidence. A failed rename leaves it as prune
-      // trash, where the age-gated sweep eventually removes it.
+    if (
+      captured == null ||
+      !BashMonitorWakeStore.recordIdentityMatches(captured, ownerWorkspaceId, id)
+    ) {
+      // Verified malformed — including a syntactically valid record whose identity
+      // disagrees with this path (see readCanonicalState): park it as evidence. A
+      // failed rename leaves it as prune trash, where the age-gated sweep eventually
+      // removes it.
       await fsPromises
         .rename(capture, `${originalPath}.malformed-${randomUUID()}`)
         .catch(() => undefined);
@@ -2124,7 +2189,7 @@ export class BashMonitorWakeStore {
         // supersession: a strictly newer pending leftover atomically replaces the
         // canonical record; otherwise the canonical record wins and the leftover is
         // dropped below as superseded.
-        const canonicalState = await this.readCanonicalState(originalPath);
+        const canonicalState = await this.readCanonicalState(originalPath, ownerWorkspaceId, id);
         if (canonicalState.kind === "absent") {
           // Vanished between the failed link and this read: keep the leftover so a
           // later scan retries with a settled canonical state.
@@ -2139,7 +2204,11 @@ export class BashMonitorWakeStore {
             // wait for the age-gated sweep.
             return null;
           }
-          const quarantined = await this.quarantineMalformedCanonical(originalPath);
+          const quarantined = await this.quarantineMalformedCanonical(
+            originalPath,
+            ownerWorkspaceId,
+            id
+          );
           if (quarantined.kind === "occupied") {
             // A valid record regenerated over the malformed one mid-quarantine: it is
             // authoritative; the leftover stays for re-reconciliation against it.
@@ -2373,7 +2442,7 @@ export class BashMonitorWakeStore {
         this.scheduleDeferredTempRecovery(ownerWorkspaceId, filePath, stat.mtimeMs);
         return null;
       }
-      const canonicalState = await this.readCanonicalState(originalPath);
+      const canonicalState = await this.readCanonicalState(originalPath, ownerWorkspaceId, id);
       if (canonicalState.kind !== "record") {
         // The complete temp record may be the ONLY durable copy of this wake (a
         // brand-new wake has no canonical file at all): place the SAME inode at the
@@ -2382,7 +2451,11 @@ export class BashMonitorWakeStore {
         // temp would be blocked forever.
         if (canonicalState.kind === "malformed") {
           if (parsed.status !== "pending") return null; // evidence outranks stale terminals
-          const quarantined = await this.quarantineMalformedCanonical(originalPath);
+          const quarantined = await this.quarantineMalformedCanonical(
+            originalPath,
+            ownerWorkspaceId,
+            id
+          );
           if (quarantined.kind === "occupied") {
             // A valid record regenerated over the malformed one mid-quarantine: it is
             // authoritative; the temp stays for re-reconciliation against it.

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -31,6 +31,10 @@ export const TERMINAL_WAKE_RETENTION_MS = 60 * 60 * 1000;
 // files (e.g. "x.json.prune-y.json.tmp-…") misparse as prune trash for the wrong id.
 const PRUNE_TRASH_SUFFIX_RE = /\.json\.prune-[^.]+$/;
 const TMP_WRITE_SUFFIX_RE = /\.json\.tmp-[^.]+$/;
+// A temp file younger than this may belong to a LIVE write (writeFile done, commit
+// rename imminent in another process); recovery must not race that rename by consuming
+// the temp. Anything older is an orphan from a crash.
+const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
 
 // Single-source the wake status enum so the exported TS type and the runtime
 // Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
@@ -801,14 +805,18 @@ export class BashMonitorWakeStore {
           continue;
         }
         // write() leaves *.json.tmp-* files behind only when the process crashed
-        // mid-write; sweep old ones so crash leaks stay bounded. A tmp file is an
-        // uncommitted write — the durable state is whatever the target path holds — so
-        // it is never restored, only swept.
+        // between writeFile and the commit rename. A COMPLETE temp record may then be
+        // the only durable copy of a wake (a brand-new wake has no canonical file at
+        // all), so orphan temps are parsed and restored rather than treated as
+        // disposable; incomplete ones sweep once old so crash leaks stay bounded.
         if (TMP_WRITE_SUFFIX_RE.test(entry)) {
-          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
-          if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
-            await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-          }
+          const rescued = await this.recoverOrphanTempFile(
+            ownerWorkspaceId,
+            filePath,
+            pruneBeforeMs
+          );
+          if (rescued != null) records.push(rescued);
+          continue;
         }
         continue;
       }
@@ -1011,11 +1019,37 @@ export class BashMonitorWakeStore {
         // supersession: a strictly newer pending leftover atomically replaces the
         // canonical record; otherwise the canonical record wins and the leftover is
         // dropped below as superseded.
-        const canonical = await this.readRecordAt(originalPath);
+        let canonicalRaw: string;
+        try {
+          canonicalRaw = await fsPromises.readFile(originalPath, "utf-8");
+        } catch (readError) {
+          if (isErrnoWithCode(readError, "ENOENT")) {
+            // Vanished between the failed link and this read: keep the leftover so a
+            // later scan retries with a settled canonical state.
+            return null;
+          }
+          throw readError;
+        }
+        const canonical = this.parse(canonicalRaw);
         if (canonical == null) {
-          // Vanished (or unparseable) between the failed link and this read: keep the
-          // leftover so a later scan retries with a settled canonical state.
-          return null;
+          // A malformed canonical file would block this valid leftover FOREVER (every
+          // scan repeats this dead end and the durable wake never delivers). Quarantine
+          // it aside as evidence — the suffix matches neither record nor trash/temp
+          // patterns, so it is never re-parsed or swept — and place the leftover.
+          if (parsed.status !== "pending") {
+            // Only a pending leftover justifies displacing evidence; terminal leftovers
+            // wait for the age-gated sweep.
+            return null;
+          }
+          await fsPromises.rename(originalPath, `${originalPath}.malformed-${randomUUID()}`);
+          try {
+            await fsPromises.link(filePath, originalPath);
+          } catch {
+            // Someone claimed the path mid-quarantine; re-reconcile next scan.
+            return null;
+          }
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          return parsed;
         }
         if (
           parsed.status === "pending" &&
@@ -1023,6 +1057,12 @@ export class BashMonitorWakeStore {
         ) {
           return this.replaceCanonicalIfUnchanged(filePath, originalPath, parsed, canonical);
         }
+        // The canonical record wins: drop the superseded leftover and PUBLISH the
+        // winner's pending state. Its file may postdate this scan's readdir snapshot
+        // (created between our failed link and now), so returning null here could
+        // report a successful empty scan for a wake whose writer already exited.
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        return canonical.status === "pending" ? canonical : null;
       }
       await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
       return restored && parsed.status === "pending" ? parsed : null;
@@ -1030,8 +1070,80 @@ export class BashMonitorWakeStore {
   }
 
   /**
-   * Compare-and-swap replacement of the canonical wake file by a strictly newer pending
-   * leftover. A plain rename would be a blind overwrite: between reading `compared` and
+   * Handle a *.json.tmp-* leftover. write() renames a fully written temp file over the
+   * canonical path; a crash between writeFile and that rename strands a COMPLETE record
+   * in the temp file — for a brand-new wake there is no canonical file at all, so
+   * treating the temp as disposable would lose the matched output permanently and
+   * startup discovery would never schedule delivery. Fresh temps are left untouched
+   * (they may belong to a live writer about to commit); orphaned ones are restored when
+   * no same-or-newer canonical record exists, and stale or incomplete ones sweep once
+   * past retention. Returns the record now visible at the canonical path when pending.
+   */
+  private async recoverOrphanTempFile(
+    ownerWorkspaceId: string,
+    filePath: string,
+    pruneBeforeMs: number
+  ): Promise<BashMonitorWakeRecord | null> {
+    const marker = /^(.*\.json)\.tmp-[^.]+$/.exec(filePath);
+    assert(marker != null, "recoverOrphanTempFile requires a *.json.tmp-* path");
+    const originalPath = marker[1];
+    const stat = await fsPromises.stat(filePath).catch(() => null);
+    if (stat == null) return null; // vanished (live writer committed it)
+    if (stat.mtimeMs >= Date.now() - TEMP_RECOVERY_MIN_AGE_MS) {
+      // Possibly a live in-flight write: consuming it would make the writer's commit
+      // rename fail. Leave it; a crash orphan is revisited once it ages past the gate.
+      return null;
+    }
+    const id = BashMonitorWakeStore.wakeIdFromFileStem(
+      path.basename(originalPath).slice(0, -".json".length)
+    );
+    return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+      const parsed = await this.readRecordAt(filePath);
+      if (parsed == null) {
+        // Vanished, or an incomplete crashed write: disposable once old.
+        const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+        if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        }
+        return null;
+      }
+      const canonical = await this.readRecordAt(originalPath);
+      if (canonical == null) {
+        // No canonical record behind this complete write: place it (no-clobber; a
+        // malformed evidence file at the path simply keeps the temp for later).
+        try {
+          await fsPromises.link(filePath, originalPath);
+        } catch {
+          return null;
+        }
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        return parsed.status === "pending" ? parsed : null;
+      }
+      if (Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)) {
+        // The crashed write postdates the canonical record (an uncommitted merge or
+        // terminal transition): commit it through the CAS so a concurrent writer can
+        // never be overwritten blindly.
+        const committed = await this.replaceCanonicalIfUnchanged(
+          filePath,
+          originalPath,
+          parsed,
+          canonical
+        );
+        return committed?.status === "pending" ? committed : null;
+      }
+      // Same-or-older than the canonical record: a stale uncommitted write, disposable
+      // once old (the canonical record is authoritative).
+      if (stat.mtimeMs < pruneBeforeMs) {
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+      }
+      return null;
+    });
+  }
+
+  /**
+   * Compare-and-swap replacement of the canonical wake file by a strictly newer record
+   * (a stranded prune leftover or an orphaned temp write). A plain rename would be a
+   * blind overwrite: between reading `compared` and
    * the rename, another instance can replace the canonical path with an even newer
    * pending (new output) or terminal (canceled) record, which must not be resurrected
    * or lost. Instead, atomically capture the canonical inode under a trash name, verify
@@ -1079,8 +1191,15 @@ export class BashMonitorWakeStore {
       // The canonical record changed under us: restore it and keep the leftover.
       try {
         await fsPromises.link(cas, originalPath);
-      } catch {
-        // A newer write already claimed the path; it supersedes the stale capture.
+      } catch (error) {
+        if (!isErrnoWithCode(error, "EEXIST")) {
+          // The cas file may be the ONLY durable copy of the changed record (the
+          // canonical path is absent unless a newer write claimed it). Keep it — it
+          // heals as ordinary prune trash — and propagate so caller retries engage;
+          // deleting it here would permanently lose pending output or terminal state.
+          throw error;
+        }
+        // EEXIST: a newer write already claimed the path; it supersedes the capture.
       }
       await fsPromises.rm(cas, { force: true }).catch(() => undefined);
       return null;

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1,4 +1,5 @@
-import type { Dirent } from "node:fs";
+import { randomUUID } from "node:crypto";
+import type { Dirent, Stats } from "node:fs";
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 
@@ -499,23 +500,24 @@ export function buildBashMonitorWakePrompt(
 
 export class BashMonitorWakeStore {
   private readonly locks = new MutexMap<string>();
-  // Pending-id index so the hot listPending path (recomputed for every background-bash
-  // UI snapshot) reads only currently-pending records instead of reading every
-  // historical wake file — terminal records are never pruned from disk, so long-lived
-  // workspaces accumulate them. Seeded per owner by one full directory scan; afterwards
-  // write() keeps it in sync because every durable mutation funnels through write().
-  // Seeding merges instead of replacing: a concurrent write can land between the
-  // directory read and installation, and the read-verify in listPending drops stale ids.
+  // Classification cache so the hot listPending path (recomputed for every
+  // background-bash UI snapshot) avoids reading every historical wake file — terminal
+  // records are never pruned from disk, so long-lived workspaces accumulate them.
   //
   // Another store instance can share this session directory (multiple service handles,
-  // or a second app process under XUM_ALLOW_MULTIPLE_INSTANCES), so the warm path still
-  // lists the directory each call — one cheap readdir, not per-file reads — and classifies
-  // only file names it has never seen (classifiedFilesByOwner), which is how wakes written
-  // by other instances are discovered. Cross-instance retirements are handled by the
-  // read-verify pass on the pending set.
-  private readonly pendingIdsByOwner = new Map<string, Set<string>>();
-  private readonly classifiedFilesByOwner = new Map<string, Set<string>>();
-  private readonly seededPendingOwners = new Set<string>();
+  // or a second app process under XUM_ALLOW_MULTIPLE_INSTANCES), and wake ids are
+  // process ids, so a retired filename can later be rewritten as a new pending wake.
+  // File names are therefore never treated as immutable: each listPending call lists
+  // the directory and stats every wake file (cheap syscalls), and re-reads contents
+  // only when the stat signature (inode/mtime/size) differs from the classified one.
+  // write() is atomic (temp + rename), so every durable mutation changes the inode and
+  // a torn in-progress write can never persist as the final content of a file.
+  // `pending` caches the parsed record for pending files (few, bounded) so unchanged
+  // pending wakes need no re-read either; terminal/malformed files cache null.
+  private readonly classifiedFilesByOwner = new Map<
+    string,
+    Map<string, { sig: string; pending: BashMonitorWakeRecord | null }>
+  >();
 
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
 
@@ -753,67 +755,53 @@ export class BashMonitorWakeStore {
     try {
       entries = await fsPromises.readdir(dir);
     } catch (error) {
-      if (isErrnoWithCode(error, "ENOENT")) {
-        this.seededPendingOwners.add(ownerWorkspaceId);
-        return [];
-      }
+      if (isErrnoWithCode(error, "ENOENT")) return [];
       throw error;
     }
 
-    const classified = this.getOrCreateOwnerSet(this.classifiedFilesByOwner, ownerWorkspaceId);
-    const ids = this.getOrCreateOwnerSet(this.pendingIdsByOwner, ownerWorkspaceId);
-    const seeding = !this.seededPendingOwners.has(ownerWorkspaceId);
+    let classified = this.classifiedFilesByOwner.get(ownerWorkspaceId);
+    if (classified == null) {
+      classified = new Map();
+      this.classifiedFilesByOwner.set(ownerWorkspaceId, classified);
+    }
     const records: BashMonitorWakeRecord[] = [];
-
-    // Read file contents only for names never classified by this instance (the whole
-    // directory when seeding; afterwards just wakes written by other store instances).
+    const seen = new Set<string>();
     for (const entry of entries) {
       if (!entry.endsWith(".json")) continue;
-      if (classified.has(entry)) continue;
-      const raw = await fsPromises.readFile(path.join(dir, entry), "utf-8").catch(() => null);
-      // Transient read failure: leave unclassified so the next call retries.
-      if (raw == null && !seeding) continue;
-      classified.add(entry);
-      const parsed = raw == null ? null : this.parse(raw);
-      if (parsed?.status === "pending") {
-        records.push(parsed);
-        ids.add(parsed.id);
-      }
-    }
-    this.seededPendingOwners.add(ownerWorkspaceId);
-
-    // Read-verify the previously known pending set; drop ids retired on disk (possibly by
-    // another instance). Newly discovered records above are already verified.
-    const discoveredIds = new Set(records.map((record) => record.id));
-    for (const id of [...ids]) {
-      if (discoveredIds.has(id)) continue;
-      let record: BashMonitorWakeRecord | null;
+      seen.add(entry);
+      const filePath = path.join(dir, entry);
+      let stat: Stats;
       try {
-        record = await this.get(ownerWorkspaceId, id);
+        stat = await fsPromises.stat(filePath);
       } catch {
-        // Transient read failure: keep the index entry so the next call retries.
+        // Deleted between readdir and stat (or transiently unreadable): drop the cache
+        // entry so the next call reclassifies from scratch.
+        classified.delete(entry);
         continue;
       }
-      if (record?.status === "pending") {
-        records.push(record);
-      } else {
-        // Terminal, deleted, or malformed on disk: the id no longer belongs in the index.
-        ids.delete(id);
+      const sig = `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
+      const cached = classified.get(entry);
+      if (cached?.sig === sig) {
+        if (cached.pending != null) records.push(cached.pending);
+        continue;
       }
+      const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
+      if (raw == null) {
+        // Transient read failure: leave unclassified so the next call retries.
+        classified.delete(entry);
+        continue;
+      }
+      const parsed = this.parse(raw);
+      const pending = parsed?.status === "pending" ? parsed : null;
+      classified.set(entry, { sig, pending });
+      if (pending != null) records.push(pending);
+    }
+    // Forget cache entries whose files vanished so the map cannot grow past the directory.
+    for (const entry of [...classified.keys()]) {
+      if (!seen.has(entry)) classified.delete(entry);
     }
     records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
     return records;
-  }
-
-  private getOrCreateOwnerSet(
-    map: Map<string, Set<string>>,
-    ownerWorkspaceId: string
-  ): Set<string> {
-    const existing = map.get(ownerWorkspaceId);
-    if (existing != null) return existing;
-    const created = new Set<string>();
-    map.set(ownerWorkspaceId, created);
-    return created;
   }
 
   async listPendingOwnerWorkspaceIds(): Promise<string[]> {
@@ -1054,24 +1042,19 @@ export class BashMonitorWakeStore {
   private async write(record: BashMonitorWakeRecord): Promise<void> {
     const dir = this.dir(record.ownerWorkspaceId);
     await fsPromises.mkdir(dir, { recursive: true });
-    await fsPromises.writeFile(
-      this.file(record.ownerWorkspaceId, record.id),
-      JSON.stringify(record, null, 2),
-      "utf-8"
-    );
-    // Keep the pending index in sync with the durable state (index only after the write
-    // succeeds, so the index can never claim a pending record that is not on disk). Also
-    // mark the file name classified so the warm listPending pass does not re-read our own
-    // writes as unknown cross-instance files.
-    this.getOrCreateOwnerSet(this.classifiedFilesByOwner, record.ownerWorkspaceId).add(
-      `${encodeURIComponent(record.id)}.json`
-    );
-    const ids = this.getOrCreateOwnerSet(this.pendingIdsByOwner, record.ownerWorkspaceId);
-    if (record.status === "pending") {
-      ids.add(record.id);
-    } else {
-      ids.delete(record.id);
-    }
+    // Atomic replace: another store instance classifying this file by stat signature must
+    // never observe a torn half-written JSON as the file's settled content, and the rename
+    // allocates a fresh inode so every durable mutation changes the signature.
+    const target = this.file(record.ownerWorkspaceId, record.id);
+    const temp = `${target}.tmp-${randomUUID()}`;
+    await fsPromises.writeFile(temp, JSON.stringify(record, null, 2), "utf-8");
+    await fsPromises.rename(temp, target);
+    // Invalidate rather than update the classification cache: computing the new stat
+    // signature here could race a concurrent rewrite by another instance and pair our
+    // record with their signature. The next listPending re-reads this one file.
+    this.classifiedFilesByOwner
+      .get(record.ownerWorkspaceId)
+      ?.delete(`${encodeURIComponent(record.id)}.json`);
   }
 
   private parse(raw: string): BashMonitorWakeRecord | null {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -790,12 +790,27 @@ export class BashMonitorWakeStore {
     for (const entry of entries) {
       const filePath = path.join(dir, entry);
       if (!entry.endsWith(".json")) {
+        const isPruneTrash = PRUNE_TRASH_SUFFIX_RE.test(entry);
+        const isTempWrite = TMP_WRITE_SUFFIX_RE.test(entry);
+        if (!isPruneTrash && !isTempWrite) continue;
+        // Non-regular artifact guard: recovery reads file contents, and readFile on a
+        // FIFO can block forever while EISDIR would fail every scan. ENOENT means a
+        // concurrent recover consumed it; transient stat failures propagate, matching
+        // the record-file policy above.
+        let artifactStat: Stats;
+        try {
+          artifactStat = await fsPromises.stat(filePath);
+        } catch (error) {
+          if (isErrnoWithCode(error, "ENOENT")) continue;
+          throw error;
+        }
+        if (!artifactStat.isFile()) continue;
         // A crash between pruneTerminalWakeFile's capture rename and its verify/restore
         // strands the captured inode as *.json.prune-*, and that inode may hold a
         // concurrently rewritten pending wake that neither scans nor delivery (both
         // address the original path) can see. Inspect stranded prune files and restore
         // pending content before any sweeping can touch it.
-        if (PRUNE_TRASH_SUFFIX_RE.test(entry)) {
+        if (isPruneTrash) {
           const rescued = await this.recoverStrandedPruneFile(
             ownerWorkspaceId,
             filePath,
@@ -805,19 +820,13 @@ export class BashMonitorWakeStore {
           continue;
         }
         // write() leaves *.json.tmp-* files behind only when the process crashed
-        // between writeFile and the commit rename. A COMPLETE temp record may then be
-        // the only durable copy of a wake (a brand-new wake has no canonical file at
-        // all), so orphan temps are parsed and restored rather than treated as
-        // disposable; incomplete ones sweep once old so crash leaks stay bounded.
-        if (TMP_WRITE_SUFFIX_RE.test(entry)) {
-          const rescued = await this.recoverOrphanTempFile(
-            ownerWorkspaceId,
-            filePath,
-            pruneBeforeMs
-          );
-          if (rescued != null) records.push(rescued);
-          continue;
-        }
+        // between writeFile and the commit rename (a rename failure observed by a live
+        // caller deletes its temp). A COMPLETE temp record may then be the only durable
+        // copy of a wake (a brand-new wake has no canonical file at all), so orphan
+        // temps are parsed and restored rather than treated as disposable; incomplete
+        // ones sweep once old so crash leaks stay bounded.
+        const rescued = await this.recoverOrphanTempFile(ownerWorkspaceId, filePath, pruneBeforeMs);
+        if (rescued != null) records.push(rescued);
         continue;
       }
       seen.add(entry);
@@ -933,6 +942,36 @@ export class BashMonitorWakeStore {
   }
 
   /**
+   * Like readRecordAt, but distinguishes an absent canonical file from a malformed one:
+   * recovery paths must quarantine malformed canonicals (or a valid stranded record is
+   * blocked forever) while treating absence as "safe to place". Transient errors throw.
+   */
+  private async readCanonicalState(
+    originalPath: string
+  ): Promise<
+    { kind: "absent" } | { kind: "malformed" } | { kind: "record"; record: BashMonitorWakeRecord }
+  > {
+    let raw: string;
+    try {
+      raw = await fsPromises.readFile(originalPath, "utf-8");
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return { kind: "absent" };
+      throw error;
+    }
+    const record = this.parse(raw);
+    return record == null ? { kind: "malformed" } : { kind: "record", record };
+  }
+
+  /**
+   * Move a malformed canonical file aside as evidence. The suffix matches neither
+   * record nor trash/temp patterns, so quarantined files are never re-parsed or swept —
+   * the same keep-as-evidence policy applied to malformed files elsewhere.
+   */
+  private async quarantineMalformedCanonical(originalPath: string): Promise<void> {
+    await fsPromises.rename(originalPath, `${originalPath}.malformed-${randomUUID()}`);
+  }
+
+  /**
    * Best-effort lock key for a wake file name. Filenames are encodeURIComponent(id);
    * fall back to the raw stem for foreign files that do not round-trip (no writer
    * contends on those ids anyway).
@@ -1019,29 +1058,22 @@ export class BashMonitorWakeStore {
         // supersession: a strictly newer pending leftover atomically replaces the
         // canonical record; otherwise the canonical record wins and the leftover is
         // dropped below as superseded.
-        let canonicalRaw: string;
-        try {
-          canonicalRaw = await fsPromises.readFile(originalPath, "utf-8");
-        } catch (readError) {
-          if (isErrnoWithCode(readError, "ENOENT")) {
-            // Vanished between the failed link and this read: keep the leftover so a
-            // later scan retries with a settled canonical state.
-            return null;
-          }
-          throw readError;
+        const canonicalState = await this.readCanonicalState(originalPath);
+        if (canonicalState.kind === "absent") {
+          // Vanished between the failed link and this read: keep the leftover so a
+          // later scan retries with a settled canonical state.
+          return null;
         }
-        const canonical = this.parse(canonicalRaw);
-        if (canonical == null) {
+        if (canonicalState.kind === "malformed") {
           // A malformed canonical file would block this valid leftover FOREVER (every
           // scan repeats this dead end and the durable wake never delivers). Quarantine
-          // it aside as evidence — the suffix matches neither record nor trash/temp
-          // patterns, so it is never re-parsed or swept — and place the leftover.
+          // it aside as evidence and place the leftover.
           if (parsed.status !== "pending") {
             // Only a pending leftover justifies displacing evidence; terminal leftovers
             // wait for the age-gated sweep.
             return null;
           }
-          await fsPromises.rename(originalPath, `${originalPath}.malformed-${randomUUID()}`);
+          await this.quarantineMalformedCanonical(originalPath);
           try {
             await fsPromises.link(filePath, originalPath);
           } catch {
@@ -1051,6 +1083,7 @@ export class BashMonitorWakeStore {
           await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
           return parsed;
         }
+        const canonical = canonicalState.record;
         if (
           parsed.status === "pending" &&
           Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)
@@ -1087,37 +1120,84 @@ export class BashMonitorWakeStore {
     const marker = /^(.*\.json)\.tmp-[^.]+$/.exec(filePath);
     assert(marker != null, "recoverOrphanTempFile requires a *.json.tmp-* path");
     const originalPath = marker[1];
-    const stat = await fsPromises.stat(filePath).catch(() => null);
-    if (stat == null) return null; // vanished (live writer committed it)
-    if (stat.mtimeMs >= Date.now() - TEMP_RECOVERY_MIN_AGE_MS) {
-      // Possibly a live in-flight write: consuming it would make the writer's commit
-      // rename fail. Leave it; a crash orphan is revisited once it ages past the gate.
-      return null;
-    }
     const id = BashMonitorWakeStore.wakeIdFromFileStem(
       path.basename(originalPath).slice(0, -".json".length)
     );
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+      const stat = await fsPromises.stat(filePath).catch(() => null);
+      if (!stat?.isFile()) return null; // vanished (live writer committed) or non-regular
+      // Consuming (deleting) a fresh temp could break a LIVE writer whose commit rename
+      // is imminent; deletion therefore waits for this gate. Placement via link is safe
+      // at any age (see below), so freshness never delays making a wake visible.
+      const consumable = stat.mtimeMs < Date.now() - TEMP_RECOVERY_MIN_AGE_MS;
+      const old = stat.mtimeMs < pruneBeforeMs;
       const parsed = await this.readRecordAt(filePath);
       if (parsed == null) {
-        // Vanished, or an incomplete crashed write: disposable once old.
-        const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
-        if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
-          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-        }
+        // Vanished, an incomplete crashed write, or a live writer mid-writeFile:
+        // disposable once old.
+        if (old) await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
         return null;
       }
-      const canonical = await this.readRecordAt(originalPath);
-      if (canonical == null) {
-        // No canonical record behind this complete write: place it (no-clobber; a
-        // malformed evidence file at the path simply keeps the temp for later).
+      const canonicalState = await this.readCanonicalState(originalPath);
+      if (canonicalState.kind !== "record") {
+        // The complete temp record may be the ONLY durable copy of this wake, and a
+        // restart within the freshness gate would otherwise leave it invisible with no
+        // re-drive (startup discovery succeeds empty and schedules nothing). Placing
+        // the SAME inode at the canonical path is exactly what the crashed commit
+        // rename would have done — and if the writer is alive after all, its rename of
+        // this inode onto the path becomes a harmless POSIX no-op. Fresh temp files are
+        // left in place for that possible live writer; consumable orphans are removed
+        // after placement. A malformed canonical is quarantined first (as evidence),
+        // or a valid pending temp would be blocked forever.
+        if (canonicalState.kind === "malformed") {
+          if (parsed.status !== "pending") return null; // evidence outranks stale terminals
+          await this.quarantineMalformedCanonical(originalPath);
+        }
         try {
           await fsPromises.link(filePath, originalPath);
         } catch {
-          return null;
+          return null; // claimed concurrently; re-reconcile next scan
         }
-        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        if (consumable) {
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        }
         return parsed.status === "pending" ? parsed : null;
+      }
+      const canonical = canonicalState.record;
+      if (!consumable) {
+        // Canonical record present and the temp may belong to a live in-flight write:
+        // the canonical record is authoritative until the temp ages past the gate.
+        return null;
+      }
+      if (
+        parsed.kind === "match" &&
+        parsed.status === "pending" &&
+        canonical.kind === "monitor-lost" &&
+        canonical.status !== "superseded"
+      ) {
+        // A crash stranded matched output, and restart recovery already wrote the
+        // monitor-lost notice for the same id BEFORE this temp was scanned — so the
+        // notice always carries the later updatedAt and a plain comparison would
+        // discard the matched lines forever. Mirror enqueueMonitorLost's upgrade
+        // instead: one pending record carrying both the lines and (when the notice is
+        // still undelivered) the lost-monitor marker. A superseded notice means the
+        // wake was canceled on purpose, so the stale lines die with it below.
+        const merged: BashMonitorWakeRecord =
+          canonical.status === "pending"
+            ? {
+                ...parsed,
+                kind: "monitor-lost",
+                ...(canonical.script != null ? { script: canonical.script } : {}),
+                updatedAt: new Date().toISOString(),
+              }
+            : {
+                // Notice already delivered: only the matched lines are still owed.
+                ...parsed,
+                updatedAt: new Date().toISOString(),
+              };
+        await this.write(merged);
+        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        return merged;
       }
       if (Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)) {
         // The crashed write postdates the canonical record (an uncommitted merge or
@@ -1133,9 +1213,7 @@ export class BashMonitorWakeStore {
       }
       // Same-or-older than the canonical record: a stale uncommitted write, disposable
       // once old (the canonical record is authoritative).
-      if (stat.mtimeMs < pruneBeforeMs) {
-        await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-      }
+      if (old) await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
       return null;
     });
   }
@@ -1183,10 +1261,12 @@ export class BashMonitorWakeStore {
       }
       throw error;
     }
-    const unchanged =
-      captured != null &&
-      captured.updatedAt === compared.updatedAt &&
-      captured.status === compared.status;
+    // Compare the FULL captured generation, not just timestamp and status: two
+    // instances updating within the same millisecond can produce a record with an
+    // identical updatedAt/status but different lines or counters, which must not be
+    // discarded as "unchanged". Both records come from the same zod schema, so key
+    // order — and therefore serialized equality — is deterministic.
+    const unchanged = captured != null && JSON.stringify(captured) === JSON.stringify(compared);
     if (!unchanged) {
       // The canonical record changed under us: restore it and keep the leftover.
       try {
@@ -1592,7 +1672,16 @@ export class BashMonitorWakeStore {
     const target = this.file(record.ownerWorkspaceId, record.id);
     const temp = `${target}.tmp-${randomUUID()}`;
     await fsPromises.writeFile(temp, JSON.stringify(record, null, 2), "utf-8");
-    await fsPromises.rename(temp, target);
+    try {
+      await fsPromises.rename(temp, target);
+    } catch (error) {
+      // The caller observes and reports this failure (e.g. a history clear returns an
+      // error and leaves the wake pending). The temp must not survive it: orphan-temp
+      // recovery would otherwise later "commit" an operation the caller was told never
+      // happened — silently canceling or rewriting the wake behind the caller's back.
+      await fsPromises.rm(temp, { force: true }).catch(() => undefined);
+      throw error;
+    }
     // Invalidate rather than update the classification cache: computing the new stat
     // signature here could race a concurrent rewrite by another instance and pair our
     // record with their signature. The next listPending re-reads this one file.

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1009,8 +1009,15 @@ export class BashMonitorWakeStore {
         // which case that newer record simply supersedes this one.
         try {
           await fsPromises.link(trash, filePath);
-        } catch {
-          // EEXIST (or transient failure): leave whatever owns the path in place.
+        } catch (error) {
+          if (!isErrnoWithCode(error, "EEXIST")) {
+            // Hard-link failure (EIO, ENOSPC, unsupported filesystem): the trash file
+            // is now the only durable copy of this record. Keep it — a later scan's
+            // recoverStrandedPruneFile retries the restore — instead of deleting it in
+            // the removal below.
+            return parsed?.status === "pending" ? parsed : null;
+          }
+          // EEXIST: a newer record owns the canonical path and supersedes this capture.
         }
       }
       await fsPromises.rm(trash, { force: true }).catch(() => undefined);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -39,6 +39,21 @@ const TMP_WRITE_SUFFIX_RE = /\.json\.tmp-[^.]+$/;
 // older is an orphan from a crash. Exported for tests.
 export const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
 
+/**
+ * Delay until a deferred fresh temp should be rechecked: an epsilon past the gate so
+ * the re-driven scan's own freshness check cannot lose a same-millisecond race against
+ * the gate arithmetic. The delay is CAPPED to one bounded recheck interval: a far-future
+ * mtime (clock rollback, corrupted timestamps) could otherwise exceed Node's maximum
+ * timer delay, which Node clamps to ~1ms — a tight rescan loop burning CPU. A capped
+ * recheck re-evaluates the file age on each pass instead. Exported for tests.
+ */
+export function deferredTempRecoveryDelayMs(mtimeMs: number, nowMs: number): number {
+  return Math.min(
+    Math.max(0, mtimeMs + TEMP_RECOVERY_MIN_AGE_MS - nowMs) + 250,
+    TEMP_RECOVERY_MIN_AGE_MS + 250
+  );
+}
+
 // Single-source the wake status enum so the exported TS type and the runtime
 // Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
 // the sibling terminalAttentionStore notification enums.
@@ -561,9 +576,7 @@ export class BashMonitorWakeStore {
     mtimeMs: number
   ): void {
     if (this.deferredTempRecoveryTimers.has(filePath)) return;
-    // Epsilon past the gate so the re-driven scan's own freshness check cannot lose a
-    // same-millisecond race against the gate arithmetic.
-    const delayMs = Math.max(0, mtimeMs + TEMP_RECOVERY_MIN_AGE_MS - Date.now()) + 250;
+    const delayMs = deferredTempRecoveryDelayMs(mtimeMs, Date.now());
     const timer = setTimeout(() => {
       this.deferredTempRecoveryTimers.delete(filePath);
       this.onDeferredTempRecoveryDue?.(ownerWorkspaceId);
@@ -819,48 +832,59 @@ export class BashMonitorWakeStore {
     const records: BashMonitorWakeRecord[] = [];
     const seen = new Set<string>();
     const pruneBeforeMs = Date.now() - TERMINAL_WAKE_RETENTION_MS;
+    // Reconcile crash artifacts BEFORE canonical records. Temp reconciliation verifies
+    // staleness against the canonical generation, so ordering matters: if a terminal
+    // canonical were pruned first (record pass below), a stale same-or-older pending
+    // temp would suddenly look like the only durable copy and be restored — quietly
+    // resurrecting and redelivering a deliberately superseded wake. Artifacts-first
+    // guarantees every temp is judged against the still-present canonical record.
+    const recordEntries: string[] = [];
     for (const entry of entries) {
+      if (entry.endsWith(".json")) {
+        recordEntries.push(entry);
+        continue;
+      }
       const filePath = path.join(dir, entry);
-      if (!entry.endsWith(".json")) {
-        const isPruneTrash = PRUNE_TRASH_SUFFIX_RE.test(entry);
-        const isTempWrite = TMP_WRITE_SUFFIX_RE.test(entry);
-        if (!isPruneTrash && !isTempWrite) continue;
-        // Non-regular artifact guard: recovery reads file contents, and readFile on a
-        // FIFO can block forever while EISDIR would fail every scan. ENOENT means a
-        // concurrent recover consumed it; transient stat failures propagate, matching
-        // the record-file policy above.
-        let artifactStat: Stats;
-        try {
-          artifactStat = await fsPromises.stat(filePath);
-        } catch (error) {
-          if (isErrnoWithCode(error, "ENOENT")) continue;
-          throw error;
-        }
-        if (!artifactStat.isFile()) continue;
-        // A crash between pruneTerminalWakeFile's capture rename and its verify/restore
-        // strands the captured inode as *.json.prune-*, and that inode may hold a
-        // concurrently rewritten pending wake that neither scans nor delivery (both
-        // address the original path) can see. Inspect stranded prune files and restore
-        // pending content before any sweeping can touch it.
-        if (isPruneTrash) {
-          const rescued = await this.recoverStrandedPruneFile(
-            ownerWorkspaceId,
-            filePath,
-            pruneBeforeMs
-          );
-          if (rescued != null) records.push(rescued);
-          continue;
-        }
-        // write() leaves *.json.tmp-* files behind only when the process crashed
-        // between writeFile and the commit rename (a rename failure observed by a live
-        // caller deletes its temp). A COMPLETE temp record may then be the only durable
-        // copy of a wake (a brand-new wake has no canonical file at all), so orphan
-        // temps are parsed and restored rather than treated as disposable; incomplete
-        // ones sweep once old so crash leaks stay bounded.
-        const rescued = await this.recoverOrphanTempFile(ownerWorkspaceId, filePath, pruneBeforeMs);
+      const isPruneTrash = PRUNE_TRASH_SUFFIX_RE.test(entry);
+      const isTempWrite = TMP_WRITE_SUFFIX_RE.test(entry);
+      if (!isPruneTrash && !isTempWrite) continue;
+      // Non-regular artifact guard: recovery reads file contents, and readFile on a
+      // FIFO can block forever while EISDIR would fail every scan. ENOENT means a
+      // concurrent recover consumed it; transient stat failures propagate, matching
+      // the record-file policy below.
+      let artifactStat: Stats;
+      try {
+        artifactStat = await fsPromises.stat(filePath);
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) continue;
+        throw error;
+      }
+      if (!artifactStat.isFile()) continue;
+      // A crash between pruneTerminalWakeFile's capture rename and its verify/restore
+      // strands the captured inode as *.json.prune-*, and that inode may hold a
+      // concurrently rewritten pending wake that neither scans nor delivery (both
+      // address the original path) can see. Inspect stranded prune files and restore
+      // pending content before any sweeping can touch it.
+      if (isPruneTrash) {
+        const rescued = await this.recoverStrandedPruneFile(
+          ownerWorkspaceId,
+          filePath,
+          pruneBeforeMs
+        );
         if (rescued != null) records.push(rescued);
         continue;
       }
+      // write() leaves *.json.tmp-* files behind only when the process crashed
+      // between writeFile and the commit rename (a rename failure observed by a live
+      // caller deletes its temp). A COMPLETE temp record may then be the only durable
+      // copy of a wake (a brand-new wake has no canonical file at all), so orphan
+      // temps are parsed and restored rather than treated as disposable; incomplete
+      // ones sweep once old so crash leaks stay bounded.
+      const rescued = await this.recoverOrphanTempFile(ownerWorkspaceId, filePath, pruneBeforeMs);
+      if (rescued != null) records.push(rescued);
+    }
+    for (const entry of recordEntries) {
+      const filePath = path.join(dir, entry);
       seen.add(entry);
       let stat: Stats;
       try {
@@ -1226,8 +1250,18 @@ export class BashMonitorWakeStore {
       path.basename(originalPath).slice(0, -".json".length)
     );
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
-      const stat = await fsPromises.stat(filePath).catch(() => null);
-      if (!stat?.isFile()) return null; // vanished (live writer committed) or non-regular
+      let stat: Stats;
+      try {
+        stat = await fsPromises.stat(filePath);
+      } catch (error) {
+        // Vanished (live writer committed): nothing to do. Any other failure (EIO,
+        // EACCES) PROPAGATES — the temp may be the ONLY durable copy after a crash,
+        // and a silent empty scan would schedule neither a drain nor the
+        // deferred-recovery timer, stranding the wake until an unrelated scan.
+        if (isErrnoWithCode(error, "ENOENT")) return null;
+        throw error;
+      }
+      if (!stat.isFile()) return null; // non-regular imposter
       const consumable = stat.mtimeMs < Date.now() - TEMP_RECOVERY_MIN_AGE_MS;
       const old = stat.mtimeMs < pruneBeforeMs;
       const parsed = await this.readRecordAt(filePath);
@@ -1347,9 +1381,13 @@ export class BashMonitorWakeStore {
         );
         return committed?.status === "pending" ? committed : null;
       }
-      // Same-or-older than the canonical record: a stale uncommitted write, disposable
-      // once old (the canonical record is authoritative).
-      if (old) await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+      // Same-or-older than the canonical record: a stale uncommitted write; the
+      // canonical record is authoritative. Discard the temp NOW, not once old —
+      // retaining it would open a resurrection window: once the (terminal) canonical
+      // ages past retention and is pruned, a later scan would see no canonical record
+      // and restore this stale pending temp, redelivering a deliberately superseded
+      // wake. The freshness gate already passed, so no live writer can still own it.
+      await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
       return null;
     });
   }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -24,6 +24,14 @@ const MAX_WAKE_LINE_BYTES = 8_192;
 // re-checks records superseded seconds earlier within one history-clear operation.
 export const TERMINAL_WAKE_RETENTION_MS = 60 * 60 * 1000;
 
+// Exact suffix shapes appended by write() (temp) and pruneTerminalWakeFile (trash): a
+// randomUUID tail contains no dots. Anchoring with a no-dot tail matters because wake
+// ids are arbitrary process ids and encodeURIComponent escapes neither dots nor
+// hyphens — an id containing ".json.prune-" would otherwise make its own temp/trash
+// files (e.g. "x.json.prune-y.json.tmp-…") misparse as prune trash for the wrong id.
+const PRUNE_TRASH_SUFFIX_RE = /\.json\.prune-[^.]+$/;
+const TMP_WRITE_SUFFIX_RE = /\.json\.tmp-[^.]+$/;
+
 // Single-source the wake status enum so the exported TS type and the runtime
 // Zod validator below can't drift. Mirrors the `as const` tuple pattern used by
 // the sibling terminalAttentionStore notification enums.
@@ -783,7 +791,7 @@ export class BashMonitorWakeStore {
         // concurrently rewritten pending wake that neither scans nor delivery (both
         // address the original path) can see. Inspect stranded prune files and restore
         // pending content before any sweeping can touch it.
-        if (entry.includes(".json.prune-")) {
+        if (PRUNE_TRASH_SUFFIX_RE.test(entry)) {
           const rescued = await this.recoverStrandedPruneFile(
             ownerWorkspaceId,
             filePath,
@@ -796,7 +804,7 @@ export class BashMonitorWakeStore {
         // mid-write; sweep old ones so crash leaks stay bounded. A tmp file is an
         // uncommitted write — the durable state is whatever the target path holds — so
         // it is never restored, only swept.
-        if (entry.includes(".json.tmp-")) {
+        if (TMP_WRITE_SUFFIX_RE.test(entry)) {
           const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
           if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
             await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
@@ -814,17 +822,19 @@ export class BashMonitorWakeStore {
           classified.delete(entry);
           continue;
         }
-        // Transient stat failure. Returning a partial result would look authoritative to
-        // callers (listBackgroundProcesses caches it as the last good pending set),
-        // silently dropping a durable pending wake. Serve the cached pending
-        // classification when we have one; otherwise propagate so the caller keeps its
-        // previous snapshot instead.
-        const cachedOnError = classified.get(entry);
-        if (cachedOnError != null) {
-          if (cachedOnError.pending != null) records.push(cachedOnError.pending);
-          continue;
-        }
+        // Transient stat failure: PROPAGATE, never serve the cached classification.
+        // Another instance may have superseded the cached pending record behind this
+        // very failure, and drains treat this listing as delivery authority — a served
+        // stale pending could append a synthetic turn for a durably canceled wake.
+        // Display continuity is the UI caller's job (last-good fallback + retry).
         throw error;
+      }
+      if (!stat.isFile()) {
+        // A directory/socket named *.json (corruption or a foreign tool) is not a wake
+        // record; skipping it keeps one weird artifact from failing every scan and
+        // blocking delivery of unrelated valid wakes.
+        classified.delete(entry);
+        continue;
       }
       const sig = `${stat.ino}:${stat.mtimeMs}:${stat.size}`;
       const cached = classified.get(entry);
@@ -945,11 +955,11 @@ export class BashMonitorWakeStore {
     filePath: string,
     pruneBeforeMs: number
   ): Promise<BashMonitorWakeRecord | null> {
-    // Split on the LAST ".json.prune-" so wake ids that themselves contain ".prune-"
-    // (encodeURIComponent escapes neither "." nor "-") still resolve correctly.
-    const marker = filePath.lastIndexOf(".json.prune-");
-    assert(marker >= 0, "recoverStrandedPruneFile requires a *.json.prune-* path");
-    const originalPath = filePath.slice(0, marker + ".json".length);
+    // The anchored suffix regex (see PRUNE_TRASH_SUFFIX_RE) guarantees the split is the
+    // actual trash marker, not a ".json.prune-" occurring inside an arbitrary wake id.
+    const marker = /^(.*\.json)\.prune-[^.]+$/.exec(filePath);
+    assert(marker != null, "recoverStrandedPruneFile requires a *.json.prune-* path");
+    const originalPath = marker[1];
     const id = BashMonitorWakeStore.wakeIdFromFileStem(
       path.basename(originalPath).slice(0, -".json".length)
     );
@@ -1011,13 +1021,78 @@ export class BashMonitorWakeStore {
           parsed.status === "pending" &&
           Date.parse(parsed.updatedAt) > Date.parse(canonical.updatedAt)
         ) {
-          await fsPromises.rename(filePath, originalPath);
-          return parsed;
+          return this.replaceCanonicalIfUnchanged(filePath, originalPath, parsed, canonical);
         }
       }
       await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
       return restored && parsed.status === "pending" ? parsed : null;
     });
+  }
+
+  /**
+   * Compare-and-swap replacement of the canonical wake file by a strictly newer pending
+   * leftover. A plain rename would be a blind overwrite: between reading `compared` and
+   * the rename, another instance can replace the canonical path with an even newer
+   * pending (new output) or terminal (canceled) record, which must not be resurrected
+   * or lost. Instead, atomically capture the canonical inode under a trash name, verify
+   * it still matches `compared`, and place the leftover with a no-clobber link. Every
+   * unexpected state backs off leaving the leftover in place — the next scan
+   * re-reconciles against the then-settled canonical record. The trash name uses the
+   * standard prune suffix, so a crash mid-swap is healed by recoverStrandedPruneFile.
+   * Caller must hold the per-record lock.
+   */
+  private async replaceCanonicalIfUnchanged(
+    leftoverPath: string,
+    originalPath: string,
+    leftover: BashMonitorWakeRecord,
+    compared: BashMonitorWakeRecord
+  ): Promise<BashMonitorWakeRecord | null> {
+    const cas = `${originalPath}.prune-${randomUUID()}`;
+    try {
+      await fsPromises.rename(originalPath, cas);
+    } catch {
+      // Canonical vanished mid-swap: back off; the next scan re-reconciles.
+      return null;
+    }
+    let captured: BashMonitorWakeRecord | null;
+    try {
+      captured = await this.readRecordAt(cas);
+    } catch (error) {
+      // Cannot verify what we captured: put it back (no-clobber) and propagate.
+      try {
+        await fsPromises.link(cas, originalPath);
+        await fsPromises.rm(cas, { force: true }).catch(() => undefined);
+      } catch {
+        // A newer write claimed the path; the cas file is healed as prune trash later.
+      }
+      throw error;
+    }
+    const unchanged =
+      captured != null &&
+      captured.updatedAt === compared.updatedAt &&
+      captured.status === compared.status;
+    if (!unchanged) {
+      // The canonical record changed under us: restore it and keep the leftover.
+      try {
+        await fsPromises.link(cas, originalPath);
+      } catch {
+        // A newer write already claimed the path; it supersedes the stale capture.
+      }
+      await fsPromises.rm(cas, { force: true }).catch(() => undefined);
+      return null;
+    }
+    let placed = false;
+    try {
+      await fsPromises.link(leftoverPath, originalPath);
+      placed = true;
+    } catch {
+      // Someone claimed the path mid-swap; keep the leftover for re-reconciliation.
+    }
+    // The captured record is verifiably the older one we compared: safe to drop.
+    await fsPromises.rm(cas, { force: true }).catch(() => undefined);
+    if (!placed) return null;
+    await fsPromises.rm(leftoverPath, { force: true }).catch(() => undefined);
+    return leftover;
   }
 
   /**

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -648,26 +648,42 @@ export class BashMonitorWakeStore {
   // abandonWorkspaceClears).
   private readonly stagedClearRefreshTimers = new Map<
     string,
-    { timer: NodeJS.Timeout; ownerWorkspaceId: string }
+    { timer: NodeJS.Timeout; ownerWorkspaceId: string; inFlight: Promise<void> | null }
   >();
 
   private armStagedClearRefresh(ownerWorkspaceId: string, clearId: string): void {
     this.disarmStagedClearRefresh(clearId);
-    const timer = setInterval(() => {
-      // Best-effort: a missed refresh only narrows the liveness window and the next
-      // tick tries again — refresh failures must never break the clear itself. The
-      // guard on clearId keeps a heartbeat that outlives its generation (raced away
-      // by a newer clear) from resurrecting or touching a foreign tombstone.
-      void this.mutateClearedAt(ownerWorkspaceId, (current) =>
-        current?.clearId === clearId && current.phase === "staged"
-          ? { ...current, stagedAt: new Date().toISOString() }
-          : "keep"
-      ).catch(() => undefined);
-    }, this.stagedClearRefreshIntervalMs);
+    const entry: {
+      timer: NodeJS.Timeout;
+      ownerWorkspaceId: string;
+      inFlight: Promise<void> | null;
+    } = {
+      timer: setInterval(() => {
+        // Best-effort: a missed refresh only narrows the liveness window and the next
+        // tick tries again — refresh failures must never break the clear itself. The
+        // guard on clearId keeps a heartbeat that outlives its generation (raced away
+        // by a newer clear) from resurrecting or touching a foreign tombstone.
+        // Tracked (not fire-and-forget) so abandonWorkspaceClears can DRAIN a tick
+        // that already fired: even a "keep" no-op re-creates the wake directory
+        // (mutateClearedAt mkdirs before capturing), which removal must never race.
+        // Ticks serialize on the per-owner tombstone lock, so the latest assignment
+        // settles last and awaiting it covers every earlier queued tick.
+        entry.inFlight = this.mutateClearedAt(ownerWorkspaceId, (current) =>
+          current?.clearId === clearId && current.phase === "staged"
+            ? { ...current, stagedAt: new Date().toISOString() }
+            : "keep"
+        ).then(
+          () => undefined,
+          () => undefined
+        );
+      }, this.stagedClearRefreshIntervalMs),
+      ownerWorkspaceId,
+      inFlight: null,
+    };
     // Never hold process shutdown open: a staging orphaned by shutdown is exactly
     // what the grace scan reconciles.
-    timer.unref();
-    this.stagedClearRefreshTimers.set(clearId, { timer, ownerWorkspaceId });
+    entry.timer.unref();
+    this.stagedClearRefreshTimers.set(clearId, entry);
   }
 
   private disarmStagedClearRefresh(clearId: string): void {
@@ -686,13 +702,20 @@ export class BashMonitorWakeStore {
    * that survives a failed removal be grace-rolled-back (fail toward delivery)
    * instead of being held forever by a marker whose owner will never settle it.
    */
-  abandonWorkspaceClears(ownerWorkspaceId: string): void {
+  async abandonWorkspaceClears(ownerWorkspaceId: string): Promise<void> {
+    const drains: Array<Promise<void>> = [];
     for (const [clearId, entry] of this.stagedClearRefreshTimers) {
       if (entry.ownerWorkspaceId !== ownerWorkspaceId) continue;
       clearInterval(entry.timer);
       this.stagedClearRefreshTimers.delete(clearId);
       this.activeClearIds.delete(clearId);
+      // clearInterval cancels ticks that have not fired, but a tick that already
+      // fired holds a live mutateClearedAt promise outside any caller-visible lock;
+      // its recursive mkdir would recreate the session directory if removal deleted
+      // it mid-mutation. Collect and drain those before the caller proceeds.
+      if (entry.inFlight != null) drains.push(entry.inFlight);
     }
+    await Promise.all(drains);
   }
 
   private scheduleDeferredTempRecovery(
@@ -1086,9 +1109,25 @@ export class BashMonitorWakeStore {
    * generation owned by a DIFFERENT clear (another instance committed a newer one) is
    * left untouched — demoting it would revive wakes that clear legitimately retired.
    */
-  private async rollbackClearTombstone(ownerWorkspaceId: string, clearId: string): Promise<void> {
+  private async rollbackClearTombstone(
+    ownerWorkspaceId: string,
+    clearId: string,
+    onlyIfStagedAt?: string
+  ): Promise<void> {
     await this.mutateClearedAt(ownerWorkspaceId, (current) => {
       if (current?.clearId !== clearId) return "keep";
+      // Crash-rollback callers pin the exact staging generation they judged crashed:
+      // between their read and this CAS, the owning instance may have refreshed
+      // stagedAt (live, not crashed) or committed (retirement final) — clearId alone
+      // cannot distinguish those. Demoting a committed tombstone would resurrect
+      // condemned pre-clear temps; demoting a refreshed staging would strip a live
+      // clear's protection mid-transaction.
+      if (
+        onlyIfStagedAt != null &&
+        (current.phase !== "staged" || current.stagedAt !== onlyIfStagedAt)
+      ) {
+        return "keep";
+      }
       if (current.previousClearedAt != null) {
         // Demoted values carry no staging state: the previous clear committed long
         // ago (a clear only becomes "previous" after committing).
@@ -1144,7 +1183,9 @@ export class BashMonitorWakeStore {
         });
       });
     }
-    await this.rollbackClearTombstone(ownerWorkspaceId, clearId);
+    // Pinned to the staging generation read above: only the exact stagedAt judged
+    // crashed may be demoted (see rollbackClearTombstone).
+    await this.rollbackClearTombstone(ownerWorkspaceId, clearId, tomb.stagedAt);
   }
 
   static wakeId(processId: string): string {
@@ -1567,8 +1608,12 @@ export class BashMonitorWakeStore {
       const cutoffMs = Date.parse(tomb.clearedAt);
       const listable: BashMonitorWakeRecord[] = [];
       for (const record of deduped) {
-        // NaN-safe: an unparseable updatedAt fails toward delivery (listed).
-        if (!(Date.parse(record.updatedAt) <= cutoffMs)) {
+        // STRICTLY before the cutoff: a wake enqueued after the clear began can be
+        // stamped in the cutoff's own millisecond, and the transaction's invariant
+        // is that mid-clear output survives. The one-millisecond ambiguity fails
+        // toward delivery, matching the store's documented bias. NaN-safe: an
+        // unparseable updatedAt also fails toward delivery (listed).
+        if (!(Date.parse(record.updatedAt) < cutoffMs)) {
           listable.push(record);
           continue;
         }
@@ -1597,7 +1642,7 @@ export class BashMonitorWakeStore {
     await this.locks.withLock(`${ownerWorkspaceId}:${snapshot.id}`, async () => {
       const record = await this.get(ownerWorkspaceId, snapshot.id);
       if (record?.status !== "pending") return;
-      if (!(Date.parse(record.updatedAt) <= cutoffMs)) return;
+      if (!(Date.parse(record.updatedAt) < cutoffMs)) return;
       await this.write(this.withTerminalStatus(record, "superseded"));
     });
   }
@@ -1830,19 +1875,32 @@ export class BashMonitorWakeStore {
       }
       const parsed = this.parse(raw);
       if (parsed?.status !== "pending") {
-        // Old terminal and malformed content was already destined for pruning; sweep it
-        // once old (the age gate keeps a live prune's in-flight trash out of reach).
-        const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
-        if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
-          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
-          return null;
+        // A superseded record stamped by an UNRESOLVED staged clear is that clear's
+        // only rollback source, and rollbackCrashedClearStaging restores canonical
+        // .json files only — an age-based sweep of this stranded copy (captured by a
+        // prune that crashed mid-verify) would permanently lose the wake if the
+        // clear later fails. Hold it regardless of age: fall through to the restore
+        // below so the record returns to its canonical path.
+        const heldForStagedClear =
+          parsed?.status === "superseded" &&
+          parsed.supersededByClearId != null &&
+          (await this.isUnresolvedStagedClear(ownerWorkspaceId, parsed.supersededByClearId));
+        if (!heldForStagedClear) {
+          // Old terminal and malformed content was already destined for pruning; sweep it
+          // once old (the age gate keeps a live prune's in-flight trash out of reach).
+          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+          if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
+            await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+            return null;
+          }
+          // Malformed-but-fresh content cannot be meaningfully restored; keep the
+          // leftover as evidence until the age gate sweeps it.
+          if (parsed == null) return null;
         }
-        // Malformed-but-fresh content cannot be meaningfully restored; keep the
-        // leftover as evidence until the age gate sweeps it.
-        if (parsed == null) return null;
-        // Fresh terminal content falls through to the restore below: a freshly
-        // superseded record must stay visible at its path or restorePendingSnapshots
-        // cannot flip it back to pending after a failed history clear.
+        // Fresh terminal content (and staged-clear-held records) falls through to the
+        // restore below: a superseded record must stay visible at its path or
+        // restorePendingSnapshots cannot flip it back to pending after a failed
+        // history clear.
       }
       let restored = false;
       try {
@@ -1901,6 +1959,18 @@ export class BashMonitorWakeStore {
           return parsed;
         }
         const canonical = canonicalState.record;
+        if (JSON.stringify(parsed) === JSON.stringify(canonical)) {
+          // The leftover IS the canonical generation: a prior recovery linked it back
+          // to the canonical path but its leftover cleanup failed or crashed, leaving
+          // two names for one inode. Any reconciliation below would double the record
+          // against itself — offset-less records (legacy, or terminal-only
+          // settlements) skip the subsumption guards entirely and would reach the
+          // divergent merge, duplicating lines and counters for a single generation.
+          // Drop the extra name; rm failure PROPAGATES so a silently surviving
+          // duplicate can never merge on a later scan.
+          await fsPromises.rm(filePath, { force: true });
+          return canonical.status === "pending" ? canonical : null;
+        }
         if (parsed.status === "pending" && canonical.status === "pending") {
           // DIVERGENT pending generations: the canonical record may have been written
           // from scratch while a prune held this generation captured, so a newer
@@ -1983,7 +2053,16 @@ export class BashMonitorWakeStore {
         await fsPromises.rm(filePath, { force: true });
         return canonical.status === "pending" ? canonical : null;
       }
-      await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+      await fsPromises.rm(filePath, { force: true }).catch((error: unknown) => {
+        // Non-fatal (the restore already succeeded, so failing the scan would only
+        // delay delivery) but never silent: the surviving duplicate name is healed by
+        // the identical-content check on the next scan, which propagates its removal
+        // failure.
+        log.debug("Failed to remove restored bash monitor prune leftover", {
+          ownerWorkspaceId,
+          error,
+        });
+      });
       return restored && parsed.status === "pending" ? parsed : null;
     });
   }
@@ -2044,7 +2123,10 @@ export class BashMonitorWakeStore {
       }
       if (parsed.status === "pending") {
         const tomb = await this.readClearedAt(ownerWorkspaceId);
-        if (tomb != null && Date.parse(parsed.updatedAt) <= Date.parse(tomb.clearedAt)) {
+        // STRICTLY before the cutoff (matching the canonical pre-cutoff check): a
+        // temp stamped in the cutoff's own millisecond may carry mid-clear output,
+        // which the transaction explicitly intends to survive.
+        if (tomb != null && Date.parse(parsed.updatedAt) < Date.parse(tomb.clearedAt)) {
           if (tomb.phase === "staged") {
             // The owning clear's outcome is UNKNOWN: hold the temp — neither restore
             // (a committed clear must not see this wake delivered) nor discard (a
@@ -2581,6 +2663,11 @@ export class BashMonitorWakeStore {
     return this.locks.withLock(`${ownerWorkspaceId}:${snapshot.id}`, async () => {
       const record = await this.get(ownerWorkspaceId, snapshot.id);
       if (record?.status !== "pending") return false;
+      // A wake enqueued after the cutoff was captured can still appear in the
+      // clear's snapshot (the scan runs after the capture, and another instance's
+      // write can land between the two). A timestamp STRICTLY after the cutoff is
+      // unambiguous mid-clear output, which the clear must never retire.
+      if (Date.parse(record.updatedAt) > Date.parse(clearedAt)) return false;
       // Only the SNAPSHOTTED generation is retired: another store instance can merge
       // NEW matched output into this record between the clear's snapshot and this
       // lock, and the clear's cutoff explicitly intends mid-clear output to survive.
@@ -2593,16 +2680,16 @@ export class BashMonitorWakeStore {
       // parses of the same writer's serialized bytes, so key order is stable.
       if (JSON.stringify(record) !== JSON.stringify(snapshot)) {
         // The surviving record must stay distinguishable from a pre-clear stray:
-        // listPending holds/retires pending records stamped at/before the cutoff
-        // (see the pre-cutoff canonical check), and a same-millisecond merge leaves
-        // updatedAt at its pre-clear value even though the content is
+        // listPending holds/retires pending records stamped strictly before the
+        // cutoff (see the pre-cutoff canonical check), and a same-millisecond merge
+        // can leave updatedAt at its pre-clear value even though the content is
         // post-snapshot. Re-stamp it past the cutoff (the +1ms floor covers a bump
         // landing within the cutoff's own millisecond) so the very clear this
         // record survived can never later retire it. In-flight delivery snapshots
         // keyed on the old updatedAt then decline and redeliver — the same
         // documented lesser failure as above.
         const cutoffMs = Date.parse(clearedAt);
-        if (Date.parse(record.updatedAt) <= cutoffMs) {
+        if (Date.parse(record.updatedAt) < cutoffMs) {
           await this.write({
             ...record,
             updatedAt: new Date(Math.max(Date.now(), cutoffMs + 1)).toISOString(),

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -992,7 +992,18 @@ export class BashMonitorWakeStore {
     // survives re-enters this same reconciliation later.
     const sweepSuperseded = async (standing: ClearTombstone): Promise<void> => {
       for (const candidate of candidates) {
-        if (!BashMonitorWakeStore.tombstoneStrictlyOutranks(standing, candidate.tomb)) continue;
+        // Swept when the standing generation strictly outranks the candidate — or
+        // when the candidate IS the identical generation (a duplicate stranded by a
+        // crash or failed cleanup): the standing canonical carries its exact
+        // protection, so the duplicate can only ever resurrect a generation that was
+        // deliberately settled. Genuinely incomparable ties (same rank, different
+        // fields) are kept.
+        if (
+          !BashMonitorWakeStore.tombstoneStrictlyOutranks(standing, candidate.tomb) &&
+          !BashMonitorWakeStore.tombstonesIdentical(standing, candidate.tomb)
+        ) {
+          continue;
+        }
         await fsPromises.rm(candidate.path, { force: true }).catch(() => undefined);
       }
     };
@@ -1033,8 +1044,9 @@ export class BashMonitorWakeStore {
    * Whether `standing` strictly outranks `candidate` under the heal selection
    * ordering (newer cutoff; committed over staged at an equal cutoff; fresher
    * stagedAt when both are staged at an equal cutoff). Used to sweep captures that a
-   * durably standing generation supersedes — exact ties are NOT outranked and are
-   * kept, because sweeping requires proof the candidate can never matter again.
+   * durably standing generation supersedes — ties are NOT outranked (sweeping on
+   * rank alone requires proof the candidate can never matter again; exact duplicates
+   * are handled separately via tombstonesIdentical).
    */
   private static tombstoneStrictlyOutranks(
     standing: ClearTombstone,
@@ -1048,6 +1060,17 @@ export class BashMonitorWakeStore {
       return Date.parse(standing.stagedAt ?? "") > Date.parse(candidate.stagedAt ?? "");
     }
     return false;
+  }
+
+  /** Whether two tombstones are the exact same generation, field for field. */
+  private static tombstonesIdentical(a: ClearTombstone, b: ClearTombstone): boolean {
+    return (
+      a.clearedAt === b.clearedAt &&
+      a.clearId === b.clearId &&
+      a.phase === b.phase &&
+      a.stagedAt === b.stagedAt &&
+      a.previousClearedAt === b.previousClearedAt
+    );
   }
 
   private static parseTombstone(raw: string): ClearTombstone | null {
@@ -1919,6 +1942,20 @@ export class BashMonitorWakeStore {
   ): Promise<
     { kind: "absent" } | { kind: "malformed" } | { kind: "record"; record: BashMonitorWakeRecord }
   > {
+    // Non-regular guard: artifacts-first recovery reaches this read BEFORE the
+    // record pass's own non-regular skip — a directory left at the canonical path by
+    // corruption would fail every scan with EISDIR, and a FIFO would block reads
+    // forever, stranding every other wake in the workspace. Classify as MALFORMED so
+    // the quarantine (which re-verifies whatever it captures) parks it as evidence
+    // and the caller can place its durable artifact.
+    let stat: Stats;
+    try {
+      stat = await fsPromises.stat(originalPath);
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return { kind: "absent" };
+      throw error;
+    }
+    if (!stat.isFile()) return { kind: "malformed" };
     let raw: string;
     try {
       raw = await fsPromises.readFile(originalPath, "utf-8");
@@ -1965,6 +2002,30 @@ export class BashMonitorWakeStore {
       // other failure propagates into caller retries.
       if (isErrnoWithCode(error, "ENOENT")) return { kind: "cleared" };
       throw error;
+    }
+    // Non-regular guard mirroring readCanonicalState: reading a captured directory
+    // fails with EISDIR and a captured FIFO blocks forever. Park it in the evidence
+    // namespace directly — it can never hold a restorable record, and left under the
+    // prune-trash name the artifact loop's isFile guard would merely skip it forever.
+    let capturedStat: Stats;
+    try {
+      capturedStat = await fsPromises.stat(capture);
+    } catch (error) {
+      // Vanished: a concurrent recover consumed the capture, so the path is free.
+      if (isErrnoWithCode(error, "ENOENT")) return { kind: "cleared" };
+      // Cannot verify what we captured; it stays behind as prune trash, where a
+      // regular record heals and anything else is skipped. Propagate into retries.
+      throw error;
+    }
+    if (!capturedStat.isFile()) {
+      log.debug("Quarantining non-regular bash monitor wake canonical", {
+        ownerWorkspaceId,
+        id,
+      });
+      await fsPromises
+        .rename(capture, `${originalPath}.malformed-${randomUUID()}`)
+        .catch(() => undefined);
+      return { kind: "cleared" };
     }
     let captured: BashMonitorWakeRecord | null;
     try {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -605,16 +605,70 @@ export class BashMonitorWakeStore {
   private async writeClearedAt(ownerWorkspaceId: string, clearedAt: string): Promise<void> {
     const target = this.clearedAtFile(ownerWorkspaceId);
     await fsPromises.mkdir(path.dirname(target), { recursive: true });
+    // Carry the value being replaced: a ROLLBACK of this clear must restore the prior
+    // tombstone rather than deleting the file wholesale, or an older successful
+    // clear's protection would die with a newer failed one and let a pre-old-clear
+    // temp deliver permanently retired output. Only one level is needed — a clear
+    // becomes "previous" only after committing, and committed clears are never
+    // rolled back.
+    const previousClearedAtMs = await this.readClearedAtMs(ownerWorkspaceId);
+    await this.writeClearedAtFile(target, {
+      clearedAt,
+      ...(previousClearedAtMs != null
+        ? { previousClearedAt: new Date(previousClearedAtMs).toISOString() }
+        : {}),
+    });
+  }
+
+  private async writeClearedAtFile(
+    target: string,
+    record: { clearedAt: string; previousClearedAt?: string }
+  ): Promise<void> {
     // Atomic like write(): a torn tombstone must never be a file's settled content.
     // The temp name matches no artifact pattern either, so scans skip it too.
     const temp = `${target}.tmp-${randomUUID()}`;
-    await fsPromises.writeFile(temp, JSON.stringify({ clearedAt }), "utf-8");
+    await fsPromises.writeFile(temp, JSON.stringify(record), "utf-8");
     try {
       await fsPromises.rename(temp, target);
     } catch (error) {
       await fsPromises.rm(temp, { force: true }).catch(() => undefined);
       throw error;
     }
+  }
+
+  /**
+   * Roll the tombstone back by one clear: restore the previous clear's value when one
+   * exists, otherwise remove the file. Called only when the CURRENT tombstone belongs
+   * to the clear being rolled back (supersedeAllPending writes its tombstone last, so
+   * its own failure never promotes one). Failures PROPAGATE — a stale surviving
+   * tombstone would silently discard a revived wake's deferred temp.
+   */
+  private async rollbackClearedAt(ownerWorkspaceId: string): Promise<void> {
+    const target = this.clearedAtFile(ownerWorkspaceId);
+    let raw: string;
+    try {
+      raw = await fsPromises.readFile(target, "utf-8");
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return; // nothing to roll back
+      throw error;
+    }
+    let previous: string | null = null;
+    try {
+      const parsed = JSON.parse(raw) as { previousClearedAt?: unknown };
+      previous =
+        typeof parsed.previousClearedAt === "string" &&
+        !Number.isNaN(Date.parse(parsed.previousClearedAt))
+          ? parsed.previousClearedAt
+          : null;
+    } catch {
+      // Malformed tombstones already provide no protection to preserve.
+      previous = null;
+    }
+    if (previous != null) {
+      await this.writeClearedAtFile(target, { clearedAt: previous });
+      return;
+    }
+    await fsPromises.rm(target, { force: true });
   }
 
   /** Epoch ms of the latest history clear, or null when none applies (absent or malformed). */
@@ -1838,7 +1892,11 @@ export class BashMonitorWakeStore {
       await this.writeClearedAt(ownerWorkspaceId, clearedAt);
       return pending;
     } catch (error) {
-      await this.restorePendingSnapshots(ownerWorkspaceId, staged);
+      // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
+      // tombstone write above is the try block's last step, so on this path it was
+      // never promoted, and demoting here would strip the PREVIOUS clear's
+      // protection instead.
+      await this.restoreSnapshotRecords(ownerWorkspaceId, staged);
       throw error;
     }
   }
@@ -1847,11 +1905,19 @@ export class BashMonitorWakeStore {
     ownerWorkspaceId: string,
     snapshots: readonly BashMonitorWakeRecord[]
   ): Promise<void> {
-    // Rolling back a failed clear also rolls back its tombstone: the wakes below
-    // return to pending, so a sibling deferred temp must not stay condemned. Removal
-    // failures PROPAGATE — a stale surviving tombstone would silently discard that
-    // temp's output even though the clear never held.
-    await fsPromises.rm(this.clearedAtFile(ownerWorkspaceId), { force: true });
+    // Rolling back a clear also rolls back ITS tombstone — restoring the previous
+    // clear's value, never deleting the file wholesale: the wakes below return to
+    // pending, so a sibling deferred temp must not stay condemned by the rolled-back
+    // clear, while a pre-old-clear temp must stay condemned by the surviving older
+    // tombstone.
+    await this.rollbackClearedAt(ownerWorkspaceId);
+    await this.restoreSnapshotRecords(ownerWorkspaceId, snapshots);
+  }
+
+  private async restoreSnapshotRecords(
+    ownerWorkspaceId: string,
+    snapshots: readonly BashMonitorWakeRecord[]
+  ): Promise<void> {
     for (const snapshot of snapshots) {
       const key = `${ownerWorkspaceId}:${snapshot.id}`;
       await this.locks.withLock(key, async () => {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -932,7 +932,7 @@ export class BashMonitorWakeStore {
       // namespace so scans stop tripping over it.
       let leftoverStat: Stats;
       try {
-        leftoverStat = await fsPromises.stat(leftoverPath);
+        leftoverStat = await fsPromises.lstat(leftoverPath);
       } catch (error) {
         if (isErrnoWithCode(error, "ENOENT")) continue; // concurrently consumed
         throw error;
@@ -1132,7 +1132,7 @@ export class BashMonitorWakeStore {
     // aside as evidence and continue as if the tombstone were malformed.
     let stat: Stats;
     try {
-      stat = await fsPromises.stat(target);
+      stat = await fsPromises.lstat(target);
     } catch (error) {
       if (!isErrnoWithCode(error, "ENOENT")) throw error;
       return this.healClearedAtFromLeftovers(ownerWorkspaceId);
@@ -1347,8 +1347,16 @@ export class BashMonitorWakeStore {
         if (record?.status !== "superseded" || record.supersededByClearId !== clearId) return;
         // Identity gate: the write below targets the PARSED identity, so restoring a
         // record whose id/owner disagrees with this path would overwrite an
-        // unrelated record or workspace (see recordIdentityMatches).
-        if (!BashMonitorWakeStore.recordIdentityMatches(record, ownerWorkspaceId, id)) return;
+        // unrelated record or workspace (see recordIdentityMatchesEntry).
+        if (
+          !BashMonitorWakeStore.recordIdentityMatchesEntry(
+            record,
+            ownerWorkspaceId,
+            entry.slice(0, -".json".length)
+          )
+        ) {
+          return;
+        }
         const { supersededByClearId: _clearStamp, pendingUpdatedAtBeforeClear, ...rest } = record;
         const written: BashMonitorWakeRecord = {
           ...rest,
@@ -1627,6 +1635,22 @@ export class BashMonitorWakeStore {
     return record.id === id && record.ownerWorkspaceId === ownerWorkspaceId;
   }
 
+  /**
+   * Entry-name flavor of recordIdentityMatches for scans, comparing the RAW filename
+   * stem against the canonical encoding of the record id (exactly what file() would
+   * name it). Decoding the stem instead would accept noncanonical percent-encoding
+   * aliases — %70roc-1.json decodes to proc-1 — publishing a wake whose every later
+   * transition (get/write build paths via encodeURIComponent) targets the canonical
+   * name, leaving the alias pending forever.
+   */
+  private static recordIdentityMatchesEntry(
+    record: BashMonitorWakeRecord,
+    ownerWorkspaceId: string,
+    stem: string
+  ): boolean {
+    return encodeURIComponent(record.id) === stem && record.ownerWorkspaceId === ownerWorkspaceId;
+  }
+
   async get(ownerWorkspaceId: string, id: string): Promise<BashMonitorWakeRecord | null> {
     let raw: string;
     try {
@@ -1691,7 +1715,7 @@ export class BashMonitorWakeStore {
       // the record-file policy below.
       let artifactStat: Stats;
       try {
-        artifactStat = await fsPromises.stat(filePath);
+        artifactStat = await fsPromises.lstat(filePath);
       } catch (error) {
         if (isErrnoWithCode(error, "ENOENT")) continue;
         throw error;
@@ -1740,21 +1764,26 @@ export class BashMonitorWakeStore {
     // rollback leaves pending are folded into the record pass: one restored from an
     // artifact rescued this very scan has no canonical entry in the readdir snapshot
     // above. The entries check keeps this off the hot path — tombstone artifacts
-    // exist only around clears and crashes. The effective tombstone is then read
-    // (post-rollback) for the pre-cutoff canonical check at the end of this scan.
-    let tomb: ClearTombstone | null = null;
+    // exist only around clears and crashes (a staging published after the snapshot
+    // cannot be grace-expired yet, so gating the ROLLBACK on the snapshot is safe).
     if (entries.some((e) => e === "cleared-at" || e.startsWith("cleared-at.cas-"))) {
       for (const entry of await this.rollbackCrashedClearStaging(ownerWorkspaceId)) {
         if (!recordEntries.includes(entry)) recordEntries.push(entry);
       }
-      tomb = await this.readClearedAt(ownerWorkspaceId);
     }
+    // The effective tombstone for the pre-cutoff canonical check at the end of this
+    // scan is read UNCONDITIONALLY (post-rollback), never gated on the readdir
+    // snapshot above: a clear can publish its tombstone after the snapshot was
+    // taken, and a crash-stalled writer can then land a pre-cutoff pending
+    // generation over an already-snapshotted entry mid-scan — served without the
+    // fence, a drain would deliver output that clear is holding or has retired.
+    const tomb = await this.readClearedAt(ownerWorkspaceId);
     for (const entry of recordEntries) {
       const filePath = path.join(dir, entry);
       seen.add(entry);
       let stat: Stats;
       try {
-        stat = await fsPromises.stat(filePath);
+        stat = await fsPromises.lstat(filePath);
       } catch (error) {
         if (isErrnoWithCode(error, "ENOENT")) {
           // Deleted between readdir and stat: legitimately gone.
@@ -1813,10 +1842,10 @@ export class BashMonitorWakeStore {
       let parsed = this.parse(raw);
       if (
         parsed != null &&
-        !BashMonitorWakeStore.recordIdentityMatches(
+        !BashMonitorWakeStore.recordIdentityMatchesEntry(
           parsed,
           ownerWorkspaceId,
-          BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length))
+          entry.slice(0, -".json".length)
         )
       ) {
         // Identity disagrees with the path (see recordIdentityMatches): treated like
@@ -1947,10 +1976,14 @@ export class BashMonitorWakeStore {
     // corruption would fail every scan with EISDIR, and a FIFO would block reads
     // forever, stranding every other wake in the workspace. Classify as MALFORMED so
     // the quarantine (which re-verifies whatever it captures) parks it as evidence
-    // and the caller can place its durable artifact.
+    // and the caller can place its durable artifact. lstat (never follows): a
+    // DANGLING SYMLINK would stat as ENOENT and classify the occupied pathname as
+    // "absent" — the recovery link then loops on EEXIST forever, never delivering
+    // the artifact. Symlinks have no legitimate writer here, so any symlink is
+    // corruption and reads as malformed.
     let stat: Stats;
     try {
-      stat = await fsPromises.stat(originalPath);
+      stat = await fsPromises.lstat(originalPath);
     } catch (error) {
       if (isErrnoWithCode(error, "ENOENT")) return { kind: "absent" };
       throw error;
@@ -2009,7 +2042,7 @@ export class BashMonitorWakeStore {
     // prune-trash name the artifact loop's isFile guard would merely skip it forever.
     let capturedStat: Stats;
     try {
-      capturedStat = await fsPromises.stat(capture);
+      capturedStat = await fsPromises.lstat(capture);
     } catch (error) {
       // Vanished: a concurrent recover consumed the capture, so the path is free.
       if (isErrnoWithCode(error, "ENOENT")) return { kind: "cleared" };
@@ -2196,10 +2229,14 @@ export class BashMonitorWakeStore {
       // Identity gate: a moved/corrupt leftover whose id or owner disagrees with the
       // canonical path it would be restored to reads as malformed (kept as evidence
       // until the age sweep) — restoring it would publish a record later transitions
-      // cannot address (see recordIdentityMatches).
+      // cannot address (see recordIdentityMatchesEntry).
       const parsed =
         parsedRaw != null &&
-        BashMonitorWakeStore.recordIdentityMatches(parsedRaw, ownerWorkspaceId, id)
+        BashMonitorWakeStore.recordIdentityMatchesEntry(
+          parsedRaw,
+          ownerWorkspaceId,
+          path.basename(originalPath).slice(0, -".json".length)
+        )
           ? parsedRaw
           : null;
       if (parsed?.status !== "pending") {
@@ -2216,7 +2253,7 @@ export class BashMonitorWakeStore {
         if (!heldForStagedClear) {
           // Old terminal and malformed content was already destined for pruning; sweep it
           // once old (the age gate keeps a live prune's in-flight trash out of reach).
-          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+          const leftoverStat = await fsPromises.lstat(filePath).catch(() => null);
           if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
             await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
             return null;
@@ -2424,7 +2461,7 @@ export class BashMonitorWakeStore {
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
       let stat: Stats;
       try {
-        stat = await fsPromises.stat(filePath);
+        stat = await fsPromises.lstat(filePath);
       } catch (error) {
         // Vanished (live writer committed): nothing to do. Any other failure (EIO,
         // EACCES) PROPAGATES — the temp may be the ONLY durable copy after a crash,
@@ -2440,10 +2477,14 @@ export class BashMonitorWakeStore {
       // Identity gate: a moved/corrupt artifact whose id or owner disagrees with the
       // canonical path it would be restored to reads as malformed (swept once old) —
       // placing it would publish a record later transitions cannot address (see
-      // recordIdentityMatches).
+      // recordIdentityMatchesEntry).
       const parsed =
         parsedRaw != null &&
-        BashMonitorWakeStore.recordIdentityMatches(parsedRaw, ownerWorkspaceId, id)
+        BashMonitorWakeStore.recordIdentityMatchesEntry(
+          parsedRaw,
+          ownerWorkspaceId,
+          path.basename(originalPath).slice(0, -".json".length)
+        )
           ? parsedRaw
           : null;
       if (parsed == null) {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1388,9 +1388,13 @@ export class BashMonitorWakeStore {
     // A staged clear tombstone abandoned past its grace window is a CRASHED clear
     // staging (see rollbackCrashedClearStaging); resolve it before anything below
     // consults the tombstone or the stamped records. The entries check keeps this off
-    // the hot path — tombstone artifacts exist only around clears and crashes.
+    // the hot path — tombstone artifacts exist only around clears and crashes. The
+    // effective tombstone is then read (post-rollback) for the pre-cutoff canonical
+    // check at the end of this scan.
+    let tomb: ClearTombstone | null = null;
     if (entries.some((e) => e === "cleared-at" || e.startsWith("cleared-at.cas-"))) {
       await this.rollbackCrashedClearStaging(ownerWorkspaceId);
+      tomb = await this.readClearedAt(ownerWorkspaceId);
     }
     const records: BashMonitorWakeRecord[] = [];
     const seen = new Set<string>();
@@ -1551,9 +1555,51 @@ export class BashMonitorWakeStore {
         newestById.set(record.id, record);
       }
     }
-    const deduped = [...newestById.values()];
+    let deduped = [...newestById.values()];
+    // Pre-cutoff records that (re)surfaced as CANONICAL after a clear's snapshot — a
+    // crash-stalled writer's rename landing late, or a cross-instance recovery
+    // restoring an old generation. The tombstone otherwise fences only orphan-temp
+    // recovery, so such a record would stay pending and deliver pre-clear output
+    // into the cleared transcript. Mirroring the temp rules: a COMMITTED cutoff
+    // retires it durably; a STAGED one holds it (neither deliver nor retire) until
+    // the transaction commits, rolls back, or is grace-rolled-back as crashed.
+    if (tomb != null) {
+      const cutoffMs = Date.parse(tomb.clearedAt);
+      const listable: BashMonitorWakeRecord[] = [];
+      for (const record of deduped) {
+        // NaN-safe: an unparseable updatedAt fails toward delivery (listed).
+        if (!(Date.parse(record.updatedAt) <= cutoffMs)) {
+          listable.push(record);
+          continue;
+        }
+        if (tomb.phase !== "staged") {
+          await this.retirePreCutoffCanonical(ownerWorkspaceId, record, cutoffMs);
+        }
+      }
+      deduped = listable;
+    }
     deduped.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
     return deduped;
+  }
+
+  /**
+   * Durably retire a pending canonical record stamped at/before a COMMITTED clear's
+   * cutoff (see the pre-cutoff check in listPending). Re-verified under the record
+   * lock against the current generation, so a post-cutoff merge racing this scan is
+   * never retired. Durable (not a per-scan suppression) so the record cannot outlive
+   * its clear indefinitely and re-deliver through any path that reads it directly.
+   */
+  private async retirePreCutoffCanonical(
+    ownerWorkspaceId: string,
+    snapshot: BashMonitorWakeRecord,
+    cutoffMs: number
+  ): Promise<void> {
+    await this.locks.withLock(`${ownerWorkspaceId}:${snapshot.id}`, async () => {
+      const record = await this.get(ownerWorkspaceId, snapshot.id);
+      if (record?.status !== "pending") return;
+      if (!(Date.parse(record.updatedAt) <= cutoffMs)) return;
+      await this.write(this.withTerminalStatus(record, "superseded"));
+    });
   }
 
   /**
@@ -2451,27 +2497,25 @@ export class BashMonitorWakeStore {
         if (current != null) {
           const currentMs = Date.parse(current.clearedAt);
           const ourMs = Date.parse(clearedAt);
-          // A strictly newer cutoff always wins; an EQUAL cutoff blocks us only while
-          // it is another clear's in-flight STAGING (same-millisecond concurrent
-          // clears). An equal COMMITTED cutoff retires exactly what ours would, so
-          // staging over it (with it as rollback predecessor) loses nothing — and
-          // same-millisecond sequential clears in one process keep working.
-          if (currentMs > ourMs || (currentMs === ourMs && current.phase === "staged")) {
+          // A COMMITTED current with a strictly newer cutoff subsumes ours. ANY
+          // staged current blocks us regardless of cutoff order: an unresolved
+          // staged transaction's stamped records are recoverable only through ITS
+          // tombstone, so replacing it (even with a newer cutoff) would — after a
+          // crash of both processes — leave restart rollback restoring only records
+          // stamped with the standing clearId, stranding the older clear's records
+          // superseded forever. A crashed staging cannot wedge this: the listPending
+          // above already rolled back stagings past their grace window. An equal
+          // COMMITTED cutoff retires exactly what ours would, so staging over it
+          // (with it as rollback predecessor) loses nothing — and same-millisecond
+          // sequential clears in one process keep working.
+          if (currentMs > ourMs || current.phase === "staged") {
             return "keep";
           }
         }
-        // The rollback predecessor must be a COMMITTED cutoff: inheriting a staged
-        // current's own cutoff would let OUR later rollback materialize it as
-        // committed, permanently retiring wakes for a clear that never succeeded. A
-        // staged current's committed predecessor carries forward instead; if its
-        // owner commits later, commitClear's monotonic branch inserts that cutoff
-        // into our previousClearedAt.
-        const committedPredecessor =
-          current == null
-            ? null
-            : current.phase === "staged"
-              ? (current.previousClearedAt ?? null)
-              : current.clearedAt;
+        // Reaching here, current is null or COMMITTED (any staged current returned
+        // above). That committed cutoff is our rollback predecessor: our later
+        // rollback restores it rather than dropping the standing protection.
+        const committedPredecessor = current == null ? null : current.clearedAt;
         decidedToStage = true;
         return {
           clearedAt,
@@ -2500,7 +2544,7 @@ export class BashMonitorWakeStore {
         // Snapshots list only what was ACTUALLY retired: a record that changed past
         // the cutoff stays pending, and restoring it on rollback would be wrong (its
         // restore would clobber the newer merged generation back to the snapshot).
-        if (await this.supersedeForClear(ownerWorkspaceId, record, clearId)) {
+        if (await this.supersedeForClear(ownerWorkspaceId, record, clearId, clearedAt)) {
           staged.push(record);
         }
       }
@@ -2531,7 +2575,8 @@ export class BashMonitorWakeStore {
   private async supersedeForClear(
     ownerWorkspaceId: string,
     snapshot: BashMonitorWakeRecord,
-    clearId: string
+    clearId: string,
+    clearedAt: string
   ): Promise<boolean> {
     return this.locks.withLock(`${ownerWorkspaceId}:${snapshot.id}`, async () => {
       const record = await this.get(ownerWorkspaceId, snapshot.id);
@@ -2546,7 +2591,25 @@ export class BashMonitorWakeStore {
       // millisecond, leaving the timestamp unchanged while lines and counters differ
       // (replaceCanonicalIfUnchanged documents the same possibility). Both sides are
       // parses of the same writer's serialized bytes, so key order is stable.
-      if (JSON.stringify(record) !== JSON.stringify(snapshot)) return false;
+      if (JSON.stringify(record) !== JSON.stringify(snapshot)) {
+        // The surviving record must stay distinguishable from a pre-clear stray:
+        // listPending holds/retires pending records stamped at/before the cutoff
+        // (see the pre-cutoff canonical check), and a same-millisecond merge leaves
+        // updatedAt at its pre-clear value even though the content is
+        // post-snapshot. Re-stamp it past the cutoff (the +1ms floor covers a bump
+        // landing within the cutoff's own millisecond) so the very clear this
+        // record survived can never later retire it. In-flight delivery snapshots
+        // keyed on the old updatedAt then decline and redeliver — the same
+        // documented lesser failure as above.
+        const cutoffMs = Date.parse(clearedAt);
+        if (Date.parse(record.updatedAt) <= cutoffMs) {
+          await this.write({
+            ...record,
+            updatedAt: new Date(Math.max(Date.now(), cutoffMs + 1)).toISOString(),
+          });
+        }
+        return false;
+      }
       await this.write({
         ...this.withTerminalStatus(record, "superseded"),
         supersededByClearId: clearId,

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -778,9 +778,25 @@ export class BashMonitorWakeStore {
     for (const entry of entries) {
       const filePath = path.join(dir, entry);
       if (!entry.endsWith(".json")) {
-        // write()/pruning leave *.json.tmp-* / *.json.prune-* files behind only when the
-        // process crashed mid-operation; sweep old ones so crash leaks stay bounded.
-        if (/\.json\.(?:tmp|prune)-/.test(entry)) {
+        // A crash between pruneTerminalWakeFile's capture rename and its verify/restore
+        // strands the captured inode as *.json.prune-*, and that inode may hold a
+        // concurrently rewritten pending wake that neither scans nor delivery (both
+        // address the original path) can see. Inspect stranded prune files and restore
+        // pending content before any sweeping can touch it.
+        if (entry.includes(".json.prune-")) {
+          const rescued = await this.recoverStrandedPruneFile(
+            ownerWorkspaceId,
+            filePath,
+            pruneBeforeMs
+          );
+          if (rescued != null) records.push(rescued);
+          continue;
+        }
+        // write() leaves *.json.tmp-* files behind only when the process crashed
+        // mid-write; sweep old ones so crash leaks stay bounded. A tmp file is an
+        // uncommitted write — the durable state is whatever the target path holds — so
+        // it is never restored, only swept.
+        if (entry.includes(".json.tmp-")) {
           const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
           if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
             await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
@@ -862,6 +878,76 @@ export class BashMonitorWakeStore {
   }
 
   /**
+   * Best-effort lock key for a wake file name. Filenames are encodeURIComponent(id);
+   * fall back to the raw stem for foreign files that do not round-trip (no writer
+   * contends on those ids anyway).
+   */
+  private static wakeIdFromFileStem(stem: string): string {
+    try {
+      return decodeURIComponent(stem);
+    } catch {
+      return stem;
+    }
+  }
+
+  /**
+   * Handle a *.json.prune-* leftover. pruneTerminalWakeFile renames the path's current
+   * inode aside before verifying it; a crash in that window strands the captured inode
+   * under the trash name, where neither scans nor delivery (both address the original
+   * path) can see it — and blind sweeping would eventually delete it. Stranded pending
+   * content is linked back to its original path (link() refuses to clobber a newer
+   * record at the path, which then supersedes the stranded one and lets it be removed)
+   * and the leftover deleted; a leftover that cannot be read or restored right now is
+   * KEPT so a later scan retries rather than ever deleting an unrecovered pending wake.
+   * Non-pending leftovers are swept once old. Returns the restored pending record.
+   */
+  private async recoverStrandedPruneFile(
+    ownerWorkspaceId: string,
+    filePath: string,
+    pruneBeforeMs: number
+  ): Promise<BashMonitorWakeRecord | null> {
+    // Split on the LAST ".json.prune-" so wake ids that themselves contain ".prune-"
+    // (encodeURIComponent escapes neither "." nor "-") still resolve correctly.
+    const marker = filePath.lastIndexOf(".json.prune-");
+    assert(marker >= 0, "recoverStrandedPruneFile requires a *.json.prune-* path");
+    const originalPath = filePath.slice(0, marker + ".json".length);
+    const id = BashMonitorWakeStore.wakeIdFromFileStem(
+      path.basename(originalPath).slice(0, -".json".length)
+    );
+    return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
+      // Unreadable (vanished via a concurrent recover, or transiently failing): keep
+      // whatever may exist for a later retry.
+      const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
+      const parsed = raw == null ? null : this.parse(raw);
+      if (parsed?.status !== "pending") {
+        // Terminal or malformed content was already destined for pruning; sweep it once
+        // old (the age gate keeps a live prune's in-flight trash out of reach).
+        if (raw != null) {
+          const leftoverStat = await fsPromises.stat(filePath).catch(() => null);
+          if (leftoverStat != null && leftoverStat.mtimeMs < pruneBeforeMs) {
+            await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+          }
+        }
+        return null;
+      }
+      let restored = false;
+      try {
+        await fsPromises.link(filePath, originalPath);
+        restored = true;
+      } catch (error) {
+        if (!isErrnoWithCode(error, "EEXIST")) {
+          // Transient link failure: keep the leftover so a later scan retries the
+          // restore instead of deleting a never-recovered pending wake.
+          return null;
+        }
+        // EEXIST: a newer record owns the original path and supersedes the stranded one.
+      }
+      await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+      return restored ? parsed : null;
+    });
+  }
+
+  /**
    * Delete a terminal wake file that is past its retention window. The prune decision is
    * check-then-act against an earlier stat/read, and wake ids are reused process ids, so
    * a concurrent writer (another store instance, or an enqueue in this process) may have
@@ -877,15 +963,7 @@ export class BashMonitorWakeStore {
     entry: string,
     filePath: string
   ): Promise<BashMonitorWakeRecord | null> {
-    const stem = entry.slice(0, -".json".length);
-    // Filenames are encodeURIComponent(id); fall back to the raw stem for foreign files
-    // that do not round-trip (no writer contends on those ids anyway).
-    let id = stem;
-    try {
-      id = decodeURIComponent(stem);
-    } catch {
-      // keep the raw stem
-    }
+    const id = BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length));
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
       const trash = `${filePath}.prune-${randomUUID()}`;
       try {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -47,6 +47,16 @@ export const TEMP_RECOVERY_MIN_AGE_MS = 60 * 1000;
 export const STAGED_CLEAR_ROLLBACK_GRACE_MS = 5 * 60 * 1000;
 
 /**
+ * Tombstone timestamps further in the future than this are implausible (clock
+ * rollback or corruption) and read as malformed. A future committed cutoff would
+ * otherwise condemn every subsequently orphaned temp while the monotonic clear logic
+ * refuses to replace it with normal current-time cutoffs; a future staged one would
+ * never reach its rollback grace and hold wakes forever. Generous enough for real
+ * cross-instance clock skew.
+ */
+export const MAX_TOMBSTONE_FUTURE_SKEW_MS = 60 * 60 * 1000;
+
+/**
  * Delay until a deferred fresh temp should be rechecked: an epsilon past the gate so
  * the re-driven scan's own freshness check cannot lose a same-millisecond race against
  * the gate arithmetic. The delay is CAPPED to one bounded recheck interval: a far-future
@@ -832,6 +842,12 @@ export class BashMonitorWakeStore {
       if (typeof parsed.clearedAt !== "string" || Number.isNaN(Date.parse(parsed.clearedAt))) {
         return null;
       }
+      // Implausibly FUTURE timestamps (see MAX_TOMBSTONE_FUTURE_SKEW_MS) read as
+      // malformed so the persisted state self-heals: fail toward delivery, and the
+      // next clear rewrites the file with a sane cutoff.
+      if (Date.parse(parsed.clearedAt) > Date.now() + MAX_TOMBSTONE_FUTURE_SKEW_MS) {
+        return null;
+      }
       if (parsed.phase != null && parsed.phase !== "staged" && parsed.phase !== "committed") {
         // An unknown phase (corruption, or a newer build's state) must not silently
         // take the committed path — only the exact "staged" value enters the hold, so
@@ -848,6 +864,11 @@ export class BashMonitorWakeStore {
         // malformed (fail toward delivery); the next clear rewrites the file.
         if (typeof parsed.clearId !== "string" || parsed.clearId.length === 0) return null;
         if (typeof parsed.stagedAt !== "string" || Number.isNaN(Date.parse(parsed.stagedAt))) {
+          return null;
+        }
+        // A far-future stagedAt would keep the staging outside its rollback grace
+        // forever, holding pre-clear temps for an outcome that never resolves.
+        if (Date.parse(parsed.stagedAt) > Date.now() + MAX_TOMBSTONE_FUTURE_SKEW_MS) {
           return null;
         }
       }
@@ -2317,9 +2338,15 @@ export class BashMonitorWakeStore {
     // the wakes below return to pending, so a sibling deferred temp must not stay
     // condemned by the rolled-back clear, while temps retired by OTHER clears must
     // stay condemned.
+    //
+    // Records FIRST, tombstone SECOND — the same order as rollbackCrashedClearStaging,
+    // and for the same reason: a crash between the two leaves the staged tombstone
+    // standing, so the grace scan can resume the rollback (record restores are
+    // idempotent). Demoting the tombstone first would strand still-stamped records
+    // with nothing left on disk to trigger their recovery.
     this.activeClearIds.delete(token.clearId);
-    await this.rollbackClearTombstone(ownerWorkspaceId, token.clearId);
     await this.restoreSnapshotRecords(ownerWorkspaceId, snapshots);
+    await this.rollbackClearTombstone(ownerWorkspaceId, token.clearId);
   }
 
   private async restoreSnapshotRecords(

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -637,13 +637,20 @@ export class BashMonitorWakeStore {
   }
 
   /**
-   * Roll the tombstone back by one clear: restore the previous clear's value when one
-   * exists, otherwise remove the file. Called only when the CURRENT tombstone belongs
-   * to the clear being rolled back (supersedeAllPending writes its tombstone last, so
-   * its own failure never promotes one). Failures PROPAGATE — a stale surviving
-   * tombstone would silently discard a revived wake's deferred temp.
+   * Roll back exactly ONE clear's tombstone, identified by the clearedAt it wrote:
+   * restore the previous clear's value when one exists, otherwise remove the file. The
+   * identity check matters with multiple instances — another instance may have
+   * committed a NEWER clear since, and demoting its tombstone would revive deferred
+   * wakes that newer clear legitimately retired; a current generation that is not the
+   * one being rolled back is left untouched. (supersedeAllPending writes its tombstone
+   * last, so its own failure path never promotes one and never calls this.) Failures
+   * PROPAGATE — a stale surviving tombstone would silently discard a revived wake's
+   * deferred temp.
    */
-  private async rollbackClearedAt(ownerWorkspaceId: string): Promise<void> {
+  private async rollbackClearedAt(
+    ownerWorkspaceId: string,
+    expectedClearedAt: string
+  ): Promise<void> {
     const target = this.clearedAtFile(ownerWorkspaceId);
     let raw: string;
     try {
@@ -652,9 +659,11 @@ export class BashMonitorWakeStore {
       if (isErrnoWithCode(error, "ENOENT")) return; // nothing to roll back
       throw error;
     }
+    let current: string | null = null;
     let previous: string | null = null;
     try {
-      const parsed = JSON.parse(raw) as { previousClearedAt?: unknown };
+      const parsed = JSON.parse(raw) as { clearedAt?: unknown; previousClearedAt?: unknown };
+      current = typeof parsed.clearedAt === "string" ? parsed.clearedAt : null;
       previous =
         typeof parsed.previousClearedAt === "string" &&
         !Number.isNaN(Date.parse(parsed.previousClearedAt))
@@ -662,7 +671,12 @@ export class BashMonitorWakeStore {
           : null;
     } catch {
       // Malformed tombstones already provide no protection to preserve.
+      current = null;
       previous = null;
+    }
+    if (current != null && current !== expectedClearedAt) {
+      // A different clear owns the current tombstone: not ours to roll back.
+      return;
     }
     if (previous != null) {
       await this.writeClearedAtFile(target, { clearedAt: previous });
@@ -1216,6 +1230,11 @@ export class BashMonitorWakeStore {
     canonical: BashMonitorWakeRecord,
     other: BashMonitorWakeRecord
   ): boolean {
+    // Subsumption must preserve NON-OUTPUT state too: a monitor-lost record carries
+    // the termination notice and relaunch script, so a plain match can never subsume
+    // it no matter what offsets say — discarding it would hand the agent matched
+    // output without revealing the task is no longer awaitable.
+    if (other.kind === "monitor-lost" && canonical.kind !== "monitor-lost") return false;
     return (
       canonical.createdAt === other.createdAt &&
       canonical.matchedThroughOffset != null &&
@@ -1389,10 +1408,24 @@ export class BashMonitorWakeStore {
             await fsPromises.rm(filePath, { force: true });
             return canonical;
           }
-          if (parsed.kind === "monitor-lost" && canonical.kind === "match") {
-            // A fresh match proves this id was re-armed by a LIVE monitor, so the
-            // captured lost notice is stale (mirrors enqueueOrMergePending's rule of
-            // replacing stale notices rather than mislabeling live output).
+          if (BashMonitorWakeStore.pendingSubsumes(parsed, canonical)) {
+            // REVERSE subsumption: the leftover already carries the canonical
+            // generation (same lineage, frontier at/past it — e.g. a captured
+            // monitor-lost upgrade restored after its older match generation).
+            // Replace instead of merging, which would duplicate the older lines.
+            return this.replaceCanonicalIfUnchanged(filePath, originalPath, parsed, canonical);
+          }
+          if (
+            parsed.kind === "monitor-lost" &&
+            canonical.kind === "match" &&
+            Date.parse(canonical.updatedAt) > Date.parse(parsed.updatedAt)
+          ) {
+            // A match STRICTLY NEWER than the captured lost notice proves this id was
+            // re-armed by a LIVE monitor, so the notice is stale (mirrors
+            // enqueueOrMergePending's rule of replacing stale notices rather than
+            // mislabeling live output). Without the timestamp guard this would also
+            // swallow a cross-lineage lost notice that postdates the match; that case
+            // falls through to the merge, which preserves the notice and script.
             await fsPromises.rm(filePath, { force: true });
             return canonical;
           }
@@ -1873,9 +1906,12 @@ export class BashMonitorWakeStore {
     return ownerWorkspaceIds;
   }
 
-  async supersedeAllPending(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
+  async supersedeAllPending(
+    ownerWorkspaceId: string
+  ): Promise<{ snapshots: BashMonitorWakeRecord[]; clearedAt: string }> {
     // Captured BEFORE the scan: the tombstone below retires only wakes stamped before
-    // the clear began, so output enqueued mid-clear survives it.
+    // the clear began, so output enqueued mid-clear survives it. Returned so a later
+    // rollback can identify exactly this clear's tombstone (see rollbackClearedAt).
     const clearedAt = new Date().toISOString();
     const pending = await this.listPending(ownerWorkspaceId);
     const staged: BashMonitorWakeRecord[] = [];
@@ -1890,7 +1926,7 @@ export class BashMonitorWakeStore {
       // pre-clear wake into the cleared transcript. Written only after every visible
       // wake retired; a failure here fails the clear (snapshots restored below).
       await this.writeClearedAt(ownerWorkspaceId, clearedAt);
-      return pending;
+      return { snapshots: pending, clearedAt };
     } catch (error) {
       // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
       // tombstone write above is the try block's last step, so on this path it was
@@ -1903,14 +1939,16 @@ export class BashMonitorWakeStore {
 
   async restorePendingSnapshots(
     ownerWorkspaceId: string,
-    snapshots: readonly BashMonitorWakeRecord[]
+    snapshots: readonly BashMonitorWakeRecord[],
+    clearedAt: string
   ): Promise<void> {
-    // Rolling back a clear also rolls back ITS tombstone — restoring the previous
-    // clear's value, never deleting the file wholesale: the wakes below return to
-    // pending, so a sibling deferred temp must not stay condemned by the rolled-back
-    // clear, while a pre-old-clear temp must stay condemned by the surviving older
-    // tombstone.
-    await this.rollbackClearedAt(ownerWorkspaceId);
+    // Rolling back a clear also rolls back ITS tombstone (identified by the clearedAt
+    // that supersedeAllPending returned) — restoring the previous clear's value, never
+    // deleting the file wholesale, and never touching a newer clear's tombstone: the
+    // wakes below return to pending, so a sibling deferred temp must not stay
+    // condemned by the rolled-back clear, while temps retired by OTHER clears must
+    // stay condemned.
+    await this.rollbackClearedAt(ownerWorkspaceId, clearedAt);
     await this.restoreSnapshotRecords(ownerWorkspaceId, snapshots);
   }
 

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -781,7 +781,18 @@ export class BashMonitorWakeStore {
         await fsPromises.rm(leftoverPath, { force: true }).catch(() => undefined);
         continue;
       }
-      if (newest == null || Date.parse(parsed.clearedAt) > Date.parse(newest.clearedAt)) {
+      if (
+        newest == null ||
+        Date.parse(parsed.clearedAt) > Date.parse(newest.clearedAt) ||
+        // On EQUAL cutoffs, committed outranks staged: a commit that crashed after
+        // publishing its committed value but before consuming its staged capture
+        // strands BOTH generations of one clear. Selecting the staged one would let
+        // the grace-window rollback restore wakes that the committed clear retired;
+        // directory order must never decide that.
+        (Date.parse(parsed.clearedAt) === Date.parse(newest.clearedAt) &&
+          newest.phase === "staged" &&
+          parsed.phase !== "staged")
+      ) {
         newest = parsed;
         newestPath = leftoverPath;
       }
@@ -819,6 +830,13 @@ export class BashMonitorWakeStore {
     try {
       const parsed = JSON.parse(raw) as Partial<ClearTombstone>;
       if (typeof parsed.clearedAt !== "string" || Number.isNaN(Date.parse(parsed.clearedAt))) {
+        return null;
+      }
+      if (parsed.phase != null && parsed.phase !== "staged" && parsed.phase !== "committed") {
+        // An unknown phase (corruption, or a newer build's state) must not silently
+        // take the committed path — only the exact "staged" value enters the hold, so
+        // anything else would permanently CONDEMN pre-clear temps. Malformed reads as
+        // "no clear": fail toward delivery.
         return null;
       }
       if (parsed.phase === "staged") {
@@ -869,7 +887,6 @@ export class BashMonitorWakeStore {
    * re-establishes the committed cutoff if a foreign rollback removed the staging.
    */
   async commitClear(ownerWorkspaceId: string, token: BashMonitorClearToken): Promise<void> {
-    this.activeClearIds.delete(token.clearId);
     await this.mutateClearedAt(ownerWorkspaceId, (current) => {
       if (current == null) {
         return { clearedAt: token.clearedAt, clearId: token.clearId, phase: "committed" };
@@ -880,7 +897,22 @@ export class BashMonitorWakeStore {
         return { ...rest, phase: "committed" };
       }
       // Monotonic: a newer (or equal) cutoff subsumes ours; never lower it.
-      if (Date.parse(current.clearedAt) >= Date.parse(token.clearedAt)) return "keep";
+      if (Date.parse(current.clearedAt) >= Date.parse(token.clearedAt)) {
+        // A newer STAGED generation may still ROLL BACK — and it can only demote to
+        // the predecessor it captured, which may predate this clear entirely (we
+        // stalled before our staging landed, so it never saw our cutoff). Record our
+        // COMMITTED cutoff as its rollback predecessor; otherwise this successful
+        // clear leaves no durable trace and a deferred wake predating it could
+        // recover into the cleared transcript after that rollback.
+        if (
+          current.phase === "staged" &&
+          (current.previousClearedAt == null ||
+            Date.parse(current.previousClearedAt) < Date.parse(token.clearedAt))
+        ) {
+          return { ...current, previousClearedAt: token.clearedAt };
+        }
+        return "keep";
+      }
       return {
         clearedAt: token.clearedAt,
         clearId: token.clearId,
@@ -888,6 +920,12 @@ export class BashMonitorWakeStore {
         previousClearedAt: current.clearedAt,
       };
     });
+    // Deactivated only AFTER the promotion durably landed: this marker is what stops
+    // the staged-clear grace scan from treating a slow-to-commit SUCCESSFUL clear as
+    // crashed and restoring the wakes it retired. On failure it stays active — the
+    // caller's retry (see WorkspaceService.scheduleBashMonitorClearCommitRetry)
+    // re-drives the promotion, and a process crash hands over to the grace scan.
+    this.activeClearIds.delete(token.clearId);
   }
 
   /**
@@ -1882,10 +1920,22 @@ export class BashMonitorWakeStore {
         const merged: BashMonitorWakeRecord =
           canonical.status === "pending"
             ? {
-                ...parsed,
-                kind: "monitor-lost",
-                ...(canonical.script != null ? { script: canonical.script } : {}),
-                updatedAt: new Date().toISOString(),
+                // Merge BOTH pending payloads: the canonical notice may itself carry
+                // undelivered matched lines from an earlier match generation, and
+                // building the replacement from the temp alone would permanently
+                // drop them from the wake prompt. The divergent merge keeps older
+                // lines first and preserves the lost-notice kind and relaunch
+                // script.
+                ...BashMonitorWakeStore.mergeDivergentPending(parsed, canonical),
+                // But pin the MATCH TEMP's lineage on the merged record: if the temp
+                // survives a failed cleanup below, the next scan must be able to
+                // PROVE the canonical subsumes it (createdAt identity + offset
+                // frontier) — under the notice's lineage it could re-merge or mint a
+                // fresh pending wake for already-delivered output.
+                createdAt: parsed.createdAt,
+                ...(canonical.createdAt !== parsed.createdAt && parsed.matchedThroughOffset != null
+                  ? { matchedThroughOffset: parsed.matchedThroughOffset }
+                  : {}),
               }
             : {
                 // Notice already delivered: only the matched lines are still owed.
@@ -2207,12 +2257,24 @@ export class BashMonitorWakeStore {
         if (current != null && Date.parse(current.clearedAt) >= Date.parse(clearedAt)) {
           return "keep";
         }
+        // The rollback predecessor must be a COMMITTED cutoff: inheriting a staged
+        // current's own cutoff would let OUR later rollback materialize it as
+        // committed, permanently retiring wakes for a clear that never succeeded. A
+        // staged current's committed predecessor carries forward instead; if its
+        // owner commits later, commitClear's monotonic branch inserts that cutoff
+        // into our previousClearedAt.
+        const committedPredecessor =
+          current == null
+            ? null
+            : current.phase === "staged"
+              ? (current.previousClearedAt ?? null)
+              : current.clearedAt;
         return {
           clearedAt,
           clearId,
           phase: "staged",
           stagedAt: new Date().toISOString(),
-          ...(current != null ? { previousClearedAt: current.clearedAt } : {}),
+          ...(committedPredecessor != null ? { previousClearedAt: committedPredecessor } : {}),
         };
       });
       return { snapshots: pending, clearedAt, clearId };

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -500,13 +500,21 @@ export function buildBashMonitorWakePrompt(
 export class BashMonitorWakeStore {
   private readonly locks = new MutexMap<string>();
   // Pending-id index so the hot listPending path (recomputed for every background-bash
-  // UI snapshot) reads only currently-pending records instead of scanning every
+  // UI snapshot) reads only currently-pending records instead of reading every
   // historical wake file — terminal records are never pruned from disk, so long-lived
   // workspaces accumulate them. Seeded per owner by one full directory scan; afterwards
   // write() keeps it in sync because every durable mutation funnels through write().
   // Seeding merges instead of replacing: a concurrent write can land between the
   // directory read and installation, and the read-verify in listPending drops stale ids.
+  //
+  // Another store instance can share this session directory (multiple service handles,
+  // or a second app process under XUM_ALLOW_MULTIPLE_INSTANCES), so the warm path still
+  // lists the directory each call — one cheap readdir, not per-file reads — and classifies
+  // only file names it has never seen (classifiedFilesByOwner), which is how wakes written
+  // by other instances are discovered. Cross-instance retirements are handled by the
+  // read-verify pass on the pending set.
   private readonly pendingIdsByOwner = new Map<string, Set<string>>();
+  private readonly classifiedFilesByOwner = new Map<string, Set<string>>();
   private readonly seededPendingOwners = new Set<string>();
 
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
@@ -740,32 +748,6 @@ export class BashMonitorWakeStore {
   }
 
   async listPending(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
-    if (!this.seededPendingOwners.has(ownerWorkspaceId)) {
-      return this.seedPendingIndex(ownerWorkspaceId);
-    }
-    const ids = this.pendingIdsByOwner.get(ownerWorkspaceId);
-    const records: BashMonitorWakeRecord[] = [];
-    for (const id of [...(ids ?? [])]) {
-      let record: BashMonitorWakeRecord | null;
-      try {
-        record = await this.get(ownerWorkspaceId, id);
-      } catch {
-        // Transient read failure: keep the index entry so the next call retries.
-        continue;
-      }
-      if (record?.status === "pending") {
-        records.push(record);
-      } else {
-        // Terminal, deleted, or malformed on disk: the id no longer belongs in the index.
-        ids?.delete(id);
-      }
-    }
-    records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
-    return records;
-  }
-
-  /** One-time-per-owner full scan that both answers listPending and seeds the index. */
-  private async seedPendingIndex(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
     const dir = this.dir(ownerWorkspaceId);
     let entries: string[];
     try {
@@ -777,22 +759,61 @@ export class BashMonitorWakeStore {
       }
       throw error;
     }
+
+    const classified = this.getOrCreateOwnerSet(this.classifiedFilesByOwner, ownerWorkspaceId);
+    const ids = this.getOrCreateOwnerSet(this.pendingIdsByOwner, ownerWorkspaceId);
+    const seeding = !this.seededPendingOwners.has(ownerWorkspaceId);
     const records: BashMonitorWakeRecord[] = [];
+
+    // Read file contents only for names never classified by this instance (the whole
+    // directory when seeding; afterwards just wakes written by other store instances).
     for (const entry of entries) {
       if (!entry.endsWith(".json")) continue;
+      if (classified.has(entry)) continue;
       const raw = await fsPromises.readFile(path.join(dir, entry), "utf-8").catch(() => null);
-      if (raw == null) continue;
-      const parsed = this.parse(raw);
-      if (parsed?.status === "pending") records.push(parsed);
+      // Transient read failure: leave unclassified so the next call retries.
+      if (raw == null && !seeding) continue;
+      classified.add(entry);
+      const parsed = raw == null ? null : this.parse(raw);
+      if (parsed?.status === "pending") {
+        records.push(parsed);
+        ids.add(parsed.id);
+      }
     }
-    const ids = this.pendingIdsByOwner.get(ownerWorkspaceId) ?? new Set<string>();
-    for (const record of records) {
-      ids.add(record.id);
-    }
-    this.pendingIdsByOwner.set(ownerWorkspaceId, ids);
     this.seededPendingOwners.add(ownerWorkspaceId);
+
+    // Read-verify the previously known pending set; drop ids retired on disk (possibly by
+    // another instance). Newly discovered records above are already verified.
+    const discoveredIds = new Set(records.map((record) => record.id));
+    for (const id of [...ids]) {
+      if (discoveredIds.has(id)) continue;
+      let record: BashMonitorWakeRecord | null;
+      try {
+        record = await this.get(ownerWorkspaceId, id);
+      } catch {
+        // Transient read failure: keep the index entry so the next call retries.
+        continue;
+      }
+      if (record?.status === "pending") {
+        records.push(record);
+      } else {
+        // Terminal, deleted, or malformed on disk: the id no longer belongs in the index.
+        ids.delete(id);
+      }
+    }
     records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
     return records;
+  }
+
+  private getOrCreateOwnerSet(
+    map: Map<string, Set<string>>,
+    ownerWorkspaceId: string
+  ): Set<string> {
+    const existing = map.get(ownerWorkspaceId);
+    if (existing != null) return existing;
+    const created = new Set<string>();
+    map.set(ownerWorkspaceId, created);
+    return created;
   }
 
   async listPendingOwnerWorkspaceIds(): Promise<string[]> {
@@ -1039,16 +1060,17 @@ export class BashMonitorWakeStore {
       "utf-8"
     );
     // Keep the pending index in sync with the durable state (index only after the write
-    // succeeds, so the index can never claim a pending record that is not on disk).
-    const ids = this.pendingIdsByOwner.get(record.ownerWorkspaceId);
+    // succeeds, so the index can never claim a pending record that is not on disk). Also
+    // mark the file name classified so the warm listPending pass does not re-read our own
+    // writes as unknown cross-instance files.
+    this.getOrCreateOwnerSet(this.classifiedFilesByOwner, record.ownerWorkspaceId).add(
+      `${encodeURIComponent(record.id)}.json`
+    );
+    const ids = this.getOrCreateOwnerSet(this.pendingIdsByOwner, record.ownerWorkspaceId);
     if (record.status === "pending") {
-      if (ids != null) {
-        ids.add(record.id);
-      } else {
-        this.pendingIdsByOwner.set(record.ownerWorkspaceId, new Set([record.id]));
-      }
+      ids.add(record.id);
     } else {
-      ids?.delete(record.id);
+      ids.delete(record.id);
     }
   }
 

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -993,8 +993,13 @@ export class BashMonitorWakeStore {
       const trash = `${filePath}.prune-${randomUUID()}`;
       try {
         await fsPromises.rename(filePath, trash);
-      } catch {
-        return null; // already gone (concurrent prune or external cleanup)
+      } catch (error) {
+        // Gone: a concurrent prune or external cleanup already took it. Anything else
+        // (EIO, EACCES) PROPAGATES — the path may hold a concurrently rewritten pending
+        // wake by now, and swallowing would return a successful snapshot without it,
+        // bypassing every caller-side retry.
+        if (isErrnoWithCode(error, "ENOENT")) return null;
+        throw error;
       }
       const raw = await fsPromises.readFile(trash, "utf-8").catch(() => null);
       const parsed = raw == null ? null : this.parse(raw);
@@ -1025,6 +1030,13 @@ export class BashMonitorWakeStore {
             return parsed?.status === "pending" ? parsed : null;
           }
           // EEXIST: a newer record owns the canonical path and supersedes this capture.
+          // Publish the canonical record's CURRENT pending state, never the discarded
+          // capture — the newer write may carry newer output or even have canceled the
+          // wake, and a drain must not deliver durably-retired content.
+          await fsPromises.rm(trash, { force: true }).catch(() => undefined);
+          const currentRaw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
+          const current = currentRaw == null ? null : this.parse(currentRaw);
+          return current?.status === "pending" ? current : null;
         }
       }
       await fsPromises.rm(trash, { force: true }).catch(() => undefined);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1050,9 +1050,13 @@ export class BashMonitorWakeStore {
     const cas = `${originalPath}.prune-${randomUUID()}`;
     try {
       await fsPromises.rename(originalPath, cas);
-    } catch {
-      // Canonical vanished mid-swap: back off; the next scan re-reconciles.
-      return null;
+    } catch (error) {
+      // Canonical vanished mid-swap: back off; the next scan re-reconciles. Any other
+      // failure (EIO, EACCES) PROPAGATES — a silent null looks like a successful empty
+      // scan, and when the canonical record is terminal, startup discovery would then
+      // schedule neither a drain nor a retry for the still-stranded pending leftover.
+      if (isErrnoWithCode(error, "ENOENT")) return null;
+      throw error;
     }
     let captured: BashMonitorWakeRecord | null;
     try {
@@ -1085,8 +1089,24 @@ export class BashMonitorWakeStore {
     try {
       await fsPromises.link(leftoverPath, originalPath);
       placed = true;
-    } catch {
-      // Someone claimed the path mid-swap; keep the leftover for re-reconciliation.
+    } catch (error) {
+      if (!isErrnoWithCode(error, "EEXIST")) {
+        // Transient placement failure (EIO, ENOSPC, unsupported links): we hold the
+        // captured canonical record in `cas` and the path is empty. Restore the
+        // capture (no-clobber) and PROPAGATE so caller retries engage — deleting the
+        // capture here would leave the wake id with no canonical record at all, and a
+        // silent null would skip startup drain scheduling. The leftover stays for
+        // re-reconciliation either way.
+        try {
+          await fsPromises.link(cas, originalPath);
+          await fsPromises.rm(cas, { force: true }).catch(() => undefined);
+        } catch {
+          // A newer write claimed the path; the cas file heals as prune trash later.
+        }
+        throw error;
+      }
+      // EEXIST: another writer claimed the path mid-swap; it wins and the leftover is
+      // kept for re-reconciliation against it.
     }
     // The captured record is verifiably the older one we compared: safe to drop.
     await fsPromises.rm(cas, { force: true }).catch(() => undefined);

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -643,8 +643,13 @@ export class BashMonitorWakeStore {
   private readonly stagedClearRefreshIntervalMs: number;
 
   // Liveness heartbeats for in-flight staged clears (see
-  // STAGED_CLEAR_REFRESH_INTERVAL_MS), keyed by clearId.
-  private readonly stagedClearRefreshTimers = new Map<string, NodeJS.Timeout>();
+  // STAGED_CLEAR_REFRESH_INTERVAL_MS), keyed by clearId. The owner is retained so
+  // workspace removal can disarm a workspace's surviving heartbeats wholesale (see
+  // abandonWorkspaceClears).
+  private readonly stagedClearRefreshTimers = new Map<
+    string,
+    { timer: NodeJS.Timeout; ownerWorkspaceId: string }
+  >();
 
   private armStagedClearRefresh(ownerWorkspaceId: string, clearId: string): void {
     this.disarmStagedClearRefresh(clearId);
@@ -662,13 +667,32 @@ export class BashMonitorWakeStore {
     // Never hold process shutdown open: a staging orphaned by shutdown is exactly
     // what the grace scan reconciles.
     timer.unref();
-    this.stagedClearRefreshTimers.set(clearId, timer);
+    this.stagedClearRefreshTimers.set(clearId, { timer, ownerWorkspaceId });
   }
 
   private disarmStagedClearRefresh(clearId: string): void {
-    const timer = this.stagedClearRefreshTimers.get(clearId);
-    if (timer != null) clearInterval(timer);
+    const entry = this.stagedClearRefreshTimers.get(clearId);
+    if (entry != null) clearInterval(entry.timer);
     this.stagedClearRefreshTimers.delete(clearId);
+  }
+
+  /**
+   * Disarm every staged-clear heartbeat a workspace owns and drop its active-clear
+   * markers. Called by workspace removal AFTER its history-lock barrier has waited
+   * out in-flight clear transactions: a commit-failed clear intentionally keeps its
+   * heartbeat armed for cross-instance liveness (see commitClear), and that
+   * heartbeat's mutateClearedAt would mkdir the session directory back into
+   * existence after removal deletes it. Dropping activeClearIds also lets a staging
+   * that survives a failed removal be grace-rolled-back (fail toward delivery)
+   * instead of being held forever by a marker whose owner will never settle it.
+   */
+  abandonWorkspaceClears(ownerWorkspaceId: string): void {
+    for (const [clearId, entry] of this.stagedClearRefreshTimers) {
+      if (entry.ownerWorkspaceId !== ownerWorkspaceId) continue;
+      clearInterval(entry.timer);
+      this.stagedClearRefreshTimers.delete(clearId);
+      this.activeClearIds.delete(clearId);
+    }
   }
 
   private scheduleDeferredTempRecovery(
@@ -989,6 +1013,21 @@ export class BashMonitorWakeStore {
       log.debug("Ignoring malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
     }
     return tomb;
+  }
+
+  /**
+   * Whether a clearId identifies a clear transaction that has neither committed nor
+   * rolled back: in flight in this process (activeClearIds), or durably STAGED on
+   * disk (another instance's live clear, or a commit-failed clear whose promotion is
+   * still retrying).
+   */
+  private async isUnresolvedStagedClear(
+    ownerWorkspaceId: string,
+    clearId: string
+  ): Promise<boolean> {
+    if (this.activeClearIds.has(clearId)) return true;
+    const tomb = await this.readClearedAt(ownerWorkspaceId);
+    return tomb?.phase === "staged" && tomb.clearId === clearId;
   }
 
   /**
@@ -2287,6 +2326,21 @@ export class BashMonitorWakeStore {
       if (parsed == null || parsed.status === "pending") {
         // Not verifiably terminal (raced rewrite, or unparseable content just now).
         restore = true;
+      } else if (
+        parsed.status === "superseded" &&
+        parsed.supersededByClearId != null &&
+        (await this.isUnresolvedStagedClear(ownerWorkspaceId, parsed.supersededByClearId))
+      ) {
+        // Owned by a clear that has neither committed nor rolled back: this record is
+        // that clear's ONLY rollback source (restores rewrite the canonical record).
+        // A clear staged longer than the retention window — a long history clear, or
+        // a promotion retrying past transient failures — would otherwise have its
+        // stamped records pruned as ordinary old terminal records, and a subsequent
+        // rollback would find nothing to restore: wakes permanently lost for a
+        // history clear that never happened. Held until the transaction settles:
+        // commit makes the record ordinary terminal (prunable next scan), rollback
+        // flips it back to pending.
+        restore = true;
       } else {
         // Terminal content still needs its age re-verified against the CAPTURED inode:
         // the prune decision came from an earlier stat, and a concurrent writer may have
@@ -2377,22 +2431,19 @@ export class BashMonitorWakeStore {
     const clearedAt = new Date().toISOString();
     const clearId = randomUUID();
     this.activeClearIds.add(clearId);
-    const pending = await this.listPending(ownerWorkspaceId);
     const staged: BashMonitorWakeRecord[] = [];
+    let stagingLanded = false;
     try {
-      for (const record of pending) {
-        // Snapshots list only what was ACTUALLY retired: a record that changed past
-        // the cutoff stays pending, and restoring it on rollback would be wrong (its
-        // restore would clobber the newer merged generation back to the snapshot).
-        if (await this.supersedeForClear(ownerWorkspaceId, record, clearId)) {
-          staged.push(record);
-        }
-      }
+      const pending = await this.listPending(ownerWorkspaceId);
       // Durable STAGED tombstone for wakes this clear could NOT see: a crash-orphaned
       // temp inside the freshness gate is invisible to the listPending above, and
       // without the tombstone its deferred re-drive would later restore and deliver a
-      // pre-clear wake into the cleared transcript. Written only after every visible
-      // wake retired; a failure here fails the clear (snapshots restored below).
+      // pre-clear wake into the cleared transcript. Published BEFORE any record is
+      // stamped: a crash mid-stamping then leaves this tombstone as the durable trace
+      // through which rollbackCrashedClearStaging discovers and restores the stamped
+      // records — stamping first would strand clear-stamped records with no tombstone
+      // on disk for any recovery to find, permanently losing wakes for a history
+      // clear that never ran.
       // Monotonic: a newer concurrent cutoff is never lowered — this clear's own
       // rollback then finds a foreign identity and correctly leaves it alone.
       let decidedToStage = false;
@@ -2443,19 +2494,32 @@ export class BashMonitorWakeStore {
           "A concurrent history clear owns the wake tombstone; retry after it settles"
         );
       }
+      stagingLanded = true;
       this.armStagedClearRefresh(ownerWorkspaceId, clearId);
+      for (const record of pending) {
+        // Snapshots list only what was ACTUALLY retired: a record that changed past
+        // the cutoff stays pending, and restoring it on rollback would be wrong (its
+        // restore would clobber the newer merged generation back to the snapshot).
+        if (await this.supersedeForClear(ownerWorkspaceId, record, clearId)) {
+          staged.push(record);
+        }
+      }
       // Snapshots are the records ACTUALLY retired (see the loop above) — a record
       // that changed past the cutoff stayed pending and must not be reported as
       // retired, restored on rollback, or counted by acceptance bookkeeping.
       return { snapshots: staged, clearedAt, clearId };
     } catch (error) {
-      // Records only — NOT the tombstone rollback in restorePendingSnapshots: the
-      // tombstone write above is the try block's last step, so on this path it was
-      // never promoted (or never landed at all), and demoting here would strip the
-      // PREVIOUS clear's protection instead.
       this.disarmStagedClearRefresh(clearId);
       this.activeClearIds.delete(clearId);
+      // Records first, tombstone second — the same order as restorePendingSnapshots,
+      // so a crash mid-rollback leaves the staged tombstone for the grace scan to
+      // resume from. The tombstone demotes only when OUR staging landed: on a staging
+      // that never landed (or was refused), demoting would strip the PREVIOUS clear's
+      // protection instead.
       await this.restoreSnapshotRecords(ownerWorkspaceId, staged);
+      if (stagingLanded) {
+        await this.rollbackClearTombstone(ownerWorkspaceId, clearId);
+      }
       throw error;
     }
   }
@@ -2477,8 +2541,12 @@ export class BashMonitorWakeStore {
       // lock, and the clear's cutoff explicitly intends mid-clear output to survive.
       // A changed generation stays pending — its pre-cutoff lines may then redeliver
       // (the documented lesser failure) instead of the post-cutoff output being
-      // permanently discarded by a clear that never saw it.
-      if (record.updatedAt !== snapshot.updatedAt) return false;
+      // permanently discarded by a clear that never saw it. Compared as the FULL
+      // generation, not updatedAt alone: a merge can land within the same
+      // millisecond, leaving the timestamp unchanged while lines and counters differ
+      // (replaceCanonicalIfUnchanged documents the same possibility). Both sides are
+      // parses of the same writer's serialized bytes, so key order is stable.
+      if (JSON.stringify(record) !== JSON.stringify(snapshot)) return false;
       await this.write({
         ...this.withTerminalStatus(record, "superseded"),
         supersededByClearId: clearId,

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -927,10 +927,17 @@ export class BashMonitorWakeStore {
       path.basename(originalPath).slice(0, -".json".length)
     );
     return this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
-      // Unreadable (vanished via a concurrent recover, or transiently failing): keep
-      // whatever may exist for a later retry.
-      const raw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
-      if (raw == null) return null;
+      // Vanished (concurrent recover already handled it): nothing to do. Any other read
+      // failure PROPAGATES — swallowing it would turn this scan into a successful empty
+      // result, silently bypassing both the caller's transient-failure policy and
+      // startup owner discovery, which would then never schedule this owner's delivery.
+      let raw: string;
+      try {
+        raw = await fsPromises.readFile(filePath, "utf-8");
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) return null;
+        throw error;
+      }
       const parsed = this.parse(raw);
       if (parsed?.status !== "pending") {
         // Old terminal and malformed content was already destined for pruning; sweep it
@@ -1037,7 +1044,19 @@ export class BashMonitorWakeStore {
     const ownerWorkspaceIds: string[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      if ((await this.listPending(entry.name)).length > 0) {
+      try {
+        if ((await this.listPending(entry.name)).length > 0) {
+          ownerWorkspaceIds.push(entry.name);
+        }
+      } catch (error) {
+        // Fail OPEN for owner discovery: a transient scan failure must not silently
+        // skip this owner — its drain would then never be scheduled and a durable
+        // pending wake could sit undelivered forever. The drain re-reads pending wakes
+        // itself, so a spurious schedule for an owner with none is a harmless no-op.
+        log.debug("Pending wake scan failed during owner discovery; scheduling anyway", {
+          ownerWorkspaceId: entry.name,
+          error,
+        });
         ownerWorkspaceIds.push(entry.name);
       }
     }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1771,13 +1771,7 @@ export class BashMonitorWakeStore {
         if (!recordEntries.includes(entry)) recordEntries.push(entry);
       }
     }
-    // The effective tombstone for the pre-cutoff canonical check at the end of this
-    // scan is read UNCONDITIONALLY (post-rollback), never gated on the readdir
-    // snapshot above: a clear can publish its tombstone after the snapshot was
-    // taken, and a crash-stalled writer can then land a pre-cutoff pending
-    // generation over an already-snapshotted entry mid-scan — served without the
-    // fence, a drain would deliver output that clear is holding or has retired.
-    const tomb = await this.readClearedAt(ownerWorkspaceId);
+
     for (const entry of recordEntries) {
       const filePath = path.join(dir, entry);
       seen.add(entry);
@@ -1894,6 +1888,17 @@ export class BashMonitorWakeStore {
     // into the cleared transcript. Mirroring the temp rules: a COMMITTED cutoff
     // retires it durably; a STAGED one holds it (neither deliver nor retire) until
     // the transaction commits, rolls back, or is grace-rolled-back as crashed.
+    //
+    // The effective tombstone is read HERE — unconditionally (never gated on the
+    // readdir snapshot), post-rollback, and AFTER the record loop above: a
+    // concurrent clear can publish its tombstone at any point during that
+    // potentially long loop, and a cutoff read before the loop would let a
+    // pre-cutoff pending generation collected mid-loop be served (and drained) while
+    // the clear is retiring it. Reading at the last responsible moment fences every
+    // record this scan actually serves against the freshest durable clear state; a
+    // clear that publishes after this read could not have retired these records —
+    // its own supersede snapshot sees them.
+    const tomb = await this.readClearedAt(ownerWorkspaceId);
     if (tomb != null) {
       const cutoffMs = Date.parse(tomb.clearedAt);
       const listable: BashMonitorWakeRecord[] = [];

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -499,6 +499,15 @@ export function buildBashMonitorWakePrompt(
 
 export class BashMonitorWakeStore {
   private readonly locks = new MutexMap<string>();
+  // Pending-id index so the hot listPending path (recomputed for every background-bash
+  // UI snapshot) reads only currently-pending records instead of scanning every
+  // historical wake file — terminal records are never pruned from disk, so long-lived
+  // workspaces accumulate them. Seeded per owner by one full directory scan; afterwards
+  // write() keeps it in sync because every durable mutation funnels through write().
+  // Seeding merges instead of replacing: a concurrent write can land between the
+  // directory read and installation, and the read-verify in listPending drops stale ids.
+  private readonly pendingIdsByOwner = new Map<string, Set<string>>();
+  private readonly seededPendingOwners = new Set<string>();
 
   constructor(private readonly config: Pick<Config, "getSessionDir" | "sessionsDir">) {}
 
@@ -731,12 +740,41 @@ export class BashMonitorWakeStore {
   }
 
   async listPending(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
+    if (!this.seededPendingOwners.has(ownerWorkspaceId)) {
+      return this.seedPendingIndex(ownerWorkspaceId);
+    }
+    const ids = this.pendingIdsByOwner.get(ownerWorkspaceId);
+    const records: BashMonitorWakeRecord[] = [];
+    for (const id of [...(ids ?? [])]) {
+      let record: BashMonitorWakeRecord | null;
+      try {
+        record = await this.get(ownerWorkspaceId, id);
+      } catch {
+        // Transient read failure: keep the index entry so the next call retries.
+        continue;
+      }
+      if (record?.status === "pending") {
+        records.push(record);
+      } else {
+        // Terminal, deleted, or malformed on disk: the id no longer belongs in the index.
+        ids?.delete(id);
+      }
+    }
+    records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
+    return records;
+  }
+
+  /** One-time-per-owner full scan that both answers listPending and seeds the index. */
+  private async seedPendingIndex(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
     const dir = this.dir(ownerWorkspaceId);
     let entries: string[];
     try {
       entries = await fsPromises.readdir(dir);
     } catch (error) {
-      if (isErrnoWithCode(error, "ENOENT")) return [];
+      if (isErrnoWithCode(error, "ENOENT")) {
+        this.seededPendingOwners.add(ownerWorkspaceId);
+        return [];
+      }
       throw error;
     }
     const records: BashMonitorWakeRecord[] = [];
@@ -747,6 +785,12 @@ export class BashMonitorWakeStore {
       const parsed = this.parse(raw);
       if (parsed?.status === "pending") records.push(parsed);
     }
+    const ids = this.pendingIdsByOwner.get(ownerWorkspaceId) ?? new Set<string>();
+    for (const record of records) {
+      ids.add(record.id);
+    }
+    this.pendingIdsByOwner.set(ownerWorkspaceId, ids);
+    this.seededPendingOwners.add(ownerWorkspaceId);
     records.sort((a, b) => a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id));
     return records;
   }
@@ -994,6 +1038,18 @@ export class BashMonitorWakeStore {
       JSON.stringify(record, null, 2),
       "utf-8"
     );
+    // Keep the pending index in sync with the durable state (index only after the write
+    // succeeds, so the index can never claim a pending record that is not on disk).
+    const ids = this.pendingIdsByOwner.get(record.ownerWorkspaceId);
+    if (record.status === "pending") {
+      if (ids != null) {
+        ids.add(record.id);
+      } else {
+        this.pendingIdsByOwner.set(record.ownerWorkspaceId, new Set([record.id]));
+      }
+    } else {
+      ids?.delete(record.id);
+    }
   }
 
   private parse(raw: string): BashMonitorWakeRecord | null {

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -293,21 +293,6 @@ function relabelStaleSettleLine(line: string): string {
   return `[monitor] an earlier run of this process ID settled:${line.slice(BASH_MONITOR_SETTLE_LINE_PREFIX.length)}; the ID has since been re-armed by a new process`;
 }
 
-/** True when `needle` appears as one contiguous run inside `haystack` (or is empty). */
-function containsContiguousSubsequence(
-  haystack: readonly string[],
-  needle: readonly string[]
-): boolean {
-  if (needle.length === 0) return true;
-  outer: for (let start = 0; start + needle.length <= haystack.length; start++) {
-    for (let index = 0; index < needle.length; index++) {
-      if (haystack[start + index] !== needle[index]) continue outer;
-    }
-    return true;
-  }
-  return false;
-}
-
 function removeDeliveredLineOverlap(
   currentLines: readonly string[],
   deliveredLines: readonly string[]
@@ -604,6 +589,56 @@ export class BashMonitorWakeStore {
   private dir(ownerWorkspaceId: string): string {
     assert(ownerWorkspaceId.trim().length > 0, "BashMonitorWakeStore requires ownerWorkspaceId");
     return path.join(this.config.getSessionDir(ownerWorkspaceId), BASH_MONITOR_WAKE_DIR);
+  }
+
+  /**
+   * Durable history-clear tombstone. A clear retires every pending wake its scan can
+   * SEE, but a crash-orphaned temp inside the live-writer freshness gate is invisible
+   * to that scan — without a durable marker, the temp's deferred re-drive would later
+   * restore and deliver a pre-clear wake into the freshly cleared transcript. The name
+   * carries no ".json" suffix and matches no artifact pattern, so scans skip it.
+   */
+  private clearedAtFile(ownerWorkspaceId: string): string {
+    return path.join(this.dir(ownerWorkspaceId), "cleared-at");
+  }
+
+  private async writeClearedAt(ownerWorkspaceId: string, clearedAt: string): Promise<void> {
+    const target = this.clearedAtFile(ownerWorkspaceId);
+    await fsPromises.mkdir(path.dirname(target), { recursive: true });
+    // Atomic like write(): a torn tombstone must never be a file's settled content.
+    // The temp name matches no artifact pattern either, so scans skip it too.
+    const temp = `${target}.tmp-${randomUUID()}`;
+    await fsPromises.writeFile(temp, JSON.stringify({ clearedAt }), "utf-8");
+    try {
+      await fsPromises.rename(temp, target);
+    } catch (error) {
+      await fsPromises.rm(temp, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  /** Epoch ms of the latest history clear, or null when none applies (absent or malformed). */
+  private async readClearedAtMs(ownerWorkspaceId: string): Promise<number | null> {
+    let raw: string;
+    try {
+      raw = await fsPromises.readFile(this.clearedAtFile(ownerWorkspaceId), "utf-8");
+    } catch (error) {
+      if (isErrnoWithCode(error, "ENOENT")) return null;
+      // Transient failures PROPAGATE: guessing "no clear happened" here could restore
+      // and deliver a retired wake; caller retries re-read instead.
+      throw error;
+    }
+    try {
+      const parsed = JSON.parse(raw) as { clearedAt?: unknown };
+      const ms = typeof parsed.clearedAt === "string" ? Date.parse(parsed.clearedAt) : NaN;
+      if (Number.isNaN(ms)) throw new Error("invalid clearedAt");
+      return ms;
+    } catch {
+      // Corrupted tombstone: fail toward DELIVERY (a lost wake is worse than a rare
+      // resurrected one) and keep the file as evidence until the next clear rewrites it.
+      log.debug("Ignoring malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
+      return null;
+    }
   }
 
   static wakeId(processId: string): string {
@@ -1115,26 +1150,24 @@ export class BashMonitorWakeStore {
 
   /**
    * Whether the canonical record already carries everything `other` offers, so `other`
-   * can be discarded without losing output. Within one process instance (equal
-   * createdAt — the instance token, see matchedThroughOffset) the offsets are
-   * comparable and only grow. Across instances (or with legacy records missing
-   * offsets), only a visible contiguous copy of the other record's lines proves
-   * subsumption; line caps can defeat that check, in which case the failure mode is a
-   * rare duplicated merge — never lost output.
+   * can be discarded without losing output. ONLY durable same-record-lineage offset
+   * evidence proves that: equal createdAt (the instance token, see
+   * matchedThroughOffset) with the canonical frontier at or past the other's. Line
+   * CONTENT is never proof — distinct events can produce identical text (two separate
+   * "ERROR" lines), and a generation written from scratch never carried the other's
+   * event no matter how its lines read. Ambiguity falls through to a merge, whose
+   * failure mode is a rare duplicated line — never lost output.
    */
   private static pendingSubsumes(
     canonical: BashMonitorWakeRecord,
     other: BashMonitorWakeRecord
   ): boolean {
-    if (
+    return (
       canonical.createdAt === other.createdAt &&
       canonical.matchedThroughOffset != null &&
       other.matchedThroughOffset != null &&
       canonical.matchedThroughOffset >= other.matchedThroughOffset
-    ) {
-      return true;
-    }
-    return containsContiguousSubsequence(canonical.lines, other.lines);
+    );
   }
 
   /**
@@ -1158,7 +1191,12 @@ export class BashMonitorWakeStore {
     const merged: BashMonitorWakeRecord = {
       ...newer,
       lines: bounded.lines,
-      totalMatches: older.totalMatches + newer.totalMatches,
+      // totalMatches is the monitor's CUMULATIVE matchesCount, and split generations
+      // of one live process both report that same counter — summing would double
+      // count (1 then 2 → 3 for 2 real matches). Max never inflates; for genuinely
+      // different instances of a reused id it can undercount, but the value is
+      // informational and an inflated banner count is the worse failure.
+      totalMatches: Math.max(older.totalMatches, newer.totalMatches),
       droppedLines: older.droppedLines + newer.droppedLines + bounded.droppedLines,
       updatedAt: new Date().toISOString(),
     };
@@ -1387,9 +1425,33 @@ export class BashMonitorWakeStore {
       const parsed = await this.readRecordAt(filePath);
       if (parsed == null) {
         // Vanished, an incomplete crashed write, or a live writer mid-writeFile:
-        // disposable once old.
-        if (old) await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        // disposable once old. A FRESH incomplete temp may be a live writeFile whose
+        // process completes the write but crashes before the commit rename — by then
+        // a complete orphan wake with no process event, pending owner, or timer left
+        // to trigger another scan. Arm the same age-gated re-drive as complete temps:
+        // the re-driven scan re-reads it (complete by then → restored; still garbage →
+        // left for the retention sweep, which needs no timer because unparseable
+        // content past the gate can never become deliverable).
+        if (old) {
+          await fsPromises.rm(filePath, { force: true }).catch(() => undefined);
+        } else if (!consumable) {
+          this.scheduleDeferredTempRecovery(ownerWorkspaceId, filePath, stat.mtimeMs);
+        }
         return null;
+      }
+      if (parsed.status === "pending") {
+        const clearedAtMs = await this.readClearedAtMs(ownerWorkspaceId);
+        if (clearedAtMs != null && Date.parse(parsed.updatedAt) <= clearedAtMs) {
+          // A history clear retired every wake stamped before it, but this temp was
+          // INVISIBLE to that clear's scan (the freshness gate deferred it). Restoring
+          // it would deliver a pre-clear wake into the freshly cleared transcript —
+          // condemn it instead. A fresh temp may still belong to a live writer, so
+          // only consumable ones are removed (failures PROPAGATE, matching the
+          // stale-discard discipline below); fresh ones are left unrestored, with no
+          // re-drive, for a later scan's consumable sweep.
+          if (consumable) await fsPromises.rm(filePath, { force: true });
+          return null;
+        }
       }
       if (!consumable) {
         // A COMPLETE fresh temp may still belong to a LIVE writer between writeFile
@@ -1758,6 +1820,9 @@ export class BashMonitorWakeStore {
   }
 
   async supersedeAllPending(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
+    // Captured BEFORE the scan: the tombstone below retires only wakes stamped before
+    // the clear began, so output enqueued mid-clear survives it.
+    const clearedAt = new Date().toISOString();
     const pending = await this.listPending(ownerWorkspaceId);
     const staged: BashMonitorWakeRecord[] = [];
     try {
@@ -1765,6 +1830,12 @@ export class BashMonitorWakeStore {
         await this.markSuperseded(ownerWorkspaceId, record.id);
         staged.push(record);
       }
+      // Durable tombstone for wakes this clear could NOT see: a crash-orphaned temp
+      // inside the freshness gate is invisible to the listPending above, and without
+      // the tombstone its deferred re-drive would later restore and deliver a
+      // pre-clear wake into the cleared transcript. Written only after every visible
+      // wake retired; a failure here fails the clear (snapshots restored below).
+      await this.writeClearedAt(ownerWorkspaceId, clearedAt);
       return pending;
     } catch (error) {
       await this.restorePendingSnapshots(ownerWorkspaceId, staged);
@@ -1776,6 +1847,11 @@ export class BashMonitorWakeStore {
     ownerWorkspaceId: string,
     snapshots: readonly BashMonitorWakeRecord[]
   ): Promise<void> {
+    // Rolling back a failed clear also rolls back its tombstone: the wakes below
+    // return to pending, so a sibling deferred temp must not stay condemned. Removal
+    // failures PROPAGATE — a stale surviving tombstone would silently discard that
+    // temp's output even though the clear never held.
+    await fsPromises.rm(this.clearedAtFile(ownerWorkspaceId), { force: true });
     for (const snapshot of snapshots) {
       const key = `${ownerWorkspaceId}:${snapshot.id}`;
       await this.locks.withLock(key, async () => {
@@ -1985,9 +2061,14 @@ export class BashMonitorWakeStore {
       await fsPromises.rename(temp, target);
     } catch (error) {
       // The caller observes and reports this failure (e.g. a history clear returns an
-      // error and leaves the wake pending). The temp must not survive it: orphan-temp
-      // recovery would otherwise later "commit" an operation the caller was told never
-      // happened — silently canceling or rewriting the wake behind the caller's back.
+      // error and leaves the wake pending). The temp must not survive it IN A
+      // RECOVERABLE FORM: orphan-temp recovery would otherwise later "commit" an
+      // operation the caller was told never happened — silently canceling or
+      // rewriting the wake behind the caller's back. Truncate FIRST: even if the
+      // removal below also fails, an empty temp is unparseable garbage that recovery
+      // sweeps instead of committing, and truncation frees rather than needs space,
+      // so it succeeds in the very ENOSPC/quota scenarios that fail a commit.
+      await fsPromises.truncate(temp, 0).catch(() => undefined);
       await fsPromises.rm(temp, { force: true }).catch(() => undefined);
       throw error;
     }

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -839,7 +839,35 @@ export class BashMonitorWakeStore {
       if (next == null) {
         // Removal failures PROPAGATE: a stranded capture would heal back as standing
         // protection (the safe direction), and the caller must know removal failed.
-        if (captured) await fsPromises.rm(capture, { force: true });
+        if (captured) {
+          await fsPromises.rm(capture, { force: true });
+          // Unlike replacements, removal has no no-clobber placement to lose: a
+          // concurrent instance's heal can consume the capture between the rename
+          // and the rm above and republish it at the target (its heartbeat then
+          // refreshing it). Verify the removal actually stands: a standing
+          // generation with the captured identity means the removal was
+          // resurrected — report the lost race so a crash-rollback caller never
+          // accepts a rollback whose staging still stands. A FOREIGN generation
+          // stands on its own (our removal landed, then someone published anew).
+          let standingRaw: string | null = null;
+          try {
+            standingRaw = await fsPromises.readFile(target, "utf-8");
+          } catch (error) {
+            if (!isErrnoWithCode(error, "ENOENT")) throw error;
+          }
+          if (standingRaw != null) {
+            const standing = BashMonitorWakeStore.parseTombstone(standingRaw);
+            if (
+              standing != null &&
+              current != null &&
+              (standing.clearId != null || current.clearId != null
+                ? standing.clearId === current.clearId
+                : JSON.stringify(standing) === JSON.stringify(current))
+            ) {
+              return false;
+            }
+          }
+        }
         return true;
       }
       const temp = `${target}.tmp-${randomUUID()}`;
@@ -935,7 +963,14 @@ export class BashMonitorWakeStore {
         // directory order must never decide that.
         (Date.parse(parsed.clearedAt) === Date.parse(newest.clearedAt) &&
           newest.phase === "staged" &&
-          parsed.phase !== "staged")
+          (parsed.phase !== "staged" ||
+            // Both STAGED at an equal cutoff: two captures of the SAME clear
+            // stranded by concurrent heartbeat mutations differ only in stagedAt
+            // (parseTombstone guarantees staged values carry one). Selecting the
+            // older liveness generation could put a LIVE clear's staging beyond its
+            // rollback grace, letting a foreign scan roll it back and restore wakes
+            // it retired; directory order must never decide that either.
+            Date.parse(parsed.stagedAt ?? "") > Date.parse(newest.stagedAt ?? "")))
       ) {
         newest = parsed;
         newestPath = leftoverPath;
@@ -1242,6 +1277,10 @@ export class BashMonitorWakeStore {
       await this.locks.withLock(`${ownerWorkspaceId}:${id}`, async () => {
         const record = await this.readRecordAt(filePath);
         if (record?.status !== "superseded" || record.supersededByClearId !== clearId) return;
+        // Identity gate: the write below targets the PARSED identity, so restoring a
+        // record whose id/owner disagrees with this path would overwrite an
+        // unrelated record or workspace (see recordIdentityMatches).
+        if (!BashMonitorWakeStore.recordIdentityMatches(record, ownerWorkspaceId, id)) return;
         const { supersededByClearId: _clearStamp, pendingUpdatedAtBeforeClear, ...rest } = record;
         const written: BashMonitorWakeRecord = {
           ...rest,
@@ -1504,6 +1543,22 @@ export class BashMonitorWakeStore {
     });
   }
 
+  /**
+   * Whether a parsed record's identity agrees with the location it was read from.
+   * Persisted corruption or a copied/moved file can leave a syntactically valid
+   * record whose id or owner disagrees with its path — later transitions address the
+   * PARSED identity (get()/write() build paths from record fields), so accepting it
+   * would leave the scanned file pending forever while deliveries and writes target
+   * a different record or workspace. Mismatches are treated like malformed content.
+   */
+  private static recordIdentityMatches(
+    record: BashMonitorWakeRecord,
+    ownerWorkspaceId: string,
+    id: string
+  ): boolean {
+    return record.id === id && record.ownerWorkspaceId === ownerWorkspaceId;
+  }
+
   async get(ownerWorkspaceId: string, id: string): Promise<BashMonitorWakeRecord | null> {
     let raw: string;
     try {
@@ -1512,7 +1567,14 @@ export class BashMonitorWakeStore {
       if (isErrnoWithCode(error, "ENOENT")) return null;
       throw error;
     }
-    return this.parse(raw);
+    const parsed = this.parse(raw);
+    if (
+      parsed != null &&
+      !BashMonitorWakeStore.recordIdentityMatches(parsed, ownerWorkspaceId, id)
+    ) {
+      return null;
+    }
+    return parsed;
   }
 
   async listPending(ownerWorkspaceId: string): Promise<BashMonitorWakeRecord[]> {
@@ -1680,7 +1742,23 @@ export class BashMonitorWakeStore {
         // hide a new one, so propagate and let caller retries re-read instead.
         throw error;
       }
-      const parsed = this.parse(raw);
+      let parsed = this.parse(raw);
+      if (
+        parsed != null &&
+        !BashMonitorWakeStore.recordIdentityMatches(
+          parsed,
+          ownerWorkspaceId,
+          BashMonitorWakeStore.wakeIdFromFileStem(entry.slice(0, -".json".length))
+        )
+      ) {
+        // Identity disagrees with the path (see recordIdentityMatches): treated like
+        // malformed content — kept as evidence, never served or transitioned.
+        log.debug("Ignoring bash monitor wake record whose identity disagrees with its path", {
+          ownerWorkspaceId,
+          entry,
+        });
+        parsed = null;
+      }
       const pending = parsed?.status === "pending" ? parsed : null;
       const prunable = parsed != null && parsed.status !== "pending";
       if (prunable && stat.mtimeMs < pruneBeforeMs) {
@@ -1988,7 +2066,16 @@ export class BashMonitorWakeStore {
         if (isErrnoWithCode(error, "ENOENT")) return null;
         throw error;
       }
-      const parsed = this.parse(raw);
+      const parsedRaw = this.parse(raw);
+      // Identity gate: a moved/corrupt leftover whose id or owner disagrees with the
+      // canonical path it would be restored to reads as malformed (kept as evidence
+      // until the age sweep) — restoring it would publish a record later transitions
+      // cannot address (see recordIdentityMatches).
+      const parsed =
+        parsedRaw != null &&
+        BashMonitorWakeStore.recordIdentityMatches(parsedRaw, ownerWorkspaceId, id)
+          ? parsedRaw
+          : null;
       if (parsed?.status !== "pending") {
         // A superseded record stamped by an UNRESOLVED staged clear is that clear's
         // only rollback source, and rollbackCrashedClearStaging restores canonical
@@ -2219,7 +2306,16 @@ export class BashMonitorWakeStore {
       if (!stat.isFile()) return null; // non-regular imposter
       const consumable = stat.mtimeMs < Date.now() - TEMP_RECOVERY_MIN_AGE_MS;
       const old = stat.mtimeMs < pruneBeforeMs;
-      const parsed = await this.readRecordAt(filePath);
+      const parsedRaw = await this.readRecordAt(filePath);
+      // Identity gate: a moved/corrupt artifact whose id or owner disagrees with the
+      // canonical path it would be restored to reads as malformed (swept once old) —
+      // placing it would publish a record later transitions cannot address (see
+      // recordIdentityMatches).
+      const parsed =
+        parsedRaw != null &&
+        BashMonitorWakeStore.recordIdentityMatches(parsedRaw, ownerWorkspaceId, id)
+          ? parsedRaw
+          : null;
       if (parsed == null) {
         // Vanished, an incomplete crashed write, or a live writer mid-writeFile:
         // disposable once old. A FRESH incomplete temp may be a live writeFile whose

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -999,10 +999,11 @@ export class BashMonitorWakeStore {
   }
 
   /**
-   * The effective clear tombstone, or null when none applies (absent or malformed).
-   * Transient failures PROPAGATE: guessing "no clear happened" could restore and
-   * deliver a retired wake. An absent canonical path falls back to crash-stranded
-   * captures so an interrupted mutation never silently drops protection.
+   * The effective clear tombstone, or null when none applies (absent, or malformed
+   * with no healable capture). Transient failures PROPAGATE: guessing "no clear
+   * happened" could restore and deliver a retired wake. An absent OR malformed
+   * canonical path falls back to crash-stranded captures so an interrupted mutation
+   * never silently drops protection.
    */
   private async readClearedAt(ownerWorkspaceId: string): Promise<ClearTombstone | null> {
     const target = this.clearedAtFile(ownerWorkspaceId);
@@ -1033,7 +1034,24 @@ export class BashMonitorWakeStore {
     }
     const tomb = BashMonitorWakeStore.parseTombstone(raw);
     if (tomb == null) {
-      log.debug("Ignoring malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
+      // A malformed canonical can sit in FRONT of a valid crash-stranded .cas-
+      // capture: judging only the canonical would read as "no clear", ignoring a
+      // committed capture (pre-clear orphan temps restored into the cleared
+      // transcript) or a staged one (its clear-stamped records left superseded with
+      // no rollback path). Capture the malformed file into the .cas- namespace and
+      // let the heal below adjudicate — captured rather than judged in place because
+      // a concurrent mutation can replace the canonical with a VALID generation
+      // between the read above and this rename: a valid capture heals straight back
+      // as standing protection, while malformed bytes are swept by the heal.
+      log.debug("Quarantining malformed bash monitor wake clear tombstone", { ownerWorkspaceId });
+      try {
+        await fsPromises.rename(target, `${target}.cas-${randomUUID()}`);
+      } catch (error) {
+        // Concurrently consumed or replaced mid-read: the heal below still reports
+        // whatever protection stands. Other failures PROPAGATE (see the doc above).
+        if (!isErrnoWithCode(error, "ENOENT")) throw error;
+      }
+      return this.healClearedAtFromLeftovers(ownerWorkspaceId);
     }
     return tomb;
   }
@@ -1060,7 +1078,7 @@ export class BashMonitorWakeStore {
    * re-establishes the committed cutoff if a foreign rollback removed the staging.
    */
   async commitClear(ownerWorkspaceId: string, token: BashMonitorClearToken): Promise<void> {
-    await this.mutateClearedAt(ownerWorkspaceId, (current) => {
+    const applied = await this.mutateClearedAt(ownerWorkspaceId, (current) => {
       if (current == null) {
         return { clearedAt: token.clearedAt, clearId: token.clearId, phase: "committed" };
       }
@@ -1093,6 +1111,21 @@ export class BashMonitorWakeStore {
         previousClearedAt: current.clearedAt,
       };
     });
+    if (!applied) {
+      // The no-clobber placement lost to a generation published mid-mutation — which
+      // can be a foreign heal republishing this SAME staged tombstone, so the
+      // promotion may not have landed at all. Treating the lost race as success
+      // would disarm the heartbeat and drop the active-clear marker below while the
+      // clear is still durably STAGED with no retry left: once the grace window
+      // expired, a scan would judge the staging crashed, roll it back, and restore
+      // wakes this SUCCESSFUL history clear retired into the cleared transcript.
+      // Fail instead — the retry below re-drives the promotion against whatever
+      // generation now stands (a re-published staging promotes; a newer committed
+      // cutoff reads as already subsumed and converges).
+      throw new Error(
+        `Bash monitor clear tombstone promotion lost its no-clobber race for workspace ${ownerWorkspaceId}`
+      );
+    }
     // Deactivated only AFTER the promotion durably landed: this marker is what stops
     // the staged-clear grace scan from treating a slow-to-commit SUCCESSFUL clear as
     // crashed and restoring the wakes it retired. On failure it stays active (and the

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -1003,11 +1003,36 @@ export class BashMonitorWakeStore {
         if (isErrnoWithCode(error, "ENOENT")) return null;
         throw error;
       }
-      const raw = await fsPromises.readFile(trash, "utf-8").catch(() => null);
-      const parsed = raw == null ? null : this.parse(raw);
+      let raw: string;
+      try {
+        raw = await fsPromises.readFile(trash, "utf-8");
+      } catch (error) {
+        if (isErrnoWithCode(error, "ENOENT")) {
+          // A concurrent recoverStrandedPruneFile consumed the trash (restored or swept
+          // it). Publish the canonical path's current state, mirroring the EEXIST branch.
+          const currentRaw = await fsPromises.readFile(filePath, "utf-8").catch(() => null);
+          const current = currentRaw == null ? null : this.parse(currentRaw);
+          return current?.status === "pending" ? current : null;
+        }
+        // Cannot verify the captured inode — it may be a concurrently rewritten pending
+        // wake. Restore it fail-safe (link never clobbers a newer record) and PROPAGATE
+        // so caller retries engage; silently restoring with an empty result would skip
+        // startup drain scheduling for a possibly-pending wake. A failed restore keeps
+        // the trash for recoverStrandedPruneFile to retry.
+        let relinked = false;
+        try {
+          await fsPromises.link(trash, filePath);
+          relinked = true;
+        } catch {
+          // Keep the trash; a later scan recovers it.
+        }
+        if (relinked) await fsPromises.rm(trash, { force: true }).catch(() => undefined);
+        throw error;
+      }
+      const parsed = this.parse(raw);
       let restore: boolean;
       if (parsed == null || parsed.status === "pending") {
-        // Not verifiably terminal (raced rewrite, or a read/parse hiccup just now).
+        // Not verifiably terminal (raced rewrite, or unparseable content just now).
         restore = true;
       } else {
         // Terminal content still needs its age re-verified against the CAPTURED inode:

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -390,6 +390,70 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a failed drain retries on a delay until the wake delivers", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-drain-retry";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      // The drain's own scan fails once. Startup recovery may be the LAST trigger a
+      // persisted wake ever gets, so a single failed drain must not strand it.
+      const realListPending = wakeStore.listPending.bind(wakeStore);
+      let listCalls = 0;
+      spyOn(wakeStore, "listPending").mockImplementation((ownerWorkspaceId: string) => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          return Promise.reject(new Error("transient scan failure"));
+        }
+        return realListPending(ownerWorkspaceId);
+      });
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-retry",
+        taskId: "bash:proc-retry",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED once"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      // The delayed retry drain must still deliver the wake with no further triggers.
+      await waitForCondition(() => sendSpy.mock.calls.length === 1, { timeoutMs: 5_000 });
+      expect(listCalls).toBeGreaterThanOrEqual(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("a partially failed delivered batch still notifies subscribers immediately", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -892,6 +892,80 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a pending clear-promotion retry does not recreate a removed workspace's session data", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-clear-commit-removed";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: mock(() => undefined),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-removed",
+        taskId: "bash:proc-removed",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: retired"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+      const clearHistory = (
+        workspaceService as unknown as {
+          clearHistoryWithRetiredBashMonitorWakes: (
+            workspaceId: string,
+            clear: () => Promise<Result<void>>,
+            options?: { discardUnacceptedOnSuccess?: boolean }
+          ) => Promise<Result<void>>;
+        }
+      ).clearHistoryWithRetiredBashMonitorWakes.bind(workspaceService);
+      // The promotion fails once, scheduling the background retry.
+      const commitSpy = spyOn(wakeStore, "commitClear").mockImplementationOnce(() =>
+        Promise.reject(new Error("EIO: tombstone write failed"))
+      );
+      const result = await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)), {
+        discardUnacceptedOnSuccess: true,
+      });
+      expect(result.success).toBe(true);
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      // The workspace is removed (and its session data deleted) BEFORE the retry
+      // fires; the retried commitClear's tombstone mutation must not mkdir the
+      // session directory back into existence for a removed workspace.
+      await config.removeWorkspace(workspaceId);
+      const sessionDir = config.getSessionDir(workspaceId);
+      await fsPromises.rm(sessionDir, { recursive: true, force: true });
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      expect(existsSync(sessionDir)).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -382,6 +382,89 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("listBackgroundProcesses surfaces wakePending until the monitor wake is delivered", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-wake-pending-listing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // A one-shot watcher: matched, printed its line, and exited before delivery.
+      const watcherProcess = {
+        id: "proc-watcher",
+        pid: 4242,
+        script: "./watch.sh",
+        displayName: "Watcher",
+        startTime: Date.now() - 5_000,
+        status: "exited" as const,
+        exitCode: 0,
+        workspaceId,
+        isForeground: false,
+      };
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([watcherProcess])),
+        getMonitorSnapshot: mock(() => ({
+          filter: "WAKE:",
+          filter_exclude: false,
+          cooldown_ms: 1_000,
+          totalMatches: 1,
+          droppedLines: 0,
+          lastLines: ["WAKE: done"],
+          stopped: true,
+        })),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park every drain so the pending record stays undelivered while we assert on it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      const record = await wakeStore.enqueueOrMergePending({
+        processId: "proc-watcher",
+        taskId: "bash:proc-watcher",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const pendingListing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(pendingListing).toHaveLength(1);
+      expect(pendingListing[0].status).toBe("exited");
+      expect(pendingListing[0].monitor?.wakePending).toBe(true);
+
+      // Once the synthetic wake turn is delivered, the indicator must clear.
+      expect(await wakeStore.markDeliveredSnapshot(workspaceId, record)).toBe(true);
+      const deliveredListing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(deliveredListing).toHaveLength(1);
+      expect(deliveredListing[0].monitor).toBeDefined();
+      expect(deliveredListing[0].monitor?.wakePending).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("explicit monitor cancellation supersedes a match racing persistence", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -966,6 +966,84 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a history clear is refused once workspace removal has begun", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-clear-vs-removal";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: mock(() => undefined),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-removal-race",
+        taskId: "bash:proc-removal-race",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: racing removal"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+      // Removal has begun (removeUnlocked sets the flag before its history-lock
+      // barrier and session deletion). A clear admitted after this point would
+      // stage a tombstone and stamp records — writes whose mkdir can recreate the
+      // deleted session directory and leak a cleared-at file into a future
+      // workspace reusing the ID.
+      (workspaceService as unknown as { removingWorkspaces: Set<string> }).removingWorkspaces.add(
+        workspaceId
+      );
+
+      const clearHistory = (
+        workspaceService as unknown as {
+          clearHistoryWithRetiredBashMonitorWakes: (
+            workspaceId: string,
+            clear: () => Promise<Result<void>>,
+            options?: { discardUnacceptedOnSuccess?: boolean }
+          ) => Promise<Result<void>>;
+        }
+      ).clearHistoryWithRetiredBashMonitorWakes.bind(workspaceService);
+      const result = await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)), {
+        discardUnacceptedOnSuccess: true,
+      });
+      expect(result.success).toBe(false);
+      // The refused clear touched nothing: no retirement, no staged tombstone.
+      expect((await wakeStore.get(workspaceId, "proc-removal-race"))?.status).toBe("pending");
+      const tombPath = path.join(
+        config.getSessionDir(workspaceId),
+        "bash-monitor-wakes",
+        "cleared-at"
+      );
+      expect(existsSync(tombPath)).toBe(false);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1140,6 +1140,63 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a terminal-only pending wake lists as settled, never as a match", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-settled-label";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([])),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park every drain so the pending record stays undelivered while we assert on it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+
+      const wakeStore = (
+        workspaceService as unknown as { bashMonitorWakeStore: BashMonitorWakeStore }
+      ).bashMonitorWakeStore;
+      // wakeOnExit settlement: the monitored process exited without ever matching
+      // its filter, so the durable record has kind "match" with zero matches.
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-settled-label",
+        taskId: "bash:proc-settled-label",
+        workspaceId,
+        filter: "NEVER",
+        filterExclude: false,
+        lines: ["[monitor] process settled: exited (code 1)"],
+        totalMatches: 0,
+        timestamp: Date.now(),
+        terminal: { status: "exited", exitCode: 1 },
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(1);
+      // No match ever occurred: the row must not claim one.
+      expect(listing[0].monitor?.pendingWakeKind).toBe("settled");
+      expect(listing[0].monitor?.totalMatches).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -324,17 +324,24 @@ describe("WorkspaceService bash monitor wakes", () => {
         runtimeConfig: { type: "local" },
       });
 
+      const notifyWakeStateChanged = mock(() => undefined);
       const backgroundProcessManager = Object.assign(new EventEmitter(), {
         cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: notifyWakeStateChanged,
       }) as unknown as BackgroundProcessManager & EventEmitter;
       const workspaceService = createWorkspaceServiceForTest({
         config,
         backgroundProcessManager,
         aiService: createMockAIService({ isStreaming: mock(() => false) }),
       });
+      // The delivered transition must reach background-bash subscribers as soon as the
+      // wake turn is accepted — not after the (potentially long) stream finishes, which
+      // is when the drain's trailing safety-net emit runs.
+      let notifyCallsWhenAccepted = -1;
       const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
         async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
           await args[3]?.onAccepted?.();
+          notifyCallsWhenAccepted = notifyWakeStateChanged.mock.calls.length;
           return Ok(undefined);
         }
       );
@@ -377,6 +384,7 @@ describe("WorkspaceService bash monitor wakes", () => {
         }
       ).bashMonitorWakeStore;
       await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+      expect(notifyCallsWhenAccepted).toBeGreaterThanOrEqual(1);
     } finally {
       await cleanup();
     }
@@ -460,6 +468,72 @@ describe("WorkspaceService bash monitor wakes", () => {
       expect(deliveredListing).toHaveLength(1);
       expect(deliveredListing[0].monitor).toBeDefined();
       expect(deliveredListing[0].monitor?.wakePending).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("listBackgroundProcesses synthesizes a row for a pending wake whose process is gone", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-orphaned-wake-listing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // App restart: the manager's in-memory table is empty while the wake store still
+      // holds the durable pending record for the vanished watcher process.
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([])),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park every drain so the pending record stays undelivered while we assert on it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      const record = await wakeStore.enqueueOrMergePending({
+        processId: "proc-restart-watcher",
+        taskId: "bash:proc-restart-watcher",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(1);
+      expect(listing[0].id).toBe("proc-restart-watcher");
+      expect(listing[0].status).toBe("exited");
+      // Synthesized rows have no live process behind them.
+      expect(listing[0].pid).toBe(0);
+      expect(listing[0].monitor?.wakePending).toBe(true);
+      expect(listing[0].monitor?.lastLines).toEqual(["WAKE: done"]);
+
+      // Once delivered, the synthesized row must disappear entirely.
+      expect(await wakeStore.markDeliveredSnapshot(workspaceId, record)).toBe(true);
+      expect(await workspaceService.listBackgroundProcesses(workspaceId)).toHaveLength(0);
     } finally {
       await cleanup();
     }
@@ -1931,8 +2005,10 @@ describe("WorkspaceService bash monitor wakes", () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
       const workspaceId = "bash-monitor-rearm-owner";
+      const notifyWakeStateChanged = mock(() => undefined);
       const backgroundProcessManager = Object.assign(new EventEmitter(), {
         cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: notifyWakeStateChanged,
       }) as unknown as BackgroundProcessManager & EventEmitter;
       // Workspace intentionally absent from config: startup recovery finds nothing, and
       // no drain can race the assertion below (drains for unknown workspaces supersede,
@@ -1971,6 +2047,10 @@ describe("WorkspaceService bash monitor wakes", () => {
       await waitForCondition(
         async () => (await wakeStore.get(workspaceId, "proc-1"))?.status === "superseded"
       );
+      // Subscribers must be nudged after the durable supersession; spawn's own change
+      // event fired before it, so without this the re-used ID keeps the stale
+      // "waking agent…" label until an unrelated process event.
+      expect(notifyWakeStateChanged.mock.calls.length).toBeGreaterThanOrEqual(1);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -3997,6 +3997,85 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a failed accepted-history scan defers the drain instead of redelivering", async () => {
+    const { config, historyService, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-verify-retry";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const seedStore = new BashMonitorWakeStore(config);
+      const record = await seedStore.enqueueOrMergePending({
+        processId: "proc-verify",
+        taskId: "bash:proc-verify",
+        workspaceId,
+        filter: "DONE",
+        filterExclude: false,
+        lines: ["DONE accepted"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 13,
+      });
+      // The synthetic turn already sits in accepted history; only the delivered
+      // transition is missing (crash window).
+      await historyService.appendToHistory(
+        workspaceId,
+        createMuxMessage("accepted-wake", "user", "Accepted monitor wake", {
+          synthetic: true,
+          muxMetadata: buildBashMonitorWakeMetadata([record]),
+        })
+      );
+      // History reads fail transiently (disk hiccup) during acceptance verification.
+      const realIterate = historyService.iterateFullHistory.bind(historyService);
+      const gate = { failHistoryReads: true };
+      const iterateSpy = spyOn(historyService, "iterateFullHistory").mockImplementation(
+        (...args: Parameters<typeof realIterate>) =>
+          gate.failHistoryReads
+            ? Promise.resolve(Err("injected transient history failure"))
+            : realIterate(...args)
+      );
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        historyService,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
+      const wakeStore = (
+        workspaceService as unknown as { bashMonitorWakeStore: BashMonitorWakeStore }
+      ).bashMonitorWakeStore;
+
+      await waitForCondition(() => iterateSpy.mock.calls.length > 0);
+      await drainPendingDispatches();
+      // Verification failure must NOT read as "not accepted": re-sending would
+      // duplicate the already-appended agent turn and any actions it takes.
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+
+      // The scan succeeds on a later drain retry: the accepted wake reconciles to
+      // delivered without ever re-sending.
+      gate.failHistoryReads = false;
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0, {
+        timeoutMs: 5_000,
+      });
+      expect((await wakeStore.get(workspaceId, "proc-verify"))?.status).toBe("delivered");
+      expect(sendSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("accepted history suppresses redelivery while wake-store reconciliation keeps failing", async () => {
     const { config, historyService, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -901,6 +901,55 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a failed pending-wake read schedules a retry change notification", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-read-retry";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const notifyMonitorWakeStateChanged = mock((_changedWorkspaceId: string) => undefined);
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([])),
+        getMonitorSnapshot: mock(() => undefined),
+        notifyMonitorWakeStateChanged,
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      spyOn(wakeStore, "listPending").mockImplementationOnce(() =>
+        Promise.reject(new Error("transient wake-store I/O failure"))
+      );
+
+      // The fallback makes this call RESOLVE, so the subscription's failure-retry path
+      // never engages — without a scheduled change notification nothing would ever
+      // re-read the wake store for an exited process.
+      expect(await workspaceService.listBackgroundProcesses(workspaceId)).toHaveLength(0);
+      const deadline = Date.now() + 5_000;
+      while (notifyMonitorWakeStateChanged.mock.calls.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      expect(notifyMonitorWakeStateChanged).toHaveBeenCalledWith(workspaceId);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("explicit monitor cancellation supersedes a match racing persistence", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -526,14 +526,88 @@ describe("WorkspaceService bash monitor wakes", () => {
       expect(listing).toHaveLength(1);
       expect(listing[0].id).toBe("proc-restart-watcher");
       expect(listing[0].status).toBe("exited");
-      // Synthesized rows have no live process behind them.
+      // Synthesized rows have no live process behind them and must say so explicitly
+      // (the renderer keys unusable actions on the marker, not the placeholder pid).
       expect(listing[0].pid).toBe(0);
+      expect(listing[0].synthesized).toBe(true);
       expect(listing[0].monitor?.pendingWakeKind).toBe("match");
       expect(listing[0].monitor?.lastLines).toEqual(["WAKE: done"]);
 
       // Once delivered, the synthesized row must disappear entirely.
       expect(await wakeStore.markDeliveredSnapshot(workspaceId, record)).toBe(true);
       expect(await workspaceService.listBackgroundProcesses(workspaceId)).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-reused-id-listing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // Post-restart: a relaunched command reuses the display-name-derived process ID but
+      // has no monitor, while the prior generation's match wake is still pending delivery.
+      const reusedProcess = {
+        id: "proc-reused",
+        pid: 5151,
+        script: "./watch.sh",
+        displayName: "Watcher",
+        startTime: Date.now() - 1_000,
+        status: "running" as const,
+        workspaceId,
+        isForeground: false,
+      };
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([reusedProcess])),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park every drain so the pending record stays undelivered while we assert on it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-reused",
+        taskId: "bash:proc-reused",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(1);
+      // The live (monitorless) row carries the wake via a record-derived snapshot instead
+      // of suppressing it; the row itself stays a real manager-backed process.
+      expect(listing[0].id).toBe("proc-reused");
+      expect(listing[0].status).toBe("running");
+      expect(listing[0].synthesized).toBeUndefined();
+      expect(listing[0].monitor?.pendingWakeKind).toBe("match");
     } finally {
       await cleanup();
     }
@@ -553,8 +627,10 @@ describe("WorkspaceService bash monitor wakes", () => {
         runtimeConfig: { type: "local" },
       });
 
+      const notifyWakeStateChanged = mock(() => undefined);
       const backgroundProcessManager = Object.assign(new EventEmitter(), {
         cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: notifyWakeStateChanged,
       }) as unknown as BackgroundProcessManager & EventEmitter;
       const workspaceService = createWorkspaceServiceForTest({
         config,
@@ -588,6 +664,9 @@ describe("WorkspaceService bash monitor wakes", () => {
       await waitForCondition(() => markSupersededSpy.mock.calls.length > 0);
       await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
       expect(sendSpy).not.toHaveBeenCalled();
+      // Cancellation retired the wake directly (no queued dispatch); subscribers must be
+      // nudged after the durable supersession or the pending-wake label lingers.
+      await waitForCondition(() => notifyWakeStateChanged.mock.calls.length > 0);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -541,6 +541,72 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("history clears notify background-bash subscribers on retire and restore", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-history-clear-notify";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const notifyWakeStateChanged = mock(() => undefined);
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: notifyWakeStateChanged,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park drains so the seeded record stays pending until the clear retires it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-clear",
+        taskId: "bash:proc-clear",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      // Retiring pending wakes for a history clear (and restoring them afterwards) has no
+      // process-state change, so the clear path itself must nudge subscribers.
+      const clearHistory = (
+        workspaceService as unknown as {
+          clearHistoryWithRetiredBashMonitorWakes: (
+            workspaceId: string,
+            clear: () => Promise<Result<void>>
+          ) => Promise<Result<void>>;
+        }
+      ).clearHistoryWithRetiredBashMonitorWakes.bind(workspaceService);
+      notifyWakeStateChanged.mockClear();
+      const result = await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)));
+      expect(result.success).toBe(true);
+      // One nudge after the durable retire, one after the post-clear restore pass.
+      expect(notifyWakeStateChanged.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1197,6 +1197,64 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("listBackgroundProcesses labels a settlement after delivered matches as settled", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-settled-after-match";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([])),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park every drain so the pending record stays undelivered while we assert on it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+
+      const wakeStore = (
+        workspaceService as unknown as { bashMonitorWakeStore: BashMonitorWakeStore }
+      ).bashMonitorWakeStore;
+      // The monitor matched earlier and that wake was DELIVERED; the process then
+      // exits without another match. The settlement record carries the monitor's
+      // cumulative nonzero totalMatches but no matched frontier — only settlement is
+      // pending, so the banner must not claim a match the user already handled.
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-settled-after-match",
+        taskId: "bash:proc-settled-after-match",
+        workspaceId,
+        filter: "ERROR",
+        filterExclude: false,
+        lines: ["[monitor] process settled: exited (code 0)"],
+        totalMatches: 3,
+        timestamp: Date.now(),
+        terminal: { status: "exited", exitCode: 0 },
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(1);
+      expect(listing[0].monitor?.pendingWakeKind).toBe("settled");
+      expect(listing[0].monitor?.totalMatches).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -605,6 +605,37 @@ describe("WorkspaceService bash monitor wakes", () => {
       expect(result.success).toBe(true);
       // One nudge after the durable retire, one after the post-clear restore pass.
       expect(notifyWakeStateChanged.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+      // A restore pass that throws partway may already have rewritten earlier records to
+      // pending; subscribers must still be nudged or they keep the post-retirement
+      // snapshot (hiding those wakes) until unrelated process activity.
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-clear",
+        taskId: "bash:proc-clear",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: again"],
+        totalMatches: 2,
+        timestamp: Date.now(),
+        matchedThroughOffset: 20,
+      });
+      const restoreSpy = spyOn(wakeStore, "restorePendingSnapshots").mockImplementation(() =>
+        Promise.reject(new Error("disk full mid-restore"))
+      );
+      notifyWakeStateChanged.mockClear();
+      let rejected = false;
+      try {
+        await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)));
+      } catch {
+        rejected = true;
+      }
+      expect(rejected).toBe(true);
+      expect(restoreSpy).toHaveBeenCalled();
+      // Retire nudge plus one from each attempted restore pass (without the finally,
+      // the throwing restore would leave only the single retire nudge).
+      expect(notifyWakeStateChanged.mock.calls.length).toBeGreaterThanOrEqual(2);
+      restoreSpy.mockRestore();
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -800,6 +800,98 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a failed tombstone promotion after a successful full clear neither restores wakes nor fails the clear", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-clear-commit-retry";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: mock(() => undefined),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park drains so the seeded record stays pending until the clear retires it.
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-commit-retry",
+        taskId: "bash:proc-commit-retry",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: retired"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const clearHistory = (
+        workspaceService as unknown as {
+          clearHistoryWithRetiredBashMonitorWakes: (
+            workspaceId: string,
+            clear: () => Promise<Result<void>>,
+            options?: { discardUnacceptedOnSuccess?: boolean }
+          ) => Promise<Result<void>>;
+        }
+      ).clearHistoryWithRetiredBashMonitorWakes.bind(workspaceService);
+      const restoreSpy = spyOn(wakeStore, "restorePendingSnapshots");
+      // The tombstone promotion fails transiently AFTER the history clear durably
+      // succeeded; subsequent calls run the real implementation (the retry path).
+      const commitSpy = spyOn(wakeStore, "commitClear").mockImplementationOnce(() =>
+        Promise.reject(new Error("EIO: tombstone write failed"))
+      );
+      const result = await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)), {
+        discardUnacceptedOnSuccess: true,
+      });
+      // The transcript is durably cleared: the caller must see the successful clear,
+      // and the retired wakes must NOT be restored into the cleared transcript.
+      expect(result.success).toBe(true);
+      expect(restoreSpy).not.toHaveBeenCalled();
+      expect(await wakeStore.listPending(workspaceId)).toEqual([]);
+      // The promotion retries in the background until the committed tombstone lands
+      // durably (otherwise the staged-clear grace scan would eventually roll the
+      // staging back and resurrect the retired wakes).
+      const tombPath = path.join(
+        config.getSessionDir(workspaceId),
+        "bash-monitor-wakes",
+        "cleared-at"
+      );
+      const deadline = Date.now() + 5_000;
+      let tomb: { phase?: string } | null = null;
+      while (Date.now() < deadline) {
+        tomb = JSON.parse(await fsPromises.readFile(tombPath, "utf-8")) as { phase?: string };
+        if (tomb.phase === "committed") break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      expect(tomb?.phase).toBe("committed");
+      expect(commitSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(restoreSpy).not.toHaveBeenCalled();
+      expect(await wakeStore.listPending(workspaceId)).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -390,7 +390,7 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
-  test("listBackgroundProcesses surfaces wakePending until the monitor wake is delivered", async () => {
+  test("listBackgroundProcesses surfaces the pending wake kind until the monitor wake is delivered", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {
       const workspaceId = "bash-monitor-wake-pending-listing";
@@ -460,14 +460,14 @@ describe("WorkspaceService bash monitor wakes", () => {
       const pendingListing = await workspaceService.listBackgroundProcesses(workspaceId);
       expect(pendingListing).toHaveLength(1);
       expect(pendingListing[0].status).toBe("exited");
-      expect(pendingListing[0].monitor?.wakePending).toBe(true);
+      expect(pendingListing[0].monitor?.pendingWakeKind).toBe("match");
 
       // Once the synthetic wake turn is delivered, the indicator must clear.
       expect(await wakeStore.markDeliveredSnapshot(workspaceId, record)).toBe(true);
       const deliveredListing = await workspaceService.listBackgroundProcesses(workspaceId);
       expect(deliveredListing).toHaveLength(1);
       expect(deliveredListing[0].monitor).toBeDefined();
-      expect(deliveredListing[0].monitor?.wakePending).toBeUndefined();
+      expect(deliveredListing[0].monitor?.pendingWakeKind).toBeUndefined();
     } finally {
       await cleanup();
     }
@@ -528,7 +528,7 @@ describe("WorkspaceService bash monitor wakes", () => {
       expect(listing[0].status).toBe("exited");
       // Synthesized rows have no live process behind them.
       expect(listing[0].pid).toBe(0);
-      expect(listing[0].monitor?.wakePending).toBe(true);
+      expect(listing[0].monitor?.pendingWakeKind).toBe("match");
       expect(listing[0].monitor?.lastLines).toEqual(["WAKE: done"]);
 
       // Once delivered, the synthesized row must disappear entirely.

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1044,6 +1044,102 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("an already-fired clear-promotion retry runs its commitClear under the history lock", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-retry-lock";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: mock(() => undefined),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as { bashMonitorWakeStore: BashMonitorWakeStore }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-retry-lock",
+        taskId: "bash:proc-retry-lock",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: retired by clear"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      // The clear succeeds but its promotion fails once, scheduling a retry.
+      const commitSpy = spyOn(wakeStore, "commitClear").mockImplementationOnce(() =>
+        Promise.reject(new Error("transient promotion failure"))
+      );
+      const clearHistory = (
+        workspaceService as unknown as {
+          clearHistoryWithRetiredBashMonitorWakes: (
+            workspaceId: string,
+            clear: () => Promise<Result<void>>,
+            options?: { discardUnacceptedOnSuccess?: boolean }
+          ) => Promise<Result<void>>;
+        }
+      ).clearHistoryWithRetiredBashMonitorWakes.bind(workspaceService);
+      const result = await clearHistory(workspaceId, () => Promise.resolve(Ok(undefined)), {
+        discardUnacceptedOnSuccess: true,
+      });
+      expect(result.success).toBe(true);
+
+      // Park the retry's commitClear mid-flight.
+      const parkedBox: { release: () => void } = { release: () => undefined };
+      const parked = new Promise<void>((resolve) => {
+        parkedBox.release = resolve;
+      });
+      commitSpy.mockImplementation(() => parked);
+      await waitForCondition(() => commitSpy.mock.calls.length >= 2, { timeoutMs: 3_000 });
+
+      // Removal's pre-deletion barrier serializes on bashMonitorHistoryLocks. The
+      // already-fired retry can pass the removingWorkspaces check just before
+      // removal begins, so its commitClear (whose tombstone mutation mkdirs the
+      // wake directory) must hold the same lock — otherwise a stalled promotion
+      // recreates session data after the directory is deleted.
+      const locks = (
+        workspaceService as unknown as {
+          bashMonitorHistoryLocks: {
+            withLock: (key: string, fn: () => Promise<void>) => Promise<void>;
+          };
+        }
+      ).bashMonitorHistoryLocks;
+      let barrierAcquired = false;
+      const barrier = locks.withLock(workspaceId, () => {
+        barrierAcquired = true;
+        return Promise.resolve();
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(barrierAcquired).toBe(false);
+
+      parkedBox.release();
+      await barrier;
+      expect(barrierAcquired).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses keeps a pending wake visible on a reused monitorless process ID", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -390,6 +390,101 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("a partially failed delivered batch still notifies subscribers immediately", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-partial-batch";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const notifyWakeStateChanged = mock(() => undefined);
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+        notifyMonitorWakeStateChanged: notifyWakeStateChanged,
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      // Park drains until both wakes are durably pending so one drain batches them.
+      let deferDrains = true;
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockImplementation(
+        () => deferDrains
+      );
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      // The delivered transition of an EARLIER record must reach subscribers even when a
+      // LATER record's transition throws: the wake turn keeps streaming, so without the
+      // notify the banner would claim "waking agent…" until the whole send returned.
+      let notifyDeltaDuringAccepted = -1;
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          const before = notifyWakeStateChanged.mock.calls.length;
+          try {
+            await args[3]?.onAccepted?.();
+          } catch {
+            // The partial transition failure propagates to the drain; the stream goes on.
+          }
+          notifyDeltaDuringAccepted = notifyWakeStateChanged.mock.calls.length - before;
+          return Ok(undefined);
+        }
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      const emitMatch = (processId: string) => {
+        backgroundProcessManager.emit("monitor:match", workspaceId, {
+          processId,
+          taskId: `bash:${processId}`,
+          workspaceId,
+          filter: "FAILED",
+          filterExclude: false,
+          lines: [`FAILED ${processId}`],
+          totalMatches: 1,
+          timestamp: Date.now(),
+        });
+      };
+      emitMatch("proc-a");
+      emitMatch("proc-b");
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 2);
+
+      const realMarkDelivered = wakeStore.markDeliveredSnapshot.bind(wakeStore);
+      let deliveredCalls = 0;
+      const markSpy = spyOn(wakeStore, "markDeliveredSnapshot").mockImplementation(
+        (ownerWorkspaceId, snapshot) => {
+          deliveredCalls += 1;
+          if (deliveredCalls === 2) {
+            return Promise.reject(new Error("transient transition failure"));
+          }
+          return realMarkDelivered(ownerWorkspaceId, snapshot);
+        }
+      );
+      deferDrains = false;
+      emitMatch("proc-c"); // schedules the drain that batches all three records
+
+      await waitForCondition(() => notifyDeltaDuringAccepted >= 0);
+      // Without the finally, the second record's failure would skip the notify entirely
+      // (delta 0) and only the drain's trailing safety-net emit would run post-stream.
+      expect(deliveredCalls).toBeGreaterThanOrEqual(2);
+      expect(notifyDeltaDuringAccepted).toBeGreaterThanOrEqual(1);
+      expect(sendSpy).toHaveBeenCalled();
+      markSpy.mockRestore();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses surfaces the pending wake kind until the monitor wake is delivered", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -682,6 +682,151 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("listBackgroundProcesses keeps a prior-generation wake off a reused monitored process", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-prior-generation-listing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // The reused process spawned AFTER the wake was created (future startTime makes the
+      // ordering deterministic without sleeping), and carries its own unrelated monitor.
+      const reusedProcess = {
+        id: "proc-gen",
+        pid: 6161,
+        script: "./watch.sh",
+        displayName: "Watcher",
+        startTime: Date.now() + 60_000,
+        status: "running" as const,
+        workspaceId,
+        isForeground: false,
+      };
+      const liveMonitor = {
+        filter: "NEW:",
+        filter_exclude: false,
+        cooldown_ms: 1_000,
+        totalMatches: 0,
+        droppedLines: 0,
+        lastLines: [],
+        stopped: false,
+      };
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([reusedProcess])),
+        getMonitorSnapshot: mock(() => liveMonitor),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-gen",
+        taskId: "bash:proc-gen",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: old generation"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(2);
+      // The live row keeps its own monitor untouched: no foreign wake kind, no mixed
+      // filter/match counts.
+      const liveRow = listing.find((row) => row.id === "proc-gen");
+      expect(liveRow?.monitor?.filter).toBe("NEW:");
+      expect(liveRow?.monitor?.pendingWakeKind).toBeUndefined();
+      // The prior-generation wake renders as its own synthesized row under a distinct id.
+      const wakeRow = listing.find((row) => row.id === "proc-gen#pending-wake");
+      expect(wakeRow?.synthesized).toBe(true);
+      expect(wakeRow?.monitor?.filter).toBe("WAKE:");
+      expect(wakeRow?.monitor?.pendingWakeKind).toBe("match");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("listBackgroundProcesses republishes the last good pending-wake set on a read failure", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-last-good-listing";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve([])),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-last-good",
+        taskId: "bash:proc-last-good",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: done"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      // Seed the last-good snapshot with a successful read.
+      expect(await workspaceService.listBackgroundProcesses(workspaceId)).toHaveLength(1);
+
+      // A transient read failure must not publish an authoritative empty set: the durable
+      // wake is still on disk and an exited process emits no later change to restore it.
+      spyOn(wakeStore, "listPending").mockImplementationOnce(() =>
+        Promise.reject(new Error("transient wake-store I/O failure"))
+      );
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      expect(listing).toHaveLength(1);
+      expect(listing[0].id).toBe("proc-last-good");
+      expect(listing[0].monitor?.pendingWakeKind).toBe("match");
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("explicit monitor cancellation supersedes a match racing persistence", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -530,6 +530,9 @@ describe("WorkspaceService bash monitor wakes", () => {
       // (the renderer keys unusable actions on the marker, not the placeholder pid).
       expect(listing[0].pid).toBe(0);
       expect(listing[0].synthesized).toBe(true);
+      // Match records may carry neither displayName nor script; the label must fall back
+      // to the (display-name derived) processId rather than rendering blank.
+      expect(listing[0].displayName).toBe("proc-restart-watcher");
       expect(listing[0].monitor?.pendingWakeKind).toBe("match");
       expect(listing[0].monitor?.lastLines).toEqual(["WAKE: done"]);
 
@@ -2648,7 +2651,9 @@ describe("WorkspaceService bash monitor wakes", () => {
           bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
         }
       ).bashMonitorWakeStore;
-      expect(await wakeStore.listPending(workspaceId)).toHaveLength(0);
+      // The sendSpy call count flips before its onAccepted delivery finishes, so wait for
+      // the durable transition instead of asserting it instantly.
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
 
       aiService.emit("error", { workspaceId, error: "startup failed" });
       await drainPendingDispatches();

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -765,6 +765,80 @@ describe("WorkspaceService bash monitor wakes", () => {
     }
   });
 
+  test("listBackgroundProcesses keeps synthesized row ids collision-free", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-row-id-collision";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      // Process ids derive from arbitrary display names, so a live process can
+      // legitimately claim the suffixed id a prior-generation wake row would use.
+      const liveProcesses = ["proc-gen", "proc-gen#pending-wake"].map((id, index) => ({
+        id,
+        pid: 7000 + index,
+        script: "./watch.sh",
+        displayName: id,
+        startTime: Date.now() + 60_000,
+        status: "running" as const,
+        workspaceId,
+        isForeground: false,
+      }));
+      const backgroundProcessManager = {
+        cleanup: mock(() => Promise.resolve()),
+        list: mock(() => Promise.resolve(liveProcesses)),
+        getMonitorSnapshot: mock(() => undefined),
+      } as unknown as BackgroundProcessManager;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(true);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: BashMonitorWakeStore;
+        }
+      ).bashMonitorWakeStore;
+      // Prior-generation wake for the reused id "proc-gen" (created before both spawns).
+      await wakeStore.enqueueOrMergePending({
+        processId: "proc-gen",
+        taskId: "bash:proc-gen",
+        workspaceId,
+        filter: "WAKE:",
+        filterExclude: false,
+        lines: ["WAKE: old generation"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+        matchedThroughOffset: 10,
+      });
+
+      const listing = await workspaceService.listBackgroundProcesses(workspaceId);
+      // Row ids double as React keys: every row keeps a unique identity even when a live
+      // process already owns the suffixed id the synthesized row would otherwise use.
+      expect(listing.map((row) => row.id).sort()).toEqual([
+        "proc-gen",
+        "proc-gen#pending-wake",
+        "proc-gen#pending-wake#pending-wake",
+      ]);
+      const wakeRow = listing.find((row) => row.synthesized === true);
+      expect(wakeRow?.id).toBe("proc-gen#pending-wake#pending-wake");
+      expect(wakeRow?.monitor?.pendingWakeKind).toBe("match");
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("listBackgroundProcesses republishes the last good pending-wake set on a read failure", async () => {
     const { config, cleanup } = await createTestHistoryService();
     try {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2623,6 +2623,11 @@ export class WorkspaceService extends EventEmitter {
       .then(() => this.drainBashMonitorWakes(ownerWorkspaceId))
       .catch((error: unknown) => {
         log.error("Bash monitor wake drain failed", { ownerWorkspaceId, error });
+        // A failed drain may be the LAST trigger a persisted wake ever gets: startup
+        // recovery runs once, and with no open UI and no later process event nothing
+        // else re-drives delivery. Retry on a delay until a drain pass succeeds; the
+        // timer dedupes per owner, so persistent failure retries at a bounded rate.
+        this.scheduleBashMonitorWakeDrainRetry(ownerWorkspaceId);
       })
       .finally(() => {
         this.pendingBashMonitorWakeDrains.delete(promise);
@@ -2632,6 +2637,20 @@ export class WorkspaceService extends EventEmitter {
       });
     this.pendingBashMonitorWakeDrainsByOwner.set(ownerWorkspaceId, promise);
     this.pendingBashMonitorWakeDrains.add(promise);
+  }
+
+  // One retry timer per owner after a failed drain (see the catch above).
+  private readonly bashMonitorWakeDrainRetryTimers = new Map<string, NodeJS.Timeout>();
+
+  private scheduleBashMonitorWakeDrainRetry(ownerWorkspaceId: string): void {
+    if (this.bashMonitorWakeDrainRetryTimers.has(ownerWorkspaceId)) return;
+    const timer = setTimeout(() => {
+      this.bashMonitorWakeDrainRetryTimers.delete(ownerWorkspaceId);
+      this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
+    }, 1_000);
+    // Never hold process shutdown open for a delivery retry.
+    timer.unref();
+    this.bashMonitorWakeDrainRetryTimers.set(ownerWorkspaceId, timer);
   }
 
   private scheduleBashMonitorWakeDrainAfterRead(

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -6520,7 +6520,10 @@ export class WorkspaceService extends EventEmitter {
       // same lock — so the barrier waits out the in-flight clear transaction AND
       // any already-fired retry.
       await this.bashMonitorHistoryLocks.withLock(workspaceId, () => Promise.resolve());
-      this.bashMonitorWakeStore.abandonWorkspaceClears(workspaceId);
+      // Awaited: abandon also DRAINS heartbeat ticks that already fired, whose
+      // mutateClearedAt (queued outside the history lock) would otherwise mkdir the
+      // directory back after the deletion below.
+      await this.bashMonitorWakeStore.abandonWorkspaceClears(workspaceId);
 
       // Remove session data
       const sessionDir = this.config.getSessionDir(workspaceId);
@@ -13845,6 +13848,18 @@ export class WorkspaceService extends EventEmitter {
       pendingWakes = this.lastGoodPendingWakesByWorkspace.get(workspaceId) ?? [];
       this.schedulePendingWakeReadRetry(workspaceId);
     }
+    // A wake whose only event is process settlement (terminal-only wakeOnExit, or an
+    // earlier run's preserved settlement) still has kind "match" in the durable
+    // record; labeling it "match" in the UI would report a match the filter never
+    // produced. Coalesced records with real matches keep the match label.
+    const pendingWakeKindOf = (
+      record: BashMonitorWakeRecord
+    ): "match" | "monitor-lost" | "settled" =>
+      record.kind === "monitor-lost"
+        ? "monitor-lost"
+        : record.totalMatches === 0 && (record.terminal != null || record.staleTerminal != null)
+          ? "settled"
+          : "match";
     // Present monitor state derived purely from a durable wake record, for rows (or reused
     // process IDs) that have no live monitor snapshot to decorate.
     const monitorFromWakeRecord = (record: BashMonitorWakeRecord) => ({
@@ -13855,7 +13870,7 @@ export class WorkspaceService extends EventEmitter {
       droppedLines: record.droppedLines,
       lastLines: record.lines,
       stopped: true,
-      pendingWakeKind: record.kind,
+      pendingWakeKind: pendingWakeKindOf(record),
     });
     const liveProcessById = new Map(processes.map((p) => [p.id, p] as const));
     // A pending wake decorates the live row only when it belongs to that process
@@ -13879,7 +13894,7 @@ export class WorkspaceService extends EventEmitter {
         pendingWake != null
           ? {
               ...(monitor ?? monitorFromWakeRecord(pendingWake)),
-              pendingWakeKind: pendingWake.kind,
+              pendingWakeKind: pendingWakeKindOf(pendingWake),
             }
           : monitor;
       return {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2594,6 +2594,9 @@ export class WorkspaceService extends EventEmitter {
             }
             throw error;
           }
+          // Surface "match found — waking agent" immediately: a one-shot watcher that
+          // matched and exited would otherwise look like a lost wake until delivery.
+          this.notifyBashMonitorWakeStateChanged(payload.workspaceId);
           this.scheduleBashMonitorWakeDrain(payload.workspaceId);
         })
       );
@@ -2705,7 +2708,13 @@ export class WorkspaceService extends EventEmitter {
     // converting stale registry records.
     return this.bashMonitorRecoveryPromise.then(() =>
       this.bashMonitorHistoryLocks.withLock(ownerWorkspaceId, () =>
-        this.drainBashMonitorWakesUnlocked(ownerWorkspaceId)
+        this.drainBashMonitorWakesUnlocked(ownerWorkspaceId).finally(() => {
+          // Coarse unconditional emit after every drain pass: delivered/superseded
+          // transitions must clear the "match found — waking agent" indicator, and the
+          // drain has many exit paths. An occasional no-op emit is cheaper than
+          // threading per-transition notifications through each of them.
+          this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
+        })
       )
     );
   }
@@ -4040,6 +4049,15 @@ export class WorkspaceService extends EventEmitter {
       return 0;
     }
     return this.backgroundProcessManager.getActiveMonitorCount(workspaceId);
+  }
+
+  private notifyBashMonitorWakeStateChanged(workspaceId: string): void {
+    // Tests may construct WorkspaceService with a partial BackgroundProcessManager stub
+    // (same reason the constructor guards the event subscriptions).
+    if (typeof this.backgroundProcessManager.notifyMonitorWakeStateChanged !== "function") {
+      return;
+    }
+    this.backgroundProcessManager.notifyMonitorWakeStateChanged(workspaceId);
   }
 
   private mergeCurrentActiveBashMonitorCount(
@@ -13610,13 +13628,31 @@ export class WorkspaceService extends EventEmitter {
         droppedLines: number;
         lastLines: string[];
         stopped: boolean;
+        wakePending?: boolean;
       };
       exitCode?: number;
     }>
   > {
     const processes = await this.backgroundProcessManager.list(workspaceId);
+    // Surface durably-pending monitor wakes (matched but not yet delivered as a synthetic
+    // turn), so a one-shot watcher that matched and exited does not look like a lost wake.
+    // Wake ids equal process ids (BashMonitorWakeStore.wakeId). The indicator must never
+    // break process listing, so a wake-store read failure degrades to "no pending wakes".
+    let pendingWakeProcessIds: ReadonlySet<string>;
+    try {
+      pendingWakeProcessIds = new Set(
+        (await this.bashMonitorWakeStore.listPending(workspaceId)).map((record) => record.processId)
+      );
+    } catch (error) {
+      log.debug("Failed to read pending bash monitor wakes for process listing", {
+        workspaceId,
+        error,
+      });
+      pendingWakeProcessIds = new Set();
+    }
     return processes.map((p) => {
       const monitor = this.backgroundProcessManager.getMonitorSnapshot(p);
+      const wakePending = pendingWakeProcessIds.has(p.id);
       return {
         id: p.id,
         pid: p.pid,
@@ -13624,7 +13660,9 @@ export class WorkspaceService extends EventEmitter {
         displayName: p.displayName,
         startTime: p.startTime,
         status: p.status,
-        ...(monitor != null ? { monitor } : {}),
+        ...(monitor != null
+          ? { monitor: wakePending ? { ...monitor, wakePending } : monitor }
+          : {}),
         exitCode: p.exitCode,
       };
     });

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2095,6 +2095,10 @@ export class WorkspaceService extends EventEmitter {
               workspaceId,
               BashMonitorWakeStore.wakeId(payload.processId)
             );
+            // The manager's process-change emit can precede this disk transition, and an
+            // already-exited process produces no later change event, so subscribers need a
+            // nudge after the supersession is durable or the pending-wake label lingers.
+            this.notifyBashMonitorWakeStateChanged(workspaceId);
           }
         })
       )
@@ -13646,13 +13650,35 @@ export class WorkspaceService extends EventEmitter {
       });
       pendingWakes = [];
     }
-    const pendingWakeKindByProcessId = new Map(
-      pendingWakes.map((record) => [record.processId, record.kind] as const)
+    // Present monitor state derived purely from a durable wake record, for rows (or reused
+    // process IDs) that have no live monitor snapshot to decorate.
+    const monitorFromWakeRecord = (record: BashMonitorWakeRecord) => ({
+      filter: record.filter,
+      filter_exclude: record.filterExclude,
+      cooldown_ms: 0,
+      totalMatches: record.totalMatches,
+      droppedLines: record.droppedLines,
+      lastLines: record.lines,
+      stopped: true,
+      pendingWakeKind: record.kind,
+    });
+    const pendingWakeByProcessId = new Map(
+      pendingWakes.map((record) => [record.processId, record] as const)
     );
     const liveProcessIds = new Set(processes.map((p) => p.id));
     const rows: BackgroundProcessInfo[] = processes.map((p) => {
       const monitor = this.backgroundProcessManager.getMonitorSnapshot(p);
-      const pendingWakeKind = pendingWakeKindByProcessId.get(p.id);
+      const pendingWake = pendingWakeByProcessId.get(p.id);
+      // A restarted workspace can reuse a display-name-derived process ID while the prior
+      // generation's wake is still pending. Even when the new process carries no monitor,
+      // the durable wake must stay visible, so fall back to a record-derived snapshot.
+      const monitorPayload =
+        pendingWake != null
+          ? {
+              ...(monitor ?? monitorFromWakeRecord(pendingWake)),
+              pendingWakeKind: pendingWake.kind,
+            }
+          : monitor;
       return {
         id: p.id,
         pid: p.pid,
@@ -13660,9 +13686,7 @@ export class WorkspaceService extends EventEmitter {
         displayName: p.displayName,
         startTime: p.startTime,
         status: p.status,
-        ...(monitor != null
-          ? { monitor: pendingWakeKind != null ? { ...monitor, pendingWakeKind } : monitor }
-          : {}),
+        ...(monitorPayload != null ? { monitor: monitorPayload } : {}),
         exitCode: p.exitCode,
       };
     });
@@ -13675,22 +13699,15 @@ export class WorkspaceService extends EventEmitter {
       const startTime = Date.parse(record.createdAt);
       rows.push({
         id: record.processId,
-        // No live process behind this row; the renderer hides non-positive pids.
+        // No live process behind this row; `synthesized` (not the pid) tells the renderer
+        // that output/terminate actions cannot work.
         pid: 0,
         script: record.script ?? "",
         displayName: record.displayName,
+        synthesized: true,
         startTime: Number.isNaN(startTime) ? Date.now() : startTime,
         status: "exited",
-        monitor: {
-          filter: record.filter,
-          filter_exclude: record.filterExclude,
-          cooldown_ms: 0,
-          totalMatches: record.totalMatches,
-          droppedLines: record.droppedLines,
-          lastLines: record.lines,
-          stopped: true,
-          pendingWakeKind: record.kind,
-        },
+        monitor: monitorFromWakeRecord(record),
         exitCode: undefined,
       });
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2761,9 +2761,24 @@ export class WorkspaceService extends EventEmitter {
       (record) =>
         !this.cancelingBashMonitorWakeKeys.has(this.bashMonitorWakeKey(ownerWorkspaceId, record.id))
     );
-    const acceptedSnapshots =
-      (await this.findAcceptedBashMonitorWakeSnapshots(ownerWorkspaceId, pendingSnapshot)) ??
-      new Set<string>();
+    const acceptedSnapshots = await this.findAcceptedBashMonitorWakeSnapshots(
+      ownerWorkspaceId,
+      pendingSnapshot
+    );
+    if (acceptedSnapshots == null) {
+      // Verification FAILURE is not "not accepted": the synthetic turn may already
+      // sit in history with only its delivered transition missing (crash window, or
+      // a failed transition), and treating a transient history-read failure as an
+      // empty accepted set would append the same turn again — duplicating the agent
+      // turn and any actions it takes. Leave every record pending and retry the
+      // scan on the deduped drain retry timer.
+      if (pendingSnapshot.length === 0) return;
+      log.debug("Accepted-wake verification failed; deferring bash monitor wake drain", {
+        ownerWorkspaceId,
+      });
+      this.scheduleBashMonitorWakeDrainRetry(ownerWorkspaceId);
+      return;
+    }
     const pending: BashMonitorWakeRecord[] = [];
     // The drain can block on a full sendMessage turn below, so transitions applied in
     // this reconcile loop must notify before that await — not from the drain's finally.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2038,6 +2038,11 @@ export class WorkspaceService extends EventEmitter {
                 cancelReason: BASH_MONITOR_REARMED_QUEUE_REASON,
               });
             }
+            // A re-armed process ID must not inherit its prior generation's pending
+            // monitor-lost wake in the background-bash listing. spawn() emits its change
+            // before this locked supersession runs, so subscribers need a fresh read now
+            // that the stale record is durably superseded.
+            this.notifyBashMonitorWakeStateChanged(payload.workspaceId);
           }
         )
       )
@@ -2709,10 +2714,9 @@ export class WorkspaceService extends EventEmitter {
     return this.bashMonitorRecoveryPromise.then(() =>
       this.bashMonitorHistoryLocks.withLock(ownerWorkspaceId, () =>
         this.drainBashMonitorWakesUnlocked(ownerWorkspaceId).finally(() => {
-          // Coarse unconditional emit after every drain pass: delivered/superseded
-          // transitions must clear the "match found — waking agent" indicator, and the
-          // drain has many exit paths. An occasional no-op emit is cheaper than
-          // threading per-transition notifications through each of them.
+          // Safety-net emit after every drain pass. Prompt transitions notify inline
+          // (reconcile loop, resolveWakeSnapshots), but the drain has many exit and
+          // error paths; a trailing no-op emit is cheaper than auditing each of them.
           this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
         })
       )
@@ -2728,6 +2732,9 @@ export class WorkspaceService extends EventEmitter {
       (await this.findAcceptedBashMonitorWakeSnapshots(ownerWorkspaceId, pendingSnapshot)) ??
       new Set<string>();
     const pending: BashMonitorWakeRecord[] = [];
+    // The drain can block on a full sendMessage turn below, so transitions applied in
+    // this reconcile loop must notify before that await — not from the drain's finally.
+    let reconciledTransition = false;
     for (const record of pendingSnapshot) {
       const snapshotKey = this.bashMonitorWakeSnapshotKey(record.processId, record.updatedAt);
       if (acceptedSnapshots.has(snapshotKey)) {
@@ -2736,6 +2743,7 @@ export class WorkspaceService extends EventEmitter {
             ownerWorkspaceId,
             record
           );
+          reconciledTransition = true;
           if (!deliveredSnapshot) {
             // New matches merged after the accepted snapshot. Keep the remainder pending for its own
             // wake rather than marking those unseen lines delivered with the older accepted turn.
@@ -2758,9 +2766,13 @@ export class WorkspaceService extends EventEmitter {
         )
       ) {
         await this.bashMonitorWakeStore.markSuperseded(ownerWorkspaceId, record.id);
+        reconciledTransition = true;
       } else {
         pending.push(record);
       }
+    }
+    if (reconciledTransition) {
+      this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
     }
     if (pending.length === 0) return;
 
@@ -2815,6 +2827,11 @@ export class WorkspaceService extends EventEmitter {
           hasUnresolvedMergedMatches = true;
         }
       }
+      // Notify as soon as the durable transition lands. The accepted-send path runs this
+      // while the drain is still awaiting the full sendMessage turn, so deferring to the
+      // drain's finally would keep "waking agent…" on screen for the whole wake-triggered
+      // stream even though the wake was already delivered.
+      this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
       if (hasUnresolvedMergedMatches) {
         this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
       }
@@ -13638,19 +13655,19 @@ export class WorkspaceService extends EventEmitter {
     // turn), so a one-shot watcher that matched and exited does not look like a lost wake.
     // Wake ids equal process ids (BashMonitorWakeStore.wakeId). The indicator must never
     // break process listing, so a wake-store read failure degrades to "no pending wakes".
-    let pendingWakeProcessIds: ReadonlySet<string>;
+    let pendingWakes: readonly BashMonitorWakeRecord[];
     try {
-      pendingWakeProcessIds = new Set(
-        (await this.bashMonitorWakeStore.listPending(workspaceId)).map((record) => record.processId)
-      );
+      pendingWakes = await this.bashMonitorWakeStore.listPending(workspaceId);
     } catch (error) {
       log.debug("Failed to read pending bash monitor wakes for process listing", {
         workspaceId,
         error,
       });
-      pendingWakeProcessIds = new Set();
+      pendingWakes = [];
     }
-    return processes.map((p) => {
+    const pendingWakeProcessIds = new Set(pendingWakes.map((record) => record.processId));
+    const liveProcessIds = new Set(processes.map((p) => p.id));
+    const rows = processes.map((p) => {
       const monitor = this.backgroundProcessManager.getMonitorSnapshot(p);
       const wakePending = pendingWakeProcessIds.has(p.id);
       return {
@@ -13666,6 +13683,35 @@ export class WorkspaceService extends EventEmitter {
         exitCode: p.exitCode,
       };
     });
+    // Durable pending wakes can outlive the in-memory process table (app restart wipes the
+    // manager while the wake store persists, and startup delivery can lag). Synthesize a row
+    // from the wake record so the pending-delivery state stays visible — that restart window
+    // is exactly the state this listing is meant to expose.
+    for (const record of pendingWakes) {
+      if (liveProcessIds.has(record.processId)) continue;
+      const startTime = Date.parse(record.createdAt);
+      rows.push({
+        id: record.processId,
+        // No live process behind this row; the renderer hides non-positive pids.
+        pid: 0,
+        script: record.script ?? "",
+        displayName: record.displayName,
+        startTime: Number.isNaN(startTime) ? Date.now() : startTime,
+        status: "exited",
+        monitor: {
+          filter: record.filter,
+          filter_exclude: record.filterExclude,
+          cooldown_ms: 0,
+          totalMatches: record.totalMatches,
+          droppedLines: record.droppedLines,
+          lastLines: record.lines,
+          stopped: true,
+          wakePending: true,
+        },
+        exitCode: undefined,
+      });
+    }
+    return rows;
   }
 
   /**

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5975,6 +5975,15 @@ export class WorkspaceService extends EventEmitter {
       return Ok(undefined);
     }
     this.removingWorkspaces.add(workspaceId);
+    // Cancel pending clear-promotion retries before any session data is deleted:
+    // their commitClear would otherwise recreate the session directory (mkdir in the
+    // tombstone mutation) after removal deletes it.
+    for (const [key, timer] of this.bashMonitorClearCommitRetryTimers) {
+      if (key.startsWith(`${workspaceId}:`)) {
+        clearTimeout(timer);
+        this.bashMonitorClearCommitRetryTimers.delete(key);
+      }
+    }
     let timelineClosed = false;
     let removedFromConfig = false;
 
@@ -12464,6 +12473,16 @@ export class WorkspaceService extends EventEmitter {
     if (this.bashMonitorClearCommitRetryTimers.has(key)) return;
     const timer = setTimeout(() => {
       this.bashMonitorClearCommitRetryTimers.delete(key);
+      // A removed (or mid-removal) workspace must never have its session directory
+      // recreated by a late promotion: the tombstone mutation's mkdir would
+      // resurrect deleted session data and could leak a cleared-at file into a
+      // future workspace reusing the ID.
+      if (
+        this.removingWorkspaces.has(workspaceId) ||
+        this.config.findWorkspace(workspaceId) == null
+      ) {
+        return;
+      }
       this.bashMonitorWakeStore.commitClear(workspaceId, clearToken).catch((error: unknown) => {
         log.debug("Bash monitor clear tombstone promotion retry failed", { workspaceId, error });
         this.scheduleBashMonitorClearCommitRetry(workspaceId, clearToken);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -4081,6 +4081,25 @@ export class WorkspaceService extends EventEmitter {
     readonly BashMonitorWakeRecord[]
   >();
 
+  // One retry timer per workspace after a failed pending-wake read. The fallback above
+  // makes listBackgroundProcesses RESOLVE, so the subscription's failure-retry path never
+  // sees the error — and with no live process there may be no later change event either.
+  // Re-emitting a change re-drives a read; if that read fails again its own catch
+  // reschedules, giving the same bounded once-per-delay retry loop as the subscription,
+  // and the chain stops as soon as a read succeeds or no subscriber re-reads.
+  private readonly pendingWakeReadRetryTimers = new Map<string, NodeJS.Timeout>();
+
+  private schedulePendingWakeReadRetry(workspaceId: string): void {
+    if (this.pendingWakeReadRetryTimers.has(workspaceId)) return;
+    const timer = setTimeout(() => {
+      this.pendingWakeReadRetryTimers.delete(workspaceId);
+      this.notifyBashMonitorWakeStateChanged(workspaceId);
+    }, 1_000);
+    // Never hold process shutdown open for a UI refresh nudge.
+    timer.unref();
+    this.pendingWakeReadRetryTimers.set(workspaceId, timer);
+  }
+
   private notifyBashMonitorWakeStateChanged(workspaceId: string): void {
     // Tests may construct WorkspaceService with a partial BackgroundProcessManager stub
     // (same reason the constructor guards the event subscriptions).
@@ -13660,12 +13679,16 @@ export class WorkspaceService extends EventEmitter {
     } catch (error) {
       // Publishing an empty set here would authoritatively clear durable pending-wake
       // state on a transient I/O failure — and an already-exited process may never emit
-      // another change event to restore it. Fail to the last good snapshot instead.
+      // another change event to restore it. Fail to the last good snapshot instead, and
+      // schedule a retry: serving the fallback makes this call resolve, so the
+      // subscription's own failure retry never engages, and the fallback may be empty
+      // (no seed yet) or stale (wakes retired since) with no later event to correct it.
       log.debug("Failed to read pending bash monitor wakes for process listing", {
         workspaceId,
         error,
       });
       pendingWakes = this.lastGoodPendingWakesByWorkspace.get(workspaceId) ?? [];
+      this.schedulePendingWakeReadRetry(workspaceId);
     }
     // Present monitor state derived purely from a durable wake record, for rows (or reused
     // process IDs) that have no live monitor snapshot to decorate.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -4073,6 +4073,14 @@ export class WorkspaceService extends EventEmitter {
     return this.backgroundProcessManager.getActiveMonitorCount(workspaceId);
   }
 
+  // Last successfully read pending-wake set per workspace. On a transient wake-store read
+  // failure, listBackgroundProcesses republishes this instead of an (authoritative-looking)
+  // empty set that would clear pending-wake UI state with no later event to restore it.
+  private readonly lastGoodPendingWakesByWorkspace = new Map<
+    string,
+    readonly BashMonitorWakeRecord[]
+  >();
+
   private notifyBashMonitorWakeStateChanged(workspaceId: string): void {
     // Tests may construct WorkspaceService with a partial BackgroundProcessManager stub
     // (same reason the constructor guards the event subscriptions).
@@ -13648,12 +13656,16 @@ export class WorkspaceService extends EventEmitter {
     let pendingWakes: readonly BashMonitorWakeRecord[];
     try {
       pendingWakes = await this.bashMonitorWakeStore.listPending(workspaceId);
+      this.lastGoodPendingWakesByWorkspace.set(workspaceId, pendingWakes);
     } catch (error) {
+      // Publishing an empty set here would authoritatively clear durable pending-wake
+      // state on a transient I/O failure — and an already-exited process may never emit
+      // another change event to restore it. Fail to the last good snapshot instead.
       log.debug("Failed to read pending bash monitor wakes for process listing", {
         workspaceId,
         error,
       });
-      pendingWakes = [];
+      pendingWakes = this.lastGoodPendingWakesByWorkspace.get(workspaceId) ?? [];
     }
     // Present monitor state derived purely from a durable wake record, for rows (or reused
     // process IDs) that have no live monitor snapshot to decorate.
@@ -13667,16 +13679,24 @@ export class WorkspaceService extends EventEmitter {
       stopped: true,
       pendingWakeKind: record.kind,
     });
-    const pendingWakeByProcessId = new Map(
-      pendingWakes.map((record) => [record.processId, record] as const)
-    );
-    const liveProcessIds = new Set(processes.map((p) => p.id));
+    const liveProcessById = new Map(processes.map((p) => [p.id, p] as const));
+    // A pending wake decorates the live row only when it belongs to that process
+    // generation (created at/after spawn). An older wake merely shares a reused
+    // display-name-derived ID; overlaying it onto the new process's monitor would mix
+    // another generation's wake with the live filter/match counts and point its output
+    // action at the wrong process, so such wakes get their own synthesized row below.
+    const wakeOnLiveRow = new Map<string, BashMonitorWakeRecord>();
+    for (const record of pendingWakes) {
+      const live = liveProcessById.get(record.processId);
+      if (live != null && Date.parse(record.createdAt) >= live.startTime) {
+        wakeOnLiveRow.set(record.processId, record);
+      }
+    }
     const rows: BackgroundProcessInfo[] = processes.map((p) => {
       const monitor = this.backgroundProcessManager.getMonitorSnapshot(p);
-      const pendingWake = pendingWakeByProcessId.get(p.id);
-      // A restarted workspace can reuse a display-name-derived process ID while the prior
-      // generation's wake is still pending. Even when the new process carries no monitor,
-      // the durable wake must stay visible, so fall back to a record-derived snapshot.
+      const pendingWake = wakeOnLiveRow.get(p.id);
+      // Same-generation wake on a monitorless row (e.g. the monitor was stopped after the
+      // match): fall back to a record-derived snapshot so the wake stays visible.
       const monitorPayload =
         pendingWake != null
           ? {
@@ -13700,10 +13720,14 @@ export class WorkspaceService extends EventEmitter {
     // from the wake record so the pending-delivery state stays visible — that restart window
     // is exactly the state this listing is meant to expose.
     for (const record of pendingWakes) {
-      if (liveProcessIds.has(record.processId)) continue;
+      if (wakeOnLiveRow.has(record.processId)) continue;
       const startTime = Date.parse(record.createdAt);
       rows.push({
-        id: record.processId,
+        // Prior-generation wakes whose ID is reused by a live process need a distinct row
+        // identity; nothing dereferences synthesized ids (no output/terminate actions).
+        id: liveProcessById.has(record.processId)
+          ? `${record.processId}#pending-wake`
+          : record.processId,
         // No live process behind this row; `synthesized` (not the pid) tells the renderer
         // that output/terminate actions cannot work.
         pid: 0,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -13708,7 +13708,9 @@ export class WorkspaceService extends EventEmitter {
         // that output/terminate actions cannot work.
         pid: 0,
         script: record.script ?? "",
-        displayName: record.displayName,
+        // Match records may carry neither displayName nor script; fall back to the
+        // processId (itself display-name derived) so the banner row is never blank.
+        displayName: record.displayName ?? record.processId,
         synthesized: true,
         startTime: Number.isNaN(startTime) ? Date.now() : startTime,
         status: "exited",

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -6500,9 +6500,10 @@ export class WorkspaceService extends EventEmitter {
       // intentionally keeps its staged heartbeat armed for cross-instance liveness,
       // and both that heartbeat and a late tombstone promotion drive
       // mutateClearedAt, whose mkdir would recreate the directory after deletion.
-      // New clears are refused by the removingWorkspaces guard (set above),
-      // promotion retries re-check it when they fire, and this barrier covers the
-      // one transaction that may already hold the lock.
+      // New clears are refused by the removingWorkspaces guard (set above), and
+      // promotion retries both re-check it and run their commitClear under this
+      // same lock — so the barrier waits out the in-flight clear transaction AND
+      // any already-fired retry.
       await this.bashMonitorHistoryLocks.withLock(workspaceId, () => Promise.resolve());
       this.bashMonitorWakeStore.abandonWorkspaceClears(workspaceId);
 
@@ -12492,20 +12493,30 @@ export class WorkspaceService extends EventEmitter {
     if (this.bashMonitorClearCommitRetryTimers.has(key)) return;
     const timer = setTimeout(() => {
       this.bashMonitorClearCommitRetryTimers.delete(key);
-      // A removed (or mid-removal) workspace must never have its session directory
-      // recreated by a late promotion: the tombstone mutation's mkdir would
-      // resurrect deleted session data and could leak a cleared-at file into a
-      // future workspace reusing the ID.
-      if (
-        this.removingWorkspaces.has(workspaceId) ||
-        this.config.findWorkspace(workspaceId) == null
-      ) {
-        return;
-      }
-      this.bashMonitorWakeStore.commitClear(workspaceId, clearToken).catch((error: unknown) => {
-        log.debug("Bash monitor clear tombstone promotion retry failed", { workspaceId, error });
-        this.scheduleBashMonitorClearCommitRetry(workspaceId, clearToken);
-      });
+      // Serialized through the history lock so removal's pre-deletion barrier also
+      // waits out an ALREADY-FIRED retry: a retry that passed the guard below just
+      // before removal began would otherwise run commitClear (whose tombstone
+      // mutation mkdirs the wake directory) concurrently with — or after — session
+      // deletion. Holding the lock also makes the removingWorkspaces re-check
+      // race-free: removal sets the flag before its barrier acquires this lock.
+      void this.bashMonitorHistoryLocks
+        .withLock(workspaceId, async () => {
+          // A removed (or mid-removal) workspace must never have its session
+          // directory recreated by a late promotion: the tombstone mutation's mkdir
+          // would resurrect deleted session data and could leak a cleared-at file
+          // into a future workspace reusing the ID.
+          if (
+            this.removingWorkspaces.has(workspaceId) ||
+            this.config.findWorkspace(workspaceId) == null
+          ) {
+            return;
+          }
+          await this.bashMonitorWakeStore.commitClear(workspaceId, clearToken);
+        })
+        .catch((error: unknown) => {
+          log.debug("Bash monitor clear tombstone promotion retry failed", { workspaceId, error });
+          this.scheduleBashMonitorClearCommitRetry(workspaceId, clearToken);
+        });
     }, 1_000);
     // Never hold process shutdown open for a promotion retry: a staging orphaned by
     // shutdown is reconciled by the staged-clear grace scan on the next start.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2356,6 +2356,14 @@ export class WorkspaceService extends EventEmitter {
   ) {
     super();
     this.bashMonitorWakeStore = new BashMonitorWakeStore(config);
+    // A crash-orphaned temp write deferred by the store's live-writer freshness gate
+    // has no natural later trigger (startup discovery already ran and saw nothing
+    // pending). When the gate elapses, re-drive delivery: the drain's scan places the
+    // recovered wake and delivers it, and the notify refreshes the banner row.
+    this.bashMonitorWakeStore.onDeferredTempRecoveryDue = (ownerWorkspaceId) => {
+      this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
+      this.scheduleBashMonitorWakeDrain(ownerWorkspaceId);
+    };
     this.bashMonitorRegistryStore = new BashMonitorRegistryStore(config);
     if (typeof this.backgroundProcessManager.on === "function") {
       this.backgroundProcessManager.on("output:shown", this.bashOutputShownListener);

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -12358,8 +12358,14 @@ export class WorkspaceService extends EventEmitter {
           (acceptedBefore.has(key) && acceptedAfter?.has(key) === true)
         );
       });
-      await this.bashMonitorWakeStore.restorePendingSnapshots(workspaceId, restorable);
-      this.notifyBashMonitorWakeStateChanged(workspaceId);
+      try {
+        await this.bashMonitorWakeStore.restorePendingSnapshots(workspaceId, restorable);
+      } finally {
+        // Notify even when restoration throws partway: earlier records in the pass are
+        // already durably pending again, and without a nudge subscribers would keep the
+        // post-retirement snapshot (hiding those wakes) until unrelated activity.
+        this.notifyBashMonitorWakeStateChanged(workspaceId);
+      }
     };
     try {
       const clearResult = await clear();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -12317,6 +12317,10 @@ export class WorkspaceService extends EventEmitter {
     }
     const retireResult = await this.retirePendingBashMonitorWakesBeforeHistoryClear(workspaceId);
     if (!retireResult.success) return retireResult;
+    // History clears retire pending wakes without any process-state change, so
+    // background-bash subscribers need explicit nudges to drop (and, after a restore,
+    // re-show) pending-wake rows; nothing else re-emits for already-exited processes.
+    this.notifyBashMonitorWakeStateChanged(workspaceId);
     const staged = retireResult.data;
     const restoreSnapshots = async (includeUnaccepted: boolean): Promise<void> => {
       const acceptedAfter = await this.findAcceptedBashMonitorWakeSnapshots(workspaceId, staged);
@@ -12328,6 +12332,7 @@ export class WorkspaceService extends EventEmitter {
         );
       });
       await this.bashMonitorWakeStore.restorePendingSnapshots(workspaceId, restorable);
+      this.notifyBashMonitorWakeStateChanged(workspaceId);
     };
     try {
       const clearResult = await clear();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -298,6 +298,7 @@ import {
   BashMonitorWakeStore,
   buildBashMonitorWakeMetadata,
   buildBashMonitorWakePrompt,
+  type BashMonitorClearToken,
   type BashMonitorWakePromptContext,
   type BashMonitorWakeRecord,
 } from "@/node/services/bashMonitorWakeStore";
@@ -12340,7 +12341,7 @@ export class WorkspaceService extends EventEmitter {
 
   private async retirePendingBashMonitorWakesBeforeHistoryClear(
     workspaceId: string
-  ): Promise<Result<{ snapshots: BashMonitorWakeRecord[]; clearedAt: string }>> {
+  ): Promise<Result<{ snapshots: BashMonitorWakeRecord[] } & BashMonitorClearToken>> {
     try {
       return Ok(await this.bashMonitorWakeStore.supersedeAllPending(workspaceId));
     } catch (error) {
@@ -12381,7 +12382,10 @@ export class WorkspaceService extends EventEmitter {
     // re-show) pending-wake rows; nothing else re-emits for already-exited processes.
     this.notifyBashMonitorWakeStateChanged(workspaceId);
     const staged = retireResult.data.snapshots;
-    const retiredClearedAt = retireResult.data.clearedAt;
+    const clearToken = {
+      clearId: retireResult.data.clearId,
+      clearedAt: retireResult.data.clearedAt,
+    };
     const restoreSnapshots = async (includeUnaccepted: boolean): Promise<void> => {
       const acceptedAfter = await this.findAcceptedBashMonitorWakeSnapshots(workspaceId, staged);
       const restorable = staged.filter((record) => {
@@ -12395,7 +12399,7 @@ export class WorkspaceService extends EventEmitter {
         await this.bashMonitorWakeStore.restorePendingSnapshots(
           workspaceId,
           restorable,
-          retiredClearedAt
+          clearToken
         );
       } finally {
         // Notify even when restoration throws partway: earlier records in the pass are
@@ -12409,6 +12413,11 @@ export class WorkspaceService extends EventEmitter {
       if (clearResult.success) {
         if (options?.discardUnacceptedOnSuccess !== true) {
           await restoreSnapshots(true);
+        } else {
+          // Full clear committed: promote the staged tombstone so pre-clear deferred
+          // temps stop being held and become condemned. Without this, a crash-scan
+          // would eventually treat the staging as failed and resurrect them.
+          await this.bashMonitorWakeStore.commitClear(workspaceId, clearToken);
         }
         return clearResult;
       }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2827,16 +2827,21 @@ export class WorkspaceService extends EventEmitter {
       resolve: (record: BashMonitorWakeRecord) => Promise<boolean>
     ): Promise<void> => {
       let hasUnresolvedMergedMatches = false;
-      for (const record of records) {
-        if (!(await resolve(record))) {
-          hasUnresolvedMergedMatches = true;
+      try {
+        for (const record of records) {
+          if (!(await resolve(record))) {
+            hasUnresolvedMergedMatches = true;
+          }
         }
+      } finally {
+        // Notify as soon as durable transitions land — even when a later record's
+        // transition throws after an earlier one already succeeded (observers must track
+        // partial durable updates). The accepted-send path runs this while the drain is
+        // still awaiting the full sendMessage turn, so deferring to the drain's finally
+        // would keep "waking agent…" on screen for the whole wake-triggered stream even
+        // though the wake was already delivered.
+        this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
       }
-      // Notify as soon as the durable transition lands. The accepted-send path runs this
-      // while the drain is still awaiting the full sendMessage turn, so deferring to the
-      // drain's finally would keep "waking agent…" on screen for the whole wake-triggered
-      // stream even though the wake was already delivered.
-      this.notifyBashMonitorWakeStateChanged(ownerWorkspaceId);
       if (hasUnresolvedMergedMatches) {
         this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
       }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -6495,6 +6495,17 @@ export class WorkspaceService extends EventEmitter {
         });
       }
 
+      // Wait out any in-flight bash-monitor history clear, then disarm surviving
+      // clear writers BEFORE deleting the session directory. A commit-failed clear
+      // intentionally keeps its staged heartbeat armed for cross-instance liveness,
+      // and both that heartbeat and a late tombstone promotion drive
+      // mutateClearedAt, whose mkdir would recreate the directory after deletion.
+      // New clears are refused by the removingWorkspaces guard (set above),
+      // promotion retries re-check it when they fire, and this barrier covers the
+      // one transaction that may already hold the lock.
+      await this.bashMonitorHistoryLocks.withLock(workspaceId, () => Promise.resolve());
+      this.bashMonitorWakeStore.abandonWorkspaceClears(workspaceId);
+
       // Remove session data
       const sessionDir = this.config.getSessionDir(workspaceId);
       // r66: identifies THIS removal attempt in the durable tombstone so the
@@ -12379,6 +12390,14 @@ export class WorkspaceService extends EventEmitter {
     clear: () => Promise<Result<T>>,
     options?: { discardUnacceptedOnSuccess?: boolean }
   ): Promise<Result<T>> {
+    // Removal deletes the session directory: a clear admitted after removal begins
+    // would stage a tombstone and stamp records — writes whose mkdir can recreate
+    // the deleted directory and leak a cleared-at file into a future workspace
+    // reusing the ID. removeUnlocked sets the flag before its history-lock barrier,
+    // so checking under this lock is race-free.
+    if (this.removingWorkspaces.has(workspaceId)) {
+      return Err("Cannot clear history while the workspace is being removed.");
+    }
     const pending = await this.bashMonitorWakeStore.listPending(workspaceId);
     const acceptedBefore = await this.findAcceptedBashMonitorWakeSnapshots(workspaceId, pending);
     if (acceptedBefore == null) {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -12408,21 +12408,9 @@ export class WorkspaceService extends EventEmitter {
         this.notifyBashMonitorWakeStateChanged(workspaceId);
       }
     };
+    let clearResult: Result<T>;
     try {
-      const clearResult = await clear();
-      if (clearResult.success) {
-        if (options?.discardUnacceptedOnSuccess !== true) {
-          await restoreSnapshots(true);
-        } else {
-          // Full clear committed: promote the staged tombstone so pre-clear deferred
-          // temps stop being held and become condemned. Without this, a crash-scan
-          // would eventually treat the staging as failed and resurrect them.
-          await this.bashMonitorWakeStore.commitClear(workspaceId, clearToken);
-        }
-        return clearResult;
-      }
-      await restoreSnapshots(true);
-      return clearResult;
+      clearResult = await clear();
     } catch (error) {
       try {
         await restoreSnapshots(true);
@@ -12434,6 +12422,57 @@ export class WorkspaceService extends EventEmitter {
       }
       throw error;
     }
+    if (!clearResult.success) {
+      await restoreSnapshots(true);
+      return clearResult;
+    }
+    if (options?.discardUnacceptedOnSuccess !== true) {
+      await restoreSnapshots(true);
+      return clearResult;
+    }
+    // Full clear committed: promote the staged tombstone so pre-clear deferred
+    // temps stop being held and become condemned. Without this, a crash-scan
+    // would eventually treat the staging as failed and resurrect them. The
+    // transcript is durably cleared at this point, so a failed promotion must
+    // NOT reach any restore path (that would resurrect retired wakes straight
+    // into the cleared transcript) nor fail the caller's successful clear —
+    // leave the staging standing (it keeps holding pre-clear temps) and retry
+    // the promotion in the background until it lands.
+    try {
+      await this.bashMonitorWakeStore.commitClear(workspaceId, clearToken);
+    } catch (commitError) {
+      log.error("Failed to promote bash monitor clear tombstone; will retry", {
+        workspaceId,
+        error: commitError,
+      });
+      this.scheduleBashMonitorClearCommitRetry(workspaceId, clearToken);
+    }
+    return clearResult;
+  }
+
+  // One retry timer per clear transaction for a tombstone promotion that failed AFTER
+  // the history clear durably succeeded (see above): nothing else re-drives the
+  // promotion, and an unpromoted staging would eventually be rolled back as crashed —
+  // resurrecting retired wakes into the cleared transcript.
+  private readonly bashMonitorClearCommitRetryTimers = new Map<string, NodeJS.Timeout>();
+
+  private scheduleBashMonitorClearCommitRetry(
+    workspaceId: string,
+    clearToken: BashMonitorClearToken
+  ): void {
+    const key = `${workspaceId}:${clearToken.clearId}`;
+    if (this.bashMonitorClearCommitRetryTimers.has(key)) return;
+    const timer = setTimeout(() => {
+      this.bashMonitorClearCommitRetryTimers.delete(key);
+      this.bashMonitorWakeStore.commitClear(workspaceId, clearToken).catch((error: unknown) => {
+        log.debug("Bash monitor clear tombstone promotion retry failed", { workspaceId, error });
+        this.scheduleBashMonitorClearCommitRetry(workspaceId, clearToken);
+      });
+    }, 1_000);
+    // Never hold process shutdown open for a promotion retry: a staging orphaned by
+    // shutdown is reconciled by the staged-clear grace scan on the next start.
+    timer.unref();
+    this.bashMonitorClearCommitRetryTimers.set(key, timer);
   }
 
   async truncateHistory(workspaceId: string, percentage?: number): Promise<Result<void>> {

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -13851,13 +13851,18 @@ export class WorkspaceService extends EventEmitter {
     // A wake whose only event is process settlement (terminal-only wakeOnExit, or an
     // earlier run's preserved settlement) still has kind "match" in the durable
     // record; labeling it "match" in the UI would report a match the filter never
-    // produced. Coalesced records with real matches keep the match label.
+    // produced. Coalesced records with real UNDELIVERED matches keep the match label
+    // — judged by the matched frontier (matchedThroughOffset), mirroring the prompt
+    // builder's terminal-only test: totalMatches is the monitor's CUMULATIVE counter,
+    // so a settlement enqueued after an earlier match wake was already delivered
+    // carries a nonzero count while only settlement is actually pending.
     const pendingWakeKindOf = (
       record: BashMonitorWakeRecord
     ): "match" | "monitor-lost" | "settled" =>
       record.kind === "monitor-lost"
         ? "monitor-lost"
-        : record.totalMatches === 0 && (record.terminal != null || record.staleTerminal != null)
+        : (record.terminal != null || record.staleTerminal != null) &&
+            record.matchedThroughOffset == null
           ? "settled"
           : "match";
     // Present monitor state derived purely from a durable wake record, for rows (or reused

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -13719,15 +13719,19 @@ export class WorkspaceService extends EventEmitter {
     // manager while the wake store persists, and startup delivery can lag). Synthesize a row
     // from the wake record so the pending-delivery state stays visible — that restart window
     // is exactly the state this listing is meant to expose.
+    // Row ids double as React keys. Process ids derive from arbitrary display names, so
+    // any fixed suffix for prior-generation wake rows can collide with a real live id
+    // (a process may literally be named "foo#pending-wake"); extend until unique instead.
+    // Nothing dereferences synthesized ids (no output/terminate actions).
+    const usedRowIds = new Set(rows.map((row) => row.id));
     for (const record of pendingWakes) {
       if (wakeOnLiveRow.has(record.processId)) continue;
       const startTime = Date.parse(record.createdAt);
+      let rowId = record.processId;
+      while (usedRowIds.has(rowId)) rowId = `${rowId}#pending-wake`;
+      usedRowIds.add(rowId);
       rows.push({
-        // Prior-generation wakes whose ID is reused by a live process need a distinct row
-        // identity; nothing dereferences synthesized ids (no output/terminate actions).
-        id: liveProcessById.has(record.processId)
-          ? `${record.processId}#pending-wake`
-          : record.processId,
+        id: rowId,
         // No live process behind this row; `synthesized` (not the pid) tells the renderer
         // that output/terminate actions cannot work.
         pid: 0,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -274,6 +274,7 @@ import type {
   ArchiveLossyUntrackedFilesConfirmation,
   ArchivePreflightResult,
   ArchiveWorkspaceResult,
+  BackgroundProcessInfo,
 } from "@/common/orpc/schemas/api";
 import type { SessionTimingService } from "@/node/services/sessionTimingService";
 import type { SessionUsageService } from "@/node/services/sessionUsageService";
@@ -13627,29 +13628,9 @@ export class WorkspaceService extends EventEmitter {
   /**
    * List background processes for a workspace.
    * Returns process info suitable for UI display (excludes handle).
+   * Typed against the shared IPC schema so the service and schema cannot drift.
    */
-  async listBackgroundProcesses(workspaceId: string): Promise<
-    Array<{
-      id: string;
-      pid: number;
-      script: string;
-      displayName?: string;
-      startTime: number;
-      status: "running" | "exited" | "killed" | "failed";
-      monitor?: {
-        filter: string;
-        filter_exclude: boolean;
-        cooldown_ms: number;
-        max_events?: number;
-        totalMatches: number;
-        droppedLines: number;
-        lastLines: string[];
-        stopped: boolean;
-        wakePending?: boolean;
-      };
-      exitCode?: number;
-    }>
-  > {
+  async listBackgroundProcesses(workspaceId: string): Promise<BackgroundProcessInfo[]> {
     const processes = await this.backgroundProcessManager.list(workspaceId);
     // Surface durably-pending monitor wakes (matched but not yet delivered as a synthetic
     // turn), so a one-shot watcher that matched and exited does not look like a lost wake.
@@ -13665,11 +13646,13 @@ export class WorkspaceService extends EventEmitter {
       });
       pendingWakes = [];
     }
-    const pendingWakeProcessIds = new Set(pendingWakes.map((record) => record.processId));
+    const pendingWakeKindByProcessId = new Map(
+      pendingWakes.map((record) => [record.processId, record.kind] as const)
+    );
     const liveProcessIds = new Set(processes.map((p) => p.id));
-    const rows = processes.map((p) => {
+    const rows: BackgroundProcessInfo[] = processes.map((p) => {
       const monitor = this.backgroundProcessManager.getMonitorSnapshot(p);
-      const wakePending = pendingWakeProcessIds.has(p.id);
+      const pendingWakeKind = pendingWakeKindByProcessId.get(p.id);
       return {
         id: p.id,
         pid: p.pid,
@@ -13678,7 +13661,7 @@ export class WorkspaceService extends EventEmitter {
         startTime: p.startTime,
         status: p.status,
         ...(monitor != null
-          ? { monitor: wakePending ? { ...monitor, wakePending } : monitor }
+          ? { monitor: pendingWakeKind != null ? { ...monitor, pendingWakeKind } : monitor }
           : {}),
         exitCode: p.exitCode,
       };
@@ -13706,7 +13689,7 @@ export class WorkspaceService extends EventEmitter {
           droppedLines: record.droppedLines,
           lastLines: record.lines,
           stopped: true,
-          wakePending: true,
+          pendingWakeKind: record.kind,
         },
         exitCode: undefined,
       });

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -12340,7 +12340,7 @@ export class WorkspaceService extends EventEmitter {
 
   private async retirePendingBashMonitorWakesBeforeHistoryClear(
     workspaceId: string
-  ): Promise<Result<BashMonitorWakeRecord[]>> {
+  ): Promise<Result<{ snapshots: BashMonitorWakeRecord[]; clearedAt: string }>> {
     try {
       return Ok(await this.bashMonitorWakeStore.supersedeAllPending(workspaceId));
     } catch (error) {
@@ -12380,7 +12380,8 @@ export class WorkspaceService extends EventEmitter {
     // background-bash subscribers need explicit nudges to drop (and, after a restore,
     // re-show) pending-wake rows; nothing else re-emits for already-exited processes.
     this.notifyBashMonitorWakeStateChanged(workspaceId);
-    const staged = retireResult.data;
+    const staged = retireResult.data.snapshots;
+    const retiredClearedAt = retireResult.data.clearedAt;
     const restoreSnapshots = async (includeUnaccepted: boolean): Promise<void> => {
       const acceptedAfter = await this.findAcceptedBashMonitorWakeSnapshots(workspaceId, staged);
       const restorable = staged.filter((record) => {
@@ -12391,7 +12392,11 @@ export class WorkspaceService extends EventEmitter {
         );
       });
       try {
-        await this.bashMonitorWakeStore.restorePendingSnapshots(workspaceId, restorable);
+        await this.bashMonitorWakeStore.restorePendingSnapshots(
+          workspaceId,
+          restorable,
+          retiredClearedAt
+        );
       } finally {
         // Notify even when restoration throws partway: earlier records in the pass are
         // already durably pending again, and without a nudge subscribers would keep the


### PR DESCRIPTION
## Summary

Surface durably-pending bash-monitor wakes in the background process UI so a one-shot watcher that matched and exited no longer looks like a lost wake.

## Background

A background bash `monitor` can match and durably enqueue a wake while its watcher process exits — the common one-shot pattern is a script that prints `WAKE:...` and exits 0. Between process exit and delivery of the synthetic wake turn, the UI previously showed nothing: `BackgroundProcessesBanner` filtered to `status === "running"` and returned `null` once the last process exited, and the sidebar/barrier monitor counts only consider running monitors.

Real incident (2026-08-25, ai-sdk dep-update workspace): watcher printed `WAKE:FINDINGS_REVIEW` and exited at 10:25:32; the wake turn only started at 10:27:49 (~50s of that was slow pre-stream prep under host load). The observer concluded the watcher "never triggered the agent" even though the wake record was sitting in `BashMonitorWakeStore` with `status: "pending"` the whole time.

## Implementation

- `monitor.wakePending?: boolean` added to the existing `backgroundBashes.subscribe` payload (`BackgroundProcessMonitorInfoSchema`), computed in `WorkspaceService.listBackgroundProcesses` by joining pending wake-store records against process ids (wake id == process id). A wake-store read failure degrades to "no indicator" and never breaks process listing.
- Wake-state transitions push the existing change stream: new `BackgroundProcessManager.notifyMonitorWakeStateChanged` is invoked after a match is enqueued and (coarsely, via `.finally()`) after every drain pass, so delivered/superseded transitions clear the indicator across all drain exit paths.
- `BackgroundProcessesBanner` keeps exited-but-wake-pending processes visible with a compact `· match found — waking agent…` suffix, hides the live duration and Terminate button for non-running rows, and keys its tick interval on whether any visible process is still running.
- `BackgroundBashStore.areMonitorSnapshotsEqual` includes `wakePending` so the frontend store does not dedupe the transition away.

## Validation

- Behavioral node test: `wakePending === true` while a wake record is pending, absent after `markDeliveredSnapshot`.
- New Storybook story: exited one-shot watcher with `wakePending: true` (banner visible with indicator).
- `workspaceService.test.ts` full file: 374 pass / 1 fail — the failing test ("accepted history suppresses redelivery while wake-store reconciliation keeps failing", from #3776) fails identically on clean `origin/main`; pre-existing, not introduced here.

## Risks

Low. The payload field is optional and additive; the only behavioral changes are banner visibility/filtering and extra (cheap, coalesced) change-stream emits after monitor matches and drain passes. Worst case on a wake-store read error is the old behavior (no indicator).

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$20.47`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=20.47 -->
