### PR TITLE
🤖 refactor: return slash command results instead of mutating the composer

### DIFF
--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -78,7 +78,8 @@ import {
 import {
   prepareCompactionMessage,
   processSlashCommand,
-  type SlashCommandContext,
+  type CommandAction,
+  type SlashCommandEnv,
 } from "@/browser/utils/chatCommands";
 import {
   addWorkflowRunCardMessageForRun,
@@ -2474,62 +2475,100 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     // Prepare file parts for commands that need to send messages with attachments
     const commandFileParts = chatAttachmentsToFileParts(attachments, { validate: true });
     const asyncCommandToken = ++asyncCommandTokenRef.current;
-    const commandContext: SlashCommandContext = {
+    const commandEnv: SlashCommandEnv = {
       api,
       variant,
       workspaceId: commandWorkspaceId,
       projectPath: commandProjectPath,
       rawInput: restoreInput,
       dynamicWorkflowsEnabled: dynamicWorkflowsExperimentEnabled,
-      openSettings: open,
       currentModel: workspaceSidebarState?.currentModel ?? null,
       sendMessageOptions: commandSendMessageOptions,
-      getInput: () => getDraft().text,
-      setInput,
-      setAttachments,
-      setSendingState: (increment: boolean) => setSendingCount((c) => c + (increment ? 1 : -1)),
-      setToast,
-      setPreferredModel,
-      setVimEnabled,
-      asyncCommandToken,
-      isAsyncCommandCurrent: (token, originWorkspaceId) => {
-        const scope = asyncCommandScopeRef.current;
-        return (
-          token === asyncCommandTokenRef.current &&
-          scope.variant === "workspace" &&
-          scope.workspaceId === originWorkspaceId
-        );
-      },
-      onResetContext: variant === "workspace" ? props.onResetContext : undefined,
-      onTruncateHistory: variant === "workspace" ? props.onTruncateHistory : undefined,
-      resetInputHeight: () => {
-        if (inputRef.current) {
-          inputRef.current.style.height = "";
-        }
-      },
+      resetContext: variant === "workspace" ? props.onResetContext : undefined,
+      truncateHistory: variant === "workspace" ? props.onTruncateHistory : undefined,
       editMessageId: editingMessageForUi?.id,
-      onCancelEdit: commandOnCancelEdit,
       reviews: reviewsData,
       attachments,
       fileParts: commandFileParts.length > 0 ? commandFileParts : undefined,
-      onMessageSent: variant === "workspace" ? props.onMessageSent : undefined,
-      onDetachAllReviews: variant === "workspace" ? props.onDetachAllReviews : undefined,
-      onCheckReviews: variant === "workspace" ? props.onCheckReviews : undefined,
       attachedReviewIds: reviewIdsForCheck,
+      isCurrent: () => {
+        const scope = asyncCommandScopeRef.current;
+        return (
+          asyncCommandToken === asyncCommandTokenRef.current &&
+          scope.variant === "workspace" &&
+          scope.workspaceId === commandWorkspaceId
+        );
+      },
     };
 
-    const result = await processSlashCommand(parsed, commandContext);
-
-    if (!result.clearInput) {
-      setInput(restoreInput);
-    } else {
-      setDraftReviews(null);
-      if (variant === "workspace" && parsed.type === "compact") {
-        if (reviewIdsForCheck.length > 0) {
-          props.onCheckReviews?.(reviewIdsForCheck);
+    // Command actions stop at the caller's UI boundary; creation mode intentionally has its own applier.
+    const applyCommandActions = (actions: CommandAction[]) => {
+      for (const action of actions) {
+        switch (action.type) {
+          case "clear-input":
+            setInput("");
+            break;
+          case "reset-input-height":
+            if (inputRef.current) inputRef.current.style.height = "";
+            break;
+          case "show-toast":
+            setToast(action.toast);
+            break;
+          case "set-preferred-model":
+            setPreferredModel(action.model);
+            break;
+          case "toggle-vim":
+            setVimEnabled((enabled) => !enabled);
+            break;
+          case "set-sending":
+            setSendingCount((count) => count + (action.sending ? 1 : -1));
+            break;
+          case "clear-attachments":
+            setAttachments([]);
+            break;
+          case "detach-reviews":
+            if (variant === "workspace") props.onDetachAllReviews?.();
+            break;
+          case "check-reviews":
+            if (variant === "workspace" && action.reviewIds.length > 0) {
+              props.onCheckReviews?.(action.reviewIds);
+            }
+            break;
+          case "message-sent":
+            if (variant === "workspace") props.onMessageSent?.(action.dispatchMode);
+            break;
+          case "cancel-edit":
+            commandOnCancelEdit?.();
+            break;
         }
-        props.onMessageSent?.(dispatchMode);
       }
+    };
+
+    let result = await processSlashCommand(parsed, commandEnv);
+    while (result.kind === "phase") {
+      applyCommandActions(result.actions);
+      result = await result.continue();
+    }
+    applyCommandActions(result.actions);
+    if (result.backgroundTask) {
+      void result.backgroundTask().then(applyCommandActions);
+    }
+
+    switch (result.inputDisposition) {
+      case "consume":
+        if (getDraft().text === restoreInput) setInput("");
+        setDraftReviews(null);
+        break;
+      case "restore":
+        setInput(restoreInput);
+        break;
+      case "restore-if-empty":
+        if (getDraft().text.trim().length === 0) {
+          setInput(restoreInput);
+        } else {
+          setDraftReviews(null);
+        }
+        break;
     }
 
     return true;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2554,21 +2554,20 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       void result.backgroundTask().then(applyCommandActions);
     }
 
-    // Async command phases can outlive the invoking render, so the disposition
-    // must be evaluated against the live persisted draft: the getDraft closure
-    // captured here still reports this render's input and would clear or refuse
-    // to restore a newer draft typed while the command ran.
-    const liveDraftText = () => readPersistedState(storageKeys.inputKey, "");
     switch (result.inputDisposition) {
       case "consume":
-        if (liveDraftText() === restoreInput) setInput("");
+        // Commands clear the composer through their own clear-input actions;
+        // clearing again here would wipe a draft typed while phases ran.
         setDraftReviews(null);
         break;
       case "restore":
         setInput(restoreInput);
         break;
       case "restore-if-empty":
-        if (liveDraftText().trim().length === 0) {
+        // Async phases can outlive the invoking render, so check the live
+        // persisted draft: the getDraft closure captured here still reports
+        // this render's input and would refuse to restore over a newer draft.
+        if (readPersistedState(storageKeys.inputKey, "").trim().length === 0) {
           setInput(restoreInput);
         } else {
           setDraftReviews(null);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2554,16 +2554,21 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       void result.backgroundTask().then(applyCommandActions);
     }
 
+    // Async command phases can outlive the invoking render, so the disposition
+    // must be evaluated against the live persisted draft: the getDraft closure
+    // captured here still reports this render's input and would clear or refuse
+    // to restore a newer draft typed while the command ran.
+    const liveDraftText = () => readPersistedState(storageKeys.inputKey, "");
     switch (result.inputDisposition) {
       case "consume":
-        if (getDraft().text === restoreInput) setInput("");
+        if (liveDraftText() === restoreInput) setInput("");
         setDraftReviews(null);
         break;
       case "restore":
         setInput(restoreInput);
         break;
       case "restore-if-empty":
-        if (getDraft().text.trim().length === 0) {
+        if (liveDraftText().trim().length === 0) {
           setInput(restoreInput);
         } else {
           setDraftReviews(null);

--- a/src/browser/features/ChatInput/useCreationWorkspace.ts
+++ b/src/browser/features/ChatInput/useCreationWorkspace.ts
@@ -66,7 +66,11 @@ import {
 } from "@/browser/features/ChatInput/draftAttachmentsStorage";
 import type { MuxMessageMetadata } from "@/common/types/message";
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
-import { processSlashCommand, type SlashCommandContext } from "@/browser/utils/chatCommands";
+import {
+  processSlashCommand,
+  type CommandAction,
+  type SlashCommandEnv,
+} from "@/browser/utils/chatCommands";
 import { CUSTOM_EVENTS, createCustomEvent } from "@/common/constants/events";
 import {
   useWorkspaceName,
@@ -741,7 +745,7 @@ export function useCreationWorkspace({
 
         if (initialSlashCommand) {
           await initialAiSettingsPersisted;
-          const commandContext: SlashCommandContext = {
+          const commandEnv: SlashCommandEnv = {
             api,
             workspaceId: metadata.id,
             variant: "workspace",
@@ -749,18 +753,25 @@ export function useCreationWorkspace({
             rawInput: messageText,
             dynamicWorkflowsEnabled,
             sendMessageOptions,
-            setInput: () => undefined,
-            setAttachments: () => undefined,
-            setSendingState: () => undefined,
-            setToast,
-            setPreferredModel: () => undefined,
-            setVimEnabled: () => undefined,
-            resetInputHeight: () => undefined,
           };
-          const commandResult = await processSlashCommand(initialSlashCommand, commandContext);
+          // Creation owns only toast state; composer actions intentionally remain local to ChatInput.
+          const applyCommandActions = (actions: CommandAction[]) => {
+            for (const action of actions) {
+              if (action.type === "show-toast") setToast(action.toast);
+            }
+          };
+          let commandResult = await processSlashCommand(initialSlashCommand, commandEnv);
+          while (commandResult.kind === "phase") {
+            applyCommandActions(commandResult.actions);
+            commandResult = await commandResult.continue();
+          }
+          applyCommandActions(commandResult.actions);
+          if (commandResult.backgroundTask) {
+            void commandResult.backgroundTask().then(applyCommandActions);
+          }
           setIsSending(false);
 
-          if (!commandResult.clearInput) {
+          if (commandResult.inputDisposition !== "consume") {
             workspaceStore.clearPendingInitialSendState(metadata.id);
             return { success: false };
           }

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -860,6 +860,7 @@ describe("detached command work", () => {
     expect(result.kind).toBe("complete");
     if (result.kind !== "complete") throw new Error("expected complete result");
     expectDisposition(result, "consume");
+    expect(result.actions).toEqual([{ type: "clear-input" }]);
     expect(consolidate).not.toHaveBeenCalled();
     const successActions = await result.backgroundTask?.();
     expect(successActions).toBeDefined();
@@ -913,7 +914,8 @@ describe("detached command work", () => {
     if (missingProposal.kind !== "complete") throw new Error("expected complete result");
     expectDisposition(missingProposal, "consume");
     expect(missingProposal.backgroundTask).toBeUndefined();
-    expect(missingProposal.actions[0]).toMatchObject({
+    expect(missingProposal.actions[0]).toEqual({ type: "clear-input" });
+    expect(missingProposal.actions[1]).toMatchObject({
       type: "show-toast",
       toast: { type: "error" },
     });

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -1095,6 +1095,84 @@ describe("compact and plan command results", () => {
       message: "No plan found for this workspace",
     });
   });
+
+  test("plan open with no plan consumes with an error toast and skips the editor", async () => {
+    const getInfo = mock(() => Promise.resolve(null));
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "plan-open" },
+        createEnv({
+          api: {
+            workspace: {
+              getPlanContent: mock(() =>
+                Promise.resolve({ success: false, error: "No plan found" })
+              ),
+              getInfo,
+            },
+          } as unknown as SlashCommandEnv["api"],
+        })
+      )
+    );
+    expectDisposition(settled.result, "consume");
+    expectToast(settled.result.actions, {
+      type: "error",
+      message: "No plan found for this workspace",
+    });
+    expect(getInfo).not.toHaveBeenCalled();
+  });
+
+  test("plan open surfaces an editor-open failure as an error toast", async () => {
+    const getPlanContent = mock(() =>
+      Promise.resolve({ success: true, data: { content: "# My Plan", path: "/path/to/plan.md" } })
+    );
+    const getInfo = mock(() =>
+      Promise.resolve({ runtimeConfig: { type: "local" } } as unknown as FrontendWorkspaceMetadata)
+    );
+    // openInEditor opens a blank placeholder window before its awaits; give it a
+    // live stub so the flow reaches the recordEditorOpen admission check, whose
+    // refusal is the deterministic failure path independent of deep-link launch.
+    const windowWithOpen = window as unknown as { open?: (...args: unknown[]) => unknown };
+    const previousOpen = windowWithOpen.open;
+    windowWithOpen.open = () => ({
+      closed: false,
+      close: () => undefined,
+      location: { href: "" },
+    });
+    // This suite aliases window to globalThis, which turns the tests/setup.ts
+    // location getter (window.location fallback) into infinite recursion when
+    // deep-link code reads location. Pin an own-value location for this test.
+    const previousLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { href: "http://localhost/", hostname: "localhost" },
+    });
+    try {
+      const settled = await finishCommand(
+        await processSlashCommand(
+          { type: "plan-open" },
+          createEnv({
+            api: {
+              workspace: { getPlanContent, getInfo },
+              general: {
+                recordEditorOpen: mock(() =>
+                  Promise.resolve({ success: false, error: "Archive in progress" })
+                ),
+              },
+            } as unknown as SlashCommandEnv["api"],
+          })
+        )
+      );
+      expectDisposition(settled.result, "consume");
+      expectToast(settled.result.actions, { type: "error", message: "Archive in progress" });
+      expect(getPlanContent).toHaveBeenCalledWith({ workspaceId: "test-ws" });
+      expect(getInfo).toHaveBeenCalledWith({ workspaceId: "test-ws" });
+    } finally {
+      windowWithOpen.open = previousOpen;
+      if (previousLocation) {
+        Object.defineProperty(globalThis, "location", previousLocation);
+      }
+    }
+  });
 });
 
 describe("prepareCompactionMessage", () => {

--- a/src/browser/utils/chatCommands.test.ts
+++ b/src/browser/utils/chatCommands.test.ts
@@ -1,17 +1,17 @@
-import { describe, expect, test, beforeEach, mock, spyOn } from "bun:test";
+import { describe, expect, test, beforeEach, mock } from "bun:test";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import { EXPERIMENT_IDS, getExperimentKey } from "@/common/constants/experiments";
 import {
   parseRuntimeString,
   prepareCompactionMessage,
-  handlePlanShowCommand,
-  handlePlanOpenCommand,
-  handleCompactCommand,
   WORKFLOW_FREEFORM_ARGS_ERROR_MESSAGE,
   processSlashCommand,
+  type CommandAction,
+  type CommandInputDisposition,
+  type CommandResult,
+  type SlashCommandEnv,
 } from "./chatCommands";
 import { parseCommand } from "./slashCommands/parser";
-import type { CommandHandlerContext, SlashCommandContext } from "./chatCommands";
 import type { ReviewNoteData } from "@/common/types/review";
 import { useWorkspaceStoreRaw, workspaceStore } from "@/browser/stores/WorkspaceStore";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
@@ -112,728 +112,484 @@ function ensureWindowDispatchEvent(): void {
   Object.defineProperty(window, "dispatchEvent", { value: mock(() => true), configurable: true });
 }
 
-function createSlashCommandContext(
-  overrides: Partial<SlashCommandContext> & Pick<SlashCommandContext, "api">
-): SlashCommandContext {
+const sendMessageOptions: SendMessageOptions = {
+  model: "anthropic:claude-sonnet-4-6",
+  thinkingLevel: "off",
+  toolPolicy: [],
+  agentId: "exec",
+};
+
+function createEnv(overrides: Partial<SlashCommandEnv> = {}): SlashCommandEnv {
   return {
+    api: null,
     workspaceId: "test-ws",
     variant: "workspace",
     projectPath: "/tmp/project",
-    setPreferredModel: mock(() => undefined),
-    setVimEnabled: mock((cb: (prev: boolean) => boolean) => cb(false)),
-    resetInputHeight: mock(() => undefined),
-    onTruncateHistory: mock(() => Promise.resolve(undefined)),
-    sendMessageOptions: {
-      model: "anthropic:claude-sonnet-4-6",
-      thinkingLevel: "off",
-      toolPolicy: [],
-      agentId: "exec",
-    },
-    setInput: mock(() => undefined),
-    setToast: mock(() => undefined),
-    setAttachments: mock(() => undefined),
-    setSendingState: mock(() => undefined),
+    sendMessageOptions,
     ...overrides,
   };
 }
 
-function createGoalCommandContext(api: SlashCommandContext["api"]): SlashCommandContext {
-  return createSlashCommandContext({
-    api,
-    workspaceId: "goal-ws",
-    onMessageSent: mock(() => undefined),
-    onCheckReviews: mock(() => undefined),
-    attachedReviewIds: [],
-    openSettings: mock(() => undefined),
-  });
+type CompleteCommandResult = Extract<CommandResult, { kind: "complete" }>;
+
+async function finishCommand(result: CommandResult): Promise<{
+  batches: CommandAction[][];
+  result: CompleteCommandResult;
+}> {
+  const batches: CommandAction[][] = [];
+  while (result.kind === "phase") {
+    batches.push(result.actions);
+    result = await result.continue();
+  }
+  batches.push(result.actions);
+  return { batches, result };
 }
 
-describe("processSlashCommand - workflow", () => {
-  test("rejects workflow execution when dynamic workflows are disabled", async () => {
+function expectDisposition(result: CompleteCommandResult, expected: CommandInputDisposition): void {
+  expect(result.inputDisposition).toBe(expected);
+}
+
+function expectToast(
+  actions: CommandAction[],
+  expected: { type: "success" | "error"; message: string; title?: string }
+): void {
+  const action = actions.find(
+    (candidate): candidate is Extract<CommandAction, { type: "show-toast" }> =>
+      candidate.type === "show-toast"
+  );
+  expect(action?.toast.type).toBe(expected.type);
+  expect(action?.toast.message).toBe(expected.message);
+  if (expected.title) expect(action?.toast.title).toBe(expected.title);
+}
+
+function setHeartbeatExperiment(enabled: boolean): void {
+  localStorage.setItem(
+    getExperimentKey(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS),
+    JSON.stringify(enabled)
+  );
+}
+
+const completedWorkflowRun = {
+  id: "wfr_123",
+  workspaceId: "test-ws",
+  workflow: {
+    name: "skill://deep-research/workflow.js",
+    description: "Deep research",
+    scope: "built-in",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:test",
+  args: { input: "mux" },
+  status: "completed" as const,
+  createdAt: "2026-05-29T00:00:00.000Z",
+  updatedAt: "2026-05-29T00:00:01.000Z",
+  events: [],
+  steps: [],
+};
+
+describe("processSlashCommand workflow results", () => {
+  test("returns validation failures without starting a workflow", async () => {
     const start = mock(() =>
       Promise.resolve({ runId: "wfr_123", status: "running", result: null })
     );
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start },
-      } as unknown as SlashCommandContext["api"],
-      dynamicWorkflowsEnabled: false,
-    });
+    const disabled = await processSlashCommand(
+      { type: "workflow-run", scriptPath: "skill://deep-research/workflow.js", argsText: "{}" },
+      createEnv({
+        api: { workflows: { start } } as unknown as SlashCommandEnv["api"],
+        dynamicWorkflowsEnabled: false,
+      })
+    );
+    expect(disabled.kind).toBe("complete");
+    if (disabled.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(disabled, "restore");
+    expectToast(disabled.actions, { type: "error", message: "Dynamic workflows are disabled" });
+    expect(start).not.toHaveBeenCalled();
 
-    const result = await processSlashCommand(
+    const invalidArgs = await processSlashCommand(
       {
         type: "workflow-run",
         scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
+        argsText: "freeform arguments",
       },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(start).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", message: "Dynamic workflows are disabled" })
-    );
-  });
-
-  test("rejects freeform workflow slash arguments", async () => {
-    const start = mock(() =>
-      Promise.resolve({ runId: "wfr_123", status: "running", result: null })
-    );
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start },
-      } as unknown as SlashCommandContext["api"],
-      dynamicWorkflowsEnabled: true,
-    });
-
-    const result = await processSlashCommand(
-      { type: "workflow-run", scriptPath: "skill://deep-research/workflow.js", argsText: "mux" },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(start).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", message: WORKFLOW_FREEFORM_ARGS_ERROR_MESSAGE })
-    );
-  });
-
-  test.each([
-    ['"hello"', "hello"],
-    ["123", 123],
-  ] as const)(
-    "passes JSON scalar workflow slash arguments from %p",
-    async (argsText, expectedArgs) => {
-      const start = mock(() =>
-        Promise.resolve({
-          runId: "wfr_123",
-          status: "running",
-          result: null,
-          invocationMessagePersisted: true,
-        })
-      );
-      const context = createSlashCommandContext({
-        api: {
-          workflows: { start },
-        } as unknown as SlashCommandContext["api"],
-        rawInput: `/workflow ./echo.js ${argsText}`,
+      createEnv({
+        api: { workflows: { start } } as unknown as SlashCommandEnv["api"],
         dynamicWorkflowsEnabled: true,
-      });
+      })
+    );
+    expect(invalidArgs.kind).toBe("complete");
+    if (invalidArgs.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(invalidArgs, "restore");
+    expectToast(invalidArgs.actions, {
+      type: "error",
+      message: WORKFLOW_FREEFORM_ARGS_ERROR_MESSAGE,
+    });
+    expect(start).not.toHaveBeenCalled();
+  });
 
-      const result = await processSlashCommand(
-        { type: "workflow-run", scriptPath: "./echo.js", argsText },
-        context
-      );
-
-      expect(result).toEqual({ clearInput: true, toastShown: true });
-      expect(start).toHaveBeenCalledWith(
-        expect.objectContaining({
-          args: expectedArgs,
-          rawCommand: `/workflow ./echo.js ${argsText}`,
-        })
-      );
-    }
-  );
-
-  test("sends completed workflow slash output to the main agent as hidden context", async () => {
+  test("keeps each workflow await behind a lazy phase", async () => {
     const workflowResult = {
       reportMarkdown: "# Research\n\nFindings",
       structuredOutput: { confidence: "high" },
     };
     const start = mock(() =>
-      Promise.resolve({
-        runId: "wfr_123",
-        status: "completed",
-        result: workflowResult,
-      })
+      Promise.resolve({ runId: "wfr_123", status: "completed" as const, result: workflowResult })
     );
-    const getRun = mock(() =>
-      Promise.resolve({
-        id: "wfr_123",
-        workspaceId: "test-ws",
-        workflow: {
-          name: "skill://deep-research/workflow.js",
-          description: "Deep research",
-          scope: "built-in",
-          executable: true,
-        },
-        source: "export default function workflow() { return null; }",
-        sourceHash: "sha256:test",
-        args: { input: "mux" },
-        status: "completed",
-        createdAt: "2026-05-29T00:00:00.000Z",
-        updatedAt: "2026-05-29T00:00:01.000Z",
-        events: [
-          {
-            sequence: 1,
-            type: "result",
-            at: "2026-05-29T00:00:01.000Z",
-            result: workflowResult,
-          },
-        ],
-        steps: [],
-      })
-    );
-    interface SentWorkflowMessage {
-      message: string;
-      options: { muxMetadata?: { type?: string; rawCommand?: string; commandPrefix?: string } };
-    }
-    const sentMessages: SentWorkflowMessage[] = [];
-    const sendMessage = mock((input: SentWorkflowMessage) => {
+    const getRun = mock(() => Promise.resolve(completedWorkflowRun));
+    const sentMessages: Array<{ message: string; options: { muxMetadata?: { type?: string } } }> =
+      [];
+    const sendMessage = mock((input: (typeof sentMessages)[number]) => {
       sentMessages.push(input);
       return Promise.resolve({ success: true });
     });
-    const onMessageSent = mock(() => undefined);
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-      onMessageSent,
-    });
-
-    const result = await processSlashCommand(
+    const initial = await processSlashCommand(
       {
         type: "workflow-run",
         scriptPath: "skill://deep-research/workflow.js",
         argsText: '{"input":"mux"}',
       },
-      context
+      createEnv({
+        api: {
+          workflows: { start, getRun },
+          workspace: { sendMessage },
+        } as unknown as SlashCommandEnv["api"],
+        rawInput: '/deep-research {"input":"mux"}',
+        dynamicWorkflowsEnabled: true,
+      })
     );
+    expect(initial.kind).toBe("phase");
+    if (initial.kind !== "phase") throw new Error("expected phase result");
+    expect(initial.actions).toEqual([
+      { type: "clear-input" },
+      { type: "set-sending", sending: true },
+    ]);
+    expect(start).not.toHaveBeenCalled();
 
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(start).toHaveBeenCalledWith({
-      workspaceId: "test-ws",
-      scriptPath: "skill://deep-research/workflow.js",
-      runInBackground: true,
-      args: { input: "mux" },
-      rawCommand: '/deep-research {"input":"mux"}',
-      continuationOptions: context.sendMessageOptions,
-    });
-    expect(getRun).toHaveBeenCalledWith({ workspaceId: "test-ws", runId: "wfr_123" });
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    const sendInput = sentMessages[0];
-    expect(sendInput).toBeDefined();
-    expect(sendInput.message).toContain('/deep-research {"input":"mux"}');
-    expect(sendInput.message).toContain("<mux_workflow_result>");
-    expect(sendInput.message).toContain("Findings");
-    expect(sendInput.message).toContain("confidence");
-    expect(sendInput.options.muxMetadata?.type).toBe("workflow-result");
-    expect(sendInput.options.muxMetadata?.rawCommand).toBe('/deep-research {"input":"mux"}');
-    expect(sendInput.options.muxMetadata?.commandPrefix).toBe("/deep-research");
-    expect(context.setSendingState).toHaveBeenNthCalledWith(1, true);
-    expect(context.setSendingState).toHaveBeenNthCalledWith(2, false);
-    expect(context.setSendingState).toHaveBeenNthCalledWith(3, true);
-    expect(context.setSendingState).toHaveBeenNthCalledWith(4, false);
-    expect(onMessageSent).toHaveBeenCalledWith("tool-end");
+    const afterStart = await initial.continue();
+    expect(afterStart.kind).toBe("phase");
+    if (afterStart.kind !== "phase") throw new Error("expected phase result");
+    expect(afterStart.actions).toEqual([{ type: "set-sending", sending: false }]);
+    expect(getRun).not.toHaveBeenCalled();
+
+    const afterPoll = await afterStart.continue();
+    expect(afterPoll.kind).toBe("phase");
+    if (afterPoll.kind !== "phase") throw new Error("expected phase result");
+    expect(afterPoll.actions).toEqual([{ type: "set-sending", sending: true }]);
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    const complete = await afterPoll.continue();
+    expect(complete.kind).toBe("complete");
+    if (complete.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(complete, "consume");
+    expect(complete.actions.slice(0, 2)).toEqual([
+      { type: "set-sending", sending: false },
+      { type: "message-sent", dispatchMode: "tool-end" },
+    ]);
+    expect(complete.actions[2]).toMatchObject({ type: "show-toast", toast: { type: "success" } });
+    expect(sentMessages[0]?.message).toContain("<mux_workflow_result>");
+    expect(sentMessages[0]?.message).toContain("Findings");
+    expect(sentMessages[0]?.options.muxMetadata?.type).toBe("workflow-result");
   });
 
-  test("leaves slash workflow continuation to backend when invocation is persisted", async () => {
+  test("completes after start when the invocation message is already persisted", async () => {
     const start = mock(() =>
       Promise.resolve({
         runId: "wfr_123",
-        status: "running",
+        status: "running" as const,
         result: null,
         invocationMessagePersisted: true,
       })
     );
-    const getRun = mock(() => Promise.resolve(null));
-    const sendMessage = mock(() => Promise.resolve({ success: true }));
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-    });
-
-    const result = await processSlashCommand(
-      {
-        type: "workflow-run",
-        scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
-      },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(start).toHaveBeenCalledWith({
-      workspaceId: "test-ws",
-      scriptPath: "skill://deep-research/workflow.js",
-      runInBackground: true,
-      args: { input: "mux" },
-      rawCommand: '/deep-research {"input":"mux"}',
-      continuationOptions: context.sendMessageOptions,
-    });
-    expect(getRun).not.toHaveBeenCalled();
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "success",
-        message: "Workflow skill://deep-research/workflow.js started",
+    const initial = await processSlashCommand(
+      { type: "workflow-run", scriptPath: "skill://flow/workflow.js", argsText: "{}" },
+      createEnv({
+        api: { workflows: { start } } as unknown as SlashCommandEnv["api"],
+        dynamicWorkflowsEnabled: true,
       })
     );
-    expect(context.setSendingState).toHaveBeenNthCalledWith(1, true);
-    expect(context.setSendingState).toHaveBeenNthCalledWith(2, false);
+    const settled = await finishCommand(initial);
+    expectDisposition(settled.result, "consume");
+    expect(settled.batches).toHaveLength(2);
+    expectToast(settled.result.actions, {
+      type: "success",
+      message: "Workflow skill://flow/workflow.js started",
+    });
   });
 
-  test("does not send terminal workflow results for superseded slash commands", async () => {
-    const workflowResult = { reportMarkdown: "done" };
+  test("returns consume without continuation actions when polling is superseded", async () => {
     const start = mock(() =>
-      Promise.resolve({
-        runId: "wfr_completed",
-        status: "completed",
-        result: workflowResult,
+      Promise.resolve({ runId: "wfr_123", status: "completed" as const, result: null })
+    );
+    const getRun = mock(() => Promise.resolve(completedWorkflowRun));
+    const initial = await processSlashCommand(
+      { type: "workflow-run", scriptPath: "skill://flow/workflow.js", argsText: "{}" },
+      createEnv({
+        api: {
+          workflows: { start, getRun },
+          workspace: { sendMessage: mock(() => Promise.resolve({ success: true })) },
+        } as unknown as SlashCommandEnv["api"],
+        dynamicWorkflowsEnabled: true,
+        isCurrent: () => false,
       })
+    );
+    const settled = await finishCommand(initial);
+    expectDisposition(settled.result, "consume");
+    expect(settled.result.actions).toEqual([]);
+  });
+
+  test("uses restore-if-empty for workflow failures", async () => {
+    const initial = await processSlashCommand(
+      { type: "workflow-run", scriptPath: "skill://flow/workflow.js", argsText: "{}" },
+      createEnv({
+        api: {
+          workflows: { start: mock(() => Promise.reject(new Error("workflow failed"))) },
+        } as unknown as SlashCommandEnv["api"],
+        dynamicWorkflowsEnabled: true,
+      })
+    );
+    const settled = await finishCommand(initial);
+    expectDisposition(settled.result, "restore-if-empty");
+    expectToast(settled.result.actions, { type: "error", message: "workflow failed" });
+    expect(settled.result.actions[0]).toEqual({ type: "set-sending", sending: false });
+  });
+
+  test("does not send an interrupted workflow result to the agent", async () => {
+    const sendMessage = mock(() => Promise.resolve({ success: true }));
+    const start = mock(() =>
+      Promise.resolve({ runId: "wfr_123", status: "interrupted" as const, result: null })
     );
     const getRun = mock(() =>
-      Promise.resolve({
-        id: "wfr_completed",
-        workspaceId: "test-ws",
-        workflow: {
-          name: "skill://deep-research/workflow.js",
-          description: "Deep research",
-          scope: "built-in",
-          executable: true,
-        },
-        source: "export default function workflow() { return null; }",
-        sourceHash: "sha256:test",
-        args: { input: "mux" },
-        status: "completed",
-        createdAt: "2026-05-29T00:00:00.000Z",
-        updatedAt: "2026-05-29T00:00:01.000Z",
-        events: [
-          { sequence: 1, type: "result", at: "2026-05-29T00:00:01.000Z", result: workflowResult },
-        ],
-        steps: [],
-      })
+      Promise.resolve({ ...completedWorkflowRun, status: "interrupted" as const })
     );
-    const sendMessage = mock(() => Promise.resolve({ success: true }));
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-      asyncCommandToken: 1,
-      isAsyncCommandCurrent: mock(() => false),
-    });
-
-    const result = await processSlashCommand(
-      {
-        type: "workflow-run",
-        scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
-      },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: false });
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(context.setToast).not.toHaveBeenCalled();
-  });
-
-  test("does not restore a superseded workflow slash command", async () => {
-    const start = mock(() =>
-      Promise.resolve({
-        runId: "wfr_running",
-        status: "running",
-        result: null,
-      })
-    );
-    const getRun = mock(() =>
-      Promise.resolve({
-        id: "wfr_running",
-        workspaceId: "test-ws",
-        workflow: {
-          name: "skill://deep-research/workflow.js",
-          description: "Deep research",
-          scope: "built-in",
-          executable: true,
-        },
-        source: "export default function workflow() { return null; }",
-        sourceHash: "sha256:test",
-        args: { input: "mux" },
-        status: "running",
-        createdAt: "2026-05-29T00:00:00.000Z",
-        updatedAt: "2026-05-29T00:00:01.000Z",
-        events: [],
-        steps: [],
-      })
-    );
-    const sendMessage = mock(() => Promise.resolve({ success: true }));
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-      asyncCommandToken: 1,
-      isAsyncCommandCurrent: mock(() => false),
-    });
-
-    const result = await processSlashCommand(
-      {
-        type: "workflow-run",
-        scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
-      },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: false });
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(context.setToast).not.toHaveBeenCalled();
-  });
-
-  test("does not restore failed workflow slash commands over newer drafts", async () => {
-    const start = mock(() =>
-      Promise.resolve({
-        runId: "wfr_failed_send",
-        status: "completed",
-        result: { reportMarkdown: "done" },
-      })
-    );
-    const getRun = mock(() =>
-      Promise.resolve({
-        id: "wfr_failed_send",
-        workspaceId: "test-ws",
-        workflow: {
-          name: "skill://deep-research/workflow.js",
-          description: "Deep research",
-          scope: "built-in",
-          executable: true,
-        },
-        source: "export default function workflow() { return null; }",
-        sourceHash: "sha256:test",
-        args: { input: "mux" },
-        status: "completed",
-        createdAt: "2026-05-29T00:00:00.000Z",
-        updatedAt: "2026-05-29T00:00:01.000Z",
-        events: [],
-        steps: [],
-      })
-    );
-    const sendMessage = mock(() => Promise.resolve({ success: false }));
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-      getInput: mock(() => "newer draft"),
-    });
-
-    const result = await processSlashCommand(
-      {
-        type: "workflow-run",
-        scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
-      },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "Failed to send workflow result to the agent",
-      })
-    );
-  });
-
-  test("does not continue the agent after an interrupted workflow slash run", async () => {
-    const start = mock(() =>
-      Promise.resolve({
-        runId: "wfr_interrupted",
-        status: "interrupted",
-        result: null,
-      })
-    );
-    const getRun = mock(() =>
-      Promise.resolve({
-        id: "wfr_interrupted",
-        workspaceId: "test-ws",
-        workflow: {
-          name: "skill://deep-research/workflow.js",
-          description: "Deep research",
-          scope: "built-in",
-          executable: true,
-        },
-        source: "export default function workflow() { return null; }",
-        sourceHash: "sha256:test",
-        args: { input: "mux" },
-        status: "interrupted",
-        createdAt: "2026-05-29T00:00:00.000Z",
-        updatedAt: "2026-05-29T00:00:01.000Z",
-        events: [],
-        steps: [],
-      })
-    );
-    const sendMessage = mock(() => Promise.resolve({ success: true }));
-    const onMessageSent = mock(() => undefined);
-    const context = createSlashCommandContext({
-      api: {
-        workflows: { start, getRun },
-        workspace: { sendMessage },
-      } as unknown as SlashCommandContext["api"],
-      rawInput: '/deep-research {"input":"mux"}',
-      dynamicWorkflowsEnabled: true,
-      onMessageSent,
-    });
-
-    const result = await processSlashCommand(
-      {
-        type: "workflow-run",
-        scriptPath: "skill://deep-research/workflow.js",
-        argsText: '{"input":"mux"}',
-      },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(onMessageSent).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "success",
-        message: "Workflow skill://deep-research/workflow.js interrupted",
-      })
-    );
-  });
-});
-
-describe("processSlashCommand - clear", () => {
-  function createClearContext(overrides: Partial<SlashCommandContext> = {}): SlashCommandContext {
-    return createSlashCommandContext({
-      api: null,
-      onDetachAllReviews: mock(() => undefined),
-      onResetContext: mock(() => Promise.resolve("reset" as const)),
-      ...overrides,
-    });
-  }
-
-  test("hard clear truncates history", async () => {
-    const context = createClearContext();
-
-    const result = await processSlashCommand({ type: "clear", mode: "hard" }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.onTruncateHistory).toHaveBeenCalledWith(1.0);
-    expect(context.setAttachments).toHaveBeenCalledWith([]);
-    expect(context.onDetachAllReviews).toHaveBeenCalled();
-    expect(context.onResetContext).not.toHaveBeenCalled();
-  });
-
-  test("soft clear resets context without truncating history", async () => {
-    const context = createClearContext();
-
-    const result = await processSlashCommand({ type: "clear", mode: "soft" }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.onResetContext).toHaveBeenCalled();
-    expect(context.setAttachments).toHaveBeenCalledWith([]);
-    expect(context.onDetachAllReviews).toHaveBeenCalled();
-    expect(context.onTruncateHistory).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Context reset; history preserved", type: "success" })
-    );
-  });
-
-  test("soft clear preserves attachments when reset is a no-op", async () => {
-    const context = createClearContext({
-      onResetContext: mock(() => Promise.resolve("noop" as const)),
-    });
-
-    const result = await processSlashCommand({ type: "clear", mode: "soft" }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.setAttachments).not.toHaveBeenCalled();
-    expect(context.onDetachAllReviews).not.toHaveBeenCalled();
-  });
-
-  test("soft clear reports errors without clearing composer state", async () => {
-    const context = createClearContext({
-      onResetContext: mock(() => Promise.reject(new Error("reset failed"))),
-    });
-    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => undefined);
-
-    try {
-      const result = await processSlashCommand({ type: "clear", mode: "soft" }, context);
-
-      expect(result).toEqual({ clearInput: false, toastShown: true });
-      expect(context.setInput).not.toHaveBeenCalled();
-      expect(context.setAttachments).not.toHaveBeenCalled();
-      expect(context.onDetachAllReviews).not.toHaveBeenCalled();
-      expect(context.setToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "reset failed", type: "error" })
-      );
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
-  });
-
-  test("soft clear reports no-op resets", async () => {
-    const context = createClearContext({
-      onResetContext: mock(() => Promise.resolve("noop" as const)),
-    });
-
-    const result = await processSlashCommand({ type: "clear", mode: "soft" }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "No context to reset", type: "success" })
-    );
-  });
-});
-
-describe("processSlashCommand - model-set", () => {
-  const createModelSetContext = (api: SlashCommandContext["api"]): SlashCommandContext =>
-    createSlashCommandContext({
-      api,
-      onMessageSent: mock(() => undefined),
-      onCheckReviews: mock(() => undefined),
-      attachedReviewIds: [],
-      openSettings: mock(() => undefined),
-    });
-
-  test("reports backend verification failure for custom providers when config loading fails", async () => {
-    const getConfig = mock(() => Promise.reject(new Error("backend offline")));
-    const context = createModelSetContext({
-      providers: {
-        getConfig,
-      },
-    } as unknown as SlashCommandContext["api"]);
-    const consoleErrorSpy = spyOn(console, "error").mockImplementation(() => undefined);
-
-    try {
-      const result = await processSlashCommand(
-        { type: "model-set", modelString: "local-vllm:qwen3-coder" },
-        context
-      );
-
-      expect(result).toEqual({ clearInput: false, toastShown: true });
-      expect(context.setToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "error",
-          message: 'Could not verify provider "local-vllm": backend unreachable. Please retry.',
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "workflow-run", scriptPath: "skill://flow/workflow.js", argsText: "{}" },
+        createEnv({
+          api: {
+            workflows: { start, getRun },
+            workspace: { sendMessage },
+          } as unknown as SlashCommandEnv["api"],
+          dynamicWorkflowsEnabled: true,
         })
-      );
-      expect(context.setToast).not.toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Unknown provider "local-vllm"' })
-      );
-    } finally {
-      consoleErrorSpy.mockRestore();
-    }
+      )
+    );
+    expectDisposition(settled.result, "consume");
+    expectToast(settled.result.actions, {
+      type: "success",
+      message: "Workflow skill://flow/workflow.js interrupted",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("processSlashCommand clear results", () => {
+  test("hard clear returns actions around truncation", async () => {
+    const truncateHistory = mock(() => Promise.resolve());
+    const initial = await processSlashCommand(
+      { type: "clear", mode: "hard" },
+      createEnv({ truncateHistory })
+    );
+    expect(initial.kind).toBe("phase");
+    if (initial.kind !== "phase") throw new Error("expected phase result");
+    expect(initial.actions).toEqual([{ type: "clear-input" }, { type: "reset-input-height" }]);
+    expect(truncateHistory).not.toHaveBeenCalled();
+    const complete = await initial.continue();
+    expect(complete.kind).toBe("complete");
+    if (complete.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(complete, "consume");
+    expect(complete.actions.slice(0, 2)).toEqual([
+      { type: "clear-attachments" },
+      { type: "detach-reviews" },
+    ]);
+    expect(truncateHistory).toHaveBeenCalledWith(1);
   });
 
-  test("refuses switching budgeted active goals to an unpriced model", async () => {
-    ensureWindowDispatchEvent();
-    const setPreferredModel = mock(() => undefined);
-    const context = createModelSetContext({
-      providers: {
-        getConfig: mock(() => Promise.resolve({})),
-        setModels: mock(() => Promise.resolve(undefined)),
-      },
-      workspace: {
-        getGoal: mock(() =>
-          Promise.resolve({
-            goal: {
-              goalId: "11111111-1111-4111-8111-111111111111",
-              status: "active",
-              budgetCents: 500,
-            },
-          })
-        ),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.setPreferredModel = setPreferredModel;
-
-    const result = await processSlashCommand(
-      { type: "model-set", modelString: "openai:not-priced-model" },
-      context
+  test("soft clear preserves attachments for no-op and restores on failure", async () => {
+    const noOp = await finishCommand(
+      await processSlashCommand(
+        { type: "clear", mode: "soft" },
+        createEnv({ resetContext: () => Promise.resolve("noop") })
+      )
     );
+    expectDisposition(noOp.result, "consume");
+    expect(noOp.result.actions).not.toContainEqual({ type: "clear-attachments" });
+    expectToast(noOp.result.actions, {
+      type: "success",
+      message: "No context to reset",
+    });
 
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(setPreferredModel).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "Target model has no pricing data. Pick a priced model before switching.",
+    const failure = await finishCommand(
+      await processSlashCommand(
+        { type: "clear", mode: "soft" },
+        createEnv({
+          resetContext: () => Promise.reject(new Error("reset failed")),
+        })
+      )
+    );
+    expectDisposition(failure.result, "restore");
+    expectToast(failure.result.actions, { type: "error", message: "reset failed" });
+  });
+
+  test("missing clear capabilities consume without a toast", async () => {
+    const soft = await processSlashCommand({ type: "clear", mode: "soft" }, createEnv());
+    expect(soft).toEqual({ kind: "complete", actions: [], inputDisposition: "consume" });
+    const hard = await finishCommand(
+      await processSlashCommand({ type: "clear", mode: "hard" }, createEnv())
+    );
+    expectDisposition(hard.result, "consume");
+    expect(hard.result.actions).toEqual([]);
+  });
+});
+
+describe("processSlashCommand model and gating results", () => {
+  test("reports provider verification failure through result data", async () => {
+    const result = await processSlashCommand(
+      { type: "model-set", modelString: "custom:model" },
+      createEnv({
+        api: {
+          providers: { getConfig: mock(() => Promise.reject(new Error("offline"))) },
+        } as unknown as SlashCommandEnv["api"],
       })
     );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(result, "restore");
+    expectToast(result.actions, {
+      type: "error",
+      message: 'Could not verify provider "custom": backend unreachable. Please retry.',
+    });
   });
 
-  test("allows switching unbudgeted active goals to an unpriced model", async () => {
-    const setPreferredModel = mock(() => undefined);
-    const context = createModelSetContext({
-      providers: {
-        getConfig: mock(() => Promise.resolve({})),
-        setModels: mock(() => Promise.resolve(undefined)),
-      },
-      workspace: {
-        getGoal: mock(() =>
-          Promise.resolve({
-            goal: {
-              goalId: "11111111-1111-4111-8111-111111111111",
-              status: "active",
-              budgetCents: null,
-            },
-          })
-        ),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.setPreferredModel = setPreferredModel;
-
+  test("refuses an unpriced model for a budgeted active goal", async () => {
     const result = await processSlashCommand(
-      { type: "model-set", modelString: "openai:not-priced-model" },
-      context
+      { type: "model-set", modelString: "openai:unpriced-model" },
+      createEnv({
+        api: {
+          providers: { getConfig: mock(() => Promise.resolve({ openai: { models: [] } })) },
+          workspace: {
+            getGoal: mock(() =>
+              Promise.resolve({
+                goal: { objective: "ship", status: "active", budgetCents: 500 },
+              })
+            ),
+          },
+        } as unknown as SlashCommandEnv["api"],
+      })
     );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(result, "restore");
+    expect(result.actions[0]).toMatchObject({ type: "show-toast", toast: { type: "error" } });
+  });
 
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(setPreferredModel).toHaveBeenCalledWith("openai:not-priced-model");
+  test("returns model and vim actions", async () => {
+    const model = await processSlashCommand(
+      { type: "model-set", modelString: "anthropic:claude-sonnet-4-6" },
+      createEnv({
+        api: {
+          providers: {
+            getConfig: mock(() => Promise.resolve({})),
+            setModels: mock(() => Promise.resolve()),
+          },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    expect(model.kind).toBe("complete");
+    if (model.kind !== "complete") throw new Error("expected complete result");
+    expect(model.actions).toContainEqual({
+      type: "set-preferred-model",
+      model: "anthropic:claude-sonnet-4-6",
+    });
+    const vim = await processSlashCommand({ type: "vim-toggle" }, createEnv());
+    expect(vim).toEqual({
+      kind: "complete",
+      actions: [{ type: "clear-input" }, { type: "toggle-vim" }],
+      inputDisposition: "consume",
+    });
+  });
+
+  test("returns goal parse errors during creation", async () => {
+    const result = await processSlashCommand(
+      { type: "command-missing-args", command: "goal", usage: "/goal <objective>" },
+      createEnv({ variant: "creation", workspaceId: undefined })
+    );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(result, "restore");
+    expectToast(result.actions, {
+      type: "error",
+      message: "/goal requires arguments",
+    });
+  });
+
+  test("returns require-client and workspace-creation guard results", async () => {
+    const disconnected = await processSlashCommand(
+      { type: "idle-compaction", hours: 2 },
+      createEnv({ api: null })
+    );
+    if (disconnected.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(disconnected, "restore");
+    expectToast(disconnected.actions, { type: "error", message: "Not connected to server" });
+
+    const guarded = await processSlashCommand(
+      { type: "clear", mode: "soft" },
+      createEnv({ variant: "creation", workspaceId: undefined })
+    );
+    if (guarded.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(guarded, "restore");
+    expectToast(guarded.actions, {
+      type: "error",
+      message: "Command not available during workspace creation",
+    });
+  });
+
+  test("returns idle-compaction and debug actions", async () => {
+    const setIdleCompaction = mock(() => Promise.resolve({ success: true, data: undefined }));
+    const idle = await processSlashCommand(
+      { type: "idle-compaction", hours: 2 },
+      createEnv({
+        api: {
+          projects: { idleCompaction: { set: setIdleCompaction } },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (idle.kind !== "phase") throw new Error("expected phase result");
+    expect(idle.actions).toEqual([{ type: "clear-input" }]);
+    expect(setIdleCompaction).not.toHaveBeenCalled();
+    const idleComplete = await idle.continue();
+    if (idleComplete.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(idleComplete, "consume");
+    expectToast(idleComplete.actions, {
+      type: "success",
+      message: "Idle compaction set to 2 hours",
+    });
+
+    ensureWindowDispatchEvent();
+    const debug = await processSlashCommand({ type: "debug-llm-request" }, createEnv());
+    expect(debug).toEqual({
+      kind: "complete",
+      actions: [{ type: "clear-input" }],
+      inputDisposition: "consume",
+    });
+    expect(window.dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "mux:openDebugLlmRequest" })
+    );
   });
 });
 
-describe("processSlashCommand - workspace command gating", () => {
-  test("shows goal parse errors during workspace creation", async () => {
-    const context = createGoalCommandContext(null);
-    context.variant = "creation";
+function createGoalEnv(api: SlashCommandEnv["api"]): SlashCommandEnv {
+  return createEnv({ api, workspaceId: "goal-ws" });
+}
 
-    const result = await processSlashCommand(
-      { type: "command-unknown-flag", command: "goal", flag: "--bogus" },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Unknown flag for /goal: --bogus" })
-    );
-  });
-});
-
-describe("processSlashCommand - goal optimistic concurrency", () => {
-  test("retries once after a goal conflict and reapplies the slash command intent", async () => {
+describe("processSlashCommand goal results", () => {
+  test("retries one conflict and returns a consumed result", async () => {
     ensureWindowDispatchEvent();
     const getGoal = mock()
       .mockResolvedValueOnce({
-        goal: {
-          goalId: "11111111-1111-4111-8111-111111111111",
-          objective: "old objective",
-        },
+        goal: { goalId: "11111111-1111-4111-8111-111111111111", objective: "old" },
       })
       .mockResolvedValueOnce({
-        goal: {
-          goalId: "22222222-2222-4222-8222-222222222222",
-          objective: "fresh objective",
-        },
+        goal: { goalId: "22222222-2222-4222-8222-222222222222", objective: "fresh" },
       });
     const setGoal = mock()
       .mockResolvedValueOnce({
@@ -846,516 +602,159 @@ describe("processSlashCommand - goal optimistic concurrency", () => {
       })
       .mockResolvedValueOnce({
         success: true,
-        data: {
-          goalId: "33333333-3333-4333-8333-333333333333",
-          objective: "new objective",
-        },
+        data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "new" },
       });
-    const context = createGoalCommandContext({
-      workspace: { getGoal, setGoal, clearGoal: mock() },
-    } as unknown as SlashCommandContext["api"]);
-
-    const result = await processSlashCommand(
-      { type: "goal-set", objective: "new objective" },
-      context
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "goal-set", objective: "new" },
+        createGoalEnv({
+          config: { getConfig: mock(() => Promise.resolve({})) },
+          workspace: { getGoal, setGoal },
+        } as unknown as SlashCommandEnv["api"])
+      )
     );
-
-    expect(result).toEqual({ clearInput: true, toastShown: false });
-    expect(getGoal).toHaveBeenCalledTimes(2);
-    expect(setGoal).toHaveBeenNthCalledWith(1, {
-      workspaceId: "goal-ws",
-      objective: "new objective",
-      budgetCents: 200,
-      turnCap: null,
-      expectedGoalId: "11111111-1111-4111-8111-111111111111",
-    });
-    expect(setGoal).toHaveBeenNthCalledWith(2, {
-      workspaceId: "goal-ws",
-      objective: "new objective",
-      budgetCents: 200,
-      turnCap: null,
-      expectedGoalId: "22222222-2222-4222-8222-222222222222",
-    });
-    expect(context.setToast).not.toHaveBeenCalled();
-  });
-
-  test("surfaces a toast and stops after two consecutive goal conflicts", async () => {
-    ensureWindowDispatchEvent();
-    const getGoal = mock()
-      .mockResolvedValueOnce({
-        goal: {
-          goalId: "11111111-1111-4111-8111-111111111111",
-          objective: "old objective",
-        },
-      })
-      .mockResolvedValueOnce({
-        goal: {
-          goalId: "22222222-2222-4222-8222-222222222222",
-          objective: "fresh objective",
-        },
-      });
-    const setGoal = mock()
-      .mockResolvedValueOnce({
-        success: false,
-        error: {
-          type: "goal_conflict",
-          expectedGoalId: "11111111-1111-4111-8111-111111111111",
-          actualGoalId: "22222222-2222-4222-8222-222222222222",
-        },
-      })
-      .mockResolvedValueOnce({
-        success: false,
-        error: {
-          type: "goal_conflict",
-          expectedGoalId: "22222222-2222-4222-8222-222222222222",
-          actualGoalId: "33333333-3333-4333-8333-333333333333",
-        },
-      });
-    const context = createGoalCommandContext({
-      workspace: { getGoal, setGoal, clearGoal: mock() },
-    } as unknown as SlashCommandContext["api"]);
-
-    const result = await processSlashCommand(
-      { type: "goal-set", objective: "new objective" },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(getGoal).toHaveBeenCalledTimes(2);
+    expect(settled.batches[0]).toEqual([{ type: "clear-input" }]);
+    expectDisposition(settled.result, "consume");
+    expect(settled.result.actions).toEqual([]);
     expect(setGoal).toHaveBeenCalledTimes(2);
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "Goal changed in another window. Please try again.",
-      })
-    );
   });
-});
 
-describe("processSlashCommand - goal lifecycle commands", () => {
-  test("surfaces invalid transition messages for lifecycle commands", async () => {
-    ensureWindowDispatchEvent();
-    const context = createGoalCommandContext({
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal: mock(() =>
-          Promise.resolve({
-            success: false,
-            error: { type: "invalid_transition", message: "Cannot pause a missing goal." },
-          })
-        ),
-        clearGoal: mock(),
+  test("surfaces a second conflict as a restore result", async () => {
+    const conflict = {
+      success: false as const,
+      error: {
+        type: "goal_conflict" as const,
+        expectedGoalId: "11111111-1111-4111-8111-111111111111",
+        actualGoalId: "22222222-2222-4222-8222-222222222222",
       },
-    } as unknown as SlashCommandContext["api"]);
-
-    const result = await processSlashCommand({ type: "goal-pause" }, context);
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", message: "Cannot pause a missing goal." })
+    };
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "goal-pause" },
+        createGoalEnv({
+          workspace: {
+            getGoal: mock(() =>
+              Promise.resolve({
+                goal: { goalId: "11111111-1111-4111-8111-111111111111" },
+              })
+            ),
+            setGoal: mock(() => Promise.resolve(conflict)),
+          },
+        } as unknown as SlashCommandEnv["api"])
+      )
     );
+    expectDisposition(settled.result, "restore");
+    expectToast(settled.result.actions, {
+      type: "error",
+      message: "Goal changed in another window. Please try again.",
+    });
   });
 
-  test("dispatches pause, resume, and complete goal commands", async () => {
+  test("passes configured defaults and multiline objectives to the backend", async () => {
     ensureWindowDispatchEvent();
+    const objective = "Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md";
+    const parsed = parseCommand("/goal " + objective);
+    if (parsed?.type !== "goal-set") throw new Error("expected goal-set");
     const setGoal = mock(() =>
       Promise.resolve({
         success: true,
-        data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "goal" },
+        data: { goalId: "33333333-3333-4333-8333-333333333333", objective },
       })
     );
-    const context = createGoalCommandContext({
-      providers: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: { status: "paused", budgetCents: null } })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    await processSlashCommand({ type: "goal-pause" }, context);
-    await processSlashCommand({ type: "goal-resume" }, context);
-    await processSlashCommand({ type: "goal-complete", summary: "Done." }, context);
-
-    expect(setGoal).toHaveBeenNthCalledWith(1, {
-      workspaceId: "goal-ws",
-      expectedGoalId: null,
-      status: "paused",
-    });
-    expect(setGoal).toHaveBeenNthCalledWith(2, {
-      workspaceId: "goal-ws",
-      status: "active",
-      expectedGoalId: null,
-    });
-    expect(setGoal).toHaveBeenNthCalledWith(3, {
-      workspaceId: "goal-ws",
-      status: "complete",
-      completionSummary: "Done.",
-      expectedGoalId: null,
-    });
-  });
-
-  test("refuses to resume a budgeted goal on an unpriced current model", async () => {
-    ensureWindowDispatchEvent();
-    const setGoal = mock(() => Promise.resolve({ success: true, data: {} }));
-    const context = createGoalCommandContext({
-      providers: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() =>
-          Promise.resolve({
-            goal: {
-              goalId: "11111111-1111-4111-8111-111111111111",
-              status: "paused",
-              budgetCents: 500,
-            },
-          })
-        ),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.sendMessageOptions.model = "custom:unpriced-model";
-
-    const result = await processSlashCommand({ type: "goal-resume" }, context);
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(setGoal).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message:
-          "Current model has no pricing data. Pick a priced model, use -b 0 with a turn cap, or change goal budget defaults in Settings.",
-      })
+    const settled = await finishCommand(
+      await processSlashCommand(
+        parsed,
+        createGoalEnv({
+          config: {
+            getConfig: mock(() =>
+              Promise.resolve({
+                goalDefaults: {
+                  defaultBudgetCents: 350,
+                  defaultTurnCap: 25,
+                  alwaysRequireExplicitBudget: true,
+                },
+              })
+            ),
+          },
+          workspace: {
+            getGoal: mock(() => Promise.resolve({ goal: null })),
+            setGoal,
+          },
+        } as unknown as SlashCommandEnv["api"])
+      )
     );
-  });
-});
-
-describe("processSlashCommand - goal budgets", () => {
-  test("applies configured defaults when budget and turn cap are omitted", async () => {
-    ensureWindowDispatchEvent();
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "new objective" },
-    });
-    const context = createGoalCommandContext({
-      config: {
-        getConfig: mock(() =>
-          Promise.resolve({
-            goalDefaults: {
-              defaultBudgetCents: 350,
-              defaultTurnCap: 25,
-              alwaysRequireExplicitBudget: true,
-            },
-          })
-        ),
-      },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    await processSlashCommand({ type: "goal-set", objective: "new objective" }, context);
-
+    expectDisposition(settled.result, "consume");
     expect(setGoal).toHaveBeenCalledWith({
       workspaceId: "goal-ws",
-      objective: "new objective",
+      objective,
       expectedGoalId: null,
       budgetCents: 350,
       turnCap: 25,
     });
   });
 
-  test("passes parsed multiline goal objectives through to setGoal", async () => {
-    ensureWindowDispatchEvent();
-    const objective = "Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md";
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { goalId: "33333333-3333-4333-8333-333333333333", objective },
-    });
-    const context = createGoalCommandContext({
-      config: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    const parsed = parseCommand("/goal Implement PRD\n\nRead first:\n- CONTEXT.md\n- PRD.md");
-    if (parsed?.type !== "goal-set") {
-      throw new Error("expected multiline /goal to parse as goal-set");
-    }
-
-    const result = await processSlashCommand(parsed, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: false });
-    expect(setGoal).toHaveBeenCalledWith({
-      workspaceId: "goal-ws",
-      objective,
-      expectedGoalId: null,
-      budgetCents: 200,
-      turnCap: null,
-    });
-    expect(context.setToast).not.toHaveBeenCalled();
-    expect(window.dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "mux:openGoalTab" })
+  test("returns lifecycle success and pricing failure actions", async () => {
+    const paused = await finishCommand(
+      await processSlashCommand(
+        { type: "goal-pause" },
+        createGoalEnv({
+          workspace: {
+            getGoal: mock(() => Promise.resolve({ goal: null })),
+            setGoal: mock(() =>
+              Promise.resolve({ success: true, data: { goalId: "id", status: "paused" } })
+            ),
+          },
+        } as unknown as SlashCommandEnv["api"])
+      )
     );
-  });
+    expectDisposition(paused.result, "consume");
+    expectToast(paused.result.actions, { type: "success", message: "Goal paused" });
 
-  test("passes explicit no-budget and turn cap through to setGoal", async () => {
-    ensureWindowDispatchEvent();
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { goalId: "33333333-3333-4333-8333-333333333333", objective: "new objective" },
-    });
-    const context = createGoalCommandContext({
-      config: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    await processSlashCommand(
-      { type: "goal-set", objective: "new objective", budgetCents: null, turnCap: 10 },
-      context
+    const resume = await finishCommand(
+      await processSlashCommand(
+        { type: "goal-resume" },
+        createGoalEnv({
+          providers: { getConfig: mock(() => Promise.resolve({})) },
+          workspace: {
+            getGoal: mock(() => Promise.resolve({ goal: { status: "paused", budgetCents: 500 } })),
+          },
+        } as unknown as SlashCommandEnv["api"])
+      )
     );
-
-    expect(setGoal).toHaveBeenCalledWith({
-      workspaceId: "goal-ws",
-      objective: "new objective",
-      expectedGoalId: null,
-      budgetCents: null,
-      turnCap: 10,
+    expectDisposition(resume.result, "restore");
+    expect(resume.result.actions[0]).toMatchObject({
+      type: "show-toast",
+      toast: { type: "error" },
     });
-  });
-
-  test("updates an existing goal budget without applying defaults", async () => {
-    ensureWindowDispatchEvent();
-    const currentGoal = {
-      goalId: "11111111-1111-4111-8111-111111111111",
-      objective: "existing objective",
-    };
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { ...currentGoal, budgetCents: 500 },
-    });
-    const context = createGoalCommandContext({
-      config: {
-        getConfig: mock(() =>
-          Promise.resolve({
-            goalDefaults: {
-              defaultBudgetCents: 350,
-              defaultTurnCap: 25,
-              alwaysRequireExplicitBudget: true,
-            },
-          })
-        ),
-      },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: currentGoal })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-
-    await processSlashCommand({ type: "goal-budget", budgetCents: 500 }, context);
-
-    expect(setGoal).toHaveBeenCalledWith({
-      workspaceId: "goal-ws",
-      budgetCents: 500,
-      expectedGoalId: currentGoal.goalId,
-    });
-  });
-
-  test("passes no-budget budget updates through on unpriced current model", async () => {
-    ensureWindowDispatchEvent();
-    const currentGoal = {
-      goalId: "11111111-1111-4111-8111-111111111111",
-      objective: "existing objective",
-    };
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { ...currentGoal, budgetCents: null },
-    });
-    const context = createGoalCommandContext({
-      config: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: currentGoal })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.sendMessageOptions.model = "custom-provider:no-price-model";
-
-    await processSlashCommand({ type: "goal-budget", budgetCents: null }, context);
-
-    expect(setGoal).toHaveBeenCalledWith({
-      workspaceId: "goal-ws",
-      budgetCents: null,
-      expectedGoalId: currentGoal.goalId,
-    });
-  });
-
-  test("passes zero-dollar budget updates through on unpriced current model", async () => {
-    ensureWindowDispatchEvent();
-    const currentGoal = {
-      goalId: "11111111-1111-4111-8111-111111111111",
-      objective: "existing objective",
-    };
-    const setGoal = mock().mockResolvedValueOnce({
-      success: true,
-      data: { ...currentGoal, budgetCents: null },
-    });
-    const context = createGoalCommandContext({
-      config: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: currentGoal })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.sendMessageOptions.model = "custom-provider:no-price-model";
-
-    await processSlashCommand({ type: "goal-budget", budgetCents: 0 }, context);
-
-    expect(setGoal).toHaveBeenCalledWith({
-      workspaceId: "goal-ws",
-      budgetCents: 0,
-      expectedGoalId: currentGoal.goalId,
-    });
-  });
-
-  test("refuses budgeted goals on an unpriced current model", async () => {
-    ensureWindowDispatchEvent();
-    const setGoal = mock();
-    const context = createGoalCommandContext({
-      config: { getConfig: mock(() => Promise.resolve({})) },
-      workspace: {
-        getGoal: mock(() => Promise.resolve({ goal: null })),
-        setGoal,
-        clearGoal: mock(),
-      },
-    } as unknown as SlashCommandContext["api"]);
-    context.sendMessageOptions.model = "custom-provider:no-price-model";
-
-    const result = await processSlashCommand(
-      { type: "goal-set", objective: "new objective", budgetCents: 500 },
-      context
-    );
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(setGoal).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message:
-          "Current model has no pricing data. Pick a priced model, use -b 0 with a turn cap, or change goal budget defaults in Settings.",
-      })
-    );
   });
 });
 
-describe("processSlashCommand - heartbeat-set", () => {
-  const HEARTBEAT_EXPERIMENT_KEY = getExperimentKey(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
-
-  function setHeartbeatExperiment(enabled: boolean) {
-    globalThis.localStorage.setItem(HEARTBEAT_EXPERIMENT_KEY, JSON.stringify(enabled));
-  }
-
-  const createSlashCommandContext = (options?: {
-    api?: SlashCommandContext["api"] | null;
-    workspaceId?: string;
-    variant?: SlashCommandContext["variant"];
-  }): SlashCommandContext => {
-    const setInput = mock(() => undefined);
-    const setToast = mock(() => undefined);
-
-    return {
-      api: options?.api ?? null,
-      workspaceId:
-        options && Object.hasOwn(options, "workspaceId") ? options.workspaceId : "test-ws",
-      variant: options?.variant ?? "workspace",
-      projectPath: "/tmp/project",
-      setPreferredModel: mock(() => undefined),
-      setVimEnabled: mock((cb: (prev: boolean) => boolean) => cb(false)),
-      resetInputHeight: mock(() => undefined),
-      onTruncateHistory: mock(() => Promise.resolve(undefined)),
-      onMessageSent: mock(() => undefined),
-      onCheckReviews: mock(() => undefined),
-      attachedReviewIds: [],
-      openSettings: mock(() => undefined),
-      sendMessageOptions: {
-        model: "anthropic:claude-sonnet-4-6",
-        thinkingLevel: "off",
-        toolPolicy: [],
-        agentId: "exec",
-      },
-      setInput,
-      setToast,
-      setAttachments: mock(() => undefined),
-      setSendingState: mock(() => undefined),
-    };
-  };
-
-  test("shows an error toast when the heartbeat experiment is disabled", async () => {
-    const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-    });
-
-    setHeartbeatExperiment(false);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: 30 }, context);
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(heartbeatSet).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message:
-          "Heartbeat configuration requires the Workspace Heartbeats experiment to be enabled",
-      })
+describe("processSlashCommand heartbeat results", () => {
+  test("returns gating errors before a phase", async () => {
+    const api = {
+      workspace: { heartbeat: { get: mock(), set: mock() } },
+    } as unknown as SlashCommandEnv["api"];
+    const disabled = await processSlashCommand(
+      { type: "heartbeat-set", minutes: 30 },
+      createEnv({ api })
     );
-  });
-
-  test("shows an error toast when no workspace is selected", async () => {
-    const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: undefined,
-    });
+    expect(disabled.kind).toBe("complete");
+    if (disabled.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(disabled, "restore");
+    expect(disabled.actions[0]).toMatchObject({ type: "show-toast", toast: { type: "error" } });
 
     setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: 30 }, context);
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(heartbeatSet).not.toHaveBeenCalled();
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "No workspace selected",
-      })
+    const missing = await processSlashCommand(
+      { type: "heartbeat-set", minutes: 30 },
+      createEnv({ api, workspaceId: undefined })
     );
+    expect(missing.kind).toBe("complete");
+    if (missing.kind !== "complete") throw new Error("expected complete result");
+    expectToast(missing.actions, { type: "error", message: "No workspace selected" });
   });
 
-  test("enables workspace heartbeats with the requested interval without clearing the saved message", async () => {
+  test("preserves saved heartbeat fields and returns success", async () => {
+    setHeartbeatExperiment(true);
     const heartbeatGet = mock(() =>
       Promise.resolve({
         enabled: true as const,
@@ -1364,135 +763,52 @@ describe("processSlashCommand - heartbeat-set", () => {
       })
     );
     const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            get: heartbeatGet,
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: "test-ws",
-    });
-
-    setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: 30 }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(context.setInput).toHaveBeenCalledWith("");
-    expect(heartbeatGet).toHaveBeenCalledWith({ workspaceId: "test-ws" });
+    const initial = await processSlashCommand(
+      { type: "heartbeat-set", minutes: 30 },
+      createEnv({
+        api: {
+          workspace: { heartbeat: { get: heartbeatGet, set: heartbeatSet } },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    expect(initial.kind).toBe("phase");
+    if (initial.kind !== "phase") throw new Error("expected phase result");
+    expect(initial.actions).toEqual([{ type: "clear-input" }]);
+    const complete = await initial.continue();
+    expect(complete.kind).toBe("complete");
+    if (complete.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(complete, "consume");
     expect(heartbeatSet).toHaveBeenCalledWith({
       workspaceId: "test-ws",
       enabled: true,
       intervalMs: 30 * 60 * 1000,
       message: "Review the workspace status before taking action.",
     });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "success",
-        message: "Heartbeat set to every 30 minutes",
-      })
-    );
+    expectToast(complete.actions, {
+      type: "success",
+      message: "Heartbeat set to every 30 minutes",
+    });
   });
 
-  test("still updates the interval when reading current heartbeat settings fails", async () => {
-    const heartbeatGet = mock(() => Promise.reject(new Error("Corrupted heartbeat settings")));
-    const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            get: heartbeatGet,
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: "test-ws",
-    });
-
+  test("uses the default interval when disabling without saved settings", async () => {
     setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: 30 }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(heartbeatGet).toHaveBeenCalledWith({ workspaceId: "test-ws" });
-    expect(heartbeatSet).toHaveBeenCalledWith({
-      workspaceId: "test-ws",
-      enabled: true,
-      intervalMs: 30 * 60 * 1000,
-    });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "success",
-        message: "Heartbeat set to every 30 minutes",
-      })
-    );
-  });
-
-  test("preserves the configured interval and message when disabling workspace heartbeats", async () => {
-    const heartbeatGet = mock(() =>
-      Promise.resolve({
-        enabled: true as const,
-        intervalMs: 45 * 60 * 1000,
-        message: "Review the workspace status before taking action.",
-      })
-    );
     const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            get: heartbeatGet,
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: "test-ws",
-    });
-
-    setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: null }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(heartbeatGet).toHaveBeenCalledWith({ workspaceId: "test-ws" });
-    expect(heartbeatSet).toHaveBeenCalledWith({
-      workspaceId: "test-ws",
-      enabled: false,
-      intervalMs: 45 * 60 * 1000,
-      message: "Review the workspace status before taking action.",
-    });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "success",
-        message: "Heartbeat disabled",
-      })
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "heartbeat-set", minutes: null },
+        createEnv({
+          api: {
+            workspace: {
+              heartbeat: {
+                get: mock(() => Promise.reject(new Error("missing"))),
+                set: heartbeatSet,
+              },
+            },
+          } as unknown as SlashCommandEnv["api"],
+        })
+      )
     );
-  });
-
-  test("uses the default interval when disabling heartbeats without saved settings", async () => {
-    const heartbeatGet = mock(() => Promise.resolve(null));
-    const heartbeatSet = mock(() => Promise.resolve({ success: true, data: undefined }));
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            get: heartbeatGet,
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: "test-ws",
-    });
-
-    setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: null }, context);
-
-    expect(result).toEqual({ clearInput: true, toastShown: true });
-    expect(heartbeatGet).toHaveBeenCalledWith({ workspaceId: "test-ws" });
+    expectDisposition(settled.result, "consume");
     expect(heartbeatSet).toHaveBeenCalledWith({
       workspaceId: "test-ws",
       enabled: false,
@@ -1500,46 +816,284 @@ describe("processSlashCommand - heartbeat-set", () => {
     });
   });
 
-  test("surfaces backend heartbeat update failures", async () => {
-    const heartbeatGet = mock(() =>
-      Promise.resolve({
-        enabled: true as const,
-        intervalMs: 45 * 60 * 1000,
-        message: "Review the workspace status before taking action.",
-      })
-    );
-    const heartbeatSet = mock(() =>
-      Promise.resolve({ success: false as const, error: "Heartbeat update failed" })
-    );
-    const context = createSlashCommandContext({
-      api: {
-        workspace: {
-          heartbeat: {
-            get: heartbeatGet,
-            set: heartbeatSet,
-          },
-        },
-      } as unknown as SlashCommandContext["api"],
-      workspaceId: "test-ws",
-    });
-
+  test("returns backend update failures with restore disposition", async () => {
     setHeartbeatExperiment(true);
-
-    const result = await processSlashCommand({ type: "heartbeat-set", minutes: 30 }, context);
-
-    expect(result).toEqual({ clearInput: false, toastShown: true });
-    expect(heartbeatSet).toHaveBeenCalledWith({
-      workspaceId: "test-ws",
-      enabled: true,
-      intervalMs: 30 * 60 * 1000,
-      message: "Review the workspace status before taking action.",
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "heartbeat-set", minutes: 30 },
+        createEnv({
+          api: {
+            workspace: {
+              heartbeat: {
+                get: mock(() => Promise.resolve({ enabled: false, intervalMs: 1 })),
+                set: mock(() =>
+                  Promise.resolve({ success: false, error: "Heartbeat update failed" })
+                ),
+              },
+            },
+          } as unknown as SlashCommandEnv["api"],
+        })
+      )
+    );
+    expectDisposition(settled.result, "restore");
+    expectToast(settled.result.actions, {
+      type: "error",
+      message: "Heartbeat update failed",
     });
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "Heartbeat update failed",
+  });
+});
+
+describe("detached command work", () => {
+  test("dream returns immediately and maps success and rejection to settle actions", async () => {
+    const consolidate = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { ops: [{ applied: true }, { applied: false }] },
       })
     );
+    const result = await processSlashCommand(
+      { type: "dream" },
+      createEnv({
+        api: { memory: { consolidate } } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(result, "consume");
+    expect(consolidate).not.toHaveBeenCalled();
+    const successActions = await result.backgroundTask?.();
+    expect(successActions).toBeDefined();
+    expectToast(successActions ?? [], {
+      type: "success",
+      message: "Memory consolidated: 1 change(s)",
+    });
+
+    const failed = await processSlashCommand(
+      { type: "dream" },
+      createEnv({
+        api: {
+          memory: {
+            consolidate: mock(() =>
+              Promise.resolve({ success: false as const, error: "backend refused" })
+            ),
+          },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (failed.kind !== "complete") throw new Error("expected complete result");
+    const failedActions = await failed.backgroundTask?.();
+    expectToast(failedActions ?? [], {
+      type: "error",
+      message: "Memory consolidation failed: backend refused",
+    });
+
+    const rejected = await processSlashCommand(
+      { type: "dream" },
+      createEnv({
+        api: {
+          memory: { consolidate: mock(() => Promise.reject(new Error("offline"))) },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (rejected.kind !== "complete") throw new Error("expected complete result");
+    const rejectedActions = await rejected.backgroundTask?.();
+    expectToast(rejectedActions ?? [], {
+      type: "error",
+      message: "Memory consolidation failed: Error: offline",
+    });
+  });
+
+  test("refine returns immediate validation or detached settle actions", async () => {
+    const missingProposal = await processSlashCommand(
+      { type: "refine", apply: true },
+      createEnv({
+        api: { refinements: {} } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (missingProposal.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(missingProposal, "consume");
+    expect(missingProposal.backgroundTask).toBeUndefined();
+    expect(missingProposal.actions[0]).toMatchObject({
+      type: "show-toast",
+      toast: { type: "error" },
+    });
+
+    const run = mock(() =>
+      Promise.resolve({
+        success: true as const,
+        data: { applied: [], staged: [{ path: "src/a.ts" }], failed: [], noOp: false },
+      })
+    );
+    const result = await processSlashCommand(
+      { type: "refine", apply: false },
+      createEnv({
+        api: { refinements: { run } } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expect(run).not.toHaveBeenCalled();
+    const actions = await result.backgroundTask?.();
+    expectToast(actions ?? [], {
+      type: "success",
+      message: "Refine: 1 edit(s) staged — approve with /refine apply",
+    });
+
+    const failed = await processSlashCommand(
+      { type: "refine", apply: false },
+      createEnv({
+        api: {
+          refinements: {
+            run: mock(() => Promise.resolve({ success: false as const, error: "backend refused" })),
+          },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (failed.kind !== "complete") throw new Error("expected complete result");
+    expectToast((await failed.backgroundTask?.()) ?? [], {
+      type: "error",
+      message: "Refine failed: backend refused",
+    });
+
+    const rejected = await processSlashCommand(
+      { type: "refine", apply: false },
+      createEnv({
+        api: {
+          refinements: { run: mock(() => Promise.reject(new Error("offline"))) },
+        } as unknown as SlashCommandEnv["api"],
+      })
+    );
+    if (rejected.kind !== "complete") throw new Error("expected complete result");
+    expectToast((await rejected.backgroundTask?.()) ?? [], {
+      type: "error",
+      message: "Refine failed: Error: offline",
+    });
+  });
+});
+
+describe("compact and plan command results", () => {
+  test("compact returns phased composer actions and terminal review actions", async () => {
+    const reviews: ReviewNoteData[] = [
+      {
+        filePath: "src/test.ts",
+        lineRange: "10-15",
+        selectedCode: "const x = 1;",
+        userNote: "Please fix this bug",
+      },
+    ];
+    const sentMessages: Array<{
+      options?: { muxMetadata?: { parsed?: { followUpContent?: { reviews?: ReviewNoteData[] } } } };
+    }> = [];
+    const sendMessage = mock((input: (typeof sentMessages)[number]) => {
+      sentMessages.push(input);
+      return Promise.resolve({ success: true });
+    });
+    const initial = await processSlashCommand(
+      { type: "compact" },
+      createEnv({
+        api: { workspace: { sendMessage } } as unknown as SlashCommandEnv["api"],
+        reviews,
+        editMessageId: "edit-id",
+        attachedReviewIds: ["review-1"],
+        sendMessageOptions: { ...sendMessageOptions, queueDispatchMode: "turn-end" },
+      })
+    );
+    expect(initial.kind).toBe("phase");
+    if (initial.kind !== "phase") throw new Error("expected phase result");
+    expect(initial.actions).toEqual([
+      { type: "clear-input" },
+      { type: "clear-attachments" },
+      { type: "set-sending", sending: true },
+    ]);
+    const complete = await initial.continue();
+    expect(complete.kind).toBe("complete");
+    if (complete.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(complete, "consume");
+    expect(complete.actions).toContainEqual({ type: "cancel-edit" });
+    expect(complete.actions).toContainEqual({ type: "check-reviews", reviewIds: ["review-1"] });
+    expect(complete.actions).toContainEqual({ type: "message-sent", dispatchMode: "turn-end" });
+    expect(sentMessages[0]?.options?.muxMetadata?.parsed?.followUpContent?.reviews).toEqual(
+      reviews
+    );
+  });
+
+  test("compact validation errors restore without starting a phase", async () => {
+    const result = await processSlashCommand(
+      { type: "compact", model: "invalid" },
+      createEnv({ api: {} as unknown as SlashCommandEnv["api"] })
+    );
+    expect(result.kind).toBe("complete");
+    if (result.kind !== "complete") throw new Error("expected complete result");
+    expectDisposition(result, "restore");
+    expect(result.actions[0]).toMatchObject({ type: "show-toast", toast: { type: "error" } });
+  });
+
+  test("plan show replaces its singleton preview", async () => {
+    const workspaceId = "test-workspace-id";
+    const store = useWorkspaceStoreRaw();
+    store.dispose();
+    const metadata: FrontendWorkspaceMetadata = {
+      id: workspaceId,
+      name: "test-workspace",
+      title: "Test Workspace",
+      projectName: "Project",
+      projectPath: "/tmp/project",
+      namedWorkspacePath: "/tmp/project/test-workspace",
+      runtimeConfig: { type: "local" },
+      createdAt: "2026-08-05T00:00:00.000Z",
+    };
+    workspaceStore.addWorkspace(metadata);
+    try {
+      for (const content of ["# First plan", "# Updated plan"]) {
+        const settled = await finishCommand(
+          await processSlashCommand(
+            { type: "plan-show" },
+            createEnv({
+              workspaceId,
+              api: {
+                workspace: {
+                  getPlanContent: mock(() =>
+                    Promise.resolve({
+                      success: true,
+                      data: { content, path: "/path/to/plan.md" },
+                    })
+                  ),
+                },
+              } as unknown as SlashCommandEnv["api"],
+            })
+          )
+        );
+        expectDisposition(settled.result, "consume");
+      }
+      const previews = store
+        .getWorkspaceState(workspaceId)
+        .messages.filter((message) => message.type === "plan-display");
+      expect(previews).toHaveLength(1);
+      expect(previews[0]).toMatchObject({ content: "# Updated plan" });
+    } finally {
+      store.dispose();
+    }
+  });
+
+  test("plan show missing result consumes with an error toast", async () => {
+    const settled = await finishCommand(
+      await processSlashCommand(
+        { type: "plan-show" },
+        createEnv({
+          api: {
+            workspace: {
+              getPlanContent: mock(() =>
+                Promise.resolve({ success: false, error: "No plan found" })
+              ),
+            },
+          } as unknown as SlashCommandEnv["api"],
+        })
+      )
+    );
+    expectDisposition(settled.result, "consume");
+    expectToast(settled.result.actions, {
+      type: "error",
+      message: "No plan found for this workspace",
+    });
   });
 });
 
@@ -1818,281 +1372,5 @@ describe("prepareCompactionMessage", () => {
     expectCompactionMetadata(metadata);
 
     expect(metadata.parsed.followUpContent?.reviews).toHaveLength(1);
-  });
-});
-
-describe("handlePlanShowCommand", () => {
-  const createMockContext = (
-    getPlanContentResult:
-      | { success: true; data: { content: string; path: string } }
-      | { success: false; error: string }
-  ): CommandHandlerContext => {
-    const setInput = mock(() => undefined);
-    const setToast = mock(() => undefined);
-
-    return {
-      workspaceId: "test-workspace-id",
-      setInput,
-      setToast,
-      api: {
-        workspace: {
-          getPlanContent: mock(() => Promise.resolve(getPlanContentResult)),
-        },
-        general: {},
-      } as unknown as CommandHandlerContext["api"],
-      // Required fields for CommandHandlerContext
-      sendMessageOptions: {
-        model: "anthropic:claude-sonnet-4-6",
-        thinkingLevel: "off",
-        toolPolicy: [],
-        agentId: "exec",
-      },
-      setAttachments: mock(() => undefined),
-      setSendingState: mock(() => undefined),
-    };
-  };
-
-  test("shows error toast when no plan exists", async () => {
-    const context = createMockContext({ success: false, error: "No plan found" });
-
-    const result = await handlePlanShowCommand(context);
-
-    expect(result.clearInput).toBe(true);
-    expect(result.toastShown).toBe(true);
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "No plan found for this workspace",
-      })
-    );
-  });
-
-  test("replaces the previous plan preview instead of stacking another tail row", async () => {
-    const workspaceId = "test-workspace-id";
-    const store = useWorkspaceStoreRaw();
-    store.dispose();
-    const metadata: FrontendWorkspaceMetadata = {
-      id: workspaceId,
-      name: "test-workspace",
-      title: "Test Workspace",
-      projectName: "Project",
-      projectPath: "/tmp/project",
-      namedWorkspacePath: "/tmp/project/test-workspace",
-      runtimeConfig: { type: "local" },
-      createdAt: "2026-08-05T00:00:00.000Z",
-    };
-    workspaceStore.addWorkspace(metadata);
-
-    try {
-      await handlePlanShowCommand(
-        createMockContext({
-          success: true,
-          data: { content: "# First plan", path: "/path/to/plan.md" },
-        })
-      );
-      await handlePlanShowCommand(
-        createMockContext({
-          success: true,
-          data: { content: "# Updated plan", path: "/path/to/plan.md" },
-        })
-      );
-
-      const previews = store
-        .getWorkspaceState(workspaceId)
-        .messages.filter((message) => message.type === "plan-display");
-      expect(previews).toHaveLength(1);
-      expect(previews[0]).toMatchObject({ content: "# Updated plan" });
-    } finally {
-      store.dispose();
-    }
-  });
-
-  test("clears input when plan is found", async () => {
-    const context = createMockContext({
-      success: true,
-      data: { content: "# My Plan\n\nStep 1", path: "/path/to/plan.md" },
-    });
-
-    const result = await handlePlanShowCommand(context);
-
-    expect(result.clearInput).toBe(true);
-    expect(result.toastShown).toBe(false);
-    expect(context.setInput).toHaveBeenCalledWith("");
-    expect(context.api.workspace.getPlanContent).toHaveBeenCalledWith({
-      workspaceId: "test-workspace-id",
-    });
-  });
-});
-
-describe("handlePlanOpenCommand", () => {
-  const createMockContext = (
-    getPlanContentResult:
-      | { success: true; data: { content: string; path: string } }
-      | { success: false; error: string },
-    openInEditorResult?: { success: true; data: undefined } | { success: false; error: string }
-  ): CommandHandlerContext => {
-    const setInput = mock(() => undefined);
-    const setToast = mock(() => undefined);
-
-    return {
-      workspaceId: "test-workspace-id",
-      setInput,
-      setToast,
-      api: {
-        workspace: {
-          getPlanContent: mock(() => Promise.resolve(getPlanContentResult)),
-          getInfo: mock(() => Promise.resolve(null)),
-        },
-        general: {
-          openInEditor: mock(() =>
-            Promise.resolve(openInEditorResult ?? { success: true, data: undefined })
-          ),
-        },
-      } as unknown as CommandHandlerContext["api"],
-      // Required fields for CommandHandlerContext
-      sendMessageOptions: {
-        model: "anthropic:claude-sonnet-4-6",
-        thinkingLevel: "off",
-        toolPolicy: [],
-        agentId: "exec",
-      },
-      setAttachments: mock(() => undefined),
-      setSendingState: mock(() => undefined),
-    };
-  };
-
-  test("shows error toast when no plan exists", async () => {
-    const context = createMockContext({ success: false, error: "No plan found" });
-
-    const result = await handlePlanOpenCommand(context);
-
-    expect(result.clearInput).toBe(true);
-    expect(result.toastShown).toBe(true);
-    expect(context.setToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "error",
-        message: "No plan found for this workspace",
-      })
-    );
-    expect(context.api.workspace.getInfo).not.toHaveBeenCalled();
-    // Should not attempt to open editor
-    expect(context.api.general.openInEditor).not.toHaveBeenCalled();
-  });
-
-  test("opens plan in editor when plan exists", async () => {
-    const context = createMockContext(
-      { success: true, data: { content: "# My Plan", path: "/path/to/plan.md" } },
-      { success: true, data: undefined }
-    );
-
-    const result = await handlePlanOpenCommand(context);
-
-    expect(result.clearInput).toBe(true);
-    expect(context.setInput).toHaveBeenCalledWith("");
-    expect(context.api.workspace.getPlanContent).toHaveBeenCalledWith({
-      workspaceId: "test-workspace-id",
-    });
-    expect(context.api.workspace.getInfo).toHaveBeenCalledWith({
-      workspaceId: "test-workspace-id",
-    });
-    // Note: Built-in editors (VS Code/Cursor/Zed) now use deep links directly
-    // via window.open(), not the backend API. The backend API is only used
-    // for custom editors.
-  });
-
-  // Note: The "editor fails to open" test was removed because built-in editors
-  // (VS Code/Cursor/Zed) now use deep links that open via window.open() and
-  // always succeed from the app's perspective. Failures happen in the external
-  // editor, not in our code path.
-});
-
-describe("handleCompactCommand", () => {
-  const createMockContext = (
-    sendMessageResult: { success: true } | { success: false; error?: string },
-    options?: { reviews?: ReviewNoteData[] }
-  ): CommandHandlerContext => {
-    const setInput = mock(() => undefined);
-    const setToast = mock(() => undefined);
-    const setAttachments = mock(() => undefined);
-    const setSendingState = mock(() => undefined);
-
-    // Track the options passed to sendMessage
-    const sendMessageMock = mock(() => Promise.resolve(sendMessageResult));
-
-    return {
-      workspaceId: "test-workspace-id",
-      setInput,
-      setToast,
-      setAttachments,
-      setSendingState,
-      reviews: options?.reviews,
-      api: {
-        workspace: {
-          sendMessage: sendMessageMock,
-        },
-      } as unknown as CommandHandlerContext["api"],
-      sendMessageOptions: {
-        model: "anthropic:claude-sonnet-4-6",
-        thinkingLevel: "off",
-        toolPolicy: [],
-        agentId: "exec",
-      },
-    };
-  };
-
-  test("passes reviews to followUpContent when reviews are attached", async () => {
-    const reviews: ReviewNoteData[] = [
-      {
-        filePath: "src/test.ts",
-        lineRange: "10-15",
-        selectedCode: "const x = 1;",
-        userNote: "Please fix this bug",
-      },
-    ];
-
-    const context = createMockContext({ success: true }, { reviews });
-
-    await handleCompactCommand({ type: "compact" }, context);
-
-    // Verify sendMessage was called with reviews in the metadata
-    const sendMessageMock = context.api.workspace.sendMessage as ReturnType<typeof mock>;
-    expect(sendMessageMock).toHaveBeenCalled();
-
-    const callArgs = sendMessageMock.mock.calls[0][0] as {
-      options?: { muxMetadata?: { parsed?: { followUpContent?: { reviews?: ReviewNoteData[] } } } };
-    };
-    const followUpContent = callArgs?.options?.muxMetadata?.parsed?.followUpContent;
-
-    expect(followUpContent).toBeDefined();
-    expect(followUpContent?.reviews).toHaveLength(1);
-    expect(followUpContent?.reviews?.[0].userNote).toBe("Please fix this bug");
-  });
-
-  test("creates followUpContent with only reviews (no text)", async () => {
-    const reviews: ReviewNoteData[] = [
-      {
-        filePath: "src/test.ts",
-        lineRange: "10",
-        selectedCode: "x = 1",
-        userNote: "Check this",
-      },
-    ];
-
-    const context = createMockContext({ success: true }, { reviews });
-
-    // No followUpContent text, just reviews
-    await handleCompactCommand({ type: "compact" }, context);
-
-    const sendMessageMock = context.api.workspace.sendMessage as ReturnType<typeof mock>;
-    expect(sendMessageMock).toHaveBeenCalled();
-
-    const callArgs = sendMessageMock.mock.calls[0][0] as {
-      options?: { muxMetadata?: { parsed?: { followUpContent?: { reviews?: ReviewNoteData[] } } } };
-    };
-    const followUpContent = callArgs?.options?.muxMetadata?.parsed?.followUpContent;
-
-    // Should have followUpContent even without text, because reviews are present
-    expect(followUpContent).toBeDefined();
-    expect(followUpContent?.reviews).toHaveLength(1);
   });
 });

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -167,41 +167,79 @@ export async function forkWorkspace(options: ForkOptions): Promise<ForkResult> {
   return { success: true, workspaceInfo };
 }
 
-export interface SlashCommandContext extends Omit<CommandHandlerContext, "workspaceId" | "api"> {
+export type CommandInputDisposition = "consume" | "restore" | "restore-if-empty";
+
+export type CommandAction =
+  | { type: "clear-input" }
+  | { type: "reset-input-height" }
+  | { type: "show-toast"; toast: Toast }
+  | { type: "set-preferred-model"; model: string }
+  | { type: "toggle-vim" }
+  | { type: "set-sending"; sending: boolean }
+  | { type: "clear-attachments" }
+  | { type: "detach-reviews" }
+  | { type: "check-reviews"; reviewIds: string[] }
+  | { type: "message-sent"; dispatchMode: QueueDispatchMode }
+  | { type: "cancel-edit" };
+
+export type CommandResult =
+  | { kind: "phase"; actions: CommandAction[]; continue: () => Promise<CommandResult> }
+  | {
+      kind: "complete";
+      actions: CommandAction[];
+      inputDisposition: CommandInputDisposition;
+      /** Detached work whose settle actions are applied independently of the command chain. */
+      backgroundTask?: () => Promise<CommandAction[]>;
+    };
+
+export interface SlashCommandEnv {
   api: RouterClient<AppRouter> | null;
   workspaceId?: string;
   variant: "workspace" | "creation";
   projectPath?: string | null;
-  openSettings?: (section?: string) => void;
-
   /** Original slash command text as typed, for durable command display. */
   rawInput?: string;
-
   /** Current dynamic-workflows experiment assignment for executable workflow commands. */
   dynamicWorkflowsEnabled?: boolean;
-
-  // Global Actions
-  setPreferredModel: (model: string) => void;
-  setVimEnabled: (cb: (prev: boolean) => boolean) => void;
-
-  // Workspace Actions
-  onResetContext?: () => Promise<"reset" | "noop">;
-  onTruncateHistory?: (percentage?: number) => Promise<void>;
-  resetInputHeight: () => void;
-  /** Read the latest composer text so async command failures don't overwrite newer drafts. */
-  getInput?: () => string;
-  /** Token identifying the command invocation that launched async follow-up work. */
-  asyncCommandToken?: number;
-  /** Return false when an async command completion belongs to a stale workspace/input. */
-  isAsyncCommandCurrent?: (token: number, workspaceId: string) => boolean;
-  /** Callback to trigger message-sent side effects (auto-scroll, auto-background) */
-  onMessageSent?: (dispatchMode: QueueDispatchMode) => void;
-  /** Callback to detach review context from the composer without marking it checked */
-  onDetachAllReviews?: () => void;
-  /** Callback to mark review IDs as checked after successful send */
-  onCheckReviews?: (reviewIds: string[]) => void;
-  /** Review IDs that are attached (for marking as checked on success) */
+  currentModel?: string | null;
+  sendMessageOptions: SendMessageOptions;
+  attachments?: ChatAttachment[];
+  fileParts?: FilePart[];
+  reviews?: ReviewNoteData[];
+  editMessageId?: string;
   attachedReviewIds?: string[];
+  resetContext?: () => Promise<"reset" | "noop">;
+  truncateHistory?: (percentage?: number) => Promise<void>;
+  isCurrent?: () => boolean;
+}
+
+interface WorkspaceCommandEnv extends SlashCommandEnv {
+  api: RouterClient<AppRouter>;
+  workspaceId: string;
+}
+
+function complete(
+  inputDisposition: CommandInputDisposition,
+  actions: CommandAction[] = [],
+  backgroundTask?: () => Promise<CommandAction[]>
+): CommandResult {
+  return {
+    kind: "complete",
+    actions,
+    inputDisposition,
+    ...(backgroundTask ? { backgroundTask } : {}),
+  };
+}
+
+function phase(
+  actions: CommandAction[],
+  continuation: () => Promise<CommandResult>
+): CommandResult {
+  return { kind: "phase", actions, continue: continuation };
+}
+
+function showToast(toast: Toast): CommandAction {
+  return { type: "show-toast", toast };
 }
 
 export const WORKFLOW_FREEFORM_ARGS_ERROR_MESSAGE =
@@ -291,86 +329,66 @@ function isWorkspaceOnlyParsedCommand(
   return WORKSPACE_ONLY_COMMAND_TYPES.has(parsed.type);
 }
 
-/**
- * Process any slash command
- * Returns true if the command was handled (even if it failed)
- * Returns false if it's not a command (should be sent as message) - though parsed usually implies it is a command
- */
+/** Dispatch a parsed slash command into caller-applied result phases. */
 export async function processSlashCommand(
   parsed: ParsedCommand,
-  context: SlashCommandContext
-): Promise<CommandHandlerResult> {
-  if (!parsed) return { clearInput: false, toastShown: false };
-  const { api: client, setInput, setToast, variant, setVimEnabled, setPreferredModel } = context;
+  env: SlashCommandEnv
+): Promise<CommandResult> {
+  if (!parsed) return complete("restore");
+  const client = env.api;
+  const notConnected = () =>
+    complete("restore", [
+      showToast({ id: Date.now().toString(), type: "error", message: "Not connected to server" }),
+    ]);
 
-  const requireClient = (): RouterClient<AppRouter> | null => {
-    if (client) return client;
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "Not connected to server",
-    });
-    return null;
-  };
-
-  // 1. Global Commands
   if (parsed.type === "model-set") {
-    const modelString = parsed.modelString;
-
-    const activeClient = client;
-    const normalized = normalizeModelInput(modelString);
-
+    const normalized = normalizeModelInput(parsed.modelString);
     if (!normalized.model) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: `Invalid model format: expected "provider:model"`,
-      });
-      return { clearInput: false, toastShown: true };
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: 'Invalid model format: expected "provider:model"',
+        }),
+      ]);
     }
-
     const selectedModel = normalized.model;
     const separatorIndex = selectedModel.indexOf(":");
     const provider = selectedModel.slice(0, separatorIndex);
     const modelId = selectedModel.slice(separatorIndex + 1);
     const canonicalModel = normalizeToCanonical(selectedModel);
     const explicitGateway = getExplicitGatewayPrefix(selectedModel);
-
     try {
       let providersConfig: ProvidersConfigMap | null = null;
       let providersConfigLoadFailed = false;
-      if (activeClient) {
+      if (client) {
         try {
-          providersConfig = await activeClient.providers.getConfig();
+          providersConfig = await client.providers.getConfig();
         } catch (error) {
           providersConfigLoadFailed = true;
           console.error("Failed to load provider settings:", error);
         }
       }
-
       const providerConfig = providersConfig?.[provider];
       if (!isValidProvider(provider) && !isCustomProviderConfig(providerConfig)) {
-        setToast({
-          id: Date.now().toString(),
-          type: "error",
-          message: providersConfigLoadFailed
-            ? `Could not verify provider "${provider}": backend unreachable. Please retry.`
-            : `Unknown provider "${provider}"`,
-        });
-        return { clearInput: false, toastShown: true };
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: providersConfigLoadFailed
+              ? 'Could not verify provider "' + provider + '": backend unreachable. Please retry.'
+              : 'Unknown provider "' + provider + '"',
+          }),
+        ]);
       }
-
       if (
         !modelHasPricingData(selectedModel, providersConfig ?? null) &&
-        (await hasBudgetedResumableGoalForWorkspaceModelSwitch(context))
+        (await hasBudgetedResumableGoalForWorkspaceModelSwitch(env))
       ) {
-        showUnpricedModelGoalToast(setToast, "target");
-        return { clearInput: false, toastShown: true };
+        return complete("restore", [showToast(createUnpricedModelGoalToast("target"))]);
       }
-
-      // Align with settings behavior: only persist non-built-in direct-provider models.
       if (
-        activeClient &&
+        client &&
         providersConfig &&
         !BUILT_IN_MODEL_SET.has(canonicalModel) &&
         !explicitGateway
@@ -378,265 +396,255 @@ export async function processSlashCommand(
         try {
           const existingModels: ProviderModelEntry[] = providerConfig?.models ?? [];
           if (!existingModels.some((entry) => getProviderModelEntryId(entry) === modelId)) {
-            // Add model via the same API as settings
-            await activeClient.providers.setModels({
-              provider,
-              models: [...existingModels, modelId],
-            });
+            await client.providers.setModels({ provider, models: [...existingModels, modelId] });
           }
         } catch (error) {
           console.error("Failed to sync model settings:", error);
         }
       }
-
-      setInput("");
-      setPreferredModel(selectedModel);
       trackCommandUsed("model");
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: `Model changed to ${selectedModel}`,
-      });
-      return { clearInput: true, toastShown: true };
+      return complete("consume", [
+        { type: "clear-input" },
+        { type: "set-preferred-model", model: selectedModel },
+        showToast({
+          id: Date.now().toString(),
+          type: "success",
+          message: "Model changed to " + selectedModel,
+        }),
+      ]);
     } catch (error) {
       console.error("Failed to update model:", error);
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: error instanceof Error ? error.message : "Failed to update model",
-      });
-      return { clearInput: false, toastShown: true };
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: error instanceof Error ? error.message : "Failed to update model",
+        }),
+      ]);
     }
   }
 
-  // model-oneshot ("/<model-alias> ...") is handled directly in ChatInput.
-  // This keeps the command parsing centralized, but routes actual sending through the
-  // normal message-send flow (so side effects like review completion and last-read
-  // tracking can't drift).
-
   if (parsed.type === "model-oneshot") {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "Model one-shot is handled in the chat input.",
-    });
-    return { clearInput: false, toastShown: true };
+    return complete("restore", [
+      showToast({
+        id: Date.now().toString(),
+        type: "error",
+        message: "Model one-shot is handled in the chat input.",
+      }),
+    ]);
   }
 
   if (parsed.type === "workflow-run") {
     const workflowsEnabled =
-      context.dynamicWorkflowsEnabled ??
-      isExperimentEnabled(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS) === true;
+      env.dynamicWorkflowsEnabled ?? isExperimentEnabled(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS) === true;
     if (!workflowsEnabled) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: "Dynamic workflows are disabled",
-      });
-      return { clearInput: false, toastShown: true };
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: "Dynamic workflows are disabled",
+        }),
+      ]);
     }
