### PR TITLE
🤖 refactor(runtime): absorb exec path translation and file I/O canonicalization into adapters

### DIFF
--- a/src/node/runtime/DevcontainerRuntime.test.ts
+++ b/src/node/runtime/DevcontainerRuntime.test.ts
@@ -61,9 +61,12 @@ describe("DevcontainerRuntime.stat", () => {
     });
     const abortController = new AbortController();
 
-    await runtime.stat("/container-only/file.txt", abortController.signal);
+    await runtime.stat("relative/file.txt", abortController.signal);
 
     expect(runtime.execOptions?.abortSignal).toBe(abortController.signal);
+    expect(runtime.execOptions?.pathEnv).toEqual({
+      XUM_INTERNAL_FILE_PATH: "relative/file.txt",
+    });
   });
 });
 
@@ -108,18 +111,6 @@ describe("DevcontainerRuntime.resolvePath", () => {
   it("passes absolute paths through", async () => {
     const runtime = createRuntime({});
     expect(await runtime.resolvePath("/tmp/test")).toBe("/tmp/test");
-  });
-});
-
-describe("DevcontainerRuntime.quoteForContainer", () => {
-  function quoteForContainer(runtime: DevcontainerRuntime, filePath: string): string {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
-    return (runtime as any).quoteForContainer(filePath);
-  }
-
-  it("uses $HOME expansion for tilde paths", () => {
-    const runtime = createRuntime({});
-    expect(quoteForContainer(runtime, "~/.mux")).toBe('"$HOME/.mux"');
   });
 });
 
@@ -179,15 +170,20 @@ describe("DevcontainerRuntime.resolveHostPathForMounted", () => {
     expect(resolveHostPathForMounted(runtime, filePath)).toBe(filePath);
   });
 });
