### PR TITLE
🤖 fix: stop one corrupt persisted row from bricking workspace fetch (onChat)

### DIFF
--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -60,7 +60,12 @@ const MuxToolPartBase = z.object({
 export const NestedToolCallSchema = z.object({
   toolCallId: z.string(),
   toolName: z.string(),
-  input: z.unknown(),
+  // Optional: kernel guests can invoke a capability with zero arguments
+  // (mux.tool()), and JSON.stringify drops the resulting `input: undefined`
+  // key on persist. Requiring the key here made onChat replay of such
+  // persisted rows fail oRPC output validation and permanently brick
+  // workspace fetch (one corrupt row killed the whole subscription).
+  input: z.unknown().optional(),
   output: z.unknown().optional(),
   state: z.enum(["input-available", "output-available", "output-redacted"]),
   failed: z.boolean().optional(),

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -1156,10 +1156,12 @@ export type DisplayedMessage =
       /** Durable workflow run attachment recovered from partial history. */
       workflowRun?: MuxToolPart["workflowRun"];
       // Nested tool calls for code_execution (from PTC streaming or reconstructed from result)
+      // input is optional to mirror NestedToolCallSchema: zero-arg kernel calls
+      // persist without an input key.
       nestedCalls?: Array<{
         toolCallId: string;
         toolName: string;
-        input: unknown;
+        input?: unknown;
         output?: unknown;
         state: "input-available" | "output-available" | "output-redacted";
         failed?: boolean;

--- a/src/node/services/agentSession.replaySelfHealing.test.ts
+++ b/src/node/services/agentSession.replaySelfHealing.test.ts
@@ -1,0 +1,153 @@
+/**
+ * onChat replay self-healing: a persisted row that fails the wire schema must be
+ * skipped (rest of the transcript intact, caught-up still delivered) instead of
+ * killing the subscription. oRPC output-validates every yielded event, so before
+ * this guard one corrupt chat.jsonl row terminated the iterator and permanently
+ * bricked workspace fetch in server mode.
+ */
+import { describe, expect, it, mock, afterEach } from "bun:test";
+import type { AIService } from "@/node/services/aiService";
+import type { MuxMessage } from "@/common/types/message";
+import { WorkspaceChatMessageSchema } from "@/common/orpc/schemas";
+import { isMuxMessage, type WorkspaceChatMessage } from "@/common/orpc/types";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+async function createReplayHarness(workspaceId: string) {
+  return await createAgentSessionHarness({
+    workspaceId,
+    aiServiceOverrides: {
+      getStreamInfo: mock((_workspaceId: string) => undefined) as AIService["getStreamInfo"],
+      replayStream: mock((_workspaceId: string, _opts?: { afterTimestamp?: number }) =>
+        Promise.resolve()
+      ),
+    },
+    initStateManagerOverrides: { replayInit: mock((_workspaceId: string) => Promise.resolve()) },
+  });
+}
+
+function textMessage(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+  timestamp: number
+): MuxMessage {
+  return { id, role, parts: [{ type: "text", text, timestamp }], metadata: { timestamp } };
+}
+
+async function replayAll(
+  session: Awaited<ReturnType<typeof createReplayHarness>>["session"]
+): Promise<WorkspaceChatMessage[]> {
+  const events: WorkspaceChatMessage[] = [];
+  await session.replayHistory(
+    ({ message }: { message: WorkspaceChatMessage }) => {
+      events.push(message);
+    },
+    { type: "full" }
+  );
+  return events;
+}
+
+describe("onChat replay self-healing", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  it("skips a persisted row that fails the wire schema instead of failing replay", async () => {
+    const workspaceId = "ws-replay-self-healing";
+    const harness = await createReplayHarness(workspaceId);
+    cleanup = harness.cleanup;
+    const { session, historyService } = harness;
+
+    expect(
+      (
+        await historyService.appendToHistory(
+          workspaceId,
+          textMessage("user-1", "user", "hi", 1_000)
+        )
+      ).success
+    ).toBe(true);
+
+    // Recorder-bug shape: an output-available tool part whose output key was
+    // dropped by JSON serialization (output: undefined). Fails the wire schema.
+    const corrupt = {
+      id: "assistant-corrupt",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "call-1",
+          toolName: "bash",
+          input: { script: "true" },
+          state: "output-available",
+        },
+      ],
+      metadata: { timestamp: 2_000 },
+    } as unknown as MuxMessage;
+    expect((await historyService.appendToHistory(workspaceId, corrupt)).success).toBe(true);
+
+    expect(
+      (
+        await historyService.appendToHistory(
+          workspaceId,
+          textMessage("assistant-2", "assistant", "done", 3_000)
+        )
+      ).success
+    ).toBe(true);
+
+    const events = await replayAll(session);
+
+    // The corrupt row is skipped; every other row still replays in order.
+    expect(events.filter(isMuxMessage).map((row) => row.id)).toEqual(["user-1", "assistant-2"]);
+    // caught-up still arrives so the client leaves its loading state.
+    expect(events.some((event) => "type" in event && event.type === "caught-up")).toBe(true);
+    // The invariant the guard protects: every replayed event survives the oRPC
+    // output validation that killed the subscription before.
+    for (const event of events) {
+      expect(WorkspaceChatMessageSchema.safeParse(event).success).toBe(true);
+    }
+  });
+
+  it("replays rows whose nested kernel calls were persisted without input", async () => {
+    // Regression for real-world data: zero-arg kernel capability calls
+    // (mux.tool()) persisted nestedCalls entries without an input key. Such
+    // rows must replay (not be skipped) so the transcript stays complete.
+    const workspaceId = "ws-replay-nested-no-input";
+    const harness = await createReplayHarness(workspaceId);
+    cleanup = harness.cleanup;
+    const { session, historyService } = harness;
+
+    const legacyRow = {
+      id: "assistant-nested",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "parent-1",
+          toolName: "code_execution",
+          input: { code: "mux.linear_get_issue_status()" },
+          state: "output-available",
+          output: { result: "ok" },
+          nestedCalls: [
+            {
+              toolCallId: "nested-1",
+              toolName: "linear_get_issue_status",
+              state: "output-available",
+              output: { error: "missing args" },
+              timestamp: 1_500,
+            },
+          ],
+        },
+      ],
+      metadata: { timestamp: 1_000 },
+    } as unknown as MuxMessage;
+    expect((await historyService.appendToHistory(workspaceId, legacyRow)).success).toBe(true);
+
+    const events = await replayAll(session);
+
+    expect(events.filter(isMuxMessage).map((row) => row.id)).toEqual(["assistant-nested"]);
+    for (const event of events) {
+      expect(WorkspaceChatMessageSchema.safeParse(event).success).toBe(true);
+    }
+  });
+});

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -38,7 +38,12 @@ import {
   type GoalSyntheticMessageKind,
 } from "@/constants/goals";
 import type { SendMessageError } from "@/common/types/errors";
