### PR TITLE
🤖 fix: focus main region after sidebar collapse

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -121,6 +121,7 @@ import {
   type CustomEventType,
   type CustomEventPayloads,
 } from "@/common/constants/events";
+import { useFocusMainRegion } from "@/browser/hooks/useFocusMainRegion";
 
 const TRANSCRIPT_ONLY_NOTICE =
   "This workspace's worktree is no longer available. This is a read-only chat transcript kept for historical and usage-tracking reasons.";
@@ -823,6 +824,7 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
   const handleChatInputReady = useCallback((api: ChatInputAPI) => {
     chatInputAPI.current = api;
   }, []);
+  useFocusMainRegion(chatInputAPI);
 
   // Handler for review notes from Code Review tab - adds review (starts attached)
   // Depend only on addReview (not whole reviews object) to keep callback stable

--- a/src/browser/components/ProjectPage/ProjectPage.tsx
+++ b/src/browser/components/ProjectPage/ProjectPage.tsx
@@ -33,6 +33,7 @@ import {
 import { Button } from "@/browser/components/Button/Button";
 import { Skeleton } from "@/browser/components/Skeleton/Skeleton";
 import { isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
+import { useFocusMainRegion } from "@/browser/hooks/useFocusMainRegion";
 
 interface ProjectPageProps {
   projectPath: string;
@@ -252,6 +253,7 @@ export const ProjectPage: React.FC<ProjectPageProps> = ({
     didAutoFocusRef.current = true;
     api.focus();
   }, []);
+  useFocusMainRegion(chatInputRef);
 
   return (
     <AgentProvider projectPath={projectPath}>

--- a/src/browser/components/ScratchPage/ScratchPage.tsx
+++ b/src/browser/components/ScratchPage/ScratchPage.tsx
@@ -16,6 +16,7 @@ import { useAPI, type APIClient } from "@/browser/contexts/API";
 import { ArchivedWorkspaces } from "@/browser/components/ArchivedWorkspaces/ArchivedWorkspaces";
 import { Button } from "@/browser/components/Button/Button";
 import { Skeleton } from "@/browser/components/Skeleton/Skeleton";
+import { useFocusMainRegion } from "@/browser/hooks/useFocusMainRegion";
 
 interface ScratchPageProps {
   leftSidebarCollapsed: boolean;
@@ -36,6 +37,7 @@ async function listArchivedScratchWorkspaces(api: APIClient | null) {
 export function ScratchPage(props: ScratchPageProps) {
   const { api } = useAPI();
   const [archivedWorkspaces, setArchivedWorkspaces] = useState<FrontendWorkspaceMetadata[]>([]);
+  const chatInputRef = useRef<ChatInputAPI | null>(null);
   const didAutoFocusRef = useRef(false);
   const { config: providersConfig, loading: providersLoading } = useProvidersConfig();
   const hasProviders = hasConfiguredProvider(providersConfig);
@@ -57,10 +59,12 @@ export function ScratchPage(props: ScratchPageProps) {
   }, [api]);
 
   function handleChatReady(api: ChatInputAPI) {
+    chatInputRef.current = api;
     if (didAutoFocusRef.current) return;
     didAutoFocusRef.current = true;
     api.focus();
   }
+  useFocusMainRegion(chatInputRef);
 
   return (
     <AgentProvider projectPath={SCRATCH_PROJECT_CONFIG_KEY}>

--- a/src/browser/components/SidebarCollapseButton/SidebarCollapseButton.test.tsx
+++ b/src/browser/components/SidebarCollapseButton/SidebarCollapseButton.test.tsx
@@ -1,0 +1,68 @@
+import "../../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { installDom } from "../../../../tests/ui/dom";
+import { CUSTOM_EVENTS } from "@/common/constants/events";
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { SidebarCollapseButton } from "./SidebarCollapseButton";
+
+let cleanupDom: (() => void) | null = null;
+
+describe("SidebarCollapseButton", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  it("requests main-region focus after collapsing", () => {
+    const onToggle = mock(() => undefined);
+    let focusRequests = 0;
+    window.addEventListener(CUSTOM_EVENTS.FOCUS_MAIN_REGION, () => {
+      focusRequests += 1;
+    });
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+
+    const view = render(
+      <TooltipProvider>
+        <SidebarCollapseButton collapsed={false} onToggle={onToggle} side="right" />
+      </TooltipProvider>
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(focusRequests).toBe(1);
+  });
+
+  it("does not request main-region focus after expanding", () => {
+    const onToggle = mock(() => undefined);
+    let focusRequests = 0;
+    window.addEventListener(CUSTOM_EVENTS.FOCUS_MAIN_REGION, () => {
+      focusRequests += 1;
+    });
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+
+    const view = render(
+      <TooltipProvider>
+        <SidebarCollapseButton collapsed onToggle={onToggle} side="right" />
+      </TooltipProvider>
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "Expand sidebar" }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(focusRequests).toBe(0);
+  });
+});

--- a/src/browser/components/SidebarCollapseButton/SidebarCollapseButton.tsx
+++ b/src/browser/components/SidebarCollapseButton/SidebarCollapseButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/browser/components/Tooltip/Tooltip";
+import { requestMainRegionFocus } from "@/browser/hooks/useFocusMainRegion";
 
 interface SidebarCollapseButtonProps {
   collapsed: boolean;
@@ -26,11 +27,20 @@ export const SidebarCollapseButton: React.FC<SidebarCollapseButtonProps> = ({
 
   const label = collapsed ? "Expand sidebar" : "Collapse sidebar";
 
+  const handleClick = () => {
+    onToggle();
+    if (collapsed) {
+      return;
+    }
+
+    requestMainRegionFocus();
+  };
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
-          onClick={onToggle}
+          onClick={handleClick}
           aria-label={label}
           className={
             collapsed

--- a/src/browser/features/Analytics/AnalyticsDashboard.tsx
+++ b/src/browser/features/Analytics/AnalyticsDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ArrowLeft, Menu } from "lucide-react";
 import { useProjectContext } from "@/browser/contexts/ProjectContext";
 import { useRouter } from "@/browser/contexts/RouterContext";
@@ -16,6 +16,7 @@ import {
 } from "@/browser/hooks/useAnalytics";
 import { DESKTOP_TITLEBAR_HEIGHT_CLASS, isDesktopMode } from "@/browser/hooks/useDesktopTitlebar";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { useFocusMainRegion } from "@/browser/hooks/useFocusMainRegion";
 import { isEditableElement, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
 import { ToggleGroup } from "@/browser/components/ToggleGroup/ToggleGroup";
 import { Button } from "@/browser/components/Button/Button";
@@ -130,6 +131,7 @@ function getBrowserTimeZone(): string {
 export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
   const { navigateFromAnalytics } = useRouter();
   const { userProjects } = useProjectContext();
+  const mainRegionRef = useRef<HTMLDivElement | null>(null);
 
   const [projectPath, setProjectPath] = useState<string | null>(null);
   const [rawTimeRange, setTimeRange] = usePersistedState<TimeRange>(
@@ -232,6 +234,7 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [navigateFromAnalytics]);
+  useFocusMainRegion(mainRegionRef);
 
   return (
     <div className="bg-surface-primary flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -347,7 +350,11 @@ export function AnalyticsDashboard(props: AnalyticsDashboardProps) {
       </div>
 
       <div className="flex-1 overflow-y-auto p-4">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-4">
+        <div
+          ref={mainRegionRef}
+          tabIndex={-1}
+          className="mx-auto flex w-full max-w-6xl flex-col gap-4 outline-none"
+        >
           <SummaryCards data={summary.data} loading={summary.loading} error={summary.error} />
           <SpendChart
             data={spendOverTime.data}

--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   ArrowLeft,
   Blocks,
@@ -32,6 +32,7 @@ import { ModelsSection } from "./Sections/ModelsSection";
 import { GovernorSection } from "./Sections/GovernorSection";
 import { MemorySection } from "./Sections/MemorySection";
 import { Button } from "@/browser/components/Button/Button";
+import { useFocusMainRegion } from "@/browser/hooks/useFocusMainRegion";
 import { MCPSettingsSection } from "./Sections/MCPSettingsSection";
 import { PluginsSettingsSection } from "./Sections/PluginsSettingsSection";
 import { SecretsSection } from "./Sections/SecretsSection";
@@ -208,6 +209,7 @@ interface SettingsPageProps {
 
 export function SettingsPage(props: SettingsPageProps) {
   const { close, activeSection, setActiveSection } = useSettings();
+  const mainRegionRef = useRef<HTMLDivElement | null>(null);
   const onboardingPause = useOnboardingPause();
   const governorEnabled = useExperimentValue(EXPERIMENT_IDS.MUX_GOVERNOR);
   const memoryEnabled = useExperimentValue(EXPERIMENT_IDS.MEMORY);
@@ -250,6 +252,8 @@ export function SettingsPage(props: SettingsPageProps) {
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [close]);
+  useFocusMainRegion(mainRegionRef);
+
   const sections = getSettingsSections(governorEnabled, memoryEnabled, agentPluginsEnabled);
   const currentSection = sections.find((section) => section.id === activeSection) ?? sections[0];
   const SectionComponent = currentSection.component;
@@ -362,7 +366,11 @@ export function SettingsPage(props: SettingsPageProps) {
             {/* Keep settings content width bounded so long forms remain readable on wide screens.
                 min-h-full + flex-col lets full-height sections (Settings → Memory editor) grow to
                 the bottom via flex-1 while content-sized sections keep their natural height. */}
-            <div className="flex min-h-full w-full max-w-4xl flex-col">
+            <div
+              ref={mainRegionRef}
+              tabIndex={-1}
+              className="flex min-h-full w-full max-w-4xl flex-col outline-none"
+            >
               {onboardingPause.paused && (
                 <div className="bg-accent/10 border-accent/30 text-foreground mb-3 flex items-center justify-between rounded-md border px-3 py-2 text-sm">
                   <span>Setup is paused while you configure providers.</span>

--- a/src/browser/hooks/useFocusMainRegion.test.tsx
+++ b/src/browser/hooks/useFocusMainRegion.test.tsx
@@ -1,0 +1,71 @@
+import "../../../tests/ui/dom";
+
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { installDom } from "../../../tests/ui/dom";
+import { createCustomEvent, CUSTOM_EVENTS } from "@/common/constants/events";
+import { requestMainRegionFocus, useFocusMainRegion } from "./useFocusMainRegion";
+
+let cleanupDom: (() => void) | null = null;
+
+function FocusTarget(props: { inert?: boolean }) {
+  const targetRef = useRef<HTMLDivElement | null>(null);
+  useFocusMainRegion(targetRef);
+
+  return (
+    <div {...(props.inert ? { inert: "" } : {})}>
+      <div ref={targetRef} tabIndex={-1} data-testid="main-region" />
+    </div>
+  );
+}
+
+describe("useFocusMainRegion", () => {
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  it("focuses the registered target when the main-region focus event fires", () => {
+    const view = render(<FocusTarget />);
+    const mainRegion = view.getByTestId("main-region");
+
+    expect(document.activeElement).not.toBe(mainRegion);
+
+    window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.FOCUS_MAIN_REGION));
+
+    expect(document.activeElement).toBe(mainRegion);
+  });
+
+  it("does not focus a target inside an inert region", () => {
+    const view = render(<FocusTarget inert />);
+    const mainRegion = view.getByTestId("main-region");
+
+    window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.FOCUS_MAIN_REGION));
+
+    expect(document.activeElement).not.toBe(mainRegion);
+  });
+
+  it("defers focus requests until after layout updates", () => {
+    let requestedFrame = false;
+    let focusRequests = 0;
+    globalThis.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      requestedFrame = true;
+      callback(0);
+      return 0;
+    };
+    window.addEventListener(CUSTOM_EVENTS.FOCUS_MAIN_REGION, () => {
+      focusRequests += 1;
+    });
+
+    requestMainRegionFocus();
+
+    expect(requestedFrame).toBe(true);
+    expect(focusRequests).toBe(1);
+  });
+});

--- a/src/browser/hooks/useFocusMainRegion.ts
+++ b/src/browser/hooks/useFocusMainRegion.ts
@@ -1,0 +1,41 @@
+import { useEffect, type RefObject } from "react";
+import { createCustomEvent, CUSTOM_EVENTS } from "@/common/constants/events";
+
+interface FocusableTarget {
+  focus: (options?: FocusOptions) => void;
+}
+
+function canFocusTarget(target: FocusableTarget | null): target is FocusableTarget {
+  if (!target) {
+    return false;
+  }
+
+  if (!(target instanceof HTMLElement)) {
+    return true;
+  }
+
+  return target.closest("[inert]") === null && !target.hidden;
+}
+
+export function requestMainRegionFocus(): void {
+  requestAnimationFrame(() => {
+    window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.FOCUS_MAIN_REGION));
+  });
+}
+
+/** Focuses the active route's primary region after collapsible layout chrome moves away. */
+export function useFocusMainRegion(targetRef: RefObject<FocusableTarget | null>): void {
+  useEffect(() => {
+    const handleFocusMainRegion = () => {
+      const target = targetRef.current;
+      if (!canFocusTarget(target)) {
+        return;
+      }
+
+      target.focus(target instanceof HTMLElement ? { preventScroll: true } : undefined);
+    };
+
+    window.addEventListener(CUSTOM_EVENTS.FOCUS_MAIN_REGION, handleFocusMainRegion);
+    return () => window.removeEventListener(CUSTOM_EVENTS.FOCUS_MAIN_REGION, handleFocusMainRegion);
+  }, [targetRef]);
+}

--- a/src/common/constants/events.ts
+++ b/src/common/constants/events.ts
@@ -29,6 +29,12 @@ export const CUSTOM_EVENTS = {
   CLEAR_CHAT_COMPOSER: "mux:clearChatComposer",
 
   /**
+   * Event to focus the active route's main region after layout chrome collapses.
+   * No detail
+   */
+  FOCUS_MAIN_REGION: "mux:focusMainRegion",
+
+  /**
    * Event to open the model selector
    * No detail
    */
@@ -158,6 +164,7 @@ export interface CustomEventPayloads {
   [CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER]: {
     workspaceId: string;
   };
+  [CUSTOM_EVENTS.FOCUS_MAIN_REGION]: never; // No payload
   [CUSTOM_EVENTS.OPEN_AGENT_PICKER]: never; // No payload
   [CUSTOM_EVENTS.CLOSE_AGENT_PICKER]: never; // No payload
   [CUSTOM_EVENTS.AGENTS_REFRESH_REQUESTED]: never; // No payload


### PR DESCRIPTION
## Summary

Focus the active route's main region after a sidebar collapse so keyboard input is not left on the collapsed rail button. Workspace, project creation, and scratch routes focus their chat composer; settings and analytics focus their main content region.

## Background

When both side panels are collapsed on desktop, the last clicked collapse button can keep focus. Pressing Enter then re-activates the rail button instead of sending the chat message. This change routes sidebar collapse through a route-owned main-region focus event rather than hard-coding every collapse to the chat input.

## Implementation

- Add a typed `FOCUS_MAIN_REGION` custom event and a `useFocusMainRegion` helper.
- Dispatch the focus request after collapsing a shared sidebar collapse button.
- Register route-appropriate main focus targets for workspace chat, project creation, scratch chats, settings, and analytics.
- Avoid focusing targets inside inert/hidden regions.

## Validation

- `bun test src/browser/hooks/useFocusMainRegion.test.tsx src/browser/components/SidebarCollapseButton/SidebarCollapseButton.test.tsx`
- `bun test src/browser/components/ProjectPage/ProjectPage.autofocus.test.tsx src/browser/features/Settings/SettingsPage.test.tsx`
- `make typecheck`
- `make lint`
- `make static-check` was attempted but the workspace is missing `uvx` and `hadolint`; other static-check subtasks that ran passed, including formatting and code-to-docs links.

## Risks

Low. The new event is route-scoped by whichever main route is mounted, and sidebar expansion does not request focus. The hidden/inert guard prevents immersive overlays from returning focus to a hidden composer.

---

_Generated with Coder Agents on behalf of @tracyjohnsonux._
