### PR TITLE
🤖 fix(pr-status): resilient PR badge lookup fallbacks

### DIFF
--- a/src/browser/stores/PRStatusStore.detectScript.test.ts
+++ b/src/browser/stores/PRStatusStore.detectScript.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { DETECT_PR_SCRIPT } from "./PRStatusStore";
+
+const LOCAL_BRANCH = "local-branch";
+const FIELDS =
+  "number,url,state,mergeable,mergeStateStatus,title,isDraft,headRefName,baseRefName,statusCheckRollup";
+const GH_SHIM = [
+  "#!/usr/bin/env bash",
+  `printf '%s\n' "$*" >> "$GH_LOG"`,
+  'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then',
+  '  if [ "$3" = "--json" ]; then',
+  `    if [ -n "$GH_ARGLESS_JSON" ]; then printf '%s\n' "$GH_ARGLESS_JSON"; exit 0; fi`,
+  "    exit 1",
+  "  fi",
+  '  if [ "$3" = "$GH_VIEW_SELECTOR" ] && [ -n "$GH_VIEW_JSON" ]; then',
+  `    printf '%s\n' "$GH_VIEW_JSON"`,
+  "    exit 0",
+  "  fi",
+  "  exit 1",
+  "fi",
+  'if [ "$1" = "api" ]; then',
+  '  if [ "$GH_API_EXIT" = "1" ]; then exit 1; fi',
+  "  printf '%s\n' \"${GH_API_NUM-}\"",
+  "  exit 0",
+  "fi",
+  "exit 1",
+  "",
+].join("\n");
+
+function run(command: string[], cwd: string): string {
+  const result = Bun.spawnSync(command, { cwd, stdout: "pipe", stderr: "pipe" });
+  if (result.exitCode !== 0) {
+    throw new Error(new TextDecoder().decode(result.stderr));
+  }
+  return new TextDecoder().decode(result.stdout).trim();
+}
+
+describe("DETECT_PR_SCRIPT", () => {
+  let tempDir: string;
+  let repoDir: string;
+  let fakeBin: string;
+  let logPath: string;
+  let headSha: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "xum-detect-pr-"));
+    repoDir = join(tempDir, "repo");
+    fakeBin = join(tempDir, "bin");
+    logPath = join(tempDir, "gh.log");
+
+    run(["mkdir", "-p", repoDir, fakeBin], tempDir);
+    run(["git", "init", "-b", LOCAL_BRANCH], repoDir);
+    run(["git", "config", "user.email", "test@example.com"], repoDir);
+    run(["git", "config", "user.name", "Test User"], repoDir);
+    run(["git", "commit", "--allow-empty", "-m", "initial"], repoDir);
+    headSha = run(["git", "rev-parse", "HEAD"], repoDir);
+
+    await writeFile(join(fakeBin, "gh"), GH_SHIM);
+    await chmod(join(fakeBin, "gh"), 0o755);
+    await writeFile(logPath, "");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function detect(env: Record<string, string> = {}) {
+    const result = Bun.spawnSync(["bash", "-c", DETECT_PR_SCRIPT], {
+      cwd: repoDir,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+        GH_LOG: logPath,
+        ...env,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: new TextDecoder().decode(result.stdout),
+    };
+  }
+
+  async function invocations(): Promise<string[]> {
+    const contents = (await readFile(logPath, "utf8")).trim();
+    return contents ? contents.split("\n") : [];
+  }
+
+  it("returns the argument-less branch match without fallbacks", async () => {
+    const json = '{"number":1,"url":"https://github.com/coder/xum/pull/1"}';
+
+    const result = detect({ GH_ARGLESS_JSON: json });
+
+    expect(result).toEqual({ exitCode: 0, stdout: `${json}\n` });
+    expect(await invocations()).toEqual([`pr view --json ${FIELDS}`]);
+  });
+
+  it("falls back to a differently named tracked merge ref", async () => {
+    const json = '{"number":2,"url":"https://github.com/coder/xum/pull/2"}';
+    run(["git", "config", `branch.${LOCAL_BRANCH}.merge`, "refs/heads/mike/other"], repoDir);
+
+    const result = detect({ GH_VIEW_SELECTOR: "mike/other", GH_VIEW_JSON: json });
+
+    expect(result).toEqual({ exitCode: 0, stdout: `${json}\n` });
+    expect(await invocations()).toEqual([
+      `pr view --json ${FIELDS}`,
+      `pr view mike/other --json ${FIELDS}`,
+    ]);
+  });
+
+  it("skips a tracked merge ref equal to the local branch", async () => {
+    const json = '{"number":3,"url":"https://github.com/coder/xum/pull/3"}';
+    run(["git", "config", `branch.${LOCAL_BRANCH}.merge`, `refs/heads/${LOCAL_BRANCH}`], repoDir);
+
+    const result = detect({ GH_API_NUM: "3", GH_VIEW_SELECTOR: "3", GH_VIEW_JSON: json });
+
+    expect(result).toEqual({ exitCode: 0, stdout: `${json}\n` });
+    expect(await invocations()).toEqual([
+      `pr view --json ${FIELDS}`,
+      `api repos/{owner}/{repo}/commits/${headSha}/pulls --jq [.[] | select(.state == "open")][0].number`,
+      `pr view 3 --json ${FIELDS}`,
+    ]);
+  });
+
+  it("falls back from an untracked branch to an open PR containing HEAD", async () => {
+    const json = '{"number":123,"url":"https://github.com/coder/xum/pull/123"}';
+
+    const result = detect({ GH_API_NUM: "123", GH_VIEW_SELECTOR: "123", GH_VIEW_JSON: json });
+
+    expect(result).toEqual({ exitCode: 0, stdout: `${json}\n` });
+    expect(await invocations()).toEqual([
+      `pr view --json ${FIELDS}`,
+      `api repos/{owner}/{repo}/commits/${headSha}/pulls --jq [.[] | select(.state == "open")][0].number`,
+      `pr view 123 --json ${FIELDS}`,
+    ]);
+  });
+
+  it.each(["null", ""])("returns no PR when the commit lookup yields %p", async (apiNum) => {
+    const result = detect({ GH_API_NUM: apiNum });
+
+    expect(result).toEqual({ exitCode: 0, stdout: '{"no_pr":true}\n' });
+    expect(await invocations()).toEqual([
+      `pr view --json ${FIELDS}`,
+      `api repos/{owner}/{repo}/commits/${headSha}/pulls --jq [.[] | select(.state == "open")][0].number`,
+    ]);
+  });
+
+  it("returns no PR with exit code zero when every lookup fails", async () => {
+    const result = detect({ GH_API_EXIT: "1" });
+
+    expect(result).toEqual({ exitCode: 0, stdout: '{"no_pr":true}\n' });
+    expect(await invocations()).toEqual([
+      `pr view --json ${FIELDS}`,
+      `api repos/{owner}/{repo}/commits/${headSha}/pulls --jq [.[] | select(.state == "open")][0].number`,
+    ]);
+  });
+});

