### PR TITLE
🤖 feat: show live durable workflow runs in the chat transcript

### DIFF
--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -47,6 +47,7 @@ interface WorkflowTimelineProps {
   view: WorkflowRunView;
   workspaceId?: string;
   nestedDepth?: number;
+  showFinalReport?: boolean;
 }
 
 interface WorkflowPhaseSectionProps {
@@ -581,7 +582,7 @@ export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = (props) => {
           <WorkflowLongText className="flex-1" text={view.errorMessage} title="Workflow error" />
         </div>
       )}
-      <WorkflowFinalReport view={view} />
+      {props.showFinalReport !== false && <WorkflowFinalReport view={view} />}
       <div className="flex flex-col gap-1">
         <div className="text-muted flex items-center gap-1.5 text-[11px] font-semibold tracking-wide uppercase">
           <ListTree className="h-3 w-3" /> Step stream

--- a/src/browser/features/RightSidebar/Workflows/useWorkflowRuns.ts
+++ b/src/browser/features/RightSidebar/Workflows/useWorkflowRuns.ts
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState } from "react";
 
-import { APIContext, useAPI } from "@/browser/contexts/API";
+import { APIContext, useAPI, type APIClient } from "@/browser/contexts/API";
 import { isAbortError } from "@/browser/utils/isAbortError";
 import type { WorkflowRunRecord, WorkflowRunStreamEvent } from "@/common/types/workflow";
 import { assertNever } from "@/common/utils/assertNever";
@@ -103,6 +103,127 @@ export function useWorkflowRuns(workspaceId: string): UseWorkflowRunsResult {
   return { runs, loading, error };
 }
 
