### PR TITLE
🤖 feat: pre-release prep for Claude Opus 5.1 / Fable 5.1 (DO NOT MERGE until GA)

### DIFF
--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -29,6 +29,11 @@ describe("formatModelDisplayName", () => {
       expect(formatModelDisplayName("claude-fable-5")).toBe("Fable 5");
       expect(formatModelDisplayName("claude-mythos-5")).toBe("Mythos 5");
     });
+
+    test("formats pre-release Opus 5.1 / Fable 5.1 ids", () => {
+      expect(formatModelDisplayName("claude-opus-5-1")).toBe("Opus 5.1");
+      expect(formatModelDisplayName("claude-fable-5-1")).toBe("Fable 5.1");
+    });
   });
 
   describe("GPT models", () => {

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -167,6 +167,17 @@ describe("Anthropic 1M context classification", () => {
     expect(hasNative1MContext("anthropic:claude-sonnet-5")).toBe(true);
   });
 
+  it("treats pre-release Opus 5.1 / Fable 5.1 as native 1M models", () => {
+    // Seeded from their direct predecessors (Opus 5 / Fable 5); confirm at release.
+    expect(getAnthropic1MContextMode("anthropic:claude-opus-5-1")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-opus-5-1-20260901")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-fable-5-1")).toBe("native");
+    expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-fable-5-1")).toBe("native");
+    expect(hasNative1MContext("anthropic:claude-opus-5-1")).toBe(true);
+    expect(supports1MContext("anthropic:claude-opus-5-1")).toBe(false);
+    expect(supports1MContext("anthropic:claude-fable-5-1")).toBe(false);
+  });
+
   it("treats Mythos-class Fable 5 / Mythos 5 as native 1M models", () => {
     expect(getAnthropic1MContextMode("anthropic:claude-fable-5")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-mythos-5")).toBe("native");

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -180,6 +180,10 @@ const ANTHROPIC_NATIVE_1M_PATTERNS = [
   // Mythos-class models (Fable 5 / Mythos 5) ship 1M context as standard metadata.
   new RegExp(`^claude-fable-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-mythos-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
+  // Pre-release Fable 5.1 / Opus 5.1: seeded to keep their predecessors' native 1M
+  // context; confirm against the announcement before release.
+  new RegExp(`^claude-fable-5-1${OPTIONAL_VERSION_SUFFIX}$`, "i"),
+  new RegExp(`^claude-opus-5-1${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-8${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-7${OPTIONAL_VERSION_SUFFIX}$`, "i"),

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -139,7 +139,14 @@ describe("buildProviderOptions - Anthropic", () => {
   // Native-xhigh models (Opus 4.7+ / Sonnet 5+): xhigh is a distinct native
   // effort and adaptive thinking requires `display: "summarized"` to return
   // thinking content.
-  for (const model of ["claude-opus-4-7", "claude-opus-5", "claude-sonnet-5"] as const) {
+  // claude-opus-5-1 is the pre-release Opus 5.1 id (unconfirmed): it must inherit
+  // the same native-xhigh wire transforms as its predecessor.
+  for (const model of [
+    "claude-opus-4-7",
+    "claude-opus-5",
+    "claude-opus-5-1",
+    "claude-sonnet-5",
+  ] as const) {
     describe(`${model} (native xhigh effort + summarized display)`, () => {
       for (const { thinking, expectedThinking, effort } of [
         {

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -431,6 +431,15 @@ describe("getThinkingPolicyForModel", () => {
       "xhigh",
       "max",
     ]);
+    // Pre-release Opus 5.1 (unconfirmed id) — inherits the forward-compatible Opus policy.
+    expect(getThinkingPolicyForModel("anthropic:claude-opus-5-1")).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
   });
 
   test("excludes 'off' for Mythos-class Fable 5 / Mythos 5 (API rejects disabled thinking)", () => {
@@ -444,6 +453,14 @@ describe("getThinkingPolicyForModel", () => {
       "max",
     ]);
     expect(getThinkingPolicyForModel("anthropic:claude-mythos-5")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    // Pre-release Fable 5.1 (unconfirmed id) — inherits the Mythos-class no-"off" policy.
+    expect(getThinkingPolicyForModel("anthropic:claude-fable-5-1")).toEqual([
       "low",
       "medium",
       "high",

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -135,6 +135,27 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_pdf_input: true,
   },
 
+  // Claude Fable 5.1 - PRE-RELEASE, NOT YET ANNOUNCED (unconfirmed id).
+  // Every value below is seeded from the direct predecessor `claude-fable-5`
+  // ($10/M input, $50/M output, cache write 1.25x input, cache read 0.1x input,
+  // native 1M context, 128K max output) and must be confirmed against
+  // Anthropic's announcement before release.
+  "claude-fable-5-1": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00001, // $10 per million input tokens (seeded from Fable 5)
+    output_cost_per_token: 0.00005, // $50 per million output tokens (seeded from Fable 5)
+    cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25x input)
+    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1x input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Claude Fable 5 / Mythos 5 - Released June 9, 2026
   // Mythos-class model (a tier above Opus). Fable 5 (`claude-fable-5`) is the
   // generally-available variant with safeguards; Mythos 5 (`claude-mythos-5`) is the same
@@ -166,6 +187,27 @@ export const modelsExtra: Record<string, ModelData> = {
     output_cost_per_token: 0.00005, // $50 per million output tokens
     cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
     cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
+  // Claude Opus 5.1 - PRE-RELEASE, NOT YET ANNOUNCED (unconfirmed id).
+  // Every value below is seeded from the direct predecessor `claude-opus-5`
+  // ($5/M input, $25/M output, cache write $6.25, cache read $0.50, native 1M
+  // context, 128K max output) and must be confirmed against Anthropic's
+  // announcement before release.
+  "claude-opus-5-1": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.000005, // $5 per million input tokens (seeded from Opus 5)
+    output_cost_per_token: 0.000025, // $25 per million output tokens (seeded from Opus 5)
+    cache_creation_input_token_cost: 0.00000625, // $6.25 per million tokens
+    cache_read_input_token_cost: 0.0000005, // $0.50 per million tokens
     litellm_provider: "anthropic",
     mode: "chat",
     supports_function_calling: true,

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -71,6 +71,9 @@ describe("supportsAnthropicNativeWebFetch", () => {
     ["claude-opus-5", true],
     ["claude-fable-5", true],
     ["claude-mythos-5", true],
+    // Pre-release 5.1 ids (unconfirmed) parse as major=5 / minor=1 and qualify.
+    ["claude-opus-5-1", true],
+    ["claude-fable-5-1", true],
     // Two-segment IDs at/after the 4.6 cutoff.
     ["claude-sonnet-4-6", true],
     ["claude-opus-4-6", true],


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE until Anthropic officially releases these models.** Everything below is pre-release preparation seeded from unconfirmed rumors; the ids, pricing, and limits must be confirmed against the official announcement first.

## Summary

Pre-release preparation for two rumored upcoming Anthropic models, **Claude Opus 5.1** (`claude-opus-5-1`) and **Claude Fable 5.1** (`claude-fable-5-1`), so that the moment they go live we only confirm the id/price facts and merge. Adds pricing/capability metadata entries plus native-1M-context pattern coverage, with behavioral tests asserting that both ids inherit the correct thinking-policy ladders, native-xhigh wire transforms, display formatting, and native web-fetch qualification.

## Background

This replicates the shape of the repo's prior model-addition commits, minus any default-model promotion:

- **ba36c818f** (#3499, "add Claude Fable 5 / Mythos 5 support") — the `models-extra.ts` metadata + native-1M pattern + behavioral-test shape. Mythos 5 is also this repo's precedent for a model that is declared but not generally available: metadata + regex coverage + tests, **no** curated `KNOWN_MODELS` entry.
- **ae6406a51** (#3750, "add support for Claude Opus 5") — the test-coverage shape (native-xhigh provider options loop, thinking policy, 1M classification, native web-fetch rows). The default-promotion parts of that commit (`KNOWN_MODELS.OPUS` repoint, gateway default seeds, docs/skill regeneration) are deliberately **not** replicated.

Both new ids are already matched by the existing forward-compatible regexes for native xhigh (`anthropicSupportsNativeXhigh`), Mythos-class no-disabled-thinking clamping, display formatting (`Opus 5.1` / `Fable 5.1`), and native web-fetch qualification — those needed only test coverage, no source changes. The two source changes that were needed: `models-extra.ts` metadata entries (pricing/limits/capabilities) and `models.ts` native-1M patterns (anchored, so `-1` suffixes did not auto-match).

## Confirm-before-merge checklist

Every item below is **seeded from the model's direct predecessor** (Opus 5 → Opus 5.1, Fable 5 → Fable 5.1) and is **unverified**. Confirm each against the official announcement/docs before merging:

**Model ids (naming convention extrapolated, may differ at release):**
- [ ] `claude-opus-5-1` is the real API id for Opus 5.1
- [ ] `claude-fable-5-1` is the real API id for Fable 5.1

**Opus 5.1 (seeded from `claude-opus-5`):**
- [ ] Input price $5/MTok (`input_cost_per_token: 0.000005`)
- [ ] Output price $25/MTok (`output_cost_per_token: 0.000025`)
- [ ] Cache write $6.25/MTok, cache read $0.50/MTok
- [ ] Native 1M context window (`max_input_tokens: 1000000` + native-1M pattern, no beta header)
- [ ] 128K max output (`max_output_tokens: 128000`)
- [ ] Thinking levels: full 6-level ladder `off/low/medium/high/xhigh/max` with native xhigh effort and `display: "summarized"` wire transforms (i.e. still matched by `anthropicSupportsNativeXhigh`, and disabled thinking still allowed → `off` stays in the policy)
- [ ] Vision / PDF / function calling / response schema support unchanged
- [ ] Native web fetch (`webFetch_20250910`) supported

**Fable 5.1 (seeded from `claude-fable-5`):**
- [ ] Input price $10/MTok (`input_cost_per_token: 0.00001`)
- [ ] Output price $50/MTok (`output_cost_per_token: 0.00005`)
- [ ] Cache write $12.50/MTok (1.25× input), cache read $1.00/MTok (0.1× input)
- [ ] Native 1M context window, 128K max output
- [ ] Thinking levels: Mythos-class 5-level ladder `low/medium/high/xhigh/max` (API rejects `thinking: {type: "disabled"}`, so `off` is excluded and clamped to `low` — same as Fable 5)
- [ ] Vision / PDF / function calling / response schema support unchanged
- [ ] Native web fetch supported
- [ ] Whether a restricted-access Mythos 5.1 twin exists (if so, add its entry the way `claude-mythos-5` was added)

**Deliberately not in this PR (follow-up at release, matching the Opus 5 commit):**
- [ ] Decide whether to repoint `KNOWN_MODELS.OPUS`/`FABLE` (aliases `opus`/`fable`, app default) — **not** done here per the no-default rule; docs/skill content regeneration and gateway default seeds only apply if/when that repoint happens

## Id-literal locations (for a mechanical rename at merge time)

If the release uses different ids, rename the literal at every location below (source first, tests after). Current as of HEAD of this branch:

**Source (behavior-defining):**
- `src/common/utils/tokens/models-extra.ts:143` — `"claude-fable-5-1"` metadata entry key (comment block above it references the id in prose)
- `src/common/utils/tokens/models-extra.ts:204` — `"claude-opus-5-1"` metadata entry key (comment block above it references the id in prose)
- `src/common/utils/ai/models.ts:185` — `^claude-fable-5-1` native-1M regex
- `src/common/utils/ai/models.ts:186` — `^claude-opus-5-1` native-1M regex

**Tests:**
- `src/common/utils/ai/models.test.ts:172-178` — native-1M classification assertions (both ids, incl. dated + `mux-gateway:` forms)
- `src/common/utils/thinking/policy.test.ts:435` — Opus 5.1 6-level ladder
- `src/common/utils/thinking/policy.test.ts:463` — Fable 5.1 5-level (no-off) ladder
- `src/common/utils/ai/providerOptions.test.ts:142` (comment) and `:147` — Opus 5.1 in the native-xhigh wire-transform loop
- `src/common/utils/ai/modelDisplay.test.ts:34-35` — display-name formatting (`Opus 5.1` / `Fable 5.1`)
- `src/common/utils/tools/tools.test.ts:75-76` — native web-fetch qualification rows

No other occurrences exist (`grep -rn "claude-opus-5-1\|claude-fable-5-1" src/`).

## Implementation notes

- Until the ids appear in upstream `models.json` or a curated `KNOWN_MODELS` entry, they are usable as custom model strings (`anthropic:claude-opus-5-1`) with correct stats/capabilities via the `models-extra.ts` fallback — exactly how `claude-mythos-5` shipped. They do not appear in the model picker or the "Treat as" catalog, and nothing defaults to them.
- No existing model was removed, deprecated, or repointed.

## Validation

- `make static-check` green locally (typecheck, eslint, prettier, docs/generated-content sync).
- Targeted suites green: `models`, `policy`, `modelDisplay`, `tools`, `providerOptions`, `modelStats`, `modelCatalog`, `knownModels` — 408 tests.

## Risks

Low while unmerged; the entries are additive and unreachable except via explicit custom model strings. The main risk is merging before confirming seeded facts — hence the checklist above and the DO-NOT-MERGE gate.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