--- a/src/browser/stores/PRStatusStore.ts
+++ b/src/browser/stores/PRStatusStore.ts
@@ -3,13 +3,13 @@
  *
  * Architecture:
  * - Lives outside React lifecycle (stable references)
- * - Detects workspace PR from current branch via `gh pr view`
+ * - Detects workspace PR via branch, tracked merge ref, then commit SHA fallbacks
  * - Caches status with TTL
  * - Refreshes on focus (like GitStatusStore)
  * - Notifies subscribers when status changes
  *
  * PR detection:
- * - Branch-based: Runs `gh pr view` without URL to detect PR for current branch
+ * - Tries `gh pr view` for the current branch, its tracked merge ref, then its commit SHA
  */
 
 import type { RouterClient } from "@orpc/server";
@@ -57,6 +57,26 @@ const STACK_CACHE_TTL_MS = 60_000;
 // GraphQL query for merge queue data (not available in `gh pr view --json`).
 const MERGE_QUEUE_QUERY =
   "query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){mergeQueueEntry{state position}}}}";
+
+export const DETECT_PR_SCRIPT = `fields='number,url,state,mergeable,mergeStateStatus,title,isDraft,headRefName,baseRefName,statusCheckRollup'
+if out=$(gh pr view --json "$fields" 2>/dev/null); then printf '%s\n' "$out"; exit 0; fi
+branch=$(git branch --show-current 2>/dev/null)
+merge_ref=$(git config "branch.$branch.merge" 2>/dev/null)
+merge_ref=\${merge_ref#refs/heads/}
+# The tracked merge ref covers local branches tracking a differently named remote branch.
+if [ -n "$merge_ref" ] && [ "$merge_ref" != "$branch" ]; then
+  if out=$(gh pr view "$merge_ref" --json "$fields" 2>/dev/null); then printf '%s\n' "$out"; exit 0; fi
+fi
+sha=$(git rev-parse HEAD 2>/dev/null)
+if [ -n "$sha" ]; then
+  # The SHA lookup is the only fallback with zero local hints after a differently named refspec push.
+  # Open-only avoids matching the merged PR that introduced an ancestor of a fresh workspace HEAD.
+  num=$(gh api "repos/{owner}/{repo}/commits/$sha/pulls" --jq '[.[] | select(.state == "open")][0].number' 2>/dev/null)
+  if [ -n "$num" ] && [ "$num" != "null" ]; then
+    if out=$(gh pr view "$num" --json "$fields" 2>/dev/null); then printf '%s\n' "$out"; exit 0; fi
+  fi
+fi
+echo '{"no_pr":true}'`;
 
 interface PersistedPRStatus {
   prLink: GitHubPRLink | null;
@@ -595,7 +615,7 @@ export class PRStatusStore {
   }
 
   /**
-   * Detect PR for workspace's current branch via `gh pr view`.
+   * Detect a workspace PR using branch, tracked merge ref, and commit SHA fallbacks.
    */
   private async detectWorkspacePR(workspaceId: string): Promise<void> {
     if (!this.client || !this.isActive) return;
@@ -611,13 +631,12 @@ export class PRStatusStore {
     this.workspacePRSubscriptions.bump(workspaceId);
 
     try {
-      // Run gh pr view without URL - detects PR for current branch
       const result = await this.client.workspace.executeBash({
         workspaceId,
-        script: `gh pr view --json number,url,state,mergeable,mergeStateStatus,title,isDraft,headRefName,baseRefName,statusCheckRollup 2>/dev/null || echo '{"no_pr":true}'`,
+        script: DETECT_PR_SCRIPT,
         // gh requires the runtime environment for devcontainer workspaces where
         // the CLI / auth may only exist inside the container.
-        options: repoRootBashOptions(15),
+        options: repoRootBashOptions(30),
       });
 
       if (!this.isActive) return;


### PR DESCRIPTION
## Problem

The workspace PR badge resolves its PR with an argument-less `gh pr view`, which matches by local branch name only. A PR whose head was pushed with an explicit refspec from a differently named local branch (e.g. an auto-generated worktree branch pushed to `refs/heads/mike/<topic>` with no upstream tracking) is invisible: the lookup returns nothing and the badge stays blank.

## Change

`detectWorkspacePR` now runs a single combined bash script (`DETECT_PR_SCRIPT`, still one `executeBash` round trip, unchanged JSON contract) that falls through three lookups:

1. `gh pr view --json ...` for the current branch (unchanged primary).
2. The tracked merge ref: `git config branch.<cur>.merge`, stripped of `refs/heads/`, skipped when unset or equal to the local name.
3. Commit SHA: `gh api repos/{owner}/{repo}/commits/<HEAD>/pulls` filtered to **open** PRs via gh's built-in `--jq`, resolved back through `gh pr view <number>` so the payload shape stays identical.

The SHA lookup is the only fallback that works with zero local hints after a refspec push without tracking. The open-only filter prevents a false-positive badge on fresh branches whose HEAD is an ancestor of main (the endpoint would otherwise return the merged PR that introduced that commit). Timeout raised 15s -> 30s for the worst-case chain.

## Tests

`PRStatusStore.detectScript.test.ts` executes the exported script with real bash in a temp git repo against a logging `gh` shim: argument-less hit, tracked-ref hit, same-name-ref skip, SHA-fallback hit, and all-fail -> `{"no_pr":true}` with exit 0. `make static-check` and `bun test PRStatusStore` (24 pass) are green.

Dogfood UAT ran remotely via Coder Agents and passed: all four badge scenarios (same-name regression, refspec-push-without-tracking SHA fallback, tracked-ref fallback, fresh-main false-positive guard) verified in the served Xum UI with screenshots, git ground truth, and console captures at this exact head.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `max` • Cost: `$32.26`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=max costs=32.26 -->

