### PR TITLE
🤖 fix: stop silent full-history re-transfers on workspace switch-back (onChat since cursor)

### DIFF
--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -5406,6 +5406,129 @@ describe("WorkspaceStore", () => {
       expect(clearedAbortReason).toBe(true);
     });
 
+    it("reuses the server-issued cursor verbatim on the next subscription", async () => {
+      const workspaceId = "cursor-reuse-workspace";
+      const serverCursor = {
+        messageId: "history-7",
+        historySequence: 7,
+        oldestHistorySequence: 3,
+        priorHistoryFingerprint: "0badf00d",
+      };
+      const firstSubscription = createReleaseGate();
+      const requestedModes: unknown[] = [];
+      let subscriptionCount = 0;
+
+      mockOnChat.mockImplementation(async function* (
+        input?: { workspaceId: string; mode?: unknown },
+        _options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        subscriptionCount += 1;
+        requestedModes.push(input?.mode);
+        if (subscriptionCount === 1) {
+          yield createHistoryMessageEvent("history-7", 7);
+          yield caughtUpEvent({ replay: "full", cursor: { history: serverCursor } });
+          await firstSubscription.wait;
+          return;
+        }
+        yield createHistoryMessageEvent("history-7", 7);
+        yield caughtUpEvent({ replay: "since", cursor: { history: serverCursor } });
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hydrated = await waitUntil(
+        () => store.getAggregator(workspaceId)?.getAllMessages().length === 1
+      );
+      expect(hydrated).toBe(true);
+      expect(requestedModes[0]).toBeUndefined();
+
+      firstSubscription.release();
+
+      const resubscribed = await waitUntil(() => subscriptionCount >= 2);
+      expect(resubscribed).toBe(true);
+      // The client must not recompute any cursor fields; the server-issued cursor is
+      // reused verbatim (fingerprint included).
+      expect(requestedModes[1]).toEqual({
+        type: "since",
+        cursor: { history: serverCursor },
+      });
+    });
+
+    it("forces a full resubscribe when caught-up carries no cursor", async () => {
+      const workspaceId = "cursor-missing-workspace";
+      const firstSubscription = createReleaseGate();
+      const requestedModes: unknown[] = [];
+      let subscriptionCount = 0;
+
+      mockOnChat.mockImplementation(async function* (
+        input?: { workspaceId: string; mode?: unknown },
+        _options?: { signal?: AbortSignal }
+      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
+        subscriptionCount += 1;
+        requestedModes.push(input?.mode);
+        // Replay failures make the server omit the cursor from caught-up.
+        yield createHistoryMessageEvent("history-1", 1);
+        yield caughtUpEvent({ replay: "full" });
+        if (subscriptionCount === 1) {
+          await firstSubscription.wait;
+        }
+      });
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const hydrated = await waitUntil(
+        () => store.getAggregator(workspaceId)?.getAllMessages().length === 1
+      );
+      expect(hydrated).toBe(true);
+
+      firstSubscription.release();
+
+      const resubscribed = await waitUntil(() => subscriptionCount >= 2);
+      expect(resubscribed).toBe(true);
+      expect(requestedModes[1]).toBeUndefined();
+    });
+
+    it("removes rows the server did not re-send from a since replay", async () => {
+      const workspaceId = "since-suffix-ghost-workspace";
+      const firstSubscription = createReleaseGate();
+      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
+        subscriptionCount === 1
+          ? [
+              createHistoryMessageEvent("history-1", 1),
+              createHistoryMessageEvent("history-2", 2),
+              fullCaughtUpEvent(2, "history-2"),
+              Promise.resolve(),
+              // Row streamed live after caught-up: it sits above the stored anchor.
+              createHistoryMessageEvent("history-3", 3),
+              firstSubscription.wait,
+            ]
+          : [
+              // Server deleted history-3 while the client was unsubscribed, so the
+              // since replay re-sends only the anchor row.
+              createHistoryMessageEvent("history-2", 2),
+              sinceCaughtUpEvent(2, "history-2"),
+            ]
+      );
+
+      createAndAddWorkspace(store, workspaceId);
+
+      const seeded = await waitUntil(
+        () => store.getAggregator(workspaceId)?.getAllMessages().length === 3
+      );
+      expect(seeded).toBe(true);
+
+      firstSubscription.release();
+
+      const ghostRemoved = await waitUntil(() => {
+        const ids = store
+          .getAggregator(workspaceId)
+          ?.getAllMessages()
+          .map((message) => message.id);
+        return getSubscriptionCount() >= 2 && JSON.stringify(ids) === '["history-1","history-2"]';
+      });
+      expect(ghostRemoved).toBe(true);
+    });
+
     it("clears stale auto-retry status when full replay reconnect replaces history", async () => {
       const workspaceId = "task-created-workspace-auto-retry-reset";
       const firstSubscription = createReleaseGate();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -488,6 +488,19 @@ const sinceCaughtUpEvent = (
     cursor: { history: { messageId, historySequence }, ...(stream ? { stream } : {}) },
   });
 
+// Full replay caught-up carrying a server cursor, as the real server issues on every
+// non-empty replay. The client reuses this cursor verbatim, making the next
+// subscription a legitimate since request.
+const fullCaughtUpEvent = (
+  historySequence = 1,
+  messageId = `history-${historySequence}`,
+  stream?: { messageId: string; lastTimestamp: number }
+): WorkspaceChatMessage =>
+  caughtUpEvent({
+    replay: "full",
+    cursor: { history: { messageId, historySequence }, ...(stream ? { stream } : {}) },
+  });
+
 const streamEndEvent = (
   workspaceId: string,
   messageId: string,
@@ -1923,12 +1936,24 @@ describe("WorkspaceStore", () => {
         subscriptionCount += 1;
 
         if (subscriptionCount === 1) {
-          yield { type: "caught-up" };
+          // Server issues a reconnect cursor on every caught-up; the client reuses
+          // it verbatim, so the second subscription legitimately requests since.
+          yield {
+            type: "caught-up",
+            cursor: {
+              history: {
+                messageId: "reconnect-pending-start",
+                historySequence: 1,
+              },
+            },
+          };
           await Promise.resolve();
           yield createUserMessageEvent("reconnect-pending-start", "hello", 1, 1_000);
           return;
         }
 
+        // Since replay re-sends the cursor-boundary row before caught-up.
+        yield createUserMessageEvent("reconnect-pending-start", "hello", 1, 1_000);
         yield {
           type: "caught-up",
           replay: "since",
@@ -2035,11 +2060,14 @@ describe("WorkspaceStore", () => {
       const requestedModel = "openai:gpt-4o-mini";
       let subscriptionCount = 0;
 
+      // Empty-history caught-ups carry no cursor, so every resubscribe legitimately
+      // requests (and receives) a full replay; the server never reports since for a
+      // full request.
       mockChatStreamFor(workspaceId, function* () {
         subscriptionCount += 1;
         yield {
           type: "caught-up",
-          replay: subscriptionCount === 1 ? "full" : "since",
+          replay: "full",
         };
       });
 
@@ -5178,13 +5206,14 @@ describe("WorkspaceStore", () => {
       const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
         subscriptionCount === 1
           ? [
-              caughtUpEvent(),
+              createHistoryMessageEvent("history-1", 1),
+              fullCaughtUpEvent(),
               Promise.resolve(),
               bashOutputEvent(workspaceId, "call-bash-4", "stale-output\n"),
               taskCreatedEvent(workspaceId, "call-task-4", "child-workspace-4", 2),
               firstSubscription.wait,
             ]
-          : [sinceCaughtUpEvent()]
+          : [createHistoryMessageEvent("history-1", 1), sinceCaughtUpEvent()]
       );
 
       createAndAddWorkspace(store, workspaceId);
@@ -5216,7 +5245,13 @@ describe("WorkspaceStore", () => {
       const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
         subscriptionCount === 1
           ? [
-              caughtUpEvent(),
+              // Cursor anchored at the row the in-flight stream below will finalize,
+              // so the second subscription legitimately requests since.
+              caughtUpEvent({
+                cursor: {
+                  history: { messageId: "msg-old-stream-missing-local", historySequence: 1 },
+                },
+              }),
               Promise.resolve(),
               streamStartEvent(workspaceId, "msg-old-stream-missing-local", {
                 startTime: 1_000,
@@ -5236,7 +5271,9 @@ describe("WorkspaceStore", () => {
               firstSubscription.wait,
             ]
           : [
-              sinceCaughtUpEvent(1, "history-1", {
+              // Since replay re-sends the cursor-boundary row before caught-up.
+              createHistoryMessageEvent("msg-old-stream-missing-local", 1),
+              sinceCaughtUpEvent(1, "msg-old-stream-missing-local", {
                 messageId: "msg-new-stream-missing-local",
                 lastTimestamp: 2_000,
               }),
@@ -5273,9 +5310,11 @@ describe("WorkspaceStore", () => {
       const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
         subscriptionCount === 1
           ? [
-              caughtUpEvent(),
+              createHistoryMessageEvent("history-1", 1),
+              fullCaughtUpEvent(),
               Promise.resolve(),
               streamStartEvent(workspaceId, "msg-old-stream", {
+                historySequence: 2,
                 startTime: 1_000,
                 model: "claude-3-5-sonnet-20241022",
               }),
@@ -5286,6 +5325,8 @@ describe("WorkspaceStore", () => {
               firstSubscription.wait,
             ]
           : [
+              // Since replay re-sends the cursor-boundary row before caught-up.
+              createHistoryMessageEvent("history-1", 1),
               sinceCaughtUpEvent(1, "history-1", {
                 messageId: "msg-new-stream",
                 lastTimestamp: 2_000,

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -271,6 +271,20 @@ export interface WorkspaceSidebarState {
 type DerivedState = Record<string, number>;
 
 /**
+ * Per-attempt context for an onChat subscription. Carries the since-mode anchor the
+ * attempt's cursor requested (so caught-up reconciliation only ever sees its own
+ * attempt's anchor) plus an abort handle used to force a full resubscribe when a
+ * since caught-up arrives without a usable anchor.
+ */
+interface OnChatAttemptContext {
+  abort: () => void;
+  since?: {
+    requestedAnchorSequence: number;
+    localActiveStreamMessageId: string | undefined;
+  };
+}
+
+/**
  * Usage metadata extracted from API responses (no tokenization).
  * Updates instantly when usage metadata arrives.
  *
@@ -3908,6 +3922,15 @@ export class WorkspaceStore {
         const aggregator = this.aggregators.get(workspaceId);
         let mode: OnChatMode | undefined;
 
+        // Attempt-scoped reconnect context: since-replay reconciliation must only ever
+        // see the anchor from its own attempt's cursor. Routed through the same
+        // attempt-guarded event path as chat events (the abort checks below drop
+        // events from stale attempts), so a caught-up from a previous attempt can
+        // never consume a newer attempt's anchor.
+        const attemptContext: OnChatAttemptContext = {
+          abort: () => attemptController.abort(),
+        };
+
         if (aggregator) {
           const cursor = aggregator.getOnChatCursor();
           if (cursor?.history) {
@@ -3917,6 +3940,10 @@ export class WorkspaceStore {
                 history: cursor.history,
                 stream: cursor.stream,
               },
+            };
+            attemptContext.since = {
+              requestedAnchorSequence: cursor.history.historySequence,
+              localActiveStreamMessageId: cursor.stream?.messageId,
             };
           }
         }
@@ -3979,7 +4006,7 @@ export class WorkspaceStore {
             if (signal.aborted || attemptSignal.aborted) {
               return;
             }
-            this.handleChatMessage(workspaceId, data);
+            this.handleChatMessage(workspaceId, data, attemptContext);
           });
         }
 
@@ -4452,7 +4479,11 @@ export class WorkspaceStore {
     );
   }
 
-  private handleChatMessage(workspaceId: string, data: WorkspaceChatMessage): void {
+  private handleChatMessage(
+    workspaceId: string,
+    data: WorkspaceChatMessage,
+    attemptContext?: OnChatAttemptContext
+  ): void {
     // Aggregator must exist - workspaces are initialized in addWorkspace() before subscriptions run.
     const aggregator = this.assertGet(workspaceId);
 
@@ -4467,6 +4498,23 @@ export class WorkspaceStore {
         console.debug(
           `[WorkspaceStore] onChat replay downgraded to full for ${workspaceId}: ${data.downgradeReason}`
         );
+      }
+
+      // The server reports since only when this client requested it, so the attempt
+      // context must carry the requested anchor. If it is somehow missing, appending
+      // would let stale suffix rows survive and replace-mode would drop rows below the
+      // anchor — force a clean full resubscribe instead. The deferred reset behavior
+      // (resetChatStateForReplay runs only after the next attempt's iterator is
+      // established) keeps the current UI visible until the full replay lands.
+      const sinceContext = replay === "since" ? attemptContext?.since : undefined;
+      if (replay === "since" && !sinceContext) {
+        console.warn(
+          `[WorkspaceStore] since caught-up without an attempt anchor for ${workspaceId}; forcing full resubscribe`
+        );
+        aggregator.setServerHistoryCursor(null);
+        this.clearReplayBuffers(workspaceId);
+        attemptContext?.abort();
+        return;
       }
 
       // Check if there's an active stream in buffered events (reconnection scenario).
@@ -4535,7 +4583,26 @@ export class WorkspaceStore {
         transient.liveTaskIds.clear();
       }
 
-      if (transient.historicalMessages.length > 0) {
+      if (sinceContext) {
+        // Since replay: the replayed rows are the authoritative suffix for
+        // rows at/above the requested anchor. Preserve the richer local assembly of
+        // the active stream only when the server-confirmed stream matches the local
+        // stream the attempt's cursor was built from; otherwise replayed rows plus
+        // subsequently replayed stream events rebuild the stream message (stale local
+        // contexts were already cleared above).
+        const preservedActiveStreamMessageId =
+          serverActiveStreamMessageId !== undefined &&
+          serverActiveStreamMessageId === sinceContext.localActiveStreamMessageId
+            ? serverActiveStreamMessageId
+            : undefined;
+        aggregator.reconcileSinceReplay({
+          requestedAnchorSequence: sinceContext.requestedAnchorSequence,
+          messages: transient.historicalMessages,
+          preservedActiveStreamMessageId,
+          hasActiveStream,
+        });
+        transient.historicalMessages.length = 0;
+      } else if (transient.historicalMessages.length > 0) {
         const loadMode = replay === "full" ? "replace" : "append";
         aggregator.loadHistoricalMessages(transient.historicalMessages, hasActiveStream, {
           mode: loadMode,
@@ -4545,6 +4612,12 @@ export class WorkspaceStore {
         // Full replay can legitimately contain zero messages (e.g. compacted to empty).
         aggregator.loadHistoricalMessages([], hasActiveStream, { mode: "replace" });
       }
+
+      // Store the server-issued cursor for the next reconnect (full and since replays
+      // both refresh it). A caught-up without a cursor means the server could not
+      // advertise a trustworthy reconnect point (e.g. replay failure), so clear the
+      // stored cursor and let the next subscribe fall back to a full replay.
+      aggregator.setServerHistoryCursor(data.cursor?.history ?? null);
 
       // Mark that we're replaying buffered history (prevents O(N) scheduling)
       transient.replayingHistory = true;
@@ -4586,6 +4659,13 @@ export class WorkspaceStore {
       // Fall back to tokenization when no cache (or stale cache) exists.
       if (aggregator.getAllMessages().length > 0) {
         this.ensureConsumersCached(workspaceId, aggregator);
+      }
+
+      // The requested anchor is consumed by exactly one caught-up. A duplicate
+      // caught-up in the same attempt would be anomalous; dropping the anchor makes
+      // it hit the hard fallback above instead of reconciling against a stale anchor.
+      if (attemptContext) {
+        attemptContext.since = undefined;
       }
 
       return;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -4461,6 +4461,14 @@ export class WorkspaceStore {
     if (isCaughtUpMessage(data)) {
       const replay = data.replay ?? "full";
 
+      if (data.downgradeReason !== undefined) {
+        // Dev observability: a requested since reconnect was downgraded to a full
+        // replay server-side. Silent downgrades previously hid full re-transfers.
+        console.debug(
+          `[WorkspaceStore] onChat replay downgraded to full for ${workspaceId}: ${data.downgradeReason}`
+        );
+      }
+
       // Check if there's an active stream in buffered events (reconnection scenario).
       const pendingEvents = transient.pendingStreamEvents;
       const hasActiveStream = getBufferedActiveStreamStart(pendingEvents) !== null;

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -4436,4 +4436,253 @@ describe("notify tool -> browser notifications", () => {
       expect(FakeNotification.created).toEqual([{ title: "Task done", body: "All checks passed" }]);
     });
   });
+
+  describe("server-issued reconnect cursor", () => {
+    test("returns undefined before any server cursor is stored", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages(
+        [createMuxMessage("history-1", "user", "hello", { historySequence: 1, timestamp: 1 })],
+        false,
+        { mode: "replace" }
+      );
+
+      // Local rows alone are not enough: only the server can issue a valid cursor.
+      expect(aggregator.getOnChatCursor()).toBeUndefined();
+    });
+
+    test("returns the stored server cursor verbatim and clears on null", () => {
+      const aggregator = createTestAggregator();
+      const serverCursor = {
+        messageId: "history-2",
+        historySequence: 2,
+        oldestHistorySequence: 1,
+        priorHistoryFingerprint: "deadbeef",
+      };
+
+      aggregator.setServerHistoryCursor(serverCursor);
+      expect(aggregator.getOnChatCursor()?.history).toEqual(serverCursor);
+
+      aggregator.setServerHistoryCursor(null);
+      expect(aggregator.getOnChatCursor()).toBeUndefined();
+    });
+
+    test("clear() drops the stored server cursor", () => {
+      const aggregator = createTestAggregator();
+      aggregator.setServerHistoryCursor({ messageId: "history-1", historySequence: 1 });
+      aggregator.clear();
+      expect(aggregator.getOnChatCursor()).toBeUndefined();
+    });
+  });
+
+  describe("since-replay suffix reconciliation", () => {
+    const persistedRow = (
+      id: string,
+      historySequence: number,
+      texts: string[],
+      role: "user" | "assistant" = "assistant"
+    ) => {
+      // createMuxMessage rejects empty user messages, so build with placeholder
+      // content and overwrite parts with the exact persisted-form layout.
+      const message = createMuxMessage(id, role, "placeholder", {
+        historySequence,
+        timestamp: historySequence * 100,
+      });
+      message.parts = texts.map((text) => ({ type: "text" as const, text }));
+      return message;
+    };
+
+    test("removes local suffix rows the server did not re-send", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages(
+        [
+          persistedRow("user-1", 1, ["hello"], "user"),
+          persistedRow("assistant-2", 2, ["kept"]),
+          persistedRow("assistant-3", 3, ["deleted server-side while away"]),
+        ],
+        false,
+        { mode: "replace" }
+      );
+
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 2,
+        messages: [persistedRow("assistant-2", 2, ["kept"])],
+        hasActiveStream: false,
+      });
+
+      expect(aggregator.getAllMessages().map((message) => message.id)).toEqual([
+        "user-1",
+        "assistant-2",
+      ]);
+    });
+
+    test("replaces rewritten rows even when the persisted form has fewer parts", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages(
+        [
+          persistedRow("user-1", 1, ["hello"], "user"),
+          persistedRow("assistant-2", 2, ["a", "b", "c"]),
+        ],
+        false,
+        { mode: "replace" }
+      );
+
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 2,
+        messages: [persistedRow("assistant-2", 2, ["rewritten"])],
+        hasActiveStream: false,
+      });
+
+      const rewritten = aggregator.getAllMessages().find((message) => message.id === "assistant-2");
+      expect(rewritten?.parts).toEqual([{ type: "text", text: "rewritten" }]);
+    });
+
+    test("keeps optimistic rows without a historySequence and does not duplicate the boundary row", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages([persistedRow("assistant-1", 1, ["turn one"])], false, {
+        mode: "replace",
+      });
+      // Optimistic send awaiting ack: no historySequence yet.
+      aggregator.addMessage(createMuxMessage("optimistic-1", "user", "queued send"));
+
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 1,
+        messages: [persistedRow("assistant-1", 1, ["turn one"])],
+        hasActiveStream: false,
+      });
+
+      const ids = aggregator.getAllMessages().map((message) => message.id);
+      expect(ids.filter((id) => id === "assistant-1")).toHaveLength(1);
+      expect(ids).toContain("optimistic-1");
+    });
+
+    test("drops derived state sourced from a removed suffix row", () => {
+      const aggregator = createTestAggregator();
+      const todos = [{ content: "task", status: "in_progress" as const }];
+      aggregator.loadHistoricalMessages(
+        [
+          persistedRow("user-1", 1, ["hello"], "user"),
+          historicalTodoMessage("todo-row", todos, { historySequence: 3 }),
+        ],
+        false,
+        { mode: "replace" }
+      );
+      expect(aggregator.getCurrentTodos()).toEqual(todos);
+
+      // The todo-bearing row was deleted server-side while the client was away.
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 2,
+        messages: [],
+        hasActiveStream: false,
+      });
+
+      expect(aggregator.getAllMessages().map((message) => message.id)).toEqual(["user-1"]);
+      expect(aggregator.getCurrentTodos()).toEqual([]);
+    });
+
+    test("rebuilds derived state from surviving rows when a suffix source is removed", () => {
+      const aggregator = createTestAggregator();
+      const keptTodos = [{ content: "kept", status: "in_progress" as const }];
+      const staleTodos = [{ content: "stale", status: "in_progress" as const }];
+      aggregator.loadHistoricalMessages(
+        [
+          historicalTodoMessage("todo-kept", keptTodos, { historySequence: 1 }),
+          historicalTodoMessage("todo-stale", staleTodos, { historySequence: 3 }),
+        ],
+        false,
+        { mode: "replace" }
+      );
+      expect(aggregator.getCurrentTodos()).toEqual(staleTodos);
+
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 2,
+        messages: [],
+        hasActiveStream: false,
+      });
+
+      // Derived state falls back to the surviving todo_write below the anchor.
+      expect(aggregator.getCurrentTodos()).toEqual(keptTodos);
+    });
+
+    test("preserves the locally assembled active-stream row when the carve-out applies", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages([persistedRow("user-1", 1, ["hello"], "user")], false, {
+        mode: "replace",
+      });
+
+      startTestStream(aggregator, { messageId: "msg-live", historySequence: 2 });
+      aggregator.handleStreamDelta({
+        type: "stream-delta",
+        workspaceId: TEST_WORKSPACE_ID,
+        messageId: "msg-live",
+        delta: "Hello ",
+        tokens: 1,
+        timestamp: 1_001,
+      });
+      aggregator.handleStreamDelta({
+        type: "stream-delta",
+        workspaceId: TEST_WORKSPACE_ID,
+        messageId: "msg-live",
+        delta: "world",
+        tokens: 1,
+        timestamp: 1_002,
+      });
+
+      // The persisted placeholder for an in-flight stream has empty parts.
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 1,
+        messages: [persistedRow("user-1", 1, ["hello"], "user"), persistedRow("msg-live", 2, [])],
+        preservedActiveStreamMessageId: "msg-live",
+        hasActiveStream: true,
+      });
+
+      const liveRow = aggregator.getAllMessages().find((message) => message.id === "msg-live");
+      expect(liveRow?.parts).toEqual([{ type: "text", text: "Hello world", timestamp: 1_001 }]);
+      expect(aggregator.getActiveStreamMessageId()).toBe("msg-live");
+
+      // Stream ending right after caught-up still finalizes the preserved message.
+      aggregator.handleStreamEnd({
+        type: "stream-end",
+        workspaceId: TEST_WORKSPACE_ID,
+        messageId: "msg-live",
+        metadata: { model: TEST_MODEL, historySequence: 2, timestamp: 1_003 },
+        parts: [],
+      });
+      const finalized = aggregator.getAllMessages().find((message) => message.id === "msg-live");
+      expect(finalized?.parts).toEqual([{ type: "text", text: "Hello world", timestamp: 1_001 }]);
+      expect(aggregator.getActiveStreamMessageId()).toBeUndefined();
+    });
+
+    test("rebuilds the stream row from persisted form when no carve-out applies", () => {
+      const aggregator = createTestAggregator();
+      aggregator.loadHistoricalMessages([persistedRow("user-1", 1, ["hello"], "user")], false, {
+        mode: "replace",
+      });
+
+      // Local stream context went stale (e.g. stream A ended while away); the store
+      // clears mismatched stream contexts before reconciling, so no carve-out applies
+      // and the persisted (finalized) form wins over the richer local assembly.
+      startTestStream(aggregator, { messageId: "msg-old", historySequence: 2 });
+      aggregator.handleStreamDelta({
+        type: "stream-delta",
+        workspaceId: TEST_WORKSPACE_ID,
+        messageId: "msg-old",
+        delta: "locally assembled much longer content",
+        tokens: 1,
+        timestamp: 1_001,
+      });
+      aggregator.clearActiveStreams();
+
+      aggregator.reconcileSinceReplay({
+        requestedAnchorSequence: 1,
+        messages: [
+          persistedRow("user-1", 1, ["hello"], "user"),
+          persistedRow("msg-old", 2, ["final"]),
+        ],
+        hasActiveStream: false,
+      });
+
+      const rebuilt = aggregator.getAllMessages().find((message) => message.id === "msg-old");
+      expect(rebuilt?.parts).toEqual([{ type: "text", text: "final" }]);
+    });
+  });
 });

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -2163,7 +2163,7 @@ describe("StreamingMessageAggregator", () => {
       expect(remaining.map((m) => m.id)).toEqual(["boundary-2"]);
     });
 
-    test("updates reconnect cursor floor when a live compaction boundary arrives", () => {
+    test("keeps returning the stored server cursor when a live compaction boundary arrives", () => {
       const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);
 
       // Simulate initial replay window starting at historySequence 40.
@@ -2182,8 +2182,16 @@ describe("StreamingMessageAggregator", () => {
         { mode: "replace" }
       );
 
+      const serverCursor = {
+        messageId: "history-41",
+        historySequence: 41,
+        oldestHistorySequence: 40,
+        priorHistoryFingerprint: "cafe1234",
+      };
+      aggregator.setServerHistoryCursor(serverCursor);
+
       const beforeCompactionCursor = aggregator.getOnChatCursor();
-      expect(beforeCompactionCursor?.history?.oldestHistorySequence).toBe(40);
+      expect(beforeCompactionCursor?.history).toEqual(serverCursor);
 
       const boundary = asChatMessage(
         createMuxMessage("boundary-60", "assistant", "Summary epoch 60", {
@@ -2196,8 +2204,11 @@ describe("StreamingMessageAggregator", () => {
       );
       aggregator.handleMessage(boundary);
 
+      // The cursor is reused verbatim: a live compaction makes it stale, and the
+      // server-side anchor validation downgrades the next reconnect to a (small)
+      // full replay of the fresh epoch instead of the client guessing a new cursor.
       const afterCompactionCursor = aggregator.getOnChatCursor();
-      expect(afterCompactionCursor?.history?.oldestHistorySequence).toBe(60);
+      expect(afterCompactionCursor?.history).toEqual(serverCursor);
     });
 
     test("keeps visible history when a live reset boundary arrives", () => {

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -48,12 +48,12 @@ import { completeInProgressTodoItems } from "@/common/utils/todoList";
 import { AgentSkillReadToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import { getToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
 
-import { computePriorHistoryFingerprint } from "@/common/orpc/onChatCursorFingerprint";
 import type {
   WorkspaceChatMessage,
   StreamErrorMessage,
   DeleteMessage,
   OnChatCursor,
+  OnChatHistoryCursor,
 } from "@/common/orpc/types";
 import { isInitStart, isInitOutput, isInitEnd, isMuxMessage } from "@/common/orpc/types";
 import {
@@ -520,6 +520,13 @@ export class StreamingMessageAggregator {
    *  Used for reconnect cursors instead of the absolute minimum (which
    *  includes user-loaded older pages via loadOlderHistory). */
   private establishedOldestHistorySequence: number | null = null;
+
+  /** Server-issued history cursor from the last caught-up, reused verbatim on reconnect.
+   *  The client's in-memory representation intentionally diverges from persisted rows
+   *  (compact-on-append parts, adopted tool outputs, client timestamps), so recomputing
+   *  cursor fingerprints locally would mismatch and silently downgrade every since
+   *  reconnect to a full replay. */
+  private lastServerHistoryCursor: OnChatHistoryCursor | null = null;
 
   // Delta history for token counting and TPS calculation
   private deltaHistory = new Map<string, DeltaRecordStorage>();
@@ -1223,6 +1230,23 @@ export class StreamingMessageAggregator {
       (a, b) => (a.metadata?.historySequence ?? 0) - (b.metadata?.historySequence ?? 0)
     );
 
+    this.replayDerivedState(chronologicalMessages, hasActiveStream, opts);
+  }
+
+  /**
+   * Replay message-derived state (skills, todos, agent status, review pins) from rows
+   * in chronological order, then run the shared post-replay normalization: persisted
+   * agent-status fallback, completed-todo cleanup on idle replays, cache invalidation,
+   * and pending-stream settle detection.
+   *
+   * Shared by loadHistoricalMessages and reconcileSinceReplay so batch loads and
+   * since-replay reconciliation keep identical derived-state semantics.
+   */
+  private replayDerivedState(
+    chronologicalMessages: readonly MuxMessage[],
+    hasActiveStream: boolean,
+    opts?: { skipDerivedState?: boolean }
+  ): void {
     let shouldClearCompletedTodosOnIdleReplay = false;
     if (!opts?.skipDerivedState) {
       // Replay historical messages in order to reconstruct derived state
@@ -1301,6 +1325,159 @@ export class StreamingMessageAggregator {
     }
   }
 
+  /** Tools whose replayed outputs feed aggregator derived state (see processToolResult). */
+  private static readonly DERIVED_STATE_TOOL_NAMES = new Set([
+    "todo_write",
+    "propose_plan",
+    "status_set",
+    "agent_skill_read",
+    "review_pane_update",
+  ]);
+
+  private messageContributesDerivedState(message: MuxMessage): boolean {
+    if (message.metadata?.agentSkillSnapshot != null) {
+      return true;
+    }
+    return message.parts.some(
+      (part) =>
+        isDynamicToolPart(part) &&
+        part.state === "output-available" &&
+        StreamingMessageAggregator.DERIVED_STATE_TOOL_NAMES.has(part.toolName)
+    );
+  }
+
+  /**
+   * Reconcile a since-mode replay: the replayed rows are the authoritative suffix for
+   * historySequence >= requestedAnchorSequence.
+   *
+   * The server-issued cursor anchor can be older than the client's cached transcript
+   * (rows streamed live since the last caught-up sit above it), and server-side cursor
+   * validation only protects rows below the anchor. Rows in [anchor, client-max] can be
+   * deleted or rewritten server-side while the client is unsubscribed, so plain append
+   * semantics would retain them as stale ghosts. Here the replayed set wins: stale rows
+   * are removed, rewritten rows are replaced by their persisted forms, and the client
+   * converges exactly to persisted state.
+   */
+  reconcileSinceReplay(args: {
+    requestedAnchorSequence: number;
+    messages: MuxMessage[];
+    /**
+     * Server-confirmed active stream that matches the local stream context from when
+     * this reconnect's cursor was built. Kept as the richer local assembly: its
+     * persisted placeholder row has empty/partial parts and stream replay only
+     * re-sends deltas after the stream cursor, so hard-replacing it would lose
+     * already-rendered content.
+     */
+    preservedActiveStreamMessageId?: string;
+    hasActiveStream: boolean;
+  }): void {
+    const { requestedAnchorSequence, preservedActiveStreamMessageId, hasActiveStream } = args;
+    assert(
+      Number.isFinite(requestedAnchorSequence) && requestedAnchorSequence >= 0,
+      `reconcileSinceReplay requires a non-negative anchor, got ${requestedAnchorSequence}`
+    );
+
+    const replayed = args.messages.map(normalizeMessageRouteProvider);
+    const replayedIds = new Set(replayed.map((message) => message.id));
+
+    // Incremental derived-state replay cannot "unapply" a discarded todo_write /
+    // status_set / review pin, so track whether any discarded local row could have
+    // fed derived state and rebuild from the full window when one did.
+    let removedDerivedStateSource = false;
+    let deletedRows = false;
+
+    // 1) Delete stale suffix rows: any local row at/above the anchor that the server
+    // did not re-send was deleted or rewritten while the client was unsubscribed.
+    // Rows without a historySequence (optimistic sends awaiting ack) are never
+    // touched, nor is the preserved active-stream row.
+    for (const [messageId, existing] of Array.from(this.messages.entries())) {
+      const historySequence = existing.metadata?.historySequence;
+      if (historySequence === undefined || historySequence < requestedAnchorSequence) {
+        continue;
+      }
+      if (messageId === preservedActiveStreamMessageId || replayedIds.has(messageId)) {
+        continue;
+      }
+      removedDerivedStateSource ||= this.messageContributesDerivedState(existing);
+      this.deleteMessage(messageId);
+      deletedRows = true;
+    }
+
+    // 2) Apply replayed rows with replace-by-id semantics: persisted rows are
+    // authoritative for finalized turns, including rewrites with FEWER parts than the
+    // local compacted copy (so these must not go through addMessage's "prefer richer
+    // content" guard). Exceptions that keep the richer local copy:
+    // - the preserved active-stream row (see preservedActiveStreamMessageId doc), and
+    // - defensive: rows below the anchor (e.g. a stale disk partial), which have no
+    //   suffix authority and follow append-mode update semantics instead.
+    const applied: MuxMessage[] = [];
+    for (const incoming of replayed) {
+      const incomingSequence = incoming.metadata?.historySequence;
+      const belowAnchor =
+        incomingSequence === undefined || incomingSequence < requestedAnchorSequence;
+      const existing = this.messages.get(incoming.id);
+
+      if (existing && (incoming.id === preservedActiveStreamMessageId || belowAnchor)) {
+        const existingParts = Array.isArray(existing.parts) ? existing.parts.length : 0;
+        const incomingParts = Array.isArray(incoming.parts) ? incoming.parts.length : 0;
+        if (incomingParts < existingParts) {
+          continue;
+        }
+      }
+
+      if (existing) {
+        removedDerivedStateSource ||= this.messageContributesDerivedState(existing);
+      }
+      this.messages.set(incoming.id, incoming);
+      this.bumpMessageVersion(incoming.id);
+      this.displayedMessageCache.delete(incoming.id);
+      applied.push(incoming);
+    }
+
+    // 3) Rebuild derived state deterministically from the post-reconcile message set
+    // when a discarded row could have contributed to it; otherwise replay just the
+    // applied rows incrementally (same semantics as append-mode loads).
+    if (removedDerivedStateSource) {
+      this.rebuildDerivedStateFromWindow(hasActiveStream);
+    } else {
+      const chronologicalApplied = [...applied].sort(
+        (a, b) => (a.metadata?.historySequence ?? 0) - (b.metadata?.historySequence ?? 0)
+      );
+      this.replayDerivedState(chronologicalApplied, hasActiveStream);
+    }
+
+    if (deletedRows) {
+      // Match handleDeleteMessage: deletions invalidate async last-user-prompt fallbacks.
+      this.historyEpoch++;
+    }
+  }
+
+  /**
+   * Deterministically rebuild message-derived state from the current replay window
+   * (rows at/above the server replay-window floor). Resets the derived stores first
+   * because incremental replay cannot "unapply" contributions from rows that
+   * reconciliation discarded. Scoped to the established window so
+   * loadOlderHistory-paginated rows (loaded with skipDerivedState) stay excluded,
+   * matching full-replay semantics.
+   */
+  private rebuildDerivedStateFromWindow(hasActiveStream: boolean): void {
+    this.loadedSkills.clear();
+    this.loadedSkillsCache = [];
+    this.skillLoadErrors.clear();
+    this.skillLoadErrorsCache = [];
+    this.currentTodos = [];
+    this.assistedReviewHunks = [];
+    this.agentStatus = undefined;
+    this.lastStatusUrl = undefined;
+
+    const windowFloor = this.establishedOldestHistorySequence ?? Number.NEGATIVE_INFINITY;
+    const windowRows = this.getAllMessages().filter((message) => {
+      const historySequence = message.metadata?.historySequence;
+      return historySequence !== undefined && historySequence >= windowFloor;
+    });
+    this.replayDerivedState(windowRows, hasActiveStream);
+  }
+
   setEstablishedOldestHistorySequence(sequence: number | null): void {
     this.establishedOldestHistorySequence = sequence;
   }
@@ -1317,69 +1494,33 @@ export class StreamingMessageAggregator {
   }
 
   /**
+   * Record the server-issued history cursor from a caught-up payload. Pass null when
+   * the server did not advertise a trustworthy cursor (e.g. replay failure), which
+   * forces the next reconnect to request a full replay.
+   */
+  setServerHistoryCursor(cursor: OnChatHistoryCursor | null): void {
+    this.lastServerHistoryCursor = cursor;
+  }
+
+  /**
    * Build a cursor for incremental onChat reconnection.
    * Returns undefined when we cannot safely represent the current state,
    * forcing a full replay.
+   *
+   * The history segment is the server-issued cursor reused verbatim (see
+   * lastServerHistoryCursor); the client-computed stream segment is advisory and
+   * clamped server-side.
    */
   getOnChatCursor(): OnChatCursor | undefined {
-    let maxHistorySequence = -1;
-    let maxHistoryMessageId: string | undefined;
-    let minHistorySequence = Number.POSITIVE_INFINITY;
-
-    for (const message of this.messages.values()) {
-      const historySequence = message.metadata?.historySequence;
-      if (historySequence === undefined) {
-        continue;
-      }
-
-      if (historySequence > maxHistorySequence) {
-        maxHistorySequence = historySequence;
-        maxHistoryMessageId = message.id;
-      }
-
-      if (historySequence < minHistorySequence) {
-        minHistorySequence = historySequence;
-      }
-    }
-
-    if (!maxHistoryMessageId || !Number.isFinite(minHistorySequence)) {
-      return undefined;
-    }
-
     if (this.activeStreams.size > 1) {
       // Defensive fallback: multiple active streams is anomalous, so force a full replay.
       return undefined;
     }
 
-    const allMessages = this.getAllMessages();
-    const establishedOldestHistorySequence = this.establishedOldestHistorySequence;
-    const fingerprintMessages =
-      establishedOldestHistorySequence != null
-        ? allMessages.filter(
-            (message) =>
-              (message.metadata?.historySequence ?? Number.POSITIVE_INFINITY) >=
-              establishedOldestHistorySequence
-          )
-        : allMessages;
-
-    // Scope fingerprint input to the established replay window. The server computes
-    // priorHistoryFingerprint from getHistoryFromLatestBoundary(skip=0), so client-
-    // paginated rows from older compaction epochs must be excluded to avoid false
-    // mismatches that force unnecessary full replay on reconnect.
-    const priorHistoryFingerprint = computePriorHistoryFingerprint(
-      fingerprintMessages,
-      maxHistorySequence
-    );
-    const oldestHistorySequence = establishedOldestHistorySequence ?? minHistorySequence;
-
-    const cursor: OnChatCursor = {
-      history: {
-        messageId: maxHistoryMessageId,
-        historySequence: maxHistorySequence,
-        oldestHistorySequence,
-        ...(priorHistoryFingerprint !== undefined ? { priorHistoryFingerprint } : {}),
-      },
-    };
+    const cursor: OnChatCursor = {};
+    if (this.lastServerHistoryCursor) {
+      cursor.history = this.lastServerHistoryCursor;
+    }
 
     if (this.activeStreams.size === 1) {
       const activeStreamEntry = this.activeStreams.entries().next().value;
@@ -1389,6 +1530,10 @@ export class StreamingMessageAggregator {
         messageId,
         lastTimestamp: context.lastServerTimestamp,
       };
+    }
+
+    if (!cursor.history && !cursor.stream) {
+      return undefined;
     }
 
     return cursor;
@@ -1952,6 +2097,9 @@ export class StreamingMessageAggregator {
     this.lastAbortReason = null;
     this.lastResponseCompletedAt = null;
     this.establishedOldestHistorySequence = null;
+    // A since cursor is only safe while rows below its anchor are present locally.
+    // Clearing the transcript invalidates that premise, so force a full reconnect.
+    this.lastServerHistoryCursor = null;
     this.invalidateCache();
   }
 

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -1434,6 +1434,11 @@ export class StreamingMessageAggregator {
       applied.push(incoming);
     }
 
+    // Flush the whole-transcript cache before the derived rebuild: deleteMessage only
+    // evicts per-message caches, and rebuildDerivedStateFromWindow must see the
+    // post-mutation message set, not a stale getAllMessages() array.
+    this.invalidateCache();
+
     // 3) Rebuild derived state deterministically from the post-reconcile message set
     // when a discarded row could have contributed to it; otherwise replay just the
     // applied rows incrementally (same semantics as append-mode loads).

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -253,6 +253,7 @@ export {
   ErrorEventSchema,
   GoalBudgetLimitedEventSchema,
   LanguageModelV2UsageSchema,
+  OnChatDowngradeReasonSchema,
   QueuedMessageChangedEventSchema,
   ReasoningDeltaEventSchema,
   ReasoningEndEventSchema,

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -64,10 +64,27 @@ export const OnChatModeSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("live") }),
 ]);
 
+/**
+ * Why a requested since-mode replay was downgraded to full replay.
+ * Ordered by check precedence: the first failing predicate wins.
+ */
+export const OnChatDowngradeReasonSchema = z.enum([
+  "cursor-row-missing",
+  "oldest-mismatch",
+  "fingerprint-mismatch",
+  "history-read-failed",
+]);
+
 export const CaughtUpMessageSchema = z.object({
   type: z.literal("caught-up"),
   /** Which replay strategy the server actually used. */
   replay: z.enum(["full", "since", "live"]).optional(),
+  /**
+   * Present only when the client requested since-mode and the server downgraded to
+   * full replay. Silent downgrades defeat incremental reconnects, so this must stay
+   * observable to clients and tests.
+   */
+  downgradeReason: OnChatDowngradeReasonSchema.optional(),
   /**
    * Authoritative pagination signal for full replays.
    * Omitted for since/live replays so the client can preserve existing pagination state.

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -39,6 +39,7 @@ export type WorkspaceChatMessage = z.infer<typeof schemas.WorkspaceChatMessageSc
 export type CaughtUpMessage = z.infer<typeof schemas.CaughtUpMessageSchema>;
 export type OnChatCursor = z.infer<typeof OnChatCursorSchema>;
 export type OnChatMode = z.infer<typeof OnChatModeSchema>;
+export type OnChatDowngradeReason = z.infer<typeof schemas.OnChatDowngradeReasonSchema>;
 export type StreamErrorMessage = z.infer<typeof schemas.StreamErrorMessageSchema>;
 export type DeleteMessage = z.infer<typeof schemas.DeleteMessageSchema>;
 export type GoalBudgetLimitedEvent = z.infer<typeof schemas.GoalBudgetLimitedEventSchema>;

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -1,6 +1,10 @@
 import type { z } from "zod";
 import type * as schemas from "./schemas";
-import type { OnChatCursorSchema, OnChatModeSchema } from "./schemas/stream";
+import type {
+  OnChatCursorSchema,
+  OnChatHistoryCursorSchema,
+  OnChatModeSchema,
+} from "./schemas/stream";
 
 import type {
   StreamStartEvent,
@@ -38,6 +42,7 @@ export type FilePart = z.infer<typeof schemas.FilePartSchema>;
 export type WorkspaceChatMessage = z.infer<typeof schemas.WorkspaceChatMessageSchema>;
 export type CaughtUpMessage = z.infer<typeof schemas.CaughtUpMessageSchema>;
 export type OnChatCursor = z.infer<typeof OnChatCursorSchema>;
+export type OnChatHistoryCursor = z.infer<typeof OnChatHistoryCursorSchema>;
 export type OnChatMode = z.infer<typeof OnChatModeSchema>;
 export type OnChatDowngradeReason = z.infer<typeof schemas.OnChatDowngradeReasonSchema>;
 export type StreamErrorMessage = z.infer<typeof schemas.StreamErrorMessageSchema>;

--- a/src/node/services/agentSession.preStreamError.test.ts
+++ b/src/node/services/agentSession.preStreamError.test.ts
@@ -610,6 +610,7 @@ describe("AgentSession pre-stream errors", () => {
     );
     expect(caughtUp).toBeDefined();
     expect(caughtUp?.replay).toBe("since");
+    expect(caughtUp?.downgradeReason).toBeUndefined();
 
     const replayedMessageIds = events.reduce<string[]>((ids, event) => {
       if (
@@ -770,11 +771,90 @@ describe("AgentSession pre-stream errors", () => {
     );
     expect(caughtUp).toBeDefined();
     expect(caughtUp?.replay).toBe("full");
+    expect(caughtUp?.downgradeReason).toBe("fingerprint-mismatch");
 
     const replayedMessageIds = events.filter(isMuxMessage).map((message) => message.id);
     expect(replayedMessageIds).toContain(persistedFirst.id);
     expect(replayedMessageIds).toContain(persistedThird.id);
     expect(replayedMessageIds).not.toContain(persistedSecond.id);
+  });
+
+  it("classifies cursor-row-missing downgrades on since replay", async () => {
+    const workspaceId = "ws-replay-downgrade-cursor-row-missing";
+    const { session, cleanup, historyService } = await createReplaySessionHarness(workspaceId);
+    historyCleanup = cleanup;
+
+    const seedMessage = createMuxMessage("msg-history-seed", "assistant", "seed");
+    expect((await historyService.appendToHistory(workspaceId, seedMessage)).success).toBe(true);
+
+    const events: WorkspaceChatMessage[] = [];
+    await session.replayHistory(
+      ({ message }) => {
+        events.push(message);
+      },
+      {
+        type: "since",
+        cursor: {
+          history: {
+            messageId: "missing-message",
+            historySequence: 123,
+            oldestHistorySequence: 123,
+          },
+        },
+      }
+    );
+
+    const caughtUp = events.find(
+      (event): event is Extract<WorkspaceChatMessage, { type: "caught-up" }> =>
+        "type" in event && event.type === "caught-up"
+    );
+    expect(caughtUp?.replay).toBe("full");
+    expect(caughtUp?.downgradeReason).toBe("cursor-row-missing");
+  });
+
+  it("classifies oldest-mismatch downgrades on since replay", async () => {
+    const workspaceId = "ws-replay-downgrade-oldest-mismatch";
+    const { session, cleanup, historyService } = await createReplaySessionHarness(workspaceId);
+    historyCleanup = cleanup;
+
+    const seedMessage = createMuxMessage("msg-history-seed", "assistant", "seed");
+    expect((await historyService.appendToHistory(workspaceId, seedMessage)).success).toBe(true);
+
+    const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+    if (!historyResult.success) {
+      throw new Error(`Failed to read seeded history: ${historyResult.error}`);
+    }
+    const persistedSeed = historyResult.data.find((message) => message.id === seedMessage.id);
+    const seedHistorySequence = persistedSeed?.metadata?.historySequence;
+    if (!persistedSeed || seedHistorySequence === undefined) {
+      throw new Error("Expected seeded history message with historySequence");
+    }
+
+    const events: WorkspaceChatMessage[] = [];
+    await session.replayHistory(
+      ({ message }) => {
+        events.push(message);
+      },
+      {
+        type: "since",
+        cursor: {
+          history: {
+            messageId: persistedSeed.id,
+            historySequence: seedHistorySequence,
+            // Claim an older replay window than the server currently has, as if rows
+            // below the cursor were truncated while the client was disconnected.
+            oldestHistorySequence: seedHistorySequence - 1,
+          },
+        },
+      }
+    );
+
+    const caughtUp = events.find(
+      (event): event is Extract<WorkspaceChatMessage, { type: "caught-up" }> =>
+        "type" in event && event.type === "caught-up"
+    );
+    expect(caughtUp?.replay).toBe("full");
+    expect(caughtUp?.downgradeReason).toBe("oldest-mismatch");
   });
 
   it("keeps since replay mode when failure occurs after incremental payload is emitted", async () => {

--- a/src/node/services/agentSession.sinceReplayContract.test.ts
+++ b/src/node/services/agentSession.sinceReplayContract.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Round-trip contract test for the onChat since-mode reconnect cursor.
+ *
+ * Server persistence writes one part per streaming delta, while the client
+ * aggregator compacts parts on append and keeps its own assembled representation
+ * at stream-end. The reconnect cursor contract must therefore be independent of
+ * the client's in-memory representation: the client reuses the server-issued
+ * cursor verbatim instead of recomputing fingerprints locally.
+ *
+ * This test drives the real server replay path (AgentSession + real
+ * HistoryService) against the real client aggregator, mirroring the
+ * WorkspaceStore caught-up handling. It fails on client-side fingerprint
+ * recomputation (silent since→full downgrade after ≥2 live-streamed turns).
+ */
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import type { AIService } from "@/node/services/aiService";
+import type { MuxMessage } from "@/common/types/message";
+import {
+  isMuxMessage,
+  type CaughtUpMessage,
+  type OnChatMode,
+  type WorkspaceChatMessage,
+} from "@/common/orpc/types";
+import { StreamingMessageAggregator } from "@/browser/utils/messages/StreamingMessageAggregator";
+import type { AgentSession } from "./agentSession";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+import type { HistoryService } from "./historyService";
+
+const TEST_MODEL = "anthropic:claude-test";
+
+async function createContractHarness(workspaceId: string) {
+  const replayStream = mock((_workspaceId: string, _opts?: { afterTimestamp?: number }) =>
+    Promise.resolve()
+  );
+  const replayInit = mock((_workspaceId: string) => Promise.resolve());
+  return await createAgentSessionHarness({
+    workspaceId,
+    aiServiceOverrides: {
+      getStreamInfo: mock((_workspaceId: string) => undefined) as AIService["getStreamInfo"],
+      replayStream,
+    },
+    initStateManagerOverrides: { replayInit },
+  });
+}
+
+/** Assistant row exactly as streamManager persists it: one text part per delta. */
+function perDeltaAssistantMessage(id: string, deltas: string[], baseTimestamp: number): MuxMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: deltas.map((text, index) => ({
+      type: "text" as const,
+      text,
+      timestamp: baseTimestamp + index,
+    })),
+    metadata: { timestamp: baseTimestamp, model: TEST_MODEL },
+  };
+}
+
+interface ReplayCapture {
+  events: WorkspaceChatMessage[];
+  rows: MuxMessage[];
+  caughtUp: CaughtUpMessage;
+}
+
+/**
+ * Run a full/since replay against the session and apply it to the aggregator the
+ * same way WorkspaceStore.handleChatMessage does: buffer rows, then load them on
+ * caught-up with replace (full) or append (since) semantics.
+ */
+async function replayIntoAggregator(
+  session: AgentSession,
+  aggregator: StreamingMessageAggregator,
+  mode?: OnChatMode
+): Promise<ReplayCapture> {
+  const events: WorkspaceChatMessage[] = [];
+  await session.replayHistory(({ message }: { message: WorkspaceChatMessage }) => {
+    events.push(message);
+  }, mode);
+
+  const caughtUp = events.find(
+    (event): event is CaughtUpMessage => "type" in event && event.type === "caught-up"
+  );
+  if (!caughtUp) {
+    throw new Error("Expected caught-up event from replayHistory");
+  }
+
+  const rows = events.filter(isMuxMessage);
+  const replay = caughtUp.replay ?? "full";
+  if (replay === "since") {
+    if (mode?.type !== "since") {
+      throw new Error("Server reported since replay without a since request");
+    }
+    aggregator.reconcileSinceReplay({
+      requestedAnchorSequence: mode.cursor.history.historySequence,
+      messages: rows,
+      hasActiveStream: false,
+    });
+  } else {
+    aggregator.loadHistoricalMessages(rows, false, { mode: "replace" });
+  }
+  // Mirror WorkspaceStore caught-up handling: reuse the server-issued cursor verbatim.
+  aggregator.setServerHistoryCursor(caughtUp.cursor?.history ?? null);
+
+  return { events, rows, caughtUp };
+}
+
+async function readPersisted(
+  historyService: HistoryService,
+  workspaceId: string,
+  messageId: string
+): Promise<MuxMessage> {
+  const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+  if (!historyResult.success) {
+    throw new Error(`Failed to read history: ${historyResult.error}`);
+  }
+  const persisted = historyResult.data.find((message) => message.id === messageId);
+  if (!persisted || persisted.metadata?.historySequence === undefined) {
+    throw new Error(`Expected persisted row with historySequence for ${messageId}`);
+  }
+  return persisted;
+}
+
+describe("onChat since-mode reconnect cursor contract", () => {
+  let historyCleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await historyCleanup?.();
+  });
+
+  it("reconnects incrementally after two live-streamed turns", async () => {
+    const workspaceId = "ws-since-cursor-contract";
+    const harness = await createContractHarness(workspaceId);
+    const { session, historyService } = harness;
+    historyCleanup = harness.cleanup;
+
+    const aggregator = new StreamingMessageAggregator("2024-01-01T00:00:00.000Z");
+
+    // --- Turn 1: fully persisted before the client connects. ---
+    expect(
+      (
+        await historyService.appendToHistory(
+          workspaceId,
+          perDeltaAssistantMessage("assistant-1", ["Hel", "lo"], 1_000)
+        )
+      ).success
+    ).toBe(true);
+
+    const first = await replayIntoAggregator(session, aggregator, { type: "full" });
+    expect(first.caughtUp.replay).toBe("full");
+
+    // --- Turns 2 and 3: streamed live while the client is watching. ---
+    // The server persists one part per delta; the client assembles compacted parts
+    // from stream events. Both live-assembled rows end up below the next cursor
+    // anchor, which is exactly the divergence that broke fingerprint recomputation.
+    const liveTurns: Array<{ id: string; deltas: string[]; baseTimestamp: number }> = [
+      { id: "assistant-2", deltas: ["foo ", "bar"], baseTimestamp: 2_000 },
+      { id: "assistant-3", deltas: ["baz ", "qux"], baseTimestamp: 3_000 },
+    ];
+
+    for (const turn of liveTurns) {
+      expect(
+        (
+          await historyService.appendToHistory(
+            workspaceId,
+            perDeltaAssistantMessage(turn.id, turn.deltas, turn.baseTimestamp)
+          )
+        ).success
+      ).toBe(true);
+      const persisted = await readPersisted(historyService, workspaceId, turn.id);
+      const historySequence = persisted.metadata?.historySequence;
+      if (historySequence === undefined) {
+        throw new Error("Expected persisted historySequence");
+      }
+
+      aggregator.handleStreamStart({
+        type: "stream-start",
+        workspaceId,
+        messageId: turn.id,
+        historySequence,
+        model: TEST_MODEL,
+        startTime: turn.baseTimestamp,
+      });
+      for (const [index, delta] of turn.deltas.entries()) {
+        aggregator.handleStreamDelta({
+          type: "stream-delta",
+          workspaceId,
+          messageId: turn.id,
+          delta,
+          tokens: 1,
+          timestamp: turn.baseTimestamp + index,
+        });
+      }
+      // Client keeps its own assembled (compacted) parts at stream-end; only tool
+      // outputs are adopted from the event's parts. The persisted row keeps one part
+      // per delta — exactly the representation divergence under test.
+      aggregator.handleStreamEnd({
+        type: "stream-end",
+        workspaceId,
+        messageId: turn.id,
+        metadata: {
+          model: TEST_MODEL,
+          historySequence,
+          timestamp: turn.baseTimestamp,
+        },
+        parts: [],
+      });
+    }
+
+    // --- Switch away and back: reconnect with the client's cursor. ---
+    const cursor = aggregator.getOnChatCursor();
+    expect(cursor?.history).toBeDefined();
+    if (!cursor?.history) {
+      throw new Error("Expected a history cursor for since reconnect");
+    }
+
+    const second = await replayIntoAggregator(session, aggregator, {
+      type: "since",
+      cursor: { history: cursor.history, stream: cursor.stream },
+    });
+
+    // The money assertions: reconnect must stay incremental.
+    expect(second.caughtUp.downgradeReason).toBeUndefined();
+    expect(second.caughtUp.replay).toBe("since");
+
+    // Only rows at/above the requested anchor are re-sent.
+    const anchorSequence = cursor.history.historySequence;
+    for (const row of second.rows) {
+      const rowSequence = row.metadata?.historySequence;
+      expect(rowSequence).toBeDefined();
+      expect(rowSequence!).toBeGreaterThanOrEqual(anchorSequence);
+    }
+
+    // The client transcript converges exactly to persisted state (no ghosts, no dupes).
+    const historyResult = await historyService.getHistoryFromLatestBoundary(workspaceId);
+    if (!historyResult.success) {
+      throw new Error(`Failed to read history: ${historyResult.error}`);
+    }
+    const persistedIds = (historyResult.data as MuxMessage[]).map((message) => message.id);
+    expect(aggregator.getAllMessages().map((message) => message.id)).toEqual(persistedIds);
+  });
+});

--- a/src/node/services/agentSession.sinceReplayContract.test.ts
+++ b/src/node/services/agentSession.sinceReplayContract.test.ts
@@ -235,7 +235,7 @@ describe("onChat since-mode reconnect cursor contract", () => {
     if (!historyResult.success) {
       throw new Error(`Failed to read history: ${historyResult.error}`);
     }
-    const persistedIds = (historyResult.data as MuxMessage[]).map((message) => message.id);
+    const persistedIds = historyResult.data.map((message) => message.id);
     expect(aggregator.getAllMessages().map((message) => message.id)).toEqual(persistedIds);
   });
 });

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -25,6 +25,7 @@ import type {
   FilePart,
   OnChatMode,
   OnChatCursor,
+  OnChatDowngradeReason,
   ProvidersConfigMap,
   StreamErrorMessage,
 } from "@/common/orpc/types";
@@ -2428,6 +2429,12 @@ export class AgentSession {
     let replayMode: "full" | "since" | "live" = "full";
     let hasOlderHistory: boolean | undefined;
     let serverCursor: OnChatCursor | undefined;
+    // Silent since→full downgrades caused full-history re-transfers on nearly every
+    // workspace switch-back for months. Keep every downgrade observable: classified
+    // reason on the caught-up payload plus a log line with row counts.
+    let downgradeReason: OnChatDowngradeReason | undefined;
+    let epochRowCount: number | undefined;
+    let sentRowCount = 0;
     let emittedReplayMessages = false;
 
     const emitReplayMessage = (message: WorkspaceChatMessage): void => {
@@ -2546,8 +2553,13 @@ export class AgentSession {
       let sinceHistorySequence: number | undefined;
       let afterTimestamp: number | undefined;
 
+      if (!historyResult.success && mode?.type === "since") {
+        downgradeReason = "history-read-failed";
+      }
+
       if (historyResult.success) {
         const history = historyResult.data;
+        epochRowCount = history.length;
 
         // Cursor-based replay: only use incremental mode when all provided cursor segments are valid.
         const historyCursor = mode?.type === "since" ? mode.cursor.history : undefined;
@@ -2599,6 +2611,13 @@ export class AgentSession {
 
           if (matchedHistoryCursor && oldestHistoryMatches && priorHistoryMatches) {
             sinceHistorySequence = historyCursor.historySequence;
+          } else {
+            // Classify by the first failing predicate so downgrades are diagnosable.
+            downgradeReason = !matchedHistoryCursor
+              ? "cursor-row-missing"
+              : !oldestHistoryMatches
+                ? "oldest-mismatch"
+                : "fingerprint-mismatch";
           }
         }
 
@@ -2663,6 +2682,7 @@ export class AgentSession {
           }
 
           // Add type: "message" for discriminated union (messages from chat.jsonl don't have it)
+          sentRowCount += 1;
           emitReplayMessage({ ...message, type: "message" });
         }
 
@@ -2727,6 +2747,9 @@ export class AgentSession {
       if (replayMode !== "full" && !emittedReplayMessages && !emittedReplayStreamEvents) {
         replayMode = "full";
       }
+      if (mode?.type === "since" && replayMode === "full") {
+        downgradeReason ??= "history-read-failed";
+      }
 
       // Replay failed, so do not advertise a trustworthy reconnect cursor.
       serverCursor = undefined;
@@ -2766,6 +2789,18 @@ export class AgentSession {
         });
       }
 
+      // Surface since→full downgrades (and replay shape in general) in logs. Row counts
+      // only — no JSON.stringify byte accounting on this hot path.
+      const wasDowngraded = mode?.type === "since" && replayMode === "full";
+      log.debug("onChat replay", {
+        workspaceId: this.workspaceId,
+        requestedMode: mode?.type ?? "full",
+        replayMode,
+        ...(wasDowngraded && downgradeReason !== undefined ? { downgradeReason } : {}),
+        epochRowCount,
+        sentRowCount,
+      });
+
       // Send caught-up after ALL historical data (including init events)
       // This signals frontend that replay is complete and future events are real-time
       listener({
@@ -2773,6 +2808,7 @@ export class AgentSession {
         message: {
           type: "caught-up",
           replay: replayMode,
+          ...(wasDowngraded && downgradeReason !== undefined ? { downgradeReason } : {}),
           ...(hasOlderHistory !== undefined ? { hasOlderHistory } : {}),
           cursor: serverCursor,
         },


### PR DESCRIPTION
## Summary

Fixes the silent full-history re-transfer over the WebSocket on nearly every workspace switch-back: the client now reuses the **server-issued** onChat reconnect cursor verbatim instead of recomputing the cursor fingerprint from its divergent in-memory representation, and since-mode replays reconcile the transcript suffix authoritatively. Adds permanent observability so since→full downgrades can never hide again.

## Background

`workspace.onChat` supports incremental reconnects (`since` mode, #2413), but a representation mismatch silently defeated it:

- The server persists **one part per streaming delta**; the client **compacts parts on append** and keeps its own assembled parts (plus client-side timestamps) at stream-end.
- The since-cursor fingerprint (FNV-1a over `JSON.stringify(message.parts)` + metadata of every row below the anchor) was recomputed client-side from that divergent representation.
- Whenever a live-assembled assistant row sat *below* the cursor anchor (≥2 turns completed while watching), fingerprints diverged → the server silently downgraded to a **full active-epoch replay** (median ~400 KB, p90 ~1.7 MB, pathological 161 MB) → full wire transfer + full aggregator rebuild. Nothing logged the downgrade.

## Implementation

- **Phase 0 (observability):** `agentSession.emitHistoricalEvents` classifies every since→full downgrade by the first failing predicate (`cursor-row-missing | oldest-mismatch | fingerprint-mismatch | history-read-failed`), logs one `onChat replay` line per replay with row counts, and carries `downgradeReason` on the `caught-up` payload (additive optional schema field; upgrade/downgrade safe).
- **Phase 1 (fix):** `StreamingMessageAggregator` stores the server-issued history cursor from each caught-up (`setServerHistoryCursor`) and `getOnChatCursor()` returns it verbatim; client-side fingerprint computation is deleted. Because the stored anchor can be older than the client's cached transcript, since-replay handling treats replayed rows as the **authoritative suffix** for `seq >= anchor` (`reconcileSinceReplay`): stale rows are deleted, rewritten rows replaced by persisted forms (even with fewer parts), optimistic rows (no `historySequence`) untouched, and the server-confirmed active stream keeps the richer local assembly via an attempt-scope-gated carve-out. Derived state (todos, agent status, skills, review pins) is deterministically rebuilt from the replay window whenever a discarded row could have contributed to it.
- **WorkspaceStore:** the requested anchor is attempt-scoped and routed through the same abort-guarded event path as chat events; a since caught-up without a usable anchor triggers a hard fallback (clear stored cursor + replay buffers, abort → full resubscribe).
- No wire-protocol changes; `OnChatModeSchema` untouched; server validation below the anchor unchanged (fail-safe).

**Accepted trade-off:** rows persisted during the current viewing session sit above the stored anchor and are re-transferred once on the next resubscribe (bounded: a few turns; the anchor ratchets forward on each caught-up — measured steady state re-sends only the anchor row).

## Validation

**Red-first contract test** (`agentSession.sinceReplayContract.test.ts`, real server replay ⇄ real aggregator). On pre-fix code:

```
error: expect(received).toBeUndefined()
Received: "fingerprint-mismatch"
(fail) onChat since-mode reconnect cursor contract > reconnects incrementally after two live-streamed turns
```

Green with the fix (replay stays `since`, no downgrade, only rows ≥ anchor re-sent, transcript converges exactly to persisted state).

**Live dogfooding** (isolated `dev-server-sandbox`, real provider turns, driven with agent-browser; `XUM_LOG_LEVEL=debug`):

| Scenario | Before (Phase-0-only build) | After (this branch) |
|---|---|---|
| 2 live turns → switch away/back | `requestedMode=since replayMode=full downgradeReason=fingerprint-mismatch sentRowCount=4/4` | `replayMode=since`, no downgrade |
| Second switch-back | always full | `since`, `sentRowCount=1/4` (anchor ratchet) |
| Mid-stream switch-back | — | `since`; stream continues, carve-out preserves assembled content |
| Interrupt (Stop) → switch-back | — | `since`; interrupted marker intact |
| 10× rapid A↔B toggle | — | every reconnect `since` `sentRowCount=1`; transcript intact; no console errors |
| `/compact` → switch-back | — | one logged `cursor-row-missing` full replay of the tiny fresh epoch, then `since` again |

Zero downgrades in the entire after-fix session log. Suites: `StreamingMessageAggregator.test.ts`, `WorkspaceStore.test.ts`, `agentSession.preStreamError.test.ts`, `agentSession.sinceReplayContract.test.ts`, `onChatCursorFingerprint.test.ts` — 303 tests green; `make static-check` green (re-run after rebase onto `main`).

## Risks

- **Reconciliation deletes local rows** (`seq >= anchor` not re-sent). This is the new authority contract; wrong anchors would drop visible rows. Mitigated by attempt-scoping the anchor through the abort-guarded event path, a hard full-resubscribe fallback when the anchor is missing, and dedicated ghost-removal/boundary-dedup/optimistic-row unit tests. Severity if wrong: visible transcript corruption in the chat pane until a full replay.
- **Active-stream carve-out** could preserve stale content if mis-gated; gated on server-confirmed stream id == the attempt cursor's stream id, with tests for match/mismatch/stream-end-right-after-caught-up.
- **Derived-state rebuild** resets todos/status/skills/review pins when a suffix source row was discarded; scoped to the server replay window so `loadOlderHistory` pages stay excluded. Worst case: todo/status UI briefly reflects only surviving rows (matches persisted reality).
- Cursor staleness below the anchor (edits/truncation/compaction while away) keeps today's fail-safe behavior: server validation downgrades to full replay — now logged and observable.

---

<details>
<summary>📋 Implementation Plan</summary>

# Fix silent full-history re-transfer over the WebSocket on workspace switch

## Problem statement (investigated & empirically confirmed)

`workspace.onChat` already supports incremental reconnects (`since` mode with a history cursor +
fingerprint, PR #2413), but a representation mismatch silently defeats it in the most common usage
pattern, causing **full active-epoch re-transfers on nearly every workspace switch-back**:

- **Server persists one part per streaming delta** (`streamManager.ts` `~3042-3048`: "Append each
  delta as a new part (merging happens at display time)"; persisted verbatim at `~3590-3599` via
  `updateHistory`). Real rows on disk have 5,000+ parts.
- **Client compacts parts on append** (`StreamingMessageAggregator.handleStreamDelta` `~2095-2110`,
  `handleReasoningDelta` `~2811+`) and keeps its own assembled parts at stream-end (only tool
  outputs adopted from `data.parts`, `~2146-2166`). Client assistant `metadata.timestamp` is a
  client-side `Date.now()` (`~2064-2066`), while the persisted row carries server metadata.
- The since-cursor fingerprint is `FNV-1a over JSON.stringify(message.parts)` + metadata of every
  row **below** the cursor anchor (`src/common/orpc/onChatCursorFingerprint.ts`). The client
  computes it from its in-memory representation (`StreamingMessageAggregator.getOnChatCursor()`
  `~1324-1395`); the server recomputes from persisted rows (`agentSession.ts` `~2568-2626`).
- **Result:** whenever a live-assembled assistant row sits *below* the cursor anchor (i.e. ≥2 turns
  completed while watching, or 1 turn + any later row such as a queued send/sub-agent report), the
  fingerprints diverge → the server **silently downgrades to full replay** → the client does
  `loadHistoricalMessages(mode: "replace")` (`WorkspaceStore.ts:4531`) → full wire transfer + full
  aggregator rebuild. Nothing logs the downgrade.

**Empirical proof** (real production modules driven in a scratch script, this machine):

| Scenario | Client fp | Server fp | Outcome |
|---|---|---|---|
| 2 live turns → switch away → back | `d2697240` | `cd3859e7` | MISMATCH → silent full replay |
| 1 live turn (control) | `0167240c` | `0167240c` | MATCH → since works (boundary row is re-sent `>=` in persisted form) |

**Measured payload cost** (1,545 sessions on this host): full replay = whole active epoch in one
shot (`getHistoryFromLatestBoundary(skip=0)`, `agentSession.ts:2541`; no within-epoch wire
pagination). Median epoch ~400 KB, p90 ~1.7 MB, top workspaces 6–23 MB, pathological 161 MB
(43k-row loop workspace with no compaction boundary). Tool outputs ≈60% of bytes, JSON overhead
≈25–30% (largely per-delta parts bloat).

## Goals

1. Make since-mode reconnects actually work after live-streamed turns (the common case).
2. Add observability so since→full downgrades can never hide again.
3. Regression-test the client↔server cursor contract end-to-end (red-first: the new contract test
   must fail on current `main`).

## Non-goals (documented follow-ups, separate PRs — see "Follow-up roadmap")

- Server-side part compaction at persist time (disk/wire JSON bloat).
- Within-epoch pagination of full replay (first paint = newest N rows).
- Runaway boundary-less workspaces (the 161 MB case).
- Frontend render-cost work (RightSidebar remount, markdown re-parse, aggregator LRU).

## Chosen design: the client reuses the **server-issued cursor** verbatim

**Key insight:** the server already computes and sends an authoritative cursor (anchor +
`oldestHistorySequence` + `priorHistoryFingerprint` over *persisted* rows) in every `caught-up`
event (`agentSession.ts` `~2669-2688` builds `serverCursor` for both full and since replays;
`CaughtUpMessageSchema.cursor`). The client currently uses only fragments of it
(`WorkspaceStore.ts:4468-4479`) and **recomputes** the fingerprint from its own divergent in-memory
representation. That recomputation is the root cause.

**Fix:** stop client-side fingerprint recomputation entirely. The aggregator stores the last
server-issued history cursor and `getOnChatCursor()` returns it verbatim (plus the existing
client-computed *stream* cursor, which is advisory and clamped server-side at
`agentSession.ts:2605-2615`).

**Required invariant — suffix reconciliation (closes the stale-row hole):** the server-issued
anchor can be *older* than the client's cached transcript (rows streamed live since the last
caught-up sit above it). Server validation (anchor row exists, epoch-oldest match, fingerprint)
only protects rows **below** the anchor. Rows in `[anchor, client-max]` could be deleted or
rewritten server-side while the client is unsubscribed (e.g. auto-retry rewrites, background
truncation), and plain append semantics would retain them as stale ghosts. Today's design is
implicitly safe here only because the anchor always equals client-max. Therefore, since-replay
handling must treat the replayed rows as the **authoritative suffix for `seq >= requestedAnchor`**
— see Phase 1, "since-replay suffix reconciliation".

Why this is correct and robust:

- **Representation-independent.** Client memory layout (compact-on-append, adopted tool outputs,
  client timestamps) no longer participates in the contract. The client keeps its
  memory-efficient compact parts.
- **Fail-safe below the anchor.** The server validates anchor row existence, epoch-oldest match,
  and prior-rows fingerprint on every subscribe (`agentSession.ts:2568-2603`) — a stale stored
  cursor (edit/truncation/compaction while away) degrades to full replay, which is today's
  behavior.
- **Authoritative at/above the anchor.** Since-replay re-sends every current row `>=` anchor in
  persisted form; with suffix reconciliation the client converges exactly to persisted state
  (stale rows removed, rewritten rows replaced, live-assembled rows replaced by canonical forms).
- **Covers all divergence sources at once** — text/reasoning delta compaction, reasoning
  `providerOptions`/`signature` stashed only server-side (`streamManager.ts:3067-3110`),
  client-generated `metadata.timestamp`, and the abort/error paths (`stream-abort` carries no
  parts, so client/persisted representations diverge for interrupted turns too).

**Accepted trade-off:** rows persisted *during* the current viewing session sit above the stored
anchor and are re-transferred once on the next resubscribe (bounded: a few turns, typically tens
of KB; vs. multi-MB full epochs today). A cursor-ratchet optimization is listed as follow-up 3d.

### Rejected alternatives

| Approach | Why rejected | est. net LoC |
|---|---|---|
| **A. Client adopts server parts at stream-end** (mirror reconnect path `~2204-2224`) | Doesn't cover `stream-abort`/`stream-error` (no parts on those events); `metadata.timestamp` still client-generated → still mismatches; regresses client memory (per-delta parts retained); keeps the fragile byte-equality contract | +50–100 |
| **B. Server-side part compaction at persist time only** | Insufficient alone: client parts still lack reasoning `providerOptions`/`signature` and carry client timestamps → still mismatches. Valuable independently for the 25–30% JSON bloat → follow-up 3a | +80–150 |
| **C. Server-computed per-row hashes carried on every terminal event; client hashes-of-hashes** | Structurally sound but strictly more machinery (new schema fields on stream-end/abort/error/message events, client hash bookkeeping) for the same outcome as the chosen design | +150–250 |

**Chosen design est. net LoC (product code): +120 to +250** (cursor storage/reuse ~30; suffix
reconciliation + derived-state rebuild ~80–160; attempt-scoped anchor plumbing + full-resubscribe
fallback ~30–60; minus ~40 of removed client-side fingerprint computation).

---

## Phase 0 — Observability first (land before the fix; est. +40–70 LoC)

Purpose: prove the bug live in dogfooding "before" evidence, and permanently guard against silent
downgrades.

Changes:

1. `src/node/services/agentSession.ts` (`emitHistoricalEvents`, `~2546-2638`):
   - Classify the downgrade reason when `mode.type === "since"` fails validation:
     `"cursor-row-missing" | "oldest-mismatch" | "fingerprint-mismatch" | "history-read-failed"`.
     The existing checks (`matchedHistoryCursor`, `oldestHistoryMatches`, `priorHistoryMatches`)
     already compute each predicate — derive the reason from the first failing one.
   - `log.debug` one line per replay with `{ workspaceId, requestedMode, replayMode,
     downgradeReason, epochRowCount, sentRowCount }`. Row counts only — no `JSON.stringify` byte
     accounting on the hot path.
2. `src/common/orpc/schemas/stream.ts` (`CaughtUpMessageSchema`): add optional
   `downgradeReason: z.enum([...]).optional()`, populated only when a requested `since` was
   downgraded. Enables behavioral tests + client-side visibility without log scraping.
   (Additive optional field → upgrade/downgrade safe.)
3. `src/browser/stores/WorkspaceStore.ts` (caught-up handler `~4461`): `console.debug` the replay
   mode + downgrade reason (dev observability; no UI).

Tests (behavioral, not tautological): reason **classification branching** — given a cursor whose
anchor row is missing vs. whose fingerprint mismatches vs. whose oldest mismatches, the caught-up
event carries the matching reason and `replay: "full"`. Extend the existing agentSession replay
test suite.

**Gate 0:** targeted tests green; sandbox dogfood shows `fingerprint-mismatch` downgrades on
unfixed code (capture logs/screenshots as "before" evidence).

## Phase 1 — Authoritative server cursor reuse + suffix reconciliation (the fix; est. +120 to +250 LoC)

**Step 0 (red-first):** write the round-trip contract test from Phase 2 item 1 **after Phase 0
has landed but before implementing Phase 1** (the test asserts `downgradeReason`, which Phase 0
introduces; on raw `main` the equivalent red assertion is simply `replay !== "since"`). Confirm it
fails on the Phase-0-only code with `replay: "full"`, `downgradeReason: "fingerprint-mismatch"`.
Write the test against the **existing black-box surfaces** (server: `replayHistory` with a
`since` mode input; client: the current `getOnChatCursor()` output after replay + live events) so
it compiles before any Phase 1 API additions land. Record the red run in the PR description.

Changes:

1. `src/browser/utils/messages/StreamingMessageAggregator.ts`:
   - New field `lastServerHistoryCursor: OnChatHistoryCursor | null = null` + setter
     `setServerHistoryCursor(cursor: OnChatHistoryCursor | null)`.
   - Rewrite `getOnChatCursor()` (`~1324-1395`): return
     `{ history: this.lastServerHistoryCursor ?? undefined, stream: <existing stream-cursor logic> }`;
     return `undefined` when there is no stored history cursor (→ full mode, as today for fresh
     aggregators). Keep the defensive `activeStreams.size > 1 → undefined` guard.
   - Delete the client-side `computePriorHistoryFingerprint` usage and the min/max sequence scan;
     drop the now-unused browser import (the function itself stays in `src/common/orpc/` — the
     server still uses it).
   - **Keep `establishedOldestHistorySequence` as-is** for now (it interacts with
     `loadOlderHistory` pagination); defer any removal to a follow-up once suffix
     reconciliation/pagination behavior has settled in production.
   - **New: since-replay suffix reconciliation.** Dedicated method, e.g.
     `reconcileSinceReplay(requestedAnchorSeq, replayedMessages, preservedActiveStreamMessageId)`:
     1. Delete every local message with a **defined** `historySequence >= requestedAnchorSeq`
        whose id is **not** in the replayed set and is **not** the preserved active-stream
        message. Rows **without** a `historySequence` (optimistic sends awaiting ack) are never
        touched.
     2. Apply replayed rows with **replace-by-id semantics** (persisted rows are authoritative for
        finalized turns — do *not* route them through `addMessage`'s "prefer richer content" guard,
        which could keep stale local content when a rewrite has fewer parts) — **except** for the
        preserved active-stream message, which keeps the richer local assembly: the persisted
        placeholder row has empty/partial parts and stream replay only re-sends deltas after the
        stream cursor, so hard-replacing it would lose already-rendered content. (This carve-out
        is exactly what the existing `addMessage` guard at `~1116-1125` protects.)
     3. **Active-stream carve-out gating:** preserve the active-stream row **only when the
        server-confirmed active stream (`caught-up.cursor.stream.messageId`) matches the locally
        active stream that existed when this attempt's cursor was built**. On mismatch or when no
        local active stream exists, apply no carve-out — replayed rows + subsequently replayed
        stream events rebuild the stream message (the existing stale-stream cleanup at
        `WorkspaceStore.ts:4487-4500` already clears mismatched local contexts before this point).
     4. **Derived-state rebuild:** after the suffix mutation, deterministically rebuild derived
        state from the post-reconcile message set rather than trusting per-delete invalidation.
        Factor the existing replace-mode derived rebuild (`loadHistoricalMessages` replace path
        rebuilds todos, loaded skills/errors, detected links, recency, caches) into a shared
        `rebuildDerivedState()` used by both replace-mode load and reconciliation, preserving
        active-stream transient state where the carve-out applies.
     5. Assert (defensive style): `requestedAnchorSeq` is a non-negative finite number; every
        replayed row with defined seq satisfies `seq >= requestedAnchorSeq`.
2. `src/browser/stores/WorkspaceStore.ts`:
   - `runOnChatSubscription` (`~3904-3922`): **attempt-scope the requested anchor.** Capture
     `{ anchor: mode.cursor.history.historySequence, localActiveStreamMessageId }` in the attempt
     context (alongside the existing `attemptController`), not as a bare shared transient field.
     The existing abort guards (`signal.aborted || attemptSignal.aborted` microtask checks,
     `~3974-3979`, plus `clearReplayBuffers` on switch-away) must provably prevent a caught-up
     from a stale attempt consuming a newer attempt's anchor; route the anchor through the same
     attempt-guarded event path so reconciliation only ever sees its own attempt's anchor.
   - Caught-up handler (`~4461-4540`):
     - `aggregator.setServerHistoryCursor(data.cursor?.history ?? null)` on **every** caught-up
       (full and since). A caught-up without a cursor (server replay failure sets
       `serverCursor = undefined`, `agentSession.ts:2732`) **clears** the stored cursor → next
       subscribe is full (safe).
     - When `replay === "since"`: call `reconcileSinceReplay(...)` with the attempt-scoped anchor
       and carve-out decision, instead of plain `loadHistoricalMessages(mode: "append")`.
     - **Missing-anchor hard fallback:** assert the attempt-scoped anchor exists when the server
       reports since (it always must — the client sent it). If it is somehow missing in
       production: `console.warn`, **clear the stored server cursor, clear the current replay
       buffers (`clearReplayBuffers`) so stale buffered rows cannot carry into the forced full
       replay, and abort/restart the subscription attempt so the next attempt performs a full
       replay** — never append (stale rows could survive, violating suffix authority) and never
       replace-mode load (drops rows below the anchor). The existing deferred-reset behavior (`resetChatStateForReplay` runs
       only after the new iterator is established, `~3953-3958`) keeps the current UI visible
       until the full replay lands.
     - Clear the attempt-scoped anchor after processing each caught-up.
3. No server changes beyond Phase 0. No wire-protocol changes. `OnChatModeSchema` untouched.

Edge cases (all verified against current code):

- **First open / fresh aggregator:** no stored cursor → full replay (unchanged).
- **Empty epoch:** caught-up may carry no history cursor → stored cursor cleared → trivial full.
- **Edit/truncation/compaction below the anchor while away:** server-side validation fails
  (anchor row missing / oldest mismatch / fingerprint mismatch) → full replay. Same as today;
  now logged via Phase 0.
- **Deletion/rewrite at or above the anchor while away:** handled by suffix reconciliation —
  missing rows are removed, rewritten rows replaced by persisted forms (see Phase 1 change 1).
- **Long viewing session (N turns since caught-up):** rows `>=` anchor re-sent once on
  resubscribe; anchor ratchets forward with the new caught-up. Bounded; follow-up 3d can ratchet
  per stream-end if it proves worth it.
- **Active stream at reconnect:** the server-confirmed active-stream message keeps the richer
  local assembly (placeholder rows have empty parts; stream replay only re-sends deltas after the
  stream cursor). If the stream ended while away, the server sends the finalized persisted row
  and no stream cursor → replace-by-id applies and stale stream context is already cleared by the
  existing `caught-up` handling (`WorkspaceStore.ts:4487-4500`).
- **Client pagination (`loadOlderHistory`):** irrelevant to the cursor — the server cursor's
  `oldestHistorySequence`/fingerprint were computed over the epoch (skip=0) server-side, matching
  exactly what server validation compares against.
- **Subscription retry loop (`runOnChatSubscription` attempts):** same path, stored cursor reused;
  a successful since replay refreshes it via its own caught-up.

## Phase 2 — Regression tests

1. **Round-trip contract test (the money test)** — written red-first in Phase 1 Step 0; fails on
   `main`, passes with the fix.
   Location: extend `agentSession` replay tests (or a focused new colocated test file) using
   `createTestHistoryService()` per the HistoryService doctrine:
   - Persist a small history where an assistant row has **per-delta parts** (as `streamManager`
     writes them: multiple `{type:"text",text,timestamp}` parts, server metadata incl. timestamp).
   - Run `replayHistory(listener, {type:"full"})`; feed all emitted events + caught-up into a real
     `StreamingMessageAggregator` (mirroring the `WorkspaceStore` caught-up handling for cursor
     storage).
   - Simulate a second live turn: append the persisted row via the history service **and** feed the
     matching live events (stream-start/deltas/stream-end with per-delta `parts`) to the aggregator.
   - Resubscribe with `mode: {type:"since", cursor: aggregator.getOnChatCursor()}` → assert
     `caught-up.replay === "since"`, no `downgradeReason`, and only rows `>=` anchor were emitted.
2. **Aggregator unit tests** (`StreamingMessageAggregator.test.ts`):
   - `getOnChatCursor()` returns the stored server cursor verbatim; returns `undefined` before any
     caught-up; cleared when `setServerHistoryCursor(null)`. Update the two existing cursor tests
     (`~2185`, `~2583`) to the new semantics.
   - **Suffix reconciliation:** (a) a local row above the anchor absent from the replayed set is
     removed; (b) a rewritten row (same id, different persisted parts — including *fewer* parts
     than the local compacted copy) is replaced by the persisted form; (c) optimistic rows without
     `historySequence` survive; (d) the boundary row is not duplicated; (e) derived state
     regression: derived state sourced from a removed suffix row (e.g. detected links / todo
     state) is gone after reconciliation.
   - **Active-stream carve-out gating:** (a) server and local active stream match → locally
     assembled content preserved; (b) mismatched or absent local active stream → no carve-out,
     stream message rebuilt from replayed rows + replayed stream events; (c) stream ends
     immediately after caught-up → the later `stream-end` finalizes the message correctly.
3. **WorkspaceStore tests** (`WorkspaceStore.test.ts`): existing since-reconnect suites
   (`~5116-5332`) keep passing — including "preserves pagination state across since reconnect
   retries" (`~5116`), which guards the `loadOlderHistory` interaction; add: second subscription
   after caught-up sends `since` with the server-issued cursor (mock asserts the exact cursor
   payload), a caught-up without cursor forces the next subscribe to full, and a since caught-up
   whose replayed set omits a previously-cached row removes that row from the rendered state.
4. **Phase 0 classification tests** as described above.
5. `onChatCursorFingerprint.test.ts` unchanged (server-side use is untouched).

Note: `workspaceService.test.ts` has one pre-existing failure at HEAD in this environment
("accepted history suppresses redelivery…", eager mockRejectedValue) — unrelated; don't chase it.

## Phase 3 — Follow-up roadmap (out of scope for this PR; file as issues or subsequent PRs)

- **3a. Persist-time part compaction** (`streamManager` stream-end/partial finalization): merge
  adjacent text/reasoning delta parts before `updateHistory`, preserving reasoning
  `providerOptions`/`signature` merge semantics. Cuts ~25–30% of epoch bytes on disk and wire.
  Old per-delta rows remain readable (readers already merge at display). Est. +80–150 LoC.
- **3b. Within-epoch replay pagination:** first paint needs only the newest ~64 rows
  (`MAX_DISPLAYED_MESSAGES` limits DOM, not wire); page older rows on demand like cross-boundary
  `history.loadMore`. Defuses the 6–23 MB epochs and the 161 MB pathological case. Est. +200–400.
- **3c. Boundary-less loop workspaces:** periodic forced boundaries or replay caps (mostly
  subsumed by 3b).
- **3d. Cursor ratchet:** server maintains a running FNV fingerprint per session (FNV extends
  sequentially over seq-sorted rows) and emits a refreshed cursor on each stream-end, eliminating
  the bounded re-transfer of the chosen design. Only if dogfooding shows it matters.

---

## Dogfooding & verification (quality gates)

Environment: use the `dev-server-sandbox` skill (isolated `XUM_ROOT` + free ports) so real user
data is untouched; drive the UI with `agent-browser` (snapshot → click/fill → re-snapshot).
Capture screenshots at every step and record a video of the switch sequence; attach via
`attach_file` for review evidence. This workspace's Coder host is headless — `agent-browser`
handles that; do not rely on Storybook for this validation.

**"Before" evidence (after Phase 0, before Phase 1):**
1. Start a sandboxed dev server; create a project + two workspaces A and B.
2. In A, run ≥2 short real turns while watching (provider keys are available in this env; the
   debug CLI `bun run debug send-message <workspace-id>` is a fallback).
3. Switch A → B → A. Grep the sandbox server log for the Phase 0 replay line: expect
   `requestedMode=since replayMode=full downgradeReason=fingerprint-mismatch` and
   `sentRowCount == epochRowCount`.
4. Screenshot the workspaces + save the log excerpt.

**"After" evidence (after Phase 1):**
5. Repeat the same scenario: expect `replayMode=since`, no downgrade reason, `sentRowCount` ≈
   rows since the anchor (small). Confirm the transcript renders identically after switch-back
   (no missing/duplicated rows), including: an interrupted turn (Esc during stream), an edited
   message (truncation → logged full replay once → since again afterwards), and a compaction
   (`/compact`) while watching.
6. Quick-switch stress: rapidly toggle A↔B ~10×; verify no assertion failures in console, no
   transcript corruption, memory stable.
7. Record the video of steps 5–6; attach screenshots + video.

**Validation commands (each phase):** `make static-check` (set `MUX_ESLINT_CONCURRENCY=1` if
memory-constrained) and targeted suites:
`bun test src/browser/utils/messages/StreamingMessageAggregator.test.ts src/browser/stores/WorkspaceStore.test.ts src/node/services/agentSession*.test.ts src/common/orpc/onChatCursorFingerprint.test.ts`.

## Acceptance criteria

1. Switching back to a workspace where ≥2 turns completed live triggers `replay: "since"` (not
   full), verified by the round-trip contract test **and** live dogfooding logs.
2. The contract test fails on unfixed `main` (red-first proof) and passes with the fix.
3. Every since→full downgrade is logged with a machine-readable reason; `caught-up` carries
   `downgradeReason` when a requested since was downgraded.
4. No wire-protocol or persisted-format breaking changes (additive optional schema field only);
   old client ↔ new server and new client ↔ old server both degrade gracefully to full replay.
5. Transcript correctness preserved across switch-back for: normal turns, interrupted turns,
   edits/truncations, compaction, empty epochs (dogfood checklist above).
6. **Suffix authority:** a row deleted or rewritten server-side *above* the stored anchor while
   the client was unsubscribed is respectively removed/replaced after a since reconnect (no stale
   ghosts); verified by the reconciliation unit tests.
7. **Pagination integrity:** `loadOlderHistory` before switch-back neither pollutes the cursor nor
   loses pagination state across a since reconnect; no boundary-row duplication.
8. `make static-check` green; all listed test suites green (modulo the documented pre-existing
   `workspaceService.test.ts` failure).

## Risks & mitigations

- **Stored cursor goes stale below the anchor in ways not anticipated** → server-side validation
  is unchanged and fail-safe there (worst case = today's full replay), now with logging to detect
  any residual downgrade hot spots.
- **Stale rows at/above the anchor** → closed by suffix reconciliation (the central new invariant);
  covered by dedicated unit tests including the delete-above-anchor and rewrite-with-fewer-parts
  cases.
- **Suffix reconciliation wipes active-stream content** → explicit carve-out for the
  server-confirmed active-stream message + a dedicated test; the existing `addMessage` richer-
  content guard remains for that path.
- **Existing tests assume client-computed fingerprints** → update them to server-cursor semantics;
  server-side fingerprint tests are untouched, so safety coverage does not shrink.
- **Behavior change in re-sent rows (`>=` anchor) surfacing duplicate-handling bugs** → since
  replay already re-sends the boundary row today; reconciliation replace-by-id semantics are
  covered by new unit tests and the round-trip contract test.
- **`requestedSinceAnchor` lifecycle bugs (retry loops, aborted attempts)** → anchor is recorded
  per subscription attempt and cleared on each caught-up; asserted present when the server reports
  `replay: "since"`; production fallback is today's append behavior (never replace).

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$105.52`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=105.52 -->