-describe("DevcontainerRuntime.mapPathForExec", () => {
+describe("DevcontainerRuntime exec path translation", () => {
+  function mapPathForExec(runtime: DevcontainerRuntime, filePath: string): string {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
+    return (runtime as any).mapPathForExec(filePath);
+  }
+
   it("maps workspace roots and nested paths into the container", () => {
     const runtime = createRuntime({
       remoteWorkspaceFolder: "/workspaces/project",
       currentWorkspacePath: "/home/user/xum/project/branch",
     });
 
-    expect(runtime.mapPathForExec("/home/user/xum/project/branch")).toBe("/workspaces/project");
-    expect(runtime.mapPathForExec("/home/user/xum/project/branch/nested/file")).toBe(
+    expect(mapPathForExec(runtime, "/home/user/xum/project/branch")).toBe("/workspaces/project");
+    expect(mapPathForExec(runtime, "/home/user/xum/project/branch/nested/file")).toBe(
       "/workspaces/project/nested/file"
     );
   });
@@ -198,13 +194,13 @@ describe("DevcontainerRuntime.mapPathForExec", () => {
       currentWorkspacePath: "/home/user/xum/project/branch",
     });
 
-    expect(runtime.mapPathForExec("/tmp/other")).toBe("/tmp/other");
+    expect(mapPathForExec(runtime, "/tmp/other")).toBe("/tmp/other");
   });
 
   it("keeps paths unchanged when the container workspace is unknown", () => {
     const runtime = createRuntime({ currentWorkspacePath: "/home/user/xum/project/branch" });
 
-    expect(runtime.mapPathForExec("/home/user/xum/project/branch/nested/file")).toBe(
+    expect(mapPathForExec(runtime, "/home/user/xum/project/branch/nested/file")).toBe(
       "/home/user/xum/project/branch/nested/file"
     );
   });

--- a/src/node/runtime/DevcontainerRuntime.ts
+++ b/src/node/runtime/DevcontainerRuntime.ts
@@ -15,9 +15,9 @@ import type {
   FileStat,
 } from "./Runtime";
 import { RuntimeError, WORKSPACE_REPO_MISSING_ERROR } from "./Runtime";
+import { buildShellPathExport } from "./shellEnv";
 import { LocalBaseRuntime } from "./LocalBaseRuntime";
 import { WorktreeManager } from "@/node/worktree/WorktreeManager";
-import { expandTildeForSSH } from "./tildeExpansion";
 import { shescape, streamToString } from "./streamUtils";
 import {
   readHostGitconfig,
@@ -37,6 +37,9 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { log } from "@/node/services/log";
 import { isGitRepository, stripTrailingSlashes } from "@/node/utils/pathUtils";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
+
+const FILE_PATH_ENV = "XUM_INTERNAL_FILE_PATH";
+const TEMP_FILE_PATH_ENV = "XUM_INTERNAL_TEMP_FILE_PATH";
 
 export interface DevcontainerRuntimeOptions {
   srcBaseDir: string;
@@ -186,13 +189,6 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     return this.mapContainerPathToHost(filePath);
   }
 
-  private quoteForContainer(filePath: string): string {
-    if (filePath === "~" || filePath.startsWith("~/")) {
-      return expandTildeForSSH(filePath);
-    }
-    return shescape.quote(filePath);
-  }
-
   /**
    * Expand tilde in file paths for container operations.
    * Returns unexpanded path when container user is unknown (before ensureReady).
@@ -290,8 +286,9 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     return new ReadableStream<Uint8Array>({
       start: async (controller) => {
         try {
-          const stream = await this.exec(`cat ${this.quoteForContainer(filePath)}`, {
+          const stream = await this.exec(`cat "$${FILE_PATH_ENV}"`, {
             cwd: this.getContainerBasePath(),
+            pathEnv: { [FILE_PATH_ENV]: filePath },
             timeout: 300,
             abortSignal,
           });
@@ -333,10 +330,8 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     filePath: string,
     abortSignal?: AbortSignal
   ): WritableStream<Uint8Array> {
-    const quotedPath = this.quoteForContainer(filePath);
     const tempPath = getAtomicWriteTempPath(filePath);
-    const quotedTempPath = this.quoteForContainer(tempPath);
-    const writeCommand = `mkdir -p $(dirname ${quotedPath}) && cat > ${quotedTempPath} && mv ${quotedTempPath} ${quotedPath}`;
+    const writeCommand = `mkdir -p "$(dirname "$${FILE_PATH_ENV}")" && cat > "$${TEMP_FILE_PATH_ENV}" && mv "$${TEMP_FILE_PATH_ENV}" "$${FILE_PATH_ENV}"`;
 
     let execPromise: Promise<ExecStream> | null = null;
     const writeAbortController = new AbortController();
@@ -353,6 +348,10 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     const getExecStream = () => {
       execPromise ??= this.exec(writeCommand, {
         cwd: this.getContainerBasePath(),
+        pathEnv: {
+          [FILE_PATH_ENV]: filePath,
+          [TEMP_FILE_PATH_ENV]: tempPath,
+        },
         timeout: 300,
         abortSignal: writeAbortController.signal,
       });
@@ -402,8 +401,9 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
   }
 
   private async ensureDirViaExec(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
-    const stream = await this.exec(`mkdir -p ${this.quoteForContainer(dirPath)}`, {
-      cwd: "/",
+    const stream = await this.exec(`mkdir -p "$${FILE_PATH_ENV}"`, {
+      cwd: this.getContainerBasePath(),
+      pathEnv: { [FILE_PATH_ENV]: dirPath },
       timeout: 10,
       abortSignal,
     });
@@ -427,8 +427,9 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
 
   private async statViaExec(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
     // -L follows symlinks so symlinked paths report the target's type
-    const stream = await this.exec(`stat -L -c '%s %Y %F' ${this.quoteForContainer(filePath)}`, {
+    const stream = await this.exec(`stat -L -c '%s %Y %F' "$${FILE_PATH_ENV}"`, {
       cwd: this.getContainerBasePath(),
+      pathEnv: { [FILE_PATH_ENV]: filePath },
       timeout: 10,
       abortSignal,
     });
@@ -458,7 +459,7 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
       isDirectory: fileType === "directory",
     };
   }
-  mapPathForExec(filePath: string): string {
+  private mapPathForExec(filePath: string): string {
     // Issue #3709: paths embedded in exec scripts must use the container namespace.
     return this.mapHostPathToContainer(filePath) ?? filePath;
   }
@@ -612,7 +613,15 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
 
     // Merge cached container credential env + caller env + non-interactive vars.
     // Spread order: container env (lowest) < caller env < NON_INTERACTIVE (highest).
-    const envVars = { ...this.containerEnv, ...options.env, ...NON_INTERACTIVE_ENV_VARS };
+    const mappedPathEnv = Object.fromEntries(
+      Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, this.mapPathForExec(value)])
+    );
+    const envVars = {
+      ...this.containerEnv,
+      ...options.env,
+      ...mappedPathEnv,
+      ...NON_INTERACTIVE_ENV_VARS,
+    };
     for (const [key, value] of Object.entries(envVars)) {
       args.push("--remote-env", `${key}=${value}`);
     }
@@ -621,7 +630,14 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     // Map host workspace path to container path; fall back to container workspace if unmappable
     const mappedCwd = options.cwd ? this.mapHostPathToContainer(options.cwd) : null;
     const cwd = mappedCwd ?? this.resolveContainerCwd(options.cwd, workspaceFolder);
-    const fullCommand = `cd ${shescape.quote(cwd)} && ${command}`;
+    const pathEnvPrelude = Object.entries(mappedPathEnv)
+      .map(([key, value]) =>
+        buildShellPathExport(key, value, (envValue) => shescape.quote(envValue))
+      )
+      .join(" && ");
+    const fullCommand = [`cd ${shescape.quote(cwd)}`, pathEnvPrelude, command]
+      .filter(Boolean)
+      .join(" && ");
     args.push("--", "bash", "-c", fullCommand);
 
     const childProcess = spawnDevcontainer(args, {

--- a/src/node/runtime/DevcontainerRuntime.ts
+++ b/src/node/runtime/DevcontainerRuntime.ts
@@ -37,6 +37,13 @@ import { getErrorMessage } from "@/common/utils/errors";
 import { log } from "@/node/services/log";
 import { isGitRepository, stripTrailingSlashes } from "@/node/utils/pathUtils";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
+import {
+  ensureDirViaExec,
+  readFileViaExec,
+  statViaExec,
+  writeFileViaExec,
+  STAT_VIA_EXEC_COMMAND,
+} from "./execFileIO";
 
 const FILE_PATH_ENV = "XUM_INTERNAL_FILE_PATH";
 const TEMP_FILE_PATH_ENV = "XUM_INTERNAL_TEMP_FILE_PATH";
@@ -282,183 +289,6 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     }
   }
 
-  private readFileViaExec(filePath: string, abortSignal?: AbortSignal): ReadableStream<Uint8Array> {
-    return new ReadableStream<Uint8Array>({
-      start: async (controller) => {
-        try {
-          const stream = await this.exec(`cat "$${FILE_PATH_ENV}"`, {
-            cwd: this.getContainerBasePath(),
-            pathEnv: { [FILE_PATH_ENV]: filePath },
-            timeout: 300,
-            abortSignal,
-          });
-
-          const reader = stream.stdout.getReader();
-          const exitCodePromise = stream.exitCode;
-
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            controller.enqueue(value);
-          }
-
-          const code = await exitCodePromise;
-          if (code !== 0) {
-            const stderr = await streamToString(stream.stderr);
-            throw new RuntimeError(`Failed to read file ${filePath}: ${stderr}`, "file_io");
-          }
-
-          controller.close();
-        } catch (err) {
-          if (err instanceof RuntimeError) {
-            controller.error(err);
-          } else {
-            controller.error(
-              new RuntimeError(
-                `Failed to read file ${filePath}: ${getErrorMessage(err)}`,
-                "file_io",
-                err instanceof Error ? err : undefined
-              )
-            );
-          }
-        }
-      },
-    });
-  }
-
-  private writeFileViaExec(
-    filePath: string,
-    abortSignal?: AbortSignal
-  ): WritableStream<Uint8Array> {
-    const tempPath = getAtomicWriteTempPath(filePath);
-    const writeCommand = `mkdir -p "$(dirname "$${FILE_PATH_ENV}")" && cat > "$${TEMP_FILE_PATH_ENV}" && mv "$${TEMP_FILE_PATH_ENV}" "$${FILE_PATH_ENV}"`;
-
-    let execPromise: Promise<ExecStream> | null = null;
-    const writeAbortController = new AbortController();
-    const abortWrite = () => writeAbortController.abort();
-    if (abortSignal?.aborted) {
-      writeAbortController.abort();
-    } else {
-      abortSignal?.addEventListener("abort", abortWrite, { once: true });
-    }
-    const cleanupAbortForwarder = () => {
-      abortSignal?.removeEventListener("abort", abortWrite);
-    };
-
-    const getExecStream = () => {
-      execPromise ??= this.exec(writeCommand, {
-        cwd: this.getContainerBasePath(),
-        pathEnv: {
-          [FILE_PATH_ENV]: filePath,
-          [TEMP_FILE_PATH_ENV]: tempPath,
-        },
-        timeout: 300,
-        abortSignal: writeAbortController.signal,
-      });
-      return execPromise;
-    };
-
-    return new WritableStream<Uint8Array>({
-      write: async (chunk) => {
-        const stream = await getExecStream();
-        const writer = stream.stdin.getWriter();
-        try {
-          await writer.write(chunk);
-        } finally {
-          writer.releaseLock();
-        }
-      },
-      close: async () => {
-        try {
-          const stream = await getExecStream();
-          await stream.stdin.close();
-          const exitCode = await stream.exitCode;
-
-          if (exitCode !== 0) {
-            const stderr = await streamToString(stream.stderr);
-            throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
-          }
-        } finally {
-          cleanupAbortForwarder();
-        }
-      },
-      abort: async (reason?: unknown) => {
-        writeAbortController.abort();
-        if (execPromise) {
-          try {
-            const stream = await execPromise;
-            await stream.stdin.abort(reason).catch(() => undefined);
-            await stream.exitCode.catch(() => undefined);
-          } finally {
-            cleanupAbortForwarder();
-          }
-        } else {
-          cleanupAbortForwarder();
-        }
-        throw new RuntimeError(`Failed to write file ${filePath}: ${String(reason)}`, "file_io");
-      },
-    });
-  }
-
-  private async ensureDirViaExec(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
-    const stream = await this.exec(`mkdir -p "$${FILE_PATH_ENV}"`, {
-      cwd: this.getContainerBasePath(),
-      pathEnv: { [FILE_PATH_ENV]: dirPath },
-      timeout: 10,
-      abortSignal,
-    });
-
-    await stream.stdin.close();
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      streamToString(stream.stdout),
-      streamToString(stream.stderr),
-      stream.exitCode,
-    ]);
-
-    if (exitCode !== 0) {
-      const extra = stderr.trim() || stdout.trim();
-      throw new RuntimeError(
-        `Failed to create directory ${dirPath}: exit code ${exitCode}${extra ? `: ${extra}` : ""}`,
-        "file_io"
-      );
-    }
-  }
-
-  private async statViaExec(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
-    // -L follows symlinks so symlinked paths report the target's type
-    const stream = await this.exec(`stat -L -c '%s %Y %F' "$${FILE_PATH_ENV}"`, {
-      cwd: this.getContainerBasePath(),
-      pathEnv: { [FILE_PATH_ENV]: filePath },
-      timeout: 10,
-      abortSignal,
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      streamToString(stream.stdout),
-      streamToString(stream.stderr),
-      stream.exitCode,
-    ]);
-
-    if (exitCode !== 0) {
-      throw new RuntimeError(`Failed to stat ${filePath}: ${stderr}`, "file_io");
-    }
-
-    const parts = stdout.trim().split(" ");
-    if (parts.length < 3) {
-      throw new RuntimeError(`Failed to parse stat output for ${filePath}: ${stdout}`, "file_io");
-    }
-
-    const size = parseInt(parts[0], 10);
-    const mtime = parseInt(parts[1], 10);
-    const fileType = parts.slice(2).join(" ");
-
-    return {
-      size,
-      modifiedTime: new Date(mtime * 1000),
-      isDirectory: fileType === "directory",
-    };
-  }
   private mapPathForExec(filePath: string): string {
     // Issue #3709: paths embedded in exec scripts must use the container namespace.
     return this.mapHostPathToContainer(filePath) ?? filePath;
@@ -739,7 +569,17 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     if (hostPath) {
       return super.readFile(hostPath, abortSignal);
     }
-    return this.readFileViaExec(filePath, abortSignal);
+    return readFileViaExec(
+      filePath,
+      (signal) =>
+        this.exec(`cat "$${FILE_PATH_ENV}"`, {
+          cwd: this.getContainerBasePath(),
+          pathEnv: { [FILE_PATH_ENV]: filePath },
+          timeout: 300,
+          abortSignal: signal,
+        }),
+      abortSignal
+    );
   }
 
   override writeFile(filePath: string, abortSignal?: AbortSignal): WritableStream<Uint8Array> {
@@ -747,23 +587,53 @@ export class DevcontainerRuntime extends LocalBaseRuntime {
     if (hostPath) {
       return super.writeFile(hostPath, abortSignal);
     }
-    return this.writeFileViaExec(filePath, abortSignal);
+    return writeFileViaExec(
+      filePath,
+      (signal) =>
+        this.exec(
+          `mkdir -p "$(dirname "$${FILE_PATH_ENV}")" && cat > "$${TEMP_FILE_PATH_ENV}" && mv "$${TEMP_FILE_PATH_ENV}" "$${FILE_PATH_ENV}"`,
+          {
+            cwd: this.getContainerBasePath(),
+            pathEnv: {
+              [FILE_PATH_ENV]: filePath,
+              [TEMP_FILE_PATH_ENV]: getAtomicWriteTempPath(filePath),
+            },
+            timeout: 300,
+            abortSignal: signal,
+          }
+        ),
+      abortSignal
+    );
   }
 
-  override async stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
+  override stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
     const hostPath = this.resolveHostPathForMounted(filePath);
     if (hostPath) {
       return super.stat(hostPath, abortSignal);
     }
-    return this.statViaExec(filePath, abortSignal);
+    return statViaExec(filePath, () =>
+      this.exec(`${STAT_VIA_EXEC_COMMAND} "$${FILE_PATH_ENV}"`, {
+        cwd: this.getContainerBasePath(),
+        pathEnv: { [FILE_PATH_ENV]: filePath },
+        timeout: 10,
+        abortSignal,
+      })
+    );
   }
 
-  override async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
+  override ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
     const hostPath = this.resolveHostPathForMounted(dirPath);
     if (hostPath) {
       return super.ensureDir(hostPath, abortSignal);
     }
-    return this.ensureDirViaExec(dirPath, abortSignal);
+    return ensureDirViaExec(dirPath, () =>
+      this.exec(`mkdir -p "$${FILE_PATH_ENV}"`, {
+        cwd: this.getContainerBasePath(),
+        pathEnv: { [FILE_PATH_ENV]: dirPath },
+        timeout: 10,
+        abortSignal,
+      })
+    );
   }
 
   override async resolvePath(filePath: string): Promise<string> {

--- a/src/node/runtime/LocalBaseRuntime.test.ts
+++ b/src/node/runtime/LocalBaseRuntime.test.ts
@@ -104,33 +104,22 @@ describe("LocalBaseRuntime.resolvePath", () => {
 });
 
 describe("LocalBaseRuntime.exec PATH handling", () => {
-  it("canonicalizes pathEnv values before command execution", async () => {
-    const runtime = new TestLocalRuntime();
-    const stream = await runtime.exec('printf "%s" "$XUM_TEST_PATH"', {
-      cwd: os.tmpdir(),
-      pathEnv: { XUM_TEST_PATH: "~/runtime-path" },
-      timeout: 5,
-    });
-    await stream.stdin.close();
-
-    expect(await readStreamAsString(stream.stdout)).toBe(path.join(os.homedir(), "runtime-path"));
-    expect(await stream.exitCode).toBe(0);
-  });
-
-  it("expands product-home pathEnv values through getXumHome like file I/O", async () => {
+  it("canonicalizes pathEnv values with file I/O semantics (tilde and product home)", async () => {
     const xumRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xum-root-"));
     const originalRoot = process.env.XUM_ROOT;
     process.env.XUM_ROOT = xumRoot;
     try {
       const runtime = new TestLocalRuntime();
-      const stream = await runtime.exec('printf "%s" "$XUM_TEST_PATH"', {
+      const stream = await runtime.exec('printf "%s\\n%s" "$XUM_TEST_PATH" "$XUM_TEST_HOME"', {
         cwd: os.tmpdir(),
-        pathEnv: { XUM_TEST_PATH: "~/.xum/plans" },
+        pathEnv: { XUM_TEST_PATH: "~/runtime-path", XUM_TEST_HOME: "~/.xum/plans" },
         timeout: 5,
       });
       await stream.stdin.close();
 
-      expect(await readStreamAsString(stream.stdout)).toBe(path.join(xumRoot, "plans"));
+      expect(await readStreamAsString(stream.stdout)).toBe(
+        `${path.join(os.homedir(), "runtime-path")}\n${path.join(xumRoot, "plans")}`
+      );
       expect(await stream.exitCode).toBe(0);
     } finally {
       if (originalRoot === undefined) {

--- a/src/node/runtime/LocalBaseRuntime.test.ts
+++ b/src/node/runtime/LocalBaseRuntime.test.ts
@@ -104,6 +104,19 @@ describe("LocalBaseRuntime.resolvePath", () => {
 });
 
 describe("LocalBaseRuntime.exec PATH handling", () => {
+  it("canonicalizes pathEnv values before command execution", async () => {
+    const runtime = new TestLocalRuntime();
+    const stream = await runtime.exec('printf "%s" "$XUM_TEST_PATH"', {
+      cwd: os.tmpdir(),
+      pathEnv: { XUM_TEST_PATH: "~/runtime-path" },
+      timeout: 5,
+    });
+    await stream.stdin.close();
+
+    expect(await readStreamAsString(stream.stdout)).toBe(path.join(os.homedir(), "runtime-path"));
+    expect(await stream.exitCode).toBe(0);
+  });
+
   it("strips mux browser shims and leaked browser env from child shells", async () => {
     const runtime = new TestLocalRuntime();
     const tempBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-path-probe-"));

--- a/src/node/runtime/LocalBaseRuntime.test.ts
+++ b/src/node/runtime/LocalBaseRuntime.test.ts
@@ -117,6 +117,31 @@ describe("LocalBaseRuntime.exec PATH handling", () => {
     expect(await stream.exitCode).toBe(0);
   });
 
+  it("expands product-home pathEnv values through getXumHome like file I/O", async () => {
+    const xumRoot = await fs.mkdtemp(path.join(os.tmpdir(), "xum-root-"));
+    const originalRoot = process.env.XUM_ROOT;
+    process.env.XUM_ROOT = xumRoot;
+    try {
+      const runtime = new TestLocalRuntime();
+      const stream = await runtime.exec('printf "%s" "$XUM_TEST_PATH"', {
+        cwd: os.tmpdir(),
+        pathEnv: { XUM_TEST_PATH: "~/.xum/plans" },
+        timeout: 5,
+      });
+      await stream.stdin.close();
+
+      expect(await readStreamAsString(stream.stdout)).toBe(path.join(xumRoot, "plans"));
+      expect(await stream.exitCode).toBe(0);
+    } finally {
+      if (originalRoot === undefined) {
+        delete process.env.XUM_ROOT;
+      } else {
+        process.env.XUM_ROOT = originalRoot;
+      }
+      await fs.rm(xumRoot, { recursive: true, force: true });
+    }
+  });
+
   it("strips mux browser shims and leaked browser env from child shells", async () => {
     const runtime = new TestLocalRuntime();
     const tempBinDir = await fs.mkdtemp(path.join(os.tmpdir(), "mux-path-probe-"));

--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -32,7 +32,7 @@ import {
 } from "./initHook";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
-import { buildShellExport } from "./shellEnv";
+import { buildShellExport, buildShellPathExport } from "./shellEnv";
 import { sanitizeXumChildEnv } from "./childProcessEnv";
 
 /**
@@ -85,10 +85,17 @@ export abstract class LocalBaseRuntime implements Runtime {
       .map(([key, value]) => buildShellExport(key, value))
       .join("\n");
 
-    const spawnArgs = ["-c", `${nonInteractivePrelude}\n${command}`];
+    const pathEnvPrelude = Object.entries(options.pathEnv ?? {})
+      .map(([key, value]) => buildShellPathExport(key, value))
+      .join("\n");
+    const spawnArgs = ["-c", `${nonInteractivePrelude}\n${pathEnvPrelude}\n${command}`];
 
     const defaultPath = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
-    const mergedEnv = sanitizeXumChildEnv({ ...process.env, ...(options.env ?? {}) });
+    const mergedEnv = sanitizeXumChildEnv({
+      ...process.env,
+      ...(options.env ?? {}),
+      ...(options.pathEnv ?? {}),
+    });
     const basePath =
       (options.env?.PATH && options.env.PATH.length > 0
         ? mergedEnv.PATH
@@ -213,9 +220,8 @@ export abstract class LocalBaseRuntime implements Runtime {
   }
 
   readFile(filePath: string, abortSignal?: AbortSignal): ReadableStream<Uint8Array> {
-    // Expand tildes before reading (Node.js fs doesn't expand ~)
-    const expandedPath = expandTilde(filePath);
-    const nodeStream = fs.createReadStream(expandedPath);
+    const resolvedPath = path.resolve(expandTilde(filePath));
+    const nodeStream = fs.createReadStream(resolvedPath);
 
     // Handle errors by wrapping in a transform
     // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
@@ -284,8 +290,7 @@ export abstract class LocalBaseRuntime implements Runtime {
 
   writeFile(filePath: string, _abortSignal?: AbortSignal): WritableStream<Uint8Array> {
     // Note: _abortSignal ignored for local operations (fast, no need for cancellation)
-    // Expand tildes before writing (Node.js fs doesn't expand ~)
-    const expandedPath = expandTilde(filePath);
+    const canonicalPath = path.resolve(expandTilde(filePath));
     let tempPath: string;
     let writer: WritableStreamDefaultWriter<Uint8Array>;
     let resolvedPath: string;
@@ -295,13 +300,12 @@ export abstract class LocalBaseRuntime implements Runtime {
       async start() {
         // Resolve symlinks to write through them (preserves the symlink)
         try {
-          resolvedPath = await fsPromises.realpath(expandedPath);
+          resolvedPath = await fsPromises.realpath(canonicalPath);
           // Save original permissions to restore after write
           const stat = await fsPromises.stat(resolvedPath);
           originalMode = stat.mode;
         } catch {
-          // If file doesn't exist, use the expanded path and default permissions
-          resolvedPath = expandedPath;
+          resolvedPath = canonicalPath;
           originalMode = undefined;
         }
 
@@ -354,10 +358,9 @@ export abstract class LocalBaseRuntime implements Runtime {
 
   async stat(filePath: string, _abortSignal?: AbortSignal): Promise<FileStat> {
     // Note: _abortSignal ignored for local operations (fast, no need for cancellation)
-    // Expand tildes before stat (Node.js fs doesn't expand ~)
-    const expandedPath = expandTilde(filePath);
+    const resolvedPath = path.resolve(expandTilde(filePath));
     try {
-      const stats = await fsPromises.stat(expandedPath);
+      const stats = await fsPromises.stat(resolvedPath);
       return {
         size: stats.size,
         modifiedTime: stats.mtime,
@@ -376,9 +379,9 @@ export abstract class LocalBaseRuntime implements Runtime {
     if (abortSignal?.aborted) {
       throw new RuntimeErrorClass("Operation aborted before directory creation", "file_io");
     }
-    const expandedPath = expandTilde(dirPath);
+    const resolvedPath = path.resolve(expandTilde(dirPath));
     try {
-      await fsPromises.mkdir(expandedPath, { recursive: true });
+      await fsPromises.mkdir(resolvedPath, { recursive: true });
     } catch (err) {
       throw new RuntimeErrorClass(
         `Failed to create directory ${dirPath}: ${getErrorMessage(err)}`,

--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -94,7 +94,6 @@ export abstract class LocalBaseRuntime implements Runtime {
     const mergedEnv = sanitizeXumChildEnv({
       ...process.env,
       ...(options.env ?? {}),
-      ...(options.pathEnv ?? {}),
     });
     const basePath =
       (options.env?.PATH && options.env.PATH.length > 0

--- a/src/node/runtime/LocalBaseRuntime.ts
+++ b/src/node/runtime/LocalBaseRuntime.ts
@@ -32,7 +32,7 @@ import {
 } from "./initHook";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
-import { buildShellExport, buildShellPathExport } from "./shellEnv";
+import { buildShellExport } from "./shellEnv";
 import { sanitizeXumChildEnv } from "./childProcessEnv";
 
 /**
@@ -85,8 +85,12 @@ export abstract class LocalBaseRuntime implements Runtime {
       .map(([key, value]) => buildShellExport(key, value))
       .join("\n");
 
+    // Expand host-side with the same semantics as local file I/O: expandTilde
+    // routes ~/.xum (and legacy homes) through getXumHome, which in-shell $HOME
+    // expansion would miss (XUM_ROOT, dev suffix), and relative values resolve
+    // against the exec cwd, matching the shell's $PWD when the exports run.
     const pathEnvPrelude = Object.entries(options.pathEnv ?? {})
-      .map(([key, value]) => buildShellPathExport(key, value))
+      .map(([key, value]) => buildShellExport(key, path.resolve(cwd, expandTilde(value))))
       .join("\n");
     const spawnArgs = ["-c", `${nonInteractivePrelude}\n${pathEnvPrelude}\n${command}`];
 

--- a/src/node/runtime/RemoteRuntime.test.ts
+++ b/src/node/runtime/RemoteRuntime.test.ts
@@ -61,6 +61,36 @@ class RecordingRemoteRuntime extends RemoteRuntime {
   }
 }
 
+function createStream(value: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(value));
+      controller.close();
+    },
+  });
+}
+
+class CanonicalPathRemoteRuntime extends RecordingRemoteRuntime {
+  commands: string[] = [];
+
+  override resolvePath(filePath: string): Promise<string> {
+    if (filePath === "~") return Promise.resolve("/home/test");
+    if (filePath.startsWith("~/")) return Promise.resolve(`/home/test/${filePath.slice(2)}`);
+    return Promise.resolve(filePath);
+  }
+
+  override exec(command: string, _options: ExecOptions): Promise<ExecStream> {
+    this.commands.push(command);
+    return Promise.resolve({
+      stdout: createStream(command.startsWith("stat ") ? "1 2 regular file\n" : "contents"),
+      stderr: createStream(""),
+      stdin: new WritableStream<Uint8Array>(),
+      exitCode: Promise.resolve(0),
+      duration: Promise.resolve(0),
+    });
+  }
+}
+
 /**
  * Fake exec: records the abortSignal readFile passes and returns a wedged
  * cat whose stdout never yields — exactly the stalled remote read the r18
@@ -85,6 +115,29 @@ class ReadFileRemoteRuntime extends RecordingRemoteRuntime {
     });
   }
 }
+
+describe("RemoteRuntime file path canonicalization", () => {
+  it("resolves relative and tilde paths inside file operations", async () => {
+    const runtime = new CanonicalPathRemoteRuntime();
+
+    const reader = runtime.readFile("nested/../read.txt").getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+    const writer = runtime.writeFile("~/write.txt").getWriter();
+    await writer.close();
+    await runtime.stat("nested/../stat.txt");
+    await runtime.ensureDir("~/dir");
+
+    expect(runtime.commands).toContain("cat '/workspace/read.txt'");
+    expect(runtime.commands.some((command) => command.includes("'/home/test/write.txt'"))).toBe(
+      true
+    );
+    expect(runtime.commands).toContain("stat -L -c '%s %Y %F' '/workspace/stat.txt'");
+    expect(runtime.commands).toContain("mkdir -p '/home/test/dir'");
+  });
+});
 
 describe("RemoteRuntime.readFile", () => {
   it("cancelling the stream aborts the underlying cat exec", async () => {

--- a/src/node/runtime/RemoteRuntime.test.ts
+++ b/src/node/runtime/RemoteRuntime.test.ts
@@ -169,6 +169,29 @@ describe("RemoteRuntime.readFile", () => {
   });
 });
 
+describe("RemoteRuntime file operation aborts", () => {
+  it("stat settles immediately when aborted instead of waiting out path resolution", async () => {
+    const runtime = new RecordingRemoteRuntime();
+    let resolverSettled = false;
+    runtime.resolvePath = () =>
+      new Promise((resolve) =>
+        setTimeout(() => {
+          resolverSettled = true;
+          resolve("/workspace");
+        }, 1000)
+      );
+    const controller = new AbortController();
+    controller.abort();
+
+    const rejected = await runtime.stat("relative/file.txt", controller.signal).then(
+      () => false,
+      () => true
+    );
+    expect(rejected).toBe(true);
+    expect(resolverSettled).toBe(false);
+  });
+});
+
 describe("RemoteRuntime.writeFile", () => {
   it("does not start a remote write command when aborted before the first write", async () => {
     const runtime = new RecordingRemoteRuntime();

--- a/src/node/runtime/RemoteRuntime.test.ts
+++ b/src/node/runtime/RemoteRuntime.test.ts
@@ -1,63 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, ExecStream } from "./Runtime";
-import { RemoteRuntime, type SpawnResult } from "./RemoteRuntime";
+import type { SpawnResult } from "./RemoteRuntime";
+import { TestRemoteRuntime } from "./testRemoteRuntime";
 
-class RecordingRemoteRuntime extends RemoteRuntime {
+class RecordingRemoteRuntime extends TestRemoteRuntime {
   spawnCount = 0;
 
-  protected readonly commandPrefix = "Recording";
-
-  protected getBasePath(): string {
-    return "/workspace";
-  }
-
-  protected quoteForRemote(filePath: string): string {
-    return `'${filePath}'`;
-  }
-
-  protected cdCommand(cwd: string): string {
-    return `cd '${cwd}'`;
-  }
-
-  protected spawnRemoteProcess(): Promise<SpawnResult> {
+  protected override spawnRemoteProcess(): Promise<SpawnResult> {
     this.spawnCount += 1;
     throw new Error("spawn should not be called");
-  }
-
-  resolvePath(filePath: string): Promise<string> {
-    return Promise.resolve(filePath);
-  }
-
-  getWorkspacePath(): string {
-    return "/workspace";
-  }
-
-  createWorkspace() {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  initWorkspace() {
-    return Promise.resolve({ success: true });
-  }
-
-  deleteWorkspace() {
-    return Promise.resolve({ success: true as const, deletedPath: "/workspace" });
-  }
-
-  renameWorkspace() {
-    return Promise.resolve({
-      success: true as const,
-      oldPath: "/workspace",
-      newPath: "/workspace",
-    });
-  }
-
-  forkWorkspace() {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  ensureReady() {
-    return Promise.resolve({ ready: true as const });
   }
 }
 

--- a/src/node/runtime/RemoteRuntime.ts
+++ b/src/node/runtime/RemoteRuntime.ts
@@ -36,11 +36,17 @@ import { log } from "@/node/services/log";
 import { attachStreamErrorHandler } from "@/node/utils/streamErrors";
 import { NON_INTERACTIVE_ENV_VARS } from "@/common/constants/env";
 import { DisposableProcess } from "@/node/utils/disposableExec";
-import { streamToString, shescape } from "./streamUtils";
-import { getErrorMessage } from "@/common/utils/errors";
+import { shescape } from "./streamUtils";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
 import { buildShellExport, buildShellPathExport } from "./shellEnv";
 import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
+import {
+  ensureDirViaExec,
+  readFileViaExec,
+  statViaExec,
+  writeFileViaExec,
+  STAT_VIA_EXEC_COMMAND,
+} from "./execFileIO";
 
 // Cap for the stderr side-buffer kept purely for error reporting on process
 // failure. 16KB comfortably covers SSH/launch diagnostics while bounding memory
@@ -394,71 +400,18 @@ export abstract class RemoteRuntime implements Runtime {
    * Read file contents as a stream via exec.
    */
   readFile(filePath: string, abortSignal?: AbortSignal): ReadableStream<Uint8Array> {
-    // Internal controller so CANCELLING the returned stream kills the remote
-    // cat: the eager pump below has no other path to the exec, and without
-    // it a cancelled wrapper (e.g. mux.load's byte ceiling) left cat blocked
-    // until its 300s timeout, accumulating remote processes (r18). The
-    // caller's abortSignal forwards into the same controller.
-    const readAbort = new AbortController();
-    const forwardAbort = () => readAbort.abort();
-    if (abortSignal?.aborted) {
-      readAbort.abort();
-    } else {
-      abortSignal?.addEventListener("abort", forwardAbort, { once: true });
-    }
-    const cleanupAbortForwarder = () => {
-      abortSignal?.removeEventListener("abort", forwardAbort);
-    };
-
-    return new ReadableStream<Uint8Array>({
-      cancel: () => {
-        readAbort.abort();
-        cleanupAbortForwarder();
+    return readFileViaExec(
+      filePath,
+      async (signal) => {
+        const resolvedPath = await this.resolveFilePath(filePath, signal);
+        return this.exec(`cat ${this.quoteForRemote(resolvedPath)}`, {
+          cwd: this.getBasePath(),
+          timeout: 300,
+          abortSignal: signal,
+        });
       },
-      start: async (controller: ReadableStreamDefaultController<Uint8Array>) => {
-        try {
-          const resolvedPath = await this.resolveFilePath(filePath, readAbort.signal);
-          const stream = await this.exec(`cat ${this.quoteForRemote(resolvedPath)}`, {
-            cwd: this.getBasePath(),
-            timeout: 300,
-            abortSignal: readAbort.signal,
-          });
-
-          const reader = stream.stdout.getReader();
-          const exitCodePromise = stream.exitCode;
-
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            controller.enqueue(value);
-          }
-
-          const code = await exitCodePromise;
-          if (code !== 0) {
-            const stderr = await streamToString(stream.stderr);
-            throw new RuntimeError(`Failed to read file ${filePath}: ${stderr}`, "file_io");
-          }
-
-          controller.close();
-        } catch (err) {
-          if (err instanceof RuntimeError) {
-            controller.error(err);
-          } else {
-            controller.error(
-              new RuntimeError(
-                `Failed to read file ${filePath}: ${getErrorMessage(err)}`,
-                "file_io",
-                err instanceof Error ? err : undefined
-              )
-            );
-          }
-        } finally {
-          // Natural completion/error: stop listening on the caller's signal
-          // so long-lived signals don't accumulate forwarders.
-          cleanupAbortForwarder();
-        }
-      },
-    });
+      abortSignal
+    );
   }
 
   /**
@@ -466,75 +419,20 @@ export abstract class RemoteRuntime implements Runtime {
    * Uses temp file + mv for atomic write.
    */
   writeFile(filePath: string, abortSignal?: AbortSignal): WritableStream<Uint8Array> {
-    let execPromise: Promise<ExecStream> | null = null;
-    const writeAbortController = new AbortController();
-    const abortWrite = () => writeAbortController.abort();
-    if (abortSignal?.aborted) {
-      writeAbortController.abort();
-    } else {
-      abortSignal?.addEventListener("abort", abortWrite, { once: true });
-    }
-    const cleanupAbortForwarder = () => {
-      abortSignal?.removeEventListener("abort", abortWrite);
-    };
-
-    const getExecStream = () => {
-      execPromise ??= this.resolveFilePath(filePath, writeAbortController.signal).then(
-        (resolvedPath) => {
-          const quotedPath = this.quoteForRemote(resolvedPath);
-          const tempPath = getAtomicWriteTempPath(resolvedPath);
-          const quotedTempPath = this.quoteForRemote(tempPath);
-          const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
-          return this.exec(writeCommand, {
-            cwd: this.getBasePath(),
-            timeout: 300,
-            abortSignal: writeAbortController.signal,
-          });
-        }
-      );
-      return execPromise;
-    };
-
-    return new WritableStream<Uint8Array>({
-      write: async (chunk: Uint8Array) => {
-        const stream = await getExecStream();
-        const writer = stream.stdin.getWriter();
-        try {
-          await writer.write(chunk);
-        } finally {
-          writer.releaseLock();
-        }
+    return writeFileViaExec(
+      filePath,
+      async (signal) => {
+        const resolvedPath = await this.resolveFilePath(filePath, signal);
+        const quotedPath = this.quoteForRemote(resolvedPath);
+        const quotedTempPath = this.quoteForRemote(getAtomicWriteTempPath(resolvedPath));
+        return this.exec(this.buildWriteCommand(quotedPath, quotedTempPath), {
+          cwd: this.getBasePath(),
+          timeout: 300,
+          abortSignal: signal,
+        });
       },
-      close: async () => {
-        try {
-          const stream = await getExecStream();
-          await stream.stdin.close();
-          const exitCode = await stream.exitCode;
-
-          if (exitCode !== 0) {
-            const stderr = await streamToString(stream.stderr);
-            throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
-          }
-        } finally {
-          cleanupAbortForwarder();
-        }
-      },
-      abort: async (reason?: unknown) => {
-        writeAbortController.abort();
-        if (execPromise) {
-          try {
-            const stream = await execPromise;
-            await stream.stdin.abort(reason).catch(() => undefined);
-            await stream.exitCode.catch(() => undefined);
-          } finally {
-            cleanupAbortForwarder();
-          }
-        } else {
-          cleanupAbortForwarder();
-        }
-        throw new RuntimeError(`Failed to write file ${filePath}: ${String(reason)}`, "file_io");
-      },
-    });
+      abortSignal
+    );
   }
 
   /**
@@ -548,67 +446,29 @@ export abstract class RemoteRuntime implements Runtime {
   /**
    * Ensure a directory exists (mkdir -p semantics).
    */
-  async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
-    const resolvedPath = await this.resolveFilePath(dirPath, abortSignal);
-    const stream = await this.exec(`mkdir -p ${this.quoteForRemote(resolvedPath)}`, {
-      cwd: "/",
-      timeout: 10,
-      abortSignal,
+  ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
+    return ensureDirViaExec(dirPath, async () => {
+      const resolvedPath = await this.resolveFilePath(dirPath, abortSignal);
+      return this.exec(`mkdir -p ${this.quoteForRemote(resolvedPath)}`, {
+        cwd: "/",
+        timeout: 10,
+        abortSignal,
+      });
     });
-
-    await stream.stdin.close();
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      streamToString(stream.stdout),
-      streamToString(stream.stderr),
-      stream.exitCode,
-    ]);
-
-    if (exitCode !== 0) {
-      const extra = stderr.trim() || stdout.trim();
-      throw new RuntimeError(
-        `Failed to create directory ${dirPath}: exit code ${exitCode}${extra ? `: ${extra}` : ""}`,
-        "file_io"
-      );
-    }
   }
 
   /**
    * Get file statistics via exec.
-   * Uses stat -L to follow symlinks (report target's type, not "symbolic link").
    */
-  async stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
-    const resolvedPath = await this.resolveFilePath(filePath, abortSignal);
-    const stream = await this.exec(`stat -L -c '%s %Y %F' ${this.quoteForRemote(resolvedPath)}`, {
-      cwd: this.getBasePath(),
-      timeout: 10,
-      abortSignal,
+  stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
+    return statViaExec(filePath, async () => {
+      const resolvedPath = await this.resolveFilePath(filePath, abortSignal);
+      return this.exec(`${STAT_VIA_EXEC_COMMAND} ${this.quoteForRemote(resolvedPath)}`, {
+        cwd: this.getBasePath(),
+        timeout: 10,
+        abortSignal,
+      });
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      streamToString(stream.stdout),
-      streamToString(stream.stderr),
-      stream.exitCode,
-    ]);
-
-    if (exitCode !== 0) {
-      throw new RuntimeError(`Failed to stat ${filePath}: ${stderr}`, "file_io");
-    }
-
-    const parts = stdout.trim().split(" ");
-    if (parts.length < 3) {
-      throw new RuntimeError(`Failed to parse stat output for ${filePath}: ${stdout}`, "file_io");
-    }
-
-    const size = parseInt(parts[0], 10);
-    const mtime = parseInt(parts[1], 10);
-    const fileType = parts.slice(2).join(" ");
-
-    return {
-      size,
-      modifiedTime: new Date(mtime * 1000),
-      isDirectory: fileType === "directory",
-    };
   }
 
   /**

--- a/src/node/runtime/RemoteRuntime.ts
+++ b/src/node/runtime/RemoteRuntime.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ChildProcess } from "child_process";
+import * as path from "node:path";
 import { Readable } from "stream";
 import type {
   Runtime,
@@ -38,7 +39,7 @@ import { DisposableProcess } from "@/node/utils/disposableExec";
 import { streamToString, shescape } from "./streamUtils";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
-import { buildShellExport } from "./shellEnv";
+import { buildShellExport, buildShellPathExport } from "./shellEnv";
 
 // Cap for the stderr side-buffer kept purely for error reporting on process
 // failure. 16KB comfortably covers SSH/launch diagnostics while bounding memory
@@ -121,6 +122,9 @@ export abstract class RemoteRuntime implements Runtime {
     const envVars = { ...options.env, ...NON_INTERACTIVE_ENV_VARS };
     for (const [key, value] of Object.entries(envVars)) {
       parts.push(buildShellExport(key, value, (envValue) => shescape.quote(envValue)));
+    }
+    for (const [key, value] of Object.entries(options.pathEnv ?? {})) {
+      parts.push(buildShellPathExport(key, value, (envValue) => shescape.quote(envValue)));
     }
 
     // Add the actual command
@@ -356,6 +360,17 @@ export abstract class RemoteRuntime implements Runtime {
     return { stdout, stderr, stdin, exitCode, duration };
   }
 
+  private async resolveFilePath(filePath: string): Promise<string> {
+    if (filePath === "~" || filePath.startsWith("~/")) {
+      return this.resolvePath(filePath);
+    }
+    if (path.posix.isAbsolute(filePath)) {
+      return path.posix.normalize(filePath);
+    }
+    const basePath = await this.resolvePath(this.getBasePath());
+    return path.posix.resolve(basePath, filePath);
+  }
+
   /**
    * Read file contents as a stream via exec.
    */
@@ -383,7 +398,8 @@ export abstract class RemoteRuntime implements Runtime {
       },
       start: async (controller: ReadableStreamDefaultController<Uint8Array>) => {
         try {
-          const stream = await this.exec(`cat ${this.quoteForRemote(filePath)}`, {
+          const resolvedPath = await this.resolveFilePath(filePath);
+          const stream = await this.exec(`cat ${this.quoteForRemote(resolvedPath)}`, {
             cwd: this.getBasePath(),
             timeout: 300,
             abortSignal: readAbort.signal,
@@ -431,13 +447,6 @@ export abstract class RemoteRuntime implements Runtime {
    * Uses temp file + mv for atomic write.
    */
   writeFile(filePath: string, abortSignal?: AbortSignal): WritableStream<Uint8Array> {
-    const quotedPath = this.quoteForRemote(filePath);
-    const tempPath = getAtomicWriteTempPath(filePath);
-    const quotedTempPath = this.quoteForRemote(tempPath);
-
-    // Build write command - subclasses can override buildWriteCommand for special handling
-    const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
-
     let execPromise: Promise<ExecStream> | null = null;
     const writeAbortController = new AbortController();
     const abortWrite = () => writeAbortController.abort();
@@ -451,10 +460,16 @@ export abstract class RemoteRuntime implements Runtime {
     };
 
     const getExecStream = () => {
-      execPromise ??= this.exec(writeCommand, {
-        cwd: this.getBasePath(),
-        timeout: 300,
-        abortSignal: writeAbortController.signal,
+      execPromise ??= this.resolveFilePath(filePath).then((resolvedPath) => {
+        const quotedPath = this.quoteForRemote(resolvedPath);
+        const tempPath = getAtomicWriteTempPath(resolvedPath);
+        const quotedTempPath = this.quoteForRemote(tempPath);
+        const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
+        return this.exec(writeCommand, {
+          cwd: this.getBasePath(),
+          timeout: 300,
+          abortSignal: writeAbortController.signal,
+        });
       });
       return execPromise;
     };
@@ -513,7 +528,8 @@ export abstract class RemoteRuntime implements Runtime {
    * Ensure a directory exists (mkdir -p semantics).
    */
   async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
-    const stream = await this.exec(`mkdir -p ${this.quoteForRemote(dirPath)}`, {
+    const resolvedPath = await this.resolveFilePath(dirPath);
+    const stream = await this.exec(`mkdir -p ${this.quoteForRemote(resolvedPath)}`, {
       cwd: "/",
       timeout: 10,
       abortSignal,
@@ -541,7 +557,8 @@ export abstract class RemoteRuntime implements Runtime {
    * Uses stat -L to follow symlinks (report target's type, not "symbolic link").
    */
   async stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
-    const stream = await this.exec(`stat -L -c '%s %Y %F' ${this.quoteForRemote(filePath)}`, {
+    const resolvedPath = await this.resolveFilePath(filePath);
+    const stream = await this.exec(`stat -L -c '%s %Y %F' ${this.quoteForRemote(resolvedPath)}`, {
       cwd: this.getBasePath(),
       timeout: 10,
       abortSignal,

--- a/src/node/runtime/RemoteRuntime.ts
+++ b/src/node/runtime/RemoteRuntime.ts
@@ -40,6 +40,7 @@ import { streamToString, shescape } from "./streamUtils";
 import { getErrorMessage } from "@/common/utils/errors";
 import { getAtomicWriteTempPath } from "./atomicWriteTempPath";
 import { buildShellExport, buildShellPathExport } from "./shellEnv";
+import { raceWithAbortAndTimeout } from "@/node/utils/concurrency/withTimeout";
 
 // Cap for the stderr side-buffer kept purely for error reporting on process
 // failure. 16KB comfortably covers SSH/launch diagnostics while bounding memory
@@ -360,15 +361,33 @@ export abstract class RemoteRuntime implements Runtime {
     return { stdout, stderr, stdin, exitCode, duration };
   }
 
-  private async resolveFilePath(filePath: string): Promise<string> {
+  private async resolveFilePath(filePath: string, abortSignal?: AbortSignal): Promise<string> {
     if (filePath === "~" || filePath.startsWith("~/")) {
-      return this.resolvePath(filePath);
+      return this.resolveWithAbort(this.resolvePath(filePath), abortSignal);
     }
     if (path.posix.isAbsolute(filePath)) {
       return path.posix.normalize(filePath);
     }
-    const basePath = await this.resolvePath(this.getBasePath());
+    const basePath = await this.resolveWithAbort(this.resolvePath(this.getBasePath()), abortSignal);
     return path.posix.resolve(basePath, filePath);
+  }
+
+  /**
+   * resolvePath has no signal path into its exec, so a canceled file operation
+   * must not wait out the resolver (up to its 10s timeout): settle the caller
+   * immediately and let the orphaned resolver finish in the background.
+   */
+  private async resolveWithAbort(
+    resolution: Promise<string>,
+    abortSignal?: AbortSignal
+  ): Promise<string> {
+    const result = await raceWithAbortAndTimeout(resolution, { signal: abortSignal });
+    if (result.kind !== "ok") {
+      resolution.catch(() => undefined);
+      abortSignal?.throwIfAborted();
+      throw new RuntimeError("Path resolution aborted", "file_io");
+    }
+    return result.value;
   }
 
   /**
@@ -398,7 +417,7 @@ export abstract class RemoteRuntime implements Runtime {
       },
       start: async (controller: ReadableStreamDefaultController<Uint8Array>) => {
         try {
-          const resolvedPath = await this.resolveFilePath(filePath);
+          const resolvedPath = await this.resolveFilePath(filePath, readAbort.signal);
           const stream = await this.exec(`cat ${this.quoteForRemote(resolvedPath)}`, {
             cwd: this.getBasePath(),
             timeout: 300,
@@ -460,17 +479,19 @@ export abstract class RemoteRuntime implements Runtime {
     };
 
     const getExecStream = () => {
-      execPromise ??= this.resolveFilePath(filePath).then((resolvedPath) => {
-        const quotedPath = this.quoteForRemote(resolvedPath);
-        const tempPath = getAtomicWriteTempPath(resolvedPath);
-        const quotedTempPath = this.quoteForRemote(tempPath);
-        const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
-        return this.exec(writeCommand, {
-          cwd: this.getBasePath(),
-          timeout: 300,
-          abortSignal: writeAbortController.signal,
-        });
-      });
+      execPromise ??= this.resolveFilePath(filePath, writeAbortController.signal).then(
+        (resolvedPath) => {
+          const quotedPath = this.quoteForRemote(resolvedPath);
+          const tempPath = getAtomicWriteTempPath(resolvedPath);
+          const quotedTempPath = this.quoteForRemote(tempPath);
+          const writeCommand = this.buildWriteCommand(quotedPath, quotedTempPath);
+          return this.exec(writeCommand, {
+            cwd: this.getBasePath(),
+            timeout: 300,
+            abortSignal: writeAbortController.signal,
+          });
+        }
+      );
       return execPromise;
     };
 
@@ -528,7 +549,7 @@ export abstract class RemoteRuntime implements Runtime {
    * Ensure a directory exists (mkdir -p semantics).
    */
   async ensureDir(dirPath: string, abortSignal?: AbortSignal): Promise<void> {
-    const resolvedPath = await this.resolveFilePath(dirPath);
+    const resolvedPath = await this.resolveFilePath(dirPath, abortSignal);
     const stream = await this.exec(`mkdir -p ${this.quoteForRemote(resolvedPath)}`, {
       cwd: "/",
       timeout: 10,
@@ -557,7 +578,7 @@ export abstract class RemoteRuntime implements Runtime {
    * Uses stat -L to follow symlinks (report target's type, not "symbolic link").
    */
   async stat(filePath: string, abortSignal?: AbortSignal): Promise<FileStat> {
-    const resolvedPath = await this.resolveFilePath(filePath);
+    const resolvedPath = await this.resolveFilePath(filePath, abortSignal);
     const stream = await this.exec(`stat -L -c '%s %Y %F' ${this.quoteForRemote(resolvedPath)}`, {
       cwd: this.getBasePath(),
       timeout: 10,

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -394,7 +394,7 @@ export interface Runtime {
   readFile(path: string, abortSignal?: AbortSignal): ReadableStream<Uint8Array>;
 
   /**
-   * Write file contents atomically from a stream
+   * Write file contents atomically from a stream. Adapters canonicalize tilde and relative paths.
    * @param path Absolute or relative path to file
    * @param abortSignal Optional abort signal for cancellation
    * @returns Writable stream for file contents
@@ -403,7 +403,7 @@ export interface Runtime {
   writeFile(path: string, abortSignal?: AbortSignal): WritableStream<Uint8Array>;
 
   /**
-   * Get file statistics
+   * Get file statistics. Adapters canonicalize tilde and relative paths.
    * @param path Absolute or relative path to file/directory
    * @param abortSignal Optional abort signal for cancellation
    * @returns File statistics
@@ -412,7 +412,7 @@ export interface Runtime {
   stat(path: string, abortSignal?: AbortSignal): Promise<FileStat>;
 
   /**
-   * Ensure a directory exists (mkdir -p semantics).
+   * Ensure a directory exists (mkdir -p semantics). Adapters canonicalize tilde and relative paths.
    *
    * This intentionally lives on the Runtime abstraction so local runtimes can use
    * Node fs APIs (Windows-safe) while remote runtimes can use shell commands.

--- a/src/node/runtime/Runtime.ts
+++ b/src/node/runtime/Runtime.ts
@@ -53,6 +53,8 @@ export interface ExecOptions {
   cwd: string;
   /** Environment variables to inject */
   env?: Record<string, string>;
+  /** Host-namespace paths to translate before exposing them as environment variables. */
+  pathEnv?: Record<string, string>;
   /**
    * Timeout in seconds.
    *
@@ -373,7 +375,8 @@ export interface Runtime {
    */
   readonly createFlags?: RuntimeCreateFlags;
   /**
-   * Execute a bash command with streaming I/O
+   * Execute a bash command with streaming I/O.
+   * cwd and pathEnv values are host-namespace paths translated by the adapter.
    * @param command The bash script to execute
    * @param options Execution options (cwd, env, timeout, etc.)
    * @returns Promise that resolves to streaming handles for stdin/stdout/stderr and completion promises
@@ -382,13 +385,7 @@ export interface Runtime {
   exec(command: string, options: ExecOptions): Promise<ExecStream>;
 
   /**
-   * Translate a host-visible path into the namespace used by exec() scripts.
-   * When absent, file I/O and exec share the same path namespace.
-   */
-  mapPathForExec?(filePath: string): string;
-
-  /**
-   * Read file contents as a stream
+   * Read file contents as a stream. Adapters canonicalize tilde and relative paths.
    * @param path Absolute or relative path to file
    * @param abortSignal Optional abort signal for cancellation
    * @returns Readable stream of file contents

--- a/src/node/runtime/backgroundCommands.ts
+++ b/src/node/runtime/backgroundCommands.ts
@@ -38,7 +38,7 @@ export interface WrapperScriptOptions {
   exitCodePath: string;
   /** Working directory for the script */
   cwd: string;
-  /** Name of the environment variable containing the translated cwd. */
+  /** Name of the environment variable containing the translated cwd; takes precedence over cwd. */
   cwdEnvVar?: string;
   /** Environment variables to export */
   env?: Record<string, string>;

--- a/src/node/runtime/backgroundCommands.ts
+++ b/src/node/runtime/backgroundCommands.ts
@@ -38,6 +38,8 @@ export interface WrapperScriptOptions {
   exitCodePath: string;
   /** Working directory for the script */
   cwd: string;
+  /** Name of the environment variable containing the translated cwd. */
+  cwdEnvVar?: string;
   /** Environment variables to export */
   env?: Record<string, string>;
   /** The actual script to run */
@@ -63,7 +65,13 @@ export function buildWrapperScript(options: WrapperScriptOptions): string {
   parts.push(`trap 'echo $? > "$__MUX_EXIT_CODE_PATH"' EXIT`);
 
   // Change to working directory
-  parts.push(`cd ${shellQuote(options.cwd)}`);
+  if (options.cwdEnvVar) {
+    parts.push(`__MUX_CWD="$${options.cwdEnvVar}"`);
+    parts.push(`unset ${options.cwdEnvVar}`);
+    parts.push('cd "$__MUX_CWD"');
+  } else {
+    parts.push(`cd ${shellQuote(options.cwd)}`);
+  }
 
   // Add environment variable exports
   if (options.env) {

--- a/src/node/runtime/execFileIO.ts
+++ b/src/node/runtime/execFileIO.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared exec-backed file I/O for runtimes whose file operations run shell
+ * commands (RemoteRuntime and DevcontainerRuntime's in-container fallback).
+ * Callers own command construction and path canonicalization via the
+ * startExec factory; these helpers own the streaming, abort, and error
+ * plumbing so all exec-backed runtimes behave identically.
+ */
+
+import type { ExecStream, FileStat } from "./Runtime";
+import { RuntimeError } from "./Runtime";
+import { getErrorMessage } from "@/common/utils/errors";
+import { streamToString } from "./streamUtils";
+
+/** Starts the exec for one file operation; must honor the given signal. */
+type StartExec = (abortSignal: AbortSignal) => Promise<ExecStream>;
+
+/**
+ * Read file contents as a stream via exec.
+ */
+export function readFileViaExec(
+  filePath: string,
+  startExec: StartExec,
+  abortSignal?: AbortSignal
+): ReadableStream<Uint8Array> {
+  // Internal controller so CANCELLING the returned stream kills the remote
+  // cat: the eager pump below has no other path to the exec, and without
+  // it a cancelled wrapper (e.g. mux.load's byte ceiling) left cat blocked
+  // until its 300s timeout, accumulating remote processes (r18). The
+  // caller's abortSignal forwards into the same controller.
+  const readAbort = new AbortController();
+  const forwardAbort = () => readAbort.abort();
+  if (abortSignal?.aborted) {
+    readAbort.abort();
+  } else {
+    abortSignal?.addEventListener("abort", forwardAbort, { once: true });
+  }
+  const cleanupAbortForwarder = () => {
+    abortSignal?.removeEventListener("abort", forwardAbort);
+  };
+
+  return new ReadableStream<Uint8Array>({
+    cancel: () => {
+      readAbort.abort();
+      cleanupAbortForwarder();
+    },
+    start: async (controller: ReadableStreamDefaultController<Uint8Array>) => {
+      try {
+        const stream = await startExec(readAbort.signal);
+        const reader = stream.stdout.getReader();
+        const exitCodePromise = stream.exitCode;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+
+        const code = await exitCodePromise;
+        if (code !== 0) {
+          const stderr = await streamToString(stream.stderr);
+          throw new RuntimeError(`Failed to read file ${filePath}: ${stderr}`, "file_io");
+        }
+
+        controller.close();
+      } catch (err) {
+        if (err instanceof RuntimeError) {
+          controller.error(err);
+        } else {
+          controller.error(
+            new RuntimeError(
+              `Failed to read file ${filePath}: ${getErrorMessage(err)}`,
+              "file_io",
+              err instanceof Error ? err : undefined
+            )
+          );
+        }
+      } finally {
+        // Natural completion/error: stop listening on the caller's signal
+        // so long-lived signals don't accumulate forwarders.
+        cleanupAbortForwarder();
+      }
+    },
+  });
+}
+
+/**
+ * Write file contents atomically via exec. The exec starts lazily on the
+ * first write, so an abort before any chunk never spawns a process.
+ */
+export function writeFileViaExec(
+  filePath: string,
+  startExec: StartExec,
+  abortSignal?: AbortSignal
+): WritableStream<Uint8Array> {
+  let execPromise: Promise<ExecStream> | null = null;
+  const writeAbortController = new AbortController();
+  const abortWrite = () => writeAbortController.abort();
+  if (abortSignal?.aborted) {
+    writeAbortController.abort();
+  } else {
+    abortSignal?.addEventListener("abort", abortWrite, { once: true });
+  }
+  const cleanupAbortForwarder = () => {
+    abortSignal?.removeEventListener("abort", abortWrite);
+  };
+
+  const getExecStream = () => {
+    execPromise ??= startExec(writeAbortController.signal);
+    return execPromise;
+  };
+
+  return new WritableStream<Uint8Array>({
+    write: async (chunk: Uint8Array) => {
+      const stream = await getExecStream();
+      const writer = stream.stdin.getWriter();
+      try {
+        await writer.write(chunk);
+      } finally {
+        writer.releaseLock();
+      }
+    },
+    close: async () => {
+      try {
+        const stream = await getExecStream();
+        await stream.stdin.close();
+        const exitCode = await stream.exitCode;
+
+        if (exitCode !== 0) {
+          const stderr = await streamToString(stream.stderr);
+          throw new RuntimeError(`Failed to write file ${filePath}: ${stderr}`, "file_io");
+        }
+      } finally {
+        cleanupAbortForwarder();
+      }
+    },
+    abort: async (reason?: unknown) => {
+      writeAbortController.abort();
+      if (execPromise) {
+        try {
+          const stream = await execPromise;
+          await stream.stdin.abort(reason).catch(() => undefined);
+          await stream.exitCode.catch(() => undefined);
+        } finally {
+          cleanupAbortForwarder();
+        }
+      } else {
+        cleanupAbortForwarder();
+      }
+      throw new RuntimeError(`Failed to write file ${filePath}: ${String(reason)}`, "file_io");
+    },
+  });
+}
+
+/**
+ * Ensure a directory exists (mkdir -p semantics).
+ */
+export async function ensureDirViaExec(
+  dirPath: string,
+  startExec: () => Promise<ExecStream>
+): Promise<void> {
+  const stream = await startExec();
+  await stream.stdin.close();
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    streamToString(stream.stdout),
+    streamToString(stream.stderr),
+    stream.exitCode,
+  ]);
+
+  if (exitCode !== 0) {
+    const extra = stderr.trim() || stdout.trim();
+    throw new RuntimeError(
+      `Failed to create directory ${dirPath}: exit code ${exitCode}${extra ? `: ${extra}` : ""}`,
+      "file_io"
+    );
+  }
+}
+
+// -L follows symlinks so symlinked paths report the target's type.
+export const STAT_VIA_EXEC_COMMAND = "stat -L -c '%s %Y %F'";
+
+/**
+ * Get file statistics via exec; parses STAT_VIA_EXEC_COMMAND output.
+ */
+export async function statViaExec(
+  filePath: string,
+  startExec: () => Promise<ExecStream>
+): Promise<FileStat> {
+  const stream = await startExec();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    streamToString(stream.stdout),
+    streamToString(stream.stderr),
+    stream.exitCode,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new RuntimeError(`Failed to stat ${filePath}: ${stderr}`, "file_io");
+  }
+
+  const parts = stdout.trim().split(" ");
+  if (parts.length < 3) {
+    throw new RuntimeError(`Failed to parse stat output for ${filePath}: ${stdout}`, "file_io");
+  }
+
+  const size = parseInt(parts[0], 10);
+  const mtime = parseInt(parts[1], 10);
+  const fileType = parts.slice(2).join(" ");
+
+  return {
+    size,
+    modifiedTime: new Date(mtime * 1000),
+    isDirectory: fileType === "directory",
+  };
+}

--- a/src/node/runtime/hostGlobalXumHome.test.ts
+++ b/src/node/runtime/hostGlobalXumHome.test.ts
@@ -1,66 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import { LEGACY_REMOTE_MUX_HOME } from "@/common/compat/legacyMux";
 import { LocalRuntime } from "./LocalRuntime";
-import { RemoteRuntime, type SpawnResult } from "./RemoteRuntime";
+import { TestRemoteRuntime } from "./testRemoteRuntime";
 import { resolveGlobalRuntime, shouldUseHostGlobalXumFallback } from "./hostGlobalXumHome";
 
-class StubRemoteRuntime extends RemoteRuntime {
+class StubRemoteRuntime extends TestRemoteRuntime {
   constructor(private readonly xumHome: string) {
     super();
   }
 
-  protected readonly commandPrefix = "StubRemote";
-
-  protected getBasePath(): string {
-    return "/workspace";
-  }
-
-  protected quoteForRemote(filePath: string): string {
-    return `'${filePath}'`;
-  }
-
-  protected cdCommand(cwd: string): string {
-    return `cd '${cwd}'`;
-  }
-
-  protected spawnRemoteProcess(): Promise<SpawnResult> {
-    throw new Error("spawn should not be called");
-  }
-
   override getXumHome(): string {
     return this.xumHome;
-  }
-
-  resolvePath(filePath: string): Promise<string> {
-    return Promise.resolve(filePath);
-  }
-
-  getWorkspacePath(): string {
-    return "/workspace";
-  }
-
-  createWorkspace() {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  initWorkspace() {
-    return Promise.resolve({ success: true });
-  }
-
-  deleteWorkspace() {
-    return Promise.resolve({ success: true as const, deletedPath: "/workspace" });
-  }
-
-  renameWorkspace() {
-    return Promise.resolve({
-      success: true as const,
-      oldPath: "/workspace",
-      newPath: "/workspace",
-    });
-  }
-
-  forkWorkspace() {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
   }
 }
 

--- a/src/node/runtime/shellEnv.test.ts
+++ b/src/node/runtime/shellEnv.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "bun:test";
-import { buildShellExport } from "./shellEnv";
+import { buildShellExport, buildShellPathExport } from "./shellEnv";
+
+/** Run the generated export snippet under bash and return the resulting value. */
+async function evalPathExport(value: string, cwd: string): Promise<string> {
+  const snippet = buildShellPathExport("MUX_TEST_PATH", value);
+  const proc = Bun.spawn(["bash", "-c", `${snippet} && printf '%s' "$MUX_TEST_PATH"`], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+  expect(exitCode).toBe(0);
+  return stdout;
+}
 
 describe("buildShellExport", () => {
   it("quotes values for valid environment variable names", () => {
@@ -10,5 +23,26 @@ describe("buildShellExport", () => {
     expect(() => buildShellExport("BAD;echo pwn", "value")).toThrow(
       "Invalid shell environment variable name"
     );
+  });
+});
+
+describe("buildShellPathExport", () => {
+  it("resolves relative paths against the shell cwd", async () => {
+    expect(await evalPathExport("rel/path", "/tmp")).toBe("/tmp/rel/path");
+  });
+
+  it("keeps POSIX absolute paths unchanged", async () => {
+    expect(await evalPathExport("/opt/data", "/tmp")).toBe("/opt/data");
+  });
+
+  // Windows local runtimes exec through Git Bash, whose cd accepts native
+  // Windows paths; treating them as relative would prepend $PWD and corrupt them.
+  it("keeps Windows drive-letter paths unchanged", async () => {
+    expect(await evalPathExport("D:\\a\\xum\\ws", "/tmp")).toBe("D:\\a\\xum\\ws");
+    expect(await evalPathExport("D:/a/xum/ws", "/tmp")).toBe("D:/a/xum/ws");
+  });
+
+  it("keeps UNC paths unchanged", async () => {
+    expect(await evalPathExport("\\\\server\\share\\dir", "/tmp")).toBe("\\\\server\\share\\dir");
   });
 });

--- a/src/node/runtime/shellEnv.ts
+++ b/src/node/runtime/shellEnv.ts
@@ -16,3 +16,16 @@ export function buildShellExport(
   assertShellEnvName(key);
   return `export ${key}=${quoteValue(value)}`;
 }
+
+export function buildShellPathExport(
+  key: string,
+  value: string,
+  quoteValue: (value: string) => string = shellQuote
+): string {
+  assertShellEnvName(key);
+  return [
+    `${key}=${quoteValue(value)}`,
+    `case "$${key}" in '~') ${key}="$HOME" ;; '~/'*) ${key}="$HOME/\${${key}:2}" ;; /*) ;; *) ${key}="$PWD/$${key}" ;; esac`,
+    `export ${key}`,
+  ].join(" && ");
+}

--- a/src/node/runtime/shellEnv.ts
+++ b/src/node/runtime/shellEnv.ts
@@ -23,9 +23,11 @@ export function buildShellPathExport(
   quoteValue: (value: string) => string = shellQuote
 ): string {
   assertShellEnvName(key);
+  // Windows drive-letter ([A-Za-z]:*) and UNC ('\\'*) paths are absolute too:
+  // Git Bash accepts them natively, and prepending $PWD would corrupt them.
   return [
     `${key}=${quoteValue(value)}`,
-    `case "$${key}" in '~') ${key}="$HOME" ;; '~/'*) ${key}="$HOME/\${${key}:2}" ;; /*) ;; *) ${key}="$PWD/$${key}" ;; esac`,
+    `case "$${key}" in '~') ${key}="$HOME" ;; '~/'*) ${key}="$HOME/\${${key}:2}" ;; /* | [A-Za-z]:* | '\\\\'*) ;; *) ${key}="$PWD/$${key}" ;; esac`,
     `export ${key}`,
   ].join(" && ");
 }

--- a/src/node/runtime/testRemoteRuntime.ts
+++ b/src/node/runtime/testRemoteRuntime.ts
@@ -1,0 +1,61 @@
+import { RemoteRuntime, type SpawnResult } from "./RemoteRuntime";
+
+/**
+ * Minimal concrete RemoteRuntime for tests: identity path resolution, throwing
+ * spawn, and stubbed lifecycle. Subclasses override only what they exercise.
+ */
+export class TestRemoteRuntime extends RemoteRuntime {
+  protected readonly commandPrefix: string = "TestRemote";
+
+  protected getBasePath(): string {
+    return "/workspace";
+  }
+
+  protected quoteForRemote(filePath: string): string {
+    return `'${filePath.replaceAll("'", "'\\''")}'`;
+  }
+
+  protected cdCommand(cwd: string): string {
+    return `cd ${this.quoteForRemote(cwd)}`;
+  }
+
+  protected spawnRemoteProcess(): Promise<SpawnResult> {
+    throw new Error("spawn should not be called");
+  }
+
+  resolvePath(filePath: string): Promise<string> {
+    return Promise.resolve(filePath);
+  }
+
+  getWorkspacePath(_projectPath: string, _workspaceName: string): string {
+    return "/workspace";
+  }
+
+  createWorkspace() {
+    return Promise.resolve({ success: false as const, error: "not implemented" });
+  }
+
+  initWorkspace() {
+    return Promise.resolve({ success: true });
+  }
+
+  deleteWorkspace() {
+    return Promise.resolve({ success: true as const, deletedPath: "/workspace" });
+  }
+
+  renameWorkspace() {
+    return Promise.resolve({
+      success: true as const,
+      oldPath: "/workspace",
+      newPath: "/workspace",
+    });
+  }
+
+  forkWorkspace() {
+    return Promise.resolve({ success: false as const, error: "not implemented" });
+  }
+
+  ensureReady() {
+    return Promise.resolve({ ready: true as const });
+  }
+}

--- a/src/node/services/backgroundProcessExecutor.test.ts
+++ b/src/node/services/backgroundProcessExecutor.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
-import type { BackgroundHandle } from "@/node/runtime/Runtime";
+import type { BackgroundHandle, ExecOptions, ExecStream } from "@/node/runtime/Runtime";
 import { shellQuote } from "@/node/runtime/backgroundCommands";
 import { BG_EXIT_CODE_FILENAME, spawnProcess } from "./backgroundProcessExecutor";
 
@@ -16,10 +16,18 @@ class ExecPathMappingRuntime extends LocalRuntime {
     super(projectPath);
   }
 
-  mapPathForExec(filePath: string): string {
-    return filePath.startsWith(this.hostPrefix)
-      ? this.execPrefix + filePath.slice(this.hostPrefix.length)
-      : filePath;
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    const mapPath = (filePath: string) =>
+      filePath.startsWith(this.hostPrefix)
+        ? this.execPrefix + filePath.slice(this.hostPrefix.length)
+        : filePath;
+    return super.exec(command, {
+      ...options,
+      cwd: mapPath(options.cwd),
+      pathEnv: Object.fromEntries(
+        Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, mapPath(value)])
+      ),
+    });
   }
 }
 

--- a/src/node/services/backgroundProcessExecutor.test.ts
+++ b/src/node/services/backgroundProcessExecutor.test.ts
@@ -97,6 +97,33 @@ describe("spawnProcess", () => {
     expect((await fs.readFile(outFile, "utf8")).trim()).toBe(execDir);
   });
 
+  it("pathEnv values win over colliding caller env in background wrappers", async () => {
+    const hostDir = await fs.mkdtemp(path.join(os.tmpdir(), "bg-pathenv-collision-"));
+    const resultDir = await fs.mkdtemp(path.join(os.tmpdir(), "bg-pathenv-result-"));
+    cleanupDirs.push(hostDir, resultDir);
+
+    const outFile = path.join(resultDir, "value.txt");
+    const result = await spawnProcess(
+      new LocalRuntime(hostDir),
+      `printf %s "$XUM_TEST_TOOLENV" > ${shellQuote(outFile)}`,
+      {
+        cwd: hostDir,
+        workspaceId: `pathenv-collision-${Date.now()}`,
+        processId: "collision",
+        env: { XUM_TEST_TOOLENV: "/wrong/value" },
+        pathEnv: { XUM_TEST_TOOLENV: "/right/value" },
+      }
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    handles.push(result.handle);
+    cleanupDirs.push(result.outputDir);
+
+    expect(await waitForExit(result.handle)).toBe(0);
+    expect((await fs.readFile(outFile, "utf8")).trim()).toBe("/right/value");
+  });
+
   it("fails the strict exit probe when the exit marker is a dangling symlink", async () => {
     const hostDir = await fs.mkdtemp(path.join(os.tmpdir(), "bg-dangling-marker-"));
     cleanupDirs.push(hostDir);

--- a/src/node/services/backgroundProcessExecutor.test.ts
+++ b/src/node/services/backgroundProcessExecutor.test.ts
@@ -3,33 +3,10 @@ import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
-import type { BackgroundHandle, ExecOptions, ExecStream } from "@/node/runtime/Runtime";
+import type { BackgroundHandle } from "@/node/runtime/Runtime";
 import { shellQuote } from "@/node/runtime/backgroundCommands";
+import { ExecPathMappingRuntime } from "./testExecPathMappingRuntime";
 import { BG_EXIT_CODE_FILENAME, spawnProcess } from "./backgroundProcessExecutor";
-
-class ExecPathMappingRuntime extends LocalRuntime {
-  constructor(
-    projectPath: string,
-    private readonly hostPrefix: string,
-    private readonly execPrefix: string
-  ) {
-    super(projectPath);
-  }
-
-  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
-    const mapPath = (filePath: string) =>
-      filePath.startsWith(this.hostPrefix)
-        ? this.execPrefix + filePath.slice(this.hostPrefix.length)
-        : filePath;
-    return super.exec(command, {
-      ...options,
-      cwd: mapPath(options.cwd),
-      pathEnv: Object.fromEntries(
-        Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, mapPath(value)])
-      ),
-    });
-  }
-}
 
 /**
  * Delegates to a real LocalRuntime but is NOT an instanceof LocalBaseRuntime, so

--- a/src/node/services/backgroundProcessExecutor.ts
+++ b/src/node/services/backgroundProcessExecutor.ts
@@ -230,11 +230,19 @@ export async function spawnProcess(
     };
   }
 
+  // The outer spawn shell exports the translated pathEnv (and cwd var) before
+  // the wrapper runs; wrapper-level env exports would overwrite those
+  // translations, so pathEnv-owned keys are stripped from the wrapper env.
+  const wrapperEnv: Record<string, string> = { ...options.env, ...NON_INTERACTIVE_ENV_VARS };
+  for (const key of [...Object.keys(options.pathEnv ?? {}), BACKGROUND_CWD_ENV]) {
+    delete wrapperEnv[key];
+  }
+
   const wrapperScript = buildWrapperScript({
     exitCodePath,
     cwd: options.cwd,
     cwdEnvVar: BACKGROUND_CWD_ENV,
-    env: { ...options.env, ...NON_INTERACTIVE_ENV_VARS },
+    env: wrapperEnv,
     script,
   });
 

--- a/src/node/services/backgroundProcessExecutor.ts
+++ b/src/node/services/backgroundProcessExecutor.ts
@@ -65,6 +65,7 @@ export function spawnRecordsAreHostLocal(runtime: Runtime): boolean {
  * NOTE: Local runtimes validate that cwd exists before spawning, so this must be a real directory.
  */
 const FALLBACK_CWD = process.platform === "win32" ? (process.env.TEMP ?? "C:\\") : "/tmp";
+const BACKGROUND_CWD_ENV = "XUM_INTERNAL_BACKGROUND_CWD";
 
 /** Helper to extract error message for logging */
 function errorMsg(error: unknown): string {
@@ -127,6 +128,8 @@ export interface SpawnOptions {
   processId: string;
   /** Environment variables to inject */
   env?: Record<string, string>;
+  /** Host-namespace paths to translate before injecting as environment variables. */
+  pathEnv?: Record<string, string>;
 }
 
 /**
@@ -160,17 +163,22 @@ export async function spawnProcess(
   // Get temp directory from runtime (absolute path, runtime-agnostic)
   const tempDir = await runtime.tempDir();
   const bgOutputDir = `${tempDir}/${BG_OUTPUT_SUBDIR}`;
-  const execCwd = runtime.mapPathForExec?.(options.cwd) ?? options.cwd;
 
   // Use shell-safe quoting for paths (handles spaces, special chars)
   const quotePath = quotePathForShell;
 
   // Verify working directory exists
-  const cwdCheck = await execBuffered(runtime, `cd ${quotePath(execCwd)}`, {
-    cwd: FALLBACK_CWD,
-    timeout: 10,
-  });
+  const cwdCheck = await execBuffered(
+    runtime,
+    `printf '%s\n' "$${BACKGROUND_CWD_ENV}"; cd "$${BACKGROUND_CWD_ENV}"`,
+    {
+      cwd: FALLBACK_CWD,
+      pathEnv: { [BACKGROUND_CWD_ENV]: options.cwd },
+      timeout: 10,
+    }
+  );
   if (cwdCheck.exitCode !== 0) {
+    const execCwd = cwdCheck.stdout.trim() || options.cwd;
     return { success: false, error: `Working directory does not exist: ${execCwd}` };
   }
 
@@ -222,11 +230,11 @@ export async function spawnProcess(
     };
   }
 
-  // Build wrapper script (same for all runtimes now that paths are absolute)
   // Note: buildWrapperScript handles quoting internally via shellQuote
   const wrapperScript = buildWrapperScript({
     exitCodePath,
-    cwd: execCwd,
+    cwd: options.cwd,
+    cwdEnvVar: BACKGROUND_CWD_ENV,
     env: { ...options.env, ...NON_INTERACTIVE_ENV_VARS },
     script,
   });
@@ -241,6 +249,7 @@ export async function spawnProcess(
     // No timeout - the spawn command backgrounds the process and returns immediately
     const result = await execBuffered(runtime, spawnCommand, {
       cwd: FALLBACK_CWD,
+      pathEnv: { ...options.pathEnv, [BACKGROUND_CWD_ENV]: options.cwd },
     });
 
     if (result.exitCode !== 0) {

--- a/src/node/services/backgroundProcessExecutor.ts
+++ b/src/node/services/backgroundProcessExecutor.ts
@@ -230,7 +230,6 @@ export async function spawnProcess(
     };
   }
 
-  // Note: buildWrapperScript handles quoting internally via shellQuote
   const wrapperScript = buildWrapperScript({
     exitCodePath,
     cwd: options.cwd,

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -1342,6 +1342,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     config: {
       cwd: string;
       env?: Record<string, string>;
+      pathEnv?: Record<string, string>;
       /** Human-readable name for the process - used to generate the process ID */
       displayName: string;
       /** If true, process is foreground (being waited on). Default: false (background) */
@@ -1413,6 +1414,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       workspaceId,
       processId,
       env: config.env,
+      pathEnv: config.pathEnv,
     });
 
     if (!result.success) {

--- a/src/node/services/hooks.test.ts
+++ b/src/node/services/hooks.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as os from "os";
@@ -28,23 +28,17 @@ describe("hooks", () => {
   });
 
   describe("exec path mapping", () => {
-    test("returns mapped project hook and tool_env paths after host discovery", async () => {
+    test("discovery returns host-namespace paths even on exec-mapping runtimes", async () => {
       const configDir = path.join(tempDir, ".xum");
       const hookPath = path.join(configDir, "tool_hook");
       const toolEnvPath = path.join(configDir, "tool_env");
-      const execPrefix = "/workspaces/project";
       await fs.mkdir(configDir, { recursive: true });
       await fs.writeFile(hookPath, "#!/bin/bash\necho test");
       await fs.writeFile(toolEnvPath, "export FOO=bar");
 
-      const mappingRuntime = new ExecPathMappingRuntime(tempDir, tempDir, execPrefix);
-      const statSpy = spyOn(mappingRuntime, "stat");
-
+      const mappingRuntime = new ExecPathMappingRuntime(tempDir, tempDir, "/workspaces/project");
       expect(await getHookPath(mappingRuntime, tempDir)).toBe(hookPath);
       expect(await getToolEnvPath(mappingRuntime, tempDir)).toBe(toolEnvPath);
-      const statPaths = statSpy.mock.calls.map(([filePath]) => filePath);
-      expect(statPaths).toContain(hookPath);
-      expect(statPaths).toContain(toolEnvPath);
     });
 
     test("hook runners export the mapped project dir as XUM_PROJECT_DIR", async () => {

--- a/src/node/services/hooks.test.ts
+++ b/src/node/services/hooks.test.ts
@@ -12,31 +12,7 @@ import {
   runPostHook,
 } from "./hooks";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
-import type { ExecOptions, ExecStream } from "@/node/runtime/Runtime";
-
-class ExecPathMappingRuntime extends LocalRuntime {
-  constructor(
-    projectPath: string,
-    private readonly hostPrefix: string,
-    private readonly execPrefix: string
-  ) {
-    super(projectPath);
-  }
-
-  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
-    const mapPath = (filePath: string) =>
-      filePath.startsWith(this.hostPrefix)
-        ? this.execPrefix + filePath.slice(this.hostPrefix.length)
-        : filePath;
-    return super.exec(command, {
-      ...options,
-      cwd: mapPath(options.cwd),
-      pathEnv: Object.fromEntries(
-        Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, mapPath(value)])
-      ),
-    });
-  }
-}
+import { ExecPathMappingRuntime } from "./testExecPathMappingRuntime";
 
 describe("hooks", () => {
   let tempDir: string;

--- a/src/node/services/hooks.test.ts
+++ b/src/node/services/hooks.test.ts
@@ -12,6 +12,7 @@ import {
   runPostHook,
 } from "./hooks";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+import type { ExecOptions, ExecStream } from "@/node/runtime/Runtime";
 
 class ExecPathMappingRuntime extends LocalRuntime {
   constructor(
@@ -22,10 +23,18 @@ class ExecPathMappingRuntime extends LocalRuntime {
     super(projectPath);
   }
 
-  mapPathForExec(filePath: string): string {
-    return filePath.startsWith(this.hostPrefix)
-      ? this.execPrefix + filePath.slice(this.hostPrefix.length)
-      : filePath;
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    const mapPath = (filePath: string) =>
+      filePath.startsWith(this.hostPrefix)
+        ? this.execPrefix + filePath.slice(this.hostPrefix.length)
+        : filePath;
+    return super.exec(command, {
+      ...options,
+      cwd: mapPath(options.cwd),
+      pathEnv: Object.fromEntries(
+        Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, mapPath(value)])
+      ),
+    });
   }
 }
 
@@ -55,26 +64,33 @@ describe("hooks", () => {
       const mappingRuntime = new ExecPathMappingRuntime(tempDir, tempDir, execPrefix);
       const statSpy = spyOn(mappingRuntime, "stat");
 
-      expect(await getHookPath(mappingRuntime, tempDir)).toBe(
-        path.posix.join(execPrefix, ".xum/tool_hook")
-      );
-      expect(await getToolEnvPath(mappingRuntime, tempDir)).toBe(
-        path.posix.join(execPrefix, ".xum/tool_env")
-      );
+      expect(await getHookPath(mappingRuntime, tempDir)).toBe(hookPath);
+      expect(await getToolEnvPath(mappingRuntime, tempDir)).toBe(toolEnvPath);
       const statPaths = statSpy.mock.calls.map(([filePath]) => filePath);
       expect(statPaths).toContain(hookPath);
       expect(statPaths).toContain(toolEnvPath);
     });
 
     test("hook runners export the mapped project dir as XUM_PROJECT_DIR", async () => {
-      const execPrefix = "/workspaces/project";
+      const execPrefix = path.join(tempDir, "exec");
       const mappingRuntime = new ExecPathMappingRuntime(tempDir, tempDir, execPrefix);
       const hookDir = path.join(tempDir, ".xum");
-      await fs.mkdir(hookDir, { recursive: true });
+      const execHookDir = path.join(execPrefix, ".xum");
+      await Promise.all([
+        fs.mkdir(hookDir, { recursive: true }),
+        fs.mkdir(execHookDir, { recursive: true }),
+      ]);
       const writeHook = async (name: string) => {
         const hookPath = path.join(hookDir, name);
-        await fs.writeFile(hookPath, '#!/bin/bash\necho "project_dir=$XUM_PROJECT_DIR"');
-        await fs.chmod(hookPath, 0o755);
+        const contents = '#!/bin/bash\necho "project_dir=$XUM_PROJECT_DIR"';
+        await Promise.all([
+          fs.writeFile(hookPath, contents),
+          fs.writeFile(path.join(execHookDir, name), contents),
+        ]);
+        await Promise.all([
+          fs.chmod(hookPath, 0o755),
+          fs.chmod(path.join(execHookDir, name), 0o755),
+        ]);
         return hookPath;
       };
       const context = {

--- a/src/node/services/hooks.ts
+++ b/src/node/services/hooks.ts
@@ -280,7 +280,6 @@ export async function runWithHook<T>(
     // Ensure the base JSON env var cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: context.projectDir,
     XUM_EXEC: execMarker,
   };
   if (toolInputPath) {
@@ -626,7 +625,6 @@ export async function runPreHook(
     // Ensure the base JSON env var cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: context.projectDir,
   };
   if (toolInputPath) {
     canonicalHookEnv.XUM_TOOL_INPUT_PATH = toolInputPath;
@@ -723,7 +721,6 @@ export async function runPostHook(
     // Ensure base JSON env vars cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: context.projectDir,
     XUM_TOOL_RESULT: resultEnv,
   };
   if (toolInputPath) {

--- a/src/node/services/hooks.ts
+++ b/src/node/services/hooks.ts
@@ -11,6 +11,7 @@ import {
   withLegacyMuxEnvironmentAliases,
 } from "@/common/compat/legacyMux";
 import { flattenToolHookValueToEnv } from "@/common/utils/tools/toolHookEnv";
+import { shellQuote } from "@/common/utils/shell";
 import type { Runtime } from "@/node/runtime/Runtime";
 import { log } from "@/node/services/log";
 import { execBuffered, writeFileString } from "@/node/utils/runtime/helpers";
@@ -26,12 +27,6 @@ const FLATTENED_TOOL_ENV_MAX_ARRAY_LENGTH = 50;
 const DEFAULT_HOOK_PHASE_TIMEOUT_MS = 10_000; // 10 seconds
 const EXEC_MARKER_PREFIX = "MUX_EXEC_";
 const HOOK_PATH_ENV = "XUM_INTERNAL_HOOK_PATH";
-
-/** Shell-escape a string for safe use in bash -c commands */
-function shellEscape(str: string): string {
-  // Wrap in single quotes and escape any embedded single quotes
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
 
 function buildHookCommand(): string {
   return `hook_path="$${HOOK_PATH_ENV}"; unset ${HOOK_PATH_ENV}; "$hook_path"`;
@@ -332,7 +327,7 @@ export async function runWithHook<T>(
     log.error("[hooks] Failed to spawn hook", { hookPath, error: err });
     if (toolInputPath) {
       try {
-        await execBuffered(runtime, `rm -f ${shellEscape(toolInputPath)}`, {
+        await execBuffered(runtime, `rm -f ${shellQuote(toolInputPath)}`, {
           cwd: context.projectDir,
           timeout: 5,
         });
@@ -512,7 +507,7 @@ export async function runWithHook<T>(
 
   if (toolInputPath) {
     try {
-      await execBuffered(runtime, `rm -f ${shellEscape(toolInputPath)}`, {
+      await execBuffered(runtime, `rm -f ${shellQuote(toolInputPath)}`, {
         cwd: context.projectDir,
         timeout: 5,
       });
@@ -736,7 +731,7 @@ export async function runPostHook(
     if (!resultPathForEnv) return;
 
     try {
-      await execBuffered(runtime, `rm -f ${shellEscape(resultPathForEnv)}`, {
+      await execBuffered(runtime, `rm -f ${shellQuote(resultPathForEnv)}`, {
         cwd: context.projectDir,
         timeout: 5,
       });
@@ -805,7 +800,7 @@ async function prepareToolInput(
   const cleanup = async () => {
     if (toolInputPath) {
       try {
-        await execBuffered(runtime, `rm -f ${shellEscape(toolInputPath)}`, {
+        await execBuffered(runtime, `rm -f ${shellQuote(toolInputPath)}`, {
           cwd: projectDir,
           timeout: 5,
         });

--- a/src/node/services/hooks.ts
+++ b/src/node/services/hooks.ts
@@ -25,6 +25,7 @@ const FLATTENED_TOOL_ENV_MAX_VARS = 200;
 const FLATTENED_TOOL_ENV_MAX_ARRAY_LENGTH = 50;
 const DEFAULT_HOOK_PHASE_TIMEOUT_MS = 10_000; // 10 seconds
 const EXEC_MARKER_PREFIX = "MUX_EXEC_";
+const HOOK_PATH_ENV = "XUM_INTERNAL_HOOK_PATH";
 
 /** Shell-escape a string for safe use in bash -c commands */
 function shellEscape(str: string): string {
@@ -32,12 +33,16 @@ function shellEscape(str: string): string {
   return `'${str.replace(/'/g, "'\\''")}'`;
 }
 
-/**
- * Hooks execute in the runtime's exec namespace, so the documented
- * XUM_PROJECT_DIR env value must be valid there (issue #3709).
- */
-function resolveExecProjectDir(runtime: Runtime, projectDir: string): string {
-  return runtime.mapPathForExec?.(projectDir) ?? projectDir;
+function buildHookCommand(): string {
+  return `hook_path="$${HOOK_PATH_ENV}"; unset ${HOOK_PATH_ENV}; "$hook_path"`;
+}
+
+function getHookPathEnv(projectDir: string, hookPath: string): Record<string, string> {
+  return {
+    [HOOK_PATH_ENV]: hookPath,
+    XUM_PROJECT_DIR: projectDir,
+    MUX_PROJECT_DIR: projectDir,
+  };
 }
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
@@ -85,8 +90,7 @@ async function getProjectOrGlobalConfigPath(
   for (const relativePath of listProjectMetadataRelativePaths(filename)) {
     const projectPath = joinPathLike(projectDir, relativePath);
     if (await isFile(runtime, projectPath)) {
-      // Hook and tool_env paths are embedded in exec scripts, so return them in that namespace.
-      return runtime.mapPathForExec?.(projectPath) ?? projectPath;
+      return projectPath;
     }
   }
   return getUserGlobalConfigPath(runtime, filename);
@@ -276,7 +280,7 @@ export async function runWithHook<T>(
     // Ensure the base JSON env var cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: resolveExecProjectDir(runtime, context.projectDir),
+    XUM_PROJECT_DIR: context.projectDir,
     XUM_EXEC: execMarker,
   };
   if (toolInputPath) {
@@ -315,11 +319,10 @@ export async function runWithHook<T>(
 
   let stream;
   try {
-    // Shell-escape the hook path to handle spaces and special characters
-    // runtime.exec() uses bash -c, so unquoted paths would break
-    stream = await runtime.exec(shellEscape(hookPath), {
+    stream = await runtime.exec(buildHookCommand(), {
       cwd: context.projectDir,
       env: hookEnv,
+      pathEnv: getHookPathEnv(context.projectDir, hookPath),
       abortSignal: abortController.signal,
     });
   } catch (err) {
@@ -623,7 +626,7 @@ export async function runPreHook(
     // Ensure the base JSON env var cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: resolveExecProjectDir(runtime, context.projectDir),
+    XUM_PROJECT_DIR: context.projectDir,
   };
   if (toolInputPath) {
     canonicalHookEnv.XUM_TOOL_INPUT_PATH = toolInputPath;
@@ -631,9 +634,10 @@ export async function runPreHook(
   const hookEnv = withLegacyMuxEnvironmentAliases(canonicalHookEnv);
 
   try {
-    const result = await execBuffered(runtime, shellEscape(hookPath), {
+    const result = await execBuffered(runtime, buildHookCommand(), {
       cwd: context.projectDir,
       env: hookEnv,
+      pathEnv: getHookPathEnv(context.projectDir, hookPath),
       timeout: Math.ceil(timeoutMs / 1000),
       abortSignal: context.abortSignal,
     });
@@ -719,7 +723,7 @@ export async function runPostHook(
     // Ensure base JSON env vars cannot be overwritten by flattened fields.
     XUM_TOOL_INPUT: toolInputEnv,
     XUM_WORKSPACE_ID: context.workspaceId,
-    XUM_PROJECT_DIR: resolveExecProjectDir(runtime, context.projectDir),
+    XUM_PROJECT_DIR: context.projectDir,
     XUM_TOOL_RESULT: resultEnv,
   };
   if (toolInputPath) {
@@ -745,9 +749,10 @@ export async function runPostHook(
   };
 
   try {
-    const result = await execBuffered(runtime, shellEscape(hookPath), {
+    const result = await execBuffered(runtime, buildHookCommand(), {
       cwd: context.projectDir,
       env: hookEnv,
+      pathEnv: getHookPathEnv(context.projectDir, hookPath),
       timeout: Math.ceil(timeoutMs / 1000),
       abortSignal: context.abortSignal,
     });

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -983,8 +983,8 @@ export class StreamManager extends EventEmitter {
     const tempDir = `~/.xum-tmp/${streamToken}`;
 
     // Resolve ~ in the runtime's context: callers need the canonical absolute
-    // path as a value. ensureDir canonicalizes internally, so the unresolved
-    // form is passed there directly.
+    // path as a value, and reusing it for ensureDir avoids a second remote
+    // resolution round trip per stream on SSH runtimes.
     let resolvedPath = (await runtime.resolvePath(tempDir)).trim();
 
     // In the main process, PlatformPaths defaults to POSIX behavior (no navigator),
@@ -994,7 +994,7 @@ export class StreamManager extends EventEmitter {
     }
 
     try {
-      await runtime.ensureDir(tempDir);
+      await runtime.ensureDir(resolvedPath);
     } catch (err) {
       const msg = getErrorMessage(err);
       throw new Error(`Failed to create temp directory ${resolvedPath}: ${msg}`);

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -982,11 +982,9 @@ export class StreamManager extends EventEmitter {
   public async createTempDirForStream(streamToken: StreamToken, runtime: Runtime): Promise<string> {
     const tempDir = `~/.xum-tmp/${streamToken}`;
 
-    // Resolve ~ in the runtime's context.
-    //
-    // IMPORTANT: On Windows local runtime, Git Bash may use a customized $HOME,
-    // while runtime.resolvePath expands ~ via Node (USERPROFILE). To avoid drift,
-    // create the directory using the resolved absolute path.
+    // Resolve ~ in the runtime's context: callers need the canonical absolute
+    // path as a value. ensureDir canonicalizes internally, so the unresolved
+    // form is passed there directly.
     let resolvedPath = (await runtime.resolvePath(tempDir)).trim();
 
     // In the main process, PlatformPaths defaults to POSIX behavior (no navigator),

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -996,7 +996,7 @@ export class StreamManager extends EventEmitter {
     }
 
     try {
-      await runtime.ensureDir(resolvedPath);
+      await runtime.ensureDir(tempDir);
     } catch (err) {
       const msg = getErrorMessage(err);
       throw new Error(`Failed to create temp directory ${resolvedPath}: ${msg}`);

--- a/src/node/services/testExecPathMappingRuntime.ts
+++ b/src/node/services/testExecPathMappingRuntime.ts
@@ -1,0 +1,30 @@
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+import type { ExecOptions, ExecStream } from "@/node/runtime/Runtime";
+
+/**
+ * Test runtime whose exec namespace differs from the host namespace: paths under
+ * hostPrefix are remapped to execPrefix (cwd and pathEnv), like DevcontainerRuntime.
+ */
+export class ExecPathMappingRuntime extends LocalRuntime {
+  constructor(
+    projectPath: string,
+    private readonly hostPrefix: string,
+    private readonly execPrefix: string
+  ) {
+    super(projectPath);
+  }
+
+  override exec(command: string, options: ExecOptions): Promise<ExecStream> {
+    const mapPath = (filePath: string) =>
+      filePath.startsWith(this.hostPrefix)
+        ? this.execPrefix + filePath.slice(this.hostPrefix.length)
+        : filePath;
+    return super.exec(command, {
+      ...options,
+      cwd: mapPath(options.cwd),
+      pathEnv: Object.fromEntries(
+        Object.entries(options.pathEnv ?? {}).map(([key, value]) => [key, mapPath(value)])
+      ),
+    });
+  }
+}

--- a/src/node/services/tools/bash.ts
+++ b/src/node/services/tools/bash.ts
@@ -821,23 +821,18 @@ function formatResult(
 }
 
 /**
- * Shell-escape a string for safe use in bash commands (single-quote wrapping).
- */
-function shellEscape(str: string): string {
-  return `'${str.replace(/'/g, "'\\''")}'`;
-}
-
-/**
  * Build script prelude that sources .xum/tool_env if present.
  * Returns empty string if no tool_env path is provided.
  */
+const TOOL_ENV_PATH_ENV = "XUM_INTERNAL_TOOL_ENV_PATH";
+
 function buildToolEnvPrelude(toolEnvPath: string | null): string {
   if (!toolEnvPath) return "";
-  // Source the tool_env file; fail with clear error if sourcing fails
-  return `if ! source ${shellEscape(toolEnvPath)} 2>&1; then
-  echo "mux: failed to source ${toolEnvPath}" >&2
+  return `if ! source "$${TOOL_ENV_PATH_ENV}" 2>&1; then
+  echo "mux: failed to source $${TOOL_ENV_PATH_ENV}" >&2
   exit 1
 fi
+unset ${TOOL_ENV_PATH_ENV}
 `;
 }
 
@@ -1035,6 +1030,7 @@ export const createBashTool: ToolFactory = (config: ToolConfiguration) => {
           {
             cwd: config.cwd,
             env: { ...(config.xumEnv ?? {}), ...(config.secrets ?? {}), ...hooksEnv },
+            pathEnv: toolEnvPath ? { [TOOL_ENV_PATH_ENV]: toolEnvPath } : undefined,
             displayName: safeDisplayName,
             isForeground: false, // Explicit background
             ...(monitorConfig ? { monitor: monitorConfig } : {}),
@@ -1114,6 +1110,7 @@ ${scriptWithEnv}`;
       const execStream = await config.runtime.exec(scriptWithClosedStdin, {
         cwd: config.cwd,
         env: { ...config.xumEnv, ...config.secrets, ...hooksEnv, ...NON_INTERACTIVE_ENV_VARS },
+        pathEnv: toolEnvPath ? { [TOOL_ENV_PATH_ENV]: toolEnvPath } : undefined,
         timeout: effectiveTimeout,
         abortSignal: wrappedAbortController.signal,
       });

--- a/src/node/services/tools/testHelpers.ts
+++ b/src/node/services/tools/testHelpers.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as os from "os";
 import type { ToolExecutionOptions } from "ai";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
-import { RemoteRuntime, type SpawnResult } from "@/node/runtime/RemoteRuntime";
+import { TestRemoteRuntime } from "@/node/runtime/testRemoteRuntime";
 import { InitStateManager } from "@/node/services/initStateManager";
 import { Config } from "@/node/config";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
@@ -305,7 +305,7 @@ export class RemotePathMappedRuntime extends LocalRuntime {
   }
 }
 
-export class TrueRemotePathMappedRuntime extends RemoteRuntime {
+export class TrueRemotePathMappedRuntime extends TestRemoteRuntime {
   private readonly delegate: RemotePathMappedRuntime;
   private readonly remoteBase: string;
 
@@ -315,22 +315,8 @@ export class TrueRemotePathMappedRuntime extends RemoteRuntime {
     this.delegate = new RemotePathMappedRuntime(localBase, remoteBase);
   }
 
-  protected readonly commandPrefix = "TestRemoteRuntime";
-
-  protected spawnRemoteProcess(): Promise<SpawnResult> {
-    throw new Error("spawnRemoteProcess should not be called");
-  }
-
-  protected getBasePath(): string {
+  protected override getBasePath(): string {
     return this.remoteBase;
-  }
-
-  protected quoteForRemote(targetPath: string): string {
-    return `'${targetPath.replaceAll("'", "'\\''")}'`;
-  }
-
-  protected cdCommand(cwd: string): string {
-    return `cd ${this.quoteForRemote(cwd)}`;
   }
 
   override exec(
@@ -372,30 +358,6 @@ export class TrueRemotePathMappedRuntime extends RemoteRuntime {
 
   override ensureDir(dirPath: string): ReturnType<LocalRuntime["ensureDir"]> {
     return this.delegate.ensureDir(dirPath);
-  }
-
-  override createWorkspace(_params: Parameters<LocalRuntime["createWorkspace"]>[0]) {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  override initWorkspace(_params: Parameters<LocalRuntime["initWorkspace"]>[0]) {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  override renameWorkspace(
-    _projectPath: string,
-    _oldWorkspaceName: string,
-    _newWorkspaceName: string
-  ) {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  override deleteWorkspace(_projectPath: string, _workspaceName: string, _deleteBranch: boolean) {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
-  }
-
-  override forkWorkspace(_params: Parameters<LocalRuntime["forkWorkspace"]>[0]) {
-    return Promise.resolve({ success: false as const, error: "not implemented" });
   }
 }
 

--- a/src/node/services/tools/xum_agents.test.ts
+++ b/src/node/services/tools/xum_agents.test.ts
@@ -4,7 +4,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import type { ToolExecutionOptions } from "ai";
 
-import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+import type { LocalRuntime } from "@/node/runtime/LocalRuntime";
 const GLOBAL_WORKSPACE_ID = "workspace-global";
 const GLOBAL_WORKSPACE_NAME = "global-scope";
 const GLOBAL_WORKSPACE_TITLE = "Global Scope";
@@ -14,7 +14,7 @@ import { FILE_EDIT_DIFF_OMITTED_MESSAGE } from "@/common/types/tools";
 import { resolveAgentsPathOnRuntime } from "./xum_agents_path";
 import { createXumAgentsReadTool } from "./xum_agents_read";
 import { createXumAgentsWriteTool } from "./xum_agents_write";
-import { TestTempDir, createTestToolConfig } from "./testHelpers";
+import { TestTempDir, createTestToolConfig, RemotePathMappedRuntime } from "./testHelpers";
 
 const mockToolCallOptions: ToolExecutionOptions<unknown> = {
   toolCallId: "test-call-id",
@@ -106,143 +106,6 @@ function mockAgentsPathProbe(
     }
     return originalExec(command, options);
   });
-}
-
-class RemotePathMappedRuntime extends LocalRuntime {
-  private readonly localWorkspaceRoot: string;
-  private readonly remoteWorkspaceRoot: string;
-  private readonly localHomeForTildeRoot: string | null;
-
-  constructor(localWorkspaceRoot: string, remoteWorkspaceRoot: string) {
-    super(localWorkspaceRoot);
-    this.localWorkspaceRoot = path.resolve(localWorkspaceRoot);
-    this.remoteWorkspaceRoot =
-      remoteWorkspaceRoot === "/" ? remoteWorkspaceRoot : remoteWorkspaceRoot.replace(/\/+$/u, "");
-
-    if (this.remoteWorkspaceRoot === "~") {
-      this.localHomeForTildeRoot = this.localWorkspaceRoot;
-    } else if (this.remoteWorkspaceRoot.startsWith("~/")) {
-      const homeRelativeSuffix = this.remoteWorkspaceRoot.slice(1);
-      const normalizedLocalRoot = this.localWorkspaceRoot.replaceAll("\\", "/");
-      if (normalizedLocalRoot.endsWith(homeRelativeSuffix)) {
-        const derivedHome = normalizedLocalRoot.slice(
-          0,
-          normalizedLocalRoot.length - homeRelativeSuffix.length
-        );
-        this.localHomeForTildeRoot = derivedHome.length > 0 ? derivedHome : "/";
-      } else {
-        this.localHomeForTildeRoot = null;
-      }
-    } else {
-      this.localHomeForTildeRoot = null;
-    }
-  }
-
-  private usesTildeWorkspaceRoot(): boolean {
-    return this.remoteWorkspaceRoot === "~" || this.remoteWorkspaceRoot.startsWith("~/");
-  }
-
-  private toLocalPath(runtimePath: string): string {
-    const normalizedRuntimePath = runtimePath.replaceAll("\\", "/");
-
-    if (normalizedRuntimePath === this.remoteWorkspaceRoot) {
-      return this.localWorkspaceRoot;
-    }
-
-    if (normalizedRuntimePath.startsWith(`${this.remoteWorkspaceRoot}/`)) {
-      const suffix = normalizedRuntimePath.slice(this.remoteWorkspaceRoot.length + 1);
-      return path.join(this.localWorkspaceRoot, ...suffix.split("/"));
-    }
-
-    return runtimePath;
-  }
-
-  private toRemotePath(localPath: string): string {
-    const resolvedLocalPath = path.resolve(localPath);
-
-    if (resolvedLocalPath === this.localWorkspaceRoot) {
-      return this.remoteWorkspaceRoot;
-    }
-
-    const localPrefix = `${this.localWorkspaceRoot}${path.sep}`;
-    if (resolvedLocalPath.startsWith(localPrefix)) {
-      const suffix = resolvedLocalPath.slice(localPrefix.length).split(path.sep).join("/");
-      return `${this.remoteWorkspaceRoot}/${suffix}`;
-    }
-
-    return localPath.replaceAll("\\", "/");
-  }
-
-  private translateCommandToLocal(command: string): string {
-    return command
-      .split(this.remoteWorkspaceRoot)
-      .join(this.localWorkspaceRoot.replaceAll("\\", "/"));
-  }
-
-  override normalizePath(targetPath: string, basePath: string): string {
-    const normalizedBasePath = this.toRemotePath(basePath);
-    const normalizedTargetPath = targetPath.replaceAll("\\", "/");
-
-    if (normalizedBasePath === "~" || normalizedBasePath.startsWith("~/")) {
-      if (
-        normalizedTargetPath === "~" ||
-        normalizedTargetPath.startsWith("~/") ||
-        normalizedTargetPath.startsWith("/")
-      ) {
-        return normalizedTargetPath;
-      }
-      return path.posix.normalize(path.posix.join(normalizedBasePath, normalizedTargetPath));
-    }
-
-    return path.posix.resolve(normalizedBasePath, normalizedTargetPath);
-  }
-
-  override async resolvePath(filePath: string): Promise<string> {
-    const resolvedLocalPath = await super.resolvePath(this.toLocalPath(filePath));
-    return this.toRemotePath(resolvedLocalPath);
-  }
-
-  override exec(
-    command: string,
-    options: Parameters<LocalRuntime["exec"]>[1]
-  ): ReturnType<LocalRuntime["exec"]> {
-    const usesTildeRoot = this.usesTildeWorkspaceRoot();
-    const localHomeForTildeRoot =
-      this.localHomeForTildeRoot ?? process.env.HOME ?? this.localWorkspaceRoot;
-
-    return super.exec(usesTildeRoot ? command : this.translateCommandToLocal(command), {
-      ...options,
-      cwd: this.toLocalPath(options.cwd),
-      env: usesTildeRoot
-        ? {
-            ...(options.env ?? {}),
-            HOME: localHomeForTildeRoot,
-          }
-        : options.env,
-    });
-  }
-
-  override stat(filePath: string, abortSignal?: AbortSignal): ReturnType<LocalRuntime["stat"]> {
-    return super.stat(this.toLocalPath(filePath), abortSignal);
-  }
-
-  override readFile(
-    filePath: string,
-    abortSignal?: AbortSignal
-  ): ReturnType<LocalRuntime["readFile"]> {
-    return super.readFile(this.toLocalPath(filePath), abortSignal);
-  }
-
-  override writeFile(
-    filePath: string,
-    abortSignal?: AbortSignal
-  ): ReturnType<LocalRuntime["writeFile"]> {
-    return super.writeFile(this.toLocalPath(filePath), abortSignal);
-  }
-
-  override ensureDir(dirPath: string): ReturnType<LocalRuntime["ensureDir"]> {
-    return super.ensureDir(this.toLocalPath(dirPath));
-  }
 }
 
 /** Simulates BSD/macOS where readlink doesn't support -f */

--- a/src/node/utils/runtime/helpers.test.ts
+++ b/src/node/utils/runtime/helpers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { ExecOptions, ExecStream, FileStat, Runtime } from "@/node/runtime/Runtime";
 import { getLegacyPlanFilePath, getPlanFilePath } from "@/common/utils/planStorage";
-import { shellQuote } from "@/common/utils/shell";
 import { copyPlanFileAcrossRuntimes, movePlanFile, readPlanFile } from "./helpers";
 
 interface MockRuntimeState {
@@ -194,7 +193,7 @@ describe("copyPlanFileAcrossRuntimes", () => {
 });
 
 describe("readPlanFile", () => {
-  it("resolves paths before building the quoted migration command", async () => {
+  it("passes unresolved migration paths through pathEnv", async () => {
     const workspaceName = "workspace-a1b2";
     const projectName = "demo-project";
     const workspaceId = "legacy-workspace-id";
@@ -206,16 +205,12 @@ describe("readPlanFile", () => {
     const planDir = planPath.substring(0, planPath.lastIndexOf("/"));
 
     const resolvedPlanPath = "/home/dev/.mux/plans/demo-project/workspace-a1b2.md";
-    const resolvedPlanDir = "/home/dev/.mux/plans/demo-project";
-    const resolvedLegacyPath = "/home/dev/.mux/plans/legacy-workspace-id.md";
 
     const state = createRuntimeState(xumHome, {
       [legacyPath]: legacyContent,
     });
 
     state.resolvedPaths.set(planPath, resolvedPlanPath);
-    state.resolvedPaths.set(planDir, resolvedPlanDir);
-    state.resolvedPaths.set(legacyPath, resolvedLegacyPath);
 
     const result = await readPlanFile(
       createMockRuntime(state),
@@ -231,11 +226,18 @@ describe("readPlanFile", () => {
     });
     expect(state.readAttempts).toEqual([planPath, legacyPath]);
     expect(state.execCalls).toHaveLength(1);
-    expect(state.execCalls[0]?.command).toBe(
-      `mkdir -p ${shellQuote(resolvedPlanDir)} && mv ${shellQuote(resolvedLegacyPath)} ${shellQuote(resolvedPlanPath)}`
-    );
-    expect(state.execCalls[0]?.options).toMatchObject({ cwd: "/tmp", timeout: 5 });
-    expect(state.execCalls[0]?.command.includes("'~")).toBe(false);
+    expect(state.execCalls[0]).toEqual({
+      command: 'mkdir -p "$XUM_PLAN_DIR" && mv "$XUM_LEGACY_PLAN" "$XUM_PLAN"',
+      options: {
+        cwd: "/tmp",
+        pathEnv: {
+          XUM_PLAN_DIR: planDir,
+          XUM_LEGACY_PLAN: legacyPath,
+          XUM_PLAN: planPath,
+        },
+        timeout: 5,
+      },
+    });
   });
 
   it.each([
@@ -277,7 +279,7 @@ describe("readPlanFile", () => {
 });
 
 describe("movePlanFile", () => {
-  it("uses resolved absolute paths when constructing the mv command", async () => {
+  it("passes unresolved plan paths through pathEnv", async () => {
     const oldWorkspaceName = "old-workspace";
     const newWorkspaceName = "new-workspace";
     const projectName = "demo-project";
@@ -285,22 +287,24 @@ describe("movePlanFile", () => {
 
     const oldPath = getPlanFilePath(oldWorkspaceName, projectName, xumHome);
     const newPath = getPlanFilePath(newWorkspaceName, projectName, xumHome);
-    const resolvedOldPath = "/home/dev/.mux/plans/demo-project/old-workspace.md";
-    const resolvedNewPath = "/home/dev/.mux/plans/demo-project/new-workspace.md";
 
     const state = createRuntimeState(xumHome, {
       [oldPath]: "# old plan\n",
     });
 
-    state.resolvedPaths.set(oldPath, resolvedOldPath);
-    state.resolvedPaths.set(newPath, resolvedNewPath);
-
     await movePlanFile(createMockRuntime(state), oldWorkspaceName, newWorkspaceName, projectName);
 
     expect(state.execCalls).toHaveLength(1);
-    expect(state.execCalls[0]?.command).toBe(
-      `mv ${shellQuote(resolvedOldPath)} ${shellQuote(resolvedNewPath)}`
-    );
-    expect(state.execCalls[0]?.options).toMatchObject({ cwd: "/tmp", timeout: 5 });
+    expect(state.execCalls[0]).toEqual({
+      command: 'mv "$XUM_OLD_PLAN" "$XUM_NEW_PLAN"',
+      options: {
+        cwd: "/tmp",
+        pathEnv: {
+          XUM_OLD_PLAN: oldPath,
+          XUM_NEW_PLAN: newPath,
+        },
+        timeout: 5,
+      },
+    });
   });
 });

--- a/src/node/utils/runtime/helpers.ts
+++ b/src/node/utils/runtime/helpers.ts
@@ -2,7 +2,6 @@ import type { Runtime, ExecOptions } from "@/node/runtime/Runtime";
 import { streamToString, streamToStringCapped } from "@/node/runtime/streamUtils";
 import { PlatformPaths } from "@/node/utils/paths.main";
 import { getLegacyPlanFilePath, getPlanFilePath } from "@/common/utils/planStorage";
-import { shellQuote } from "@/common/utils/shell";
 
 /**
  * Convenience helpers for working with streaming Runtime APIs.
@@ -151,16 +150,18 @@ export async function readPlanFile(
     try {
       const content = await readFileString(runtime, legacyPath);
       // Migrate: move to new location.
-      // Resolve paths first because shellQuote() intentionally prevents ~ expansion.
       try {
         const planDir = planPath.substring(0, planPath.lastIndexOf("/"));
-        const resolvedPlanDir = await runtime.resolvePath(planDir);
-        const resolvedLegacyPath = await runtime.resolvePath(legacyPath);
         await execBuffered(
           runtime,
-          `mkdir -p ${shellQuote(resolvedPlanDir)} && mv ${shellQuote(resolvedLegacyPath)} ${shellQuote(resolvedPath)}`,
+          'mkdir -p "$XUM_PLAN_DIR" && mv "$XUM_LEGACY_PLAN" "$XUM_PLAN"',
           {
             cwd: "/tmp",
+            pathEnv: {
+              XUM_PLAN_DIR: planDir,
+              XUM_LEGACY_PLAN: legacyPath,
+              XUM_PLAN: planPath,
+            },
             timeout: 5,
           }
         );
@@ -224,17 +225,14 @@ export async function movePlanFile(
 
   try {
     await runtime.stat(oldPath);
-    // Resolve tildes to absolute paths - bash doesn't expand ~ inside quotes
-    const resolvedOldPath = await runtime.resolvePath(oldPath);
-    const resolvedNewPath = await runtime.resolvePath(newPath);
-    await execBuffered(
-      runtime,
-      `mv ${shellQuote(resolvedOldPath)} ${shellQuote(resolvedNewPath)}`,
-      {
-        cwd: "/tmp",
-        timeout: 5,
-      }
-    );
+    await execBuffered(runtime, 'mv "$XUM_OLD_PLAN" "$XUM_NEW_PLAN"', {
+      cwd: "/tmp",
+      pathEnv: {
+        XUM_OLD_PLAN: oldPath,
+        XUM_NEW_PLAN: newPath,
+      },
+      timeout: 5,
+    });
   } catch {
     // No plan file to move, that's fine
   }

--- a/src/node/utils/runtime/helpers.ts
+++ b/src/node/utils/runtime/helpers.ts
@@ -239,40 +239,6 @@ export async function movePlanFile(
 }
 
 /**
- * Copy a plan file from one workspace to another (e.g., during fork).
- * Checks both new path format and legacy path format for the source.
- * Silently succeeds if source file doesn't exist at either location.
- */
-export async function copyPlanFile(
-  runtime: Runtime,
-  sourceWorkspaceName: string,
-  sourceWorkspaceId: string,
-  targetWorkspaceName: string,
-  projectName: string
-): Promise<void> {
-  const xumHome = runtime.getXumHome();
-  const sourcePath = getPlanFilePath(sourceWorkspaceName, projectName, xumHome);
-  const legacySourcePath = getLegacyPlanFilePath(sourceWorkspaceId, xumHome);
-  const targetPath = getPlanFilePath(targetWorkspaceName, projectName, xumHome);
-
-  // Prefer the new layout, but fall back to the legacy layout.
-  //
-  // Note: we intentionally use runtime file I/O instead of `cp` because:
-  // 1) bash doesn't expand ~ inside quotes
-  // 2) the target per-project plan directory may not exist yet
-  // 3) runtime.writeFile() already handles directory creation + tilde expansion
-  for (const candidatePath of [sourcePath, legacySourcePath]) {
-    try {
-      const content = await readFileString(runtime, candidatePath);
-      await writeFileString(runtime, targetPath, content);
-      return;
-    } catch {
-      // Try next candidate
-    }
-  }
-}
-
-/**
  * Copy a plan file across runtimes (e.g., during fork where source/target may be
  * different containers). Uses separate runtime handles to avoid the identity mutation
  * bug where DockerRuntime.forkWorkspace() changes this.containerName to the target.


### PR DESCRIPTION
## Summary

Deepens the Runtime seam so execution-environment quirks live inside adapters instead of leaking to callers: adapters now own exec-namespace path translation (new `ExecOptions.pathEnv`) and file I/O canonicalizes tilde/relative paths internally, and `mapPathForExec` is removed from the public `Runtime` interface.

## Background

`Runtime` is the seam between services/tools and 9 production adapters (local worktree, SSH, Coder, Devcontainer, Docker, ...), but environment invariants escaped it. Callers had to remember `runtime.mapPathForExec(...)` before embedding paths in exec scripts or env vars (forgetting broke only on Devcontainer, where host worktree paths are meaningless inside the container), and to pre-`resolvePath` before file I/O. This PR moves those rituals inside the adapters so callers can treat Runtime as a cohesive virtual execution environment.

This is one of a set of parallel architecture-improvement PRs; it stays strictly inside the Runtime seam.

## Implementation

- `ExecOptions.pathEnv`: env vars whose values are host paths that must be valid in the exec namespace. Every adapter translates and exports them itself (local runtimes expand host-side with the same `expandTilde`/`getXumHome` semantics as their file I/O; remote runtimes use an in-shell `export` prelude; Devcontainer maps host paths to container paths and passes `--remote-env`). `ExecOptions.cwd` is likewise translated by the adapter, and background wrappers cannot shadow pathEnv keys with caller env.
- Review-round hardening: Windows drive-letter/UNC values pass through shell path exports untouched (Git Bash accepts them natively), and remote file operations propagate their abort signals through path resolution instead of waiting out the resolver.
- `backgroundProcessExecutor` and `hooks` no longer call `mapPathForExec`: the background wrapper resolves its cwd from a translated env var, and hooks pass `XUM_PROJECT_DIR`/hook paths via `pathEnv` (preserving the issue #3709 contract that hooks see exec-namespace paths).
- `readFile`/`writeFile`/`stat`/`ensureDir` canonicalize tilde and relative paths internally across all adapters; caller-side `resolvePath` preludes were deleted where they existed only to make file I/O work (`resolvePath` stays for callers that need the canonical path as a value).
- `mapPathForExec` is gone from the `Runtime` interface (Devcontainer keeps the translation private).
- Net simplification: the branch lands net-negative vs main (+816/-866 lines). The duplicated exec-backed file I/O plumbing (readFile/writeFile/stat/ensureDir streaming, abort forwarding, error wrapping) in `RemoteRuntime` and `DevcontainerRuntime` moved into a shared `execFileIO` module that takes a start-exec factory; each adapter keeps only its command construction and path canonicalization. Devcontainer's in-container `readFile` thereby gains the cancel-kills-the-remote-cat abort handling `RemoteRuntime` already had.
- Test boilerplate consolidated: a shared `TestRemoteRuntime` stub replaces per-suite concrete `RemoteRuntime` scaffolding, and `xum_agents.test.ts` reuses the shared `RemotePathMappedRuntime` fake instead of a duplicate copy (the `agent_skill_read` fake stays local on purpose: its non-translating `exec` emulates a true split-root remote for the realpath escape probe). Dead `copyPlanFile` and a local `shellEscape` (replaced by the shared `shellQuote`) were deleted, and private-method tests were collapsed into behavior tests.
- Out of scope, intentionally untouched: `createFlags` absorption into `createWorkspace` (Coder deferred access + collision detection). Absorbing it would require a disproportionately large workspace-creation protocol redesign; it is a coherent follow-up, and no call site is left half-migrated.

## Validation

- Behavior-preservation was the hard requirement: remote dogfood UAT ran the full local-runtime lifecycle (workspace creation, bash cwd, relative/tilde file read/edit, background processes, missing-cwd errors, `tool_env`/hook `XUM_PROJECT_DIR`) side by side against trunk at the same base and found byte-identical user-visible behavior, including on paths with spaces.
- SSH/Devcontainer/Docker semantics are pinned by the adapter test suites; Devcontainer path translation, background cwd mapping, and hook path mapping now have runtime-level tests instead of only caller-level ones.

- After the consolidation pass: `make static-check` green and 272 tests across the 13 touched suites pass locally.

## Risks

Medium-touch refactor of path handling across all adapters. Highest-risk areas are Devcontainer exec (cwd/env translation) and background process spawning; both are covered by unit tests and the trunk-parity UAT above. Local and SSH runtimes canonicalize via the same helper (`buildShellPathExport`), so a quoting regression would surface across suites.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$118.37`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=118.37 -->


