### PR TITLE
🤖 refactor: extract a pure goal continuation policy from workspaceGoalService

### DIFF
--- a/src/node/services/goalContinuationPolicy.test.ts
+++ b/src/node/services/goalContinuationPolicy.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, test } from "bun:test";
+import type { GoalRecordV1 } from "@/common/types/goal";
+import {
+  applyBudgetDrivenStatus,
+  evaluateGoalContinuation,
+  hasReachedAnyGoalLimit,
+  hasReachedGoalBudgetLimit,
+  hasReachedGoalTurnLimit,
+  isBudgetWrapupEligibleOrigin,
+  type GoalContinuationDecision,
+  type GoalContinuationPolicyState,
+  type GoalStreamOriginKind,
+} from "./goalContinuationPolicy";
+
+const GOAL_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_GOAL_ID = "22222222-2222-4222-8222-222222222222";
+
+function goal(overrides: Partial<GoalRecordV1> = {}): GoalRecordV1 {
+  return {
+    version: 1,
+    goalId: GOAL_ID,
+    objective: "Finish the refactor",
+    status: "active",
+    budgetCents: 100,
+    turnCap: 10,
+    costCents: 0,
+    costMicroCents: 0,
+    turnsUsed: 0,
+    attributedChildren: [],
+    budgetLimitInjectedForGoalId: null,
+    budgetLimitOriginKind: null,
+    requireUserAcknowledgmentSinceMs: null,
+    lastContinuationFiredAtMs: null,
+    createdAtMs: 1_000,
+    updatedAtMs: 1_000,
+    ...overrides,
+  };
+}
+
+type PolicyOverrides = Omit<
+  Partial<GoalContinuationPolicyState>,
+  "candidate" | "workspace" | "runtime" | "goal" | "lastStreamStamp"
+> & {
+  candidate?: GoalContinuationPolicyState["candidate"];
+  workspace?: Partial<GoalContinuationPolicyState["workspace"]>;
+  runtime?: Partial<GoalContinuationPolicyState["runtime"]>;
+  goal?: GoalContinuationPolicyState["goal"];
+  lastStreamStamp?: GoalContinuationPolicyState["lastStreamStamp"];
+};
+
+function policyState(overrides: PolicyOverrides = {}): GoalContinuationPolicyState {
+  const base: GoalContinuationPolicyState = {
+    nowMs: 10_000,
+    bridgeRegistered: true,
+    candidate: {
+      goalId: GOAL_ID,
+      source: "stream_end",
+      sendOptions: { agentId: "exec", mode: "exec" },
+    },
+    workspace: { found: true, archived: false, hasPath: true, isChild: false },
+    hasActiveDescendantTasks: false,
+    runtime: {
+      isInitializing: false,
+      isRuntimeCompatible: true,
+      isBusy: false,
+      hasQueuedMessages: false,
+      hasPendingFollowUp: false,
+    },
+    isStreaming: false,
+    userStopAtMs: null,
+    stopCheckGoal: null,
+    goal: goal(),
+    lastStreamStamp: null,
+    continuationCooldownMs: 1_000,
+    allowUserOriginBudgetWrapup: false,
+  };
+  return {
+    ...base,
+    ...overrides,
+    candidate: overrides.candidate === undefined ? base.candidate : overrides.candidate,
+    workspace: { ...base.workspace, ...overrides.workspace },
+    runtime: { ...base.runtime, ...overrides.runtime },
+    goal: overrides.goal === undefined ? base.goal : overrides.goal,
+    lastStreamStamp:
+      overrides.lastStreamStamp === undefined ? base.lastStreamStamp : overrides.lastStreamStamp,
+  };
+}
+
+describe("evaluateGoalContinuation", () => {
+  const cases: Array<{
+    name: string;
+    state: PolicyOverrides;
+    expected: GoalContinuationDecision;
+  }> = [
+    {
+      name: "stops without a pending candidate",
+      state: { candidate: null },
+      expected: { kind: "stop", reason: "no_pending_candidate", dropCandidate: false },
+    },
+    {
+      name: "keeps the candidate when no bridge is registered",
+      state: { bridgeRegistered: false },
+      expected: { kind: "stop", reason: "not_registered", dropCandidate: false },
+    },
+    {
+      name: "drops a candidate for a missing workspace",
+      state: { workspace: { found: false } },
+      expected: { kind: "stop", reason: "workspace_not_found", dropCandidate: true },
+    },
+    {
+      name: "drops a candidate for an archived workspace",
+      state: { workspace: { archived: true } },
+      expected: { kind: "stop", reason: "archived", dropCandidate: true },
+    },
+    {
+      name: "drops a transcript-only workspace candidate",
+      state: { workspace: { hasPath: false } },
+      expected: { kind: "stop", reason: "transcript_only", dropCandidate: true },
+    },
+    {
+      name: "drops a child workspace candidate",
+      state: { workspace: { isChild: true } },
+      expected: { kind: "stop", reason: "child_workspace", dropCandidate: true },
+    },
+    {
+      name: "keeps a candidate while descendant tasks are active",
+      state: { hasActiveDescendantTasks: true },
+      expected: { kind: "stop", reason: "active_descendant_tasks", dropCandidate: false },
+    },
+    {
+      name: "defers while the runtime initializes",
+      state: { runtime: { isInitializing: true } },
+      expected: { kind: "defer", reason: "initializing", untilMs: 11_000 },
+    },
+    {
+      name: "drops an incompatible runtime candidate",
+      state: { runtime: { isRuntimeCompatible: false } },
+      expected: { kind: "stop", reason: "incompatible_runtime", dropCandidate: true },
+    },
+    {
+      name: "defers while the runtime is busy",
+      state: { runtime: { isBusy: true } },
+      expected: { kind: "defer", reason: "currently_streaming", untilMs: 11_000 },
+    },
+    {
+      name: "defers while the workspace streams",
+      state: { isStreaming: true },
+      expected: { kind: "defer", reason: "currently_streaming", untilMs: 11_000 },
+    },
+    {
+      name: "keeps a candidate behind queued user input",
+      state: { runtime: { hasQueuedMessages: true } },
+      expected: { kind: "stop", reason: "queued_user_input", dropCandidate: false },
+    },
+    {
+      name: "keeps a candidate behind a pending follow-up",
+      state: { runtime: { hasPendingFollowUp: true } },
+      expected: { kind: "stop", reason: "pending_follow_up", dropCandidate: false },
+    },
+    {
+      name: "drops plan-mode candidates",
+      state: {
+        candidate: {
+          goalId: GOAL_ID,
+          source: "stream_end",
+          sendOptions: { agentId: "plan", mode: "exec" },
+        },
+      },
+      expected: { kind: "stop", reason: "plan_mode", dropCandidate: true },
+    },
+    {
+      name: "drops compact-mode candidates",
+      state: {
+        candidate: {
+          goalId: GOAL_ID,
+          source: "stream_end",
+          sendOptions: { agentId: "exec", mode: "compact" },
+        },
+      },
+      expected: { kind: "stop", reason: "compact_mode", dropCandidate: true },
+    },
+    {
+      name: "drops when the stop-check goal is missing",
+      state: { userStopAtMs: 2_000, stopCheckGoal: null },
+      expected: { kind: "stop", reason: "goal_missing", dropCandidate: true },
+    },
+    {
+      name: "drops when the user stopped after goal creation",
+      state: { userStopAtMs: 2_000, stopCheckGoal: { createdAtMs: 2_000 } },
+      expected: { kind: "stop", reason: "user_stop", dropCandidate: true },
+    },
+    {
+      name: "drops when the normalized goal is missing",
+      state: { goal: null },
+      expected: { kind: "stop", reason: "goal_missing", dropCandidate: true },
+    },
+    {
+      name: "drops when goal identity changed",
+      state: { goal: goal({ goalId: OTHER_GOAL_ID }) },
+      expected: { kind: "stop", reason: "goal_mismatch", dropCandidate: true },
+    },
+    {
+      name: "drops inactive goals",
+      state: { goal: goal({ status: "complete" }) },
+      expected: { kind: "stop", reason: "goal_not_active", dropCandidate: true },
+    },
+    {
+      name: "allows a paused kickoff",
+      state: {
+        candidate: { goalId: GOAL_ID, source: "kickoff", sendOptions: { agentId: "exec" } },
+        goal: goal({ status: "paused" }),
+      },
+      expected: { kind: "continue", mode: "continuation" },
+    },
+    {
+      name: "keeps a candidate while acknowledgment is required",
+      state: { goal: goal({ requireUserAcknowledgmentSinceMs: 9_000 }) },
+      expected: { kind: "stop", reason: "requires_ack", dropCandidate: false },
+    },
+    {
+      name: "drops an already-fired budget wrap-up",
+      state: {
+        goal: goal({ status: "budget_limited", budgetLimitInjectedForGoalId: GOAL_ID }),
+      },
+      expected: { kind: "stop", reason: "budget_wrapup_already_fired", dropCandidate: true },
+    },
+    {
+      name: "drops a suppressed budget wrap-up",
+      state: {
+        goal: goal({ status: "budget_limited" }),
+        lastStreamStamp: { goalId: GOAL_ID, originKind: "user" },
+      },
+      expected: { kind: "stop", reason: "budget_wrapup_suppressed", dropCandidate: true },
+    },
+    {
+      name: "continues an eligible budget wrap-up",
+      state: {
+        goal: goal({ status: "budget_limited" }),
+        lastStreamStamp: { goalId: GOAL_ID, originKind: "goal_continuation" },
+      },
+      expected: { kind: "continue", mode: "budget_wrapup" },
+    },
+    {
+      name: "defers during cooldown",
+      state: { goal: goal({ lastContinuationFiredAtMs: 9_500 }) },
+      expected: { kind: "defer", reason: "cooldown", untilMs: 10_500 },
+    },
+    {
+      name: "continues exactly at the cooldown boundary",
+      state: { goal: goal({ lastContinuationFiredAtMs: 9_000 }) },
+      expected: { kind: "continue", mode: "continuation" },
+    },
+    {
+      name: "continues immediately when CLI cooldown is zero",
+      state: { continuationCooldownMs: 0, goal: goal({ lastContinuationFiredAtMs: 10_000 }) },
+      expected: { kind: "continue", mode: "continuation" },
+    },
+  ];
+
+  for (const entry of cases) {
+    test(entry.name, () => {
+      expect(evaluateGoalContinuation(policyState(entry.state))).toEqual(entry.expected);
+    });
+  }
+});
+
+describe("budget wrap-up origins", () => {
+  const origins: GoalStreamOriginKind[] = [
+    "goal_continuation",
+    "goal_budget_limit",
+    "user",
+    "other",
+  ];
+  for (const allowUserOriginBudgetWrapup of [false, true]) {
+    for (const origin of origins) {
+      test(String({ origin, allowUserOriginBudgetWrapup }), () => {
+        expect(isBudgetWrapupEligibleOrigin(origin, allowUserOriginBudgetWrapup)).toBe(
+          origin !== "user" || allowUserOriginBudgetWrapup
+        );
+      });
+    }
+  }
+});
+
+describe("goal limit helpers", () => {
+  test("uses micro-cent precision at the budget boundary", () => {
+    expect(hasReachedGoalBudgetLimit(goal({ costCents: 100, costMicroCents: 99_999_999 }))).toBe(
+      false
+    );
+    expect(hasReachedGoalBudgetLimit(goal({ costCents: 99, costMicroCents: 100_000_000 }))).toBe(
+      true
+    );
+  });
+
+  test("uses whole cents for legacy goals", () => {
+    expect(hasReachedGoalBudgetLimit(goal({ costCents: 100, costMicroCents: undefined }))).toBe(
+      true
+    );
+    expect(hasReachedGoalBudgetLimit(goal({ budgetCents: 0, costCents: 100 }))).toBe(false);
+  });
+
+  test("reaches the turn limit at the cap", () => {
+    expect(hasReachedGoalTurnLimit(goal({ turnsUsed: 9 }))).toBe(false);
+    expect(hasReachedGoalTurnLimit(goal({ turnsUsed: 10 }))).toBe(true);
+    expect(hasReachedAnyGoalLimit(goal({ budgetCents: null, turnsUsed: 10 }))).toBe(true);
+  });
+});
+
+describe("applyBudgetDrivenStatus", () => {
+  test("limits an active goal and persists the origin", () => {
+    expect(
+      applyBudgetDrivenStatus(goal({ turnsUsed: 10 }), {
+        originKind: "goal_continuation",
+        nowMs: 2_000,
+      })
+    ).toMatchObject({
+      status: "budget_limited",
+      budgetLimitOriginKind: "goal_continuation",
+      updatedAtMs: 2_000,
+    });
+  });
+
+  test("re-arms a budget-limited goal when its cap is raised", () => {
+    expect(
+      applyBudgetDrivenStatus(
+        goal({
+          status: "budget_limited",
+          turnsUsed: 10,
+          turnCap: 20,
+          budgetLimitInjectedForGoalId: GOAL_ID,
+          budgetLimitOriginKind: "goal_continuation",
+        }),
+        { nowMs: 2_000 }
+      )
+    ).toMatchObject({
+      status: "active",
+      budgetLimitInjectedForGoalId: null,
+      budgetLimitOriginKind: null,
+      updatedAtMs: 2_000,
+    });
+  });
+
+  test("normalizes zero budgets before evaluating limits", () => {
+    expect(
+      applyBudgetDrivenStatus(goal({ status: "budget_limited", budgetCents: 0 }), {
+        nowMs: 2_000,
+      })
+    ).toMatchObject({ status: "active", budgetCents: null, updatedAtMs: 2_000 });
+  });
+});