-
-    const activeClient = requireClient();
-    if (!activeClient) {
-      return { clearInput: false, toastShown: true };
+    if (!client) return notConnected();
+    if (!env.workspaceId) {
+      return complete("restore", [
+        showToast({ id: Date.now().toString(), type: "error", message: "No workspace selected" }),
+      ]);
     }
-    if (!context.workspaceId) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: "No workspace selected",
-      });
-      return { clearInput: false, toastShown: true };
-    }
-
     let args: unknown;
     try {
       args = parseWorkflowSlashArgs(parsed.argsText);
     } catch (error) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: error instanceof Error ? error.message : "Invalid workflow arguments",
-      });
-      return { clearInput: false, toastShown: true };
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: error instanceof Error ? error.message : "Invalid workflow arguments",
+        }),
+      ]);
     }
-
-    const workspaceId = context.workspaceId;
+    const workspaceId = env.workspaceId;
     const scriptPath = parsed.scriptPath;
-    const rawInput = context.rawInput?.trim();
-    const rawCommand = rawInput && rawInput.length > 0 ? rawInput : `/${scriptPath}`;
-    const commandPrefix = rawCommand.split(/\s+/u)[0] ?? `/${scriptPath}`;
-    const isCurrent =
-      context.asyncCommandToken != null && context.isAsyncCommandCurrent != null
-        ? () => context.isAsyncCommandCurrent?.(context.asyncCommandToken!, workspaceId) !== false
-        : undefined;
-
-    setInput("");
+    const rawInput = env.rawInput?.trim();
+    const rawCommand = rawInput && rawInput.length > 0 ? rawInput : "/" + scriptPath;
+    const commandPrefix = rawCommand.split(/\s+/u)[0] ?? "/" + scriptPath;
     let sendingStateActive = false;
