### PR TITLE
🤖 tests: isolate CoderOauthService catalog concurrency test from cross-file fetch-mock pollution

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -226,6 +226,9 @@ jobs:
             # reliable in its own process. Took the merge queue down on 2026-08-29
             # when runner file enumeration order changed.
             src/browser/components/ChatPane/WorkspaceFooterBar.test.tsx
+            # Post-login catalog refreshes can outlive their test and hit a later global fetch mock,
+            # making catalog-call assertions order-dependent in the shared process.
+            src/node/services/coderOauthService.test.ts
           )
           # One process per file rather than one shared isolated process. Sharing it still
           # segfaults Bun on the runner (exit 132, "Bun has crashed", zero failing assertions)

--- a/src/node/services/coderOauthService.test.ts
+++ b/src/node/services/coderOauthService.test.ts
@@ -3883,6 +3883,14 @@ describe("CoderOauthService", () => {
         if (url === `${DEPLOYMENT_URL}/api/v2/ai/providers`) {
           return Promise.resolve(aiProvidersResponse());
         }
+        // Earlier tests can finish their OAuth flow before post-login catalog discovery settles.
+        // Keep those stale requests from participating in this flow's concurrency gate.
+        if (
+          url.includes("/api/v2/aibridge/") &&
+          new Headers(init?.headers).get("Authorization") !== "Bearer at_concurrent"
+        ) {
+          return new Response("stale test flow", { status: 404 });
+        }
         if (url === `${DEPLOYMENT_URL}/api/v2/aibridge/anthropic/v1/models`) {
           catalogSignals.push(init?.signal);
           await anthropicGate; // Stalled until openai is queried.


### PR DESCRIPTION
## Summary

Fixes the last remaining order-dependent unit test breaking merge-queue runs: `CoderOauthService > startDesktopFlow > fetches origin catalogs concurrently so a stalled origin cannot starve a healthy one` failed pr-4003's merge-group composition twice in a row while passing standalone. Same class as #4005's unit leg (shared bun process + unsorted `find` file order), different mechanism.

## Background

`waitForDesktopFlow()` resolves when `commitDesktopLogin()` calls `desktopFlows.finish()`, before the background task awaits `refreshBridgeModels()`; `dispose()` only shuts down registered flows, so an already-finished flow's catalog retries survive the test. A 250ms retry then calls a LATER test's `globalThis.fetch` mock: the victim observed 4 catalog calls instead of 2, with stale Authorization tokens from three earlier tests in the same file (confirmed via temporary diagnostics; deterministic with a 300ms window).

## Implementation

- Victim isolation: the concurrency test's fetch mock now returns 404 for `/aibridge/` requests whose Authorization is not its own `Bearer at_concurrent`, so stale services from earlier tests cannot release its gate or inflate its signal count.
- Defense in depth: quarantine `coderOauthService.test.ts` in `pr.yml`'s `isolated_unit_tests` (same precedent as `WorkspaceFooterBar.test.tsx` from #4005).

## Validation

- Red: each confirmed polluter + delayed victim failed (received 4 vs expected 2). Green: same pairs pass 0-fail with the isolation; victim file standalone 88/88; diagnostics removed.
- `make static-check` green locally.

## Risks

Test-only + CI quarantine entry; no production code changed.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$107.70`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=107.70 -->