--- a/src/node/services/goalContinuationPolicy.test.ts
+++ b/src/node/services/goalContinuationPolicy.test.ts
@@ -273,7 +273,7 @@ describe("budget wrap-up origins", () => {
   ];
   for (const allowUserOriginBudgetWrapup of [false, true]) {
     for (const origin of origins) {
-      test(String({ origin, allowUserOriginBudgetWrapup }), () => {
+      test(`${origin} with user-origin ${allowUserOriginBudgetWrapup ? "allowed" : "blocked"}`, () => {
         expect(isBudgetWrapupEligibleOrigin(origin, allowUserOriginBudgetWrapup)).toBe(
           origin !== "user" || allowUserOriginBudgetWrapup
         );

--- a/src/node/services/goalContinuationPolicy.ts
+++ b/src/node/services/goalContinuationPolicy.ts
@@ -1,0 +1,286 @@
+import type { GoalRecordV1 } from "@/common/types/goal";
+import type { SendMessageOptions } from "@/common/orpc/types";
+
+const MICRO_CENTS_PER_CENT = 1_000_000;
+
+export type GoalContinuationSkipReason =
+  | "not_registered"
+  | "no_pending_candidate"
+  | "workspace_not_found"
+  | "archived"
+  | "transcript_only"
+  | "initializing"
+  | "incompatible_runtime"
+  | "child_workspace"
+  | "active_descendant_tasks"
+  | "currently_streaming"
+  | "queued_user_input"
+  | "pending_follow_up"
+  | "plan_mode"
+  | "compact_mode"
+  | "user_stop"
+  | "goal_missing"
+  | "goal_mismatch"
+  | "goal_not_active"
+  | "requires_ack"
+  | "budget_wrapup_already_fired"
+  | "budget_wrapup_suppressed"
+  | "cooldown";
+
+export type GoalStreamOriginKind = "goal_continuation" | "goal_budget_limit" | "user" | "other";
+
+export type GoalContinuationDecision =
+  | { kind: "continue"; mode: "continuation" | "budget_wrapup" }
+  | { kind: "defer"; reason: GoalContinuationSkipReason; untilMs: number }
+  | { kind: "stop"; reason: GoalContinuationSkipReason; dropCandidate: boolean };
+
+export interface GoalContinuationPolicyCandidate {
+  goalId: string;
+  source: "stream_end" | "kickoff" | "budget_wrapup";
+  sendOptions: Pick<SendMessageOptions, "agentId" | "mode">;
+}
+
+export interface GoalContinuationPolicyState {
+  nowMs: number;
+  bridgeRegistered: boolean;
+  candidate: GoalContinuationPolicyCandidate | null;
+  workspace: { found: boolean; archived: boolean; hasPath: boolean; isChild: boolean };
+  hasActiveDescendantTasks: boolean;
+  runtime: {
+    isInitializing: boolean;
+    isRuntimeCompatible: boolean;
+    isBusy: boolean;
+    hasQueuedMessages: boolean;
+    hasPendingFollowUp: boolean;
+  };
+  isStreaming: boolean;
+  userStopAtMs: number | null;
+  stopCheckGoal: Pick<GoalRecordV1, "createdAtMs"> | null;
+  goal: Pick<
+    GoalRecordV1,
+    | "goalId"
+    | "status"
+    | "requireUserAcknowledgmentSinceMs"
+    | "budgetLimitInjectedForGoalId"
+    | "lastContinuationFiredAtMs"
+  > | null;
+  lastStreamStamp: Pick<GoalStreamStamp, "goalId" | "originKind"> | null;
+  continuationCooldownMs: number;
+  allowUserOriginBudgetWrapup: boolean;
+}
+
+export interface GoalStreamStamp {
+  goalId: string | null;
+  originKind: GoalStreamOriginKind;
+}
+
+const stop = (
+  reason: GoalContinuationSkipReason,
+  dropCandidate: boolean
+): GoalContinuationDecision => ({ kind: "stop", reason, dropCandidate });
+
+export function evaluateGoalContinuationRegistration(
+  state: Pick<GoalContinuationPolicyState, "candidate" | "bridgeRegistered">
+): GoalContinuationDecision | null {
+  if (!state.candidate) {
+    return stop("no_pending_candidate", false);
+  }
+  if (!state.bridgeRegistered) {
+    return stop("not_registered", false);
+  }
+  return null;
+}
+
+export function evaluateGoalContinuationWorkspace(
+  state: Pick<GoalContinuationPolicyState, "workspace" | "hasActiveDescendantTasks">
+): GoalContinuationDecision | null {
+  if (!state.workspace.found) {
+    return stop("workspace_not_found", true);
+  }
+  if (state.workspace.archived) {
+    return stop("archived", true);
+  }
+  if (!state.workspace.hasPath) {
+    return stop("transcript_only", true);
+  }
+  if (state.workspace.isChild) {
+    return stop("child_workspace", true);
+  }
+  if (state.hasActiveDescendantTasks) {
+    return stop("active_descendant_tasks", false);
+  }
+  return null;
+}
+
+export function evaluateGoalContinuationRuntime(
+  state: Pick<GoalContinuationPolicyState, "nowMs" | "runtime" | "candidate"> & {
+    isStreaming: boolean | null;
+  }
+): GoalContinuationDecision | null {
+  if (state.runtime.isInitializing) {
+    return { kind: "defer", reason: "initializing", untilMs: state.nowMs + 1_000 };
+  }
+  if (!state.runtime.isRuntimeCompatible) {
+    return stop("incompatible_runtime", true);
+  }
+  if (state.runtime.isBusy || state.isStreaming === true) {
+    return { kind: "defer", reason: "currently_streaming", untilMs: state.nowMs + 1_000 };
+  }
+  if (state.isStreaming == null) {
+    return null;
+  }
+  if (state.runtime.hasQueuedMessages) {
+    return stop("queued_user_input", false);
+  }
+  if (state.runtime.hasPendingFollowUp) {
+    return stop("pending_follow_up", false);
+  }
+  const sendOptions = state.candidate?.sendOptions;
+  if (sendOptions?.agentId === "plan" || sendOptions?.mode === "plan") {
+    return stop("plan_mode", true);
+  }
+  if (sendOptions?.agentId === "compact" || sendOptions?.mode === "compact") {
+    return stop("compact_mode", true);
+  }
+  return null;
+}
+
+export function evaluateGoalContinuationStopCheck(
+  state: Pick<GoalContinuationPolicyState, "userStopAtMs" | "stopCheckGoal">
+): GoalContinuationDecision | null {
+  if (state.userStopAtMs == null) {
+    return null;
+  }
+  if (!state.stopCheckGoal) {
+    return stop("goal_missing", true);
+  }
+  if (state.userStopAtMs >= state.stopCheckGoal.createdAtMs) {
+    return stop("user_stop", true);
+  }
+  return null;
+}
+
+export function evaluateGoalContinuationGoal(
+  state: Pick<
+    GoalContinuationPolicyState,
+    | "nowMs"
+    | "candidate"
+    | "goal"
+    | "lastStreamStamp"
+    | "continuationCooldownMs"
+    | "allowUserOriginBudgetWrapup"
+  >
+): GoalContinuationDecision {
+  const candidate = state.candidate;
+  const goal = state.goal;
+  if (!goal || !candidate) {
+    return stop("goal_missing", true);
+  }
+  if (goal.goalId !== candidate.goalId) {
+    return stop("goal_mismatch", true);
+  }
+  if (
+    goal.status !== "active" &&
+    goal.status !== "budget_limited" &&
+    (goal.status !== "paused" || candidate.source !== "kickoff")
+  ) {
+    return stop("goal_not_active", true);
+  }
+  if (goal.requireUserAcknowledgmentSinceMs != null) {
+    return stop("requires_ack", false);
+  }
+  if (goal.status === "budget_limited") {
+    if (goal.budgetLimitInjectedForGoalId === goal.goalId) {
+      return stop("budget_wrapup_already_fired", true);
+    }
+    if (
+      state.lastStreamStamp?.goalId !== goal.goalId ||
+      !isBudgetWrapupEligibleOrigin(
+        state.lastStreamStamp.originKind,
+        state.allowUserOriginBudgetWrapup
+      )
+    ) {
+      return stop("budget_wrapup_suppressed", true);
+    }
+    return { kind: "continue", mode: "budget_wrapup" };
+  }
+  const lastFiredAtMs = goal.lastContinuationFiredAtMs ?? null;
+  if (lastFiredAtMs != null && state.nowMs - lastFiredAtMs < state.continuationCooldownMs) {
+    return {
+      kind: "defer",
+      reason: "cooldown",
+      untilMs: lastFiredAtMs + state.continuationCooldownMs,
+    };
+  }
+  return { kind: "continue", mode: "continuation" };
+}
+
+export function evaluateGoalContinuation(
+  state: GoalContinuationPolicyState
+): GoalContinuationDecision {
+  return (
+    evaluateGoalContinuationRegistration(state) ??
+    evaluateGoalContinuationWorkspace(state) ??
+    evaluateGoalContinuationRuntime(state) ??
+    evaluateGoalContinuationStopCheck(state) ??
+    evaluateGoalContinuationGoal(state)
+  );
+}
+
+function getGoalCostMicroCents(goal: GoalRecordV1): number {
+  return goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
+}
+
+export function hasReachedGoalBudgetLimit(goal: GoalRecordV1): boolean {
+  return (
+    goal.budgetCents != null &&
+    goal.budgetCents > 0 &&
+    getGoalCostMicroCents(goal) >= goal.budgetCents * MICRO_CENTS_PER_CENT
+  );
+}
+
+export function hasReachedGoalTurnLimit(goal: GoalRecordV1): boolean {
+  return goal.turnCap != null && goal.turnsUsed >= goal.turnCap;
+}
+
+export function hasReachedAnyGoalLimit(goal: GoalRecordV1): boolean {
+  return hasReachedGoalBudgetLimit(goal) || hasReachedGoalTurnLimit(goal);
+}
+
+export function isBudgetWrapupEligibleOrigin(
+  originKind: GoalStreamOriginKind,
+  allowUserOriginBudgetWrapup: boolean
+): boolean {
+  return allowUserOriginBudgetWrapup || originKind !== "user";
+}
+
+export function applyBudgetDrivenStatus(
+  goal: GoalRecordV1,
+  options: { originKind?: GoalStreamOriginKind; nowMs: number }
+): GoalRecordV1 {
+  const normalizedBudgetCents =
+    goal.budgetCents != null && goal.budgetCents > 0 ? goal.budgetCents : null;
+  const normalized =
+    normalizedBudgetCents === goal.budgetCents
+      ? goal
+      : { ...goal, budgetCents: normalizedBudgetCents, updatedAtMs: options.nowMs };
+  const reachedLimit = hasReachedAnyGoalLimit(normalized);
+  const shouldLimitActiveGoal = normalized.status === "active" && reachedLimit;
+  const shouldRearmBudgetLimitedGoal = normalized.status === "budget_limited" && !reachedLimit;
+  if (!shouldLimitActiveGoal && !shouldRearmBudgetLimitedGoal) {
+    return normalized;
+  }
+  return {
+    ...normalized,
+    status: shouldLimitActiveGoal ? "budget_limited" : "active",
+    budgetLimitInjectedForGoalId: shouldRearmBudgetLimitedGoal
+      ? null
+      : normalized.budgetLimitInjectedForGoalId,
+    budgetLimitOriginKind: shouldLimitActiveGoal
+      ? (options.originKind ?? null)
+      : shouldRearmBudgetLimitedGoal
+        ? null
+        : normalized.budgetLimitOriginKind,
+    updatedAtMs: options.nowMs,
+  };
+}

--- a/src/node/services/goalContinuationPolicy.ts
+++ b/src/node/services/goalContinuationPolicy.ts
@@ -1,32 +1,40 @@
 import type { GoalRecordV1 } from "@/common/types/goal";
+import { hasGoalBudgetLimit, normalizeGoalBudgetCents } from "@/common/utils/goals/budgetPricing";
 
-const MICRO_CENTS_PER_CENT = 1_000_000;
-const _SKIP_REASONS = [
-  "not_registered",
-  "no_pending_candidate",
-  "workspace_not_found",
-  "archived",
-  "transcript_only",
-  "initializing",
-  "incompatible_runtime",
-  "child_workspace",
-  "active_descendant_tasks",
-  "currently_streaming",
-  "queued_user_input",
-  "pending_follow_up",
-  "plan_mode",
-  "compact_mode",
-  "user_stop",
-  "goal_missing",
-  "goal_mismatch",
-  "goal_not_active",
-  "requires_ack",
-  "budget_wrapup_already_fired",
-  "budget_wrapup_suppressed",
-  "cooldown",
-] as const;
+export const MICRO_CENTS_PER_CENT = 1_000_000;
 
-export type GoalContinuationSkipReason = (typeof _SKIP_REASONS)[number];
+/**
+ * Returns the goal's accumulated cost in micro-cents, falling back to the
+ * coarser `costCents` field for goals persisted before micro-cent tracking
+ * was added.
+ */
+export function getGoalCostMicroCents(goal: GoalRecordV1): number {
+  return goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
+}
+
+export type GoalContinuationSkipReason =
+  | "not_registered"
+  | "no_pending_candidate"
+  | "workspace_not_found"
+  | "archived"
+  | "transcript_only"
+  | "initializing"
+  | "incompatible_runtime"
+  | "child_workspace"
+  | "active_descendant_tasks"
+  | "currently_streaming"
+  | "queued_user_input"
+  | "pending_follow_up"
+  | "plan_mode"
+  | "compact_mode"
+  | "user_stop"
+  | "goal_missing"
+  | "goal_mismatch"
+  | "goal_not_active"
+  | "requires_ack"
+  | "budget_wrapup_already_fired"
+  | "budget_wrapup_suppressed"
+  | "cooldown";
 export type GoalStreamOriginKind = "goal_continuation" | "goal_budget_limit" | "user" | "other";
 export type GoalContinuationDecision =
   | { kind: "continue"; mode: "continuation" | "budget_wrapup" }
@@ -66,6 +74,13 @@ export interface GoalContinuationPolicyState {
   allowUserOriginBudgetWrapup: boolean;
 }
 
+/**
+ * Staged input for `evaluateGoalContinuationBeforeGoal`: the shell gathers
+ * I/O progressively and an absent (undefined) field means "not gathered yet",
+ * so evaluation stops there with null. This keeps the pre-extraction I/O
+ * gating (e.g. no goal-file reads while the workspace is busy) while every
+ * decision branch stays pure.
+ */
 export type GoalContinuationPolicyProbe = Pick<
   GoalContinuationPolicyState,
   "nowMs" | "bridgeRegistered" | "candidate"
@@ -176,12 +191,11 @@ export function evaluateGoalContinuation(
 }
 
 export function hasReachedGoalBudgetLimit(goal: GoalRecordV1): boolean {
-  const cost = goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
-  return (
-    goal.budgetCents != null &&
-    goal.budgetCents > 0 &&
-    cost >= goal.budgetCents * MICRO_CENTS_PER_CENT
-  );
+  const { budgetCents } = goal;
+  if (budgetCents == null || !hasGoalBudgetLimit(budgetCents)) {
+    return false;
+  }
+  return getGoalCostMicroCents(goal) >= budgetCents * MICRO_CENTS_PER_CENT;
 }
 
 export function hasReachedGoalTurnLimit(goal: GoalRecordV1): boolean {
@@ -203,7 +217,7 @@ export function applyBudgetDrivenStatus(
   goal: GoalRecordV1,
   options: { originKind?: GoalStreamOriginKind; nowMs: number }
 ): GoalRecordV1 {
-  const budgetCents = goal.budgetCents != null && goal.budgetCents > 0 ? goal.budgetCents : null;
+  const budgetCents = normalizeGoalBudgetCents(goal.budgetCents);
   const normalized =
     budgetCents === goal.budgetCents ? goal : { ...goal, budgetCents, updatedAtMs: options.nowMs };
   const reachedLimit = hasReachedAnyGoalLimit(normalized);

--- a/src/node/services/goalContinuationPolicy.ts
+++ b/src/node/services/goalContinuationPolicy.ts
@@ -1,73 +1,67 @@
 import type { GoalRecordV1 } from "@/common/types/goal";
 
 const MICRO_CENTS_PER_CENT = 1_000_000;
+const _SKIP_REASONS = [
+  "not_registered",
+  "no_pending_candidate",
+  "workspace_not_found",
+  "archived",
+  "transcript_only",
+  "initializing",
+  "incompatible_runtime",
+  "child_workspace",
+  "active_descendant_tasks",
+  "currently_streaming",
+  "queued_user_input",
+  "pending_follow_up",
+  "plan_mode",
+  "compact_mode",
+  "user_stop",
+  "goal_missing",
+  "goal_mismatch",
+  "goal_not_active",
+  "requires_ack",
+  "budget_wrapup_already_fired",
+  "budget_wrapup_suppressed",
+  "cooldown",
+] as const;
 
-export type GoalContinuationSkipReason =
-  | "not_registered"
-  | "no_pending_candidate"
-  | "workspace_not_found"
-  | "archived"
-  | "transcript_only"
-  | "initializing"
-  | "incompatible_runtime"
-  | "child_workspace"
-  | "active_descendant_tasks"
-  | "currently_streaming"
-  | "queued_user_input"
-  | "pending_follow_up"
-  | "plan_mode"
-  | "compact_mode"
-  | "user_stop"
-  | "goal_missing"
-  | "goal_mismatch"
-  | "goal_not_active"
-  | "requires_ack"
-  | "budget_wrapup_already_fired"
-  | "budget_wrapup_suppressed"
-  | "cooldown";
-
+export type GoalContinuationSkipReason = (typeof _SKIP_REASONS)[number];
 export type GoalStreamOriginKind = "goal_continuation" | "goal_budget_limit" | "user" | "other";
-
 export type GoalContinuationDecision =
   | { kind: "continue"; mode: "continuation" | "budget_wrapup" }
   | { kind: "defer"; reason: GoalContinuationSkipReason; untilMs: number }
   | { kind: "stop"; reason: GoalContinuationSkipReason; dropCandidate: boolean };
 
-type Candidate = {
-  goalId: string;
-  source: "stream_end" | "kickoff" | "budget_wrapup";
-  sendOptions: { agentId?: string | null; mode?: string | null };
-};
-type WorkspaceState = { found: boolean; archived: boolean; hasPath: boolean; isChild: boolean };
-type RuntimeState = {
-  isInitializing: boolean;
-  isRuntimeCompatible: boolean;
-  isBusy: boolean;
-  hasQueuedMessages: boolean;
-  hasPendingFollowUp: boolean;
-};
-type PolicyGoal = Pick<
-  GoalRecordV1,
-  | "goalId"
-  | "status"
-  | "requireUserAcknowledgmentSinceMs"
-  | "budgetLimitInjectedForGoalId"
-  | "lastContinuationFiredAtMs"
->;
-export type GoalStreamStamp = { goalId: string | null; originKind: GoalStreamOriginKind };
-
 export interface GoalContinuationPolicyState {
   nowMs: number;
   bridgeRegistered: boolean;
-  candidate: Candidate | null;
-  workspace: WorkspaceState;
+  candidate: {
+    goalId: string;
+    source: "stream_end" | "kickoff" | "budget_wrapup";
+    sendOptions: { agentId?: string | null; mode?: string | null };
+  } | null;
+  workspace: { found: boolean; archived: boolean; hasPath: boolean; isChild: boolean };
   hasActiveDescendantTasks: boolean;
-  runtime: RuntimeState;
+  runtime: {
+    isInitializing: boolean;
+    isRuntimeCompatible: boolean;
+    isBusy: boolean;
+    hasQueuedMessages: boolean;
+    hasPendingFollowUp: boolean;
+  };
   isStreaming: boolean;
   userStopAtMs: number | null;
   stopCheckGoal: Pick<GoalRecordV1, "createdAtMs"> | null;
-  goal: PolicyGoal | null;
-  lastStreamStamp: GoalStreamStamp | null;
+  goal: Pick<
+    GoalRecordV1,
+    | "goalId"
+    | "status"
+    | "requireUserAcknowledgmentSinceMs"
+    | "budgetLimitInjectedForGoalId"
+    | "lastContinuationFiredAtMs"
+  > | null;
+  lastStreamStamp: { goalId: string | null; originKind: GoalStreamOriginKind } | null;
   continuationCooldownMs: number;
   allowUserOriginBudgetWrapup: boolean;
 }
@@ -92,6 +86,11 @@ const stop = (
   reason: GoalContinuationSkipReason,
   dropCandidate: boolean
 ): GoalContinuationDecision => ({ kind: "stop", reason, dropCandidate });
+const defer = (reason: GoalContinuationSkipReason, untilMs: number): GoalContinuationDecision => ({
+  kind: "defer",
+  reason,
+  untilMs,
+});
 
 export function evaluateGoalContinuationBeforeGoal(
   state: GoalContinuationPolicyProbe
@@ -107,17 +106,11 @@ export function evaluateGoalContinuationBeforeGoal(
   if (state.hasActiveDescendantTasks == null) return null;
   if (state.hasActiveDescendantTasks) return stop("active_descendant_tasks", false);
   if (!state.runtime) return null;
-  if (state.runtime.isInitializing) {
-    return { kind: "defer", reason: "initializing", untilMs: state.nowMs + 1_000 };
-  }
+  if (state.runtime.isInitializing) return defer("initializing", state.nowMs + 1_000);
   if (!state.runtime.isRuntimeCompatible) return stop("incompatible_runtime", true);
-  if (state.runtime.isBusy) {
-    return { kind: "defer", reason: "currently_streaming", untilMs: state.nowMs + 1_000 };
-  }
+  if (state.runtime.isBusy) return defer("currently_streaming", state.nowMs + 1_000);
   if (state.isStreaming == null) return null;
-  if (state.isStreaming) {
-    return { kind: "defer", reason: "currently_streaming", untilMs: state.nowMs + 1_000 };
-  }
+  if (state.isStreaming) return defer("currently_streaming", state.nowMs + 1_000);
   if (state.runtime.hasQueuedMessages) return stop("queued_user_input", false);
   if (state.runtime.hasPendingFollowUp) return stop("pending_follow_up", false);
   if (candidate.sendOptions.agentId === "plan" || candidate.sendOptions.mode === "plan") {
@@ -127,12 +120,10 @@ export function evaluateGoalContinuationBeforeGoal(
     return stop("compact_mode", true);
   }
   if (state.userStopAtMs === undefined) return null;
-  if (state.userStopAtMs != null) {
-    if (state.stopCheckGoal === undefined) return null;
-    if (!state.stopCheckGoal) return stop("goal_missing", true);
-    if (state.userStopAtMs >= state.stopCheckGoal.createdAtMs) return stop("user_stop", true);
-  }
-  return null;
+  if (state.userStopAtMs == null) return null;
+  if (state.stopCheckGoal === undefined) return null;
+  if (!state.stopCheckGoal) return stop("goal_missing", true);
+  return state.userStopAtMs >= state.stopCheckGoal.createdAtMs ? stop("user_stop", true) : null;
 }
 
 export function evaluateGoalContinuationGoal(
@@ -174,11 +165,7 @@ export function evaluateGoalContinuationGoal(
   }
   const lastFiredAtMs = goal.lastContinuationFiredAtMs ?? null;
   return lastFiredAtMs != null && state.nowMs - lastFiredAtMs < state.continuationCooldownMs
-    ? {
-        kind: "defer",
-        reason: "cooldown",
-        untilMs: lastFiredAtMs + state.continuationCooldownMs,
-      }
+    ? defer("cooldown", lastFiredAtMs + state.continuationCooldownMs)
     : { kind: "continue", mode: "continuation" };
 }
 
@@ -189,11 +176,11 @@ export function evaluateGoalContinuation(
 }
 
 export function hasReachedGoalBudgetLimit(goal: GoalRecordV1): boolean {
-  const costMicroCents = goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
+  const cost = goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
   return (
     goal.budgetCents != null &&
     goal.budgetCents > 0 &&
-    costMicroCents >= goal.budgetCents * MICRO_CENTS_PER_CENT
+    cost >= goal.budgetCents * MICRO_CENTS_PER_CENT
   );
 }
 

--- a/src/node/services/goalContinuationPolicy.ts
+++ b/src/node/services/goalContinuationPolicy.ts
@@ -1,5 +1,4 @@
 import type { GoalRecordV1 } from "@/common/types/goal";
-import type { SendMessageOptions } from "@/common/orpc/types";
 
 const MICRO_CENTS_PER_CENT = 1_000_000;
 
@@ -34,128 +33,104 @@ export type GoalContinuationDecision =
   | { kind: "defer"; reason: GoalContinuationSkipReason; untilMs: number }
   | { kind: "stop"; reason: GoalContinuationSkipReason; dropCandidate: boolean };
 
-export interface GoalContinuationPolicyCandidate {
+type Candidate = {
   goalId: string;
   source: "stream_end" | "kickoff" | "budget_wrapup";
-  sendOptions: Pick<SendMessageOptions, "agentId" | "mode">;
-}
+  sendOptions: { agentId?: string | null; mode?: string | null };
+};
+type WorkspaceState = { found: boolean; archived: boolean; hasPath: boolean; isChild: boolean };
+type RuntimeState = {
+  isInitializing: boolean;
+  isRuntimeCompatible: boolean;
+  isBusy: boolean;
+  hasQueuedMessages: boolean;
+  hasPendingFollowUp: boolean;
+};
+type PolicyGoal = Pick<
+  GoalRecordV1,
+  | "goalId"
+  | "status"
+  | "requireUserAcknowledgmentSinceMs"
+  | "budgetLimitInjectedForGoalId"
+  | "lastContinuationFiredAtMs"
+>;
+export type GoalStreamStamp = { goalId: string | null; originKind: GoalStreamOriginKind };
 
 export interface GoalContinuationPolicyState {
   nowMs: number;
   bridgeRegistered: boolean;
-  candidate: GoalContinuationPolicyCandidate | null;
-  workspace: { found: boolean; archived: boolean; hasPath: boolean; isChild: boolean };
+  candidate: Candidate | null;
+  workspace: WorkspaceState;
   hasActiveDescendantTasks: boolean;
-  runtime: {
-    isInitializing: boolean;
-    isRuntimeCompatible: boolean;
-    isBusy: boolean;
-    hasQueuedMessages: boolean;
-    hasPendingFollowUp: boolean;
-  };
+  runtime: RuntimeState;
   isStreaming: boolean;
   userStopAtMs: number | null;
   stopCheckGoal: Pick<GoalRecordV1, "createdAtMs"> | null;
-  goal: Pick<
-    GoalRecordV1,
-    | "goalId"
-    | "status"
-    | "requireUserAcknowledgmentSinceMs"
-    | "budgetLimitInjectedForGoalId"
-    | "lastContinuationFiredAtMs"
-  > | null;
-  lastStreamStamp: Pick<GoalStreamStamp, "goalId" | "originKind"> | null;
+  goal: PolicyGoal | null;
+  lastStreamStamp: GoalStreamStamp | null;
   continuationCooldownMs: number;
   allowUserOriginBudgetWrapup: boolean;
 }
 
-export interface GoalStreamStamp {
-  goalId: string | null;
-  originKind: GoalStreamOriginKind;
-}
+export type GoalContinuationPolicyProbe = Pick<
+  GoalContinuationPolicyState,
+  "nowMs" | "bridgeRegistered" | "candidate"
+> &
+  Partial<
+    Pick<
+      GoalContinuationPolicyState,
+      | "workspace"
+      | "hasActiveDescendantTasks"
+      | "runtime"
+      | "isStreaming"
+      | "userStopAtMs"
+      | "stopCheckGoal"
+    >
+  >;
 
 const stop = (
   reason: GoalContinuationSkipReason,
   dropCandidate: boolean
 ): GoalContinuationDecision => ({ kind: "stop", reason, dropCandidate });
 
-export function evaluateGoalContinuationRegistration(
-  state: Pick<GoalContinuationPolicyState, "candidate" | "bridgeRegistered">
+export function evaluateGoalContinuationBeforeGoal(
+  state: GoalContinuationPolicyProbe
 ): GoalContinuationDecision | null {
-  if (!state.candidate) {
-    return stop("no_pending_candidate", false);
-  }
-  if (!state.bridgeRegistered) {
-    return stop("not_registered", false);
-  }
-  return null;
-}
-
-export function evaluateGoalContinuationWorkspace(
-  state: Pick<GoalContinuationPolicyState, "workspace" | "hasActiveDescendantTasks">
-): GoalContinuationDecision | null {
-  if (!state.workspace.found) {
-    return stop("workspace_not_found", true);
-  }
-  if (state.workspace.archived) {
-    return stop("archived", true);
-  }
-  if (!state.workspace.hasPath) {
-    return stop("transcript_only", true);
-  }
-  if (state.workspace.isChild) {
-    return stop("child_workspace", true);
-  }
-  if (state.hasActiveDescendantTasks) {
-    return stop("active_descendant_tasks", false);
-  }
-  return null;
-}
-
-export function evaluateGoalContinuationRuntime(
-  state: Pick<GoalContinuationPolicyState, "nowMs" | "runtime" | "candidate"> & {
-    isStreaming: boolean | null;
-  }
-): GoalContinuationDecision | null {
+  const candidate = state.candidate;
+  if (!candidate) return stop("no_pending_candidate", false);
+  if (!state.bridgeRegistered) return stop("not_registered", false);
+  if (!state.workspace) return null;
+  if (!state.workspace.found) return stop("workspace_not_found", true);
+  if (state.workspace.archived) return stop("archived", true);
+  if (!state.workspace.hasPath) return stop("transcript_only", true);
+  if (state.workspace.isChild) return stop("child_workspace", true);
+  if (state.hasActiveDescendantTasks == null) return null;
+  if (state.hasActiveDescendantTasks) return stop("active_descendant_tasks", false);
+  if (!state.runtime) return null;
   if (state.runtime.isInitializing) {
     return { kind: "defer", reason: "initializing", untilMs: state.nowMs + 1_000 };
   }
-  if (!state.runtime.isRuntimeCompatible) {
-    return stop("incompatible_runtime", true);
-  }
-  if (state.runtime.isBusy || state.isStreaming === true) {
+  if (!state.runtime.isRuntimeCompatible) return stop("incompatible_runtime", true);
+  if (state.runtime.isBusy) {
     return { kind: "defer", reason: "currently_streaming", untilMs: state.nowMs + 1_000 };
   }
-  if (state.isStreaming == null) {
-    return null;
+  if (state.isStreaming == null) return null;
+  if (state.isStreaming) {
+    return { kind: "defer", reason: "currently_streaming", untilMs: state.nowMs + 1_000 };
   }
-  if (state.runtime.hasQueuedMessages) {
-    return stop("queued_user_input", false);
-  }
-  if (state.runtime.hasPendingFollowUp) {
-    return stop("pending_follow_up", false);
-  }
-  const sendOptions = state.candidate?.sendOptions;
-  if (sendOptions?.agentId === "plan" || sendOptions?.mode === "plan") {
+  if (state.runtime.hasQueuedMessages) return stop("queued_user_input", false);
+  if (state.runtime.hasPendingFollowUp) return stop("pending_follow_up", false);
+  if (candidate.sendOptions.agentId === "plan" || candidate.sendOptions.mode === "plan") {
     return stop("plan_mode", true);
   }
-  if (sendOptions?.agentId === "compact" || sendOptions?.mode === "compact") {
+  if (candidate.sendOptions.agentId === "compact" || candidate.sendOptions.mode === "compact") {
     return stop("compact_mode", true);
   }
-  return null;
-}
-
-export function evaluateGoalContinuationStopCheck(
-  state: Pick<GoalContinuationPolicyState, "userStopAtMs" | "stopCheckGoal">
-): GoalContinuationDecision | null {
-  if (state.userStopAtMs == null) {
-    return null;
-  }
-  if (!state.stopCheckGoal) {
-    return stop("goal_missing", true);
-  }
-  if (state.userStopAtMs >= state.stopCheckGoal.createdAtMs) {
-    return stop("user_stop", true);
+  if (state.userStopAtMs === undefined) return null;
+  if (state.userStopAtMs != null) {
+    if (state.stopCheckGoal === undefined) return null;
+    if (!state.stopCheckGoal) return stop("goal_missing", true);
+    if (state.userStopAtMs >= state.stopCheckGoal.createdAtMs) return stop("user_stop", true);
   }
   return null;
 }
@@ -171,14 +146,9 @@ export function evaluateGoalContinuationGoal(
     | "allowUserOriginBudgetWrapup"
   >
 ): GoalContinuationDecision {
-  const candidate = state.candidate;
-  const goal = state.goal;
-  if (!goal || !candidate) {
-    return stop("goal_missing", true);
-  }
-  if (goal.goalId !== candidate.goalId) {
-    return stop("goal_mismatch", true);
-  }
+  const { candidate, goal } = state;
+  if (!goal || !candidate) return stop("goal_missing", true);
+  if (goal.goalId !== candidate.goalId) return stop("goal_mismatch", true);
   if (
     goal.status !== "active" &&
     goal.status !== "budget_limited" &&
@@ -186,9 +156,7 @@ export function evaluateGoalContinuationGoal(
   ) {
     return stop("goal_not_active", true);
   }
-  if (goal.requireUserAcknowledgmentSinceMs != null) {
-    return stop("requires_ack", false);
-  }
+  if (goal.requireUserAcknowledgmentSinceMs != null) return stop("requires_ack", false);
   if (goal.status === "budget_limited") {
     if (goal.budgetLimitInjectedForGoalId === goal.goalId) {
       return stop("budget_wrapup_already_fired", true);
@@ -205,37 +173,27 @@ export function evaluateGoalContinuationGoal(
     return { kind: "continue", mode: "budget_wrapup" };
   }
   const lastFiredAtMs = goal.lastContinuationFiredAtMs ?? null;
-  if (lastFiredAtMs != null && state.nowMs - lastFiredAtMs < state.continuationCooldownMs) {
-    return {
-      kind: "defer",
-      reason: "cooldown",
-      untilMs: lastFiredAtMs + state.continuationCooldownMs,
-    };
-  }
-  return { kind: "continue", mode: "continuation" };
+  return lastFiredAtMs != null && state.nowMs - lastFiredAtMs < state.continuationCooldownMs
+    ? {
+        kind: "defer",
+        reason: "cooldown",
+        untilMs: lastFiredAtMs + state.continuationCooldownMs,
+      }
+    : { kind: "continue", mode: "continuation" };
 }
 
 export function evaluateGoalContinuation(
   state: GoalContinuationPolicyState
 ): GoalContinuationDecision {
-  return (
-    evaluateGoalContinuationRegistration(state) ??
-    evaluateGoalContinuationWorkspace(state) ??
-    evaluateGoalContinuationRuntime(state) ??
-    evaluateGoalContinuationStopCheck(state) ??
-    evaluateGoalContinuationGoal(state)
-  );
-}
-
-function getGoalCostMicroCents(goal: GoalRecordV1): number {
-  return goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
+  return evaluateGoalContinuationBeforeGoal(state) ?? evaluateGoalContinuationGoal(state);
 }
 
 export function hasReachedGoalBudgetLimit(goal: GoalRecordV1): boolean {
+  const costMicroCents = goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
   return (
     goal.budgetCents != null &&
     goal.budgetCents > 0 &&
-    getGoalCostMicroCents(goal) >= goal.budgetCents * MICRO_CENTS_PER_CENT
+    costMicroCents >= goal.budgetCents * MICRO_CENTS_PER_CENT
   );
 }
 
@@ -258,29 +216,18 @@ export function applyBudgetDrivenStatus(
   goal: GoalRecordV1,
   options: { originKind?: GoalStreamOriginKind; nowMs: number }
 ): GoalRecordV1 {
-  const normalizedBudgetCents =
-    goal.budgetCents != null && goal.budgetCents > 0 ? goal.budgetCents : null;
+  const budgetCents = goal.budgetCents != null && goal.budgetCents > 0 ? goal.budgetCents : null;
   const normalized =
-    normalizedBudgetCents === goal.budgetCents
-      ? goal
-      : { ...goal, budgetCents: normalizedBudgetCents, updatedAtMs: options.nowMs };
+    budgetCents === goal.budgetCents ? goal : { ...goal, budgetCents, updatedAtMs: options.nowMs };
   const reachedLimit = hasReachedAnyGoalLimit(normalized);
-  const shouldLimitActiveGoal = normalized.status === "active" && reachedLimit;
-  const shouldRearmBudgetLimitedGoal = normalized.status === "budget_limited" && !reachedLimit;
-  if (!shouldLimitActiveGoal && !shouldRearmBudgetLimitedGoal) {
-    return normalized;
-  }
+  const limit = normalized.status === "active" && reachedLimit;
+  const rearm = normalized.status === "budget_limited" && !reachedLimit;
+  if (!limit && !rearm) return normalized;
   return {
     ...normalized,
-    status: shouldLimitActiveGoal ? "budget_limited" : "active",
-    budgetLimitInjectedForGoalId: shouldRearmBudgetLimitedGoal
-      ? null
-      : normalized.budgetLimitInjectedForGoalId,
-    budgetLimitOriginKind: shouldLimitActiveGoal
-      ? (options.originKind ?? null)
-      : shouldRearmBudgetLimitedGoal
-        ? null
-        : normalized.budgetLimitOriginKind,
+    status: limit ? "budget_limited" : "active",
+    budgetLimitInjectedForGoalId: rearm ? null : normalized.budgetLimitInjectedForGoalId,
+    budgetLimitOriginKind: limit ? (options.originKind ?? null) : null,
     updatedAtMs: options.nowMs,
   };
 }

--- a/src/node/services/workspaceGoalService.test.ts
+++ b/src/node/services/workspaceGoalService.test.ts
@@ -320,45 +320,6 @@ describe("WorkspaceGoalService", () => {
     expect((await service.getGoalBoard(workspaceId)).entries).toHaveLength(1);
   });
 
-  test("treats zero-budget goals as unbudgeted even when kickoff model has no pricing", async () => {
-    const dispatcher = new IdleDispatcher();
-    service.registerGoalContinuationConsumer(dispatcher, {
-      ...continuationBridge(),
-      getKickoffSendOptions: () =>
-        Promise.resolve({ model: "custom:unpriced-model", agentId: "exec" }),
-    });
-
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Do not enforce a dollar budget",
-      budgetCents: 0,
-    });
-
-    await drainPendingDispatches();
-
-    expect(created).toMatchObject({ status: "active", budgetCents: null });
-    expect(await service.getGoal(workspaceId)).toMatchObject({
-      status: "active",
-      budgetCents: null,
-    });
-  });
-
-  test("creates zero-budget goals as active goals without arming a budget wrap-up", async () => {
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    service.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
-
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Track without a dollar limit",
-      budgetCents: 0,
-    });
-    await drainPendingDispatches();
-
-    expect(created).toMatchObject({ status: "active", budgetCents: null });
-    expect(execute).not.toHaveBeenCalled();
-  });
-
   test("arms a kickoff continuation when a brand-new goal is set on an idle workspace", async () => {
     const dispatcher = new IdleDispatcher();
     const executed: Array<{
@@ -956,44 +917,6 @@ describe("WorkspaceGoalService", () => {
     );
   });
 
-  test("dispatches budget-limit wrap-up after an agent-initiated non-continuation stream exhausts the budget", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Stop cleanly after agent-initiated budget hit",
-      budgetCents: 100,
-    });
-    const dispatcher = new IdleDispatcher();
-    const executed: Array<{ kind: string | undefined; message: string }> = [];
-    service.registerGoalContinuationConsumer(
-      dispatcher,
-      continuationBridge((input) => {
-        executed.push({ kind: input.kind, message: input.message });
-        return Promise.resolve(true);
-      })
-    );
-
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "other",
-    });
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 20_000,
-    });
-    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
-
-    expect(executed).toHaveLength(1);
-    expect(executed[0]).toMatchObject({ kind: GOAL_BUDGET_LIMIT_KIND });
-    expect(await service.getGoal(workspaceId)).toMatchObject({
-      status: "budget_limited",
-      budgetLimitInjectedForGoalId: created.goalId,
-      budgetLimitOriginKind: "other",
-    });
-  });
-
   test("model-created goals stay active and arm kickoff after a normal user turn", async () => {
     const appendResult = await historyService.appendToHistory(
       workspaceId,
@@ -1466,68 +1389,6 @@ describe("WorkspaceGoalService", () => {
     });
   });
 
-  test("suppresses budget-limit wrap-up after user-origin stream exhaustion", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "User owns over-budget turn",
-      budgetCents: 100,
-    });
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    service.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
-
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "user",
-    });
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 20_000,
-    });
-
-    expect(execute).not.toHaveBeenCalled();
-    expect(await service.getGoal(workspaceId)).toMatchObject({
-      status: "budget_limited",
-      budgetLimitInjectedForGoalId: null,
-    });
-  });
-
-  test("can allow budget-limit wrap-up after user-origin stream exhaustion", async () => {
-    service = new WorkspaceGoalService(config, historyService, extensionMetadata, analytics, {
-      allowUserOriginBudgetWrapup: true,
-    });
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "CLI owns over-budget kickoff",
-      budgetCents: 100,
-    });
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    service.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
-
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "user",
-    });
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 20_000,
-    });
-    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
-
-    expect(execute).toHaveBeenCalledTimes(1);
-    expect(await service.getGoal(workspaceId)).toMatchObject({
-      status: "budget_limited",
-      budgetLimitInjectedForGoalId: created.goalId,
-    });
-  });
-
   test("recoverPendingDispatchAfterRestart re-arms a stranded budget_limited wrap-up", async () => {
     // Regression: Simulates a process
     // restart by:
@@ -1603,115 +1464,6 @@ describe("WorkspaceGoalService", () => {
     });
   });
 
