### PR TITLE
fix: cascade-remove inactive descendants when deleting archived workspaces

### DIFF
--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8813,11 +8813,14 @@ export class TaskService implements AgentTaskIntegration {
 
     // Sort by depth (deepest first) so leaf children are removed before their parents.
     // Ties are broken by insertion order (stable sort).
+    // Cap the parent-chain walk at ids.length to avoid hanging on corrupted
+    // parentWorkspaceId cycles (depth can never exceed the descendant count).
+    const maxDepth = ids.length;
     const depthById = new Map<string, number>();
     for (const id of ids) {
       let depth = 0;
       let current: string | undefined = id;
-      while (current != null && current !== workspaceId) {
+      while (current != null && current !== workspaceId && depth < maxDepth) {
         depth++;
         current = index.parentById.get(current);
       }

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8797,6 +8797,36 @@ export class TaskService implements AgentTaskIntegration {
     return this.listDescendantAgentTaskIdsFromIndex(index, workspaceId).length > 0;
   }
 
+  /**
+   * List all descendant agent task IDs sorted deepest-first so callers can
+   * cascade-remove children before their parents without tripping the orphan guard.
+   */
+  listDescendantAgentTaskIdsDeepestFirst(workspaceId: string): string[] {
+    assert(
+      workspaceId.length > 0,
+      "listDescendantAgentTaskIdsDeepestFirst: workspaceId must be non-empty"
+    );
+
+    const cfg = this.config.loadConfigOrDefault();
+    const index = this.buildAgentTaskIndex(cfg);
+    const ids = this.listDescendantAgentTaskIdsFromIndex(index, workspaceId);
+
+    // Sort by depth (deepest first) so leaf children are removed before their parents.
+    // Ties are broken by insertion order (stable sort).
+    const depthById = new Map<string, number>();
+    for (const id of ids) {
+      let depth = 0;
+      let current: string | undefined = id;
+      while (current != null && current !== workspaceId) {
+        depth++;
+        current = index.parentById.get(current);
+      }
+      depthById.set(id, depth);
+    }
+
+    return ids.sort((a, b) => (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0));
+  }
+
   hasActiveDescendantAgentTasksForWorkspace(workspaceId: string): boolean {
     assert(
       workspaceId.length > 0,

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -8827,6 +8827,76 @@ export class TaskService implements AgentTaskIntegration {
     return ids.sort((a, b) => (depthById.get(b) ?? 0) - (depthById.get(a) ?? 0));
   }
 
+  /**
+   * Cascade-remove all inactive descendant agent tasks deepest-first.
+   * Must be called while the task-tree lifecycle lock is already held (the caller
+   * in WorkspaceService.remove() acquires it). Includes all safeguards from
+   * removeInactiveDescendantAgentTask: active/streaming checks, git-patch-artifact
+   * wait, tombstone persistence, and force-flag passthrough.
+   */
+  async cascadeRemoveInactiveDescendantsWhileTaskTreeLocked(
+    workspaceId: string,
+    force: boolean
+  ): Promise<Result<void>> {
+    const descendantIds = this.listDescendantAgentTaskIdsDeepestFirst(workspaceId);
+
+    for (const descendantId of descendantIds) {
+      const config = this.config.loadConfigOrDefault();
+      const entry = findWorkspaceEntry(config, descendantId);
+      if (entry == null) continue; // already removed
+
+      // Safety: active tasks should have been caught by the guard in removeUnlocked,
+      // but double-check to avoid removing a task that became active in the meantime.
+      if (
+        this.isActiveAgentTaskEntry({ ...entry.workspace, projectPath: entry.projectPath }) ||
+        this.aiService.isStreaming(descendantId)
+      ) {
+        return Err(
+          `Descendant workspace ${descendantId} is still active. Stop it before removing.`
+        );
+      }
+
+      const result = await this.gitPatchArtifactService.withOperationLock(
+        descendantId,
+        async () => {
+          // Wait for any in-flight format-patch job before removal so the artifact
+          // isn't lost. Refuse removal if a durable pending marker remains (needs the
+          // child worktree to recover).
+          await this.gitPatchArtifactService.waitForGeneration(descendantId);
+          const parentWsId = entry.workspace.parentWorkspaceId;
+          if (parentWsId) {
+            const patchArtifact = await readSubagentGitPatchArtifact(
+              path.join(this.config.sessionsDir, parentWsId),
+              descendantId
+            );
+            if (patchArtifact?.status === "pending") {
+              return Err(
+                `Cannot cascade-remove descendant ${descendantId}: git patch artifact is still pending.`
+              );
+            }
+          }
+
+          const tombstoneResult = await this.persistRemovedAgentTaskTombstones(descendantId);
+          if (!tombstoneResult.success) {
+            return Err(
+              `Failed to persist tombstones for descendant ${descendantId}: ${tombstoneResult.error}`
+            );
+          }
+
+          return await this.workspaceService.removeWhileTaskTreeLocked(descendantId, force);
+        }
+      );
+
+      if (!result.success) {
+        return Err(
+          `Failed to cascade-remove descendant workspace ${descendantId}: ${result.error}`
+        );
+      }
+    }
+
+    return Ok(undefined);
+  }
+
   hasActiveDescendantAgentTasksForWorkspace(workspaceId: string): boolean {
     assert(
       workspaceId.length > 0,

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -65,6 +65,7 @@ export function makeAgentTaskIntegrationFake(
       operation(),
     hasDescendantAgentTasks: () => false,
     hasActiveDescendantAgentTasksForWorkspace: () => false,
+    listDescendantAgentTaskIdsDeepestFirst: () => [],
     hasActiveTopLevelWorkflowRunsForWorkspace: () => Promise.resolve(false),
     getAgentTaskStatus: () => undefined,
     resetAutoResumeCount: () => undefined,

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -65,7 +65,7 @@ export function makeAgentTaskIntegrationFake(
       operation(),
     hasDescendantAgentTasks: () => false,
     hasActiveDescendantAgentTasksForWorkspace: () => false,
-    listDescendantAgentTaskIdsDeepestFirst: () => [],
+    cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
     hasActiveTopLevelWorkflowRunsForWorkspace: () => Promise.resolve(false),
     getAgentTaskStatus: () => undefined,
     resetAutoResumeCount: () => undefined,

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -514,7 +514,10 @@ export interface AgentTaskIntegration {
   withTaskTreeLifecycleLock<T>(workspaceId: string, operation: () => Promise<T>): Promise<T>;
   hasDescendantAgentTasks(workspaceId: string): boolean;
   hasActiveDescendantAgentTasksForWorkspace(workspaceId: string): boolean;
-  listDescendantAgentTaskIdsDeepestFirst(workspaceId: string): string[];
+  cascadeRemoveInactiveDescendantsWhileTaskTreeLocked(
+    workspaceId: string,
+    force: boolean
+  ): Promise<Result<void>>;
   hasActiveTopLevelWorkflowRunsForWorkspace(workspaceId: string): Promise<boolean>;
   getAgentTaskStatus(workspaceId: string): AgentTaskStatus | null | undefined;
   resetAutoResumeCount(workspaceId: string): void;

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -514,6 +514,7 @@ export interface AgentTaskIntegration {
   withTaskTreeLifecycleLock<T>(workspaceId: string, operation: () => Promise<T>): Promise<T>;
   hasDescendantAgentTasks(workspaceId: string): boolean;
   hasActiveDescendantAgentTasksForWorkspace(workspaceId: string): boolean;
+  listDescendantAgentTaskIdsDeepestFirst(workspaceId: string): string[];
   hasActiveTopLevelWorkflowRunsForWorkspace(workspaceId: string): Promise<boolean>;
   getAgentTaskStatus(workspaceId: string): AgentTaskStatus | null | undefined;
   resetAutoResumeCount(workspaceId: string): void;

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -12378,7 +12378,7 @@ describe("WorkspaceService remove lifecycle coordination", () => {
       makeAgentTaskIntegrationFake({
         withTaskTreeLifecycleLock: runWithTaskTreeLifecycleLock,
         hasActiveDescendantAgentTasksForWorkspace,
-        cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: mock(async () => Ok(undefined)),
+        cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: mock(() => Promise.resolve(Ok(undefined))),
       })
     );
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -12378,7 +12378,7 @@ describe("WorkspaceService remove lifecycle coordination", () => {
       makeAgentTaskIntegrationFake({
         withTaskTreeLifecycleLock: runWithTaskTreeLifecycleLock,
         hasActiveDescendantAgentTasksForWorkspace,
-        listDescendantAgentTaskIdsDeepestFirst: mock(() => []),
+        cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: mock(async () => Ok(undefined)),
       })
     );
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -12378,7 +12378,9 @@ describe("WorkspaceService remove lifecycle coordination", () => {
       makeAgentTaskIntegrationFake({
         withTaskTreeLifecycleLock: runWithTaskTreeLifecycleLock,
         hasActiveDescendantAgentTasksForWorkspace,
-        cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: mock(() => Promise.resolve(Ok(undefined))),
+        cascadeRemoveInactiveDescendantsWhileTaskTreeLocked: mock(() =>
+          Promise.resolve(Ok(undefined))
+        ),
       })
     );
 

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -12347,7 +12347,7 @@ describe("WorkspaceService assertPricedModelForBudgetedGoal", () => {
 });
 
 describe("WorkspaceService remove lifecycle coordination", () => {
-  test("checks descendant tasks while holding the task-tree lifecycle lock", async () => {
+  test("blocks removal when active descendant tasks exist", async () => {
     const workspaceId = "parent-remove-lifecycle";
     const workspaceService = createWorkspaceServiceForTest({
       config: {
@@ -12370,24 +12370,25 @@ describe("WorkspaceService remove lifecycle coordination", () => {
         insideLifecycleLock = false;
       }
     };
-    const hasDescendantAgentTasks = mock(() => {
+    const hasActiveDescendantAgentTasksForWorkspace = mock(() => {
       expect(insideLifecycleLock).toBe(true);
       return true;
     });
     workspaceService.setAgentTaskIntegration(
       makeAgentTaskIntegrationFake({
         withTaskTreeLifecycleLock: runWithTaskTreeLifecycleLock,
-        hasDescendantAgentTasks,
+        hasActiveDescendantAgentTasksForWorkspace,
+        listDescendantAgentTaskIdsDeepestFirst: mock(() => []),
       })
     );
 
     expect(await workspaceService.remove(workspaceId, true)).toEqual(
       Err(
-        "This workspace has descendant sub-agent workspaces. Remove those descendants deepest-first before removing their parent."
+        "This workspace has active descendant sub-agent workspaces. Stop them before removing their parent."
       )
     );
     expect(withTaskTreeLifecycleLock).toHaveBeenCalledWith(workspaceId, expect.any(Function));
-    expect(hasDescendantAgentTasks).toHaveBeenCalledWith(workspaceId);
+    expect(hasActiveDescendantAgentTasksForWorkspace).toHaveBeenCalledWith(workspaceId);
   });
 });
 

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -5558,15 +5558,15 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
         return Err(DESCENDANT_WORKSPACE_REMOVE_ERROR);
       }
 
-      const descendantIds =
-        this.agentTaskIntegration?.listDescendantAgentTaskIdsDeepestFirst(workspaceId) ?? [];
-      for (const descendantId of descendantIds) {
-        const childResult = await this.removeUnlocked(descendantId, true);
-        if (!childResult.success) {
-          return Err(
-            `Failed to cascade-remove descendant workspace ${descendantId}: ${childResult.error}`
-          );
-        }
+      // Cascade-remove inactive descendants through TaskService, which handles
+      // git-patch-artifact waits, ownership tombstones, and force-flag passthrough.
+      const cascadeResult =
+        await this.agentTaskIntegration?.cascadeRemoveInactiveDescendantsWhileTaskTreeLocked(
+          workspaceId,
+          force
+        );
+      if (cascadeResult != null && !cascadeResult.success) {
+        return Err(cascadeResult.error);
       }
 
       // Stop any active stream before deleting metadata/config to avoid tool calls racing with removal.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -642,7 +642,7 @@ type WorkspaceDevToolsCleanup = Pick<DevToolsService, "hasWorkspaceData" | "remo
 const POST_COMPACTION_METADATA_REFRESH_DEBOUNCE_MS = 100;
 
 const DESCENDANT_WORKSPACE_REMOVE_ERROR =
-  "This workspace has descendant sub-agent workspaces. Remove those descendants deepest-first before removing their parent.";
+  "This workspace has active descendant sub-agent workspaces. Stop them before removing their parent.";
 const ACTIVE_DESCENDANT_ARCHIVE_ERROR =
   "This workspace has active descendant sub-agents. Stop them before archiving their parent.";
 const MULTI_PROJECT_WORKSPACES_DISABLED_ERROR = "Multi-project workspaces experiment is disabled";
@@ -5549,8 +5549,24 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
 
     // Try to remove from runtime (filesystem)
     try {
-      if (this.agentTaskIntegration?.hasDescendantAgentTasks(workspaceId) === true) {
+      // Block deletion when active descendants are still running — the user must
+      // stop them first. Inactive (reported/interrupted) descendants are cascade-removed
+      // deepest-first so persistent sub-agents don't permanently block parent deletion.
+      if (
+        this.agentTaskIntegration?.hasActiveDescendantAgentTasksForWorkspace(workspaceId) === true
+      ) {
         return Err(DESCENDANT_WORKSPACE_REMOVE_ERROR);
+      }
+
+      const descendantIds =
+        this.agentTaskIntegration?.listDescendantAgentTaskIdsDeepestFirst(workspaceId) ?? [];
+      for (const descendantId of descendantIds) {
+        const childResult = await this.removeUnlocked(descendantId, true);
+        if (!childResult.success) {
+          return Err(
+            `Failed to cascade-remove descendant workspace ${descendantId}: ${childResult.error}`
+          );
+        }
       }
 
       // Stop any active stream before deleting metadata/config to avoid tool calls racing with removal.


### PR DESCRIPTION
## Summary

Shift+click to bypass the force-delete modal on archived workspaces stopped working after the persistent sub-agent lifecycle change (PR #3825).

## Root Cause

`removeUnlocked` had a guard using `hasDescendantAgentTasks()` that checks for **any** descendants (active or inactive) and fires before the `force` flag is even evaluated. Since PR #3825 made completed sub-agents persist as inactive children in config, any workspace that ever spawned a sub-agent could never be deleted — shift+click bypass, force delete, and normal delete all hit this guard.

## Fix

- **Guard:** Changed from `hasDescendantAgentTasks` → `hasActiveDescendantAgentTasksForWorkspace` — only blocks deletion when children are actively running (queued/starting/running)
- **Cascade removal:** Before removing the parent, cascade-remove all inactive descendants deepest-first via `removeUnlocked(childId, true)`. This mirrors what `task_remove` requires users to do manually but happens automatically during workspace deletion
- **New method:** Added `listDescendantAgentTaskIdsDeepestFirst()` to TaskService for the cascade ordering

## What this fixes

- Shift+click delete on archived workspaces works again (skips force-confirm modal)
- Regular and bulk delete on archived workspaces with finished sub-agents works again
- Active sub-agents still correctly block parent deletion

## Risks

Low — the safe default (block on active descendants) is preserved. Only inactive (reported/interrupted) descendants are cascade-removed, and each child removal goes through the full `removeUnlocked` path including all cleanup steps.