+interface WorkflowFeedListener {
+  runId: string;
+  onRun: (run: WorkflowRunRecord) => void;
+  onFailure: () => void;
+}
+
+interface WorkspaceWorkflowFeed {
+  controller: AbortController;
+  iterator: AsyncIterator<WorkflowRunStreamEvent> | null;
+  listeners: Set<WorkflowFeedListener>;
+  latestByRunId: Map<string, WorkflowRunRecord>;
+  failed: boolean;
+}
+
+// One workflows.subscribe stream per (api, workspace), shared by every transcript card: the
+// backend runs crash recovery plus a full listRuns for each new stream and fans every delta out
+// to every stream, so N concurrent cards must not open N workspace-wide streams. Keying by api
+// instance drops feeds naturally when a connection is replaced.
+const workflowFeedsByApi = new WeakMap<APIClient, Map<string, WorkspaceWorkflowFeed>>();
+
+function notifyWorkflowFeedRun(feed: WorkspaceWorkflowFeed, run: WorkflowRunRecord): void {
+  for (const listener of [...feed.listeners]) {
+    if (listener.runId === run.id) {
+      listener.onRun(run);
+    }
+  }
+}
+
+function createWorkspaceWorkflowFeed(api: APIClient, workspaceId: string): WorkspaceWorkflowFeed {
+  const controller = new AbortController();
+  const { signal } = controller;
+  const feed: WorkspaceWorkflowFeed = {
+    controller,
+    iterator: null,
+    listeners: new Set(),
+    latestByRunId: new Map(),
+    failed: false,
+  };
+
+  const pump = async () => {
+    const iterator = await api.workflows.subscribe({ workspaceId }, { signal });
+    if (signal.aborted) {
+      void iterator.return?.();
+      return;
+    }
+    feed.iterator = iterator;
+
+    for await (const event of iterator) {
+      if (signal.aborted) {
+        break;
+      }
+      switch (event.type) {
+        case "snapshot":
+          for (const run of event.runs) {
+            feed.latestByRunId.set(run.id, run);
+            notifyWorkflowFeedRun(feed, run);
+          }
+          break;
+        case "run-changed":
+          feed.latestByRunId.set(event.run.id, event.run);
+          notifyWorkflowFeedRun(feed, event.run);
+          break;
+        default:
+          assertNever(event);
+      }
+    }
+  };
+
+  pump().catch((subscriptionError: unknown) => {
+    if (signal.aborted || isAbortError(subscriptionError)) {
+      return;
+    }
+    feed.failed = true;
+    for (const listener of [...feed.listeners]) {
+      listener.onFailure();
+    }
+  });
+
+  return feed;
+}
+
+/**
+ * Attach a listener to the shared per-workspace feed, creating it on first use. Replays the
+ * cached state for the listener's run (or the failure) so late subscribers do not wait for the
+ * next delta. Returns a release callback; the last release tears the stream down.
+ */
+function acquireWorkflowFeed(
+  api: APIClient,
+  workspaceId: string,
+  listener: WorkflowFeedListener
+): () => void {
+  let feeds = workflowFeedsByApi.get(api);
+  if (feeds == null) {
+    feeds = new Map();
+    workflowFeedsByApi.set(api, feeds);
+  }
+  let feed = feeds.get(workspaceId);
+  if (feed == null) {
+    feed = createWorkspaceWorkflowFeed(api, workspaceId);
+    feeds.set(workspaceId, feed);
+  }
+  feed.listeners.add(listener);
+
+  const cachedRun = feed.latestByRunId.get(listener.runId);
+  if (cachedRun != null) {
+    listener.onRun(cachedRun);
+  }
+  if (feed.failed) {
+    listener.onFailure();
+  }
+
+  return () => {
+    feed.listeners.delete(listener);
+    if (feed.listeners.size === 0) {
+      feeds.delete(workspaceId);
+      feed.controller.abort();
+      void feed.iterator?.return?.();
+    }
+  };
+}
+
 /** Live snapshots for one known run, used by transcript tool cards while the run is active. */
 export function useWorkflowRunLiveSnapshot(input: {
   workspaceId?: string;
@@ -132,58 +253,18 @@ export function useWorkflowRunLiveSnapshot(input: {
       return;
     }
 
-    const workspaceId = input.workspaceId;
-    const runId = input.runId;
     setState({ key: subscriptionKey, run: null, failed: false });
-
-    const controller = new AbortController();
-    const { signal } = controller;
-    let iterator: AsyncIterator<WorkflowRunStreamEvent> | null = null;
-
-    const subscribe = async () => {
-      const subscribedIterator = await api.workflows.subscribe({ workspaceId }, { signal });
-      if (signal.aborted) {
-        void subscribedIterator.return?.();
-        return;
-      }
-      iterator = subscribedIterator;
-
-      for await (const event of subscribedIterator) {
-        if (signal.aborted) {
-          break;
-        }
-        switch (event.type) {
-          case "snapshot": {
-            const matchingRun = event.runs.find((candidate) => candidate.id === runId);
-            if (matchingRun != null) {
-              setState({ key: subscriptionKey, run: matchingRun, failed: false });
-            }
-            break;
-          }
-          case "run-changed":
-            if (event.run.id === runId) {
-              setState({ key: subscriptionKey, run: event.run, failed: false });
-            }
-            break;
-          default:
-            assertNever(event);
-        }
-      }
-    };
-
-    subscribe().catch((subscriptionError: unknown) => {
-      if (signal.aborted || isAbortError(subscriptionError)) {
-        return;
-      }
-      setState((current) =>
-        current.key === subscriptionKey ? { ...current, failed: true } : current
-      );
+    return acquireWorkflowFeed(api, input.workspaceId, {
+      runId: input.runId,
+      onRun: (nextRun) => {
+        setState({ key: subscriptionKey, run: nextRun, failed: false });
+      },
+      onFailure: () => {
+        setState((current) =>
+          current.key === subscriptionKey ? { ...current, failed: true } : current
+        );
+      },
     });
-
-    return () => {
-      controller.abort();
-      void iterator?.return?.();
-    };
   }, [api, input.runId, input.workspaceId, subscriptionKey]);
 
   return { run, failed };

--- a/src/browser/features/RightSidebar/Workflows/useWorkflowRuns.ts
+++ b/src/browser/features/RightSidebar/Workflows/useWorkflowRuns.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
-import { useAPI } from "@/browser/contexts/API";
+import { APIContext, useAPI } from "@/browser/contexts/API";
 import { isAbortError } from "@/browser/utils/isAbortError";
 import type { WorkflowRunRecord, WorkflowRunStreamEvent } from "@/common/types/workflow";
 import { assertNever } from "@/common/utils/assertNever";
@@ -11,6 +11,11 @@ export interface UseWorkflowRunsResult {
   /** True until the first snapshot arrives. */
   loading: boolean;
   error: string | null;
+}
+
+export interface UseWorkflowRunLiveSnapshotResult {
+  run: WorkflowRunRecord | null;
+  failed: boolean;
 }
 
 function recency(run: WorkflowRunRecord): number {
@@ -96,4 +101,90 @@ export function useWorkflowRuns(workspaceId: string): UseWorkflowRunsResult {
   // React Compiler memoizes this derivation; no manual useMemo needed.
   const runs = [...runsById.values()].sort((a, b) => recency(b) - recency(a));
   return { runs, loading, error };
+}
+
+/** Live snapshots for one known run, used by transcript tool cards while the run is active. */
+export function useWorkflowRunLiveSnapshot(input: {
+  workspaceId?: string;
+  runId?: string;
+  enabled: boolean;
+}): UseWorkflowRunLiveSnapshotResult {
+  const api = useContext(APIContext)?.api;
+  const subscriptionKey =
+    input.enabled && api != null && input.workspaceId != null && input.runId != null
+      ? `${input.workspaceId}:${input.runId}`
+      : null;
+  const [state, setState] = useState<{
+    key: string;
+    run: WorkflowRunRecord | null;
+    failed: boolean;
+  }>({ key: "", run: null, failed: false });
+  const run = state.key === subscriptionKey ? state.run : null;
+  const failed = state.key === subscriptionKey && state.failed;
+
+  useEffect(() => {
+    if (
+      subscriptionKey == null ||
+      api == null ||
+      input.workspaceId == null ||
+      input.runId == null
+    ) {
+      return;
+    }
+
+    const workspaceId = input.workspaceId;
+    const runId = input.runId;
+    setState({ key: subscriptionKey, run: null, failed: false });
+
+    const controller = new AbortController();
+    const { signal } = controller;
+    let iterator: AsyncIterator<WorkflowRunStreamEvent> | null = null;
+
+    const subscribe = async () => {
+      const subscribedIterator = await api.workflows.subscribe({ workspaceId }, { signal });
+      if (signal.aborted) {
+        void subscribedIterator.return?.();
+        return;
+      }
+      iterator = subscribedIterator;
+
+      for await (const event of subscribedIterator) {
+        if (signal.aborted) {
+          break;
+        }
+        switch (event.type) {
+          case "snapshot": {
+            const matchingRun = event.runs.find((candidate) => candidate.id === runId);
+            if (matchingRun != null) {
+              setState({ key: subscriptionKey, run: matchingRun, failed: false });
+            }
+            break;
+          }
+          case "run-changed":
+            if (event.run.id === runId) {
+              setState({ key: subscriptionKey, run: event.run, failed: false });
+            }
+            break;
+          default:
+            assertNever(event);
+        }
+      }
+    };
+
+    subscribe().catch((subscriptionError: unknown) => {
+      if (signal.aborted || isAbortError(subscriptionError)) {
+        return;
+      }
+      setState((current) =>
+        current.key === subscriptionKey ? { ...current, failed: true } : current
+      );
+    });
+
+    return () => {
+      controller.abort();
+      void iterator?.return?.();
+    };
+  }, [api, input.runId, input.workspaceId, subscriptionKey]);
+
+  return { run, failed };
 }

--- a/src/browser/features/Tools/CodeExecutionToolCall.tsx
+++ b/src/browser/features/Tools/CodeExecutionToolCall.tsx
@@ -27,6 +27,8 @@ interface CodeExecutionToolCallProps {
   status?: ToolStatus;
   /** Nested tool calls from streaming (takes precedence over result.toolCalls) */
   nestedCalls?: NestedToolCall[];
+  workspaceId?: string;
+  toolCallTimestamp?: number;
 }
 
 interface ViewToggleProps {
@@ -70,6 +72,8 @@ export const CodeExecutionToolCall: React.FC<CodeExecutionToolCallProps> = ({
   result,
   status = "pending",
   nestedCalls,
+  workspaceId,
+  toolCallTimestamp,
 }) => {
   // Use streaming nested calls if available, otherwise fall back to result
   const toolCalls = nestedCalls ?? [];
@@ -192,7 +196,12 @@ export const CodeExecutionToolCall: React.FC<CodeExecutionToolCallProps> = ({
 
       {/* Content based on view mode */}
       {effectiveViewMode === "tools" && hasToolCalls && (
-        <NestedToolsContainer calls={toolCalls} parentInterrupted={isInterrupted} />
+        <NestedToolsContainer
+          calls={toolCalls}
+          parentInterrupted={isInterrupted}
+          workspaceId={workspaceId}
+          toolCallTimestamp={toolCallTimestamp}
+        />
       )}
 
       {effectiveViewMode === "code" && (

--- a/src/browser/features/Tools/Shared/NestedToolRenderer.test.tsx
+++ b/src/browser/features/Tools/Shared/NestedToolRenderer.test.tsx
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type { ReactNode } from "react";
 
 import { BackgroundBashProvider } from "@/browser/contexts/BackgroundBashContext";
+import { APIContext } from "@/browser/contexts/API";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { NestedToolRenderer } from "./NestedToolRenderer";
 
@@ -120,5 +121,47 @@ describe("NestedToolRenderer", () => {
 
     expect(getByText(/took 2s/)).toBeDefined();
     expect(getByText("0")).toBeDefined();
+  });
+
+  test("passes workspace identity to nested workflow components", async () => {
+    const iterator: AsyncIterableIterator<never> = {
+      next: () => new Promise(() => undefined),
+      return: () => Promise.resolve({ value: undefined, done: true }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const subscribe = mock((_input: { workspaceId: string }, _options: { signal: AbortSignal }) =>
+      Promise.resolve(iterator)
+    );
+    const getRun = mock(() => Promise.resolve(null));
+    const client = { workflows: { subscribe, getRun } };
+
+    render(
+      <APIContext.Provider
+        value={{
+          status: "connected",
+          api: client as never,
+          error: null,
+          authenticate: () => undefined,
+          retry: () => undefined,
+        }}
+      >
+        <Providers>
+          <NestedToolRenderer
+            toolName="workflow_run"
+            input={{ script_path: "skill://research/workflow.js", run_in_background: true }}
+            output={{ status: "running", runId: "wfr_nested", result: null }}
+            status="executing"
+            workspaceId="ws-nested"
+            toolCallId="nested-tool-call"
+          />
+        </Providers>
+      </APIContext.Provider>
+    );
+
+    await waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1));
+    expect(subscribe.mock.calls[0]?.[0]).toEqual({ workspaceId: "ws-nested" });
+    expect(subscribe.mock.calls[0]?.[1].signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/src/browser/features/Tools/Shared/NestedToolRenderer.tsx
+++ b/src/browser/features/Tools/Shared/NestedToolRenderer.tsx
@@ -9,6 +9,9 @@ interface NestedToolRendererProps {
   input: unknown;
   output?: unknown;
   status: ToolStatus;
+  workspaceId?: string;
+  toolCallId?: string;
+  toolCallTimestamp?: number;
 }
 
 /**
@@ -20,6 +23,9 @@ export const NestedToolRenderer: React.FC<NestedToolRendererProps> = ({
   input,
   output,
   status,
+  workspaceId,
+  toolCallId,
+  toolCallTimestamp,
 }) => {
   const ToolComponent = getToolComponent(toolName, input);
   const hookOutput = extractHookOutput(output);
@@ -29,7 +35,15 @@ export const NestedToolRenderer: React.FC<NestedToolRendererProps> = ({
     <>
       {/* ToolNameProvider lets useStickyExpand key the auto-expand preference by tool name. */}
       <ToolNameProvider toolName={toolName}>
-        <ToolComponent args={input} result={output} status={status} toolName={toolName} />
+        <ToolComponent
+          args={input}
+          result={output}
+          status={status}
+          toolName={toolName}
+          workspaceId={workspaceId}
+          toolCallId={toolCallId}
+          toolCallTimestamp={toolCallTimestamp}
+        />
       </ToolNameProvider>
       {hookOutput && <HookOutputDisplay output={hookOutput} durationMs={hookDuration} />}
     </>

--- a/src/browser/features/Tools/Shared/NestedToolsContainer.tsx
+++ b/src/browser/features/Tools/Shared/NestedToolsContainer.tsx
@@ -7,6 +7,8 @@ interface NestedToolsContainerProps {
   calls: NestedToolCall[];
   /** When true, incomplete tools show as interrupted instead of executing */
   parentInterrupted?: boolean;
+  workspaceId?: string;
+  toolCallTimestamp?: number;
 }
 
 /**
@@ -16,6 +18,8 @@ interface NestedToolsContainerProps {
 export const NestedToolsContainer: React.FC<NestedToolsContainerProps> = ({
   calls,
   parentInterrupted,
+  workspaceId,
+  toolCallTimestamp,
 }) => {
   if (calls.length === 0) return null;
 
@@ -35,6 +39,9 @@ export const NestedToolsContainer: React.FC<NestedToolsContainerProps> = ({
             input={call.input}
             output={call.state === "output-available" ? call.output : undefined}
             status={status}
+            workspaceId={workspaceId}
+            toolCallId={call.toolCallId}
+            toolCallTimestamp={call.timestamp ?? toolCallTimestamp}
           />
         );
       })}

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -472,7 +472,9 @@ export const LiveRunningTimeline: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await fireEvent.click(await canvas.findByText("implementation"));
+    // "implementation" is both the workflow name (header + script card spans) and the
+    // phase label; only the phase disclosure is a button, so query by role.
+    await fireEvent.click(await canvas.findByRole("button", { name: /implementation/ }));
     await canvas.findByText("Summarize source 16");
     await canvas.findByText("extract-claims");
     const container = canvas.getByTestId("live-workflow-card");

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -458,6 +458,40 @@ export const RunningBackgroundWithRun: Story = {
   },
 };
 
+export const LiveRunningTimeline: Story = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    pixel: { matrix: { viewports: ["phone"] } },
+  },
+  render: (args) => (
+    <div data-testid="live-workflow-card" style={{ width: 360 }}>
+      <WorkflowRunToolCall {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fireEvent.click(await canvas.findByText("implementation"));
+    await canvas.findByText("Summarize source 16");
+    await canvas.findByText("extract-claims");
+    const container = canvas.getByTestId("live-workflow-card");
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `Workflow card overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
+  },
+  args: {
+    ...taskActionsProps,
+    status: "executing",
+  },
+};
+
 /**
  * Narrow-container regression: a long workflow name must truncate instead of
  * starving the collapsed header's progress summary. No API provider, so the

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 import { APIContext } from "@/browser/contexts/API";
-import type { WorkflowRunRecord } from "@/common/types/workflow";
+import type { WorkflowRunRecord, WorkflowRunStreamEvent } from "@/common/types/workflow";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
   CommandRegistryProvider,
@@ -108,12 +108,10 @@ void mock.module("@/browser/components/Dialog/Dialog", () => ({
   ),
 }));
 
-// WorkflowRunToolCall reads the dynamic-workflows experiment to decide whether to auto-collapse.
-// Force it off so these tests are hermetic: in the full bun-test suite, cross-file experiment
-// state (shared happy-dom localStorage) can otherwise flip the card to collapsed and hide the
-// expanded content these tests assert.
+// Keep experiment state local to this suite so cross-file happy-dom storage cannot affect cards.
+let dynamicWorkflowsEnabled = false;
 void mock.module("@/browser/contexts/ExperimentsContext", () => ({
-  useExperimentValue: () => false,
+  useExperimentValue: () => dynamicWorkflowsEnabled,
 }));
 
 import { WorkflowResumeToolCall, WorkflowRunToolCall } from "./WorkflowRunToolCall";
@@ -213,6 +211,95 @@ function createWorkflowRunForExpansionTest(input: {
   };
 }
 
+function createTimelineRun(input: {
+  id: string;
+  status?: "running" | "backgrounded" | "completed";
+  stepTitle?: string;
+  updatedAt?: string;
+}): WorkflowRunRecord {
+  const status = input.status ?? "running";
+  const stepTitle = input.stepTitle ?? "Collect sources";
+  const completed = status === "completed";
+  const base = createWorkflowRunForExpansionTest({
+    id: input.id,
+    status: completed ? "completed" : "running",
+  });
+  const updatedAt =
+    input.updatedAt ?? (completed ? "2026-05-29T00:00:03.000Z" : "2026-05-29T00:00:02.000Z");
+  return {
+    ...base,
+    status,
+    updatedAt,
+    events: [
+      { sequence: 1, type: "status", at: "2026-05-29T00:00:01.000Z", status },
+      { sequence: 2, type: "phase", at: "2026-05-29T00:00:01.000Z", name: "Research" },
+      {
+        sequence: 3,
+        type: "task",
+        at: "2026-05-29T00:00:01.000Z",
+        stepId: "collect",
+        taskId: "task_collect",
+        status: completed ? "completed" : "started",
+        title: stepTitle,
+      },
+      ...(completed
+        ? [{ sequence: 4, type: "status" as const, at: updatedAt, status: "completed" as const }]
+        : []),
+    ],
+    steps: [
+      {
+        stepId: "collect",
+        inputHash: "sha256:collect",
+        status: completed ? "completed" : "started",
+        taskId: "task_collect",
+        startedAt: "2026-05-29T00:00:01.000Z",
+        ...(completed ? { completedAt: updatedAt } : {}),
+      },
+    ],
+  };
+}
+
+function createWorkflowSubscription() {
+  const queued: WorkflowRunStreamEvent[] = [];
+  let resolveNext: ((result: IteratorResult<WorkflowRunStreamEvent>) => void) | null = null;
+  let closed = false;
+  const iterator: AsyncIterableIterator<WorkflowRunStreamEvent> = {
+    next: () => {
+      const event = queued.shift();
+      if (event != null) {
+        return Promise.resolve({ value: event, done: false });
+      }
+      if (closed) {
+        return Promise.resolve({ value: undefined, done: true });
+      }
+      return new Promise((resolve) => {
+        resolveNext = resolve;
+      });
+    },
+    return: () => {
+      closed = true;
+      resolveNext?.({ value: undefined, done: true });
+      resolveNext = null;
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+  return {
+    iterator,
+    emit(event: WorkflowRunStreamEvent) {
+      if (resolveNext != null) {
+        const resolve = resolveNext;
+        resolveNext = null;
+        resolve({ value: event, done: false });
+        return;
+      }
+      queued.push(event);
+    },
+  };
+}
+
 function CommandActionCapture(props: { onActions: (actions: CommandAction[]) => void }) {
   const registry = useCommandRegistry();
   useEffect(() => {
@@ -230,6 +317,13 @@ function getWorkflowHeader(view: ReturnType<typeof render>): HTMLElement {
   return header as HTMLElement;
 }
 
+function openEventLog(view: ReturnType<typeof render>): void {
+  const disclosure = view.queryByText("Event log");
+  if (disclosure != null) {
+    fireEvent.click(disclosure);
+  }
+}
+
 describe("WorkflowRunToolCall", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
@@ -242,6 +336,7 @@ describe("WorkflowRunToolCall", () => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
     globalThis.localStorage = globalThis.window.localStorage;
+    dynamicWorkflowsEnabled = false;
   });
 
   afterEach(() => {
@@ -298,6 +393,79 @@ describe("WorkflowRunToolCall", () => {
     expect(getStoredPrefs()).toBeNull();
   });
 
+  test("keeps active workflow runs expanded with the workflows experiment enabled", () => {
+    dynamicWorkflowsEnabled = true;
+
+    for (const status of ["running", "backgrounded"] as const) {
+      const run = createTimelineRun({ id: `wfr_active_${status}`, status });
+      const view = renderWithStickyToolProviders(
+        <WorkflowRunToolCall
+          args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+          status={status === "backgrounded" ? "backgrounded" : "executing"}
+          result={{ status, runId: run.id, result: null, run }}
+        />
+      );
+
+      expect(view.getByText(run.id)).toBeTruthy();
+      expect(view.getByText("Research")).toBeTruthy();
+      view.unmount();
+    }
+
+    const completedRun = createTimelineRun({ id: "wfr_dynamic_completed", status: "completed" });
+    const completedView = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: false }}
+        status="completed"
+        result={{ status: "completed", runId: completedRun.id, result: null, run: completedRun }}
+      />
+    );
+    expect(completedView.queryByText(completedRun.id)).toBeNull();
+  });
+
+  test("auto-collapses a non-interacted card when its run becomes terminal", () => {
+    dynamicWorkflowsEnabled = true;
+    const runningRun = createTimelineRun({ id: "wfr_transition" });
+    const completedRun = createTimelineRun({ id: runningRun.id, status: "completed" });
+    const renderCard = (run: WorkflowRunRecord) =>
+      withStickyToolProviders(
+        <WorkflowRunToolCall
+          args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+          status={run.status === "completed" ? "completed" : "executing"}
+          result={{ status: run.status, runId: run.id, result: null, run }}
+        />
+      );
+    const view = render(renderCard(runningRun));
+
+    expect(view.getByText(runningRun.id)).toBeTruthy();
+    view.rerender(renderCard(completedRun));
+    expect(view.queryByText(completedRun.id)).toBeNull();
+  });
+
+  test("manual collapse sticks while the live header summary updates", () => {
+    dynamicWorkflowsEnabled = true;
+    const runningRun = createTimelineRun({ id: "wfr_manual_live" });
+    const updatedRun = createTimelineRun({
+      id: runningRun.id,
+      stepTitle: "Verify claims",
+      updatedAt: "2026-05-29T00:00:03.000Z",
+    });
+    const renderCard = (run: WorkflowRunRecord) =>
+      withStickyToolProviders(
+        <WorkflowRunToolCall
+          args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+          status="executing"
+          result={{ status: "running", runId: run.id, result: null, run }}
+        />
+      );
+    const view = render(renderCard(runningRun));
+
+    fireEvent.click(getWorkflowHeader(view));
+    expect(view.queryByText(runningRun.id)).toBeNull();
+    view.rerender(renderCard(updatedRun));
+
+    expect(view.queryByText(updatedRun.id)).toBeNull();
+    expect(getWorkflowHeader(view).textContent).toContain("0/1 steps · Verify claims");
+  });
   test("resets completed workflow auto-collapse interaction for a new run id", () => {
     const firstRun = createWorkflowRunForExpansionTest({ id: "wfr_first", status: "completed" });
     const secondRun = createWorkflowRunForExpansionTest({ id: "wfr_second", status: "completed" });
@@ -469,6 +637,7 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByText("wfr_123")).toBeNull();
 
     fireEvent.click(workflowHeader);
+    openEventLog(view);
 
     expect(view.getByText("wfr_123")).toBeTruthy();
     const getDisclosureForTitle = (title: string) => view.getByText(title).closest("details");
@@ -486,11 +655,15 @@ describe("WorkflowRunToolCall", () => {
     expect(firstEventIndex).toBeTruthy();
     expect(firstEventIndex.getAttribute("title")).toBeNull();
     expect(firstEventIndex.getAttribute("aria-label")).toBe("Raw event #2");
-    expect(view.getByText("scope").closest("div")?.className).toContain("bg-plan-mode-alpha");
+    expect(
+      view
+        .getAllByText("scope")
+        .some((element) => element.closest("div")?.className.includes("bg-plan-mode-alpha"))
+    ).toBe(true);
     expect(view.getByText("Scoped topic").closest("div")?.className).not.toContain(
       "bg-plan-mode-alpha"
     );
-    expect(view.getByText("Workflow events (6)")).toBeTruthy();
+    expect(view.getByText("Event log")).toBeTruthy();
     const taskEventRow = view.getByText("scope-topic / task_scope / completed");
     const taskEventIndex = view.getByText("#3");
     expect(taskEventIndex.className).toContain("cursor-help");
@@ -615,6 +788,7 @@ describe("WorkflowRunToolCall", () => {
       </APIHarness>
     );
 
+    openEventLog(view);
     await waitFor(() => {
       expect(view.getByText("child-phase")).toBeTruthy();
     });
@@ -976,6 +1150,7 @@ describe("WorkflowRunToolCall", () => {
       </APIHarness>
     );
 
+    openEventLog(view);
     await waitFor(() => {
       expect(view.getByText("Nested workflow run is not available.")).toBeTruthy();
     });
@@ -1090,6 +1265,7 @@ describe("WorkflowRunToolCall", () => {
       </ThemeProvider>
     );
 
+    openEventLog(view);
     expect(view.getAllByText("implement / task_live / completed")).toHaveLength(1);
     expect(view.queryByText("implement / task_live / started")).toBeNull();
     expect(view.getByText("implement / task_retry / started")).toBeTruthy();
@@ -1227,6 +1403,7 @@ describe("WorkflowRunToolCall", () => {
       </ThemeProvider>
     );
 
+    openEventLog(view);
     expect(view.queryByLabelText("Open report for task_structured_only")).toBeNull();
     expect(view.container.textContent).not.toContain(
       STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN
@@ -1717,6 +1894,7 @@ describe("WorkflowRunToolCall", () => {
       </ThemeProvider>
     );
 
+    openEventLog(view);
     expect(view.queryByLabelText("Open task workspace for task_deleted_report")).toBeNull();
     expect(view.queryByText("Open")).toBeNull();
     expect(
@@ -1731,6 +1909,25 @@ describe("WorkflowRunToolCall", () => {
     });
   });
 
+  test("renders the projected timeline with the raw event log collapsed", () => {
+    const run = createTimelineRun({ id: "wfr_projected_timeline" });
+    const view = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+        status="executing"
+        result={{ status: "running", runId: run.id, result: null, run }}
+      />
+    );
+
+    expect(view.getByText("0/1 steps")).toBeTruthy();
+    fireEvent.click(view.getByText("Research"));
+    expect(view.getByText("Collect sources")).toBeTruthy();
+    expect(view.getByText("Event log")).toBeTruthy();
+    expect(view.queryByLabelText("Raw event #3")).toBeNull();
+
+    fireEvent.click(view.getByText("Event log"));
+    expect(view.getByLabelText("Raw event #3")).toBeTruthy();
+  });
   test("shows invocation arguments and script source before workflow events", () => {
     const runningRun = {
       id: "wfr_event_priority",
@@ -1782,6 +1979,7 @@ describe("WorkflowRunToolCall", () => {
     const argumentsTitle = view.getByText("Arguments");
     const sourceTitle = view.getByText("Script source");
     const eventsTitle = view.getByText("Workflow events (1)");
+    expect(view.queryByText("Event log")).toBeNull();
     expect(Boolean(argumentsTitle.compareDocumentPosition(eventsTitle) & 4)).toBe(true);
     expect(Boolean(sourceTitle.compareDocumentPosition(eventsTitle) & 4)).toBe(true);
     expect(view.getByText("collect-sources / github.issue.get / completed")).toBeTruthy();
@@ -2086,7 +2284,7 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByText("wfr_stale")).toBeNull();
     expect(view.queryByText("stale")).toBeNull();
     expect(view.getAllByText("built-in").length).toBeGreaterThan(0);
-    expect(view.getByText("Workflow events (1)")).toBeTruthy();
+    expect(view.getByText("Event log")).toBeTruthy();
     expect(view.getByText("scope")).toBeTruthy();
     expect(listRuns).toHaveBeenCalledWith({ workspaceId: "workspace-1" });
 
@@ -2308,7 +2506,7 @@ describe("WorkflowRunToolCall", () => {
     expect(getWorkflowHeader(view).textContent).toContain("executing");
     expect(view.getByText("wfr_known")).toBeTruthy();
     expect(view.getAllByText("built-in").length).toBeGreaterThan(0);
-    expect(view.getByText("Workflow events (1)")).toBeTruthy();
+    expect(view.getByText("Event log")).toBeTruthy();
     expect(view.getByText("scope")).toBeTruthy();
     // The fetched snapshot matches the args' run id and this workspace, so the run is
     // actionable before the blocking tool call returns a result.
@@ -2448,6 +2646,92 @@ describe("WorkflowRunToolCall", () => {
     expect(view.queryByRole("button", { name: "Resume workflow" })).toBeNull();
   });
 
+  test("applies matching workflow subscription updates without polling", async () => {
+    const initialRun = createTimelineRun({ id: "wfr_subscribed", stepTitle: "Collect sources" });
+    const updatedRun = createTimelineRun({
+      id: initialRun.id,
+      stepTitle: "Verify sources",
+      updatedAt: "2026-05-29T00:00:03.000Z",
+    });
+    const otherRun = createTimelineRun({ id: "wfr_other", stepTitle: "Ignore me" });
+    const stream = createWorkflowSubscription();
+    const subscribe = mock(async () => stream.iterator);
+    const getRun = mock(async () => initialRun);
+    const view = render(
+      <APIHarness client={{ workflows: { subscribe, getRun } }}>
+        {withStickyToolProviders(
+          <WorkflowRunToolCall
+            args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+            status="executing"
+            workspaceId={TEST_WORKSPACE_ID}
+            result={{ status: "running", runId: initialRun.id, result: null, run: initialRun }}
+          />
+        )}
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(subscribe).toHaveBeenCalledTimes(1));
+    fireEvent.click(view.getByText("Research"));
+    expect(view.getByText("Collect sources")).toBeTruthy();
+    stream.emit({ type: "run-changed", run: otherRun });
+    stream.emit({ type: "run-changed", run: updatedRun });
+
+    await waitFor(() => expect(view.getByText("Verify sources")).toBeTruthy());
+    expect(view.queryByText("Ignore me")).toBeNull();
+    expect(getRun).not.toHaveBeenCalled();
+  });
+
+  test("falls back to workflow polling when the live subscription fails", async () => {
+    const initialRun = createTimelineRun({ id: "wfr_subscription_fallback" });
+    const completedRun = createTimelineRun({ id: initialRun.id, status: "completed" });
+    const subscribe = mock(async () => {
+      throw new Error("stream unavailable");
+    });
+    const getRun = mock(async () => completedRun);
+    const view = render(
+      <APIHarness client={{ workflows: { subscribe, getRun } }}>
+        {withStickyToolProviders(
+          <WorkflowRunToolCall
+            args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+            status="executing"
+            workspaceId={TEST_WORKSPACE_ID}
+            result={{ status: "running", runId: initialRun.id, result: null, run: initialRun }}
+          />
+        )}
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(getRun).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getWorkflowHeader(view).textContent).toContain("completed"));
+  });
+
+  test("does not subscribe terminal workflow cards", async () => {
+    const completedRun = createTimelineRun({
+      id: "wfr_terminal_no_subscription",
+      status: "completed",
+    });
+    const subscribe = mock(async () => createWorkflowSubscription().iterator);
+    render(
+      <APIHarness client={{ workflows: { subscribe } }}>
+        {withStickyToolProviders(
+          <WorkflowRunToolCall
+            args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: false }}
+            status="completed"
+            workspaceId={TEST_WORKSPACE_ID}
+            result={{
+              status: "completed",
+              runId: completedRun.id,
+              result: null,
+              run: completedRun,
+            }}
+          />
+        )}
+      </APIHarness>
+    );
+
+    await Promise.resolve();
+    expect(subscribe).not.toHaveBeenCalled();
+  });
   test("keeps the newest workflow refresh snapshot when polls resolve out of order", async () => {
     const originalSetInterval = globalThis.window.setInterval;
     const originalClearInterval = globalThis.window.clearInterval;
@@ -2914,6 +3198,7 @@ describe("WorkflowRunToolCall", () => {
     );
 
     await waitFor(() => expect(pendingRefresh.resolve).toBeDefined());
+    openEventLog(view);
     fireEvent.click(view.getByLabelText("Open report for task_report"));
     await waitFor(() => {
       expect(document.querySelector('[role="dialog"]')?.textContent).toContain(
@@ -3034,6 +3319,7 @@ describe("WorkflowRunToolCall", () => {
     );
 
     await waitFor(() => expect(pendingRefresh.resolve).toBeDefined());
+    openEventLog(view);
     fireEvent.click(
       view.getByRole("button", {
         name: "Expand structured output for workflow task task_structured",

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -2735,6 +2735,102 @@ describe("WorkflowRunToolCall", () => {
     await Promise.resolve();
     expect(subscribe).not.toHaveBeenCalled();
   });
+
+  test("keeps polling nested runs the subscription feed omits", async () => {
+    const parentWorkflow = {
+      runId: "wfr_parent",
+      stepId: "spawn-child",
+      inputHash: "sha256:child",
+      depth: 1,
+    };
+    const nestedRun = {
+      ...createTimelineRun({ id: "wfr_nested_child" }),
+      parentWorkflow,
+    };
+    const updatedNestedRun = {
+      ...createTimelineRun({
+        id: nestedRun.id,
+        stepTitle: "Verify sources",
+        updatedAt: "2026-05-29T00:00:03.000Z",
+      }),
+      parentWorkflow,
+    };
+    const subscribe = mock(async () => createWorkflowSubscription().iterator);
+    const getRun = mock(async () => updatedNestedRun);
+    const view = render(
+      <APIHarness client={{ workflows: { subscribe, getRun } }}>
+        {withStickyToolProviders(
+          <WorkflowRunToolCall
+            args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+            status="executing"
+            workspaceId={TEST_WORKSPACE_ID}
+            result={{ status: "running", runId: nestedRun.id, result: null, run: nestedRun }}
+          />
+        )}
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(getRun).toHaveBeenCalled());
+    fireEvent.click(view.getByText("Research"));
+    await waitFor(() => expect(view.getByText("Verify sources")).toBeTruthy());
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  test("shares one workspace subscription across concurrent workflow cards", async () => {
+    const firstRun = createTimelineRun({ id: "wfr_shared_first", stepTitle: "First initial" });
+    const secondRun = createTimelineRun({ id: "wfr_shared_second", stepTitle: "Second initial" });
+    const stream = createWorkflowSubscription();
+    const subscribe = mock(async () => stream.iterator);
+    const view = render(
+      <APIHarness client={{ workflows: { subscribe } }}>
+        {withStickyToolProviders(
+          <>
+            <WorkflowRunToolCall
+              args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+              status="executing"
+              workspaceId={TEST_WORKSPACE_ID}
+              result={{ status: "running", runId: firstRun.id, result: null, run: firstRun }}
+            />
+            <WorkflowRunToolCall
+              args={{ script_path: TEST_WORKFLOW_SCRIPT_PATH, run_in_background: true }}
+              status="executing"
+              workspaceId={TEST_WORKSPACE_ID}
+              result={{ status: "running", runId: secondRun.id, result: null, run: secondRun }}
+            />
+          </>
+        )}
+      </APIHarness>
+    );
+
+    await waitFor(() => expect(subscribe).toHaveBeenCalled());
+    for (const phase of view.getAllByText("Research")) {
+      fireEvent.click(phase);
+    }
+    expect(view.getByText("First initial")).toBeTruthy();
+    expect(view.getByText("Second initial")).toBeTruthy();
+
+    stream.emit({
+      type: "run-changed",
+      run: createTimelineRun({
+        id: firstRun.id,
+        stepTitle: "First updated",
+        updatedAt: "2026-05-29T00:00:03.000Z",
+      }),
+    });
+    stream.emit({
+      type: "run-changed",
+      run: createTimelineRun({
+        id: secondRun.id,
+        stepTitle: "Second updated",
+        updatedAt: "2026-05-29T00:00:03.000Z",
+      }),
+    });
+
+    await waitFor(() => expect(view.getByText("First updated")).toBeTruthy());
+    await waitFor(() => expect(view.getByText("Second updated")).toBeTruthy());
+    expect(subscribe).toHaveBeenCalledTimes(1);
+  });
+
   test("keeps the newest workflow refresh snapshot when polls resolve out of order", async () => {
     const originalSetInterval = globalThis.window.setInterval;
     const originalClearInterval = globalThis.window.clearInterval;

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1920,6 +1920,9 @@ describe("WorkflowRunToolCall", () => {
     );
 
     expect(view.getByText("0/1 steps")).toBeTruthy();
+    // Without a usage overlay the stats row omits the token/cost cells entirely
+    // (mirroring WorkflowRunHeader) instead of rendering dash placeholders.
+    expect(view.queryByText(/tokens/)).toBeNull();
     fireEvent.click(view.getByText("Research"));
     expect(view.getByText("Collect sources")).toBeTruthy();
     expect(view.getByText("Event log")).toBeTruthy();

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1808,7 +1808,11 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
 
           {hasProjectedTimeline && workflowView != null ? (
             <>
-              <div className="border-border bg-background/20 counter-nums mb-3 grid grid-cols-2 gap-x-3 gap-y-1 rounded border px-2 py-1.5 text-[10px] @sm:grid-cols-4">
+              <div
+                className={`border-border bg-background/20 counter-nums mb-3 grid grid-cols-2 gap-x-3 gap-y-1 rounded border px-2 py-1.5 text-[10px] ${
+                  workflowView.stats.usage != null ? "@sm:grid-cols-4" : ""
+                }`}
+              >
                 <span>
                   {workflowView.stats.done}/{workflowView.stats.total} steps
                 </span>

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1315,6 +1315,10 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     typeof apiState?.api?.workflows.subscribe === "function" &&
     workflowWorkspaceId != null &&
     runId != null &&
+    // The workflows.subscribe feed deliberately omits nested (parentWorkflow) runs, so a card
+    // whose snapshot is confirmed nested must keep the getRun poller instead of freezing on a
+    // healthy stream that will never yield its run.
+    run?.parentWorkflow == null &&
     (shouldRefreshWorkflow(displayStatus) ||
       resumingRunId === runId ||
       workflowControlInFlightRunId === runId);

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1813,8 +1813,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                   {workflowView.stats.done}/{workflowView.stats.total} steps
                 </span>
                 <span>{formatWorkflowDuration(workflowView.stats.elapsedMs)}</span>
-                <span>{formatWorkflowTokens(workflowView.stats.usage?.tokens)} tokens</span>
-                <span>{formatWorkflowCost(workflowView.stats.usage?.costUsd)}</span>
+                {/* Usage exists only when a per-task overlay was supplied to projectWorkflowRun;
+                    mirror WorkflowRunHeader and omit the cells instead of rendering dashes. */}
+                {workflowView.stats.usage != null && (
+                  <>
+                    <span>{formatWorkflowTokens(workflowView.stats.usage.tokens)} tokens</span>
+                    <span>{formatWorkflowCost(workflowView.stats.usage.costUsd)}</span>
+                  </>
+                )}
               </div>
               <div
                 className="max-h-[400px] overflow-y-auto pr-1"

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -18,6 +18,12 @@ import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import { WorkflowTimeline } from "@/browser/features/RightSidebar/Workflows/WorkflowTimeline";
 import { projectWorkflowRun } from "@/browser/features/RightSidebar/Workflows/projectWorkflowRun";
+import {
+  formatWorkflowCost,
+  formatWorkflowDuration,
+  formatWorkflowTokens,
+} from "@/browser/features/RightSidebar/Workflows/workflowDisplay";
+import { useWorkflowRunLiveSnapshot } from "@/browser/features/RightSidebar/Workflows/useWorkflowRuns";
 import { useWorkflowRunById } from "@/browser/hooks/useWorkflowRunById";
 import {
   isActiveWorkflowChildEventStatus,
@@ -268,8 +274,8 @@ function getWorkflowChildProgressSummary(run: WorkflowRunRecord | null): string 
 /**
  * Compact "what is the workflow doing right now" line for the card header: steps
  * done/observed plus the running step title (or active phase when several steps
- * run). The card auto-collapses while the Workflows tab owns the detail view, so
- * without this the collapsed header reveals nothing about a run's current state.
+ * run). Manually collapsed active cards keep this summary visible so progress remains
+ * scannable without reopening the full timeline.
  * Totals are observed-so-far, not planned (see WorkflowPhaseView.total).
  */
 export function getWorkflowHeaderProgressSummary(
@@ -524,7 +530,34 @@ function WorkflowDisclosureSection(props: {
   title: string;
   children: React.ReactNode;
   className?: string;
+  unmountCollapsed?: boolean;
+  onOpen?: () => void;
 }) {
+  const [open, setOpen] = useState(false);
+  if (props.unmountCollapsed) {
+    return (
+      <div className={`group mb-2 ${props.className ?? ""}`}>
+        <button
+          type="button"
+          aria-expanded={open}
+          className="text-muted hover:text-foreground flex cursor-pointer list-none items-center gap-2 text-[10px] tracking-wide uppercase"
+          onClick={() => {
+            const nextOpen = !open;
+            setOpen(nextOpen);
+            if (nextOpen) {
+              props.onOpen?.();
+            }
+          }}
+        >
+          <span className={open ? "rotate-90 transition-transform" : "transition-transform"}>
+            ▶
+          </span>
+          <span>{props.title}</span>
+        </button>
+        {open && <div className="mt-1">{props.children}</div>}
+      </div>
+    );
+  }
   return (
     <details className={`group mb-2 ${props.className ?? ""}`}>
       <summary className="text-muted hover:text-foreground flex cursor-pointer list-none items-center gap-2 text-[10px] tracking-wide uppercase [&::-webkit-details-marker]:hidden">
@@ -1233,6 +1266,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   });
   const runId = selectedRun.runId;
   const run = selectedRun.run;
+  const workflowWorkspaceId = run?.workspaceId ?? workspaceId;
   const hasRefreshedRunSnapshot =
     refreshedRun != null && refreshedRun.id === runId && run === refreshedRun;
   // workflow_resume can return a fresh dispatch status while intentionally omitting a stale
@@ -1255,8 +1289,8 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const headerProgressSummary =
     displayStatus === "completed" ? null : getWorkflowHeaderProgressSummary(run);
   const workspaceStore = useWorkspaceStoreRaw();
-  // The Workflows right-sidebar tab (gated on the dynamic-workflows experiment) is the primary
-  // surface for run detail, so when it's available the in-chat card is redundant.
+  // Active runs stay visible in the transcript as a live surface. The Workflows tab remains the
+  // broader detail and history surface once a run settles.
   const workflowsTabEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
   const {
     expanded,
@@ -1264,22 +1298,33 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     toggleExpanded,
     markInteracted: markExpansionInteracted,
   } = useAutoCollapsingToolExpansion(true, {
-    // With the Workflows tab available (dynamic-workflows experiment on), auto-collapse the
-    // in-chat card for ANY status — the tab is the primary detail surface. Without the tab,
-    // preserve the prior behavior of auto-collapsing only completed runs (which can carry large
-    // reports/event logs). But never auto-collapse a tool-error card: pre-run failures (invalid
-    // args / unresolved script path) create no durable run, so the Workflows tab has nothing to
-    // show and the failure reason lives only here. Manual expansion always wins, per run.
-    autoCollapsed: (workflowsTabEnabled || displayStatus === "completed") && errorResult == null,
+    // Active runs are a live transcript surface even when the Workflows tab is available. Once a
+    // run settles, the experiment restores the compact history presentation. Without the tab, only
+    // completed runs collapse. Tool errors always stay open because no durable run may exist.
+    autoCollapsed:
+      errorResult == null &&
+      !parentRunActive &&
+      (workflowsTabEnabled || displayStatus === "completed"),
     resetKey: runId,
   });
 
   const [actionError, setActionError] = useState<string | null>(null);
   const resumeOrRetryPendingForRun =
     runId != null && (resumingRunId === runId || workflowControlInFlightRunId === runId);
+  const liveSubscriptionEnabled =
+    typeof apiState?.api?.workflows.subscribe === "function" &&
+    workflowWorkspaceId != null &&
+    runId != null &&
+    (shouldRefreshWorkflow(displayStatus) ||
+      resumingRunId === runId ||
+      workflowControlInFlightRunId === runId);
+  const liveSnapshot = useWorkflowRunLiveSnapshot({
+    workspaceId: workflowWorkspaceId,
+    runId,
+    enabled: liveSubscriptionEnabled,
+  });
   const displayWorkflow = run?.workflow;
   const runSource = getWorkflowRunSource(run);
-  const workflowWorkspaceId = run?.workspaceId ?? workspaceId;
   // workflow_resume cards only know the run ID until a snapshot loads; prefer the real
   // workflow name once available.
   const displayName = displayWorkflow?.name ?? getWorkflowRunDisplayName(args);
@@ -1368,6 +1413,23 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       setResumingRunId(null);
     }
   }, [resumingRunId, run, runId]);
+
+  useEffect(() => {
+    const nextRun = liveSnapshot.run;
+    if (nextRun == null) {
+      return;
+    }
+    setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
+    if (
+      !shouldKeepWorkflowControlPolling({
+        action: "retryFromCheckpoint",
+        run: nextRun,
+        baselineSequence: displayEventSequence,
+      })
+    ) {
+      setResumingRunId(null);
+    }
+  }, [displayEventSequence, liveSnapshot.run]);
 
   useEffect(() => {
     if (registerCommandSource == null || runId == null || run?.workspaceId == null) {
@@ -1542,7 +1604,8 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       apiState?.api == null ||
       runId == null ||
       run?.workspaceId == null ||
-      (!shouldRefreshWorkflow(displayStatus) && resumingRunId !== runId)
+      (!shouldRefreshWorkflow(displayStatus) && resumingRunId !== runId) ||
+      (liveSubscriptionEnabled && !liveSnapshot.failed)
     ) {
       return;
     }
@@ -1579,10 +1642,81 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       ignore = true;
       window.clearInterval(interval);
     };
-  }, [apiState?.api, displayEventSequence, displayStatus, resumingRunId, run?.workspaceId, runId]);
+  }, [
+    apiState?.api,
+    displayEventSequence,
+    displayStatus,
+    liveSnapshot.failed,
+    liveSubscriptionEnabled,
+    resumingRunId,
+    run?.workspaceId,
+    runId,
+  ]);
+
+  const workflowView = run != null ? projectWorkflowRun(run) : null;
+  const hasProjectedTimeline =
+    workflowView != null && (workflowView.phases.length > 0 || workflowView.steps.length > 0);
+  const eventLog =
+    displayRows.length > 0 ? (
+      <div className="border-border bg-background/20 max-h-[220px] overflow-y-auto rounded border">
+        <ol className="divide-border/60 divide-y">
+          {displayRows.map((row, index) => {
+            if (row.kind === "task") {
+              return (
+                <WorkflowTaskRow
+                  key={getDisplayRowKey(row)}
+                  row={row}
+                  displayIndex={index + 1}
+                  steps={run?.steps ?? []}
+                  onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
+                  onOpenReport={() => {
+                    markExpansionInteracted();
+                  }}
+                  onInspectStructuredOutput={() => {
+                    markExpansionInteracted();
+                  }}
+                />
+              );
+            }
+            if (row.kind === "workflow") {
+              return (
+                <WorkflowChildRunRow
+                  key={getDisplayRowKey(row)}
+                  row={row}
+                  displayIndex={index + 1}
+                  workspaceId={workflowWorkspaceId}
+                  parentRunActive={parentRunActive}
+                  depth={0}
+                />
+              );
+            }
+            if (row.kind === "patch") {
+              return (
+                <WorkflowEventRow
+                  key={getDisplayRowKey(row)}
+                  event={row.latestEvent}
+                  tooltipEvent={row.firstEvent}
+                  detailOverride={getWorkflowMergedRowDetail(row)}
+                  displayIndex={index + 1}
+                  steps={run?.steps ?? []}
+                />
+              );
+            }
+            return (
+              <WorkflowEventRow
+                key={getDisplayRowKey(row)}
+                event={row.event}
+                displayIndex={index + 1}
+                steps={run?.steps ?? []}
+              />
+            );
+          })}
+        </ol>
+      </div>
+    ) : null;
 
   return (
-    <ToolContainer expanded={expanded}>
+    <ToolContainer expanded={expanded} className="@container">
       <ToolHeader onClick={toggleExpanded}>
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName={toolName} />
@@ -1672,66 +1806,44 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
 
           {actionError && <ErrorBox className="mb-2">{actionError}</ErrorBox>}
 
-          {displayRows.length > 0 && (
-            <WorkflowSection title={`Workflow events (${displayRows.length})`}>
-              <div className="border-border bg-background/20 max-h-[220px] overflow-y-auto rounded border">
-                <ol className="divide-border/60 divide-y">
-                  {displayRows.map((row, index) => {
-                    if (row.kind === "task") {
-                      return (
-                        <WorkflowTaskRow
-                          key={getDisplayRowKey(row)}
-                          row={row}
-                          displayIndex={index + 1}
-                          steps={run?.steps ?? []}
-                          onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
-                          onOpenReport={() => {
-                            markExpansionInteracted();
-                          }}
-                          onInspectStructuredOutput={() => {
-                            markExpansionInteracted();
-                          }}
-                        />
-                      );
-                    }
-                    if (row.kind === "workflow") {
-                      return (
-                        <WorkflowChildRunRow
-                          key={getDisplayRowKey(row)}
-                          row={row}
-                          displayIndex={index + 1}
-                          workspaceId={run?.workspaceId ?? workspaceId}
-                          parentRunActive={parentRunActive}
-                          depth={0}
-                        />
-                      );
-                    }
-                    if (row.kind === "patch") {
-                      return (
-                        <WorkflowEventRow
-                          key={getDisplayRowKey(row)}
-                          event={row.latestEvent}
-                          tooltipEvent={row.firstEvent}
-                          detailOverride={getWorkflowMergedRowDetail(row)}
-                          displayIndex={index + 1}
-                          steps={run?.steps ?? []}
-                        />
-                      );
-                    }
-                    return (
-                      <WorkflowEventRow
-                        key={getDisplayRowKey(row)}
-                        event={row.event}
-                        displayIndex={index + 1}
-                        steps={run?.steps ?? []}
-                      />
-                    );
-                  })}
-                </ol>
+          {hasProjectedTimeline && workflowView != null ? (
+            <>
+              <div className="border-border bg-background/20 counter-nums mb-3 grid grid-cols-2 gap-x-3 gap-y-1 rounded border px-2 py-1.5 text-[10px] @sm:grid-cols-4">
+                <span>
+                  {workflowView.stats.done}/{workflowView.stats.total} steps
+                </span>
+                <span>{formatWorkflowDuration(workflowView.stats.elapsedMs)}</span>
+                <span>{formatWorkflowTokens(workflowView.stats.usage?.tokens)} tokens</span>
+                <span>{formatWorkflowCost(workflowView.stats.usage?.costUsd)}</span>
               </div>
-            </WorkflowSection>
+              <div
+                className="max-h-[400px] overflow-y-auto pr-1"
+                onClickCapture={markExpansionInteracted}
+              >
+                <WorkflowTimeline
+                  view={workflowView}
+                  workspaceId={workflowWorkspaceId}
+                  showFinalReport={false}
+                />
+              </div>
+              {eventLog != null && (
+                <WorkflowDisclosureSection
+                  title="Event log"
+                  className="mt-2"
+                  unmountCollapsed
+                  onOpen={markExpansionInteracted}
+                >
+                  {eventLog}
+                </WorkflowDisclosureSection>
+              )}
+            </>
+          ) : (
+            eventLog != null && (
+              <WorkflowSection title={`Workflow events (${displayRows.length})`}>
+                {eventLog}
+              </WorkflowSection>
+            )
           )}
-
           {structuredOutput !== undefined && (
             <WorkflowDisclosureSection title="Structured output" className="mt-2">
               <WorkflowJsonBlock value={structuredOutput} className="max-h-[220px]" />


### PR DESCRIPTION
## Summary

Running durable workflows now show up live in the chat transcript: the `workflow_run` / `workflow_resume` tool card stays expanded while a run is active and renders the same phased timeline and stats projection as the right-sidebar Workflows tab, updated in real time through the workflow push subscription.

## Background

With the dynamic-workflows experiment on, the transcript card auto-collapsed for every status (the sidebar tab was treated as the only detail surface), rendered just a raw event list when expanded, and refreshed by 2s HTTP polling. A running workflow was effectively invisible in the chat itself.

## Implementation

- **Live body**: when a run snapshot exists, the expanded card renders `projectWorkflowRun` output — a compact stats row (steps, elapsed, plus tokens/cost only when a usage overlay exists, matching `WorkflowRunHeader`) and `WorkflowTimeline` in a bounded scroll region. The raw event rows move behind a collapsed "Event log" disclosure, and remain the inline fallback when the projection has no phases/steps yet.
- **Expansion policy**: active runs (pending/running/backgrounded) are never auto-collapsed; terminal runs collapse as before; tool-error cards stay open; manual interaction still wins per run.
- **Live updates**: a new `useWorkflowRunLiveSnapshot` hook consumes the `workflows.subscribe` push stream. All transcript cards share one ref-counted feed per (api client, workspace) — `acquireWorkflowFeed` opens the stream on first use, replays cached run state to late subscribers, and tears down on last release — so N concurrent cards never open N workspace-wide streams. Snapshots feed the existing freshness-merged `refreshedRun` path. The 2s `getRun` polling remains for nested (`parentWorkflow`) runs, which the subscribe feed deliberately omits, and as a fallback when the subscription is unavailable or errors; run-ID discovery polling is unchanged.
- **Nested passthrough**: `CodeExecutionToolCall` → `NestedToolsContainer` → `NestedToolRenderer` now pass `workspaceId` and per-call identity, so `mux.workflow_run` calls made inside `code_execution` also discover their run and live-update.

## Validation

- Remote dogfood UAT (2 rounds) against the pushed heads: foreground/background live updates, auto-collapse transition, manual-collapse stickiness, interrupt/resume from the card, reload rediscovery, 375px layout, sidebar parity, and nested code_execution cards all verified with screenshot evidence; the round-1 finding (dash token/cost placeholders) is fixed and re-verified in round 2.
- Red-green on the behavior guards: no-usage stats row, nested-run polling gate, and shared-subscription tests each fail with their fix reverted.

## Risks

Medium-touch change to a single high-traffic transcript component. Main regression surfaces: card expansion behavior for historical/terminal workflow cards (covered by transition and manual-interaction tests) and subscription lifecycle (shared ref-counted feed with abort/cleanup; polling fallback preserved). Sidebar behavior is unchanged apart from the shared hook file gaining the feed manager.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