-  test("recoverPendingDispatchAfterRestart migrates legacy zero-budget limited goals", async () => {
-    const legacy = await setGoalOk(service, {
-      workspaceId,
-      objective: "Legacy zero budget",
-      budgetCents: 100,
-    });
-    await fs.writeFile(
-      path.join(config.getSessionDir(workspaceId), "goal.json"),
-      JSON.stringify({ ...legacy, status: "budget_limited", budgetCents: 0 })
-    );
-    const restartedService = new WorkspaceGoalService(
-      config,
-      historyService,
-      extensionMetadata,
-      analytics
-    );
-
-    await restartedService.recoverPendingDispatchAfterRestart(workspaceId);
-
-    expect(await restartedService.getGoal(workspaceId)).toMatchObject({
-      status: "active",
-      budgetCents: null,
-    });
-  });
-
-  test("recoverPendingDispatchAfterRestart skips wrap-up when the budget hit was user-origin ()", async () => {
-    // The pre-restart code suppressed wrap-ups when the originating stream
-    // was user-origin (`checkGoalContinuationEligibility` returns
-    // `budget_wrapup_suppressed`). After restart, in-memory
-    // `lastGoalStreamStamps` is empty, so without persisted origin info the
-    // recovery function would synthesize a GOAL_CONTINUATION_KIND stamp and
-    // bypass the suppression. Persisting `budgetLimitOriginKind` on the
-    // active→budget_limited transition fixes this.
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "User exhausts budget mid-clarification",
-      budgetCents: 100,
-    });
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "user",
-    });
-    const persisted = await service.getGoal(workspaceId);
-    expect(persisted).toMatchObject({
-      status: "budget_limited",
-      budgetLimitInjectedForGoalId: null,
-      budgetLimitOriginKind: "user",
-    });
-
-    // Simulate restart.
-    const restartedService = new WorkspaceGoalService(
-      config,
-      historyService,
-      extensionMetadata,
-      analytics
-    );
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    restartedService.registerGoalContinuationConsumer(dispatcher, {
-      hasActiveDescendantTasks: () => false,
-      getRuntimeState: () => ({ isRuntimeCompatible: true }),
-      executeGoalContinuation: execute,
-      getKickoffSendOptions: () => Promise.resolve({ model: "openai:gpt-4o", agentId: "exec" }),
-    });
-
-    await restartedService.recoverPendingDispatchAfterRestart(workspaceId);
-    await drainPendingDispatches();
-
-    expect(execute).not.toHaveBeenCalled();
-  });
-
-  test("recoverPendingDispatchAfterRestart is a no-op for already-fired wrap-ups", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Already wrapped up",
-      budgetCents: 100,
-    });
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "goal_continuation",
-    });
-    // Simulate wrap-up already firing pre-restart.
-    await setGoalOk(service, {
-      workspaceId,
-      objective: created.objective,
-      status: "complete",
-      completionSummary: "Done.",
-    });
-
-    const restartedService = new WorkspaceGoalService(
-      config,
-      historyService,
-      extensionMetadata,
-      analytics
-    );
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    restartedService.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
-
-    await restartedService.recoverPendingDispatchAfterRestart(workspaceId);
-    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
-
-    expect(execute).not.toHaveBeenCalled();
-  });
-
   test("recordUserStoppedStream drops queued goal mutations alongside continuation candidates", async () => {
     // Regression for pendingGoalMutations
     // were not cleared on user stop, so a setGoal racing with a stop would
@@ -1760,57 +1512,6 @@ describe("WorkspaceGoalService", () => {
     expect(applied).toBeNull();
     expect(await service.getGoal(workspaceId)).toMatchObject({
       objective: "Original objective",
-    });
-  });
-
-  test("raising the budget re-arms one later continuation-origin wrap-up", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Re-arm wrap-up",
-      budgetCents: 100,
-    });
-    const dispatcher = new IdleDispatcher();
-    const executed: Array<{ kind: string | undefined }> = [];
-    service.registerGoalContinuationConsumer(
-      dispatcher,
-      continuationBridge((input) => {
-        executed.push({ kind: input.kind });
-        return Promise.resolve(true);
-      })
-    );
-
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.25,
-      streamStartedAtMs: created.createdAtMs + 1,
-      streamOriginKind: "goal_continuation",
-    });
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 20_000,
-    });
-    expect(executed).toHaveLength(1);
-
-    const rearmed = await setGoalOk(service, { workspaceId, budgetCents: 200 });
-    expect(rearmed).toMatchObject({ status: "active", budgetLimitInjectedForGoalId: null });
-
-    await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1,
-      streamStartedAtMs: rearmed.createdAtMs + 1,
-      streamOriginKind: "goal_continuation",
-    });
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 30_000,
-    });
-
-    expect(executed).toEqual([{ kind: GOAL_BUDGET_LIMIT_KIND }, { kind: GOAL_BUDGET_LIMIT_KIND }]);
-    expect(await service.getGoal(workspaceId)).toMatchObject({
-      status: "budget_limited",
-      budgetLimitInjectedForGoalId: created.goalId,
     });
   });
 