-    const setWorkflowSendingState = (active: boolean) => {
-      if (sendingStateActive === active) {
-        return;
-      }
-      sendingStateActive = active;
-      context.setSendingState(active);
+    const setWorkflowSending = (sending: boolean): CommandAction[] => {
+      if (sendingStateActive === sending) return [];
+      sendingStateActive = sending;
+      return [{ type: "set-sending", sending }];
     };
-
-    setWorkflowSendingState(true);
-    try {
-      const result = await activeClient.workflows.start({
-        workspaceId,
-        scriptPath,
-        runInBackground: true,
-        args,
-        continuationOptions: context.sendMessageOptions,
-        rawCommand,
-      });
-      // The workflow is durable and backgrounded; do not pin the composer while polling for
-      // completion, otherwise the user cannot supersede a long-running slash workflow.
-      setWorkflowSendingState(false);
-      if (result.invocationMessagePersisted === true) {
-        trackCommandUsed("workflow");
-        setToast({
-          id: Date.now().toString(),
-          type: "success",
-          message: `Workflow ${scriptPath} started`,
+    return phase([{ type: "clear-input" }, ...setWorkflowSending(true)], async () => {
+      try {
+        const result = await client.workflows.start({
+          workspaceId,
+          scriptPath,
+          runInBackground: true,
+          args,
+          continuationOptions: env.sendMessageOptions,
+          rawCommand,
         });
-        return { clearInput: true, toastShown: true };
-      }
-      const run = await waitForWorkflowTerminalRun({
-        client: activeClient,
-        workspaceId,
-        runId: result.runId,
-        initialStatus: result.status,
-        isCurrent,
-      });
-      const terminalStatus = run?.status ?? result.status;
-      if (terminalStatus === "interrupted") {
-        trackCommandUsed("workflow");
-        setToast({
-          id: Date.now().toString(),
-          type: "success",
-          message: `Workflow ${scriptPath} interrupted`,
+        const stoppedActions = setWorkflowSending(false);
+        if (result.invocationMessagePersisted === true) {
+          trackCommandUsed("workflow");
+          return complete("consume", [
+            ...stoppedActions,
+            showToast({
+              id: Date.now().toString(),
+              type: "success",
+              message: "Workflow " + scriptPath + " started",
+            }),
+          ]);
+        }
+        return phase(stoppedActions, async () => {
+          try {
+            const run = await waitForWorkflowTerminalRun({
+              client,
+              workspaceId,
+              runId: result.runId,
+              initialStatus: result.status,
+              isCurrent: env.isCurrent,
+            });
+            const terminalStatus = run?.status ?? result.status;
+            if (terminalStatus === "interrupted") {
+              trackCommandUsed("workflow");
+              return complete("consume", [
+                showToast({
+                  id: Date.now().toString(),
+                  type: "success",
+                  message: "Workflow " + scriptPath + " interrupted",
+                }),
+              ]);
+            }
+            const workflowResultMessage = buildWorkflowResultContextMessage({
+              rawCommand,
+              name: scriptPath,
+              runId: result.runId,
+              status: terminalStatus,
+              result: result.result,
+              run,
+            });
+            return phase(setWorkflowSending(true), async () => {
+              try {
+                const sendResult = await client.workspace.sendMessage({
+                  workspaceId,
+                  message: workflowResultMessage,
+                  options: {
+                    ...env.sendMessageOptions,
+                    muxMetadata: {
+                      type: WORKFLOW_RESULT_METADATA_TYPE,
+                      rawCommand,
+                      commandPrefix,
+                      runId: result.runId,
+                      requestedModel: env.sendMessageOptions.model,
+                    },
+                  },
+                });
+                if (!sendResult.success) {
+                  throw new Error("Failed to send workflow result to the agent");
+                }
+                trackCommandUsed("workflow");
+                return complete("consume", [
+                  ...setWorkflowSending(false),
+                  {
+                    type: "message-sent",
+                    dispatchMode: env.sendMessageOptions.queueDispatchMode ?? "tool-end",
+                  },
+                  showToast({
+                    id: Date.now().toString(),
+                    type: "success",
+                    message: "Workflow " + scriptPath + " " + terminalStatus,
+                  }),
+                ]);
+              } catch (error) {
+                return complete("restore-if-empty", [
+                  ...setWorkflowSending(false),
+                  showToast({
+                    id: Date.now().toString(),
+                    type: "error",
+                    message: error instanceof Error ? error.message : "Failed to run workflow",
+                  }),
+                ]);
+              }
+            });
+          } catch (error) {
+            if (error instanceof Error && error.message === WORKFLOW_COMMAND_SUPERSEDED_MESSAGE) {
+              return complete("consume");
+            }
+            return complete("restore-if-empty", [
+              showToast({
+                id: Date.now().toString(),
+                type: "error",
+                message: error instanceof Error ? error.message : "Failed to run workflow",
+              }),
+            ]);
+          }
         });
-        return { clearInput: true, toastShown: true };
+      } catch (error) {
+        return complete("restore-if-empty", [
+          ...setWorkflowSending(false),
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to run workflow",
+          }),
+        ]);
       }
-      const workflowResultMessage = buildWorkflowResultContextMessage({
-        rawCommand,
-        name: scriptPath,
-        runId: result.runId,
-        status: terminalStatus,
-        result: result.result,
-        run,
-      });
-      // Keep workflow outputs model-visible but UI-hidden: rawCommand drives transcript display,
-      // while the XML block below gives the main agent the completed workflow result.
-      setWorkflowSendingState(true);
-      const sendResult = await activeClient.workspace.sendMessage({
-        workspaceId,
-        message: workflowResultMessage,
-        options: {
-          ...context.sendMessageOptions,
-          muxMetadata: {
-            type: WORKFLOW_RESULT_METADATA_TYPE,
-            rawCommand,
-            commandPrefix,
-            runId: result.runId,
-            requestedModel: context.sendMessageOptions.model,
-          },
-        },
-      });
-      if (!sendResult.success) {
-        throw new Error("Failed to send workflow result to the agent");
-      }
-      context.onMessageSent?.(context.sendMessageOptions.queueDispatchMode ?? "tool-end");
-      trackCommandUsed("workflow");
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: `Workflow ${scriptPath} ${terminalStatus}`,
-      });
-      return { clearInput: true, toastShown: true };
-    } catch (error) {
-      if (error instanceof Error && error.message === WORKFLOW_COMMAND_SUPERSEDED_MESSAGE) {
-        return { clearInput: true, toastShown: false };
-      }
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: error instanceof Error ? error.message : "Failed to run workflow",
-      });
-      const currentInput = context.getInput?.();
-      const shouldRestoreCommand = currentInput === undefined || currentInput.trim().length === 0;
-      return { clearInput: !shouldRestoreCommand, toastShown: true };
-    } finally {
-      setWorkflowSendingState(false);
-    }
+    });
   }
 
   if (parsed.type === "debug-llm-request") {
-    setInput("");
     window.dispatchEvent(createCustomEvent(CUSTOM_EVENTS.OPEN_DEBUG_LLM_REQUEST));
-    return { clearInput: true, toastShown: false };
+    return complete("consume", [{ type: "clear-input" }]);
   }
 
   if (parsed.type === "idle-compaction") {
-    const activeClient = requireClient();
-    if (!activeClient) {
-      return { clearInput: false, toastShown: true };
+    if (!client) return notConnected();
+    if (!env.projectPath) {
+      return complete("restore", [
+        showToast({ id: Date.now().toString(), type: "error", message: "No project selected" }),
+      ]);
     }
-
-    if (!context.projectPath) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: "No project selected",
-      });
-      return { clearInput: false, toastShown: true };
-    }
-
-    setInput("");
-
-    try {
-      const result = await activeClient.projects.idleCompaction.set({
-        projectPath: context.projectPath,
-        hours: parsed.hours,
-      });
-
-      if (!result.success) {
-        setToast({
-          id: Date.now().toString(),
-          type: "error",
-          message: result.error ?? "Failed to update setting",
+    const projectPath = env.projectPath;
+    return phase([{ type: "clear-input" }], async () => {
+      try {
+        const result = await client.projects.idleCompaction.set({
+          projectPath,
+          hours: parsed.hours,
         });
-        return { clearInput: false, toastShown: true };
+        if (!result.success) {
+          return complete("restore", [
+            showToast({
+              id: Date.now().toString(),
+              type: "error",
+              message: result.error ?? "Failed to update setting",
+            }),
+          ]);
+        }
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: parsed.hours
+              ? "Idle compaction set to " + parsed.hours + " hours"
+              : "Idle compaction disabled",
+          }),
+        ]);
+      } catch (error) {
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to update setting",
+          }),
+        ]);
       }
