### PR TITLE
🤖 refactor: segregate the task/workspace seam into role interfaces

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -526,28 +526,35 @@ type WorkspaceHostMockOverrides = Partial<{
 
 function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {}) {
   const defaults = makeWorkspaceHostFake();
-  const sendMessage = overrides.sendMessage ?? mock(defaults.sendMessage);
-  const resumeStream = overrides.resumeStream ?? mock(defaults.resumeStream);
-  const clearQueue = overrides.clearQueue ?? mock(defaults.clearQueue);
+  const sendMessage = overrides.sendMessage ?? mock(defaults.sendMessage.bind(defaults));
+  const resumeStream = overrides.resumeStream ?? mock(defaults.resumeStream.bind(defaults));
+  const clearQueue = overrides.clearQueue ?? mock(defaults.clearQueue.bind(defaults));
   const removeQueuedWorkspaceTurn =
-    overrides.removeQueuedWorkspaceTurn ?? mock(defaults.removeQueuedWorkspaceTurn);
-  const isBusyForMessage = overrides.isBusyForMessage ?? mock(defaults.isBusyForMessage);
-  const getQueueCutCutter = overrides.getQueueCutCutter ?? mock(defaults.getQueueCutCutter);
-  const remove = overrides.remove ?? overrides.removeWhileTaskTreeLocked ?? mock(defaults.remove);
-  const updateTitle = overrides.updateTitle ?? mock(defaults.updateTitle);
-  const emitChatEvent = overrides.emitChatEvent ?? mock(defaults.emitChatEvent);
+    overrides.removeQueuedWorkspaceTurn ?? mock(defaults.removeQueuedWorkspaceTurn.bind(defaults));
+  const isBusyForMessage =
+    overrides.isBusyForMessage ?? mock(defaults.isBusyForMessage.bind(defaults));
+  const getQueueCutCutter =
+    overrides.getQueueCutCutter ?? mock(defaults.getQueueCutCutter.bind(defaults));
+  const remove =
+    overrides.remove ?? overrides.removeWhileTaskTreeLocked ?? mock(defaults.remove.bind(defaults));
+  const updateTitle = overrides.updateTitle ?? mock(defaults.updateTitle.bind(defaults));
+  const emitChatEvent = overrides.emitChatEvent ?? mock(defaults.emitChatEvent.bind(defaults));
   const emit = overrides.emit ?? mock(() => true);
   const archive =
-    overrides.archive ?? overrides.archiveWhileTaskTreeLocked ?? mock(defaults.archive);
+    overrides.archive ??
+    overrides.archiveWhileTaskTreeLocked ??
+    mock(defaults.archive.bind(defaults));
   const unarchive =
     overrides.unarchive ??
     overrides.unarchiveWhileTaskTreeLocked ??
-    mock(defaults.unarchiveWhileTaskTreeLocked);
+    mock(defaults.unarchiveWhileTaskTreeLocked.bind(defaults));
   const isWorkflowInvocationCurrent =
-    overrides.isWorkflowInvocationCurrent ?? mock(defaults.isWorkflowInvocationCurrent);
-  const create = overrides.create ?? mock(defaults.create);
+    overrides.isWorkflowInvocationCurrent ??
+    mock(defaults.isWorkflowInvocationCurrent.bind(defaults));
+  const create = overrides.create ?? mock(defaults.create.bind(defaults));
   const discardExtensionMetadataEntry =
-    overrides.discardExtensionMetadataEntry ?? mock(defaults.discardExtensionMetadataEntry);
+    overrides.discardExtensionMetadataEntry ??
+    mock(defaults.discardExtensionMetadataEntry.bind(defaults));
 
   const workspaceService = makeWorkspaceHostFake({
     ...overrides,
@@ -555,7 +562,8 @@ function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {})
     discardExtensionMetadataEntry,
     // Task-create tests exercise launch flow, not plugin-override sanitization.
     sanitizeMaterializedTaskWorkspace:
-      overrides.sanitizeMaterializedTaskWorkspace ?? defaults.sanitizeMaterializedTaskWorkspace,
+      overrides.sanitizeMaterializedTaskWorkspace ??
+      defaults.sanitizeMaterializedTaskWorkspace.bind(defaults),
     sendMessage,
     resumeStream,
     clearQueue,
@@ -565,10 +573,11 @@ function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {})
     // Keep-style behavior makes archive eligibility independent of untracked files.
     isSnapshotArchiveEligibilityMutationSensitive:
       overrides.isSnapshotArchiveEligibilityMutationSensitive ??
-      defaults.isSnapshotArchiveEligibilityMutationSensitive,
+      defaults.isSnapshotArchiveEligibilityMutationSensitive.bind(defaults),
     // No live activity grants the archive hold so tests reach interruption behavior.
     acquirePreInterruptionArchiveHold:
-      overrides.acquirePreInterruptionArchiveHold ?? defaults.acquirePreInterruptionArchiveHold,
+      overrides.acquirePreInterruptionArchiveHold ??
+      defaults.acquirePreInterruptionArchiveHold.bind(defaults),
     archive,
     archiveWhileTaskTreeLocked: archive,
     unarchiveWhileTaskTreeLocked: unarchive,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -525,59 +525,53 @@ type WorkspaceHostMockOverrides = Partial<{
 }> & { unarchive?: ReturnType<typeof mock> };
 
 function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {}) {
-  const defaults = makeWorkspaceHostFake();
-  const sendMessage = overrides.sendMessage ?? mock(defaults.sendMessage.bind(defaults));
-  const resumeStream = overrides.resumeStream ?? mock(defaults.resumeStream.bind(defaults));
-  const clearQueue = overrides.clearQueue ?? mock(defaults.clearQueue.bind(defaults));
+  const sendMessage =
+    overrides.sendMessage ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
+  const resumeStream =
+    overrides.resumeStream ??
+    mock((): Promise<Result<{ started: boolean }>> => Promise.resolve(Ok({ started: true })));
+  const clearQueue = overrides.clearQueue ?? mock((): Result<void> => Ok(undefined));
   const removeQueuedWorkspaceTurn =
-    overrides.removeQueuedWorkspaceTurn ?? mock(defaults.removeQueuedWorkspaceTurn.bind(defaults));
-  const isBusyForMessage =
-    overrides.isBusyForMessage ?? mock(defaults.isBusyForMessage.bind(defaults));
-  const getQueueCutCutter =
-    overrides.getQueueCutCutter ?? mock(defaults.getQueueCutCutter.bind(defaults));
+    overrides.removeQueuedWorkspaceTurn ?? mock((): Result<boolean> => Ok(true));
+  const isBusyForMessage = overrides.isBusyForMessage ?? mock(() => false);
+  const getQueueCutCutter = overrides.getQueueCutCutter ?? mock(() => undefined);
   const remove =
-    overrides.remove ?? overrides.removeWhileTaskTreeLocked ?? mock(defaults.remove.bind(defaults));
-  const updateTitle = overrides.updateTitle ?? mock(defaults.updateTitle.bind(defaults));
-  const emitChatEvent = overrides.emitChatEvent ?? mock(defaults.emitChatEvent.bind(defaults));
+    overrides.remove ??
+    overrides.removeWhileTaskTreeLocked ??
+    mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
+  const updateTitle =
+    overrides.updateTitle ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
+  const emitChatEvent = overrides.emitChatEvent ?? mock(() => undefined);
   const emit = overrides.emit ?? mock(() => true);
   const archive =
     overrides.archive ??
     overrides.archiveWhileTaskTreeLocked ??
-    mock(defaults.archive.bind(defaults));
+    mock((): Promise<Result<{ kind: "archived" }>> => Promise.resolve(Ok({ kind: "archived" })));
   const unarchive =
     overrides.unarchive ??
     overrides.unarchiveWhileTaskTreeLocked ??
-    mock(defaults.unarchiveWhileTaskTreeLocked.bind(defaults));
+    mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
   const isWorkflowInvocationCurrent =
-    overrides.isWorkflowInvocationCurrent ??
-    mock(defaults.isWorkflowInvocationCurrent.bind(defaults));
-  const create = overrides.create ?? mock(defaults.create.bind(defaults));
+    overrides.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true));
+  const create =
+    overrides.create ??
+    mock(
+      (): Promise<Result<{ metadata: WorkspaceMetadata }>> =>
+        Promise.resolve(Err("workspaceHost.create not mocked"))
+    );
   const discardExtensionMetadataEntry =
