### PR TITLE
🤖 feat: promote Claude Fable 5.1 as the fable model

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -13,7 +13,7 @@ Xum ships with curated models kept up to date with the frontier. Use any custom 
 
 | Model                  | ID                            | Aliases                                                      | Default |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |
-| Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |
+| Fable 5.1              | anthropic:claude-fable-5-1    | `fable`                                                      |         |
 | Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |
 | Opus 5                 | anthropic:claude-opus-5       | `opus`                                                       | ✓       |
 | Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |

--- a/src/common/config/schemas/appConfigOnDisk.ts
+++ b/src/common/config/schemas/appConfigOnDisk.ts
@@ -117,6 +117,12 @@ export const AppConfigMigrationsSchema = z
     userPreferencesInitialized: z.boolean().optional(),
     /** One-time seed of DEFAULT_MODEL_FALLBACKS; not re-applied while true. */
     defaultModelFallbacksSeeded: z.boolean().optional(),
+    /**
+     * One-time re-run of the fallback seed after the fable alias moved to
+     * Fable 5.1: configs seeded before the promotion lack a chain for the new
+     * source key.
+     */
+    defaultModelFallbacksSeededFable51: z.boolean().optional(),
     /** One-time migration from the legacy auto-delete default to persistent sub-agents. */
     persistentSubagentsDefaulted: z.boolean().optional(),
   })

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -27,13 +27,13 @@ interface KnownModel extends KnownModelDefinition {
 // Model definitions. Note we avoid listing legacy models here. These represent the focal models
 // of the community.
 const MODEL_DEFINITIONS = {
-  // Claude Fable 5 - Mythos-class model (a tier above Opus) released June 9, 2026.
-  // It is the generally-available variant of the Mythos 5 model, shipped with safeguards
-  // enabled (a small fraction of flagged requests fall back to Opus 4.8 server-side, which
-  // is transparent to API clients). API id `claude-fable-5`; $10/M input, $50/M output.
+  // Claude Fable 5.1 - Mythos-class model (a tier above Opus), successor to Fable 5
+  // (released June 9, 2026) as the generally-available safeguarded variant, at unchanged
+  // pricing ($10/M input, $50/M output). API id `claude-fable-5-1`; Fable 5 stays usable
+  // as the custom model string `anthropic:claude-fable-5`.
   FABLE: {
     provider: "anthropic",
-    providerModelId: "claude-fable-5",
+    providerModelId: "claude-fable-5-1",
     aliases: ["fable"],
     warm: true,
     // Fable/Mythos use the newer Opus 4.7+ tokenizer, which isn't published upstream;

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -282,11 +282,23 @@ export const MODEL_ABBREVIATIONS: Record<string, string> = Object.fromEntries(
     .sort(([a], [b]) => a.localeCompare(b))
 );
 
-export const TOKENIZER_MODEL_OVERRIDES: Record<string, string> = Object.fromEntries(
-  Object.values(KNOWN_MODELS)
-    .filter((model) => Boolean(model.tokenizerOverride))
-    .map((model) => [model.id, model.tokenizerOverride!])
-);
+// Retired first-class models stay documented as custom model strings (see the
+// FABLE/OPUS comments); keep their approximate-tokenizer overrides so exact-id
+// lookup does not fall back to the generic per-provider tokenizer.
+const LEGACY_TOKENIZER_MODEL_OVERRIDES: Record<string, string> = {
+  "anthropic:claude-fable-5": "anthropic/claude-opus-4.5",
+  "anthropic:claude-opus-4-8": "anthropic/claude-opus-4.5",
+};
+
+export const TOKENIZER_MODEL_OVERRIDES: Record<string, string> = {
+  ...LEGACY_TOKENIZER_MODEL_OVERRIDES,
+  // Spread current models last so a returning id always wins over its legacy entry.
+  ...Object.fromEntries(
+    Object.values(KNOWN_MODELS)
+      .filter((model) => Boolean(model.tokenizerOverride))
+      .map((model) => [model.id, model.tokenizerOverride!])
+  ),
+};
 
 /** Tooltip-friendly abbreviation examples: show representative shortcuts */
 export const MODEL_ABBREVIATION_EXAMPLES = (["opus", "sonnet"] as const).map((abbrev) => ({

--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -27,6 +27,7 @@ describe("formatModelDisplayName", () => {
 
     test("formats Mythos-class Fable / Mythos models", () => {
       expect(formatModelDisplayName("claude-fable-5")).toBe("Fable 5");
+      expect(formatModelDisplayName("claude-fable-5-1")).toBe("Fable 5.1");
       expect(formatModelDisplayName("claude-mythos-5")).toBe("Mythos 5");
     });
   });

--- a/src/common/utils/ai/modelFallbacks.ts
+++ b/src/common/utils/ai/modelFallbacks.ts
@@ -16,7 +16,9 @@ export const MODEL_FALLBACK_CHAIN_LIMIT = 3;
  * the sensible out-of-the-box behavior.
  *
  * Seeded into the config exactly once, guarded by
- * migrations.defaultModelFallbacksSeeded — on versions that know the flag,
+ * migrations.defaultModelFallbacksSeeded (plus the one-shot
+ * defaultModelFallbacksSeededFable51 re-seed for the key move to Fable 5.1)
+ * — on versions that know the flag,
  * user edits or deletions of these chains are never overridden by updates.
  * (Versions predating the flag strip it on save, so a downgrade→save→
  * re-upgrade round-trip re-seeds a deleted chain; bounded to re-adding this

--- a/src/common/utils/ai/modelFallbacks.ts
+++ b/src/common/utils/ai/modelFallbacks.ts
@@ -27,10 +27,25 @@ export const MODEL_FALLBACK_CHAIN_LIMIT = 3;
 export const DEFAULT_MODEL_FALLBACKS: ModelFallbacks = {
   [KNOWN_MODELS.FABLE.id]: { models: [KNOWN_MODELS.OPUS.id] },
 };
+
+/**
+ * Legacy default chain for the pre-5.1 fable id, seeded alongside
+ * DEFAULT_MODEL_FALLBACKS whenever the original seed pass runs (fresh installs
+ * and configs that never completed it). Those configs mark
+ * defaultModelFallbacksSeeded, so a downgrade to a build whose FABLE is
+ * Fable 5 would skip its own seed; carrying this chain keeps the old build's
+ * refusal fallback intact.
+ */
+export const LEGACY_DEFAULT_MODEL_FALLBACKS: ModelFallbacks = {
+  "anthropic:claude-fable-5": { models: [KNOWN_MODELS.OPUS.id] },
+};
 // Deep-freeze: entries are spread by reference into live configs (fresh-install
 // defaults, seed merge). Accidental in-place mutation must crash fast instead
 // of silently corrupting the process-wide default.
-for (const entry of Object.values(Object.freeze(DEFAULT_MODEL_FALLBACKS))) {
+for (const entry of [
+  ...Object.values(Object.freeze(DEFAULT_MODEL_FALLBACKS)),
+  ...Object.values(Object.freeze(LEGACY_DEFAULT_MODEL_FALLBACKS)),
+]) {
   Object.freeze(entry);
   Object.freeze(entry.models);
 }

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -167,12 +167,14 @@ describe("Anthropic 1M context classification", () => {
     expect(hasNative1MContext("anthropic:claude-sonnet-5")).toBe(true);
   });
 
-  it("treats Mythos-class Fable 5 / Mythos 5 as native 1M models", () => {
+  it("treats Mythos-class Fable 5 / Fable 5.1 / Mythos 5 as native 1M models", () => {
     expect(getAnthropic1MContextMode("anthropic:claude-fable-5")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-fable-5-1")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-mythos-5")).toBe("native");
-    expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-fable-5")).toBe("native");
+    expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-fable-5-1")).toBe("native");
     expect(hasNative1MContext("anthropic:claude-fable-5")).toBe(true);
-    expect(supports1MContext("anthropic:claude-fable-5")).toBe(false);
+    expect(hasNative1MContext("anthropic:claude-fable-5-1")).toBe(true);
+    expect(supports1MContext("anthropic:claude-fable-5-1")).toBe(false);
   });
 
   it("returns none for models without Anthropic 1M support", () => {

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -179,6 +179,7 @@ const OPTIONAL_VERSION_SUFFIX = String.raw`(?:-(?:\d{8}|\d{4}-\d{2}-\d{2}))?`;
 const ANTHROPIC_NATIVE_1M_PATTERNS = [
   // Mythos-class models (Fable 5 / Mythos 5) ship 1M context as standard metadata.
   new RegExp(`^claude-fable-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
+  new RegExp(`^claude-fable-5-1${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-mythos-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-8${OPTIONAL_VERSION_SUFFIX}$`, "i"),

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -180,6 +180,12 @@ describe("buildProviderOptions - Anthropic", () => {
       // the summarized display flag.
       expect(anthropic.thinking).toEqual({ type: "adaptive", display: "summarized" });
       expect(anthropic.effort).toBe("medium");
+      // Fable 5.1 rides the same Mythos-class wildcard matcher.
+      const anthropic51 = anthropicProviderOptions(
+        buildProviderOptions("anthropic:claude-fable-5-1", "medium")
+      );
+      expect(anthropic51.thinking).toEqual({ type: "adaptive", display: "summarized" });
+      expect(anthropic51.effort).toBe("medium");
     });
 
     test("omits thinking instead of sending disabled when off", () => {
@@ -187,6 +193,9 @@ describe("buildProviderOptions - Anthropic", () => {
       // omitting the field lets it default to adaptive. "off" can still reach here
       // when no thinking level was provided upstream (defaults to off).
       expect(buildProviderOptions("anthropic:claude-fable-5", "off")).toEqual({
+        anthropic: { ...baseAnthropicOptions, effort: "low" },
+      });
+      expect(buildProviderOptions("anthropic:claude-fable-5-1", "off")).toEqual({
         anthropic: { ...baseAnthropicOptions, effort: "low" },
       });
     });

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -443,6 +443,13 @@ describe("getThinkingPolicyForModel", () => {
       "xhigh",
       "max",
     ]);
+    expect(getThinkingPolicyForModel("anthropic:claude-fable-5-1")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
     expect(getThinkingPolicyForModel("anthropic:claude-mythos-5")).toEqual([
       "low",
       "medium",
@@ -455,6 +462,7 @@ describe("getThinkingPolicyForModel", () => {
   test("clamps 'off' up to 'low' for Mythos-class models", () => {
     // A stored/legacy "off" selection must not reach the wire as disabled thinking.
     expect(enforceThinkingPolicy("anthropic:claude-fable-5", "off")).toBe("low");
+    expect(enforceThinkingPolicy("anthropic:claude-fable-5-1", "off")).toBe("low");
     expect(enforceThinkingPolicy("anthropic:claude-mythos-5", "off")).toBe("low");
   });
 

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -136,15 +136,16 @@ export const modelsExtra: Record<string, ModelData> = {
   },
 
   // Claude Fable 5.1 - successor to Fable 5 in the Mythos-class tier at the same
-  // pricing/shape: $10/M input, $50/M output, cache write 1.25x input / cache read
-  // 0.1x input, native 1M context, 128K max output, native xhigh effort level.
+  // input/output pricing: $10/M input, $50/M output, cache write 1.25x input. Cache
+  // reads are cheaper than Fable 5 at $0.25/M (0.025x input, a quarter of the old
+  // 0.1x ratio). Native 1M context, 128K max output, native xhigh effort level.
   "claude-fable-5-1": {
     max_input_tokens: 1000000,
     max_output_tokens: 128000,
     input_cost_per_token: 0.00001, // $10 per million input tokens
     output_cost_per_token: 0.00005, // $50 per million output tokens
     cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
-    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    cache_read_input_token_cost: 0.00000025, // $0.25 per million tokens (0.025× input)
     litellm_provider: "anthropic",
     mode: "chat",
     supports_function_calling: true,

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -135,6 +135,25 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_pdf_input: true,
   },
 
+  // Claude Fable 5.1 - successor to Fable 5 in the Mythos-class tier at the same
+  // pricing/shape: $10/M input, $50/M output, cache write 1.25x input / cache read
+  // 0.1x input, native 1M context, 128K max output, native xhigh effort level.
+  "claude-fable-5-1": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00001, // $10 per million input tokens
+    output_cost_per_token: 0.00005, // $50 per million output tokens
+    cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
+    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Claude Fable 5 / Mythos 5 - Released June 9, 2026
   // Mythos-class model (a tier above Opus). Fable 5 (`claude-fable-5`) is the
   // generally-available variant with safeguards; Mythos 5 (`claude-mythos-5`) is the same

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -72,6 +72,7 @@ describe("supportsAnthropicNativeWebFetch", () => {
     ["claude-fable-5", true],
     ["claude-mythos-5", true],
     // Two-segment IDs at/after the 4.6 cutoff.
+    ["claude-fable-5-1", true],
     ["claude-sonnet-4-6", true],
     ["claude-opus-4-6", true],
     ["claude-opus-4-8", true],

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -1518,6 +1518,7 @@ describe("Config", () => {
 
   describe("default model fallbacks seeding", () => {
     const FABLE = KNOWN_MODELS.FABLE.id;
+    const LEGACY_FABLE = "anthropic:claude-fable-5";
     const OPUS = KNOWN_MODELS.OPUS.id;
     const configFilePath = () => path.join(tempDir, "config.json");
 
@@ -1525,7 +1526,12 @@ describe("Config", () => {
       fs.writeFileSync(configFilePath(), JSON.stringify({ projects: [] }));
 
       const loaded = config.loadConfigOrDefault();
-      expect(loaded.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      // The original seed pass also carries the legacy Fable 5 chain so a
+      // downgraded build (whose FABLE is Fable 5) still finds its default.
+      expect(loaded.modelFallbacks).toEqual({
+        [LEGACY_FABLE]: { models: [OPUS] },
+        [FABLE]: { models: [OPUS] },
+      });
       expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
 
       // Seed is written back so the flag survives restarts even without saves.
@@ -1534,7 +1540,10 @@ describe("Config", () => {
         modelFallbacks?: unknown;
         migrations?: { defaultModelFallbacksSeeded?: unknown };
       };
-      expect(raw.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      expect(raw.modelFallbacks).toEqual({
+        [LEGACY_FABLE]: { models: [OPUS] },
+        [FABLE]: { models: [OPUS] },
+      });
       expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
     });
 
@@ -1556,7 +1565,8 @@ describe("Config", () => {
     it("seeds the Fable 5.1 chain once for configs seeded before the 5.1 promotion", async () => {
       // Pre-5.1 configs carry a chain only for the old source key
       // (anthropic:claude-fable-5); the promoted FABLE key must get its own
-      // one-time seed without touching the legacy chain.
+      // one-time seed without touching the legacy chain (the legacy default
+      // is only added while the original seed pass itself runs).
       fs.writeFileSync(
         configFilePath(),
         JSON.stringify({
@@ -1620,6 +1630,7 @@ describe("Config", () => {
       const loaded = config.loadConfigOrDefault();
       expect(loaded.modelFallbacks).toEqual({
         "anthropic:claude-opus-4-6": { models: ["openai:gpt-5.5"] },
+        [LEGACY_FABLE]: { models: [OPUS] },
         [FABLE]: { models: [OPUS] },
       });
 
@@ -1631,6 +1642,7 @@ describe("Config", () => {
       };
       expect(raw.modelFallbacks).toEqual({
         "anthropic:claude-opus-4-6": { models: ["openai:gpt-5.5"] },
+        [LEGACY_FABLE]: { models: [OPUS] },
         [FABLE]: { models: [OPUS] },
       });
       expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
@@ -1651,6 +1663,7 @@ describe("Config", () => {
       // the seed must treat it as configured and leave the user's chain alone.
       expect(config.loadConfigOrDefault().modelFallbacks).toEqual({
         [FABLE]: { models: ["openai:gpt-5.5"] },
+        [LEGACY_FABLE]: { models: [OPUS] },
       });
     });
 
@@ -1668,10 +1681,15 @@ describe("Config", () => {
       const loaded = config.loadConfigOrDefault();
       // The entry sanitizes to nothing at runtime (no fallback fires), but it
       // is still user intent: the seed must not replace it with an enabled
-      // default chain, and the raw on-disk form must survive.
-      expect(loaded.modelFallbacks).toBeUndefined();
+      // default chain, and the raw on-disk form must survive. Only the
+      // untouched legacy key gets seeded.
+      expect(loaded.modelFallbacks).toEqual({
+        [LEGACY_FABLE]: { models: [OPUS] },
+      });
       expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
 
+      // Raw file read before the async write-back flushes: the tombstone's
+      // on-disk form must survive untouched.
       const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
         modelFallbacks?: unknown;
       };
@@ -1712,12 +1730,14 @@ describe("Config", () => {
       const loaded = config.loadConfigOrDefault();
       expect(loaded.modelFallbacks).toEqual({
         [FABLE]: { enabled: false, models: ["openai:gpt-5.5"] },
+        [LEGACY_FABLE]: { models: [OPUS] },
       });
       expect(loaded.migrations?.defaultModelFallbacksSeeded).toBe(true);
     });
 
     it("applies the defaults to fresh installs and locks the flag on first save", async () => {
       expect(config.loadConfigOrDefault().modelFallbacks).toEqual({
+        [LEGACY_FABLE]: { models: [OPUS] },
         [FABLE]: { models: [OPUS] },
       });
 
@@ -1727,7 +1747,10 @@ describe("Config", () => {
         modelFallbacks?: unknown;
         migrations?: { defaultModelFallbacksSeeded?: unknown };
       };
-      expect(raw.modelFallbacks).toEqual({ [FABLE]: { models: [OPUS] } });
+      expect(raw.modelFallbacks).toEqual({
+        [LEGACY_FABLE]: { models: [OPUS] },
+        [FABLE]: { models: [OPUS] },
+      });
       expect(raw.migrations?.defaultModelFallbacksSeeded).toBe(true);
     });
   });

--- a/src/node/config.test.ts
+++ b/src/node/config.test.ts
@@ -70,6 +70,7 @@ describe("Config", () => {
           taskSettings: { preserveSubagentsUntilArchive: true },
           migrations: {
             defaultModelFallbacksSeeded: true,
+            defaultModelFallbacksSeededFable51: true,
             persistentSubagentsDefaulted: true,
           },
         })
@@ -1484,7 +1485,10 @@ describe("Config", () => {
         JSON.stringify({
           projects: [],
           // Keep this test focused on normalization, not default seeding.
-          migrations: { defaultModelFallbacksSeeded: true },
+          migrations: {
+            defaultModelFallbacksSeeded: true,
+            defaultModelFallbacksSeededFable51: true,
+          },
           modelFallbacks: {
             // Gateway-prefixed key + non-string chain entries + unknown trigger.
             "openrouter:anthropic/claude-opus-4-6": {
@@ -1539,11 +1543,67 @@ describe("Config", () => {
         configFilePath(),
         JSON.stringify({
           projects: [],
-          migrations: { defaultModelFallbacksSeeded: true },
+          migrations: {
+            defaultModelFallbacksSeeded: true,
+            defaultModelFallbacksSeededFable51: true,
+          },
         })
       );
 
       expect(config.loadConfigOrDefault().modelFallbacks).toBeUndefined();
+    });
+
+    it("seeds the Fable 5.1 chain once for configs seeded before the 5.1 promotion", async () => {
+      // Pre-5.1 configs carry a chain only for the old source key
+      // (anthropic:claude-fable-5); the promoted FABLE key must get its own
+      // one-time seed without touching the legacy chain.
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          migrations: { defaultModelFallbacksSeeded: true },
+          modelFallbacks: {
+            "anthropic:claude-fable-5": { models: ["anthropic:claude-opus-4-8"] },
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.modelFallbacks).toEqual({
+        "anthropic:claude-fable-5": { models: ["anthropic:claude-opus-4-8"] },
+        [FABLE]: { models: [OPUS] },
+      });
+      expect(loaded.migrations?.defaultModelFallbacksSeededFable51).toBe(true);
+
+      await flushConfigEdits();
+      const raw = JSON.parse(fs.readFileSync(configFilePath(), "utf-8")) as {
+        modelFallbacks?: unknown;
+        migrations?: { defaultModelFallbacksSeededFable51?: unknown };
+      };
+      expect(raw.modelFallbacks).toEqual({
+        "anthropic:claude-fable-5": { models: ["anthropic:claude-opus-4-8"] },
+        [FABLE]: { models: [OPUS] },
+      });
+      expect(raw.migrations?.defaultModelFallbacksSeededFable51).toBe(true);
+    });
+
+    it("does not overwrite an existing Fable 5.1 chain during the 5.1 re-seed", () => {
+      fs.writeFileSync(
+        configFilePath(),
+        JSON.stringify({
+          projects: [],
+          migrations: { defaultModelFallbacksSeeded: true },
+          modelFallbacks: {
+            [FABLE]: { models: ["openai:gpt-5.5"] },
+          },
+        })
+      );
+
+      const loaded = config.loadConfigOrDefault();
+      expect(loaded.modelFallbacks).toEqual({
+        [FABLE]: { models: ["openai:gpt-5.5"] },
+      });
+      expect(loaded.migrations?.defaultModelFallbacksSeededFable51).toBe(true);
     });
 
     it("merges the seeded default with pre-existing chains for other source models", async () => {
@@ -1582,7 +1642,7 @@ describe("Config", () => {
         JSON.stringify({
           projects: [],
           modelFallbacks: {
-            "openrouter:anthropic/claude-fable-5": { models: ["openai:gpt-5.5"] },
+            "openrouter:anthropic/claude-fable-5-1": { models: ["openai:gpt-5.5"] },
           },
         })
       );
@@ -2269,9 +2329,12 @@ describe("Config", () => {
           routeOverrides: {
             "openai:gpt-4o": "direct",
           },
-          // Without this flag the one-time default-fallbacks seed would write
-          // the file, which is not the rewrite this test guards against.
-          migrations: { defaultModelFallbacksSeeded: true },
+          // Without these flags the one-time default-fallbacks seeds would
+          // write the file, which is not the rewrite this test guards against.
+          migrations: {
+            defaultModelFallbacksSeeded: true,
+            defaultModelFallbacksSeededFable51: true,
+          },
         })
       );
 

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -25,7 +25,11 @@ import type {
   BaseProviderConfig as ProviderConfig,
   ModelFallbacks,
 } from "@/common/config/schemas";
-import { DEFAULT_MODEL_FALLBACKS, sanitizeModelFallbacks } from "@/common/utils/ai/modelFallbacks";
+import {
+  DEFAULT_MODEL_FALLBACKS,
+  LEGACY_DEFAULT_MODEL_FALLBACKS,
+  sanitizeModelFallbacks,
+} from "@/common/utils/ai/modelFallbacks";
 import { DEFAULT_TASK_SETTINGS, normalizeTaskSettings } from "@/common/types/tasks";
 import { normalizeUserPreferences } from "@/common/config/schemas/userPreferences";
 import { SettingsBackupSchema } from "@/common/config/schemas/settingsBackup";
@@ -1609,8 +1613,15 @@ export class Config {
           const existingCanonicalKeys = new Set(
             Object.keys(rawFallbacks).map((key) => normalizeToCanonical(key).trim())
           );
+          // Completing the original seed pass claims defaultModelFallbacksSeeded,
+          // which downgraded builds trust for their own (pre-5.1) default keys;
+          // seed those legacy chains too so a downgrade keeps refusal fallback.
+          const seedDefaults =
+            migrationsBeforeSeed.defaultModelFallbacksSeeded !== true
+              ? { ...LEGACY_DEFAULT_MODEL_FALLBACKS, ...DEFAULT_MODEL_FALLBACKS }
+              : DEFAULT_MODEL_FALLBACKS;
           const missingDefaults = Object.fromEntries(
-            Object.entries(DEFAULT_MODEL_FALLBACKS).filter(
+            Object.entries(seedDefaults).filter(
               ([sourceModel]) => !existingCanonicalKeys.has(sourceModel)
             )
           );
@@ -1805,7 +1816,7 @@ export class Config {
       // Fresh installs get the default refusal-fallback chains immediately; the
       // migration flag rides along so the first save locks in seed-once
       // semantics (later loads never re-apply the defaults).
-      modelFallbacks: { ...DEFAULT_MODEL_FALLBACKS },
+      modelFallbacks: { ...LEGACY_DEFAULT_MODEL_FALLBACKS, ...DEFAULT_MODEL_FALLBACKS },
       migrations: {
         defaultModelFallbacksSeeded: true,
         defaultModelFallbacksSeededFable51: true,

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1581,12 +1581,20 @@ export class Config {
         const minThinkingLevelByModel = normalizeMinThinkingLevelByModel(
           parsed.minThinkingLevelByModel
         );
-        // One-time seed of the default refusal-fallback chains (e.g. Fable 5 →
+        // One-time seed of the default refusal-fallback chains (e.g. Fable →
         // Opus). Guarded by migrations.defaultModelFallbacksSeeded so the
         // seed is applied exactly once: users who later edit or delete the
         // default chains are not overridden on subsequent loads/updates.
+        // defaultModelFallbacksSeededFable51 re-runs the gap-check once after
+        // the fable alias moved to Fable 5.1: pre-5.1 configs only have a
+        // chain for the old source key, and the new key is a new default that
+        // deserves one seed of its own (still never overwriting an existing
+        // 5.1 chain).
         const migrationsBeforeSeed = normalizeConfigMigrations(parsed.migrations);
-        if (migrationsBeforeSeed.defaultModelFallbacksSeeded !== true) {
+        if (
+          migrationsBeforeSeed.defaultModelFallbacksSeeded !== true ||
+          migrationsBeforeSeed.defaultModelFallbacksSeededFable51 !== true
+        ) {
           // Gap-check against the RAW on-disk map with canonicalized keys, not
           // the sanitized map: a hand-edited entry whose chain sanitizes away
           // (e.g. {enabled:false, models:[]}) is still user intent and must not
@@ -1616,6 +1624,7 @@ export class Config {
           parsed.migrations = {
             ...migrationsBeforeSeed,
             defaultModelFallbacksSeeded: true,
+            defaultModelFallbacksSeededFable51: true,
           };
           configModified = true;
         }
@@ -1799,6 +1808,7 @@ export class Config {
       modelFallbacks: { ...DEFAULT_MODEL_FALLBACKS },
       migrations: {
         defaultModelFallbacksSeeded: true,
+        defaultModelFallbacksSeededFable51: true,
         persistentSubagentsDefaulted: true,
       },
     };

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3850,7 +3850,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "",
       "| Model                  | ID                            | Aliases                                                      | Default |",
       "| ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |",
-      "| Fable 5                | anthropic:claude-fable-5      | `fable`                                                      |         |",
+      "| Fable 5.1              | anthropic:claude-fable-5-1    | `fable`                                                      |         |",
       "| Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |",
       "| Opus 5                 | anthropic:claude-opus-5       | `opus`                                                       | ✓       |",
       "| Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |",

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -369,7 +369,7 @@ describe("WorkflowRunner", () => {
       expect.objectContaining({
         id: "verify",
         agentId: "exec",
-        modelString: "anthropic:claude-fable-5",
+        modelString: "anthropic:claude-fable-5-1",
         thinkingLevel: "high",
       }),
     ]);


### PR DESCRIPTION
## Summary

Prepares Xum for the Claude Fable 5.1 drop: promotes Fable 5.1 (`anthropic:claude-fable-5-1`) to the `FABLE` known model, so the `fable` alias, the `/fable` command, tokenizer warming, and the default refusal-fallback chain all route to the new model. Fable 5 stays usable as the custom model string `anthropic:claude-fable-5` and keeps its metadata entry and tokenizer approximation.

> [!NOTE]
> **Launch confirmed.** Anthropic released Claude Fable 5.1 on September 1, 2026. All assumptions below were verified against the official model overview; the API id and $10/$50 pricing were correct as assumed. The one correction: cache reads are $0.25/M (0.025x input), a quarter of the assumed 0.1x ratio, fixed in `models-extra.ts`.

## Background

This PR was prepared ahead of the drop (same play as the Opus 5 promotion in #3750), with assumptions confirmed on release day against the official docs:

- **API id**: `claude-fable-5-1` (dash form, dateless, matching the 5-generation convention of `claude-sonnet-5` / `claude-opus-5` and the dash style of `claude-haiku-4-5`).
- **Pricing**: unchanged from Fable 5 for input/output, $10/M input, $50/M output, cache write 1.25x input. Cache read turned out cheaper at launch: $0.25/M (0.025x input), corrected in this PR.
- **Envelope**: unchanged, native 1M context, 128K max output, full effort ladder with native xhigh and max, adaptive thinking only (disabled thinking rejected), safeguard classifiers retained so the refusal fallback stays relevant.

## Implementation

- `knownModels.ts`: `FABLE` -> `claude-fable-5-1` (keeps the `fable` alias and tokenizer warming; tokenizer override stays on the Opus 4.5 approximation).
- `models-extra.ts`: new `claude-fable-5-1` pricing/limits entry; the Fable 5 entry is retained.
- `models.ts`: `claude-fable-5-1` added to the native-1M patterns (the existing `claude-fable-5` pattern only tolerates date suffixes, not `-1`).
- No wire-format changes needed for thinking/effort: the Mythos-class wildcard matchers (`anthropicSupportsNativeXhigh`, `anthropicRejectsDisabledThinking`) and native web-fetch id parsing already match the new id; tests now pin that.
- **Fallback seed migration**: `DEFAULT_MODEL_FALLBACKS` is keyed by the FABLE id and the one-time seed is guarded by `migrations.defaultModelFallbacksSeeded`, so already-seeded configs would never get a chain for the new source key. A second one-shot flag (`defaultModelFallbacksSeededFable51`) re-runs the gap-check once: pre-5.1 configs get the Fable 5.1 -> Opus chain, an existing 5.1 chain is never overwritten, and the legacy Fable 5 chain is left byte-identical on disk.
- **Downgrade safety** (Codex round 1): completing the original seed pass claims `defaultModelFallbacksSeeded`, which pre-5.1 builds trust for their own `claude-fable-5` key. The original seed pass (and the fresh-install default config) now also carries a `LEGACY_DEFAULT_MODEL_FALLBACKS` chain for `anthropic:claude-fable-5`, so a downgrade still finds its expected default instead of silently losing refusal fallback.
- **Legacy tokenizer overrides** (Codex round 1): `TOKENIZER_MODEL_OVERRIDES` is derived from current KNOWN_MODELS ids, so retiring an id dropped its approximate-tokenizer mapping. A `LEGACY_TOKENIZER_MODEL_OVERRIDES` map retains `anthropic:claude-fable-5` and the identical pre-existing case `anthropic:claude-opus-4-8`; exact-id lookup resolves both to the intended Opus 4.5 approximation instead of warning and falling back to the generic per-provider tokenizer.
- Docs model table and built-in skill content regenerated.
- **Launch-day verification**: rebased onto main and corrected the `models-extra.ts` cache-read cost to the official $0.25/M; everything else matched the official model page.

## Validation

- Behavioral coverage added for the new id: native-1M classification, display formatting (`Fable 5.1`), 5-level thinking policy with off-clamp, provider options (adaptive + summarized display, no disabled thinking), native web-fetch support, and the config seeding semantics (legacy chain carried by the original seed pass, 5.1 chain seeded once for pre-5.1 configs, existing 5.1 chains and deletions respected).
- The WorkflowRunner alias-mapping test caught the alias flip (`fable` -> 5.1) and was updated; remaining `claude-fable-5` fixtures were audited and stay valid as explicit custom model strings.

## Risks

Low: additive registry/metadata changes plus config migration flags. The main user-visible effect is that the `fable` alias and `/fable` route to Fable 5.1. Until the model exists at the API, alias sends would fail, which is why the merge gate above matters. Existing Fable 5 selections and user-edited fallback chains are unaffected; note that with current ai-tokenizer data the legacy tokenizer fix changes no token counts (both approximations share the `claude` encoding), it removes warning spam and future drift risk.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$45.64`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=45.64 -->