-
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: parsed.hours
-          ? `Idle compaction set to ${parsed.hours} hours`
-          : "Idle compaction disabled",
-      });
-      return { clearInput: true, toastShown: true };
-    } catch (error) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: error instanceof Error ? error.message : "Failed to update setting",
-      });
-      return { clearInput: false, toastShown: true };
-    }
+    });
   }
 
   if (parsed.type === "heartbeat-set") {
-    const activeClient = requireClient();
-    if (!activeClient) {
-      return { clearInput: false, toastShown: true };
-    }
-
-    // Manual /heartbeat invocations stay gated until the experiment is explicitly enabled.
-    // Guard the experiment check so non-browser test environments treat it as disabled safely.
+    if (!client) return notConnected();
     let heartbeatExperimentEnabled: boolean | undefined;
     try {
       heartbeatExperimentEnabled = isExperimentEnabled(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
@@ -644,94 +652,79 @@ export async function processSlashCommand(
       heartbeatExperimentEnabled = false;
     }
     if (!heartbeatExperimentEnabled) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message:
-          "Heartbeat configuration requires the Workspace Heartbeats experiment to be enabled",
-      });
-      return { clearInput: false, toastShown: true };
-    }
-
-    if (!context.workspaceId) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: "No workspace selected",
-      });
-      return { clearInput: false, toastShown: true };
-    }
-
-    setInput("");
-
-    try {
-      // Best-effort read: malformed persisted heartbeat settings should not block a command that
-      // can repair them by writing a fresh interval or disabling the feature.
-      let currentHeartbeatSettings: Awaited<
-        ReturnType<typeof activeClient.workspace.heartbeat.get>
-      > | null = null;
-      try {
-        currentHeartbeatSettings = await activeClient.workspace.heartbeat.get({
-          workspaceId: context.workspaceId,
-        });
-      } catch {
-        currentHeartbeatSettings = null;
-      }
-
-      // Preserve the stored cadence when toggling heartbeats off so re-enabling restores it,
-      // and keep any saved custom heartbeat message when commands only change cadence.
-      const intervalMs =
-        parsed.minutes === null
-          ? (currentHeartbeatSettings?.intervalMs ?? HEARTBEAT_DEFAULT_INTERVAL_MS)
-          : parsed.minutes * 60 * 1000;
-      const result = await activeClient.workspace.heartbeat.set({
-        workspaceId: context.workspaceId,
-        enabled: parsed.minutes !== null,
-        intervalMs,
-        // Omit message when the best-effort read failed; WorkspaceService preserves the
-        // persisted custom message when this field is absent.
-        ...(currentHeartbeatSettings?.message != null
-          ? { message: currentHeartbeatSettings.message }
-          : {}),
-      });
-
-      if (!result.success) {
-        setToast({
+      return complete("restore", [
+        showToast({
           id: Date.now().toString(),
           type: "error",
-          message: result.error ?? "Failed to update setting",
-        });
-        return { clearInput: false, toastShown: true };
-      }
-
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message:
-          parsed.minutes === null
-            ? "Heartbeat disabled"
-            : `Heartbeat set to every ${parsed.minutes} minutes`,
-      });
-      return { clearInput: true, toastShown: true };
-    } catch (error) {
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: error instanceof Error ? error.message : "Failed to update setting",
-      });
-      return { clearInput: false, toastShown: true };
+          message:
+            "Heartbeat configuration requires the Workspace Heartbeats experiment to be enabled",
+        }),
+      ]);
     }