-    overrides.discardExtensionMetadataEntry ??
-    mock(defaults.discardExtensionMetadataEntry.bind(defaults));
+    overrides.discardExtensionMetadataEntry ?? mock(() => Promise.resolve());
 
   const workspaceService = makeWorkspaceHostFake({
     ...overrides,
     create,
     discardExtensionMetadataEntry,
-    // Task-create tests exercise launch flow, not plugin-override sanitization.
-    sanitizeMaterializedTaskWorkspace:
-      overrides.sanitizeMaterializedTaskWorkspace ??
-      defaults.sanitizeMaterializedTaskWorkspace.bind(defaults),
     sendMessage,
     resumeStream,
     clearQueue,
     removeQueuedWorkspaceTurn,
     isBusyForMessage,
     getQueueCutCutter,
-    // Keep-style behavior makes archive eligibility independent of untracked files.
-    isSnapshotArchiveEligibilityMutationSensitive:
-      overrides.isSnapshotArchiveEligibilityMutationSensitive ??
-      defaults.isSnapshotArchiveEligibilityMutationSensitive.bind(defaults),
-    // No live activity grants the archive hold so tests reach interruption behavior.
-    acquirePreInterruptionArchiveHold:
-      overrides.acquirePreInterruptionArchiveHold ??
-      defaults.acquirePreInterruptionArchiveHold.bind(defaults),
     archive,
     archiveWhileTaskTreeLocked: archive,
     unarchiveWhileTaskTreeLocked: unarchive,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -81,9 +81,10 @@ import {
   WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE,
 } from "@/common/utils/workflowRunMessages";
 import type { WorkspaceMetadata } from "@/common/types/workspace";
-import type { ProvidersConfigMap, WorkspaceChatMessage } from "@/common/orpc/types";
+import type { ProvidersConfigMap } from "@/common/orpc/types";
 import type { AIService } from "@/node/services/aiService";
 import type { WorkspaceHost } from "@/node/services/taskWorkspaceSeam";
+import { makeWorkspaceHostFake } from "@/node/services/taskWorkspaceSeam.testUtils";
 import type { InitStateManager } from "@/node/services/initStateManager";
 import { InitStateManager as RealInitStateManager } from "@/node/services/initStateManager";
 import assert from "node:assert";
@@ -519,177 +520,68 @@ function simulateAcceptedFamilySends(
   );
 }
 
-function createWorkspaceServiceMocks(
-  overrides?: Partial<{
-    sendMessage: ReturnType<typeof mock>;
-    resumeStream: ReturnType<typeof mock>;
-    clearQueue: ReturnType<typeof mock>;
-    removeQueuedWorkspaceTurn: ReturnType<typeof mock>;
-    removeQueuedMessagesByDedupeKeyPrefix: ReturnType<typeof mock>;
-    hasQueuedWorkspaceTurn: ReturnType<typeof mock>;
-    hasQueuedMessages: ReturnType<typeof mock>;
-    isBusyForMessage: ReturnType<typeof mock>;
-    hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
-    hasPendingBashMonitorWakeContinuation: ReturnType<typeof mock>;
-    hasPendingWorkspaceTurnContinuation: ReturnType<typeof mock>;
-    getQueueCutCutter: ReturnType<typeof mock>;
-    hasPendingAutoRetry: ReturnType<typeof mock>;
-    waitForIdleAndNoQueuedMessages: ReturnType<typeof mock>;
-    waitForPendingCompactionCompletionDecision: ReturnType<typeof mock>;
-    waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
-    archive: ReturnType<typeof mock>;
-    unarchive: ReturnType<typeof mock>;
-    preflightArchive: ReturnType<typeof mock>;
-    listLiveWorkspaceActivity: ReturnType<typeof mock>;
-    hasRunningBackgroundBashProcesses: ReturnType<typeof mock>;
-    isSnapshotArchiveEligibilityMutationSensitive: ReturnType<typeof mock>;
-    hasUntrackableExternalAppOpen: ReturnType<typeof mock>;
-    acquirePreInterruptionArchiveHold: ReturnType<typeof mock>;
-    remove: ReturnType<typeof mock>;
-    emit: ReturnType<typeof mock>;
-    getInfo: ReturnType<typeof mock>;
-    replaceHistory: ReturnType<typeof mock>;
-    updateTitle: ReturnType<typeof mock>;
-    isExperimentEnabled: ReturnType<typeof mock>;
-    emitChatEvent: ReturnType<typeof mock>;
-    isWorkflowInvocationCurrent: ReturnType<typeof mock>;
-    create: ReturnType<typeof mock>;
-    countQueuedAgentPeerMessages: ReturnType<typeof mock>;
-  }>
-) {
-  const sendMessage =
-    overrides?.sendMessage ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const resumeStream =
-    overrides?.resumeStream ??
-    mock((): Promise<Result<{ started: boolean }>> => Promise.resolve(Ok({ started: true })));
-  const clearQueue = overrides?.clearQueue ?? mock((): Result<void> => Ok(undefined));
-  const removeQueuedWorkspaceTurn =
-    overrides?.removeQueuedWorkspaceTurn ?? mock((): Result<boolean> => Ok(true));
-  const removeQueuedMessagesByDedupeKeyPrefix =
-    overrides?.removeQueuedMessagesByDedupeKeyPrefix ?? mock((): Result<number> => Ok(0));
-  const hasQueuedWorkspaceTurn = overrides?.hasQueuedWorkspaceTurn ?? mock(() => false);
-  const hasQueuedMessages = overrides?.hasQueuedMessages ?? mock(() => false);
-  const isBusyForMessage = overrides?.isBusyForMessage ?? mock(() => false);
-  const hasPendingQueuedOrPreparingTurn =
-    overrides?.hasPendingQueuedOrPreparingTurn ?? mock(() => false);
-  const hasPendingBashMonitorWakeContinuation =
-    overrides?.hasPendingBashMonitorWakeContinuation ?? mock(() => false);
-  const hasPendingWorkspaceTurnContinuation =
-    overrides?.hasPendingWorkspaceTurnContinuation ?? mock(() => false);
-  const getQueueCutCutter = overrides?.getQueueCutCutter ?? mock(() => undefined);
-  const hasPendingAutoRetry = overrides?.hasPendingAutoRetry ?? mock(() => false);
-  const waitForIdleAndNoQueuedMessages =
-    overrides?.waitForIdleAndNoQueuedMessages ?? mock((): Promise<void> => Promise.resolve());
-  const waitForPendingCompactionCompletionDecision =
-    overrides?.waitForPendingCompactionCompletionDecision ??
-    mock((): Promise<boolean> => Promise.resolve(true));
-  const waitForPendingStreamErrorRecoveryDecision =
-    overrides?.waitForPendingStreamErrorRecoveryDecision ??
-    mock((): Promise<void> => Promise.resolve());
-  const archive =
-    overrides?.archive ??
-    mock((): Promise<Result<{ kind: "archived" }>> => Promise.resolve(Ok({ kind: "archived" })));
-  const unarchive =
-    overrides?.unarchive ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const preflightArchive =
-    overrides?.preflightArchive ??
-    mock((): Promise<Result<{ kind: "ready" }>> => Promise.resolve(Ok({ kind: "ready" })));
-  const listLiveWorkspaceActivity =
-    overrides?.listLiveWorkspaceActivity ??
-    mock(() => ({
-      streaming: false,
-      queuedMessages: false,
-      backgroundBashProcesses: false,
-      terminalSessions: false,
-      desktopSession: false,
-    }));
-  const hasRunningBackgroundBashProcesses =
-    overrides?.hasRunningBackgroundBashProcesses ??
-    mock((): Promise<boolean> => Promise.resolve(false));
-  // Default false = "keep"-style behavior where archive eligibility never depends on the
-  // untracked-file set, so interrupt_active tests exercise the interruption path.
-  const isSnapshotArchiveEligibilityMutationSensitive =
-    overrides?.isSnapshotArchiveEligibilityMutationSensitive ?? mock(() => false);
-  const hasUntrackableExternalAppOpen =
-    overrides?.hasUntrackableExternalAppOpen ?? mock(() => false);
-  const remove =
-    overrides?.remove ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const emit = overrides?.emit ?? mock(() => true);
-  const getInfo = overrides?.getInfo ?? mock(() => Promise.resolve(null));
-  const replaceHistory =
-    overrides?.replaceHistory ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const updateTitle =
-    overrides?.updateTitle ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const isExperimentEnabled = overrides?.isExperimentEnabled ?? mock(() => false);
-  const emitChatEvent =
-    overrides?.emitChatEvent ??
-    mock((_workspaceId: string, _message: WorkspaceChatMessage) => undefined);
-  const isWorkflowInvocationCurrent =
-    overrides?.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true));
-  const countQueuedAgentPeerMessages = overrides?.countQueuedAgentPeerMessages ?? mock(() => 0);
-  // Granted by default (no live user activity): interrupt_active tests exercise the
-  // interruption/archive flow; the hold's own refusal logic lives in workspaceService.test.ts.
-  const acquirePreInterruptionArchiveHold =
-    overrides?.acquirePreInterruptionArchiveHold ??
-    mock((): Result<Disposable> => Ok({ [Symbol.dispose]: () => undefined }));
+type WorkspaceHostMockOverrides = Partial<{
+  [K in keyof WorkspaceHost]: ReturnType<typeof mock>;
+}> & { unarchive?: ReturnType<typeof mock> };
 
