### PR TITLE
🤖 feat: first-class refusal & downgrade analytics in DuckDB

### DIFF
--- a/src/browser/features/Analytics/SqlExplorer.test.ts
+++ b/src/browser/features/Analytics/SqlExplorer.test.ts
@@ -23,21 +23,23 @@ INSERT INTO events (
   output_tokens,
   reasoning_tokens,
   cached_tokens,
-  cache_create_tokens
-) VALUES (
-  'workspace-1',
-  'openai:gpt-4.1',
-  1.25,
-  DATE '2026-03-01',
-  'agent-1',
-  520,
-  'high',
-  100,
-  50,
-  10,
-  5,
-  2
-)
+  cache_create_tokens,
+  tool_name,
+  requested_model,
+  refused_models_json
+) VALUES
+  -- Ordinary committed turn.
+  ('workspace-1', 'openai:gpt-4.1', 1.25, DATE '2026-03-01', 'agent-1', 520, 'high',
+   100, 50, 10, 5, 2, NULL, NULL, NULL),
+  -- Downgraded turn: answered by the fallback model, downgrade metadata on the main row.
+  ('workspace-1', 'openai:gpt-4.1', 0.42, DATE '2026-03-02', 'agent-1', 610, 'high',
+   80, 40, 0, 0, 0, NULL, 'anthropic:fable-1', '["anthropic:fable-1"]'),
+  -- Refused fallback hop recorded on the committed downgraded turn.
+  ('workspace-1', 'anthropic:fable-1', 0, DATE '2026-03-02', 'agent-1', NULL, 'high',
+   12, 0, 0, 0, 0, 'model_fallback_refusal', NULL, NULL),
+  -- Zero-usage terminal refusal on a turn that never committed.
+  ('workspace-1', 'anthropic:fable-1', 0, DATE '2026-03-03', 'agent-1', NULL, NULL,
+   0, 0, 0, 0, 0, 'headless:refused_stream', NULL, NULL)
 `;
 
 type SampleQuery = (typeof SAMPLE_QUERIES)[number];

--- a/src/browser/features/Analytics/SqlExplorer.tsx
+++ b/src/browser/features/Analytics/SqlExplorer.tsx
@@ -41,11 +41,14 @@ export const SAMPLE_QUERIES = [
     sql: "SELECT requested_model, model as answered_model, count(*) as turns\nFROM events\nWHERE requested_model IS NOT NULL AND tool_name IS NULL\nGROUP BY requested_model, model\nORDER BY turns DESC;",
   },
   {
-    // Attempts are attributed to the model that actually ran: refusal rows
-    // already count the refused model's attempt, so the answered side must
-    // NOT coalesce requested_model (that would double-count downgraded turns).
+    // Every events row is one recorded invocation of `model` (committed turns,
+    // tool-internal calls, and billed errored/aborted/refused attempts via
+    // headless:* rows), so attempts = count(*) per model and refusal rows are
+    // a subset — billed non-refusal failures count in the denominator instead
+    // of inflating refusal_pct. Refusal rows already carry the refused model,
+    // so requested_model must not be coalesced in (double-count).
     label: "Refusal Rate by Model",
-    sql: "WITH answered AS (\n  SELECT model, count(*) as n FROM events\n  WHERE tool_name IS NULL AND model IS NOT NULL GROUP BY model\n),\nrefused AS (\n  SELECT model, count(*) as n FROM events\n  WHERE tool_name IN ('model_fallback_refusal', 'headless:refused_stream')\n    AND model IS NOT NULL GROUP BY model\n)\nSELECT COALESCE(a.model, r.model) as model,\n  COALESCE(r.n, 0) as refusals,\n  COALESCE(a.n, 0) + COALESCE(r.n, 0) as attempts,\n  ROUND(100.0 * COALESCE(r.n, 0) / NULLIF(COALESCE(a.n, 0) + COALESCE(r.n, 0), 0), 2) as refusal_pct\nFROM answered a FULL OUTER JOIN refused r USING (model)\nORDER BY refusals DESC;",
+    sql: "WITH attempts AS (\n  SELECT model, count(*) as n FROM events\n  WHERE model IS NOT NULL GROUP BY model\n),\nrefused AS (\n  SELECT model, count(*) as n FROM events\n  WHERE tool_name IN ('model_fallback_refusal', 'headless:refused_stream')\n    AND model IS NOT NULL GROUP BY model\n)\nSELECT a.model,\n  COALESCE(r.n, 0) as refusals,\n  a.n as attempts,\n  ROUND(100.0 * COALESCE(r.n, 0) / a.n, 2) as refusal_pct\nFROM attempts a LEFT JOIN refused r USING (model)\nORDER BY refusals DESC;",
   },
 ];
 

--- a/src/browser/features/Analytics/SqlExplorer.tsx
+++ b/src/browser/features/Analytics/SqlExplorer.tsx
@@ -29,6 +29,24 @@ export const SAMPLE_QUERIES = [
     label: "Tokens by Thinking Level",
     sql: "SELECT thinking_level, sum(input_tokens + output_tokens + reasoning_tokens + cached_tokens + cache_create_tokens) as total_tokens\nFROM events\nWHERE thinking_level IS NOT NULL\nGROUP BY thinking_level\nORDER BY total_tokens DESC;",
   },
+  // Refusal analytics: 'model_fallback_refusal' rows are refused fallback hops
+  // on committed turns; 'headless:refused_stream' rows are refusals on turns
+  // that never committed (terminal refusals, aborted/errored refusal turns).
+  {
+    label: "Refusals per Day",
+    sql: "SELECT date, model, count(*) as refusals\nFROM events\nWHERE tool_name IN ('model_fallback_refusal', 'headless:refused_stream')\nGROUP BY date, model\nORDER BY date ASC;",
+  },
+  {
+    label: "Refusal Downgrades (Requested → Answered)",
+    sql: "SELECT requested_model, model as answered_model, count(*) as turns\nFROM events\nWHERE requested_model IS NOT NULL AND tool_name IS NULL\nGROUP BY requested_model, model\nORDER BY turns DESC;",
+  },
+  {
+    // Attempts are attributed to the model that actually ran: refusal rows
+    // already count the refused model's attempt, so the answered side must
+    // NOT coalesce requested_model (that would double-count downgraded turns).
+    label: "Refusal Rate by Model",
+    sql: "WITH answered AS (\n  SELECT model, count(*) as n FROM events\n  WHERE tool_name IS NULL AND model IS NOT NULL GROUP BY model\n),\nrefused AS (\n  SELECT model, count(*) as n FROM events\n  WHERE tool_name IN ('model_fallback_refusal', 'headless:refused_stream')\n    AND model IS NOT NULL GROUP BY model\n)\nSELECT COALESCE(a.model, r.model) as model,\n  COALESCE(r.n, 0) as refusals,\n  COALESCE(a.n, 0) + COALESCE(r.n, 0) as attempts,\n  ROUND(100.0 * COALESCE(r.n, 0) / NULLIF(COALESCE(a.n, 0) + COALESCE(r.n, 0), 0), 2) as refusal_pct\nFROM answered a FULL OUTER JOIN refused r USING (model)\nORDER BY refusals DESC;",
+  },
 ];
 
 interface SqlExplorerProps {

--- a/src/browser/features/Analytics/sqlExplorerSampleQueryRunner.cjs
+++ b/src/browser/features/Analytics/sqlExplorerSampleQueryRunner.cjs
@@ -41,7 +41,11 @@ async function runSampleQuery() {
   try {
     await conn.run(payload.createEventsTableSql);
     await conn.run(payload.seedEventsRowSql);
-    await conn.run(payload.sample.sql);
+    const result = await conn.run(payload.sample.sql);
+    const rows = await result.getRowObjectsJS();
+    // Every sample query must return data against the seeded fixture rows —
+    // an empty result means the query no longer matches what the ETL writes.
+    assert(rows.length > 0, `Sample query "${payload.sample.label}" returned no rows against the seed`);
   } finally {
     conn.closeSync();
     instance.closeSync();

--- a/src/common/analytics/schemaSql.ts
+++ b/src/common/analytics/schemaSql.ts
@@ -27,7 +27,9 @@ CREATE TABLE IF NOT EXISTS events (
   output_tps DOUBLE,
   response_index INTEGER,
   is_sub_agent BOOLEAN DEFAULT false,
-  tool_name TEXT
+  tool_name TEXT,
+  requested_model VARCHAR,
+  refused_models_json VARCHAR
 )
 `;
 