-import { AgentIdSchema, SendMessageOptionsSchema, SkillNameSchema } from "@/common/orpc/schemas";
+import {
+  AgentIdSchema,
+  ChatMuxMessageSchema,
+  SendMessageOptionsSchema,
+  SkillNameSchema,
+} from "@/common/orpc/schemas";
 import { normalizeAgentId, resolvePersistedAgentIdCandidates } from "@/common/utils/agentIds";
 import {
   buildStreamErrorEventData,
@@ -2437,9 +2442,26 @@ export class AgentSession {
     let sentRowCount = 0;
     let emittedReplayMessages = false;
 
-    const emitReplayMessage = (message: WorkspaceChatMessage): void => {
+    // Self-healing: persisted rows can fail the current wire schema (older
+    // writers, schema drift, corruption). oRPC validates every event yielded to
+    // onChat subscribers and a single invalid row terminates the iterator,
+    // which would permanently brick workspace fetch. Skip such rows instead of
+    // letting one bad line take down the whole transcript.
+    const emitReplayMessage = (message: WorkspaceChatMessage): boolean => {
+      const validation = ChatMuxMessageSchema.safeParse(message);
+      if (!validation.success) {
+        const row = message as { id?: string; metadata?: { historySequence?: number } };
+        log.warn("onChat replay: skipping persisted row that fails the wire schema", {
+          workspaceId: this.workspaceId,
+          messageId: row.id,
+          historySequence: row.metadata?.historySequence,
+          issue: validation.error.issues[0],
+        });
+        return false;
+      }
       emittedReplayMessages = true;
       listener({ workspaceId: this.workspaceId, message });
+      return true;
     };
 
     let replayedTerminalStreamError = false;
@@ -2682,8 +2704,9 @@ export class AgentSession {
           }
 
           // Add type: "message" for discriminated union (messages from chat.jsonl don't have it)
-          sentRowCount += 1;
-          emitReplayMessage({ ...message, type: "message" });
+          if (emitReplayMessage({ ...message, type: "message" })) {
+            sentRowCount += 1;
+          }
         }
 
         for (let index = history.length - 1; index >= 0; index -= 1) {

--- a/src/node/services/ptc/toolBridge.test.ts
+++ b/src/node/services/ptc/toolBridge.test.ts
@@ -251,6 +251,45 @@ describe("ToolBridge", () => {
       expect(result).toEqual({ echoed: { query: "eng" } });
     });
 
+    it("normalizes a zero-argument call to empty args", async () => {
+      // Guests may call mux.tool() with no arguments. Providers always send an
+      // args object and downstream consumers (MCP servers, Zod object schemas)
+      // assume one — undefined must become {} so the call behaves like the
+      // provider path instead of dying with an opaque TypeError downstream.
+      const mcpExecute = mock((args: unknown) => ({ echoed: args }));
+      const zodExecute = mock(() => ({ ok: true }));
+      const tools: Record<string, Tool> = {
+        mcp_list: {
+          description: "MCP-style tool with only optional params",
+          inputSchema: jsonSchema<{ limit?: number }>({
+            type: "object",
+            properties: { limit: { type: "number" } },
+          }),
+          execute: (args) => Promise.resolve(mcpExecute(args)),
+        },
+        file_read: createMockTool("file_read", z.object({}), zodExecute),
+      };
+
+      const bridge = new ToolBridge(tools);
+
+      let registeredMux: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+      const mockRegisterObject = mock(
+        (name: string, obj: Record<string, (...args: unknown[]) => Promise<unknown>>) => {
+          if (name === "mux") registeredMux = obj;
+          return undefined;
+        }
+      );
+      bridge.register(createMockRuntime({ registerObject: mockRegisterObject }));
+
+      const mcpList = registeredMux.mcp_list as (...args: unknown[]) => Promise<unknown>;
+      await mcpList();
+      expect(mcpExecute).toHaveBeenCalledWith({});
+
+      const fileRead = registeredMux.file_read as (...args: unknown[]) => Promise<unknown>;
+      await fileRead();
+      expect(zodExecute).toHaveBeenCalledTimes(1);
+    });
+
     it("honors a jsonSchema wrapper's custom validator (reject + normalize)", async () => {
       const mockExecute = mock((args: unknown) => ({ echoed: args }));
       const tools: Record<string, Tool> = {

--- a/src/node/services/ptc/toolBridge.ts
+++ b/src/node/services/ptc/toolBridge.ts
@@ -423,6 +423,15 @@ export class ToolBridge {
     args: unknown,
     abortSignal?: AbortSignal
   ): Promise<unknown> {
+    // Guests may call a capability with zero arguments (mux.tool()). Provider
+    // tool calls always deliver an args object, and downstream consumers (MCP
+    // servers, Zod object schemas) assume one — passing undefined through
+    // produced opaque TypeErrors instead of readable validation errors.
+    // Treat a zero-arg call as the canonical empty-args call.
+    if (args === undefined) {
+      args = {};
+    }
+
     // AI SDK tools carry their schema on 'inputSchema'; some legacy tools use 'parameters'.
     const toolRecord = tool as { inputSchema?: unknown; parameters?: unknown };
     const schema = toolRecord.inputSchema ?? toolRecord.parameters;

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import type { ProvidersConfigMap } from "@/common/orpc/types";
-import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
+import { StreamEndEventSchema, ToolCallStartEventSchema } from "@/common/orpc/schemas/stream";
 import type {
   CompletedMessagePart,
   ToolCallExecutionStartEvent,
@@ -356,6 +356,50 @@ describe("StreamManager - workflow run attachments", () => {
       runId: "wfr_race",
       timestamp: timestamp + 1,
     });
+  });
+});
+
+describe("StreamManager - nested tool call normalization", () => {
+  test("normalizes zero-arg nested calls to {} for the persisted record and the wire event", () => {
+    const streamManager = new StreamManager(historyService);
+    const workspaceId = "nested-normalize-workspace";
+    const messageId = "nested-normalize-message";
+    const timestamp = Date.now();
+    const parts: CompletedMessagePart[] = [
+      {
+        type: "dynamic-tool",
+        toolCallId: "parent-1",
+        toolName: "code_execution",
+        input: { code: "mux.linear_list_teams()" },
+        state: "input-available",
+        timestamp,
+      },
+    ];
+    const streamInfo = createStreamInfoForTests({ messageId, parts });
+    getWorkspaceStreamsForTests(streamManager).set(workspaceId, streamInfo);
+
+    const events: unknown[] = [];
+    streamManager.on("tool-call-start", (event: unknown) => events.push(event));
+
+    streamManager.emitNestedToolEvent(workspaceId, messageId, {
+      type: "tool-call-start",
+      callId: "nested-1",
+      toolName: "linear_list_teams",
+      // Zero-argument guest call: JSON cannot represent undefined, so both the
+      // persisted record and the wire event must carry {} instead.
+      args: undefined,
+      parentToolCallId: "parent-1",
+      startTime: timestamp,
+    });
+
+    const parentPart = parts[0] as { nestedCalls?: Array<{ input?: unknown }> };
+    expect(parentPart.nestedCalls).toHaveLength(1);
+    expect(parentPart.nestedCalls?.[0]?.input).toEqual({});
+
+    // The live event must survive oRPC output validation (args key required).
+    expect(events).toHaveLength(1);
+    expect(ToolCallStartEventSchema.safeParse(events[0]).success).toBe(true);
+    expect((events[0] as { args?: unknown }).args).toEqual({});
   });
 });
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -2312,6 +2312,13 @@ export class StreamManager extends EventEmitter {
       error?: string;
     }
   ): void {
+    // Kernel guests can call capabilities with zero arguments. JSON.stringify
+    // drops an `args: undefined` key, and the wire schema requires args on
+    // tool-call-start, so an unnormalized event would fail oRPC output
+    // validation and kill every live onChat subscription. Normalize to {} —
+    // the same shape a provider zero-arg tool call carries.
+    const args = event.args === undefined ? {} : event.args;
+
     // Persist nested calls to streamInfo.parts for crash/interrupt resilience
     const streamInfo = this.workspaceStreams.get(workspaceId as WorkspaceId);
     if (streamInfo) {
@@ -2328,7 +2335,7 @@ export class StreamManager extends EventEmitter {
           nestedCalls.push({
             toolCallId: event.callId,
             toolName: event.toolName,
-            input: event.args,
+            input: args,
             state: "input-available",
             timestamp: event.startTime,
           });
@@ -2358,7 +2365,7 @@ export class StreamManager extends EventEmitter {
         messageId,
         toolCallId: event.callId,
         toolName: event.toolName,
-        args: event.args,
+        args,
         tokens: 0, // Nested calls don't count toward stream tokens
         timestamp: event.startTime,
         parentToolCallId: event.parentToolCallId,


### PR DESCRIPTION
## Summary

One malformed persisted assistant row permanently bricked `workspace.onChat` for an entire workspace: a `code_execution` part recorded a nested kernel call made with zero arguments, `JSON.stringify` dropped the `input: undefined` key on persist, and the strict `NestedToolCallSchema` then rejected the row during replay output validation — killing the event iterator on every subscription (`Event iterator validation failed`). This PR heals such rows at the schema level, makes replay self-healing against any row that still fails wire validation, and normalizes zero-arg nested calls at write time so new rows can never be persisted without `input`.

## Background

Hit in production (server `v0.28.3-nightly.99`): a workspace's chat could no longer be fetched at all — the replay died after 5 events on a single row (seq 65) containing `mux.linear_get_issue_status()` called with no arguments. The zero-arg call also produced a `Cannot read properties of undefined (reading 'length')` TypeError inside the tool handler at call time, and the live `tool-call-start` event failed the same way mid-stream. One bad line in `chat.jsonl` should never brick a workspace (see AGENTS.md self-healing rules).

## Implementation

Four layers, from data compatibility to prevention:

1. **Schema heal** (`src/common/orpc/schemas/message.ts`, `src/common/types/message.ts`): `NestedToolCallSchema.input` is now optional, so existing rows missing the key validate on read. Consumers treat a missing `input` as `{}`.
2. **Replay self-healing** (`src/node/services/agentSession.ts`): every replayed history row is gated through `safeParse` against the wire schema; a row that fails is skipped and logged instead of propagating a fatal iterator validation error. A single corrupt row now costs that row, not the workspace.
3. **Live-event normalization** (`src/node/services/streamManager.ts`): nested calls with missing args stream and persist as `{}`, so the live `tool-call-start` path and newly persisted `nestedCalls` always carry an input.
4. **Kernel boundary** (`src/node/services/ptc/toolBridge.ts`): a zero-arg capability invocation is treated as `{}`, matching provider semantics — tools return readable validation errors instead of throwing TypeErrors.

## Validation

- New tests: replay skips a corrupt row while delivering the remaining rows plus `caught-up`; legacy nested-call rows without `input` replay successfully; streamManager and toolBridge normalization paths.
- Reproduced the original failure over the wire against a live server, then verified end-to-end (dev-server seeded with a copy of the real broken session) that replay delivers all rows — including the previously fatal 414 KB one — and reaches `caught-up`.
- `make static-check` and the touched test suites (`agentSession.replaySelfHealing`, `streamManager`, `toolBridge`) pass locally.

## Risks

Low. The schema change is a strict loosening (accepts previously rejected rows; all previously valid rows behave identically). The replay `safeParse` gate only alters behavior for rows that would previously hard-fail the whole subscription; worst case a corrupt row is omitted from the transcript instead of bricking fetch, with a log line for diagnosis. Affected area: onChat replay/streaming of nested tool calls.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$29.04`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=29.04 -->