-  const create =
-    overrides?.create ??
-    mock(
-      (): Promise<Result<{ metadata: WorkspaceMetadata }>> =>
-        Promise.resolve(Err("workspaceService.create not mocked"))
-    );
-  const discardExtensionMetadataEntry = mock((): Promise<void> => Promise.resolve());
+function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {}) {
+  const defaults = makeWorkspaceHostFake();
+  const sendMessage = overrides.sendMessage ?? mock(defaults.sendMessage);
+  const resumeStream = overrides.resumeStream ?? mock(defaults.resumeStream);
+  const clearQueue = overrides.clearQueue ?? mock(defaults.clearQueue);
+  const removeQueuedWorkspaceTurn =
+    overrides.removeQueuedWorkspaceTurn ?? mock(defaults.removeQueuedWorkspaceTurn);
+  const isBusyForMessage = overrides.isBusyForMessage ?? mock(defaults.isBusyForMessage);
+  const getQueueCutCutter = overrides.getQueueCutCutter ?? mock(defaults.getQueueCutCutter);
+  const remove = overrides.remove ?? overrides.removeWhileTaskTreeLocked ?? mock(defaults.remove);
+  const updateTitle = overrides.updateTitle ?? mock(defaults.updateTitle);
+  const emitChatEvent = overrides.emitChatEvent ?? mock(defaults.emitChatEvent);
+  const emit = overrides.emit ?? mock(() => true);
+  const archive =
+    overrides.archive ?? overrides.archiveWhileTaskTreeLocked ?? mock(defaults.archive);
+  const unarchive =
+    overrides.unarchive ??
+    overrides.unarchiveWhileTaskTreeLocked ??
+    mock(defaults.unarchiveWhileTaskTreeLocked);
+  const isWorkflowInvocationCurrent =
+    overrides.isWorkflowInvocationCurrent ?? mock(defaults.isWorkflowInvocationCurrent);
+  const create = overrides.create ?? mock(defaults.create);
+  const discardExtensionMetadataEntry =
+    overrides.discardExtensionMetadataEntry ?? mock(defaults.discardExtensionMetadataEntry);
+
+  const workspaceService = makeWorkspaceHostFake({
+    ...overrides,
+    create,
+    discardExtensionMetadataEntry,
+    // Task-create tests exercise launch flow, not plugin-override sanitization.
+    sanitizeMaterializedTaskWorkspace:
+      overrides.sanitizeMaterializedTaskWorkspace ?? defaults.sanitizeMaterializedTaskWorkspace,
+    sendMessage,
+    resumeStream,
+    clearQueue,
+    removeQueuedWorkspaceTurn,
+    isBusyForMessage,
+    getQueueCutCutter,
+    // Keep-style behavior makes archive eligibility independent of untracked files.
+    isSnapshotArchiveEligibilityMutationSensitive:
+      overrides.isSnapshotArchiveEligibilityMutationSensitive ??
+      defaults.isSnapshotArchiveEligibilityMutationSensitive,
+    // No live activity grants the archive hold so tests reach interruption behavior.
+    acquirePreInterruptionArchiveHold:
+      overrides.acquirePreInterruptionArchiveHold ?? defaults.acquirePreInterruptionArchiveHold,
+    archive,
+    archiveWhileTaskTreeLocked: archive,
+    unarchiveWhileTaskTreeLocked: unarchive,
+    remove,
+    removeWhileTaskTreeLocked: remove,
+    updateTitle,
+    emitChatEvent,
+    emit,
+    isWorkflowInvocationCurrent,
+  });
 
   return {
-    workspaceService: {
-      create,
-      discardExtensionMetadataEntry,
-      // No-op by default: task-create tests exercise launch flow, not the
-      // registration-time plugin-override sanitizer (workspaceService.test.ts
-      // covers it). Returning undefined means "clean".
-      sanitizeMaterializedTaskWorkspace: mock(() => Promise.resolve(undefined)),
-      sendMessage,
-      resumeStream,
-      clearQueue,
-      removeQueuedWorkspaceTurn,
-      removeQueuedMessagesByDedupeKeyPrefix,
-      isBusyForMessage,
-      hasQueuedWorkspaceTurn,
-      hasQueuedMessages,
-      hasPendingQueuedOrPreparingTurn,
-      hasPendingBashMonitorWakeContinuation,
-      hasPendingWorkspaceTurnContinuation,
-      getQueueCutCutter,
-      hasPendingAutoRetry,
-      waitForIdleAndNoQueuedMessages,
-      waitForPendingCompactionCompletionDecision,
-      waitForPendingStreamErrorRecoveryDecision,
-      archive,
-      // Same mocks: the lifecycle path holds the (real) task-tree lock and calls the
-      // WhileTaskTreeLocked sinks; assertions target one archive/unarchive surface.
-      archiveWhileTaskTreeLocked: archive,
-      unarchiveWhileTaskTreeLocked: unarchive,
-      preflightArchive,
-      listLiveWorkspaceActivity,
-      hasRunningBackgroundBashProcesses,
-      isSnapshotArchiveEligibilityMutationSensitive,
-      hasUntrackableExternalAppOpen,
-      acquirePreInterruptionArchiveHold,
-      // Task launches register their fire-and-forget background inits for archive gating;
-      // a no-op suffices since these tests archive nothing mid-init.
-      registerExternalBackgroundInit: mock(() => undefined),
-      removeWhileTaskTreeLocked: remove,
-      remove,
-      emit,
-      getInfo,
-      replaceHistory,
-      updateTitle,
-      isExperimentEnabled,
-      emitChatEvent,
-      isWorkflowInvocationCurrent,
-      countQueuedAgentPeerMessages,
-    } satisfies WorkspaceHost,
+    workspaceService,
     create,
     discardExtensionMetadataEntry,
     sendMessage,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -564,6 +564,8 @@ function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {})
       overrides.discardExtensionMetadataEntry ?? mock(() => Promise.resolve()),
   };
   const { unarchive, ...hostMocks } = mocks;