--- a/src/common/orpc/schemas/analytics.ts
+++ b/src/common/orpc/schemas/analytics.ts
@@ -162,6 +162,10 @@ export const EventRowSchema = z.object({
   output_tps: z.number().nullable(),
   response_index: z.number().nullable(),
   is_sub_agent: z.boolean().default(false),
+  // Refusal-fallback downgrade metadata, populated only on the main turn row
+  // (tool_name IS NULL) when the turn was answered by a fallback model.
+  requested_model: z.string().nullable().default(null),
+  refused_models_json: z.string().nullable().default(null),
 });
 export type EventRow = z.infer<typeof EventRowSchema>;
 

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -833,6 +833,29 @@ export interface PersistedToolModelUsage {
 }
 
 /**
+ * PersistedToolModelUsage.toolName marker for a refused fallback attempt.
+ * Analytics keys on this exact string (events.tool_name), the sidecar flatten
+ * path uses it to relabel refusal usage as "refused_stream", and the session
+ * ledger rebuild uses it to skip zero-usage refusal markers (which exist only
+ * so analytics can count refused attempts, never as ledger entries).
+ */
+export const MODEL_FALLBACK_REFUSAL_TOOL_NAME = "model_fallback_refusal";
+
+/** True when any token counter on the usage payload is positive. */
+export function hasTokenUsage(
+  usage: LanguageModelV2Usage | undefined
+): usage is LanguageModelV2Usage {
+  return (
+    usage !== undefined &&
+    ((usage.inputTokens ?? 0) > 0 ||
+      (usage.outputTokens ?? 0) > 0 ||
+      (usage.totalTokens ?? 0) > 0 ||
+      (usage.cachedInputTokens ?? 0) > 0 ||
+      (usage.reasoningTokens ?? 0) > 0)
+  );
+}
+
+/**
  * Record of a model-fallback chain application. `requestedModel` is the model
  * originally asked for; `refusedModels` lists every model that refused, in
  * chain order (the requested model is always the first entry). The effective

--- a/src/node/services/analytics/analyticsWorker.ts
+++ b/src/node/services/analytics/analyticsWorker.ts
@@ -6,13 +6,16 @@ import { log } from "@/node/services/log";
 import { decideSyncPlan, type SyncAction } from "./backfillDecision";
 import { shouldCheckpointAfterSync } from "./checkpointDecision";
 import {
+  CURRENT_ETL_SEMANTICS_VERSION,
   clearWorkspaceAnalyticsState,
   deleteCorruptAnalyticsRows,
   getCurrentPricingFingerprint,
   ingestWorkspace,
+  readStoredEtlSemanticsVersion,
   readStoredPricingFingerprint,
   rebuildAll,
   statSessionChatHistory,
+  storeEtlSemanticsVersion,
   storePricingFingerprint,
 } from "./etl";
 import {
@@ -97,6 +100,10 @@ interface RawQueryData {
 
 const EVENTS_COLUMN_MIGRATIONS_SQL = [
   "ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT",
+  // Refusal-fallback downgrade columns: order must match CREATE_EVENTS_TABLE_SQL
+  // so migrated and fresh DBs share the physical column order the appender uses.
+  "ALTER TABLE events ADD COLUMN IF NOT EXISTS requested_model VARCHAR",
+  "ALTER TABLE events ADD COLUMN IF NOT EXISTS refused_models_json VARCHAR",
 ] as const;
 
 const DELEGATION_ROLLUPS_COLUMN_MIGRATIONS_SQL = [
@@ -192,9 +199,11 @@ async function handleRebuildAll(data: RebuildAllData): Promise<{ workspacesInges
 
   const result = await rebuildAll(getConn(), data.sessionsDir, data.workspaceMetaById ?? {});
   await sweepCorruptRows("rebuildAll", result.failedWorkspaceIds);
-  // A completed rebuild priced everything with the current tables; refresh the
-  // fingerprint so the next sync check does not schedule a redundant rebuild.
+  // A completed rebuild priced everything with the current tables and derived
+  // all current ETL columns; refresh the fingerprint and semantics version so
+  // the next sync check does not schedule a redundant rebuild.
   await storePricingFingerprint(getConn());
+  await storeEtlSemanticsVersion(getConn());
   return { workspacesIngested: result.workspacesIngested };
 }
 
@@ -376,6 +385,11 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   const storedPricingFingerprint = await readStoredPricingFingerprint(getConn());
   const pricingFingerprintChanged = storedPricingFingerprint !== getCurrentPricingFingerprint();
 
+  // ETL semantics version: rows ingested before a new derived column existed
+  // (e.g. refusal-downgrade metadata) must be backfilled via a full rebuild.
+  const storedEtlSemanticsVersion = await readStoredEtlSemanticsVersion(getConn());
+  const semanticsVersionChanged = storedEtlSemanticsVersion !== CURRENT_ETL_SEMANTICS_VERSION;
+
   const plan = decideSyncPlan({
     eventCount,
     watermarkCount,
@@ -383,6 +397,7 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     watermarkWorkspaceIds,
     hasAnyWatermarkAtOrAboveZero,
     pricingFingerprintChanged,
+    semanticsVersionChanged,
     changedSignalWorkspaceIds,
   });
 
@@ -392,6 +407,10 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
   // crashed repricing rebuild re-triggers on the next sync check.
   if (pricingFingerprintChanged && plan.action !== "full_rebuild") {
     await storePricingFingerprint(getConn());
+  }
+  // Same store-after-success policy for the ETL semantics version.
+  if (semanticsVersionChanged && plan.action !== "full_rebuild") {
+    await storeEtlSemanticsVersion(getConn());
   }
 
   if (plan.action === "noop") {
@@ -416,6 +435,9 @@ async function handleSyncCheck(data: SyncCheckData): Promise<SyncCheckResult> {
     await sweepCorruptRows("syncCheck full_rebuild", failedWorkspaceIds);
     if (pricingFingerprintChanged) {
       await storePricingFingerprint(getConn());
+    }
+    if (semanticsVersionChanged) {
+      await storeEtlSemanticsVersion(getConn());
     }
     await checkpointIfNeeded(plan.action, workspacesIngested, 0);
 

--- a/src/node/services/analytics/backfillDecision.test.ts
+++ b/src/node/services/analytics/backfillDecision.test.ts
@@ -9,6 +9,7 @@ function makeInput(overrides: Partial<SyncPlanInput> = {}): SyncPlanInput {
     watermarkWorkspaceIds: new Set(),
     hasAnyWatermarkAtOrAboveZero: false,
     pricingFingerprintChanged: false,
+    semanticsVersionChanged: false,
     changedSignalWorkspaceIds: new Set(),
     ...overrides,
   };
@@ -264,6 +265,43 @@ describe("decideSyncPlan", () => {
             knownWorkspaceIds: new Set(["ws-1"]),
             watermarkWorkspaceIds: new Set(["ws-1"]),
             pricingFingerprintChanged: true,
+          })
+        )
+      ).toEqual({
+        action: "noop",
+        workspaceIdsToIngest: [],
+        workspaceIdsToPurge: [],
+      });
+    });
+
+    test("returns full_rebuild to backfill existing events when ETL semantics changed", () => {
+      expect(
+        decideSyncPlan(
+          makeInput({
+            eventCount: 10,
+            watermarkCount: 2,
+            knownWorkspaceIds: new Set(["ws-1", "ws-2"]),
+            watermarkWorkspaceIds: new Set(["ws-1", "ws-2"]),
+            hasAnyWatermarkAtOrAboveZero: true,
+            semanticsVersionChanged: true,
+          })
+        )
+      ).toEqual({
+        action: "full_rebuild",
+        workspaceIdsToIngest: [],
+        workspaceIdsToPurge: [],
+      });
+    });
+
+    test("does not rebuild for a semantics change when no events exist", () => {
+      expect(
+        decideSyncPlan(
+          makeInput({
+            eventCount: 0,
+            watermarkCount: 1,
+            knownWorkspaceIds: new Set(["ws-1"]),
+            watermarkWorkspaceIds: new Set(["ws-1"]),
+            semanticsVersionChanged: true,
           })
         )
       ).toEqual({

--- a/src/node/services/analytics/backfillDecision.ts
+++ b/src/node/services/analytics/backfillDecision.ts
@@ -23,6 +23,13 @@ export interface SyncPlanInput {
    */
   pricingFingerprintChanged: boolean;
   /**
+   * True when the ETL semantics version stored in ingest_meta is missing or
+   * outdated: the ETL now derives new columns (e.g. refusal-downgrade
+   * metadata) from already-committed chat.jsonl data, so existing rows lack
+   * them and need one full rebuild to backfill.
+   */
+  semanticsVersionChanged: boolean;
+  /**
    * Watermarked workspaces whose on-disk change signal (chat files +
    * headless-usage sidecar) no longer matches the stored watermark — writes
    * that landed after the last ingest but before an app exit. Without this,
@@ -57,6 +64,13 @@ export function decideSyncPlan(input: SyncPlanInput): SyncPlan {
   // Skipped when the events table is empty: nothing is stale, and the caller
   // persists the new fingerprint after every sync check.
   if (input.pricingFingerprintChanged && input.eventCount > 0) {
+    return REBUILD;
+  }
+
+  // ETL semantics changed (new derived columns) and rows exist → backfill via
+  // full rebuild. Same empty-table skip as the pricing fingerprint: the
+  // caller persists the current version after every sync check.
+  if (input.semanticsVersionChanged && input.eventCount > 0) {
     return REBUILD;
   }
 

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -95,6 +95,7 @@ function makeAssistantLine(
     providerMetadata?: Record<string, unknown>;
     toolModelUsages?: unknown[];
     modelFallback?: unknown;
+    partial?: boolean;
   } = {}
 ): string {
   return JSON.stringify({
@@ -114,6 +115,7 @@ function makeAssistantLine(
       ...(opts.providerMetadata != null ? { providerMetadata: opts.providerMetadata } : {}),
       ...(opts.toolModelUsages != null ? { toolModelUsages: opts.toolModelUsages } : {}),
       ...(opts.modelFallback != null ? { modelFallback: opts.modelFallback } : {}),
+      ...(opts.partial != null ? { partial: opts.partial } : {}),
     },
   });
 }
@@ -656,6 +658,15 @@ describe("appendEvents", () => {
           refusedModels: ["anthropic:fable-1", "  "],
         },
       }),
+      // ModelFallbackRecord invariant violation: the requested model must be
+      // the first refused entry, so a mismatched chain is corrupted history.
+      makeAssistantLine({
+        sequence: 6,
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:other-model"],
+        },
+      }),
     ]);
 
     await ingestWorkspace(conn, workspaceId, sessionDir, {});
@@ -665,11 +676,88 @@ describe("appendEvents", () => {
       "SELECT requested_model, refused_models_json FROM events WHERE workspace_id = ?",
       [workspaceId]
     );
-    expect(rows).toHaveLength(5);
+    expect(rows).toHaveLength(6);
     for (const row of rows) {
       expect(row.requested_model).toBeNull();
       expect(row.refused_models_json).toBeNull();
     }
+  });
+
+  test("interrupted (partial) fallback turns do not count as answered downgrades", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-downgrade-partial";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      // Valid downgrade record, but the turn committed as an interrupted
+      // partial: billed attempt, not an answered downgrade.
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        partial: true,
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1"],
+        },
+      }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, {});
+
+    const rows = await queryRows(
+      conn,
+      "SELECT model, requested_model, refused_models_json FROM events WHERE workspace_id = ?",
+      [workspaceId]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].model).toBe("openai:gpt-4"); // usage still ingested
+    expect(rows[0].requested_model).toBeNull();
+    expect(rows[0].refused_models_json).toBeNull();
+  });
+
+  test("events.model uses the shared attribution key for coder and gateway identities", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-attribution-key";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      // Coder route: answered main row and tool row must key by the pinned
+      // metadata identity so they group with headless sidecar rows (which
+      // recordHeadlessUsageLocked already writes canonically).
+      makeAssistantLine({
+        sequence: 1,
+        model: "coder:prod/claude-opus-4-5",
+        metadataModel: "anthropic:claude-opus-4-5",
+        toolModelUsages: [
+          {
+            toolName: "model_fallback_refusal",
+            timestamp: 1_700_000_000_025,
+            model: "coder:prod/claude-opus-4-5",
+            metadataModel: "anthropic:claude-opus-4-5",
+            usage: { inputTokens: 5, outputTokens: 0, totalTokens: 5 },
+          },
+        ],
+      }),
+      // Gateway route canonicalizes; coder without a pinned identity keeps
+      // its raw (only durable) key.
+      makeAssistantLine({ sequence: 2, model: "mux-gateway:anthropic/claude-opus-4-5" }),
+      makeAssistantLine({ sequence: 3, model: "coder:unmapped/some-model" }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, {});
+
+    const rows = await queryRows(
+      conn,
+      "SELECT model, tool_name FROM events WHERE workspace_id = ? ORDER BY model, tool_name NULLS FIRST",
+      [workspaceId]
+    );
+    expect(rows.map((row) => [row.model, row.tool_name])).toEqual([
+      ["anthropic:claude-opus-4-5", null],
+      ["anthropic:claude-opus-4-5", null],
+      ["anthropic:claude-opus-4-5", "model_fallback_refusal"],
+      ["coder:unmapped/some-model", null],
+    ]);
   });
 
   test("emits one assistant row plus one row per tool model usage with inherited context", async () => {

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -640,6 +640,22 @@ describe("appendEvents", () => {
         sequence: 3,
         modelFallback: { requestedModel: "anthropic:fable-1", refusedModels: [17, null] },
       }),
+      // Partially malformed arrays are rejected wholesale: dropping bad hops
+      // would emit a truncated chain that reads as valid history.
+      makeAssistantLine({
+        sequence: 4,
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1", 42],
+        },
+      }),
+      makeAssistantLine({
+        sequence: 5,
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1", "  "],
+        },
+      }),
     ]);
 
     await ingestWorkspace(conn, workspaceId, sessionDir, {});
@@ -649,7 +665,7 @@ describe("appendEvents", () => {
       "SELECT requested_model, refused_models_json FROM events WHERE workspace_id = ?",
       [workspaceId]
     );
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(5);
     for (const row of rows) {
       expect(row.requested_model).toBeNull();
       expect(row.refused_models_json).toBeNull();

--- a/src/node/services/analytics/etl.test.ts
+++ b/src/node/services/analytics/etl.test.ts
@@ -9,14 +9,17 @@ import {
   appendEvents,
   CHAT_FILE_NAME,
   clearWorkspaceAnalyticsState,
+  CURRENT_ETL_SEMANTICS_VERSION,
   deleteCorruptAnalyticsRows,
   getCurrentPricingFingerprint,
   ingestWorkspace,
   parseWorkspaceFromDisk,
   readPersistedWorkspaceHeadSignature,
+  readStoredEtlSemanticsVersion,
   readStoredPricingFingerprint,
   rebuildAll,
   statSessionChatHistory,
+  storeEtlSemanticsVersion,
   storePricingFingerprint,
 } from "./etl";
 import {
@@ -29,12 +32,23 @@ import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 
 const SUBAGENT_TRANSCRIPTS_DIR_NAME = "subagent-transcripts";
 
+// Pre-tool_name table shape: strips every column added by
+// EVENTS_COLUMN_MIGRATIONS_SQL so migration tests replay the real upgrade
+// path (ALTERs append columns in migration-list order).
 const CREATE_EVENTS_TABLE_WITHOUT_TOOL_NAME_SQL = CREATE_EVENTS_TABLE_SQL.replace(
   "\n  tool_name TEXT,",
   ""
 )
-  .replace("\n  tool_name TEXT", "")
+  .replace("\n  requested_model VARCHAR,", "")
+  .replace("\n  refused_models_json VARCHAR", "")
   .replace(",\n)", "\n)");
+
+// Pre-refusal-columns table shape (tool_name already migrated): the upgrade
+// path current installs take when the refusal-downgrade columns land.
+const CREATE_EVENTS_TABLE_WITHOUT_REFUSAL_COLUMNS_SQL = CREATE_EVENTS_TABLE_SQL.replace(
+  ",\n  requested_model VARCHAR,\n  refused_models_json VARCHAR",
+  ""
+);
 
 const tempDirsToClean: string[] = [];
 const duckDbHandlesToClose: Array<{ instance: DuckDBInstance; conn: DuckDBConnection }> = [];
@@ -80,6 +94,7 @@ function makeAssistantLine(
     ttftMs?: number;
     providerMetadata?: Record<string, unknown>;
     toolModelUsages?: unknown[];
+    modelFallback?: unknown;
   } = {}
 ): string {
   return JSON.stringify({
@@ -98,6 +113,7 @@ function makeAssistantLine(
       ...(opts.ttftMs != null ? { ttftMs: opts.ttftMs } : {}),
       ...(opts.providerMetadata != null ? { providerMetadata: opts.providerMetadata } : {}),
       ...(opts.toolModelUsages != null ? { toolModelUsages: opts.toolModelUsages } : {}),
+      ...(opts.modelFallback != null ? { modelFallback: opts.modelFallback } : {}),
     },
   });
 }
@@ -437,7 +453,13 @@ describe("appendEvents", () => {
     const freshConn = await createTestConn();
     const migratedConn = await createTestConn({
       createEventsTableSql: CREATE_EVENTS_TABLE_WITHOUT_TOOL_NAME_SQL,
-      postCreateEventsSql: ["ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT"],
+      // Mirror EVENTS_COLUMN_MIGRATIONS_SQL order so the migrated physical
+      // column order matches a fresh table (the appender relies on it).
+      postCreateEventsSql: [
+        "ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT",
+        "ALTER TABLE events ADD COLUMN IF NOT EXISTS requested_model VARCHAR",
+        "ALTER TABLE events ADD COLUMN IF NOT EXISTS refused_models_json VARCHAR",
+      ],
     });
     const sessionDir = await createTempSessionDir();
     const workspaceId = "ws-tool-column-order";
@@ -498,6 +520,140 @@ describe("appendEvents", () => {
       },
     ]);
     expect(migratedRows).toEqual(freshRows);
+  });
+
+  test("keeps downgrade columns aligned across fresh and refusal-column-migrated tables", async () => {
+    const freshConn = await createTestConn();
+    const migratedConn = await createTestConn({
+      createEventsTableSql: CREATE_EVENTS_TABLE_WITHOUT_REFUSAL_COLUMNS_SQL,
+      postCreateEventsSql: [
+        "ALTER TABLE events ADD COLUMN IF NOT EXISTS requested_model VARCHAR",
+        "ALTER TABLE events ADD COLUMN IF NOT EXISTS refused_models_json VARCHAR",
+      ],
+    });
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-downgrade-column-order";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1"],
+        },
+      }),
+    ]);
+
+    const parsed = await parseWorkspaceFromDisk(workspaceId, sessionDir, {});
+    expect(parsed).not.toBeNull();
+    assert(
+      parsed,
+      "downgrade column-order test expected parseWorkspaceFromDisk to parse workspace"
+    );
+
+    await appendEvents(freshConn, parsed.events);
+    await appendEvents(migratedConn, parsed.events);
+
+    const selectedSql =
+      "SELECT model, tool_name, requested_model, refused_models_json FROM events WHERE workspace_id = ?";
+    const freshRows = await queryRows(freshConn, selectedSql, [workspaceId]);
+    const migratedRows = await queryRows(migratedConn, selectedSql, [workspaceId]);
+
+    expect(freshRows).toEqual([
+      {
+        model: "openai:gpt-4",
+        tool_name: null,
+        requested_model: "anthropic:fable-1",
+        refused_models_json: '["anthropic:fable-1"]',
+      },
+    ]);
+    expect(migratedRows).toEqual(freshRows);
+  });
+
+  test("populates downgrade columns on the main turn row only", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-downgrade";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1", "openai:gpt-4-mini"],
+        },
+        toolModelUsages: [
+          {
+            toolName: "model_fallback_refusal",
+            timestamp: 1_700_000_000_025,
+            model: "anthropic:fable-1",
+            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          },
+        ],
+      }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, {});
+
+    const rows = await queryRows(
+      conn,
+      "SELECT tool_name, model, requested_model, refused_models_json, input_tokens, total_cost_usd FROM events WHERE workspace_id = ? ORDER BY tool_name NULLS FIRST",
+      [workspaceId]
+    );
+    expect(rows).toHaveLength(2);
+    // Main turn row: answering model + downgrade metadata.
+    expect(rows[0].tool_name).toBeNull();
+    expect(rows[0].model).toBe("openai:gpt-4");
+    expect(rows[0].requested_model).toBe("anthropic:fable-1");
+    expect(rows[0].refused_models_json).toBe('["anthropic:fable-1","openai:gpt-4-mini"]');
+    // Refusal hop row: zero-usage refusals still produce a countable row,
+    // with downgrade metadata left NULL (main-row-only semantics).
+    expect(rows[1].tool_name).toBe("model_fallback_refusal");
+    expect(rows[1].model).toBe("anthropic:fable-1");
+    expect(rows[1].requested_model).toBeNull();
+    expect(rows[1].refused_models_json).toBeNull();
+    expect(parseInteger(rows[1].input_tokens, "hop input_tokens")).toBe(0);
+    expect(Number(rows[1].total_cost_usd)).toBe(0);
+
+    // Delete+reinsert idempotency holds for downgrade rows.
+    await ingestWorkspace(conn, workspaceId, sessionDir, {});
+    expect(await queryEventCount(conn, workspaceId)).toBe(2);
+  });
+
+  test("malformed modelFallback yields NULL downgrade columns without dropping the row", async () => {
+    const conn = await createTestConn();
+    const sessionDir = await createTempSessionDir();
+    const workspaceId = "ws-downgrade-malformed";
+
+    await writeChatJsonl(sessionDir, [
+      makeUserLine(),
+      // Non-record modelFallback.
+      makeAssistantLine({ sequence: 1, modelFallback: "bogus" }),
+      // Wrong field types / empty refusedModels after string filtering.
+      makeAssistantLine({
+        sequence: 2,
+        modelFallback: { requestedModel: 42, refusedModels: ["anthropic:fable-1"] },
+      }),
+      makeAssistantLine({
+        sequence: 3,
+        modelFallback: { requestedModel: "anthropic:fable-1", refusedModels: [17, null] },
+      }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, {});
+
+    const rows = await queryRows(
+      conn,
+      "SELECT requested_model, refused_models_json FROM events WHERE workspace_id = ?",
+      [workspaceId]
+    );
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.requested_model).toBeNull();
+      expect(row.refused_models_json).toBeNull();
+    }
   });
 
   test("emits one assistant row plus one row per tool model usage with inherited context", async () => {
@@ -1430,6 +1586,35 @@ describe("headless usage ingestion", () => {
     expect(await queryEventCount(conn, workspaceId)).toBe(3);
   });
 
+  test("ingests zero-usage refused_stream sidecar rows as countable refusal events", async () => {
+    const conn = await createTestConn();
+    const workspaceId = "headless-refused-ws";
+    const sessionDir = await createTempSessionDir();
+    await writeBasicChatJsonl(sessionDir);
+    await writeHeadlessUsageJsonl(sessionDir, [
+      // Terminal refusal the provider billed nothing for: the row must still
+      // exist so refusal counts include zero-usage refusals.
+      makeHeadlessLine({ source: "refused_stream", inputTokens: 0, outputTokens: 0 }),
+    ]);
+
+    await ingestWorkspace(conn, workspaceId, sessionDir, { projectPath: "/test" });
+
+    const refusedRows = await queryRows(
+      conn,
+      "SELECT tool_name, model, input_tokens, output_tokens, total_cost_usd FROM events WHERE workspace_id = ? AND tool_name = 'headless:refused_stream'",
+      [workspaceId]
+    );
+    expect(refusedRows).toHaveLength(1);
+    expect(refusedRows[0].model).toBe("anthropic:claude-sonnet-4-20250514");
+    expect(parseInteger(refusedRows[0].input_tokens, "input_tokens")).toBe(0);
+    expect(parseInteger(refusedRows[0].output_tokens, "output_tokens")).toBe(0);
+    expect(Number(refusedRows[0].total_cost_usd)).toBe(0);
+
+    // Delete+reinsert idempotency holds for refused_stream rows.
+    await ingestWorkspace(conn, workspaceId, sessionDir, { projectPath: "/test" });
+    expect(await queryEventCount(conn, workspaceId)).toBe(2); // 1 chat + 1 refused
+  });
+
   test("clears stale headless rows when the sidecar disappears", async () => {
     const conn = await createTestConn();
     const workspaceId = "headless-ws-removed";
@@ -1655,6 +1840,48 @@ describe("pricing fingerprint", () => {
     // Idempotent upsert: storing again keeps a single row with the same value.
     await storePricingFingerprint(conn);
     expect(await readStoredPricingFingerprint(conn)).toBe(getCurrentPricingFingerprint());
+  });
+});
+
+describe("etl semantics version", () => {
+  test("round-trips through ingest_meta and starts unset", async () => {
+    const conn = await createTestConn();
+
+    // Missing on pre-upgrade DBs: the sync check treats null as changed and
+    // schedules the one-time backfill rebuild (see decideSyncPlan tests).
+    expect(await readStoredEtlSemanticsVersion(conn)).toBeNull();
+
+    await storeEtlSemanticsVersion(conn);
+    expect(await readStoredEtlSemanticsVersion(conn)).toBe(CURRENT_ETL_SEMANTICS_VERSION);
+  });
+
+  test("full rebuild backfills downgrade columns from pre-existing chat.jsonl", async () => {
+    const conn = await createTestConn();
+    const sessionsDir = await createTempSessionDir();
+    const workspaceDir = path.join(sessionsDir, "ws-backfill");
+    await fs.mkdir(workspaceDir);
+    // Historical committed downgrade turn written before this feature existed.
+    await writeChatJsonl(workspaceDir, [
+      makeUserLine(),
+      makeAssistantLine({
+        model: "openai:gpt-4",
+        modelFallback: {
+          requestedModel: "anthropic:fable-1",
+          refusedModels: ["anthropic:fable-1"],
+        },
+      }),
+    ]);
+
+    await rebuildAll(conn, sessionsDir, {});
+
+    const rows = await queryRows(
+      conn,
+      "SELECT requested_model, refused_models_json FROM events WHERE workspace_id = ? AND tool_name IS NULL",
+      ["ws-backfill"]
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].requested_model).toBe("anthropic:fable-1");
+    expect(rows[0].refused_models_json).toBe('["anthropic:fable-1"]');
   });
 });
 

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -135,11 +135,13 @@ INSERT INTO events (
   tool_execution_ms,
   output_tps,
   response_index,
-  is_sub_agent
+  is_sub_agent,
+  requested_model,
+  refused_models_json
 ) VALUES (
   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
   ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-  ?, ?, ?, ?, ?, ?
+  ?, ?, ?, ?, ?, ?, ?, ?
 )
 `;
 
@@ -196,6 +198,8 @@ async function insertEventRow(
     row.output_tps,
     row.response_index,
     row.is_sub_agent,
+    row.requested_model,
+    row.refused_models_json,
   ]);
 }
 
@@ -290,6 +294,8 @@ export async function appendEvents(conn: DuckDBConnection, events: IngestEvent[]
       appendIntegerOrNull(appender, row.response_index);
       appender.appendBoolean(row.is_sub_agent);
       appendVarcharOrNull(appender, row.tool_name);
+      appendVarcharOrNull(appender, row.requested_model);
+      appendVarcharOrNull(appender, row.refused_models_json);
       appender.endRow();
     }
 
@@ -349,6 +355,9 @@ function buildIngestEventRow(params: {
   durationMs: number | null;
   ttftMs: number | null;
   outputTps: number | null;
+  /** Refusal-fallback downgrade metadata; main turn rows only. */
+  requestedModel?: string | null;
+  refusedModelsJson?: string | null;
 }): {
   parsed: ReturnType<typeof EventRowSchema.safeParse>;
   date: string | null;
@@ -396,6 +405,8 @@ function buildIngestEventRow(params: {
       output_tps: params.outputTps,
       response_index: params.inheritedContext.responseIndex,
       is_sub_agent: params.inheritedContext.isSubAgent,
+      requested_model: params.requestedModel ?? null,
+      refused_models_json: params.refusedModelsJson ?? null,
     }),
     date: dateBucketFromTimestamp(params.timestamp),
   };