+    if (!env.workspaceId) {
+      return complete("restore", [
+        showToast({ id: Date.now().toString(), type: "error", message: "No workspace selected" }),
+      ]);
+    }
+    const workspaceId = env.workspaceId;
+    return phase([{ type: "clear-input" }], async () => {
+      try {
+        let currentHeartbeatSettings: Awaited<
+          ReturnType<typeof client.workspace.heartbeat.get>
+        > | null = null;
+        try {
+          currentHeartbeatSettings = await client.workspace.heartbeat.get({ workspaceId });
+        } catch {
+          currentHeartbeatSettings = null;
+        }
+        const intervalMs =
+          parsed.minutes === null
+            ? (currentHeartbeatSettings?.intervalMs ?? HEARTBEAT_DEFAULT_INTERVAL_MS)
+            : parsed.minutes * 60 * 1000;
+        const result = await client.workspace.heartbeat.set({
+          workspaceId,
+          enabled: parsed.minutes !== null,
+          intervalMs,
+          ...(currentHeartbeatSettings?.message != null
+            ? { message: currentHeartbeatSettings.message }
+            : {}),
+        });
+        if (!result.success) {
+          return complete("restore", [
+            showToast({
+              id: Date.now().toString(),
+              type: "error",
+              message: result.error ?? "Failed to update setting",
+            }),
+          ]);
+        }
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message:
+              parsed.minutes === null
+                ? "Heartbeat disabled"
+                : "Heartbeat set to every " + parsed.minutes + " minutes",
+          }),
+        ]);
+      } catch (error) {
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to update setting",
+          }),
+        ]);
+      }
+    });
   }
 
   if (parsed.type === "vim-toggle") {
-    setInput("");
-    setVimEnabled((prev) => !prev);
     trackCommandUsed("vim");
-    return { clearInput: true, toastShown: false };
+    return complete("consume", [{ type: "clear-input" }, { type: "toggle-vim" }]);
   }
 