+  // Same mocks for the locked sinks: the lifecycle path holds the (real) task-tree lock and
+  // calls the WhileTaskTreeLocked variants; assertions target one archive/remove surface.
   const workspaceService = makeWorkspaceHostFake({
     ...overrides,
     ...hostMocks,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -525,82 +525,54 @@ type WorkspaceHostMockOverrides = Partial<{
 }> & { unarchive?: ReturnType<typeof mock> };
 
 function createWorkspaceServiceMocks(overrides: WorkspaceHostMockOverrides = {}) {
-  const sendMessage =
-    overrides.sendMessage ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const resumeStream =
-    overrides.resumeStream ??
-    mock((): Promise<Result<{ started: boolean }>> => Promise.resolve(Ok({ started: true })));
-  const clearQueue = overrides.clearQueue ?? mock((): Result<void> => Ok(undefined));
-  const removeQueuedWorkspaceTurn =
-    overrides.removeQueuedWorkspaceTurn ?? mock((): Result<boolean> => Ok(true));
-  const isBusyForMessage = overrides.isBusyForMessage ?? mock(() => false);
-  const getQueueCutCutter = overrides.getQueueCutCutter ?? mock(() => undefined);
-  const remove =
-    overrides.remove ??
-    overrides.removeWhileTaskTreeLocked ??
-    mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const updateTitle =
-    overrides.updateTitle ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const emitChatEvent = overrides.emitChatEvent ?? mock(() => undefined);
-  const emit = overrides.emit ?? mock(() => true);
-  const archive =
-    overrides.archive ??
-    overrides.archiveWhileTaskTreeLocked ??
-    mock((): Promise<Result<{ kind: "archived" }>> => Promise.resolve(Ok({ kind: "archived" })));
-  const unarchive =
-    overrides.unarchive ??
-    overrides.unarchiveWhileTaskTreeLocked ??
-    mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined)));
-  const isWorkflowInvocationCurrent =
-    overrides.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true));
-  const create =
-    overrides.create ??
-    mock(
-      (): Promise<Result<{ metadata: WorkspaceMetadata }>> =>
-        Promise.resolve(Err("workspaceHost.create not mocked"))
-    );
-  const discardExtensionMetadataEntry =
-    overrides.discardExtensionMetadataEntry ?? mock(() => Promise.resolve());
-
+  const mocks = {
+    sendMessage:
+      overrides.sendMessage ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined))),
+    resumeStream:
+      overrides.resumeStream ??
+      mock((): Promise<Result<{ started: boolean }>> => Promise.resolve(Ok({ started: true }))),
+    clearQueue: overrides.clearQueue ?? mock((): Result<void> => Ok(undefined)),
+    removeQueuedWorkspaceTurn:
+      overrides.removeQueuedWorkspaceTurn ?? mock((): Result<boolean> => Ok(true)),
+    isBusyForMessage: overrides.isBusyForMessage ?? mock(() => false),
+    getQueueCutCutter: overrides.getQueueCutCutter ?? mock(() => undefined),
+    remove:
+      overrides.remove ??
+      overrides.removeWhileTaskTreeLocked ??
+      mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined))),
+    updateTitle:
+      overrides.updateTitle ?? mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined))),
+    emitChatEvent: overrides.emitChatEvent ?? mock(() => undefined),
+    emit: overrides.emit ?? mock(() => true),
+    archive:
+      overrides.archive ??
+      overrides.archiveWhileTaskTreeLocked ??
+      mock((): Promise<Result<{ kind: "archived" }>> => Promise.resolve(Ok({ kind: "archived" }))),
+    unarchive:
+      overrides.unarchive ??
+      overrides.unarchiveWhileTaskTreeLocked ??
+      mock((): Promise<Result<void>> => Promise.resolve(Ok(undefined))),
+    isWorkflowInvocationCurrent:
+      overrides.isWorkflowInvocationCurrent ?? mock(() => Promise.resolve(true)),
+    create:
+      overrides.create ??
+      mock(
+        (): Promise<Result<{ metadata: WorkspaceMetadata }>> =>
+          Promise.resolve(Err("workspaceHost.create not mocked"))
+      ),
+    discardExtensionMetadataEntry:
+      overrides.discardExtensionMetadataEntry ?? mock(() => Promise.resolve()),
+  };
+  const { unarchive, ...hostMocks } = mocks;
   const workspaceService = makeWorkspaceHostFake({
     ...overrides,
-    create,
-    discardExtensionMetadataEntry,
-    sendMessage,
-    resumeStream,
-    clearQueue,
-    removeQueuedWorkspaceTurn,
-    isBusyForMessage,
-    getQueueCutCutter,
-    archive,
-    archiveWhileTaskTreeLocked: archive,
+    ...hostMocks,
+    archiveWhileTaskTreeLocked: mocks.archive,
     unarchiveWhileTaskTreeLocked: unarchive,
-    remove,
-    removeWhileTaskTreeLocked: remove,
-    updateTitle,
-    emitChatEvent,
-    emit,
-    isWorkflowInvocationCurrent,
+    removeWhileTaskTreeLocked: mocks.remove,
   });
 