@@ -482,6 +493,31 @@ function toOptionalString(value: unknown): string | undefined {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Parse metadata.modelFallback (ModelFallbackRecord: { requestedModel,
+ * refusedModels }) into the events downgrade columns. Populated only when
+ * requestedModel is a non-empty string AND refusedModels is a non-empty
+ * string array; malformed records yield nulls (the row is still ingested).
+ */
+function parseModelFallback(rawModelFallback: unknown): {
+  requestedModel: string | null;
+  refusedModelsJson: string | null;
+} {
+  if (!isRecord(rawModelFallback)) {
+    return { requestedModel: null, refusedModelsJson: null };
+  }
+
+  const requestedModel = toOptionalString(rawModelFallback.requestedModel);
+  const refusedModels = Array.isArray(rawModelFallback.refusedModels)
+    ? rawModelFallback.refusedModels.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  if (!requestedModel || refusedModels.length === 0) {
+    return { requestedModel: null, refusedModelsJson: null };
+  }
+
+  return { requestedModel, refusedModelsJson: JSON.stringify(refusedModels) };
 }
 
 function parseCreatedAtTimestamp(value: unknown): number | null {
@@ -717,6 +753,9 @@ function extractIngestEvents(params: {
   // Tool usage snapshots can survive even when the parent assistant usage payload is missing.
   // Keep ingesting those rows so malformed or partial history does not drop tool costs.
   if (usage) {
+    // Downgrade metadata rides the main turn row only (tool rows stay null):
+    // the `model` column is the answering model, requested_model the original.
+    const modelFallback = parseModelFallback(metadata.modelFallback);
     const parentRow = buildIngestEventRow({
       inheritedContext,
       model: toOptionalString(metadata.model) ?? null,
@@ -728,6 +767,8 @@ function extractIngestEvents(params: {
       durationMs,
       ttftMs: extractTtftMs(metadata),
       outputTps: null,
+      requestedModel: modelFallback.requestedModel,
+      refusedModelsJson: modelFallback.refusedModelsJson,
     });
     if (!parentRow.parsed.success) {
       log.warn("[analytics-etl] Skipping invalid analytics row", {
@@ -1851,6 +1892,38 @@ export async function storePricingFingerprint(conn: DuckDBConnection): Promise<v
   await conn.run("INSERT OR REPLACE INTO ingest_meta (key, value) VALUES (?, ?)", [
     PRICING_FINGERPRINT_META_KEY,
     getCurrentPricingFingerprint(),
+  ]);
+}
+
+const ETL_SEMANTICS_META_KEY = "etl_semantics_version";
+
+/**
+ * Bump when the ETL starts deriving NEW columns/semantics from data that
+ * already exists in chat.jsonl: previously ingested rows lack the new fields,
+ * so a version mismatch forces one full rebuild to backfill them from the
+ * durable source. Same read → decide → store-after-success flow as the
+ * pricing fingerprint above.
+ *
+ * refusal-analytics-v1: requested_model / refused_models_json columns from
+ * metadata.modelFallback.
+ */
+export const CURRENT_ETL_SEMANTICS_VERSION = "refusal-analytics-v1";
+
+export async function readStoredEtlSemanticsVersion(
+  conn: DuckDBConnection
+): Promise<string | null> {
+  const result = await conn.run("SELECT value FROM ingest_meta WHERE key = ?", [
+    ETL_SEMANTICS_META_KEY,
+  ]);
+  const rows = await result.getRowObjectsJS();
+  const value = rows[0]?.value;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export async function storeEtlSemanticsVersion(conn: DuckDBConnection): Promise<void> {
+  await conn.run("INSERT OR REPLACE INTO ingest_meta (key, value) VALUES (?, ?)", [
+    ETL_SEMANTICS_META_KEY,
+    CURRENT_ETL_SEMANTICS_VERSION,
   ]);
 }
 

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import type { LanguageModelV2Usage } from "@ai-sdk/provider";
 import { DuckDBAppender, DuckDBDateValue, type DuckDBConnection } from "@duckdb/node-api";
 import { EventRowSchema, type EventRow } from "@/common/orpc/schemas/analytics";
+import { normalizeToCanonical } from "@/common/utils/ai/models";
 import { getErrorMessage } from "@/common/utils/errors";
 import { createDisplayUsage } from "@/common/utils/tokens/displayUsage";
 import modelsData from "@/common/utils/tokens/models.json";
@@ -381,7 +382,7 @@ function buildIngestEventRow(params: {
       parent_workspace_id: params.inheritedContext.workspaceMeta.parentWorkspaceId ?? null,
       agent_id: params.inheritedContext.agentId,
       timestamp: params.timestamp,
-      model: params.model,
+      model: analyticsAttributionModel(params.model, params.metadataModel),
       tool_name: params.toolName,
       thinking_level: params.inheritedContext.thinkingLevel,
       input_tokens: displayUsage.input.tokens,
@@ -528,7 +529,40 @@ function parseModelFallback(rawModelFallback: unknown): {
     refusedModels.push(refusedModel);
   }
 
+  // ModelFallbackRecord invariant: the requested model is always the first
+  // refused entry (the writer canonicalizes both with the same helper). A
+  // mismatch means corrupted history — reject the record rather than report
+  // an A→answered downgrade while the stored chain claims B refused.
+  if (refusedModels[0] !== requestedModel) {
+    return MALFORMED;
+  }
+
   return { requestedModel, refusedModelsJson: JSON.stringify(refusedModels) };
+}
+
+/**
+ * Analytics attribution key for events.model, mirroring
+ * SessionUsageService.recordHeadlessUsageLocked (and StreamManager's
+ * usageAttributionModel): Coder identities use the record-time pinned
+ * metadata identity — the raw coder: string is a mutable instance route the
+ * ETL cannot re-resolve — and every other identity canonicalizes gateway
+ * strings. Without one shared key, answered main rows, refusal hop rows, and
+ * headless sidecar rows would split a single configured model across several
+ * buckets in GROUP BY model queries (e.g. coder:prod/opus vs anthropic:opus).
+ * Coder rows without a persisted metadataModel keep the raw identity — it is
+ * their only durable key.
+ */
+function analyticsAttributionModel(
+  model: string | null,
+  metadataModel: string | undefined
+): string | null {
+  if (model === null) {
+    return null;
+  }
+  if (model.startsWith("coder:")) {
+    return metadataModel ?? model;
+  }
+  return normalizeToCanonical(model);
 }
 
 function parseCreatedAtTimestamp(value: unknown): number | null {
@@ -766,7 +800,12 @@ function extractIngestEvents(params: {
   if (usage) {
     // Downgrade metadata rides the main turn row only (tool rows stay null):
     // the `model` column is the answering model, requested_model the original.
-    const modelFallback = parseModelFallback(metadata.modelFallback);
+    // Interrupted fallback turns commit with partial: true — they are billed
+    // attempts but not answered downgrades, so the columns stay null there.
+    const modelFallback =
+      metadata.partial === true
+        ? { requestedModel: null, refusedModelsJson: null }
+        : parseModelFallback(metadata.modelFallback);
     const parentRow = buildIngestEventRow({
       inheritedContext,
       model: toOptionalString(metadata.model) ?? null,
@@ -1917,8 +1956,11 @@ const ETL_SEMANTICS_META_KEY = "etl_semantics_version";
  *
  * refusal-analytics-v1: requested_model / refused_models_json columns from
  * metadata.modelFallback.
+ * refusal-analytics-v2: events.model keyed by analyticsAttributionModel,
+ * downgrade columns gated on non-partial turns, strict modelFallback chain
+ * validation.
  */
-export const CURRENT_ETL_SEMANTICS_VERSION = "refusal-analytics-v1";
+export const CURRENT_ETL_SEMANTICS_VERSION = "refusal-analytics-v2";
 
 export async function readStoredEtlSemanticsVersion(
   conn: DuckDBConnection

--- a/src/node/services/analytics/etl.ts
+++ b/src/node/services/analytics/etl.ts
@@ -498,23 +498,34 @@ function toOptionalString(value: unknown): string | undefined {
 /**
  * Parse metadata.modelFallback (ModelFallbackRecord: { requestedModel,
  * refusedModels }) into the events downgrade columns. Populated only when
- * requestedModel is a non-empty string AND refusedModels is a non-empty
- * string array; malformed records yield nulls (the row is still ingested).
+ * requestedModel is a non-empty string AND refusedModels is a non-empty array
+ * whose EVERY entry is a trimmed non-empty string; any malformed record or
+ * entry yields nulls for both columns (the row is still ingested). Partially
+ * valid arrays are rejected wholesale — silently dropping bad hops would emit
+ * a truncated chain that reads as valid history.
  */
 function parseModelFallback(rawModelFallback: unknown): {
   requestedModel: string | null;
   refusedModelsJson: string | null;
 } {
+  const MALFORMED = { requestedModel: null, refusedModelsJson: null };
   if (!isRecord(rawModelFallback)) {
-    return { requestedModel: null, refusedModelsJson: null };
+    return MALFORMED;
   }
 
   const requestedModel = toOptionalString(rawModelFallback.requestedModel);
-  const refusedModels = Array.isArray(rawModelFallback.refusedModels)
-    ? rawModelFallback.refusedModels.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  if (!requestedModel || refusedModels.length === 0) {
-    return { requestedModel: null, refusedModelsJson: null };
+  const rawRefusedModels = rawModelFallback.refusedModels;
+  if (!requestedModel || !Array.isArray(rawRefusedModels) || rawRefusedModels.length === 0) {
+    return MALFORMED;
+  }
+
+  const refusedModels: string[] = [];
+  for (const entry of rawRefusedModels) {
+    const refusedModel = toOptionalString(entry);
+    if (!refusedModel) {
+      return MALFORMED;
+    }
+    refusedModels.push(refusedModel);
   }
 
   return { requestedModel, refusedModelsJson: JSON.stringify(refusedModels) };

--- a/src/node/services/sessionUsageService.test.ts
+++ b/src/node/services/sessionUsageService.test.ts
@@ -885,6 +885,49 @@ describe("SessionUsageService", () => {
       expect(result?.lastRequest?.model).toBe(metadataModel);
     });
 
+    it("skips zero-usage refusal markers but keeps billed refusal usage during rebuild", async () => {
+      // Zero-usage model_fallback_refusal entries are analytics-only markers:
+      // the live path never records them in the session ledger, so a rebuild
+      // must not surface 0-token/$0 Costs rows for models that only refused.
+      const workspaceId = "tool-usage-rebuild-skips-zero-refusals";
+      const answeringModel = "anthropic:claude-opus-4-5";
+      const refusedZeroModel = "anthropic:claude-sonnet-4-20250514";
+      const refusedBilledModel = "openai:gpt-5.2";
+      const assistantMessage = createMuxMessage("msg-zero-refusal", "assistant", "Hello", {
+        historySequence: 1,
+        timestamp: Date.now(),
+        model: answeringModel,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      });
+      Object.assign((assistantMessage.metadata ??= {}), {
+        toolModelUsages: [
+          {
+            toolName: "model_fallback_refusal",
+            timestamp: Date.now(),
+            model: refusedZeroModel,
+            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          },
+          {
+            toolName: "model_fallback_refusal",
+            timestamp: Date.now(),
+            model: refusedBilledModel,
+            usage: { inputTokens: 40, outputTokens: 0, totalTokens: 40 },
+          },
+        ],
+      });
+
+      await service.rebuildFromMessages(workspaceId, [assistantMessage]);
+
+      const result = await service.getSessionUsage(workspaceId);
+      expect(result).toBeDefined();
+      const models = Object.keys(result?.byModel ?? {});
+      // Billed refusal usage still merges (live path records it too)…
+      expect(models).toContain(normalizeToCanonical(answeringModel));
+      expect(models).toContain(normalizeToCanonical(refusedBilledModel));
+      // …but the zero-usage marker leaves no ledger entry.
+      expect(models).not.toContain(normalizeToCanonical(refusedZeroModel));
+    });
+
     it("should skip malformed tool model usage entries during rebuild", async () => {
       const workspaceId = "tool-usage-rebuild-skips-malformed";
       const sameModel = "openai:gpt-4";

--- a/src/node/services/sessionUsageService.ts
+++ b/src/node/services/sessionUsageService.ts
@@ -19,6 +19,7 @@ import type { RolledUpChildEntry } from "@/common/orpc/schemas/chatStats";
 import type { TokenConsumer } from "@/common/types/chatStats";
 import { HEADLESS_USAGE_FILE_NAME } from "@/common/constants/paths";
 import type { MuxMessage, PersistedToolModelUsage } from "@/common/types/message";
+import { hasTokenUsage, MODEL_FALLBACK_REFUSAL_TOOL_NAME } from "@/common/types/message";
 import {
   normalizeUsageModelKey,
   resolveModelForMetadata,
@@ -687,6 +688,18 @@ export class SessionUsageService {
 
       const rawModel = toolModelUsage.model.trim();
       if (!rawModel) {
+        return;
+      }
+
+      // Zero-usage refusal markers exist only so analytics can count refused
+      // attempts; the live path never records them in the session ledger
+      // (recordRefusedAttemptUsage skips recordSessionUsage without tokens).
+      // Skip them here too so a rebuilt ledger matches the live one instead
+      // of growing 0-token/$0 Costs rows for models that only ever refused.
+      if (
+        toolModelUsage.toolName === MODEL_FALLBACK_REFUSAL_TOOL_NAME &&
+        !hasTokenUsage(toolModelUsage.usage)
+      ) {
         return;
       }
 

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -806,6 +806,51 @@ describe("StreamManager - refusal usage attribution", () => {
     expect(recordUsage).not.toHaveBeenCalled();
   });
 
+  test("refused attempt entries persist the attribution key, not the raw gateway identity", async () => {
+    // Sidecar refused_stream rows are keyed by recordHeadlessUsageLocked's
+    // canonical model; a raw mux-gateway identity on committed hop rows would
+    // split one model across two analytics buckets in the refusal queries.
+    const recordUsage = mock((_workspaceId: string, _model: string, _usage: unknown) =>
+      Promise.resolve(undefined)
+    );
+    const sessionUsageService = { recordUsage } as unknown as SessionUsageService;
+    const streamManager = new StreamManager(historyService, sessionUsageService);
+    const tryFallback = Reflect.get(streamManager, "tryModelFallbackAfterRefusal") as (
+      workspaceId: string,
+      streamInfo: Record<string, unknown>,
+      refusalFinishReason: string
+    ) => Promise<{ kind: string }>;
+    expect(typeof tryFallback).toBe("function");
+
+    const toolModelUsages: Array<{ toolName: string; model: string }> = [];
+    const streamInfo = {
+      model: "mux-gateway:anthropic/claude-opus-4-5",
+      metadataModel: "anthropic:claude-opus-4-5",
+      cumulativeUsage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 },
+      cumulativeProviderMetadata: { anthropic: {} },
+      startTime: Date.now(),
+      initialMetadata: undefined,
+      parts: [],
+      toolModelUsages,
+      abortController: { signal: { aborted: false } },
+      softInterrupt: { pending: false },
+      modelFallback: {
+        options: { chain: [], prepare: mock(() => Promise.reject(new Error("unused"))) },
+        requestedModel: "mux-gateway:anthropic/claude-opus-4-5",
+        refusedModels: [],
+        original: { maxOutputTokens: undefined },
+      },
+    };
+
+    const outcome = await tryFallback.call(streamManager, "ws-gateway-hop", streamInfo, "refusal");
+    expect(outcome.kind).toBe("terminal");
+    expect(toolModelUsages).toHaveLength(1);
+    expect(toolModelUsages[0]).toMatchObject({
+      toolName: "model_fallback_refusal",
+      model: "anthropic:claude-opus-4-5",
+    });
+  });
+
   test("sidecar flatten labels refusal hops refused_stream and keeps the drop reason for other usage", async () => {
     const recordHeadlessUsage = mock(
       (

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -751,6 +751,136 @@ describe("StreamManager - refusal usage attribution", () => {
     expect(recordedKeys).toEqual(["anthropic:claude-opus-4-5"]);
   });
 
+  test("zero-usage refused attempt still records a zero-usage hop entry without touching the session ledger", async () => {
+    const recordUsage = mock((_workspaceId: string, _model: string, _usage: unknown) =>
+      Promise.resolve(undefined)
+    );
+    const sessionUsageService = { recordUsage } as unknown as SessionUsageService;
+    const streamManager = new StreamManager(historyService, sessionUsageService);
+    const tryFallback = Reflect.get(streamManager, "tryModelFallbackAfterRefusal") as (
+      workspaceId: string,
+      streamInfo: Record<string, unknown>,
+      refusalFinishReason: string
+    ) => Promise<{ kind: string }>;
+    expect(typeof tryFallback).toBe("function");
+
+    const toolModelUsages: Array<{ toolName: string; model: string; usage: unknown }> = [];
+    const streamInfo = {
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      // No billed usage anywhere: neither live-tracked nor via streamResult.
+      cumulativeUsage: undefined,
+      cumulativeProviderMetadata: undefined,
+      streamResult: { usage: Promise.resolve(undefined), finalStep: Promise.resolve(undefined) },
+      startTime: Date.now(),
+      initialMetadata: undefined,
+      parts: [],
+      toolModelUsages,
+      abortController: { signal: { aborted: false } },
+      softInterrupt: { pending: false },
+      // Empty chain: the hop is recorded, then the chain exhausts terminally.
+      modelFallback: {
+        options: { chain: [], prepare: mock(() => Promise.reject(new Error("unused"))) },
+        requestedModel: KNOWN_MODELS.SONNET.id,
+        refusedModels: [],
+        original: { maxOutputTokens: undefined },
+      },
+    };
+
+    const outcome = await tryFallback.call(
+      streamManager,
+      "ws-zero-usage-hop",
+      streamInfo,
+      "refusal"
+    );
+    expect(outcome.kind).toBe("terminal");
+
+    // The refused attempt is durably recorded with explicit zero usage so
+    // analytics counts it, while the session cost ledger stays untouched.
+    expect(toolModelUsages).toHaveLength(1);
+    expect(toolModelUsages[0]).toMatchObject({
+      toolName: "model_fallback_refusal",
+      model: KNOWN_MODELS.SONNET.id,
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    });
+    expect(recordUsage).not.toHaveBeenCalled();
+  });
+
+  test("sidecar flatten labels refusal hops refused_stream and keeps the drop reason for other usage", async () => {
+    const recordHeadlessUsage = mock(
+      (
+        _workspaceId: string,
+        _model: string,
+        _usage: unknown,
+        _providerMetadata: unknown,
+        _options: unknown
+      ) => Promise.resolve(undefined)
+    );
+    const sessionUsageService = { recordHeadlessUsage } as unknown as SessionUsageService;
+    const streamManager = new StreamManager(historyService, sessionUsageService);
+    const recordDropped = Reflect.get(streamManager, "recordDroppedPartialUsageInSidecar") as (
+      workspaceId: string,
+      streamInfo: Record<string, unknown>,
+      usage: Record<string, number> | undefined,
+      providerMetadata: Record<string, unknown> | undefined,
+      analyticsSource: string,
+      streamUsageSource?: string
+    ) => Promise<void>;
+    expect(typeof recordDropped).toBe("function");
+
+    const streamInfo = {
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      toolModelUsages: [
+        {
+          toolName: "model_fallback_refusal",
+          timestamp: 1,
+          model: KNOWN_MODELS.SONNET.id,
+          metadataModel: KNOWN_MODELS.SONNET.id,
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        },
+        {
+          toolName: "task",
+          timestamp: 2,
+          model: KNOWN_MODELS.GPT.id,
+          metadataModel: KNOWN_MODELS.GPT.id,
+          usage: { inputTokens: 7, outputTokens: 1, totalTokens: 8 },
+        },
+      ],
+    };
+    const sourcesOf = () =>
+      recordHeadlessUsage.mock.calls.map(
+        (call) => (call[4] as { analyticsSource?: string }).analyticsSource
+      );
+
+    // Aborted turn with a prior refusal hop: the stream's own usage row keeps
+    // the abort label (default streamUsageSource), the hop is still a refusal,
+    // and unrelated tool usage keeps the drop reason.
+    await recordDropped.call(
+      streamManager,
+      "ws-flatten-aborted",
+      streamInfo,
+      { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+      undefined,
+      "aborted_stream"
+    );
+    expect(sourcesOf()).toEqual(["aborted_stream", "refused_stream", "aborted_stream"]);
+
+    // Terminal-refusal error turn: the stream's own usage row is explicitly
+    // labeled refused_stream while non-refusal tool usage stays errored_stream.
+    recordHeadlessUsage.mockClear();
+    await recordDropped.call(
+      streamManager,
+      "ws-flatten-refused",
+      streamInfo,
+      { inputTokens: 2, outputTokens: 1, totalTokens: 3 },
+      undefined,
+      "errored_stream",
+      "refused_stream"
+    );
+    expect(sourcesOf()).toEqual(["refused_stream", "refused_stream", "errored_stream"]);
+  });
+
   test("ledger key uses the stream's pinned metadata identity when instance metadata is gone", async () => {
     // A catalog refresh can remove/retag the instance while the turn is
     // active: the LIVE config no longer resolves coder:prod/<claude>, so a
@@ -2646,6 +2776,75 @@ describe("StreamManager - empty stream completions", () => {
     expect(committed?.metadata?.errorType).toBeUndefined();
   });
 
+  test("zero-usage terminal refusal reaches the sidecar as refused_stream without touching the session ledger", async () => {
+    const recordUsage = mock((_workspaceId: string, _model: string, _usage: unknown) =>
+      Promise.resolve(undefined)
+    );
+    const recordHeadlessUsage = mock(
+      (
+        _workspaceId: string,
+        _model: string,
+        _usage: unknown,
+        _providerMetadata: unknown,
+        _options: unknown
+      ) => Promise.resolve(undefined)
+    );
+    const sessionUsageService = {
+      recordUsage,
+      recordHeadlessUsage,
+    } as unknown as SessionUsageService;
+    const streamManager = new StreamManager(historyService, sessionUsageService);
+    streamManager.on("error", () => undefined);
+
+    Reflect.set(streamManager, "tokenTracker", {
+      setModel: () => Promise.resolve(undefined),
+      countTokens: () => Promise.resolve(0),
+    });
+
+    const workspaceId = "refusal-zero-usage-sidecar-workspace";
+    const messageId = "refusal-zero-usage-sidecar-message";
+    const historySequence = 1;
+
+    await appendPartialAssistantForTests(workspaceId, messageId, historySequence);
+    const processStreamWithCleanup = getProcessStreamWithCleanupForTests(streamManager);
+    const startTime = Date.now() - 250;
+    const streamInfo = createStreamInfoForTests({
+      streamResult: createStreamResultForTests(
+        (async function* () {
+          await Promise.resolve();
+          yield { type: "finish", finishReason: "content-filter", rawFinishReason: "refusal" };
+        })(),
+        { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+      ),
+      messageId,
+      startTime,
+      lastPartTimestamp: startTime,
+      model: KNOWN_MODELS.SONNET.id,
+      metadataModel: KNOWN_MODELS.SONNET.id,
+      historySequence,
+      initialMetadata: { agentId: "plan" },
+      runtime,
+    });
+
+    await processStreamWithCleanup.call(streamManager, workspaceId, streamInfo, historySequence);
+
+    // A refusal the provider billed nothing for is still a refusal: exactly
+    // one refused_stream analytics record with explicit zero usage…
+    expect(recordHeadlessUsage).toHaveBeenCalledTimes(1);
+    expect(recordHeadlessUsage.mock.calls[0]?.[0]).toBe(workspaceId);
+    expect(recordHeadlessUsage.mock.calls[0]?.[2]).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    });
+    expect(recordHeadlessUsage.mock.calls[0]?.[4]).toMatchObject({
+      analyticsSource: "refused_stream",
+      skipSessionLedger: true,
+    });
+    // …and no zero-cost noise in the session cost ledger.
+    expect(recordUsage).not.toHaveBeenCalled();
+  });
+
   test("refusal finish after partial output fails visibly when no fallback is configured", async () => {
     const recordUsage = mock((_workspaceId: string, _model: string, _usage: unknown) =>
       Promise.resolve(undefined)
@@ -2730,8 +2929,10 @@ describe("StreamManager - empty stream completions", () => {
     expect(recordHeadlessUsage).toHaveBeenCalledTimes(1);
     expect(recordHeadlessUsage.mock.calls[0]?.[0]).toBe(workspaceId);
     expect(recordHeadlessUsage.mock.calls[0]?.[2]).toMatchObject({ inputTokens: 3 });
+    // Terminal refusals are labeled refused_stream (not errored_stream) so
+    // analytics can distinguish refusals from generic stream errors.
     expect(recordHeadlessUsage.mock.calls[0]?.[4]).toMatchObject({
-      analyticsSource: "errored_stream",
+      analyticsSource: "refused_stream",
       skipSessionLedger: true,
     });
 
@@ -3635,8 +3836,10 @@ describe("StreamManager - empty stream completions", () => {
     expect(sidecarCalls[1]?.[1]).toBe(fallbackModel);
     expect(sidecarCalls[1]?.[2]).toMatchObject({ inputTokens: 10 });
     for (const call of sidecarCalls) {
+      // Both flattened entries are refused fallback hops, so they carry the
+      // refusal-specific analytics label rather than the generic drop reason.
       expect(call?.[4]).toMatchObject({
-        analyticsSource: "errored_stream",
+        analyticsSource: "refused_stream",
         skipSessionLedger: true,
       });
     }

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1661,23 +1661,29 @@ export class StreamManager extends EventEmitter {
       return;
     }
     const workspaceLog = this.getWorkspaceLogger(workspaceId, streamInfo);
-    // Ledger key for Coder identities: the stream's PINNED record-time
-    // metadata identity (streamInfo.metadataModel), NOT a live re-resolution
-    // of the raw model. A catalog refresh can remove/retag the instance while
-    // the turn is active; re-resolving here would key the ledger differently
-    // from the pricing identity createDisplayUsage just used, and repricing
-    // would later change or strip the row. Non-Coder models keep the
-    // canonical key: their metadata identity can be a mappedToModel alias
-    // target — a pricing identity, deliberately not the ledger bucket.
-    const ledgerModel =
-      model.startsWith("coder:") && streamInfo?.metadataModel
-        ? streamInfo.metadataModel
-        : normalizeUsageModelKey(model, this.getProvidersConfig());
+    const ledgerModel = this.usageAttributionModel(model, streamInfo?.metadataModel);
     try {
       await this.sessionUsageService.recordUsage(workspaceId as string, ledgerModel, messageUsage);
     } catch (error) {
       (logLevel === "error" ? workspaceLog.error : workspaceLog.warn)(logMessage, { error });
     }
+  }
+
+  /**
+   * Usage-attribution key, mirroring SessionUsageService.recordHeadlessUsageLocked.
+   * Coder identities keep the stream's PINNED record-time metadata identity
+   * (streamInfo.metadataModel), NOT a live re-resolution of the raw model: a
+   * catalog refresh can remove/retag the instance while the turn is active,
+   * and re-resolving would key the ledger differently from the pricing
+   * identity createDisplayUsage used, so repricing would later change or
+   * strip the row. Non-Coder models resolve to the canonical usage key —
+   * their metadata identity can be a mappedToModel alias target (a pricing
+   * identity, deliberately not the attribution bucket).
+   */
+  private usageAttributionModel(model: string, metadataModel: string | undefined): string {
+    return model.startsWith("coder:") && metadataModel
+      ? metadataModel
+      : normalizeUsageModelKey(model, this.getProvidersConfig());
   }
 
   private buildStreamRequestConfig(
@@ -2591,10 +2597,17 @@ export class StreamManager extends EventEmitter {
     // still real refused attempts: record an explicit all-zero entry so
     // analytics counts the refusal, but skip the session ledger below — no
     // zero-cost noise in the costs UI.
+    //
+    // The persisted entry carries the ATTRIBUTION key, not the raw stream
+    // identity: sidecar refused_stream rows are keyed by
+    // recordHeadlessUsageLocked's canonical model, so a raw gateway/Coder
+    // identity here (e.g. mux-gateway:openai/gpt-5 vs openai:gpt-5) would
+    // split one model across two analytics buckets when queries group
+    // committed hop rows and sidecar rows together.
     streamInfo.toolModelUsages.push({
       toolName: MODEL_FALLBACK_REFUSAL_TOOL_NAME,
       timestamp: Date.now(),
-      model: refusedModel,
+      model: this.usageAttributionModel(refusedModel, streamInfo.metadataModel),
       metadataModel: streamInfo.metadataModel,
       usage: usage ?? zeroTokenUsage(),
       ...(providerMetadata ? { providerMetadata } : {}),

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -111,6 +111,18 @@ const EMPTY_STREAM_OUTPUT_ERROR_MESSAGE =
   "The model ended the stream before producing any assistant-visible output. This usually means the upstream stream was dropped rather than completed normally. Xum will retry automatically when possible, and if retries keep failing you should try again or switch models.";
 
 const MAX_EMPTY_STREAM_RECOVERY_ATTEMPTS = 1;
+
+/**
+ * toolModelUsages entry marker for a refused fallback attempt. Analytics keys
+ * on this exact string (events.tool_name), and the sidecar flatten path uses
+ * it to relabel refusal usage as "refused_stream" on non-committed turns.
+ */
+const MODEL_FALLBACK_REFUSAL_TOOL_NAME = "model_fallback_refusal";
+
+/** Drop reason for a partial that never reaches chat.jsonl. */
+type DroppedStreamSource = "aborted_stream" | "errored_stream";
+/** Sidecar analytics label: drop reason, or the refusal-specific label. */
+type HeadlessDropSource = DroppedStreamSource | "refused_stream";
 const STREAM_TRUNCATED_MESSAGE_SUFFIX =
   "stream closed unexpectedly before the response completed. Xum will retry automatically when possible, and if retries keep failing you should try again or switch models.";
 
@@ -531,6 +543,16 @@ function hasTokenUsage(usage: LanguageModelV2Usage | undefined): usage is Langua
 
 function cloneUsage(usage: LanguageModelV2Usage): LanguageModelV2Usage {
   return { ...usage };
+}
+
+/**
+ * Fresh all-zero usage object for refusals where the provider billed nothing
+ * (or usage never arrived). A new object per call — downstream code mutates
+ * usage objects (e.g. reasoning-token backfill), so a shared singleton would
+ * leak counts across records.
+ */
+function zeroTokenUsage(): LanguageModelV2Usage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 }
 
 function hasIncompleteToolCallPart(parts: CompletedMessagePart[]): boolean {
@@ -1588,7 +1610,12 @@ export class StreamManager extends EventEmitter {
     streamInfo: Pick<WorkspaceStreamInfo, "model" | "metadataModel" | "toolModelUsages">,
     usage: LanguageModelV2Usage | undefined,
     providerMetadata: Record<string, unknown> | undefined,
-    analyticsSource: "aborted_stream" | "errored_stream"
+    analyticsSource: DroppedStreamSource,
+    // Label for the stream's OWN usage row only. The error path passes
+    // "refused_stream" when the turn died as a terminal model refusal (the
+    // stream usage is then terminalRefusalUsage), so refusals are not
+    // conflated with generic errored_stream rows in analytics.
+    streamUsageSource: HeadlessDropSource = analyticsSource
   ): Promise<void> {
     // Thread the request-pinned metadata identities through the sidecar
     // write: recordHeadlessUsage would otherwise re-resolve the raw model
@@ -1600,16 +1627,31 @@ export class StreamManager extends EventEmitter {
         streamInfo.model,
         cloneUsage(usage),
         providerMetadata,
-        { analyticsSource, skipSessionLedger: true, metadataModel: streamInfo.metadataModel }
+        {
+          analyticsSource: streamUsageSource,
+          skipSessionLedger: true,
+          metadataModel: streamInfo.metadataModel,
+        }
       );
     }
     for (const toolUsage of streamInfo.toolModelUsages) {
+      // Refused fallback hops ARE refusals regardless of how the turn ended
+      // (aborted, errored, exhausted chain); every other tool-internal usage
+      // entry keeps the turn's drop reason.
+      const entrySource: HeadlessDropSource =
+        toolUsage.toolName === MODEL_FALLBACK_REFUSAL_TOOL_NAME
+          ? "refused_stream"
+          : analyticsSource;
       await this.sessionUsageService?.recordHeadlessUsage(
         workspaceId as string,
         toolUsage.model,
         cloneUsage(toolUsage.usage),
         toolUsage.providerMetadata,
-        { analyticsSource, skipSessionLedger: true, metadataModel: toolUsage.metadataModel }
+        {
+          analyticsSource: entrySource,
+          skipSessionLedger: true,
+          metadataModel: toolUsage.metadataModel,
+        }
       );
     }
   }
@@ -2561,18 +2603,23 @@ export class StreamManager extends EventEmitter {
     refusedModel: string
   ): Promise<void> {
     const { usage, providerMetadata } = await this.getRefusalUsageSnapshot(streamInfo);
-    if (!usage) {
-      return;
-    }
 
+    // Zero-usage refusals (provider billed nothing / usage never arrived) are
+    // still real refused attempts: record an explicit all-zero entry so
+    // analytics counts the refusal, but skip the session ledger below — no
+    // zero-cost noise in the costs UI.
     streamInfo.toolModelUsages.push({
-      toolName: "model_fallback_refusal",
+      toolName: MODEL_FALLBACK_REFUSAL_TOOL_NAME,
       timestamp: Date.now(),
       model: refusedModel,
       metadataModel: streamInfo.metadataModel,
-      usage,
+      usage: usage ?? zeroTokenUsage(),
       ...(providerMetadata ? { providerMetadata } : {}),
     });
+
+    if (!usage) {
+      return;
+    }
 
     await this.recordSessionUsage(
       workspaceId,
@@ -2591,12 +2638,17 @@ export class StreamManager extends EventEmitter {
     refusedModel: string
   ): Promise<void> {
     const { usage, providerMetadata } = await this.getRefusalUsageSnapshot(streamInfo);
+
+    // Same zero-usage policy as recordRefusedAttemptUsage: the terminal
+    // refusal must reach the analytics sidecar (persistStreamError writes
+    // terminalRefusalUsage as a "refused_stream" row) even when the provider
+    // billed nothing, but the session ledger stays free of zero-cost entries.
+    streamInfo.terminalRefusalUsage = usage ?? zeroTokenUsage();
+    streamInfo.terminalRefusalProviderMetadata = providerMetadata;
+
     if (!usage) {
       return;
     }
-
-    streamInfo.terminalRefusalUsage = usage;
-    streamInfo.terminalRefusalProviderMetadata = providerMetadata;
 
     await this.recordSessionUsage(
       workspaceId,
@@ -3950,7 +4002,11 @@ export class StreamManager extends EventEmitter {
         streamInfo,
         errorUsage,
         errorProviderMetadata,
-        "errored_stream"
+        "errored_stream",
+        // A model_refusal error's stream usage row is terminalRefusalUsage
+        // (only set for terminal no-fallback refusals); label it as a refusal
+        // so analytics can distinguish refusals from generic stream errors.
+        payload.errorType === "model_refusal" ? "refused_stream" : "errored_stream"
       );
     } catch (error) {
       log.error("Failed to record errored-stream usage in headless sidecar", { error });

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -33,6 +33,7 @@ import type {
 
 import type { SendMessageError, StreamErrorType } from "@/common/types/errors";
 import type { MuxMetadata, MuxMessage, PersistedToolModelUsage } from "@/common/types/message";
+import { hasTokenUsage, MODEL_FALLBACK_REFUSAL_TOOL_NAME } from "@/common/types/message";
 import {
   findFirstReasoningPartIndexInTrailingRun,
   mergeReasoningProviderOptions,
@@ -111,13 +112,6 @@ const EMPTY_STREAM_OUTPUT_ERROR_MESSAGE =
   "The model ended the stream before producing any assistant-visible output. This usually means the upstream stream was dropped rather than completed normally. Xum will retry automatically when possible, and if retries keep failing you should try again or switch models.";
 
 const MAX_EMPTY_STREAM_RECOVERY_ATTEMPTS = 1;
-
-/**
- * toolModelUsages entry marker for a refused fallback attempt. Analytics keys
- * on this exact string (events.tool_name), and the sidecar flatten path uses
- * it to relabel refusal usage as "refused_stream" on non-committed turns.
- */
-const MODEL_FALLBACK_REFUSAL_TOOL_NAME = "model_fallback_refusal";
 
 /** Drop reason for a partial that never reaches chat.jsonl. */
 type DroppedStreamSource = "aborted_stream" | "errored_stream";
@@ -528,17 +522,6 @@ function clonePersistedToolModelUsage(event: PersistedToolModelUsage): Persisted
     usage: { ...event.usage },
     ...(event.providerMetadata != null ? { providerMetadata: event.providerMetadata } : {}),
   };
-}
-
-function hasTokenUsage(usage: LanguageModelV2Usage | undefined): usage is LanguageModelV2Usage {
-  return (
-    usage !== undefined &&
-    ((usage.inputTokens ?? 0) > 0 ||
-      (usage.outputTokens ?? 0) > 0 ||
-      (usage.totalTokens ?? 0) > 0 ||
-      (usage.cachedInputTokens ?? 0) > 0 ||
-      (usage.reasoningTokens ?? 0) > 0)
-  );
 }
 
 function cloneUsage(usage: LanguageModelV2Usage): LanguageModelV2Usage {


### PR DESCRIPTION
## Summary

Adds first-class tracking of model refusals and refusal-fallback downgrades to the DuckDB analytics pipeline: terminal refusals get their own analytics label instead of being conflated with generic stream errors, persisted `ModelFallbackRecord` metadata is ingested as queryable columns (with automatic historical backfill), zero-usage refusals are counted, and three one-click SQL Explorer sample queries surface the data.

Closes #3977

## Background

Refusals (`content-filter` / `refusal` finish reasons) previously left an incomplete analytics trail:

1. Terminal refusals were written to the headless sidecar as `errored_stream`, indistinguishable from generic stream errors.
2. The persisted `metadata.modelFallback` record (requested model + refused models) was rendered as a transcript badge but never ingested by the ETL, so "how often does Fable fall back to Opus?" was unanswerable.
3. Refusals where the provider billed nothing were dropped entirely (`getRefusalUsageSnapshot` early-return), undercounting refusal rates.
4. No ready-made queries existed for any of this.

## Implementation

- **`refused_stream` sidecar source** (`streamManager.ts`): `recordDroppedPartialUsageInSidecar` now takes two source knobs — the turn's drop reason (`aborted_stream`/`errored_stream`) for unrelated tool usage, and a stream-usage label that `persistStreamError` sets to `refused_stream` for `model_refusal` errors. `model_fallback_refusal` hop entries are always relabeled `refused_stream` regardless of how the turn ended. The sidecar `source` field is a plain string end to end, so old app versions ingest the new label without code changes.
- **Downgrade columns** (`schemaSql.ts`, `analyticsWorker.ts`, `etl.ts`): new nullable `requested_model` + `refused_models_json` columns on `events`, populated only on the main turn row (`tool_name IS NULL`) from defensively parsed `metadata.modelFallback`. Added via the established `ADD COLUMN IF NOT EXISTS` migration list; physical column order matches fresh tables so the DuckDB appender stays aligned.
- **One-time backfill**: a new `etl_semantics_version` key in `ingest_meta` (mirroring the pricing-fingerprint read → decide → store-after-success flow) forces one full rebuild on upgrade, so historical committed downgrade turns get the new columns from durable `chat.jsonl`.
- **Zero-usage refusals**: `recordRefusedAttemptUsage` / `recordTerminalRefusalUsage` now record an explicit all-zero usage object instead of early-returning, while still skipping the session cost ledger (no zero-cost noise in the costs UI). A consumer audit confirmed every downstream reader (cost aggregation, ledger rebuild, ETL, display) is zero-safe.
- **Surfacing**: three `SAMPLE_QUERIES` entries — _Refusals per Day_, _Refusal Downgrades (Requested → Answered)_, _Refusal Rate by Model_. The rate query deliberately does not coalesce `requested_model` into the answered side: the refused model's attempt is already counted by its refusal row, so coalescing would double-count downgraded turns. The sample-query runner test now also asserts every sample returns non-empty results against a refusal-seeded fixture.

Resulting row semantics: every refused model attempt is exactly one row — `tool_name='model_fallback_refusal'` (hop on a committed turn) or `tool_name='headless:refused_stream'` (any refusal on a turn that never committed), with no double counting (refusal turns skip the cumulative-usage error row).

## Validation

- Targeted suites: streamManager (113), sessionUsageService (27), analytics node incl. new ETL/migration/backfill tests (128), Analytics browser incl. sample-query runner (34) — all green post-rebase; `make static-check` green.
- End-to-end dogfood in a `dev-server-sandbox`: seeded a downgraded turn (fable → opus with one billed and one zero-usage refusal hop) plus billed and zero-usage `refused_stream` sidecar records, then verified in the live SQL Explorer that all three sample queries return exactly the expected counts (fable 3/3 = 100% refusal rate, sonnet 1/1, opus 0/1) and the raw `events` rows carry the designed per-row semantics (screenshots + a video walkthrough were captured in the workspace; image upload to GitHub was blocked by org SSO in this environment).

## Risks

- **Analytics-only downgrade friction**: an older appender (28 columns) against the widened table fails ETL ingestion until the analytics DB file is deleted (it rebuilds fully from `chat.jsonl`/sidecars — no data loss). Same scoped exposure the `tool_name` migration shipped with; analytics worker errors are caught and disable analytics for the session, never crashing the app.
- The stream-side relabeling only touches sidecar `analyticsSource` strings and refusal-usage recording; session-ledger and commit paths are behavior-preserving for non-refusal turns (covered by the existing 100+ streamManager tests).
- Historical terminal refusals remain `headless:errored_stream` (label was dropped at write time before this change) and historical zero-usage refusals remain absent — both forward-only fixes by design.

---

<details>
<summary>📋 Implementation Plan</summary>

# Issue #3977 — First-class refusal & downgrade analytics in DuckDB

Implement first-class tracking of model refusals and refusal-fallback downgrades in the DuckDB
analytics pipeline, per the four proposed directions in the issue: (1) distinguish terminal
refusals from generic stream errors, (2) ingest the persisted `ModelFallbackRecord`, (3) count
zero-usage refusals, (4) surface the data with ready-made queries.

## Verified current behavior (investigation evidence)

All facts below verified by code investigation on this branch.

**Refusal runtime (`src/node/services/streamManager.ts`):**

- Refusals are detected via `isRefusalFinishReason` (`src/common/utils/messages/refusalFinishReason.ts`:
  `"content-filter" | "refusal"`), then routed through `tryModelFallbackAfterRefusal` (~L2671).
- **Hop refusal (fallback configured):** `recordRefusedAttemptUsage` (~L2558) pushes
  `{ toolName: "model_fallback_refusal", model: <refused>, usage, ... }` into
  `streamInfo.toolModelUsages` and records session usage. **Early-returns when
  `getRefusalUsageSnapshot` finds no token usage** (`hasTokenUsage` false → `{}`), so zero-usage
  refusals leave no trace.
- **Terminal refusal, no fallback configured:** `recordTerminalRefusalUsage` (~L2588) sets
  `streamInfo.terminalRefusalUsage` (not `toolModelUsages`) + session usage; same zero-usage
  early-return.
- **Error path:** `persistStreamError` (~L3884) computes
  `errorUsage = terminalRefusalUsage ?? cumulativeErrorUsage` (cumulative is skipped when
  `payload.errorType === "model_refusal"`, so there is **no double count** with hop entries), then
  calls `recordDroppedPartialUsageInSidecar(..., "errored_stream")` (~L1586), which writes to the
  headless sidecar: one record for the stream's own usage (only if `usage !== undefined`) plus one
  record per `toolModelUsages` entry — **dropping `toolName`**, so hop refusals on errored/aborted
  turns are indistinguishable from other tool-internal usage.
- `payload.errorType === "model_refusal"` **is available** at the `persistStreamError` sidecar
  write site (checked at ~L3879/3898), so threading a distinct source requires no new plumbing.
- Abort path (~L1539/L1556) uses the same flatten helper with `"aborted_stream"`.
- The helper's `analyticsSource` param is locally typed `"aborted_stream" | "errored_stream"`;
  `SessionUsageService.recordHeadlessUsage` takes `analyticsSource?: string` (plain string, no
  enum) and appends `{ timestamp, source, model, metadataModel, usage, providerMetadata? }` to
  `headless-usage.jsonl`. It does **not** skip all-zero usage (only `undefined`), and
  `createDisplayUsage` accepts zeros.

**`ModelFallbackRecord` (`src/common/orpc/schemas/message.ts` L122–125, L160):**
`{ requestedModel: string, refusedModels: string[] }`, persisted on assistant-message
`metadata.modelFallback` (written via `streamInfo.initialMetadata` on every successful swap,
committed to `chat.jsonl`). `refusedModels[0]` is always the requested model. Rendered as a
transcript badge (`ModelFallbackBadge.tsx`); **never read by the ETL**.

**ETL (`src/node/services/analytics/etl.ts`):**

- `extractIngestEvents` (~L686) parses assistant `message.metadata`: main row from
  `metadata.usage` (`tool_name = NULL`), one row per `metadata.toolModelUsages` entry
  (`tool_name = <toolName>`, e.g. `model_fallback_refusal`). `metadata.modelFallback` is ignored.
- `parseUsage` (~L513) returns a zeros object for all-zero usage (only `undefined` when **all**
  fields are missing/non-finite) → zero-usage rows **would** be emitted today; the gap is purely
  on the recording side in streamManager.
- `ingestHeadlessUsage` (~L1321) maps each sidecar line to `tool_name = 'headless:' + source`
  with `response_index = NULL`; **any** non-empty source string is accepted (manual field reads,
  no enum). Idempotency: `DELETE FROM events WHERE workspace_id = ? AND tool_name LIKE 'headless:%'`
  then reinsert; turn rows use delete-by-`response_index` / delete-by-workspace.
- Appender column order (`appendEvents`, ~L265) must match the **physical** table column order;
  `tool_name` is currently last both in `CREATE_EVENTS_TABLE_SQL` (`src/common/analytics/schemaSql.ts`)
  and via `EVENTS_COLUMN_MIGRATIONS_SQL` (`ALTER TABLE events ADD COLUMN IF NOT EXISTS tool_name TEXT`
  in `src/node/services/analytics/analyticsWorker.ts`) — the established additive-migration precedent.
- Row validation: `EventRowSchema` (`src/common/orpc/schemas/analytics.ts` L137–166).
- Queries select explicit column lists (`src/node/services/analytics/queries.ts`); no `SELECT *`.

**Surfacing:** `SAMPLE_QUERIES` in `src/browser/features/Analytics/SqlExplorer.tsx` (L15–32,
`{ label, sql }`, chart type inferred); entries are executed as raw SQL by an existing test
runner, so they must stay valid DuckDB SQL. Saved queries + dashboard cards also exist but need
schema/orpc/hook/component plumbing per card.

## Design decisions

### D1. Terminal refusals → new headless source `"refused_stream"` (issue item 1)

`recordDroppedPartialUsageInSidecar` gains **two distinct source knobs** so refusal rows are
labeled precisely without mislabeling unrelated usage on the same turn:

```ts
type DroppedStreamSource = "aborted_stream" | "errored_stream";           // drop reason
type HeadlessDropSource = DroppedStreamSource | "refused_stream";         // + refusal label

private async recordDroppedPartialUsageInSidecar(
  workspaceId, streamInfo, usage, providerMetadata,
  analyticsSource: DroppedStreamSource,                  // applied to non-refusal tool entries
  streamUsageSource: HeadlessDropSource = analyticsSource // applied to the stream's own usage row
)
```

- **Stream's own usage row** → `streamUsageSource`. `persistStreamError` passes
  `payload.errorType === "model_refusal" ? "refused_stream" : "errored_stream"` (the refusal
  stream-row usage is `terminalRefusalUsage`, only set for terminal no-fallback refusals).
- **`toolModelUsages` entries** → `toolName === "model_fallback_refusal"` ⇒ `"refused_stream"`
  (it *is* a refusal, even on an aborted or otherwise-errored turn); **all other tool entries keep
  `analyticsSource`** (`"errored_stream"` / `"aborted_stream"` per the original drop reason), so
  non-refusal tool-internal usage on a refusal-errored turn is *not* counted as a refusal.
- Abort call sites (~L1539/L1556) are unchanged (default `streamUsageSource = analyticsSource`).

- Rejected alternative: `error_type` column on `events`. The sidecar source needs zero schema
  changes, reuses the generic `headless:<source>` mapping (old ETL versions ingest it unchanged —
  source is a plain string end to end), and matches the issue's preferred sketch.
- Rejected alternative: preserving `toolName` in the sidecar record. Would break the
  `tool_name LIKE 'headless:%'` delete+reinsert idempotency contract or require new delete logic.
- Resulting semantics: every refused model attempt is exactly one row —
  `tool_name = 'model_fallback_refusal'` (hop on a committed turn) or
  `tool_name = 'headless:refused_stream'` (any refusal on a turn that never committed, including
  terminal refusals). No double count (verified `errorUsage` dedup above).

### D2. Ingest `metadata.modelFallback` as columns on the main turn row (issue item 2)

Add two nullable columns to `events`, populated only on the main assistant-turn row
(`tool_name IS NULL`) when `metadata.modelFallback` is present:

- `requested_model VARCHAR` — `modelFallback.requestedModel`; non-NULL ⇒ this turn was answered
  by a downgraded model (`model` column = answering model).
- `refused_models_json VARCHAR` — JSON array text (`JSON.stringify(refusedModels)`); the `_json`
  suffix makes the encoding explicit. Self-contained, retroactive multi-hop detail (historical
  zero-usage hops have no hop rows, but the committed metadata survives a full rebuild).

Both populated only when `requestedModel` parses as a non-empty string **and** `refusedModels` is
a non-empty string array; malformed records yield NULLs (row still ingested).

**One-time backfill on upgrade:** `metadata.modelFallback` already survives in historical
`chat.jsonl`, so users should see historical downgrades after upgrading — not only newly ingested
turns. Mirror the existing `pricing_fingerprint` mechanism: store an
`etl_semantics_version` key (value e.g. `"refusal-analytics-v1"`) in `ingest_meta`, feed a
`semanticsVersionChanged` input into `decideSyncPlan` (`src/node/services/analytics/backfillDecision.ts`)
that triggers `full_rebuild` when the key is missing/outdated, and write the key only after a
successful rebuild/sync — exactly the read→decide→write-after-success flow the pricing
fingerprint uses.

Rejected alternative: side table. Columns ride the existing delete+reinsert idempotency for free;
a side table needs its own lifecycle/watermarks (~3–4× the code).

### D3. Record zero-usage refusals (issue item 3)

In `recordRefusedAttemptUsage` and `recordTerminalRefusalUsage`: instead of early-returning when
the usage snapshot is empty, substitute `{ inputTokens: 0, outputTokens: 0, totalTokens: 0 }`
(a fresh object per record, never a shared singleton — downstream code mutates usage objects) for
the analytics-visible record (`toolModelUsages` entry / `terminalRefusalUsage`), while **still
skipping `recordSessionUsage`** when there are no tokens (no zero-cost noise in the session
ledger / costs UI). Verified downstream: ETL `parseUsage`, `recordHeadlessUsage`, and
`createDisplayUsage` all accept explicit zeros and emit rows.

### D4. Surface via built-in SQL Explorer sample queries (issue item 4)

Add three entries to `SAMPLE_QUERIES` in `SqlExplorer.tsx` (one-click, auto-executed as raw SQL
by the existing sample-query runner test — so plain valid DuckDB SQL, no `{{time_filter}}`
placeholder, consistent with the existing four samples):

1. **Refusals per Day** — `WHERE tool_name IN ('model_fallback_refusal','headless:refused_stream')`,
   grouped by `date, model` (`model` = the refused model on both row kinds).
2. **Refusal Downgrades (Requested → Answered)** — `WHERE requested_model IS NOT NULL AND
   tool_name IS NULL`, grouped by `requested_model, model`.
3. **Refusal Rate by Model** — attempts attributed to the model that actually ran:

   ```sql
   WITH answered AS (
     SELECT model, COUNT(*) AS n FROM events
     WHERE tool_name IS NULL AND model IS NOT NULL GROUP BY model
   ),
   refused AS (
     SELECT model, COUNT(*) AS n FROM events
     WHERE tool_name IN ('model_fallback_refusal', 'headless:refused_stream')
       AND model IS NOT NULL GROUP BY model
   )
   SELECT COALESCE(a.model, r.model) AS model,
          COALESCE(r.n, 0) AS refusals,
          COALESCE(a.n, 0) + COALESCE(r.n, 0) AS attempts,
          ROUND(100.0 * COALESCE(r.n, 0) / NULLIF(COALESCE(a.n, 0) + COALESCE(r.n, 0), 0), 2)
            AS refusal_pct
   FROM answered a FULL OUTER JOIN refused r USING (model)
   ORDER BY refusals DESC;
   ```

   Note the denominator deliberately does **not** use `COALESCE(requested_model, model)`: on a
   downgraded turn the requested model's attempt is already counted by its refusal hop row, and
   the answered row is the fallback model's (successful) attempt — coalescing would double-count
   the requested model's attempts. `requested_model` is for the downgrade query only.

Rejected for this PR: a dedicated dashboard card (schema + named query + oRPC + hook + component,
~100+ LoC). The issue explicitly allows "dashboard card **or** saved query"; sample queries are
the minimal trustworthy-data-first step. A card can be a follow-up once the data proves useful.

## Implementation plan

### Phase 1 — Stream-side recording (`src/node/services/streamManager.ts`)

1. Hoist the `"model_fallback_refusal"` literal into a module-level const (now used in two places).
2. `recordDroppedPartialUsageInSidecar` (~L1586): implement the D1 two-knob signature
   (`analyticsSource` for tool entries / `streamUsageSource` for the stream's own row, defaulting
   to `analyticsSource`) + per-entry `model_fallback_refusal` ⇒ `"refused_stream"` classification.
3. `persistStreamError` (~L3948): pass `streamUsageSource = payload.errorType === "model_refusal"
   ? "refused_stream" : "errored_stream"`; keep `analyticsSource = "errored_stream"`.
4. `recordRefusedAttemptUsage` / `recordTerminalRefusalUsage` (~L2558–2610): zero-usage
   substitution per D3 (push/assign always; session-usage recording stays token-gated).
   `getRefusalUsageSnapshot` itself stays unchanged.
5. **Consumer audit for zero-usage entries:** `rg` all `toolModelUsages` / `terminalRefusalUsage`
   consumers (committed message metadata → costs aggregation/UI, session-usage paths, ETL) and
   confirm zero-usage entries cause no cost/UI artifacts; adjust the D3 approach if any consumer
   assumes non-zero usage.

**Tests (`src/node/services/streamManager.test.ts`, extending existing refusal/sidecar suites at
~L2501–3643, ~L5150–5295):**
- Zero-usage hop refusal → `toolModelUsages` gains a zero-usage `model_fallback_refusal` entry;
  session ledger untouched and cost totals unchanged.
- Terminal refusal without fallback → sidecar line with `source: "refused_stream"` (both with and
  without token usage).
- Exhausted chain → hop entries flattened with `source: "refused_stream"`; a non-refusal
  `toolModelUsages` entry on the same refusal-errored turn keeps `"errored_stream"` (does **not**
  become `headless:refused_stream`).
- Aborted turn with a prior hop refusal → hop entry `"refused_stream"`, stream's own usage row
  `"aborted_stream"`.
- Update existing assertions that expect `"errored_stream"` for refusal terminations (~L3639).

**Gate:** `bun test src/node/services/streamManager.test.ts src/node/services/sessionUsageService.test.ts` + `make typecheck`.

### Phase 2 — Schema & ETL

1. `src/common/analytics/schemaSql.ts`: append `requested_model VARCHAR` and
   `refused_models_json VARCHAR` **after** `tool_name` in `CREATE_EVENTS_TABLE_SQL` (physical
   column order must match migrated DBs for the appender).
2. `src/node/services/analytics/analyticsWorker.ts`: two `ALTER TABLE events ADD COLUMN IF NOT
   EXISTS ...` entries appended to `EVENTS_COLUMN_MIGRATIONS_SQL`, same order.
3. `src/common/orpc/schemas/analytics.ts`: add `requested_model` / `refused_models_json` to
   `EventRowSchema` as `z.string().nullable().default(null)` (defaults keep untouched row-builder
   call sites — headless, archived-transcript — valid).
4. `src/node/services/analytics/etl.ts`:
   - `extractIngestEvents`: defensively parse `metadata.modelFallback` (`isRecord` +
     `toOptionalString(requestedModel)` + string-filtered non-empty `refusedModels` array,
     matching the ETL's existing manual-guard style; malformed → NULLs); populate the two fields
     on the **parent row only**.
   - `buildIngestEventRow`: accept the optional fields.
   - `INSERT_EVENT_SQL` / `insertEventRow`: add the two columns + bind params.
   - `appendEvents`: `appendVarcharOrNull` for both, **after** `tool_name`.
5. **One-time semantics rebuild** (per D2): new `etl_semantics_version` `ingest_meta` key
   (constant next to the pricing-fingerprint constant), `semanticsVersionChanged` input to
   `decideSyncPlan` in `src/node/services/analytics/backfillDecision.ts` (missing/outdated ⇒
   `full_rebuild`), key written only after a successful rebuild/sync — mirroring the
   `pricing_fingerprint` read/decide/write-after-success flow in the worker/service sync path.
6. Check `SEED_EVENTS_ROW_SQL` in `src/browser/features/Analytics/SqlExplorer.test.ts` (explicit
   column-list inserts keep working since new columns are nullable; extend the seed with one
   downgraded turn + one `headless:refused_stream` row so Phase 3 queries return rows).

**Tests (`src/node/services/analytics/etl.test.ts`, following `makeAssistantLine` fixture style):**
- Assistant line with `metadata.modelFallback` → main row has `requested_model` +
  `refused_models_json` (JSON text) populated; sibling tool rows have NULL.
- Malformed `modelFallback` (non-record / non-string entries) → NULLs, row still ingested.
- Sidecar line with `source: "refused_stream"` and zero usage → row
  `tool_name = 'headless:refused_stream'`, zero tokens/cost.
- Delete+reinsert idempotency still holds for both new paths (re-ingest same workspace → no dupes).
- Migration coverage: create the events table with the **old** shape, run
  `EVENTS_COLUMN_MIGRATIONS_SQL`, then `appendEvents` a row with the new fields.
- Semantics rebuild (`backfillDecision.test.ts` + ETL): missing/outdated `etl_semantics_version`
  ⇒ `full_rebuild`; matching version ⇒ no forced rebuild; a pre-existing `chat.jsonl` turn with
  `metadata.modelFallback` has `requested_model`/`refused_models_json` populated after the rebuild.

**Gate:** `bun test src/node/services/analytics/` + `make typecheck`.

### Phase 3 — Surfacing

- Add the three D4 entries to `SAMPLE_QUERIES` (`src/browser/features/Analytics/SqlExplorer.tsx`).
- Existing sample-query runner test executes them against the seeded DB; verify the Phase-2 seed
  rows make them return non-empty results.

**Gate:** `bun test src/browser/features/Analytics/`.

### Phase 4 — Full validation & dogfooding

- `make static-check` (lint + typecheck + fmt + docs links) and the full targeted test set.
- Dogfooding (below), then commit. **No PR unless explicitly requested.**

## Upgrade / downgrade compatibility

- **Sidecar:** `source` is a plain string at write and read; old app versions ingest
  `refused_stream` lines as `headless:refused_stream` without code changes. Zero-usage records
  are already accepted by old ETL (`parseUsage` zeros behavior). Fully compatible both ways.
- **DuckDB columns:** upgrade is handled by `ADD COLUMN IF NOT EXISTS` at worker init (existing
  `tool_name` precedent). **Downgrade is not frictionless for analytics**: an older appender
  (28 columns) against the widened table fails ETL ingestion until the analytics DB file is
  deleted (it rebuilds fully from `chat.jsonl` / sidecars, the durable source of truth — no data
  loss). This is a scoped, analytics-only limitation with a durable-source rebuild escape hatch —
  the same exposure the `tool_name` migration shipped with; per repo policy ("skip migrations when
  breakage is tightly scoped"), acceptable. App stability is unaffected: analytics worker errors
  are caught in `analyticsService.ts` and analytics is disabled for the session, never crashing
  the app.
- **Historical data:** on first upgrade, the `etl_semantics_version` key forces one full rebuild,
  populating `requested_model` / `refused_models_json` for all historical committed downgrade
  turns. Historical **terminal** refusals remain `headless:errored_stream` (the refusal marker was
  dropped before this change) and historical zero-usage refusals remain absent (never recorded at
  the source) — both documented, forward-only fixes.

## Dogfooding & verification evidence

Quality gates between phases are the targeted test runs above. End-to-end dogfood after Phase 4:

1. **Sandbox:** use the project `dev-server-sandbox` skill (temp `XUM_ROOT` + free ports,
   `DEV_SERVER_SANDBOX_ARGS="--clean-projects"` + a scratch repo project, per skill/memory notes).
2. **Seed fixtures** in the sandbox `XUM_ROOT/sessions/<workspace>/` mirroring `etl.test.ts`
   fixtures: `metadata.json`, `chat.jsonl` with (a) a committed assistant turn carrying
   `metadata.modelFallback = { requestedModel: fable, refusedModels: [fable] }` +
   a `model_fallback_refusal` toolModelUsages entry (one with tokens, one zero-usage), and
   `headless-usage.jsonl` with `refused_stream` records (terminal + zero-usage).
3. **Drive the UI with `agent-browser`:** open the Analytics view, wait for ETL ingest, run each
   new sample query in the SQL Explorer, and confirm: refusal counts match the seeded fixtures
   exactly (including the zero-usage ones), downgrade query shows `fable → opus`, and the main
   turn row shows `requested_model`.
4. **Evidence:** capture an `agent-browser` video recording of the SQL Explorer walkthrough
   **plus** screenshots of each query result (and the transcript `ModelFallbackBadge` for the
   seeded turn if visible); `attach_file` all of it for review. Screenshots are the fallback
   primary evidence if the recorder misbehaves (`record stop` is known-flaky per project memory —
   report the exact blocker if so).
5. Optionally verify via the `analytics_query` tool path (`executeRawQuery`) from a chat to prove
   the agent-facing surface sees the same rows.

## Acceptance criteria

1. Every client-visible refusal produces exactly one DuckDB row **per refused model attempt**
   (a multi-hop exhausted chain yields one row per hop): hop-on-committed-turn →
   `tool_name='model_fallback_refusal'`; any refused attempt on a non-committed turn →
   `tool_name='headless:refused_stream'`. No refused attempt is double-counted, and non-refusal
   tool usage on refusal-errored turns is not misclassified (verified by tests).
2. Zero-usage refusals produce rows (zero tokens/cost) in both paths; session cost ledger stays
   free of zero-usage entries.
3. Terminal refusals are no longer conflated with `headless:errored_stream`.
4. Committed downgraded turns carry `requested_model` + `refused_models_json` on the main row;
   NULL for normal turns; historical downgrade turns are backfilled automatically by the one-time
   semantics rebuild on upgrade.
5. The three sample queries run one-click in the SQL Explorer and return **non-empty, correct**
   results against seeded data (sample-query runner test with refusal/downgrade seed rows +
   dogfood evidence).
6. Existing DBs upgrade in place via column migration; fresh DBs and migrated DBs have identical
   physical column order (appender-safe).
7. `make static-check` and all touched test suites pass.

## Net LoC estimate (product code)

- `streamManager.ts`: ~+30
- `schemaSql.ts` / `analyticsWorker.ts` / `orpc/schemas/analytics.ts`: ~+8
- `etl.ts`: ~+25
- Semantics-version rebuild (`backfillDecision.ts` + worker/service sync path): ~+25
- `SqlExplorer.tsx` sample queries: ~+20
- **Total: ~ +110 net LoC** (excluding tests).

## Out of scope

- PostHog `trackError` wiring (issue lists it as a gap but excludes it from the proposed direction).
- Dedicated dashboard card / named oRPC query (follow-up once data is validated in the field).
- Server-side silent Fable→Opus fallback (invisible to clients, per issue caveat).
- Backfilling historical zero-usage refusals (unrecorded at the source).

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$51.33`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=51.33 -->