@@ -5294,40 +4995,6 @@ describe("WorkspaceGoalService", () => {
     });
   });
 
-  test("child attribution that reaches turn cap arms a wrap-up dispatch", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Drive into budget_limited via child turn cap",
-      turnCap: 1,
-    });
-    const dispatcher = new IdleDispatcher();
-    const executed: Array<{ kind: string | undefined }> = [];
-    service.registerGoalContinuationConsumer(dispatcher, {
-      hasActiveDescendantTasks: () => false,
-      getRuntimeState: () => ({ isRuntimeCompatible: true }),
-      executeGoalContinuation: (input) => {
-        executed.push({ kind: input.kind });
-        return Promise.resolve(true);
-      },
-      getKickoffSendOptions: () => Promise.resolve({ model: "openai:gpt-4o", agentId: "exec" }),
-    });
-
-    const result = await service.attributeChildReport({
-      parentWorkspaceId: workspaceId,
-      childWorkspaceId: "child-turn-cap",
-      childCostCents: 0,
-    });
-
-    expect(result?.causedBudgetLimit).toBe(true);
-    expect(result?.goalAfter).toMatchObject({
-      goalId: created.goalId,
-      status: "budget_limited",
-      turnsUsed: 1,
-    });
-    await waitForCondition(() => executed.length > 0, { timeoutMs: 1_000 });
-    expect(executed[0]?.kind).toBe(GOAL_BUDGET_LIMIT_KIND);
-  });
-
   test("child report attribution flips active goals to budget-limited once", async () => {
     await setGoalOk(service, {
       workspaceId,
@@ -5622,23 +5289,6 @@ describe("WorkspaceGoalService", () => {
     ).toMatchObject({ costCents: 0, status: "paused" });
   });
 
-  test("does not budget-limit zero-dollar goals after paid streams", async () => {
-    await setGoalOk(service, {
-      workspaceId,
-      objective: "Track paid work without a dollar limit",
-      budgetCents: 0,
-    });
-
-    const updated = await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 1.24,
-      streamOriginKind: "goal_continuation",
-    });
-
-    expect(updated).toMatchObject({ costCents: 124, turnsUsed: 1, status: "active" });
-    expect(updated?.budgetCents).toBeNull();
-  });
-
   test("flips active goals to budget-limited when stream cost reaches the budget", async () => {
     const created = await setGoalOk(service, {
       workspaceId,
@@ -5658,137 +5308,6 @@ describe("WorkspaceGoalService", () => {
     expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledWith(
       "goal_budget_limited",
       expect.objectContaining({ "cost-overshoot": "0" })
-    );
-  });
-
-  test("flips active goals to budget-limited when stream turns reach the cap", async () => {
-    await setGoalOk(service, {
-      workspaceId,
-      objective: "Hit turn cap",
-      turnCap: 1,
-    });
-
-    const updated = await service.recordStreamAccounting({
-      workspaceId,
-      costUsd: 0.01,
-      streamOriginKind: "goal_continuation",
-    });
-
-    expect(updated).toMatchObject({ turnsUsed: 1, status: "budget_limited" });
-    expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledWith(
-      "goal_budget_limited",
-      expect.objectContaining({ "turn-overshoot": "0" })
-    );
-  });
-
-  test("lowering active goal budget below spend arms a budget wrap-up", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Budget edit wraps",
-      budgetCents: 500,
-    });
-    await fs.writeFile(
-      path.join(config.getSessionDir(workspaceId), "goal.json"),
-      JSON.stringify({ ...created, costCents: 250, costMicroCents: 250_000_000 })
-    );
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    service.registerGoalContinuationConsumer(dispatcher, {
-      ...continuationBridge(execute),
-      getKickoffSendOptions: () => Promise.resolve({ model: "openai:gpt-4o", agentId: "exec" }),
-    });
-
-    const updated = await setGoalOk(service, { workspaceId, budgetCents: 200 });
-    await waitForCondition(() => execute.mock.calls.length > 0, { timeoutMs: 1_000 });
-
-    expect(updated).toMatchObject({ status: "budget_limited", budgetCents: 200 });
-    expect(execute).toHaveBeenCalledTimes(1);
-  });
-
-  test("raising a budget-limited goal budget flips active and clears budget injection", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Re-arm on budget raise",
-      status: "budget_limited",
-      budgetCents: 100,
-    });
-    await fs.writeFile(
-      path.join(config.getSessionDir(workspaceId), "goal.json"),
-      JSON.stringify({
-        ...created,
-        costCents: 150,
-        costMicroCents: 150_000_000,
-        budgetLimitInjectedForGoalId: created.goalId,
-      })
-    );
-
-    const updated = await setGoalOk(service, { workspaceId, budgetCents: 200 });
-
-    expect(updated).toMatchObject({
-      status: "active",
-      budgetCents: 200,
-      budgetLimitInjectedForGoalId: null,
-    });
-    expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledWith(
-      "goal_budget_changed",
-      expect.objectContaining({ "budget-raised-vs-lowered": "raised" })
-    );
-    expect(analytics.recordGoalLifecycleEvent).not.toHaveBeenCalledWith(
-      "goal_resumed",
-      expect.anything()
-    );
-  });
-
-  test("removing budget from a budget-limited goal flips active", async () => {
-    await setGoalOk(service, {
-      workspaceId,
-      objective: "Remove exhausted budget",
-      status: "budget_limited",
-      budgetCents: 100,
-    });
-
-    const updated = await setGoalOk(service, { workspaceId, budgetCents: null });
-
-    expect(updated).toMatchObject({ status: "active", budgetCents: null });
-  });
-
-  test("lowering active goal budget below current spend flips budget-limited", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Tighten budget",
-      budgetCents: 500,
-    });
-    await fs.writeFile(
-      path.join(config.getSessionDir(workspaceId), "goal.json"),
-      JSON.stringify({ ...created, costCents: 250, costMicroCents: 250_000_000 })
-    );
-
-    const updated = await setGoalOk(service, { workspaceId, budgetCents: 200 });
-
-    expect(updated).toMatchObject({ status: "budget_limited", budgetCents: 200 });
-    expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledWith(
-      "goal_budget_limited",
-      expect.objectContaining({ "cost-overshoot": "1-99" })
-    );
-  });
-
-  test("setting an exhausted budget on a paused goal preserves paused status", async () => {
-    const created = await setGoalOk(service, {
-      workspaceId,
-      objective: "Paused budget edit",
-      status: "paused",
-    });
-    await fs.writeFile(
-      path.join(config.getSessionDir(workspaceId), "goal.json"),
-      JSON.stringify({ ...created, costCents: 250 })
-    );
-
-    const updated = await setGoalOk(service, { workspaceId, budgetCents: 200 });
-
-    expect(updated).toMatchObject({ status: "paused", budgetCents: 200 });
-    expect(analytics.recordGoalLifecycleEvent).not.toHaveBeenCalledWith(
-      "goal_budget_limited",
-      expect.anything()
     );
   });
 