-  return {
-    workspaceService,
-    create,
-    discardExtensionMetadataEntry,
-    sendMessage,
-    resumeStream,
-    clearQueue,
-    removeQueuedWorkspaceTurn,
-    isBusyForMessage,
-    getQueueCutCutter,
-    remove,
-    updateTitle,
-    emitChatEvent,
-    emit,
-    archive,
-    unarchive,
-    isWorkflowInvocationCurrent,
-  };
+  return { workspaceService, ...mocks };
 }
 
 // Registers the created workspace-turn checkout in config the way the real create()

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -1,4 +1,56 @@
-import type { AgentTaskIntegration } from "@/node/services/taskWorkspaceSeam";
+import { Err, Ok } from "@/common/types/result";
+import type { AgentTaskIntegration, WorkspaceHost } from "@/node/services/taskWorkspaceSeam";
+
+export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): WorkspaceHost {
+  return {
+    sendMessage: () => Promise.resolve(Ok(undefined)),
+    resumeStream: () => Promise.resolve(Ok({ started: true })),
+    clearQueue: () => Ok(undefined),
+    replaceHistory: () => Promise.resolve(Ok(undefined)),
+    waitForIdleAndNoQueuedMessages: () => Promise.resolve(),
+    waitForPendingCompactionCompletionDecision: () => Promise.resolve(true),
+    waitForPendingStreamErrorRecoveryDecision: () => Promise.resolve(undefined),
+    isBusyForMessage: () => false,
+    hasQueuedMessages: () => false,
+    hasPendingQueuedOrPreparingTurn: () => false,
+    hasPendingAutoRetry: () => false,
+    hasPendingBashMonitorWakeContinuation: () => false,
+    hasPendingWorkspaceTurnContinuation: () => false,
+    hasQueuedWorkspaceTurn: () => false,
+    removeQueuedWorkspaceTurn: () => Ok(true),
+    removeQueuedMessagesByDedupeKeyPrefix: () => Ok(0),
+    getQueueCutCutter: () => undefined,
+    countQueuedAgentPeerMessages: () => 0,
+    archive: () => Promise.resolve(Ok({ kind: "archived" })),
+    archiveWhileTaskTreeLocked: () => Promise.resolve(Ok({ kind: "archived" })),
+    unarchiveWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
+    preflightArchive: () => Promise.resolve(Ok({ kind: "ready" })),
+    acquirePreInterruptionArchiveHold: () => Ok({ [Symbol.dispose]: () => undefined }),
+    listLiveWorkspaceActivity: () => ({
+      streaming: false,
+      queuedMessages: false,
+      backgroundBashProcesses: false,
+      terminalSessions: false,
+      desktopSession: false,
+    }),
+    hasRunningBackgroundBashProcesses: () => Promise.resolve(false),
+    hasUntrackableExternalAppOpen: () => Promise.resolve(false),
+    isSnapshotArchiveEligibilityMutationSensitive: () => false,
+    remove: () => Promise.resolve(Ok(undefined)),
+    removeWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
+    create: () => Promise.resolve(Err("workspaceHost.create not mocked")),
+    sanitizeMaterializedTaskWorkspace: () => Promise.resolve(undefined),
+    discardExtensionMetadataEntry: () => Promise.resolve(),
+    registerExternalBackgroundInit: () => undefined,
+    getInfo: () => Promise.resolve(null),
+    updateTitle: () => Promise.resolve(Ok(undefined)),
+    emit: () => true,
+    emitChatEvent: () => undefined,
+    isExperimentEnabled: () => false,
+    isWorkflowInvocationCurrent: () => Promise.resolve(true),
+    ...overrides,
+  };
+}
 
 export function makeAgentTaskIntegrationFake(
   overrides: Partial<AgentTaskIntegration> = {}

--- a/src/node/services/taskWorkspaceSeam.testUtils.ts
+++ b/src/node/services/taskWorkspaceSeam.testUtils.ts
@@ -25,6 +25,7 @@ export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): W
     archiveWhileTaskTreeLocked: () => Promise.resolve(Ok({ kind: "archived" })),
     unarchiveWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
     preflightArchive: () => Promise.resolve(Ok({ kind: "ready" })),
+    // No live activity grants the hold so task tests reach interruption behavior.
     acquirePreInterruptionArchiveHold: () => Ok({ [Symbol.dispose]: () => undefined }),
     listLiveWorkspaceActivity: () => ({
       streaming: false,
@@ -35,10 +36,12 @@ export function makeWorkspaceHostFake(overrides: Partial<WorkspaceHost> = {}): W
     }),
     hasRunningBackgroundBashProcesses: () => Promise.resolve(false),
     hasUntrackableExternalAppOpen: () => Promise.resolve(false),
+    // Keep-style behavior makes archive eligibility independent of untracked files.
     isSnapshotArchiveEligibilityMutationSensitive: () => false,
     remove: () => Promise.resolve(Ok(undefined)),
     removeWhileTaskTreeLocked: () => Promise.resolve(Ok(undefined)),
     create: () => Promise.resolve(Err("workspaceHost.create not mocked")),