-  // 2. Workspace Commands
-  // Use command keys for help/invalid variants so creation mode doesn't surface workspace-only help text.
   const workspaceOnlyKey = (() => {
     switch (parsed.type) {
       case "command-missing-args":
@@ -743,216 +736,153 @@ export async function processSlashCommand(
         return null;
     }
   })();
-
   const isWorkspaceCommandType = isWorkspaceOnlyParsedCommand(parsed);
   const isWorkspaceOnlyCommand =
     isWorkspaceCommandType ||
     (workspaceOnlyKey ? WORKSPACE_ONLY_COMMAND_KEYS.has(workspaceOnlyKey) : false);
-
-  if (isWorkspaceOnlyCommand && variant !== "workspace") {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "Command not available during workspace creation",
-    });
-    return { clearInput: false, toastShown: true };
+  if (isWorkspaceOnlyCommand && env.variant !== "workspace") {
+    return complete("restore", [
+      showToast({
+        id: Date.now().toString(),
+        type: "error",
+        message: "Command not available during workspace creation",
+      }),
+    ]);
   }
 
   if (isWorkspaceCommandType) {
-    // Dispatch workspace commands
     switch (parsed.type) {
       case "clear":
-        return handleClearCommand(parsed, context);
+        return handleClearCommand(parsed, env);
       case "compact":
-        // handleCompactCommand expects workspaceId in context
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handleCompactCommand(parsed, {
-          ...context,
-          api: client,
-          workspaceId: context.workspaceId,
-        } as CommandHandlerContext);
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        return handleCompactCommand(parsed, { ...env, api: client, workspaceId: env.workspaceId });
       case "dream": {
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        const dreamClient = requireClient();
-        if (!dreamClient) {
-          return { clearInput: false, toastShown: true };
-        }
-        // Fire-and-forget by design (PRD #3534): the dream run is background
-        // housekeeping; results surface in the Memory tab, not the chat. The
-        // only toast is the settle toast — an optimistic "started" success
-        // toast would flash green-then-red whenever the backend rejects
-        // immediately (experiment off, debounced, run already in flight).
-        const dreamWorkspaceId = context.workspaceId;
-        void dreamClient.memory
-          .consolidate({ workspaceId: dreamWorkspaceId })
-          .then((result) => {
-            // "Changes" counts applied ops only; the journal also records
-            // rejected/failed commands, which are not changes.
-            const applied = result.success ? result.data.ops.filter((op) => op.applied).length : 0;
-            context.setToast(
-              result.success
-                ? {
-                    id: Date.now().toString(),
-                    type: "success",
-                    message:
-                      applied === 0
-                        ? "Memory consolidation: no changes needed"
-                        : `Memory consolidated: ${applied} change(s)`,
-                  }
-                : {
-                    id: Date.now().toString(),
-                    type: "error",
-                    message: `Memory consolidation failed: ${result.error}`,
-                  }
-            );
-          })
-          .catch((error: unknown) => {
-            context.setToast({
-              id: Date.now().toString(),
-              type: "error",
-              message: `Memory consolidation failed: ${String(error)}`,
-            });
-          });
-        return { clearInput: true, toastShown: true };
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        const workspaceId = env.workspaceId;
+        return complete("consume", [], async () => {
+          try {
+            const result = await client.memory.consolidate({ workspaceId });
+            const applied = result.success
+              ? result.data.ops.filter((operation) => operation.applied).length
+              : 0;
+            return [
+              showToast(
+                result.success
+                  ? {
+                      id: Date.now().toString(),
+                      type: "success",
+                      message:
+                        applied === 0
+                          ? "Memory consolidation: no changes needed"
+                          : "Memory consolidated: " + applied + " change(s)",
+                    }
+                  : {
+                      id: Date.now().toString(),
+                      type: "error",
+                      message: "Memory consolidation failed: " + result.error,
+                    }
+              ),
+            ];
+          } catch (error) {
+            return [
+              showToast({
+                id: Date.now().toString(),
+                type: "error",
+                message: "Memory consolidation failed: " + String(error),
+              }),
+            ];
+          }
+        });
       }
       case "refine": {
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        const refineClient = requireClient();
-        if (!refineClient) {
-          return { clearInput: false, toastShown: true };
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        const workspaceId = env.workspaceId;
+        const apply = parsed.apply === true;
+        const displayedProposalHash = apply ? getDisplayedRefineProposalHash(workspaceId) : null;
+        if (apply && displayedProposalHash === null) {
+          return complete("consume", [
+            showToast({
+              id: Date.now().toString(),
+              type: "error",
+              message:
+                "Refine failed: no staged /refine proposal is visible in this chat; run /refine first",
+            }),
+          ]);
         }
-        // Fire-and-forget like /dream: the pass runs in the background and
-        // posts its own labeled summary row into the chat when edits were
-        // staged/applied. Only the settle toast is shown — an optimistic
-        // "started" toast would flash green-then-red when the backend rejects
-        // immediately (RLM off, run already in flight). Plain /refine only
-        // STAGES edits (security: model output is never auto-applied);
-        // /refine apply is the explicit approval step.
-        const refineWorkspaceId = context.workspaceId;
-        const refineApply = parsed.apply === true;
-        // Ride the renderer's effective experiment flags with the request:
-        // backend override persistence is asynchronous/best-effort, so a
-        // backend-only gate could refuse /refine while this client already
-        // offers the command and runs with the RLM kernel.
-        const refineExperiments = context.sendMessageOptions.experiments;
-        // r64: bind approval to the proposal THIS window rendered. The shared
-        // transcript can hold a newer foreign proposal (second app instance
-        // over the same root) that this renderer never displayed; the backend
-        // refuses to apply when the staged set no longer hashes to the
-        // proposal we send here.
-        const displayedProposalHash = refineApply
-          ? getDisplayedRefineProposalHash(refineWorkspaceId)
-          : null;
-        if (refineApply && displayedProposalHash === null) {
-          context.setToast({
-            id: Date.now().toString(),
-            type: "error",
-            message:
-              "Refine failed: no staged /refine proposal is visible in this chat; run /refine first",
-          });
-          return { clearInput: true, toastShown: true };
-        }
-        void (
-          refineApply && displayedProposalHash !== null
-            ? refineClient.refinements.apply({
-                workspaceId: refineWorkspaceId,
-                approvedProposalHash: displayedProposalHash,
-                experiments: refineExperiments,
-              })
-            : refineClient.refinements.run({
-                workspaceId: refineWorkspaceId,
-                experiments: refineExperiments,
-              })
-        )
-          .then((result) => {
-            // untrackedApplied: edits that succeeded but could not be
-            // journaled (no rollback id) — still real, so counted.
+        const experiments = env.sendMessageOptions.experiments;
+        return complete("consume", [], async () => {
+          try {
+            const result =
+              apply && displayedProposalHash !== null
+                ? await client.refinements.apply({
+                    workspaceId,
+                    approvedProposalHash: displayedProposalHash,
+                    experiments,
+                  })
+                : await client.refinements.run({ workspaceId, experiments });
             const appliedCount = result.success
               ? result.data.applied.length + (result.data.untrackedApplied ?? 0)
               : 0;
             const failedCount = result.success ? (result.data.failed?.length ?? 0) : 0;
-            // r55: an apply where every edit failed (e.g. all staged targets
-            // changed) returns success:true with zero applied edits — a green
-            // "0 edit(s) applied, N failed" toast would read like the
-            // approved changes landed. Surface it as an error instead.
             const allFailed =
-              result.success &&
-              refineApply &&
-              !result.data.noOp &&
-              appliedCount === 0 &&
-              failedCount > 0;
-            context.setToast(
-              result.success
-                ? {
-                    id: Date.now().toString(),
-                    type: allFailed ? "error" : "success",
-                    message: result.data.noOp
-                      ? refineApply
-                        ? "Refine: nothing was applied"
-                        : "Refine: nothing worth distilling"
-                      : refineApply
-                        ? `Refine: ${appliedCount} edit(s) applied${
-                            failedCount > 0 ? `, ${failedCount} failed` : ""
-                          } (see chat summary)`
-                        : `Refine: ${result.data.staged?.length ?? 0} edit(s) staged — approve with /refine apply`,
-                  }
-                : {
-                    id: Date.now().toString(),
-                    type: "error",
-                    message: `Refine failed: ${result.error}`,
-                  }
-            );
-          })
-          .catch((error: unknown) => {
-            context.setToast({
-              id: Date.now().toString(),
-              type: "error",
-              message: `Refine failed: ${String(error)}`,
-            });
-          });
-        return { clearInput: true, toastShown: true };
+              result.success && apply && !result.data.noOp && appliedCount === 0 && failedCount > 0;
+            return [
+              showToast(
+                result.success
+                  ? {
+                      id: Date.now().toString(),
+                      type: allFailed ? "error" : "success",
+                      message: result.data.noOp
+                        ? apply
+                          ? "Refine: nothing was applied"
+                          : "Refine: nothing worth distilling"
+                        : apply
+                          ? "Refine: " +
+                            appliedCount +
+                            " edit(s) applied" +
+                            (failedCount > 0 ? ", " + failedCount + " failed" : "") +
+                            " (see chat summary)"
+                          : "Refine: " +
+                            (result.data.staged?.length ?? 0) +
+                            " edit(s) staged — approve with /refine apply",
+                    }
+                  : {
+                      id: Date.now().toString(),
+                      type: "error",
+                      message: "Refine failed: " + result.error,
+                    }
+              ),
+            ];
+          } catch (error) {
+            return [
+              showToast({
+                id: Date.now().toString(),
+                type: "error",
+                message: "Refine failed: " + String(error),
+              }),
+            ];
+          }
+        });
       }
       case "fork":
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handleForkCommand(parsed, {
-          ...context,
-          api: client,
-        });
+        if (!client) return notConnected();
+        return handleForkCommand(parsed, { ...env, api: client });
       case "new":
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handleNewCommand(parsed, {
-          ...context,
-          api: client,
-          workspaceId: context.workspaceId,
-        } as CommandHandlerContext);
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        return handleNewCommand(parsed, { ...env, api: client, workspaceId: env.workspaceId });
       case "plan-show":
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handlePlanShowCommand({
-          ...context,
-          api: client,
-          workspaceId: context.workspaceId,
-        } as CommandHandlerContext);
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        return handlePlanShowCommand({ ...env, api: client, workspaceId: env.workspaceId });
       case "plan-open":
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handlePlanOpenCommand({
-          ...context,
-          api: client,
-          workspaceId: context.workspaceId,
-        } as CommandHandlerContext);
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        return handlePlanOpenCommand({ ...env, api: client, workspaceId: env.workspaceId });
       case "goal-show":
       case "goal-set":
       case "goal-budget":
@@ -960,30 +890,15 @@ export async function processSlashCommand(
       case "goal-resume":
       case "goal-complete":
       case "goal-clear":
-        if (!context.workspaceId) throw new Error("Workspace ID required");
-        if (!requireClient()) {
-          return { clearInput: false, toastShown: true };
-        }
-        return handleGoalCommand(parsed, {
-          ...context,
-          api: client,
-          workspaceId: context.workspaceId,
-        } as CommandHandlerContext);
-      // No default: parsed is narrowed to workspace-only commands (minus
-      // workflow-run/heartbeat-set, which returned above), so adding a type
-      // to WORKSPACE_ONLY_COMMAND_TYPE_LIST without a case fails the
-      // switch-exhaustiveness lint here.
+        if (!env.workspaceId) throw new Error("Workspace ID required");
+        if (!client) return notConnected();
+        return handleGoalCommand(parsed, { ...env, api: client, workspaceId: env.workspaceId });
     }
   }
 
-  // 3. Fallback / Help / Unknown
   const commandToast = createCommandToast(parsed);
-  if (commandToast) {
-    setToast(commandToast);
-    return { clearInput: false, toastShown: true };
-  }
-
-  return { clearInput: false, toastShown: false };
+  if (commandToast) return complete("restore", [showToast(commandToast)]);
+  return complete("restore");
 }
 
 // ============================================================================
@@ -1008,35 +923,22 @@ type GoalSetCommandResult =
   | { success: false; error: GoalSetError };
 
 async function setGoalWithSingleConflictRetry(
-  context: CommandHandlerContext,
+  env: WorkspaceCommandEnv,
   intent: GoalSetCommandIntent
 ): Promise<GoalSetCommandResult> {
-  // Shared retry helper centralized in `@/browser/utils/goals/` to avoid the
-  // three-way drift Coder-agents-review P3 DEREM-25 flagged. Adapts the raw
-  // API result to the typed `GoalSetCommandResult` this caller exposes.
-  const result = await setGoalWithConflictRetry(context.api, context.workspaceId, intent);
-  if (result.success) {
-    return { success: true, goal: result.data };
-  }
+  const result = await setGoalWithConflictRetry(env.api, env.workspaceId, intent);
+  if (result.success) return { success: true, goal: result.data };
   return { success: false, error: result.error };
 }
 
-async function getGoalDefaults(context: CommandHandlerContext): Promise<GoalDefaults> {
-  // Centralized in `@/browser/utils/goals/` so the slash command path and
-  // the command palette path read defaults the same way (Coder-agents-
-  // review P3 DEREM-27). Pass the workspaceId so the helper layers any
-  // per-workspace override on top of the global default — workspace rules
-  // win for `/goal` invocations inside that workspace.
-  return loadGoalDefaults(context.api, context.workspaceId);
+async function getGoalDefaults(env: WorkspaceCommandEnv): Promise<GoalDefaults> {
+  return loadGoalDefaults(env.api, env.workspaceId);
 }
 
 function resolveSlashGoalSetIntent(
   parsed: Extract<ParsedCommand, { type: "goal-set" }>,
   defaults: GoalDefaults
 ): GoalSetCommandIntent {
-  // The slash command's parser leaves `budgetCents`/`turnCap` undefined
-  // when omitted (rather than `null`), so we forward as-is to the shared
-  // resolver which treats `undefined` as "apply default".
   return resolveGoalSetIntent(
     {
       objective: parsed.objective,
@@ -1048,42 +950,36 @@ function resolveSlashGoalSetIntent(
 }
 
 async function hasBudgetedResumableGoalForWorkspaceModelSwitch(
-  context: SlashCommandContext
+  env: SlashCommandEnv
 ): Promise<boolean> {
-  if (context.variant !== "workspace" || !context.api || !context.workspaceId) {
-    return false;
-  }
-
+  if (env.variant !== "workspace" || !env.api || !env.workspaceId) return false;
   try {
-    const result = await context.api.workspace.getGoal({ workspaceId: context.workspaceId });
+    const result = await env.api.workspace.getGoal({ workspaceId: env.workspaceId });
     return hasBudgetedResumableGoal(result.goal);
   } catch {
     return false;
   }
 }
 
-async function currentModelHasPricingData(context: CommandHandlerContext): Promise<boolean> {
+async function currentModelHasPricingData(env: WorkspaceCommandEnv): Promise<boolean> {
   let providersConfig: unknown = null;
   try {
-    providersConfig = await context.api.providers.getConfig();
+    providersConfig = await env.api.providers.getConfig();
   } catch {
     providersConfig = null;
   }
-  return modelHasPricingData(context.sendMessageOptions.model, providersConfig);
+  return modelHasPricingData(env.sendMessageOptions.model, providersConfig);
 }
 
-function showUnpricedModelGoalToast(
-  setToast: (toast: Toast) => void,
-  modelPosition: "current" | "target" = "current"
-): void {
-  setToast({
+function createUnpricedModelGoalToast(modelPosition: "current" | "target" = "current"): Toast {
+  return {
     id: Date.now().toString(),
     type: "error",
     message:
       modelPosition === "current"
         ? UNPRICED_CURRENT_MODEL_GOAL_MESSAGE
         : UNPRICED_TARGET_MODEL_GOAL_MESSAGE,
-  });
+  };
 }
 
 function getGoalSetErrorMessage(error: GoalSetError): string {
@@ -1093,15 +989,15 @@ function getGoalSetErrorMessage(error: GoalSetError): string {
   return error.message;
 }
 
-function showGoalSetErrorToast(setToast: (toast: Toast) => void, error: GoalSetError): void {
-  setToast({
+function createGoalSetErrorToast(error: GoalSetError): Toast {
+  return {
     id: Date.now().toString(),
     type: "error",
     message: getGoalSetErrorMessage(error),
-  });
+  };
 }
 
-async function handleGoalCommand(
+function handleGoalCommand(
   parsed: Extract<
     ParsedCommand,
     {
@@ -1115,277 +1011,260 @@ async function handleGoalCommand(
         | "goal-clear";
     }
   >,
-  context: CommandHandlerContext
-): Promise<CommandHandlerResult> {
-  const { api, workspaceId, setInput, setToast } = context;
-
-  setInput("");
-
-  try {
-    if (parsed.type === "goal-show") {
-      const result = await api.workspace.getGoal({ workspaceId });
-      if (result.goal) {
-        window.dispatchEvent?.(createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId }));
-        return { clearInput: true, toastShown: false };
+  env: WorkspaceCommandEnv
+): CommandResult {
+  return phase([{ type: "clear-input" }], async () => {
+    try {
+      if (parsed.type === "goal-show") {
+        const result = await env.api.workspace.getGoal({ workspaceId: env.workspaceId });
+        if (result.goal) {
+          window.dispatchEvent?.(
+            createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId: env.workspaceId })
+          );
+          return complete("consume");
+        }
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: "No goal is set. Use /goal <objective> to create one.",
+          }),
+        ]);
       }
 
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: "No goal is set. Use /goal <objective> to create one.",
-      });
-      return { clearInput: true, toastShown: true };
-    }
-
-    if (parsed.type === "goal-pause") {
-      const result = await setGoalWithSingleConflictRetry(context, { status: "paused" });
-      if (!result.success) {
-        showGoalSetErrorToast(setToast, result.error);
-        return { clearInput: false, toastShown: true };
-      }
-      setToast({ id: Date.now().toString(), type: "success", message: "Goal paused" });
-      trackCommandUsed("goal");
-      return { clearInput: true, toastShown: true };
-    }
-
-    if (parsed.type === "goal-resume") {
-      const currentGoal = await api.workspace.getGoal({ workspaceId });
-      if (
-        hasBudgetedResumableGoal(currentGoal.goal) &&
-        !(await currentModelHasPricingData(context))
-      ) {
-        showUnpricedModelGoalToast(setToast);
-        return { clearInput: false, toastShown: true };
+      if (parsed.type === "goal-pause") {
+        const result = await setGoalWithSingleConflictRetry(env, { status: "paused" });
+        if (!result.success) {
+          return complete("restore", [showToast(createGoalSetErrorToast(result.error))]);
+        }
+        trackCommandUsed("goal");
+        return complete("consume", [
+          showToast({ id: Date.now().toString(), type: "success", message: "Goal paused" }),
+        ]);
       }
 
-      const result = await setGoalWithSingleConflictRetry(context, { status: "active" });
-      if (!result.success) {
-        showGoalSetErrorToast(setToast, result.error);
-        return { clearInput: false, toastShown: true };
+      if (parsed.type === "goal-resume") {
+        const currentGoal = await env.api.workspace.getGoal({ workspaceId: env.workspaceId });
+        if (
+          hasBudgetedResumableGoal(currentGoal.goal) &&
+          !(await currentModelHasPricingData(env))
+        ) {
+          return complete("restore", [showToast(createUnpricedModelGoalToast())]);
+        }
+        const result = await setGoalWithSingleConflictRetry(env, { status: "active" });
+        if (!result.success) {
+          return complete("restore", [showToast(createGoalSetErrorToast(result.error))]);
+        }
+        trackCommandUsed("goal");
+        return complete("consume", [
+          showToast({ id: Date.now().toString(), type: "success", message: "Goal resumed" }),
+        ]);
       }
-      setToast({ id: Date.now().toString(), type: "success", message: "Goal resumed" });
-      trackCommandUsed("goal");
-      return { clearInput: true, toastShown: true };
-    }
 
-    if (parsed.type === "goal-complete") {
-      if (!parsed.summary) {
+      if (parsed.type === "goal-complete") {
+        if (!parsed.summary) {
+          window.dispatchEvent?.(
+            createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, {
+              workspaceId: env.workspaceId,
+              openCompleteInput: true,
+            })
+          );
+          return complete("consume");
+        }
+        const result = await setGoalWithSingleConflictRetry(env, {
+          status: "complete",
+          completionSummary: parsed.summary,
+        });
+        if (!result.success) {
+          return complete("restore", [showToast(createGoalSetErrorToast(result.error))]);
+        }
         window.dispatchEvent?.(
-          createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, {
-            workspaceId,
-            openCompleteInput: true,
+          createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId: env.workspaceId })
+        );
+        trackCommandUsed("goal");
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: "Goal marked complete",
+          }),
+        ]);
+      }
+
+      if (parsed.type === "goal-clear") {
+        const result = await env.api.workspace.clearGoal({ workspaceId: env.workspaceId });
+        trackCommandUsed("goal");
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: result.cleared ? "Goal cleared" : "No goal was set",
+          }),
+        ]);
+      }
+
+      if (parsed.type === "goal-budget") {
+        if (hasGoalBudgetLimit(parsed.budgetCents) && !(await currentModelHasPricingData(env))) {
+          return complete("restore", [showToast(createUnpricedModelGoalToast())]);
+        }
+        const result = await setGoalWithSingleConflictRetry(env, {
+          budgetCents: parsed.budgetCents,
+        });
+        if (!result.success) {
+          return complete("restore", [showToast(createGoalSetErrorToast(result.error))]);
+        }
+        window.dispatchEvent?.(
+          createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId: env.workspaceId })
+        );
+        trackCommandUsed("goal");
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: "Goal budget updated",
+          }),
+        ]);
+      }
+
+      const goalDefaults = await getGoalDefaults(env);
+      const goalSetIntent = resolveSlashGoalSetIntent(parsed, goalDefaults);
+      if (
+        hasGoalBudgetLimit(goalSetIntent.budgetCents) &&
+        !(await currentModelHasPricingData(env))
+      ) {
+        return complete("restore", [showToast(createUnpricedModelGoalToast())]);
+      }
+      const result = await setGoalWithSingleConflictRetry(env, goalSetIntent);
+      if (!result.success) {
+        return complete("restore", [showToast(createGoalSetErrorToast(result.error))]);
+      }
+      window.dispatchEvent?.(
+        createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId: env.workspaceId })
+      );
+      trackCommandUsed("goal");
+      return complete("consume");
+    } catch (error) {
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: error instanceof Error ? error.message : "Goal command failed",
+        }),
+      ]);
+    }
+  });
+}
+
+function handleClearCommand(
+  parsed: Extract<ParsedCommand, { type: "clear" }>,
+  env: SlashCommandEnv
+): CommandResult {
+  if (parsed.mode === "soft") {
+    if (!env.resetContext) return complete("consume");
+    return phase([], async () => {
+      try {
+        const result = await env.resetContext?.();
+        const actions: CommandAction[] = [{ type: "clear-input" }, { type: "reset-input-height" }];
+        if (result === "reset") {
+          actions.push({ type: "clear-attachments" }, { type: "detach-reviews" });
+        }
+        trackCommandUsed("clear:soft");
+        actions.push(
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: getContextResetSuccessMessage(result ?? "noop"),
           })
         );
-        return { clearInput: true, toastShown: false };
+        return complete("consume", actions);
+      } catch (error) {
+        const normalized = error instanceof Error ? error : new Error("Failed to reset context");
+        console.error("Failed to reset context:", normalized);
+        return complete("restore", [
+          showToast({ id: Date.now().toString(), type: "error", message: normalized.message }),
+        ]);
       }
-
-      const result = await setGoalWithSingleConflictRetry(context, {
-        status: "complete",
-        completionSummary: parsed.summary,
-      });
-      if (!result.success) {
-        showGoalSetErrorToast(setToast, result.error);
-        return { clearInput: false, toastShown: true };
-      }
-      setToast({ id: Date.now().toString(), type: "success", message: "Goal marked complete" });
-      window.dispatchEvent?.(createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId }));
-      trackCommandUsed("goal");
-      return { clearInput: true, toastShown: true };
-    }
-
-    if (parsed.type === "goal-clear") {
-      const result = await api.workspace.clearGoal({ workspaceId });
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: result.cleared ? "Goal cleared" : "No goal was set",
-      });
-      trackCommandUsed("goal");
-      return { clearInput: true, toastShown: true };
-    }
-
-    if (parsed.type === "goal-budget") {
-      if (hasGoalBudgetLimit(parsed.budgetCents) && !(await currentModelHasPricingData(context))) {
-        showUnpricedModelGoalToast(setToast);
-        return { clearInput: false, toastShown: true };
-      }
-
-      const result = await setGoalWithSingleConflictRetry(context, {
-        budgetCents: parsed.budgetCents,
-      });
-      if (!result.success) {
-        showGoalSetErrorToast(setToast, result.error);
-        return { clearInput: false, toastShown: true };
-      }
-      setToast({ id: Date.now().toString(), type: "success", message: "Goal budget updated" });
-      window.dispatchEvent?.(createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId }));
-      trackCommandUsed("goal");
-      return { clearInput: true, toastShown: true };
-    }
-
-    const goalDefaults = await getGoalDefaults(context);
-    const goalSetIntent = resolveSlashGoalSetIntent(parsed, goalDefaults);
-    if (
-      hasGoalBudgetLimit(goalSetIntent.budgetCents) &&
-      !(await currentModelHasPricingData(context))
-    ) {
-      showUnpricedModelGoalToast(setToast);
-      return { clearInput: false, toastShown: true };
-    }
-
-    const result = await setGoalWithSingleConflictRetry(context, goalSetIntent);
-    if (!result.success) {
-      showGoalSetErrorToast(setToast, result.error);
-      return { clearInput: false, toastShown: true };
-    }
-    window.dispatchEvent?.(createCustomEvent(CUSTOM_EVENTS.OPEN_GOAL_TAB, { workspaceId }));
-    trackCommandUsed("goal");
-    return { clearInput: true, toastShown: false };
-  } catch (error) {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: error instanceof Error ? error.message : "Goal command failed",
     });
