### PR TITLE
🤖 tests: fix test-order pollution and review e2e race that block the merge queue

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -218,6 +218,14 @@ jobs:
             # or installDom alike) makes the portal land in a stale document. Verified
             # order-dependent on origin/main; only reliable in its own process.
             src/browser/features/RightSidebar/Memory/MemoryTab.test.tsx
+            # Its "last prompt" popup tests fail when any earlier test file in the
+            # shared process evaluated UI modules without a DOM installed (Radix's
+            # use-layout-effect binds to `globalThis.document` at module eval, so a
+            # DOM-less first import caches the broken no-op mode process-wide).
+            # Verified order-dependent on origin/main via a two-file repro; only
+            # reliable in its own process. Took the merge queue down on 2026-08-29
+            # when runner file enumeration order changed.
+            src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
           )
           # One process per file rather than one shared isolated process. Sharing it still
           # segfaults Bun on the runner (exit 132, "Bun has crashed", zero failing assertions)

--- a/src/browser/components/ChatPane/useChatViewDataReady.test.ts
+++ b/src/browser/components/ChatPane/useChatViewDataReady.test.ts
@@ -1,3 +1,10 @@
+// Bootstrap the baseline DOM before this file's import graph evaluates: the hook's
+// transitive UI imports include modules (e.g. Radix's use-layout-effect) that decide
+// behavior at module-eval time based on `globalThis.document`. Without this, running
+// this file first in a shared bun test process poisons those cached modules for every
+// later UI test file (see tests/ui/dom.ts bootstrap comment).
+import "../../../../tests/ui/dom";
+
 import { describe, expect, test } from "bun:test";
 import { computeChatViewReveal } from "./useChatViewDataReady";
 

--- a/tests/e2e/scenarios/review.spec.ts
+++ b/tests/e2e/scenarios/review.spec.ts
@@ -22,6 +22,7 @@ test("review scenario", async ({ ui, page }) => {
   await ui.chat.clickActionButton("Edit");
   await ui.chat.sendMessage(MOCK_REVIEW_PROMPTS.SHOW_ONBOARDING_DOC);
   await ui.chat.expectTranscriptContains("Found it. Here’s the quick-start summary:");
+  await ui.chat.expectTurnSettled();
 
   await ui.chat.sendMessage("/clear");
   // Confirm the destructive action in the modal

--- a/tests/e2e/utils/ui.ts
+++ b/tests/e2e/utils/ui.ts
@@ -30,6 +30,7 @@ export interface WorkspaceUI {
     setThinkingLevel(value: number): Promise<void>;
     sendMessage(message: string): Promise<void>;
     expectTranscriptContains(text: string): Promise<void>;
+    expectTurnSettled(): Promise<void>;
     expectActionButtonVisible(label: string): Promise<void>;
     clickActionButton(label: string): Promise<void>;
     expectStatusMessageContains(text: string): Promise<void>;
@@ -216,6 +217,12 @@ export function createWorkspaceUI(page: Page, context: DemoProjectConfig): Works
 
     async expectTranscriptContains(text: string): Promise<void> {
       await expect(transcriptLocator(page)).toContainText(text, { timeout: 45_000 });
+    },
+
+    async expectTurnSettled(): Promise<void> {
+      await expect(page.getByRole("button", { name: "Stop streaming" })).toBeHidden({
+        timeout: 45_000,
+      });
     },
 
     async expectActionButtonVisible(label: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the two latent test defects on `main` that took down the merge queue on 2026-08-29 (~00:48 UTC): an order-dependent unit-test pollution in the shared bun process and a settle race in the review e2e scenario. Both reproduced deterministically on unchanged `origin/main` with zero commits in the flip window, so every queued PR was failing regardless of its content.

## Background

An atomic 5-PR stack merge was dequeued four times with two distinct signatures while every PR-head check was green:

- `Test / Unit`: `WorkspaceFooterBar last prompt` (3 tests) failing in merge-group runs.
- `Test / E2E (linux)`: `review scenario` timing out at the `/clear` step.

Both legs passed in CI at 00:33-00:44 and failed consistently from 00:51 onward, pointing at a runner-environment change exposing latent order/timing dependencies rather than any queued code.

## Implementation

**Unit leg** (bisected to a two-file repro: `bun test useChatViewDataReady.test.ts WorkspaceFooterBar.test.tsx`):

- `useChatViewDataReady.test.ts` imported browser modules with no DOM installed. In a shared bun process this evaluates document-sensitive modules (Radix `use-layout-effect` decides at module-eval time based on `globalThis.document`) into a broken no-op mode cached for every later UI test file. Import the `tests/ui/dom` bootstrap first, matching the existing convention.
- Quarantine `WorkspaceFooterBar.test.tsx` in `pr.yml`'s `isolated_unit_tests`: CI enumerates unit files with unsorted `find`, so any other DOM-less file running first can re-trigger the same class; this is the established pattern for order-sensitive files (same list, same reasons as `MemoryTab.test.tsx`).

**E2E leg**:

- `review scenario` sent `/clear` as soon as the mock turn's text was visible, racing post-stream bookkeeping; the truncate guard rejects with "Cannot truncate history while a turn is active" and the expected status toast never appears. The transcript assertion matches a response prefix while mock chunks are still streaming (each chunk was hitting the tokenizer's 150ms fallback timeout, widening the window on slow runners).
- Added `ui.chat.expectTurnSettled()`, which waits for the accessible "Stop streaming" control to disappear - a renderer signal emitted from `stream-end` after post-stream bookkeeping, with main transitioning COMPLETING -> IDLE in the same continuation - and called it before `/clear`. Deterministic signal, no sleeps.

## Validation

- Unit: two-file repro red pre-fix, green post-fix; `bun test src/browser/components/ChatPane` green; polluter standalone green.
- E2E: reverted-fix run fails deterministically with the truncate-guard error; fixed repro passed 3 consecutive local runs (`xvfb-run -a make test-e2e PLAYWRIGHT_ARGS="tests/e2e/scenarios/review.spec.ts"`).
- `make static-check` green locally.

## Risks

Test-only plus a CI quarantine entry; no production code changed. Main risk is masking rather than fixing: mitigated for the unit leg by fixing the polluter at the source (the quarantine is defense-in-depth against the class), and for the e2e leg by using a deterministic renderer idle signal instead of a timeout.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$107.70`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=107.70 -->