+    // Task-create tests exercise launch flow, not plugin-override sanitization.
     sanitizeMaterializedTaskWorkspace: () => Promise.resolve(undefined),
     discardExtensionMetadataEntry: () => Promise.resolve(),
     registerExternalBackgroundInit: () => undefined,

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -27,49 +27,18 @@ import type { QueueCutCutter } from "@/node/services/messageQueue";
 export type AgentTaskStatus = NonNullable<WorkspaceConfigEntry["taskStatus"]>;
 
 export interface ArchiveWorkspaceOptions {
-  /**
-   * Refuse to archive when the effective worktree archive behavior would delete the checkout
-   * ("delete"). Model-facing callers set this so a concurrent settings flip cannot turn an
-   * agent-driven archive into an unconfirmed checkout deletion; enforced against the same
-   * behavior read that drives the snapshot/deletion decisions.
-   */
+  /** Prevent an agent-driven archive from deleting a checkout after a concurrent settings flip. */
   forbidWorktreeCheckoutDeletion?: boolean;
   /**
-   * Refuse to archive when live user activity exists at the sink (a stream, a send still in
-   * its pre-admission window, queued/preparing turns, terminal sessions, or a desktop
-   * session). Model-facing callers set this so an agent-driven archive fails closed instead
-   * of silently terminating user work that started after the caller's earlier activity check.
-   * Checked synchronously in the same block that marks the workspace as archiving, pairing
-   * with sendMessage's synchronous entry guards: whichever side runs first is observed by the
-   * other. Also holds the session's turn admission for the rest of the archive so a queued
-   * entry cannot dispatch through AgentSession's internal send path (which bypasses
-   * WorkspaceService.sendMessage) into the workspace mid-archive. The user-driven archive
-   * path intentionally omits this and keeps its stop-activity semantics.
+   * Fail closed if user activity starts after the caller's earlier check, and hold turn admission
+   * through the archive. User-driven archives intentionally keep their stop-activity behavior.
    */
   refuseLiveUserActivity?: boolean;
-  /**
-   * Behavior snapshot read by the caller before it committed to the archive (e.g. before
-   * interrupting active turns). The sink uses it for every snapshot/deletion decision instead
-   * of re-reading config, so a concurrent settings flip cannot change archive eligibility
-   * between the caller's checks and the sink — e.g. flipping keep → snapshot after turns were
-   * interrupted would otherwise bounce with requires_confirmation, stranding destroyed work.
-   */
+  /** Keep archive eligibility stable after the caller commits to interrupting active turns. */
   worktreeArchiveBehaviorOverride?: WorktreeArchiveBehavior;
-  /**
-   * Refuse to archive when the Coder workspace-on-archive policy would permanently delete a
-   * dedicated (mux-created) remote Coder workspace via the before-archive hook. Unarchive
-   * does not recreate deleted Coder workspaces, so a model-facing "reversible" archive must
-   * fail closed instead; route that policy through user-mediated archive.
-   */
+  /** Prevent a reversible agent archive from permanently deleting its remote Coder workspace. */
   forbidCoderWorkspaceDeletion?: boolean;
-  /**
-   * Coder archive-policy snapshot read by the caller before it committed to the archive (e.g.
-   * before deciding interrupt_active eligibility and interrupting turns). Mirrors
-   * worktreeArchiveBehaviorOverride: the sink's deletion guard and the before-archive hook honor
-   * this same read, so a keep → stop/delete settings flip after the caller's checks cannot make
-   * the sink run (or refuse on) a remote stop/deletion the caller never admitted — which would
-   * otherwise strand already-interrupted turns behind a failed archive.
-   */
+  /** Keep the Coder stop/deletion policy stable after the caller commits to interruption. */
   coderWorkspaceArchiveBehaviorOverride?: CoderWorkspaceArchiveBehavior;
 }
 
@@ -142,86 +111,19 @@ export interface SendMessageInternalOptions {
   yieldToQueuedMessages?: boolean;
 }
 