-    return { clearInput: false, toastShown: true };
   }
-}
 
-async function handleClearCommand(
-  parsed: Extract<ParsedCommand, { type: "clear" }>,
-  context: SlashCommandContext
-): Promise<CommandHandlerResult> {
-  const {
-    setInput,
-    setAttachments,
-    onDetachAllReviews,
-    onResetContext,
-    onTruncateHistory,
-    resetInputHeight,
-    setToast,
-  } = context;
-
-  if (parsed.mode === "soft") {
-    if (!onResetContext) return { clearInput: true, toastShown: false };
-
+  const initialActions: CommandAction[] = [{ type: "clear-input" }, { type: "reset-input-height" }];
+  if (!env.truncateHistory) {
+    return phase(initialActions, () => Promise.resolve(complete("consume")));
+  }
+  return phase(initialActions, async () => {
     try {
-      const result = await onResetContext();
-      setInput("");
-      resetInputHeight();
-      if (result === "reset") {
-        setAttachments([]);
-        onDetachAllReviews?.();
-      }
-      trackCommandUsed("clear:soft");
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: getContextResetSuccessMessage(result),
-      });
-      return { clearInput: true, toastShown: true };
+      await env.truncateHistory?.(1.0);
+      trackCommandUsed("clear:hard");
+      return complete("consume", [
+        { type: "clear-attachments" },
+        { type: "detach-reviews" },
+        showToast({
+          id: Date.now().toString(),
+          type: "success",
+          message: "Chat history cleared",
+        }),
+      ]);
     } catch (error) {
-      const normalized = error instanceof Error ? error : new Error("Failed to reset context");
-      console.error("Failed to reset context:", normalized);
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: normalized.message,
-      });
-      return { clearInput: false, toastShown: true };
+      const normalized = error instanceof Error ? error : new Error("Failed to clear history");
+      console.error("Failed to clear history:", normalized);
+      return complete("restore", [
+        showToast({ id: Date.now().toString(), type: "error", message: normalized.message }),
+      ]);
     }
-  }
-
-  setInput("");
-  resetInputHeight();
-
-  if (!onTruncateHistory) return { clearInput: true, toastShown: false };
-
-  try {
-    await onTruncateHistory(1.0);
-    setAttachments([]);
-    onDetachAllReviews?.();
-    trackCommandUsed("clear:hard");
-    setToast({
-      id: Date.now().toString(),
-      type: "success",
-      message: "Chat history cleared",
-    });
-    return { clearInput: true, toastShown: true };
-  } catch (error) {
-    const normalized = error instanceof Error ? error : new Error("Failed to clear history");
-    console.error("Failed to clear history:", normalized);
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: normalized.message,
-    });
-    return { clearInput: false, toastShown: true };
-  }
+  });
 }
 
-async function handleForkCommand(
+function handleForkCommand(
   parsed: Extract<ParsedCommand, { type: "fork" }>,
-  context: SlashCommandContext
-): Promise<CommandHandlerResult> {
-  const {
-    api: client,
-    workspaceId,
-    sendMessageOptions,
-    setInput,
-    setSendingState,
-    setToast,
-  } = context;
-
-  setInput(""); // Clear input immediately
-  setSendingState(true);
-
-  try {
-    // Note: workspaceId is required for fork, but SlashCommandContext allows undefined workspaceId.
-    // If we are here, variant === "workspace", so workspaceId should be defined.
-    if (!workspaceId) throw new Error("Workspace ID required for fork");
-
-    if (!client) throw new Error("Client required for fork");
-    const forkResult = await forkWorkspace({
-      client,
-      sourceWorkspaceId: workspaceId,
-      startMessage: parsed.startMessage,
-      sendMessageOptions,
-    });
-
-    if (!forkResult.success) {
-      const errorMsg = forkResult.error ?? "Failed to fork workspace";
-      console.error("Failed to fork workspace:", errorMsg);
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        title: "Fork Failed",
-        message: errorMsg,
+  env: SlashCommandEnv & { api: RouterClient<AppRouter> }
+): CommandResult {
+  return phase([{ type: "clear-input" }, { type: "set-sending", sending: true }], async () => {
+    try {
+      if (!env.workspaceId) throw new Error("Workspace ID required for fork");
+      const result = await forkWorkspace({
+        client: env.api,
+        sourceWorkspaceId: env.workspaceId,
+        startMessage: parsed.startMessage,
+        sendMessageOptions: env.sendMessageOptions,
       });
-      return { clearInput: false, toastShown: true };
-    } else {
+      if (!result.success) {
+        const message = result.error ?? "Failed to fork workspace";
+        console.error("Failed to fork workspace:", message);
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            title: "Fork Failed",
+            message,
+          }),
+          { type: "set-sending", sending: false },
+        ]);
+      }
       trackCommandUsed("fork");
       const displayName =
-        forkResult.workspaceInfo?.title ?? forkResult.workspaceInfo?.name ?? "new workspace";
-      setToast({
-        id: Date.now().toString(),
-        type: "success",
-        message: `Forked to workspace "${displayName}"`,
-      });
-      return { clearInput: true, toastShown: true };
+        result.workspaceInfo?.title ?? result.workspaceInfo?.name ?? "new workspace";
+      return complete("consume", [
+        showToast({
+          id: Date.now().toString(),
+          type: "success",
+          message: 'Forked to workspace "' + displayName + '"',
+        }),
+        { type: "set-sending", sending: false },
+      ]);
+    } catch (error) {
+      const normalized = error instanceof Error ? error : new Error("Failed to fork workspace");
+      console.error("Fork error:", normalized);
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          title: "Fork Failed",
+          message: normalized.message,
+        }),
+        { type: "set-sending", sending: false },
+      ]);
     }