@@ -5916,26 +5435,6 @@ describe("WorkspaceGoalService", () => {
       expect.objectContaining({ workspaceIdLengthBucket: "10-49" })
     );
     expect(analytics.recordGoalLifecycleEvent).toHaveBeenCalledTimes(2);
-  });
-
-  test("continuation consumer rejects while acknowledgment is pending and fires after it clears", async () => {
-    await setGoalOk(service, { workspaceId, objective: "Continue after acknowledgment" });
-    await service.requireUserAcknowledgment(workspaceId, 20_000);
-    const dispatcher = new IdleDispatcher();
-    const execute = mock(() => Promise.resolve(true));
-    service.registerGoalContinuationConsumer(dispatcher, continuationBridge(execute));
-
-    await service.requestContinuationAfterStreamEnd({
-      workspaceId,
-      sendOptions: { model: "openai:gpt-4o", agentId: "exec" },
-      streamEndedAtMs: 30_000,
-    });
-    expect(execute).not.toHaveBeenCalled();
-
-    await service.acknowledgeUser(workspaceId);
-    await dispatcher.requestDispatch(workspaceId, GOAL_CONTINUATION_IDLE_CONSUMER_NAME);
-
-    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   test("rejects illegal user lifecycle transitions with typed errors", async () => {

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -55,15 +55,13 @@ import { log } from "./log";
 import { NOOP_TIMELINE_RECORDER, type TimelineRecorder } from "./timelineRecorder";
 import {
   applyBudgetDrivenStatus,
+  evaluateGoalContinuationBeforeGoal,
   evaluateGoalContinuationGoal,
-  evaluateGoalContinuationRegistration,
-  evaluateGoalContinuationRuntime,
-  evaluateGoalContinuationStopCheck,
-  evaluateGoalContinuationWorkspace,
   hasReachedGoalBudgetLimit,
   hasReachedGoalTurnLimit,
   isBudgetWrapupEligibleOrigin,
   type GoalContinuationDecision,
+  type GoalContinuationPolicyProbe,
   type GoalContinuationSkipReason,
   type GoalStreamOriginKind,
 } from "./goalContinuationPolicy";
@@ -2133,76 +2131,56 @@ export class WorkspaceGoalService {
         ...(decision.kind === "defer" ? { deferUntilMs: decision.untilMs } : {}),
       };
     };
-
     const bridge = this.goalContinuationBridge;
-    let decision = evaluateGoalContinuationRegistration({
+    const probe: GoalContinuationPolicyProbe = {
+      nowMs,
       candidate,
       bridgeRegistered: bridge != null,
-    });
-    if (decision) {
-      return finish(decision);
-    }
+    };
+    const evaluateProbe = () => evaluateGoalContinuationBeforeGoal(probe);
+    let decision = evaluateProbe();
+    if (decision) return finish(decision);
     assert(
       candidate != null && bridge != null,
       "registered continuation requires candidate and bridge"
     );
 
     const workspace = this.findWorkspaceConfigEntry(workspaceId);
-    const workspaceState = {
+    probe.workspace = {
       found: workspace != null,
       archived:
         workspace != null && isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt),
-      hasPath: workspace?.path != null,
+      hasPath: Boolean(workspace?.path),
       isChild: workspace?.parentWorkspaceId != null,
     };
-    decision = evaluateGoalContinuationWorkspace({
-      workspace: workspaceState,
-      hasActiveDescendantTasks: false,
-    });
-    if (decision) {
-      return finish(decision);
-    }
-    decision = evaluateGoalContinuationWorkspace({
-      workspace: workspaceState,
-      hasActiveDescendantTasks: bridge.hasActiveDescendantTasks(workspaceId),
-    });
-    if (decision) {
-      return finish(decision);
-    }
+    decision = evaluateProbe();
+    if (decision) return finish(decision);
+
+    probe.hasActiveDescendantTasks = bridge.hasActiveDescendantTasks(workspaceId);
+    decision = evaluateProbe();
+    if (decision) return finish(decision);
 
     const runtimeState = bridge.getRuntimeState(workspaceId);
-    const runtime = {
+    probe.runtime = {
       isInitializing: runtimeState.isInitializing === true,
       isRuntimeCompatible: runtimeState.isRuntimeCompatible !== false,
       isBusy: runtimeState.isBusy === true,
       hasQueuedMessages: runtimeState.hasQueuedMessages === true,
       hasPendingFollowUp: runtimeState.hasPendingFollowUp === true,
     };
-    decision = evaluateGoalContinuationRuntime({
-      nowMs,
-      runtime,
-      isStreaming: null,
-      candidate,
-    });
-    if (decision) {
-      return finish(decision);
-    }
-    decision = evaluateGoalContinuationRuntime({
-      nowMs,
-      runtime,
-      isStreaming: await this.isWorkspaceStreaming(workspaceId),
-      candidate,
-    });
-    if (decision) {
-      return finish(decision);
-    }
+    decision = evaluateProbe();
+    if (decision) return finish(decision);
 
-    const userStopAtMs = this.lastUserStopAtMsByWorkspace.get(workspaceId) ?? null;
-    const stopCheckGoal = userStopAtMs != null ? await this.readGoalFile(workspaceId) : null;
-    decision = evaluateGoalContinuationStopCheck({ userStopAtMs, stopCheckGoal });
-    if (decision) {
-      return finish(decision);
+    probe.isStreaming = await this.isWorkspaceStreaming(workspaceId);
+    decision = evaluateProbe();
+    if (decision) return finish(decision);
+
+    probe.userStopAtMs = this.lastUserStopAtMsByWorkspace.get(workspaceId) ?? null;
+    if (probe.userStopAtMs != null) {
+      probe.stopCheckGoal = await this.readGoalFile(workspaceId);
     }
+    decision = evaluateProbe();
+    if (decision) return finish(decision);
 
     const goal = await this.normalizeGoalLimits(workspaceId, {
       syncChatTail: candidate.source !== "kickoff",

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -57,9 +57,11 @@ import {
   applyBudgetDrivenStatus,
   evaluateGoalContinuationBeforeGoal,
   evaluateGoalContinuationGoal,
+  getGoalCostMicroCents,
   hasReachedGoalBudgetLimit,
   hasReachedGoalTurnLimit,
   isBudgetWrapupEligibleOrigin,
+  MICRO_CENTS_PER_CENT,
   type GoalContinuationDecision,
   type GoalContinuationPolicyProbe,
   type GoalContinuationSkipReason,
@@ -84,19 +86,9 @@ const GOAL_HISTORY_FILE = "goal-history.jsonl";
 // generous cap still keeps the response payload bounded; older entries remain
 // on disk in the JSONL but are simply not surfaced to the UI.
 const GOAL_HISTORY_RENDER_CAP = 200;
-const MICRO_CENTS_PER_CENT = 1_000_000;
 
 function costUsdToMicroCents(costUsd: number | null | undefined): number {
   return Math.max(0, Math.round((costUsd ?? 0) * 100 * MICRO_CENTS_PER_CENT));
-}
-
-/**
- * Returns the goal's accumulated cost in micro-cents, falling back to the
- * coarser `costCents` field for goals persisted before micro-cent tracking
- * was added.
- */
-function getGoalCostMicroCents(goal: GoalRecordV1): number {
-  return goal.costMicroCents ?? goal.costCents * MICRO_CENTS_PER_CENT;
 }
 
 type GoalLifecycleEvent =

--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -32,7 +32,6 @@ import type { ProvidersConfigMap, SendMessageOptions } from "@/common/orpc/types
 import { isWorkspaceArchived } from "@/common/utils/archive";
 import {
   hasBudgetedResumableGoal,
-  hasGoalBudgetLimit,
   modelHasPricingData,
   normalizeGoalBudgetCents,
   UNPRICED_TARGET_MODEL_GOAL_MESSAGE,
@@ -54,6 +53,20 @@ import { buildGoalBudgetLimitMessage, buildGoalContinuationMessage } from "@/con
 import type { IdleDispatcher, IdleDispatchPayload } from "./idleDispatcher";
 import { log } from "./log";
 import { NOOP_TIMELINE_RECORDER, type TimelineRecorder } from "./timelineRecorder";
+import {
+  applyBudgetDrivenStatus,
+  evaluateGoalContinuationGoal,
+  evaluateGoalContinuationRegistration,
+  evaluateGoalContinuationRuntime,
+  evaluateGoalContinuationStopCheck,
+  evaluateGoalContinuationWorkspace,
+  hasReachedGoalBudgetLimit,
+  hasReachedGoalTurnLimit,
+  isBudgetWrapupEligibleOrigin,
+  type GoalContinuationDecision,
+  type GoalContinuationSkipReason,
+  type GoalStreamOriginKind,
+} from "./goalContinuationPolicy";
 
 const GOAL_FILE = "goal.json";
 const GOAL_BOARD_FILE = "goal-board.json";
@@ -142,29 +155,7 @@ export interface SetGoalInput {
   editInPlace?: boolean | null;
 }
 
-export type GoalContinuationSkipReason =
-  | "not_registered"
-  | "no_pending_candidate"
-  | "workspace_not_found"
-  | "archived"
-  | "transcript_only"
-  | "initializing"
-  | "incompatible_runtime"
-  | "child_workspace"
-  | "active_descendant_tasks"
-  | "currently_streaming"
-  | "queued_user_input"
-  | "pending_follow_up"
-  | "plan_mode"
-  | "compact_mode"
-  | "user_stop"
-  | "goal_missing"
-  | "goal_mismatch"
-  | "goal_not_active"
-  | "requires_ack"
-  | "budget_wrapup_already_fired"
-  | "budget_wrapup_suppressed"
-  | "cooldown";
+export type { GoalContinuationSkipReason, GoalStreamOriginKind } from "./goalContinuationPolicy";
 
 export interface GoalContinuationRuntimeState {
   isInitializing?: boolean;
@@ -329,8 +320,6 @@ interface PendingGoalMutation {
    */
   editInPlace?: boolean | null;
 }
-
-export type GoalStreamOriginKind = "goal_continuation" | "goal_budget_limit" | "user" | "other";
 
 interface GoalStreamStamp {
   originKind: GoalStreamOriginKind;
@@ -1008,7 +997,7 @@ export class WorkspaceGoalService {
       status: desiredStatus,
       updatedAtMs: Date.now(),
     });
-    return this.applyBudgetDrivenStatus(next);
+    return applyBudgetDrivenStatus(next, { nowMs: Date.now() });
   }
 
   private async syncGoalStatusToChatTail(workspaceId: string): Promise<GoalRecordV1 | null> {
@@ -1166,7 +1155,7 @@ export class WorkspaceGoalService {
       createdAtMs: now,
       updatedAtMs: now,
     });
-    return status === "active" ? this.applyBudgetDrivenStatus(goal) : goal;
+    return status === "active" ? applyBudgetDrivenStatus(goal, { nowMs: Date.now() }) : goal;
   }
 
   private async writeGoal(workspaceId: string, goal: GoalRecordV1): Promise<void> {
@@ -1989,7 +1978,7 @@ export class WorkspaceGoalService {
               const stamp = this.lastGoalStreamStamps.get(workspaceId);
               if (
                 stamp?.goalId !== goal.goalId ||
-                !this.isBudgetWrapupEligibleOrigin(stamp.originKind)
+                !isBudgetWrapupEligibleOrigin(stamp.originKind, this.allowUserOriginBudgetWrapup)
               ) {
                 return true;
               }
@@ -2126,125 +2115,111 @@ export class WorkspaceGoalService {
     assert(workspaceId.trim().length > 0, "checkGoalContinuationEligibility requires workspaceId");
     assert(Number.isFinite(nowMs) && nowMs >= 0, "checkGoalContinuationEligibility requires nowMs");
 
-    const candidate = this.pendingContinuationCandidates.get(workspaceId);
-    if (!candidate) {
-      return { eligible: false, reason: "no_pending_candidate" };
-    }
+    const candidate = this.pendingContinuationCandidates.get(workspaceId) ?? null;
+    const finish = (
+      decision: GoalContinuationDecision,
+      goal?: GoalRecordV1,
+      lastStreamStamp?: GoalStreamStamp
+    ): GoalContinuationEligibilityResult => {
+      if (decision.kind === "continue") {
+        return { eligible: true, goal, candidate: candidate ?? undefined, lastStreamStamp };
+      }
+      if (decision.kind === "stop" && decision.dropCandidate) {
+        this.pendingContinuationCandidates.delete(workspaceId);
+      }
+      return {
+        eligible: false,
+        reason: decision.reason,
+        ...(decision.kind === "defer" ? { deferUntilMs: decision.untilMs } : {}),
+      };
+    };
+
     const bridge = this.goalContinuationBridge;
-    if (!bridge) {
-      return { eligible: false, reason: "not_registered" };
+    let decision = evaluateGoalContinuationRegistration({
+      candidate,
+      bridgeRegistered: bridge != null,
+    });
+    if (decision) {
+      return finish(decision);
     }
+    assert(
+      candidate != null && bridge != null,
+      "registered continuation requires candidate and bridge"
+    );
 
     const workspace = this.findWorkspaceConfigEntry(workspaceId);
-    if (!workspace) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "workspace_not_found" };
+    const workspaceState = {
+      found: workspace != null,
+      archived:
+        workspace != null && isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt),
+      hasPath: workspace?.path != null,
+      isChild: workspace?.parentWorkspaceId != null,
+    };
+    decision = evaluateGoalContinuationWorkspace({
+      workspace: workspaceState,
+      hasActiveDescendantTasks: false,
+    });
+    if (decision) {
+      return finish(decision);
     }
-    if (isWorkspaceArchived(workspace.archivedAt, workspace.unarchivedAt)) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "archived" };
-    }
-    if (!workspace.path) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "transcript_only" };
-    }
-    if (workspace.parentWorkspaceId != null) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "child_workspace" };
-    }
-    if (bridge.hasActiveDescendantTasks(workspaceId)) {
-      return { eligible: false, reason: "active_descendant_tasks" };
+    decision = evaluateGoalContinuationWorkspace({
+      workspace: workspaceState,
+      hasActiveDescendantTasks: bridge.hasActiveDescendantTasks(workspaceId),
+    });
+    if (decision) {
+      return finish(decision);
     }
 
     const runtimeState = bridge.getRuntimeState(workspaceId);
-    if (runtimeState.isInitializing === true) {
-      return { eligible: false, reason: "initializing", deferUntilMs: nowMs + 1_000 };
+    const runtime = {
+      isInitializing: runtimeState.isInitializing === true,
+      isRuntimeCompatible: runtimeState.isRuntimeCompatible !== false,
+      isBusy: runtimeState.isBusy === true,
+      hasQueuedMessages: runtimeState.hasQueuedMessages === true,
+      hasPendingFollowUp: runtimeState.hasPendingFollowUp === true,
+    };
+    decision = evaluateGoalContinuationRuntime({
+      nowMs,
+      runtime,
+      isStreaming: null,
+      candidate,
+    });
+    if (decision) {
+      return finish(decision);
     }
-    if (runtimeState.isRuntimeCompatible === false) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "incompatible_runtime" };
-    }
-    if (runtimeState.isBusy === true || (await this.isWorkspaceStreaming(workspaceId))) {
-      return { eligible: false, reason: "currently_streaming", deferUntilMs: nowMs + 1_000 };
-    }
-    if (runtimeState.hasQueuedMessages === true) {
-      return { eligible: false, reason: "queued_user_input" };
-    }
-    if (runtimeState.hasPendingFollowUp === true) {
-      return { eligible: false, reason: "pending_follow_up" };
-    }
-    if (candidate.sendOptions.agentId === "plan" || candidate.sendOptions.mode === "plan") {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "plan_mode" };
-    }
-    if (candidate.sendOptions.agentId === "compact" || candidate.sendOptions.mode === "compact") {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "compact_mode" };
+    decision = evaluateGoalContinuationRuntime({
+      nowMs,
+      runtime,
+      isStreaming: await this.isWorkspaceStreaming(workspaceId),
+      candidate,
+    });
+    if (decision) {
+      return finish(decision);
     }
 
-    const userStopAtMs = this.lastUserStopAtMsByWorkspace.get(workspaceId);
-    if (userStopAtMs != null) {
-      const goalForStopCheck = await this.readGoalFile(workspaceId);
-      if (!goalForStopCheck) {
-        this.pendingContinuationCandidates.delete(workspaceId);
-        return { eligible: false, reason: "goal_missing" };
-      }
-      if (userStopAtMs >= goalForStopCheck.createdAtMs) {
-        this.pendingContinuationCandidates.delete(workspaceId);
-        return { eligible: false, reason: "user_stop" };
-      }
+    const userStopAtMs = this.lastUserStopAtMsByWorkspace.get(workspaceId) ?? null;
+    const stopCheckGoal = userStopAtMs != null ? await this.readGoalFile(workspaceId) : null;
+    decision = evaluateGoalContinuationStopCheck({ userStopAtMs, stopCheckGoal });
+    if (decision) {
+      return finish(decision);
     }
 
     const goal = await this.normalizeGoalLimits(workspaceId, {
       syncChatTail: candidate.source !== "kickoff",
     });
-    if (!goal) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "goal_missing" };
-    }
-    if (goal.goalId !== candidate.goalId) {
-      this.pendingContinuationCandidates.delete(workspaceId);
-      return { eligible: false, reason: "goal_mismatch" };
-    }
-    if (goal.status !== "active" && goal.status !== "budget_limited") {
-      if (goal.status !== "paused" || candidate.source !== "kickoff") {
-        this.pendingContinuationCandidates.delete(workspaceId);
-        return { eligible: false, reason: "goal_not_active" };
-      }
-    }
-    if (goal.requireUserAcknowledgmentSinceMs != null) {
-      return { eligible: false, reason: "requires_ack" };
-    }
-
-    if (goal.status === "budget_limited") {
-      const lastStreamStamp = this.lastGoalStreamStamps.get(workspaceId);
-      if (goal.budgetLimitInjectedForGoalId === goal.goalId) {
-        this.pendingContinuationCandidates.delete(workspaceId);
-        return { eligible: false, reason: "budget_wrapup_already_fired" };
-      }
-      if (
-        lastStreamStamp?.goalId !== goal.goalId ||
-        !this.isBudgetWrapupEligibleOrigin(lastStreamStamp.originKind)
-      ) {
-        this.pendingContinuationCandidates.delete(workspaceId);
-        return { eligible: false, reason: "budget_wrapup_suppressed" };
-      }
-      return { eligible: true, goal, candidate, lastStreamStamp };
-    }
-
-    const lastContinuationFiredAtMs = goal.lastContinuationFiredAtMs ?? null;
-    if (
-      lastContinuationFiredAtMs != null &&
-      nowMs - lastContinuationFiredAtMs < this.continuationCooldownMs
-    ) {
-      return {
-        eligible: false,
-        reason: "cooldown",
-        deferUntilMs: lastContinuationFiredAtMs + this.continuationCooldownMs,
-      };
-    }
-
-    return { eligible: true, goal, candidate };
+    const lastStreamStamp =
+      goal?.status === "budget_limited"
+        ? (this.lastGoalStreamStamps.get(workspaceId) ?? null)
+        : null;
+    decision = evaluateGoalContinuationGoal({
+      nowMs,
+      candidate,
+      goal,
+      lastStreamStamp,
+      continuationCooldownMs: this.continuationCooldownMs,
+      allowUserOriginBudgetWrapup: this.allowUserOriginBudgetWrapup,
+    });
+    return finish(decision, goal ?? undefined, lastStreamStamp ?? undefined);
   }
 
   private scheduleContinuationReRequest(workspaceId: string, dueAtMs: number): void {
@@ -2302,7 +2277,7 @@ export class WorkspaceGoalService {
         preReadChatTailMode != null && current.goalId === preRead?.goalId
           ? preReadChatTailMode
           : null;
-      const budgetNormalized = this.applyBudgetDrivenStatus(current);
+      const budgetNormalized = applyBudgetDrivenStatus(current, { nowMs: Date.now() });
       const next = chatTailMode
         ? this.applyChatTailGoalMode(workspaceId, budgetNormalized, chatTailMode)
         : budgetNormalized;
@@ -2380,10 +2355,6 @@ export class WorkspaceGoalService {
     });
   }
 
-  private isBudgetWrapupEligibleOrigin(originKind: GoalStreamOriginKind): boolean {
-    return this.allowUserOriginBudgetWrapup || originKind !== "user";
-  }
-
   private async tryMarkBudgetLimitInjected(
     workspaceId: string,
     expectedGoalId: string,
@@ -2391,7 +2362,10 @@ export class WorkspaceGoalService {
   ): Promise<GoalRecordV1 | null> {
     assert(expectedGoalId.trim().length > 0, "budget wrap-up reservation requires a goal id");
     assert(
-      this.isBudgetWrapupEligibleOrigin(expectedLastStreamStamp.originKind),
+      isBudgetWrapupEligibleOrigin(
+        expectedLastStreamStamp.originKind,
+        this.allowUserOriginBudgetWrapup
+      ),
       "budget wrap-up reservation requires a goal-attributable stream"
     );
 
@@ -2399,7 +2373,7 @@ export class WorkspaceGoalService {
       const currentStamp = this.lastGoalStreamStamps.get(workspaceId);
       if (
         currentStamp?.goalId !== expectedGoalId ||
-        !this.isBudgetWrapupEligibleOrigin(currentStamp.originKind)
+        !isBudgetWrapupEligibleOrigin(currentStamp.originKind, this.allowUserOriginBudgetWrapup)
       ) {
         return null;
       }
@@ -2576,23 +2550,7 @@ export class WorkspaceGoalService {
       ...completionSummaryPatch(input.status, completionSummary),
       updatedAtMs: Date.now(),
     });
-    return this.applyBudgetDrivenStatus(next);
-  }
-
-  private hasReachedBudgetLimit(goal: GoalRecordV1): boolean {
-    const { budgetCents } = goal;
-    if (budgetCents == null || !hasGoalBudgetLimit(budgetCents)) {
-      return false;
-    }
-    return getGoalCostMicroCents(goal) >= budgetCents * MICRO_CENTS_PER_CENT;
-  }
-
-  private hasReachedTurnLimit(goal: GoalRecordV1): boolean {
-    return goal.turnCap != null && goal.turnsUsed >= goal.turnCap;
-  }
-
-  private hasReachedAnyLimit(goal: GoalRecordV1): boolean {
-    return this.hasReachedBudgetLimit(goal) || this.hasReachedTurnLimit(goal);
+    return applyBudgetDrivenStatus(next, { nowMs: Date.now() });
   }
 
   private applyCostAccounting(
@@ -2604,45 +2562,6 @@ export class WorkspaceGoalService {
       costCents: Math.round(costMicroCents / MICRO_CENTS_PER_CENT),
       costMicroCents,
     };
-  }
-
-  private applyBudgetDrivenStatus(
-    next: GoalRecordV1,
-    options?: { originKind?: GoalStreamOriginKind }
-  ): GoalRecordV1 {
-    const normalizedBudgetCents = normalizeGoalBudgetCents(next.budgetCents);
-    const normalized =
-      normalizedBudgetCents === next.budgetCents
-        ? next
-        : GoalRecordV1Schema.parse({
-            ...next,
-            budgetCents: normalizedBudgetCents,
-            updatedAtMs: Date.now(),
-          });
-    const reachedLimit = this.hasReachedAnyLimit(normalized);
-    const shouldLimitActiveGoal = normalized.status === "active" && reachedLimit;
-    const shouldRearmBudgetLimitedGoal = normalized.status === "budget_limited" && !reachedLimit;
-    if (!shouldLimitActiveGoal && !shouldRearmBudgetLimitedGoal) {
-      return normalized;
-    }
-
-    return GoalRecordV1Schema.parse({
-      ...normalized,
-      status: shouldLimitActiveGoal ? "budget_limited" : "active",
-      // Raising/removing limits re-arms the one-shot budget wrap-up.
-      budgetLimitInjectedForGoalId: shouldRearmBudgetLimitedGoal
-        ? null
-        : normalized.budgetLimitInjectedForGoalId,
-      // Persist the origin kind on active→budget_limited so restart recovery
-      // can decide whether to arm a wrap-up. Clear it when re-arming back to
-      // `active` after the budget is raised or removed.
-      budgetLimitOriginKind: shouldLimitActiveGoal
-        ? (options?.originKind ?? null)
-        : shouldRearmBudgetLimitedGoal
-          ? null
-          : normalized.budgetLimitOriginKind,
-      updatedAtMs: Date.now(),
-    });
   }
 
   private emitBudgetLimited(
@@ -2664,10 +2583,10 @@ export class WorkspaceGoalService {
     this.emitLifecycle("goal_budget_limited", {
       hasBudget: goal.budgetCents != null,
       hasTurnCap: goal.turnCap != null,
-      "cost-overshoot": this.hasReachedBudgetLimit(goal)
+      "cost-overshoot": hasReachedGoalBudgetLimit(goal)
         ? centsBucket(Math.max(0, goal.costCents - (goal.budgetCents ?? 0)))
         : null,
-      "turn-overshoot": this.hasReachedTurnLimit(goal)
+      "turn-overshoot": hasReachedGoalTurnLimit(goal)
         ? countBucket(Math.max(0, goal.turnsUsed - (goal.turnCap ?? 0)))
         : null,
       ...(properties ?? {}),
@@ -4225,7 +4144,7 @@ export class WorkspaceGoalService {
         turnsUsed: current.turnsUsed + turnsDelta,
         updatedAtMs: Date.now(),
       });
-      const next = this.applyBudgetDrivenStatus(accounted, { originKind });
+      const next = applyBudgetDrivenStatus(accounted, { originKind, nowMs: Date.now() });
       if (input.streamStartedAtMs != null) {
         this.recordedStreamStartedAtMsByWorkspace.set(input.workspaceId, input.streamStartedAtMs);
       }
@@ -4284,7 +4203,10 @@ export class WorkspaceGoalService {
       // wrap-up is owed . `goal_continuation` is the right tag here
       // because the wrap-up MUST fire — child attribution is goal-attributable
       // work. The recovery path checks for `!= "user"`.
-      const next = this.applyBudgetDrivenStatus(accounted, { originKind: "goal_continuation" });
+      const next = applyBudgetDrivenStatus(accounted, {
+        originKind: "goal_continuation",
+        nowMs: Date.now(),
+      });
       const causedLimit = current.status === "active" && next.status === "budget_limited";
 
       await this.writeGoal(input.parentWorkspaceId, next);
@@ -5163,7 +5085,7 @@ export class WorkspaceGoalService {
         // activation consent (see stampUserActivation).
         lastUserActivationAtMs: now,
       });
-      const activated = this.applyBudgetDrivenStatus(baseActivated);
+      const activated = applyBudgetDrivenStatus(baseActivated, { nowMs: Date.now() });
 
       // gate budgeted goal promotion on pricing data. A user
       // who queued a goal under a priced model and then switched to an
@@ -5339,7 +5261,7 @@ export class WorkspaceGoalService {
       // queue-race pause bypasses fail closed for this activation.
       lastUserActivationAtMs: null,
     });
-    const activated = this.applyBudgetDrivenStatus(baseActivated);
+    const activated = applyBudgetDrivenStatus(baseActivated, { nowMs: Date.now() });
     // same pricing gate as `promoteUpcomingGoal`. If the next
     // queued goal is budgeted and the workspace is currently on an
     // unpriced model, refuse the auto-promotion — otherwise we'd leave


### PR DESCRIPTION
## Summary

Extracts the goal-continuation decision logic out of `WorkspaceGoalService` into a pure, synchronous policy module (`goalContinuationPolicy.ts`). The service becomes the I/O shell (file locks, goal-file reads/writes, chat-tail sync, analytics/timeline emission) around a single decision point that returns a discriminated union: `continue` | `defer(untilMs)` | `stop(reason, dropCandidate)`.

## Background

`workspaceGoalService.ts` (5,401 lines) interleaved continuation decisions with I/O: `checkGoalContinuationEligibility` mixed in-memory candidate maps, runtime-bridge probes, gated goal-file reads, `normalizeGoalLimits` (a locked read-modify-write with chat-tail reconciliation), one-shot budget wrap-up gating, and cooldown math. The decision had no interface of its own, so testing one cooldown branch required a real session directory, file locks, and mocked services. Refactor #9 of the 2026-08-29 architecture review, based on main @ f04e0f8a3. Behavior-preserving.

## Implementation

- `evaluateGoalContinuation(state)` mirrors the previous branch order and candidate-disposition semantics exactly; every skip reason keeps its value (they feed logs and CLI eligibility hints).
- A staged probe (`evaluateGoalContinuationBeforeGoal`) preserves the pre-existing I/O gating: undefined probe fields mean "not gathered yet", so the shell still performs no goal-file read while the workspace is busy/streaming and runs `normalizeGoalLimits` only after all runtime gates pass.
- Pure helpers moved with it: budget/turn-cap limit checks, budget-driven status transitions (`applyBudgetDrivenStatus`, now takes `nowMs`), wrap-up origin eligibility, and the cost micro-cent helpers.
- Per ADR-0004, interactive and CLI goal runs drive the same policy with different inputs: `continuationCooldownMs` (CLI: 0) and `allowUserOriginBudgetWrapup` (CLI: true) are plain policy-state fields; no CLI-vs-interactive conditionals in the policy. `checkGoalContinuationEligibility` keeps its public shape, so `src/cli/goalRunDriver.ts` is untouched.
- Stateful race guards stay in the shell unchanged: `admissionStale` generation probes, dispatch closures, pause/terminal/identity generations, chat-tail reconciliation.

### Net LOC (vs f04e0f8a3)

- Production: **+126** (+342/-216)
- Tests: **-151** (+350/-501)
- Combined: **-25**

The production increase is the cost of giving the decision an explicit interface: the policy-state/probe/decision types (~70 lines) had no prior representation (state was implicit in service fields and closure context), and the staged-probe evaluation preserving I/O gating adds ~15 lines. All decision branches were moved, not duplicated; the service shed the same logic plus its duplicated cost helpers. On the test side, 42 table-driven pure cases (zero filesystem, zero mocks) replace 18 disk-harness permutation tests; all stateful race-invariant and shell-wiring tests were retained.

## Validation

- Remote dogfood UAT (Coder Agents, real UI + real model, unmodified 60s cooldown) passed all five live goal scenarios on the pushed SHA: continuation fire + cooldown defer, turn-cap flip to `budget_limited` with exactly one wrap-up, re-arm on cap raise/removal, pause/manual-message suppression of pending continuations, and the user Stop acknowledgment gate.
- `make static-check` and whole-file runs of the five goal-related test suites (290 tests) are green.

## Risks

Behavior-preserving refactor of race-sensitive logic; the main risk is decision/branch-order fidelity. Mitigated by mirroring the branch order exactly (reviewable side by side in the diff), leaving every stateful race guard in the shell untouched, retaining the race-invariant test suite, and live UAT of the continuation lifecycle.

---

_Xum acted on Mike's behalf. Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: \$37.87_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=37.87 -->

## Stack

Layer 1/10 of the architecture refactor stack (net -5,101 LOC overall). This PR's diff is only this layer, against `main`.