-export interface WorkspaceHost {
-  acquirePreInterruptionArchiveHold(
+export interface WorkspaceTurnHost {
+  sendMessage(
     workspaceId: string,
-    options: {
-      queuedDelegatedTurnCount: number;
-      expectedDelegatedTurnCorrelations: readonly WorkspaceTurnTaskCorrelation[];
-    }
-  ): Result<Disposable>;
-  archive(
+    message: string,
+    options: SendMessageOptions & { fileParts?: FilePart[] },
+    internal?: SendMessageInternalOptions
+  ): Promise<Result<void, SendMessageError>>;
+  resumeStream(
     workspaceId: string,
-    acknowledgedUntrackedPaths?: string[],
-    options?: ArchiveWorkspaceOptions
-  ): Promise<Result<ArchiveWorkspaceResult>>;
-  archiveWhileTaskTreeLocked(
-    workspaceId: string,
-    acknowledgedUntrackedPaths?: string[],
-    options?: ArchiveWorkspaceOptions
-  ): Promise<Result<ArchiveWorkspaceResult>>;
+    options: SendMessageOptions,
+    internal?: { allowQueuedAgentTask?: boolean; agentInitiated?: boolean }
+  ): Promise<Result<{ started: boolean }, SendMessageError>>;
   clearQueue(workspaceId: string, options?: { cancelReason?: string }): Result<void>;
-  countQueuedAgentPeerMessages(workspaceId: string): number;
-  create(
-    projectPath: string,
-    branchName: string | undefined,
-    trunkBranch: string | undefined,
-    title?: string,
-    runtimeConfig?: RuntimeConfig,
-    subProjectPath?: string,
-    pendingAutoTitle?: boolean,
-    tags?: Record<string, string>
-  ): Promise<Result<{ metadata: FrontendWorkspaceMetadata }>>;
-  discardExtensionMetadataEntry(workspaceId: string): Promise<void>;
-  emit(
-    event: "metadata",
-    payload: { workspaceId: string; metadata: FrontendWorkspaceMetadata | null }
-  ): boolean;
-  emit(event: "chat", payload: { workspaceId: string; message: WorkspaceChatMessage }): boolean;
-  emitChatEvent(workspaceId: string, message: WorkspaceChatMessage): void;
-  getInfo(workspaceId: string): Promise<FrontendWorkspaceMetadata | null>;
-  getQueueCutCutter(workspaceId: string): QueueCutCutter | undefined;
-  hasPendingAutoRetry(workspaceId: string): boolean;
-  hasPendingBashMonitorWakeContinuation(workspaceId: string): boolean;
-  hasPendingQueuedOrPreparingTurn(workspaceId: string): boolean;
-  hasPendingWorkspaceTurnContinuation(
-    workspaceId: string,
-    metadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
-  ): boolean;
-  hasQueuedMessages(workspaceId: string, dispatchMode?: "tool-end" | "turn-end"): boolean;
-  hasQueuedWorkspaceTurn(workspaceId: string, handleId: string): boolean;
-  hasRunningBackgroundBashProcesses(workspaceId: string): Promise<boolean>;
-  hasUntrackableExternalAppOpen(workspaceId: string): Promise<boolean>;
-  isBusyForMessage(workspaceId: string): boolean;
-  isExperimentEnabled(experimentId: ExperimentId): boolean;
-  isSnapshotArchiveEligibilityMutationSensitive(
-    workspaceId: string,
-    worktreeArchiveBehavior?: WorktreeArchiveBehavior,
-    metadata?: WorkspaceMetadata
-  ): boolean;
-  isWorkflowInvocationCurrent(workspaceId: string, runId: string): Promise<boolean>;
-  listLiveWorkspaceActivity(workspaceId: string): WorkspaceLiveActivity;
-  preflightArchive(
-    workspaceId: string,
-    options?: { worktreeArchiveBehaviorOverride?: WorktreeArchiveBehavior }
-  ): Promise<Result<ArchivePreflightResult>>;
-  registerExternalBackgroundInit(
-    workspaceId: string,
-    abortController: AbortController,
-    settled: Promise<unknown>
-  ): void;
-  remove(workspaceId: string, force?: boolean): Promise<Result<void>>;
-  removeQueuedMessagesByDedupeKeyPrefix(
-    workspaceId: string,
-    prefix: string,
-    options?: { cancelReason?: string }
-  ): Result<number>;
-  removeQueuedWorkspaceTurn(
-    workspaceId: string,
-    handleId: string,
-    options: { cancelReason: string }
-  ): Result<boolean>;
-  removeWhileTaskTreeLocked(workspaceId: string, force?: boolean): Promise<Result<void>>;
   replaceHistory(
     workspaceId: string,
     summaryMessage: MuxMessage,
@@ -230,25 +132,6 @@ export interface WorkspaceHost {
       deletePlanFile?: boolean;
     }
   ): Promise<Result<void>>;
-  resumeStream(
-    workspaceId: string,
-    options: SendMessageOptions,
-    internal?: { allowQueuedAgentTask?: boolean; agentInitiated?: boolean }
-  ): Promise<Result<{ started: boolean }, SendMessageError>>;
-  sanitizeMaterializedTaskWorkspace(
-    workspaceId: string,
-    workspacePath: string,
-    runtimeConfig: RuntimeConfig | undefined,
-    persistentSiblingConfig?: Pick<Config, "loadConfigOrDefault">
-  ): Promise<string | undefined>;
-  sendMessage(
-    workspaceId: string,
-    message: string,
-    options: SendMessageOptions & { fileParts?: FilePart[] },
-    internal?: SendMessageInternalOptions
-  ): Promise<Result<void, SendMessageError>>;
-  unarchiveWhileTaskTreeLocked(workspaceId: string): Promise<Result<void>>;
-  updateTitle(workspaceId: string, title: string): Promise<Result<void>>;
   waitForIdleAndNoQueuedMessages(workspaceId: string): Promise<void>;
   waitForPendingCompactionCompletionDecision(
     workspaceId: string,
@@ -259,6 +142,110 @@ export interface WorkspaceHost {
     messageId: string
   ): Promise<StreamErrorRecoveryOutcome | undefined>;
 }
+
+export interface TurnAdmissionHost {
+  isBusyForMessage(workspaceId: string): boolean;
+  hasQueuedMessages(workspaceId: string, dispatchMode?: "tool-end" | "turn-end"): boolean;
+  hasPendingQueuedOrPreparingTurn(workspaceId: string): boolean;
+  hasPendingAutoRetry(workspaceId: string): boolean;
+  hasPendingBashMonitorWakeContinuation(workspaceId: string): boolean;
+  hasPendingWorkspaceTurnContinuation(
+    workspaceId: string,
+    metadata: Extract<MuxMessageMetadata, { type: "workspace-turn-task" }>
+  ): boolean;
+  hasQueuedWorkspaceTurn(workspaceId: string, handleId: string): boolean;
+  removeQueuedWorkspaceTurn(
+    workspaceId: string,
+    handleId: string,
+    options: { cancelReason: string }
+  ): Result<boolean>;
+  removeQueuedMessagesByDedupeKeyPrefix(
+    workspaceId: string,
+    prefix: string,
+    options?: { cancelReason?: string }
+  ): Result<number>;
+  getQueueCutCutter(workspaceId: string): QueueCutCutter | undefined;
+  countQueuedAgentPeerMessages(workspaceId: string): number;
+}
+
+export interface WorkspaceLifecycleHost {
+  archive(
+    workspaceId: string,
+    acknowledgedUntrackedPaths?: string[],
+    options?: ArchiveWorkspaceOptions
+  ): Promise<Result<ArchiveWorkspaceResult>>;
+  archiveWhileTaskTreeLocked(
+    workspaceId: string,
+    acknowledgedUntrackedPaths?: string[],
+    options?: ArchiveWorkspaceOptions
+  ): Promise<Result<ArchiveWorkspaceResult>>;
+  unarchiveWhileTaskTreeLocked(workspaceId: string): Promise<Result<void>>;
+  preflightArchive(
+    workspaceId: string,
+    options?: { worktreeArchiveBehaviorOverride?: WorktreeArchiveBehavior }
+  ): Promise<Result<ArchivePreflightResult>>;
+  acquirePreInterruptionArchiveHold(
+    workspaceId: string,
+    options: {
+      queuedDelegatedTurnCount: number;
+      expectedDelegatedTurnCorrelations: readonly WorkspaceTurnTaskCorrelation[];
+    }
+  ): Result<Disposable>;
+  listLiveWorkspaceActivity(workspaceId: string): WorkspaceLiveActivity;
+  hasRunningBackgroundBashProcesses(workspaceId: string): Promise<boolean>;
+  hasUntrackableExternalAppOpen(workspaceId: string): Promise<boolean>;
+  isSnapshotArchiveEligibilityMutationSensitive(
+    workspaceId: string,
+    worktreeArchiveBehavior?: WorktreeArchiveBehavior,
+    metadata?: WorkspaceMetadata
+  ): boolean;
+  remove(workspaceId: string, force?: boolean): Promise<Result<void>>;
+  removeWhileTaskTreeLocked(workspaceId: string, force?: boolean): Promise<Result<void>>;
+}
+
+export interface WorkspaceProvisioningHost {
+  create(
+    projectPath: string,
+    branchName: string | undefined,
+    trunkBranch: string | undefined,
+    title?: string,
+    runtimeConfig?: RuntimeConfig,
+    subProjectPath?: string,
+    pendingAutoTitle?: boolean,
+    tags?: Record<string, string>
+  ): Promise<Result<{ metadata: FrontendWorkspaceMetadata }>>;
+  sanitizeMaterializedTaskWorkspace(
+    workspaceId: string,
+    workspacePath: string,
+    runtimeConfig: RuntimeConfig | undefined,
+    persistentSiblingConfig?: Pick<Config, "loadConfigOrDefault">
+  ): Promise<string | undefined>;
+  discardExtensionMetadataEntry(workspaceId: string): Promise<void>;
+  registerExternalBackgroundInit(
+    workspaceId: string,
+    abortController: AbortController,
+    settled: Promise<unknown>
+  ): void;
+}
+
+export interface WorkspaceMetadataHost {
+  getInfo(workspaceId: string): Promise<FrontendWorkspaceMetadata | null>;
+  updateTitle(workspaceId: string, title: string): Promise<Result<void>>;
+  emit(
+    event: "metadata",
+    payload: { workspaceId: string; metadata: FrontendWorkspaceMetadata | null }
+  ): boolean;
+  emit(event: "chat", payload: { workspaceId: string; message: WorkspaceChatMessage }): boolean;
+  emitChatEvent(workspaceId: string, message: WorkspaceChatMessage): void;
+  isExperimentEnabled(experimentId: ExperimentId): boolean;
+  isWorkflowInvocationCurrent(workspaceId: string, runId: string): Promise<boolean>;
+}
+
+export type WorkspaceHost = WorkspaceTurnHost &
+  TurnAdmissionHost &
+  WorkspaceLifecycleHost &
+  WorkspaceProvisioningHost &
+  WorkspaceMetadataHost;
 
 export interface AgentTaskIntegration {
   withTaskTreeLifecycleLock<T>(workspaceId: string, operation: () => Promise<T>): Promise<T>;

--- a/src/node/services/taskWorkspaceSeam.ts
+++ b/src/node/services/taskWorkspaceSeam.ts
@@ -27,18 +27,49 @@ import type { QueueCutCutter } from "@/node/services/messageQueue";
 export type AgentTaskStatus = NonNullable<WorkspaceConfigEntry["taskStatus"]>;
 
 export interface ArchiveWorkspaceOptions {
-  /** Prevent an agent-driven archive from deleting a checkout after a concurrent settings flip. */
+  /**
+   * Refuse to archive when the effective worktree archive behavior would delete the checkout
+   * ("delete"). Model-facing callers set this so a concurrent settings flip cannot turn an
+   * agent-driven archive into an unconfirmed checkout deletion; enforced against the same
+   * behavior read that drives the snapshot/deletion decisions.
+   */
   forbidWorktreeCheckoutDeletion?: boolean;
   /**
-   * Fail closed if user activity starts after the caller's earlier check, and hold turn admission
-   * through the archive. User-driven archives intentionally keep their stop-activity behavior.
+   * Refuse to archive when live user activity exists at the sink (a stream, a send still in
+   * its pre-admission window, queued/preparing turns, terminal sessions, or a desktop
+   * session). Model-facing callers set this so an agent-driven archive fails closed instead
+   * of silently terminating user work that started after the caller's earlier activity check.
+   * Checked synchronously in the same block that marks the workspace as archiving, pairing
+   * with sendMessage's synchronous entry guards: whichever side runs first is observed by the
+   * other. Also holds the session's turn admission for the rest of the archive so a queued
+   * entry cannot dispatch through AgentSession's internal send path (which bypasses
+   * WorkspaceService.sendMessage) into the workspace mid-archive. The user-driven archive
+   * path intentionally omits this and keeps its stop-activity semantics.
    */
   refuseLiveUserActivity?: boolean;
-  /** Keep archive eligibility stable after the caller commits to interrupting active turns. */
+  /**
+   * Behavior snapshot read by the caller before it committed to the archive (e.g. before
+   * interrupting active turns). The sink uses it for every snapshot/deletion decision instead
+   * of re-reading config, so a concurrent settings flip cannot change archive eligibility
+   * between the caller's checks and the sink — e.g. flipping keep → snapshot after turns were
+   * interrupted would otherwise bounce with requires_confirmation, stranding destroyed work.
+   */
   worktreeArchiveBehaviorOverride?: WorktreeArchiveBehavior;
-  /** Prevent a reversible agent archive from permanently deleting its remote Coder workspace. */
+  /**
+   * Refuse to archive when the Coder workspace-on-archive policy would permanently delete a
+   * dedicated (mux-created) remote Coder workspace via the before-archive hook. Unarchive
+   * does not recreate deleted Coder workspaces, so a model-facing "reversible" archive must
+   * fail closed instead; route that policy through user-mediated archive.
+   */
   forbidCoderWorkspaceDeletion?: boolean;
-  /** Keep the Coder stop/deletion policy stable after the caller commits to interruption. */
+  /**
+   * Coder archive-policy snapshot read by the caller before it committed to the archive (e.g.
+   * before deciding interrupt_active eligibility and interrupting turns). Mirrors
+   * worktreeArchiveBehaviorOverride: the sink's deletion guard and the before-archive hook honor
+   * this same read, so a keep → stop/delete settings flip after the caller's checks cannot make
+   * the sink run (or refuse on) a remote stop/deletion the caller never admitted — which would
+   * otherwise strand already-interrupted turns behind a failed archive.
+   */
   coderWorkspaceArchiveBehaviorOverride?: CoderWorkspaceArchiveBehavior;
 }
 


### PR DESCRIPTION
## Summary

Splits the 36-method `WorkspaceHost` grab-bag on the task/workspace seam into five role interfaces named for what task-side callers do (`WorkspaceTurnHost`, `TurnAdmissionHost`, `WorkspaceLifecycleHost`, `WorkspaceProvisioningHost`, `WorkspaceMetadataHost`), keeps `WorkspaceHost` as their intersection so no call site or wiring changes, and collapses the ~180-line hand-rolled test mock onto one shared `makeWorkspaceHostFake`.

## Background

#3996 cut the taskService/workspaceService dependency cycle at a typed seam, but the seam stayed shallow: one interface mirroring 36 of WorkspaceService's internal mechanics. Every task test stubbed all 36 methods through a ~180-line mock in `taskService.test.ts` (reached from 318 call sites), and the seam, service, and test harness churned in lockstep on every change. This builds on #3996 rather than reverting it: same seam, deeper interface. Refactor #5 from the 2026-08-29 architecture review (evidence at main @ f04e0f8a3).

## Implementation

- `taskWorkspaceSeam.ts`: the five role interfaces group methods by caller intent (turn execution, queue/admission probes, archive/remove lifecycle, child-workspace provisioning, metadata/events). Every method signature is byte-identical to before; `WorkspaceHost` is now `WorkspaceTurnHost & TurnAdmissionHost & WorkspaceLifecycleHost & WorkspaceProvisioningHost & WorkspaceMetadataHost`. `TaskService` (the only production consumer) legitimately uses all five roles, so its single constructor param stays; new narrow consumers can now depend on one role instead of the full host.
- `taskWorkspaceSeam.testUtils.ts`: adds framework-free `makeWorkspaceHostFake(overrides)` beside the existing `makeAgentTaskIntegrationFake`, carrying the harness's default stub semantics (granted archive hold, "keep"-style snapshot eligibility, sanitizer no-op).
- `taskService.test.ts`: `createWorkspaceServiceMocks` shrinks from ~180 lines to ~55 on top of the shared fake, with a mapped type over `keyof WorkspaceHost` replacing the hand-written 36-entry overrides list. Returned mock handles and the archive/remove locked-sink aliasing are preserved, so all 318 harness call sites are untouched.

## Net LOC delta vs main (f04e0f8a3)

- Production (`taskWorkspaceSeam.ts`): **+18** (+103/-85)
- Tests (`taskService.test.ts` + `taskWorkspaceSeam.testUtils.ts`): **-76** (+112/-188)
- Overall: **-58**

Irreducible production additions: the five role interface declarations plus the intersection type (the point of the refactor), and the archive race-invariant docs on `ArchiveWorkspaceOptions`, which review feedback correctly required keeping verbatim rather than counting as savings. Test additions are `makeWorkspaceHostFake`'s default bodies (moved from the harness, now reusable by any seam consumer's tests).

## Validation

- Remote dogfood UAT ran against the pushed SHA and passed: sub-agent spawn/report/interrupt/reawaken, workspace turns (new + queued follow-up race), archive/unarchive including `interrupt_active` and live-activity refusal, heartbeats, tree listing, and monitor wakes. The UAT runner additionally verified the emitted JavaScript is byte-identical between base and feature for the production file.
- Whole-file `bun test` of `taskService.test.ts`, `workspaceService.test.ts`, `heartbeatService.test.ts`, `tools/task_list.test.ts`: the fail set is identical to a clean worktree at base f04e0f8a3 (3 pre-existing host-environment failures; none branch-attributable).

## Risks

Low. The production change is type-only interface restructuring with byte-identical emitted JS; regression surface is the test-harness consolidation, which preserves each mock's default behavior and aliasing semantics.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$29.31`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=29.31 -->

## Stack

Layer 4/10 of the architecture refactor stack (net -5,101 LOC overall). This PR's diff is only this layer, against `mike/arch-peer-message-broker`.
