### PR TITLE
🤖 feat: promote Claude Mythos 5.1 as the mythos model

### DIFF
--- a/docs/config/models.mdx
+++ b/docs/config/models.mdx
@@ -14,7 +14,7 @@ Xum ships with curated models kept up to date with the frontier. Use any custom 
 | Model                  | ID                            | Aliases                                                      | Default |
 | ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |
 | Fable 5.1              | anthropic:claude-fable-5-1    | `fable`                                                      |         |
-| Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |
+| Mythos 5.1             | anthropic:claude-mythos-5-1   | `mythos`                                                     |         |
 | Opus 5                 | anthropic:claude-opus-5       | `opus`                                                       | ✓       |
 | Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |
 | Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -42,15 +42,16 @@ const MODEL_DEFINITIONS = {
     // same text, so real usage can run ~1.0-1.3x higher than this estimate.
     tokenizerOverride: "anthropic/claude-opus-4.5",
   },
-  // Claude Mythos 5 - released June 9, 2026 alongside Fable 5. Same underlying model,
-  // specs, and pricing as Fable 5 ($10/M input, $50/M output) but with safeguards lifted
-  // in some areas. Limited availability: restricted to approved Project Glasswing /
-  // trusted-access customers (no self-serve sign-up). API id `claude-mythos-5`.
+  // Claude Mythos 5.1 - successor to Mythos 5 (released June 9, 2026 alongside Fable 5)
+  // as the restricted-access, safeguards-lifted twin of Fable 5.1, assumed at unchanged
+  // pricing ($10/M input, $50/M output) and availability (approved Project Glasswing /
+  // trusted-access customers, no self-serve sign-up). API id `claude-mythos-5-1`;
+  // Mythos 5 stays usable as the custom model string `anthropic:claude-mythos-5`.
   // Not warmed: most users cannot access it, and its tokenizer override is already
   // warmed via FABLE.
   MYTHOS: {
     provider: "anthropic",
-    providerModelId: "claude-mythos-5",
+    providerModelId: "claude-mythos-5-1",
     aliases: ["mythos"],
     // Same tokenizer situation as Fable 5 (see FABLE above): reuse Opus 4.5 for
     // approximate counting; real usage can run ~1.0-1.3x higher.
@@ -287,6 +288,7 @@ export const MODEL_ABBREVIATIONS: Record<string, string> = Object.fromEntries(
 // lookup does not fall back to the generic per-provider tokenizer.
 const LEGACY_TOKENIZER_MODEL_OVERRIDES: Record<string, string> = {
   "anthropic:claude-fable-5": "anthropic/claude-opus-4.5",
+  "anthropic:claude-mythos-5": "anthropic/claude-opus-4.5",
   "anthropic:claude-opus-4-8": "anthropic/claude-opus-4.5",
 };
 

--- a/src/common/constants/knownModels.ts
+++ b/src/common/constants/knownModels.ts
@@ -28,9 +28,10 @@ interface KnownModel extends KnownModelDefinition {
 // of the community.
 const MODEL_DEFINITIONS = {
   // Claude Fable 5.1 - Mythos-class model (a tier above Opus), successor to Fable 5
-  // (released June 9, 2026) as the generally-available safeguarded variant, at unchanged
-  // pricing ($10/M input, $50/M output). API id `claude-fable-5-1`; Fable 5 stays usable
-  // as the custom model string `anthropic:claude-fable-5`.
+  // (released June 9, 2026) as the generally-available safeguarded variant, at the same
+  // pricing ($10/M input, $50/M output) except cheaper cache reads (0.025x input).
+  // API id `claude-fable-5-1`; Fable 5 stays usable as the custom model string
+  // `anthropic:claude-fable-5`.
   FABLE: {
     provider: "anthropic",
     providerModelId: "claude-fable-5-1",
@@ -43,10 +44,11 @@ const MODEL_DEFINITIONS = {
     tokenizerOverride: "anthropic/claude-opus-4.5",
   },
   // Claude Mythos 5.1 - successor to Mythos 5 (released June 9, 2026 alongside Fable 5)
-  // as the restricted-access, safeguards-lifted twin of Fable 5.1, assumed at unchanged
-  // pricing ($10/M input, $50/M output) and availability (approved Project Glasswing /
-  // trusted-access customers, no self-serve sign-up). API id `claude-mythos-5-1`;
-  // Mythos 5 stays usable as the custom model string `anthropic:claude-mythos-5`.
+  // as the restricted-access, safeguards-lifted twin of Fable 5.1, with identical specs
+  // and pricing ($10/M input, $50/M output, 0.025x-input cache reads) and unchanged
+  // availability (approved Project Glasswing customers only, no self-serve sign-up).
+  // API id `claude-mythos-5-1`; Mythos 5 stays usable as the custom model string
+  // `anthropic:claude-mythos-5`.
   // Not warmed: most users cannot access it, and its tokenizer override is already
   // warmed via FABLE.
   MYTHOS: {

--- a/src/common/utils/ai/modelDisplay.test.ts
+++ b/src/common/utils/ai/modelDisplay.test.ts
@@ -29,6 +29,7 @@ describe("formatModelDisplayName", () => {
       expect(formatModelDisplayName("claude-fable-5")).toBe("Fable 5");
       expect(formatModelDisplayName("claude-fable-5-1")).toBe("Fable 5.1");
       expect(formatModelDisplayName("claude-mythos-5")).toBe("Mythos 5");
+      expect(formatModelDisplayName("claude-mythos-5-1")).toBe("Mythos 5.1");
     });
   });
 

--- a/src/common/utils/ai/models.test.ts
+++ b/src/common/utils/ai/models.test.ts
@@ -167,14 +167,18 @@ describe("Anthropic 1M context classification", () => {
     expect(hasNative1MContext("anthropic:claude-sonnet-5")).toBe(true);
   });
 
-  it("treats Mythos-class Fable 5 / Fable 5.1 / Mythos 5 as native 1M models", () => {
+  it("treats Mythos-class Fable 5 / Fable 5.1 / Mythos 5 / Mythos 5.1 as native 1M models", () => {
     expect(getAnthropic1MContextMode("anthropic:claude-fable-5")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-fable-5-1")).toBe("native");
     expect(getAnthropic1MContextMode("anthropic:claude-mythos-5")).toBe("native");
+    expect(getAnthropic1MContextMode("anthropic:claude-mythos-5-1")).toBe("native");
     expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-fable-5-1")).toBe("native");
+    expect(getAnthropic1MContextMode("mux-gateway:anthropic/claude-mythos-5-1")).toBe("native");
     expect(hasNative1MContext("anthropic:claude-fable-5")).toBe(true);
     expect(hasNative1MContext("anthropic:claude-fable-5-1")).toBe(true);
+    expect(hasNative1MContext("anthropic:claude-mythos-5-1")).toBe(true);
     expect(supports1MContext("anthropic:claude-fable-5-1")).toBe(false);
+    expect(supports1MContext("anthropic:claude-mythos-5-1")).toBe(false);
   });
 
   it("returns none for models without Anthropic 1M support", () => {

--- a/src/common/utils/ai/models.ts
+++ b/src/common/utils/ai/models.ts
@@ -181,6 +181,7 @@ const ANTHROPIC_NATIVE_1M_PATTERNS = [
   new RegExp(`^claude-fable-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-fable-5-1${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-mythos-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
+  new RegExp(`^claude-mythos-5-1${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-5${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-8${OPTIONAL_VERSION_SUFFIX}$`, "i"),
   new RegExp(`^claude-opus-4-7${OPTIONAL_VERSION_SUFFIX}$`, "i"),

--- a/src/common/utils/ai/providerOptions.test.ts
+++ b/src/common/utils/ai/providerOptions.test.ts
@@ -186,6 +186,12 @@ describe("buildProviderOptions - Anthropic", () => {
       );
       expect(anthropic51.thinking).toEqual({ type: "adaptive", display: "summarized" });
       expect(anthropic51.effort).toBe("medium");
+      // Mythos 5.1 does too.
+      const mythos51 = anthropicProviderOptions(
+        buildProviderOptions("anthropic:claude-mythos-5-1", "medium")
+      );
+      expect(mythos51.thinking).toEqual({ type: "adaptive", display: "summarized" });
+      expect(mythos51.effort).toBe("medium");
     });
 
     test("omits thinking instead of sending disabled when off", () => {
@@ -196,6 +202,9 @@ describe("buildProviderOptions - Anthropic", () => {
         anthropic: { ...baseAnthropicOptions, effort: "low" },
       });
       expect(buildProviderOptions("anthropic:claude-fable-5-1", "off")).toEqual({
+        anthropic: { ...baseAnthropicOptions, effort: "low" },
+      });
+      expect(buildProviderOptions("anthropic:claude-mythos-5-1", "off")).toEqual({
         anthropic: { ...baseAnthropicOptions, effort: "low" },
       });
     });

--- a/src/common/utils/thinking/policy.test.ts
+++ b/src/common/utils/thinking/policy.test.ts
@@ -457,6 +457,13 @@ describe("getThinkingPolicyForModel", () => {
       "xhigh",
       "max",
     ]);
+    expect(getThinkingPolicyForModel("anthropic:claude-mythos-5-1")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
   });
 
   test("clamps 'off' up to 'low' for Mythos-class models", () => {
@@ -464,6 +471,7 @@ describe("getThinkingPolicyForModel", () => {
     expect(enforceThinkingPolicy("anthropic:claude-fable-5", "off")).toBe("low");
     expect(enforceThinkingPolicy("anthropic:claude-fable-5-1", "off")).toBe("low");
     expect(enforceThinkingPolicy("anthropic:claude-mythos-5", "off")).toBe("low");
+    expect(enforceThinkingPolicy("anthropic:claude-mythos-5-1", "off")).toBe("low");
   });
 
   test("resolveEffectiveThinkingLevel clamps unset/off for forced-thinking models", () => {

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -178,9 +178,10 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
-  // Claude Mythos 5.1 - successor to Mythos 5, the restricted-access twin of
-  // Fable 5.1, assumed at the same pricing/shape: $10/M input, $50/M output, cache
-  // write 1.25x input / cache read 0.1x input, native 1M context, 128K max output,
+  // Claude Mythos 5.1 - successor to Mythos 5, the restricted-access (Project
+  // Glasswing) twin of Fable 5.1 with identical announced specs and pricing:
+  // $10/M input, $50/M output, cache write 1.25x input, cache read 0.025x input
+  // ($0.25/M, down from Mythos 5's 0.1x), native 1M context, 128K max output,
   // native xhigh effort level.
   "claude-mythos-5-1": {
     max_input_tokens: 1000000,
@@ -188,7 +189,7 @@ export const modelsExtra: Record<string, ModelData> = {
     input_cost_per_token: 0.00001, // $10 per million input tokens
     output_cost_per_token: 0.00005, // $50 per million output tokens
     cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
-    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    cache_read_input_token_cost: 0.00000025, // $0.25 per million tokens (0.025× input)
     litellm_provider: "anthropic",
     mode: "chat",
     supports_function_calling: true,

--- a/src/common/utils/tokens/models-extra.ts
+++ b/src/common/utils/tokens/models-extra.ts
@@ -178,6 +178,26 @@ export const modelsExtra: Record<string, ModelData> = {
     supports_response_schema: true,
   },
 
+  // Claude Mythos 5.1 - successor to Mythos 5, the restricted-access twin of
+  // Fable 5.1, assumed at the same pricing/shape: $10/M input, $50/M output, cache
+  // write 1.25x input / cache read 0.1x input, native 1M context, 128K max output,
+  // native xhigh effort level.
+  "claude-mythos-5-1": {
+    max_input_tokens: 1000000,
+    max_output_tokens: 128000,
+    input_cost_per_token: 0.00001, // $10 per million input tokens
+    output_cost_per_token: 0.00005, // $50 per million output tokens
+    cache_creation_input_token_cost: 0.0000125, // $12.50 per million tokens (1.25× input)
+    cache_read_input_token_cost: 0.000001, // $1.00 per million tokens (0.1× input)
+    litellm_provider: "anthropic",
+    mode: "chat",
+    supports_function_calling: true,
+    supports_vision: true,
+    supports_pdf_input: true,
+    supports_reasoning: true,
+    supports_response_schema: true,
+  },
+
   // Same underlying model as Fable 5 (identical pricing/shape); restricted access.
   "claude-mythos-5": {
     max_input_tokens: 1000000,

--- a/src/common/utils/tools/tools.test.ts
+++ b/src/common/utils/tools/tools.test.ts
@@ -73,6 +73,7 @@ describe("supportsAnthropicNativeWebFetch", () => {
     ["claude-mythos-5", true],
     // Two-segment IDs at/after the 4.6 cutoff.
     ["claude-fable-5-1", true],
+    ["claude-mythos-5-1", true],
     ["claude-sonnet-4-6", true],
     ["claude-opus-4-6", true],
     ["claude-opus-4-8", true],

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -3851,7 +3851,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| Model                  | ID                            | Aliases                                                      | Default |",
       "| ---------------------- | ----------------------------- | ------------------------------------------------------------ | ------- |",
       "| Fable 5.1              | anthropic:claude-fable-5-1    | `fable`                                                      |         |",
-      "| Mythos 5               | anthropic:claude-mythos-5     | `mythos`                                                     |         |",
+      "| Mythos 5.1             | anthropic:claude-mythos-5-1   | `mythos`                                                     |         |",
       "| Opus 5                 | anthropic:claude-opus-5       | `opus`                                                       | ✓       |",
       "| Sonnet 5               | anthropic:claude-sonnet-5     | `sonnet`                                                     |         |",
       "| Haiku 4.5              | anthropic:claude-haiku-4-5    | `haiku`                                                      |         |",


### PR DESCRIPTION
## Summary

Promotes Mythos 5.1 (`anthropic:claude-mythos-5-1`) to the `MYTHOS` known model, so the `mythos` alias and model picker route to the new id. Mythos 5 stays usable as the custom model string `anthropic:claude-mythos-5` and keeps its metadata entry and tokenizer approximation. This is the Mythos twin of the Fable 5.1 promotion (#3988) and is stacked on `mike/fable-5-1-drop` (this PR contains only the Mythos-side changes).

Anthropic has announced Fable 5.1 / Mythos 5.1 ([What's new](https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1)), so the original merge gate is lifted and all previously-assumed numbers below are verified. The corresponding Fable 5.1 cache-read pricing fix landed on the base branch; this PR applies the same announced price to Mythos 5.1.

## Background

Fable 5 and Mythos 5 shipped together in ba36c818f; #3988 prepped the Fable 5.1 promotion and this PR is the Mythos twin, originally merge-gated as speculative prep and now verified against the announcement.

## Verified against the announcement

- **API id**: `claude-mythos-5-1` ✓ (docs list it as the successor to Mythos 5, Project Glasswing–restricted).
- **Envelope**: native 1M context (default and maximum), 128K max output ✓.
- **Thinking/effort**: adaptive thinking always on, disabled thinking rejected, effort parameter with the full ladder ✓ — matches the existing Mythos-class wildcard matchers and off→low clamp.
- **Tokenizer**: same as Fable 5 (Opus 4.7 tokenizer, unpublished upstream) ✓ — the Opus 4.5 approximation stays.
- **Pricing**: $10/M input, $50/M output, cache write 1.25× ✓ — except cache reads dropped to 0.025× input ($0.25/M) from the assumed 0.1×; applied here for `claude-mythos-5-1` (the `claude-fable-5-1` fix is on the base branch).

### Breaking-changes audit (announcement vs Mux)

- **Forced tool use returns 400** (`tool_choice: any/tool`): Mux never forces tool choice on Anthropic models — the only `toolChoice: "required"` path (`streamManager` first-step forcing) is xAI-only, and `workspaceTitleGenerator` deliberately relies on prompt + `tools.require`/`stopWhen` enforcement instead. No change needed.
- **Thinking-block model binding / prefix-edit invalidation**: enforced only for accounts created on/after Aug 31, 2026, otherwise opt-in via the `thinking-binding-controls-2026-08-01` beta header, which Mux does not send; unreadable blocks on model switches are dropped server-side without error. No change needed for the model drop; adopting the beta controls (and `display: "updates"`, per-message effort, turn-scoped system messages) is follow-up feature work.
- **Refusal fallback**: Mythos remains without a default chain (safeguards lifted; no Mythos key in `DEFAULT_MODEL_FALLBACKS`), so no `defaultModelFallbacksSeededMythos51` migration is needed and the migrations schema is untouched — trivially coexisting with `defaultModelFallbacksSeededFable51` and any sibling flags.

## Implementation

Mirrors #3988 surface-for-surface, adapted to Mythos:

- `knownModels.ts`: `MYTHOS` → `claude-mythos-5-1` (keeps the `mythos` alias; stays unwarmed since most users cannot access it and its tokenizer override is already warmed via FABLE). `LEGACY_TOKENIZER_MODEL_OVERRIDES` retains `anthropic:claude-mythos-5`, exactly like the retired `claude-fable-5` / `claude-opus-4-8` ids.
- `models-extra.ts`: new `claude-mythos-5-1` entry with announced pricing (incl. $0.25/M cache reads); Mythos 5 entry retained.
- `models.ts`: `claude-mythos-5-1` added to the native-1M patterns (anchored; the existing `claude-mythos-5` pattern tolerates date suffixes but not a `-1` minor).
- No wire-format changes for thinking/effort/web-fetch: the Mythos-class wildcard matchers already match the new id; tests pin that.
- Docs model table and built-in skill content regenerated, not hand-edited.
- No WorkflowRunner fixture change: no fixture pins the `mythos` alias.

## Validation

- Behavioral coverage for the new id: native-1M classification (direct + gateway-prefixed), display formatting (`Mythos 5.1`), 5-level thinking policy with off-clamp, provider options (adaptive + summarized display, no disabled thinking), native web-fetch support.
- `make static-check` green; targeted suites (tokens, models, modelDisplay, policy, providerOptions, tools) and `config.test.ts` pass.

## Risks

Low: additive registry/metadata changes. The user-visible effect is that the `mythos` alias routes to Mythos 5.1 (now live at the API) with announced pricing. Existing Mythos 5 selections keep working as custom model strings with unchanged token accounting.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