-  } catch (error) {
-    const normalized = error instanceof Error ? error : new Error("Failed to fork workspace");
-    console.error("Fork error:", normalized);
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      title: "Fork Failed",
-      message: normalized.message,
-    });
-    return { clearInput: false, toastShown: true };
-  } finally {
-    setSendingState(false);
-  }
+  });
 }
 
 /**
@@ -1709,300 +1588,231 @@ export async function executeCompaction(
   return { success: true };
 }
 
-// ============================================================================
-// Command Handler Types
-// ============================================================================
-
-export interface CommandHandlerContext {
-  api: RouterClient<AppRouter>;
-  workspaceId: string;
-  currentModel?: string | null;
-  sendMessageOptions: SendMessageOptions;
-  attachments?: ChatAttachment[];
-  fileParts?: FilePart[];
-  /** Reviews attached to the message (from code review panel) */
-  reviews?: ReviewNoteData[];
-  editMessageId?: string;
-  setInput: (value: string) => void;
-  setAttachments: (attachments: ChatAttachment[]) => void;
-  /** Increment/decrement the sending counter. Pass true to increment, false to decrement. */
-  setSendingState: (increment: boolean) => void;
-  setToast: (toast: Toast) => void;
-  onCancelEdit?: () => void;
-}
-
-export interface CommandHandlerResult {
-  /** Whether the input should be cleared */
-  clearInput: boolean;
-  /** Whether to show a toast (already set via context.setToast) */
-  toastShown: boolean;
-}
-
-/**
- * Handle /new command execution.
- *
- * Mirrors /fork's seamless flow: no modal, no required workspace name. The
- * backend auto-generates a branch name, and when a start message is supplied
- * we ask it to fill in the workspace title from that message via
- * `pendingAutoTitle`.
- */
-export async function handleNewCommand(
+/** Handle /new command execution. */
+export function handleNewCommand(
   parsed: Extract<ParsedCommand, { type: "new" }>,
-  context: CommandHandlerContext
-): Promise<CommandHandlerResult> {
-  const {
-    api: client,
-    workspaceId,
-    sendMessageOptions,
-    setInput,
-    setSendingState,
-    setToast,
-  } = context;
-
-  setInput(""); // Clear input immediately, like /fork.
-  setSendingState(true);
-
-  try {
-    // Get workspace info to extract projectPath. /new is a workspace-only
-    // command, so the parent workspace's project becomes the new workspace's
-    // project.
-    const workspaceInfo = await client.workspace.getInfo({ workspaceId });
-    if (!workspaceInfo) {
-      throw new Error("Failed to get workspace info");
-    }
-
-    // Treat blank/whitespace-only payloads the same as no message — pendingAutoTitle
-    // only makes sense when there is real content for the LLM to title from.
-    const trimmedStartMessage = parsed.startMessage?.trim() ?? "";
-    const startMessage = trimmedStartMessage.length > 0 ? trimmedStartMessage : undefined;
-
-    const createResult = await createNewWorkspace({
-      client,
-      projectPath: workspaceInfo.projectPath,
-      // workspaceName intentionally omitted — backend auto-generates (like /fork).
-      startMessage,
-      sendMessageOptions,
-      // Match /fork: only flag pendingAutoTitle when there is a message to
-      // generate the title from.
-      pendingAutoTitle: Boolean(startMessage),
-    });
-
-    if (!createResult.success) {
-      const errorMsg = createResult.error ?? "Failed to create workspace";
-      console.error("Failed to create workspace:", errorMsg);
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        title: "Create Failed",
-        message: errorMsg,
+  env: WorkspaceCommandEnv
+): CommandResult {
+  return phase([{ type: "clear-input" }, { type: "set-sending", sending: true }], async () => {
+    try {
+      const workspaceInfo = await env.api.workspace.getInfo({ workspaceId: env.workspaceId });
+      if (!workspaceInfo) throw new Error("Failed to get workspace info");
+      const trimmedStartMessage = parsed.startMessage?.trim() ?? "";
+      const startMessage = trimmedStartMessage.length > 0 ? trimmedStartMessage : undefined;
+      const result = await createNewWorkspace({
+        client: env.api,
+        projectPath: workspaceInfo.projectPath,
+        startMessage,
+        sendMessageOptions: env.sendMessageOptions,
+        pendingAutoTitle: Boolean(startMessage),
       });
-      return { clearInput: false, toastShown: true };
+      if (!result.success) {
+        const message = result.error ?? "Failed to create workspace";
+        console.error("Failed to create workspace:", message);
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            title: "Create Failed",
+            message,
+          }),
+          { type: "set-sending", sending: false },
+        ]);
+      }
+      trackCommandUsed("new");
+      const displayName =
+        result.workspaceInfo?.title ?? result.workspaceInfo?.name ?? "new workspace";
+      return complete("consume", [
+        showToast({
+          id: Date.now().toString(),
+          type: "success",
+          message: 'Created workspace "' + displayName + '"',
+        }),
+        { type: "set-sending", sending: false },
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create workspace";
+      console.error("Create error:", error);
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          title: "Create Failed",
+          message,
+        }),
+        { type: "set-sending", sending: false },
+      ]);
     }
-
-    trackCommandUsed("new");
-    const displayName =
-      createResult.workspaceInfo?.title ?? createResult.workspaceInfo?.name ?? "new workspace";
-    setToast({
-      id: Date.now().toString(),
-      type: "success",
-      message: `Created workspace "${displayName}"`,
-    });
-    return { clearInput: true, toastShown: true };
-  } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : "Failed to create workspace";
-    console.error("Create error:", error);
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      title: "Create Failed",
-      message: errorMsg,
-    });
-    return { clearInput: false, toastShown: true };
-  } finally {
-    setSendingState(false);
-  }
+  });
 }
 
-/**
- * Handle /compact command execution
- */
-export async function handleCompactCommand(
+/** Handle /compact command execution. */
+export function handleCompactCommand(
   parsed: Extract<ParsedCommand, { type: "compact" }>,
-  context: CommandHandlerContext
-): Promise<CommandHandlerResult> {
-  const {
-    api,
-    workspaceId,
-    sendMessageOptions,
-    editMessageId,
-    setInput,
-    setAttachments,
-    setSendingState,
-    setToast,
-    onCancelEdit,
-  } = context;
-
-  // normalizeModelInput handles null/empty — returns { model: null } for empty input
+  env: WorkspaceCommandEnv
+): CommandResult {
   const normalizedModel = normalizeModelInput(parsed.model);
-
-  // Validate model format early - fail fast before sending to backend
   if (parsed.model && !normalizedModel.model) {
-    setToast(createInvalidCompactModelToast(parsed.model));
-    return { clearInput: false, toastShown: true };
+    return complete("restore", [showToast(createInvalidCompactModelToast(parsed.model))]);
   }
 
-  setInput("");
-  setAttachments([]);
-  setSendingState(true);
-
-  try {
-    // Build followUpContent directly from parsed command + context.
-    const stagedAttachments = context.attachments ? getStagedAttachments(context.attachments) : [];
-    const hasContent =
-      parsed.continueMessage ??
-      context.fileParts?.length ??
-      context.reviews?.length ??
-      stagedAttachments.length;
-    const followUpContent: CompactionFollowUpInput | undefined = hasContent
-      ? {
-          text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", stagedAttachments),
-          fileParts: context.fileParts,
-          reviews: context.reviews,
+  return phase(
+    [
+      { type: "clear-input" },
+      { type: "clear-attachments" },
+      { type: "set-sending", sending: true },
+    ],
+    async () => {
+      try {
+        const stagedAttachments = env.attachments ? getStagedAttachments(env.attachments) : [];
+        const hasContent =
+          parsed.continueMessage ??
+          env.fileParts?.length ??
+          env.reviews?.length ??
+          stagedAttachments.length;
+        const followUpContent: CompactionFollowUpInput | undefined = hasContent
+          ? {
+              text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", stagedAttachments),
+              fileParts: env.fileParts,
+              reviews: env.reviews,
+            }
+          : undefined;
+        const result = await executeCompaction({
+          api: env.api,
+          workspaceId: env.workspaceId,
+          maxOutputTokens: parsed.maxOutputTokens,
+          followUpContent,
+          model: normalizedModel.model ?? undefined,
+          sendMessageOptions: env.sendMessageOptions,
+          editMessageId: env.editMessageId,
+        });
+        if (!result.success) {
+          console.error("Failed to initiate compaction:", result.error);
+          return complete("restore", [
+            showToast({
+              id: Date.now().toString(),
+              type: "error",
+              message: result.error ?? "Failed to start compaction",
+            }),
+            { type: "set-sending", sending: false },
+          ]);
         }
-      : undefined;
+        trackCommandUsed("compact");
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "success",
+            message: parsed.continueMessage
+              ? "Compaction started. Will continue automatically after completion."
+              : "Compaction started. AI will summarize the conversation.",
+          }),
+          ...(env.editMessageId ? ([{ type: "cancel-edit" }] satisfies CommandAction[]) : []),
+          { type: "set-sending", sending: false },
+          { type: "check-reviews", reviewIds: env.attachedReviewIds ?? [] },
+          {
+            type: "message-sent",
+            dispatchMode: env.sendMessageOptions.queueDispatchMode ?? "tool-end",
+          },
+        ]);
+      } catch (error) {
+        console.error("Compaction error:", error);
+        return complete("restore", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: error instanceof Error ? error.message : "Failed to start compaction",
+          }),
+          { type: "set-sending", sending: false },
+        ]);
+      }
+    }
+  );
+}
 
-    const resolvedModel = normalizedModel.model ?? undefined;
-
-    const result = await executeCompaction({
-      api,
-      workspaceId,
-      maxOutputTokens: parsed.maxOutputTokens,
-      followUpContent,
-      model: resolvedModel,
-      sendMessageOptions,
-      editMessageId,
-    });
-
-    if (!result.success) {
-      console.error("Failed to initiate compaction:", result.error);
-      const errorMsg = result.error ?? "Failed to start compaction";
-      setToast({
-        id: Date.now().toString(),
-        type: "error",
-        message: errorMsg,
+export function handlePlanShowCommand(env: WorkspaceCommandEnv): CommandResult {
+  return phase([{ type: "clear-input" }], async () => {
+    try {
+      const result = await env.api.workspace.getPlanContent({ workspaceId: env.workspaceId });
+      if (!result.success) {
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: "No plan found for this workspace",
+          }),
+        ]);
+      }
+      addEphemeralMessage(env.workspaceId, {
+        id: "plan-display-preview",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: result.data.content }],
+        metadata: {
+          historySequence: Number.MAX_SAFE_INTEGER,
+          muxMetadata: { type: "plan-display" as const, path: result.data.path },
+        },
       });
-      return { clearInput: false, toastShown: true };
+      trackCommandUsed("plan");
+      return complete("consume");
+    } catch (error) {
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: error instanceof Error ? error.message : "Failed to show plan",
+        }),
+      ]);
     }
-
-    trackCommandUsed("compact");
-    setToast({
-      id: Date.now().toString(),
-      type: "success",
-      message: parsed.continueMessage
-        ? "Compaction started. Will continue automatically after completion."
-        : "Compaction started. AI will summarize the conversation.",
-    });
-
-    // Clear editing state on success
-    if (editMessageId && onCancelEdit) {
-      onCancelEdit();
-    }
-
-    return { clearInput: true, toastShown: true };
-  } catch (error) {
-    console.error("Compaction error:", error);
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: error instanceof Error ? error.message : "Failed to start compaction",
-    });
-    return { clearInput: false, toastShown: true };
-  } finally {
-    setSendingState(false);
-  }
+  });
 }
 
-// ============================================================================
-// Plan Command Handlers
-// ============================================================================
-
-export async function handlePlanShowCommand(
-  context: CommandHandlerContext
-): Promise<CommandHandlerResult> {
-  const { api, workspaceId, setInput, setToast } = context;
-
-  setInput("");
-
-  const result = await api.workspace.getPlanContent({ workspaceId });
-  if (!result.success) {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "No plan found for this workspace",
-    });
-    return { clearInput: true, toastShown: true };
-  }
-
-  // Keep the ephemeral preview a singleton so repeated /plan show calls replace it instead of
-  // accumulating permanent-looking cards at the transcript bottom.
-  const planMessage = {
-    id: "plan-display-preview",
-    role: "assistant" as const,
-    parts: [{ type: "text" as const, text: result.data.content }],
-    metadata: {
-      historySequence: Number.MAX_SAFE_INTEGER, // Appear at end of chat
-      muxMetadata: { type: "plan-display" as const, path: result.data.path },
-    },
-  };
-  addEphemeralMessage(workspaceId, planMessage);
-
-  trackCommandUsed("plan");
-  return { clearInput: true, toastShown: false };
-}
-
-export async function handlePlanOpenCommand(
-  context: CommandHandlerContext
-): Promise<CommandHandlerResult> {
-  const { api, workspaceId, setInput, setToast } = context;
-
-  setInput("");
-
-  // First get the plan path
-  const planResult = await api.workspace.getPlanContent({ workspaceId });
-  if (!planResult.success) {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: "No plan found for this workspace",
-    });
-    return { clearInput: true, toastShown: true };
-  }
-
-  const workspaceInfo = await api.workspace.getInfo({ workspaceId });
-  const openResult = await openInEditor({
-    api,
-    workspaceId,
-    targetPath: planResult.data.path,
-    runtimeConfig: workspaceInfo?.runtimeConfig,
-    isFile: true,
+export function handlePlanOpenCommand(env: WorkspaceCommandEnv): CommandResult {
+  return phase([{ type: "clear-input" }], async () => {
+    try {
+      const planResult = await env.api.workspace.getPlanContent({ workspaceId: env.workspaceId });
+      if (!planResult.success) {
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: "No plan found for this workspace",
+          }),
+        ]);
+      }
+      const workspaceInfo = await env.api.workspace.getInfo({ workspaceId: env.workspaceId });
+      const openResult = await openInEditor({
+        api: env.api,
+        workspaceId: env.workspaceId,
+        targetPath: planResult.data.path,
+        runtimeConfig: workspaceInfo?.runtimeConfig,
+        isFile: true,
+      });
+      if (!openResult.success) {
+        return complete("consume", [
+          showToast({
+            id: Date.now().toString(),
+            type: "error",
+            message: openResult.error ?? "Failed to open editor",
+          }),
+        ]);
+      }
+      trackCommandUsed("plan");
+      return complete("consume", [
+        showToast({
+          id: Date.now().toString(),
+          type: "success",
+          message: "Opened plan in editor",
+        }),
+      ]);
+    } catch (error) {
+      return complete("restore", [
+        showToast({
+          id: Date.now().toString(),
+          type: "error",
+          message: error instanceof Error ? error.message : "Failed to open plan",
+        }),
+      ]);
+    }
   });
-
-  if (!openResult.success) {
-    setToast({
-      id: Date.now().toString(),
-      type: "error",
-      message: openResult.error ?? "Failed to open editor",
-    });
-    return { clearInput: true, toastShown: true };
-  }
-
-  trackCommandUsed("plan");
-  setToast({
-    id: Date.now().toString(),
-    type: "success",
-    message: "Opened plan in editor",
-  });
-  return { clearInput: true, toastShown: true };
 }
 
 // ============================================================================

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -762,7 +762,7 @@ export async function processSlashCommand(
         if (!env.workspaceId) throw new Error("Workspace ID required");
         if (!client) return notConnected();
         const workspaceId = env.workspaceId;
-        return complete("consume", [], async () => {
+        return complete("consume", [{ type: "clear-input" }], async () => {
           try {
             const result = await client.memory.consolidate({ workspaceId });
             const applied = result.success
@@ -805,6 +805,7 @@ export async function processSlashCommand(
         const displayedProposalHash = apply ? getDisplayedRefineProposalHash(workspaceId) : null;
         if (apply && displayedProposalHash === null) {
           return complete("consume", [
+            { type: "clear-input" },
             showToast({
               id: Date.now().toString(),
               type: "error",
@@ -814,7 +815,7 @@ export async function processSlashCommand(
           ]);
         }
         const experiments = env.sendMessageOptions.experiments;
-        return complete("consume", [], async () => {
+        return complete("consume", [{ type: "clear-input" }], async () => {
           try {
             const result =
               apply && displayedProposalHash !== null

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -1589,7 +1589,7 @@ export async function executeCompaction(
 }
 
 /** Handle /new command execution. */
-export function handleNewCommand(
+function handleNewCommand(
   parsed: Extract<ParsedCommand, { type: "new" }>,
   env: WorkspaceCommandEnv
 ): CommandResult {
@@ -1647,7 +1647,7 @@ export function handleNewCommand(
 }
 
 /** Handle /compact command execution. */
-export function handleCompactCommand(
+function handleCompactCommand(
   parsed: Extract<ParsedCommand, { type: "compact" }>,
   env: WorkspaceCommandEnv
 ): CommandResult {
@@ -1729,7 +1729,7 @@ export function handleCompactCommand(
   );
 }
 
-export function handlePlanShowCommand(env: WorkspaceCommandEnv): CommandResult {
+function handlePlanShowCommand(env: WorkspaceCommandEnv): CommandResult {
   return phase([{ type: "clear-input" }], async () => {
     try {
       const result = await env.api.workspace.getPlanContent({ workspaceId: env.workspaceId });
@@ -1765,7 +1765,7 @@ export function handlePlanShowCommand(env: WorkspaceCommandEnv): CommandResult {
   });
 }
 
-export function handlePlanOpenCommand(env: WorkspaceCommandEnv): CommandResult {
+function handlePlanOpenCommand(env: WorkspaceCommandEnv): CommandResult {
   return phase([{ type: "clear-input" }], async () => {
     try {
       const planResult = await env.api.workspace.getPlanContent({ workspaceId: env.workspaceId });


### PR DESCRIPTION
## Summary

Slash command dispatch now returns a structured result instead of mutating the composer. `processSlashCommand` takes a parsed command plus a minimal `SlashCommandEnv` (data, the oRPC client, two caller-owned domain capabilities, and a cancellation predicate) and returns a discriminated-union `CommandResult`; each caller applies the returned actions to its own UI state. The ~15-callback context bag is deleted and the command tests assert on returned result data instead of callback mocks.

## Background

Command execution was shallow and inverted: `processSlashCommand` took a ~28-property context bag and manipulated the composer's internals through ~15 callbacks (`setInput`, `setToast`, `setAttachments`, `setSendingState`, `setPreferredModel`, `setVimEnabled`, ...). Every invoker had to wire the full bag (the creation flow stubbed 7 no-op setters), and the 2.1k-line test suite could only assert "mockSetToast was called". This deepens the dispatch seam so one interface can serve any invoker, while keeping every command's observable behavior identical.

## Implementation

- `CommandResult` is a phased union: `{ kind: "phase", actions, continue }` for each await boundary (preserves mid-command UI timing: input clears and the sending spinner toggles exactly when they did before), and `{ kind: "complete", actions, inputDisposition, backgroundTask? }` at the end.
  - `continue` is a lazy thunk so no phase's backend work starts before the caller applied the prior actions; thunks never reject (errors are mapped to actions/dispositions inside dispatch).
  - `inputDisposition` (`consume` / `restore` / `restore-if-empty`) replaces the old `clearInput` boolean; `restore-if-empty` lets the caller evaluate the workflow-error draft-restore condition against its own live state, replacing the `getInput()` callback.
  - `backgroundTask` carries detached fire-and-forget work (`/dream`, `/refine` settle toasts) so the blocking chain never pins the composer.
- `SlashCommandEnv` keeps only data plus `resetContext`/`truncateHistory` (caller-owned ChatPane operations) and `isCurrent` (cancellation for `/workflow` polling, replacing the token pair).
- ChatInput and `useCreationWorkspace` each apply actions with a small local switch; the creation applier intentionally no-ops composer actions it never supported. ChatInput's `compact` special case moved into dispatch as `check-reviews` + `message-sent` actions.
- Tests walk phases explicitly and assert action batches, dispositions, and detached settle actions as plain data; UI-callback mocks are gone (stubs remain only for the api boundary and the two domain capabilities).

## Validation

- Remote dogfood UAT on a Coder workspace ran the real Electron app at the pushed SHA against real models: model switch (valid + invalid), `/clear` soft/hard (confirmation, persistence across restart), `/compact` (spinner phases, mid-compact workspace switch), `/vim`, unknown/missing-args restore behavior, `/new`, `/fork`, palette insert-then-execute, creation-mode initial command, and narrow-viewport rendering, all matching trunk.
- UAT flagged one issue: `/new` and `/fork` success toasts never render. An A/B re-run of the same probe on the trunk parent commit (`e41ba293f`) reproduced it identically (0/4 trials): the composer is keyed by `workspaceId`, so it unmounts on the workspace switch before the toast applies. Pre-existing product gap, unchanged by this PR, so it is not fixed here.
- One deliberate deviation from trunk (Codex review round 3): `/dream` and `/refine` now clear the composer when the command is accepted. Trunk left the typed command sitting in the composer where Enter would rerun it; the handlers now emit an explicit `clear-input` action.

## Risks

Medium surface, low semantic risk: dispatch internals were restructured wholesale, but each command's phases were mapped 1:1 from the old control flow and re-verified path-by-path (toasts, ordering, sending-state pairing, restore conditions, window events, telemetry). Highest-risk areas are the multi-phase commands (`/workflow`, `/compact`, `/fork`, `/new`) where a mispaired `set-sending` action would stick the composer spinner; covered by phase-walking tests including the superseded and error paths.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
