### PR TITLE
🤖 refactor: decompose the ChatInput composer into deep hooks

### DIFF
--- a/src/browser/features/ChatInput/CommandSuggestions.test.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.test.tsx
@@ -1,19 +1,19 @@
-import React from "react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { GlobalWindow } from "happy-dom";
 import { cleanup, fireEvent, render } from "@testing-library/react";
-
-import { CommandSuggestions } from "./CommandSuggestions";
 import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
+import { CommandSuggestions } from "./CommandSuggestions";
 
-function makeSuggestion(id: string): SlashSuggestion {
-  return {
-    id,
-    display: id,
-    description: `desc:${id}`,
-    replacement: id,
-  };
-}
+const makeSuggestion = (id: string): SlashSuggestion => ({
+  id,
+  display: id,
+  description: `desc:${id}`,
+  replacement: id,
+});
+const suggestions = ["a", "b", "c"].map(makeSuggestion);
+const option = (getByText: (text: string) => HTMLElement, id: string) =>
+  getByText(id).closest('[role="option"]')?.getAttribute("aria-selected");
 
 describe("CommandSuggestions", () => {
   let originalScrollIntoView: ((...args: unknown[]) => unknown) | undefined;
@@ -21,179 +21,104 @@ describe("CommandSuggestions", () => {
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
-
     const prototype = globalThis.window.HTMLElement.prototype as unknown as {
       scrollIntoView?: (...args: unknown[]) => unknown;
     };
-
     originalScrollIntoView = prototype.scrollIntoView;
     prototype.scrollIntoView = () => undefined;
   });
 
   afterEach(() => {
     cleanup();
-
     const prototype = globalThis.window.HTMLElement.prototype as unknown as {
       scrollIntoView?: (...args: unknown[]) => unknown;
     };
-
     prototype.scrollIntoView = originalScrollIntoView;
-
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;
   });
 
-  it("preserves the selected suggestion by id when suggestions reorder", () => {
-    const initialSuggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
-    const nextSuggestions = [makeSuggestion("c"), makeSuggestion("a"), makeSuggestion("b")];
-
+  it.each([
+    {
+      name: "preserves selection by id after reorder",
+      downs: 1,
+      before: "b",
+      next: ["c", "a", "b"],
+      after: "b",
+    },
+    {
+      name: "clamps selection when the selected item disappears",
+      downs: 2,
+      before: "c",
+      next: ["a", "b"],
+      after: "b",
+    },
+  ])("$name", ({ downs, before, next, after }) => {
     function Harness() {
-      const [suggestions, setSuggestions] = React.useState(initialSuggestions);
+      const [items, setItems] = useState(suggestions);
       return (
         <div>
           <CommandSuggestions
-            suggestions={suggestions}
+            suggestions={items}
             onSelectSuggestion={() => undefined}
             onDismiss={() => undefined}
             isVisible
           />
-          <button onClick={() => setSuggestions(nextSuggestions)}>Update</button>
+          <button onClick={() => setItems(next.map(makeSuggestion))}>Update</button>
         </div>
       );
     }
-
     const { getByText } = render(<Harness />);
-
-    // Move selection from 'a' -> 'b'
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-
-    expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
-
-    // Reorder suggestions; selection should follow 'b'
+    for (let index = 0; index < downs; index++) fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(option(getByText, before)).toBe("true");
     fireEvent.click(getByText("Update"));
-
-    expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
+    expect(option(getByText, after)).toBe("true");
   });
 
-  it("clamps the selection when the selected suggestion disappears", () => {
-    const initialSuggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
-    const nextSuggestions = [makeSuggestion("a"), makeSuggestion("b")];
-
-    function Harness() {
-      const [suggestions, setSuggestions] = React.useState(initialSuggestions);
-      return (
-        <div>
-          <CommandSuggestions
-            suggestions={suggestions}
-            onSelectSuggestion={() => undefined}
-            onDismiss={() => undefined}
-            isVisible
-          />
-          <button onClick={() => setSuggestions(nextSuggestions)}>Update</button>
-        </div>
-      );
-    }
-
-    const { getByText } = render(<Harness />);
-
-    // Move selection from 'a' -> 'c'
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-
-    expect(getByText("c").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
-
-    // Remove 'c'; selection should clamp (no out-of-range)
-    fireEvent.click(getByText("Update"));
-
-    expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
-  });
-
-  it("accepts the selected suggestion on Enter (slash commands)", () => {
-    const suggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
-    let selected: SlashSuggestion | null = null;
-
+  it.each([
+    ["Enter", 1, "b"],
+    ["Tab", 2, "c"],
+  ] as const)("accepts the selected suggestion on %s", (key, downs, expected) => {
+    const selectedIds: string[] = [];
     const { getByText } = render(
       <CommandSuggestions
         suggestions={suggestions}
-        onSelectSuggestion={(s) => {
-          selected = s;
-        }}
-        onDismiss={() => undefined}
-        isVisible
-        isFileSuggestion={false}
-      />
-    );
-
-    // Navigate to 'b'
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    expect(getByText("b").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
-
-    // Press Enter to accept
-    fireEvent.keyDown(document, { key: "Enter" });
-
-    expect(selected).not.toBeNull();
-    expect(selected!.id).toBe("b");
-  });
-
-  it("accepts the selected suggestion on Tab", () => {
-    const suggestions = [makeSuggestion("a"), makeSuggestion("b"), makeSuggestion("c")];
-    let selected: SlashSuggestion | null = null;
-
-    const { getByText } = render(
-      <CommandSuggestions
-        suggestions={suggestions}
-        onSelectSuggestion={(s) => {
-          selected = s;
+        onSelectSuggestion={(suggestion) => {
+          selectedIds.push(suggestion.id);
         }}
         onDismiss={() => undefined}
         isVisible
       />
     );
-
-    // Navigate to 'c'
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    fireEvent.keyDown(document, { key: "ArrowDown" });
-    expect(getByText("c").closest('[role="option"]')?.getAttribute("aria-selected")).toBe("true");
-
-    // Press Tab to accept
-    fireEvent.keyDown(document, { key: "Tab" });
-
-    expect(selected).not.toBeNull();
-    expect(selected!.id).toBe("c");
+    for (let index = 0; index < downs; index++) fireEvent.keyDown(document, { key: "ArrowDown" });
+    expect(option(getByText, expected)).toBe("true");
+    fireEvent.keyDown(document, { key });
+    expect(selectedIds).toEqual([expected]);
   });
 
-  it("does not accept on Shift+Enter (allows newline)", () => {
-    const suggestions = [makeSuggestion("a"), makeSuggestion("b")];
+  it("does not accept Shift+Enter", () => {
     let selected: SlashSuggestion | null = null;
-
     render(
       <CommandSuggestions
         suggestions={suggestions}
-        onSelectSuggestion={(s) => {
-          selected = s;
+        onSelectSuggestion={(suggestion) => {
+          selected = suggestion;
         }}
         onDismiss={() => undefined}
         isVisible
       />
     );
-
-    // Press Shift+Enter (should not select)
     fireEvent.keyDown(document, { key: "Enter", shiftKey: true });
-
     expect(selected).toBeNull();
   });
 
-  it("dismisses on Escape and stops propagation", () => {
-    const suggestions = [makeSuggestion("a"), makeSuggestion("b")];
+  it("dismisses on Escape without propagation", () => {
     let dismissed = false;
     let propagated = false;
-
-    // Add a window listener to detect if event propagates
     const windowListener = () => {
       propagated = true;
     };
     window.addEventListener("keydown", windowListener);
-
     render(
       <CommandSuggestions
         suggestions={suggestions}
@@ -204,13 +129,9 @@ describe("CommandSuggestions", () => {
         isVisible
       />
     );
-
-    // Press Escape
     fireEvent.keyDown(document, { key: "Escape" });
-
     expect(dismissed).toBe(true);
     expect(propagated).toBe(false);
-
     window.removeEventListener("keydown", windowListener);
   });
 });

--- a/src/browser/features/ChatInput/CommandSuggestions.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.tsx
@@ -96,14 +96,44 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
   anchorRef,
   highlightQuery,
   isFileSuggestion = false,
-  selectedIndex = 0,
-  onSelectedIndexChange = () => undefined,
+  selectedIndex: selectedIndexProp,
+  onSelectedIndexChange,
 }) => {
+  const [uncontrolledSelectedIndex, setUncontrolledSelectedIndex] = useState(0);
+  const selectedIndex = selectedIndexProp ?? uncontrolledSelectedIndex;
+  const isSelectionControlled = selectedIndexProp !== undefined && onSelectedIndexChange != null;
+  const setSelectedIndex = (next: React.SetStateAction<number>) => {
+    const resolved = typeof next === "function" ? next(selectedIndex) : next;
+    if (!isSelectionControlled) setUncontrolledSelectedIndex(resolved);
+    onSelectedIndexChange?.(resolved);
+  };
   const [position, setPosition] = useState<{ top: number; left: number; width: number } | null>(
     null
   );
   const menuRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLDivElement>(null);
+  const previousSuggestionsRef = useRef<SlashSuggestion[]>(suggestions);
+  const wasVisibleRef = useRef(isVisible);
+
+  useLayoutEffect(() => {
+    if (isSelectionControlled) return;
+    const wasVisible = wasVisibleRef.current;
+    wasVisibleRef.current = isVisible;
+    const previousSuggestions = previousSuggestionsRef.current;
+    previousSuggestionsRef.current = suggestions;
+    if (!isVisible || suggestions.length === 0 || !wasVisible) {
+      setUncontrolledSelectedIndex(0);
+      return;
+    }
+    setUncontrolledSelectedIndex((previousIndex) => {
+      const previousSelected = previousSuggestions[previousIndex];
+      const nextIndex = previousSelected
+        ? suggestions.findIndex((suggestion) => suggestion.id === previousSelected.id)
+        : -1;
+      return nextIndex >= 0 ? nextIndex : Math.min(previousIndex, suggestions.length - 1);
+    });
+  }, [isSelectionControlled, isVisible, suggestions]);
+
   // Scroll selected item into view
   useLayoutEffect(() => {
     selectedRef.current?.scrollIntoView({ block: "nearest" });
@@ -140,6 +170,29 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
       window.removeEventListener("scroll", updatePosition, true);
     };
   }, [anchorRef, isVisible, suggestions]);
+
+  useEffect(() => {
+    if (isSelectionControlled || !isVisible || suggestions.length === 0) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const delta = event.key === "ArrowDown" ? 1 : -1;
+        setUncontrolledSelectedIndex(
+          (index) => (index + delta + suggestions.length) % suggestions.length
+        );
+      } else if ((event.key === "Tab" || event.key === "Enter") && !event.shiftKey) {
+        event.preventDefault();
+        const suggestion = suggestions[selectedIndex];
+        if (suggestion) onSelectSuggestion(suggestion);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onDismiss();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isSelectionControlled, isVisible, onDismiss, onSelectSuggestion, selectedIndex, suggestions]);
 
   // Click outside handler
   useEffect(() => {
@@ -193,7 +246,7 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
         <div
           key={suggestion.id}
           ref={index === selectedIndex ? selectedRef : undefined}
-          onMouseEnter={() => onSelectedIndexChange(index)}
+          onMouseEnter={() => setSelectedIndex(index)}
           onClick={() => onSelectSuggestion(suggestion)}
           id={`${resolvedListId}-option-${suggestion.id}`}
           role="option"

--- a/src/browser/features/ChatInput/CommandSuggestions.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.tsx
@@ -81,6 +81,8 @@ interface CommandSuggestionsProps {
   highlightQuery?: string;
   /** Whether suggestions are file paths (enables file icons) */
   isFileSuggestion?: boolean;
+  selectedIndex?: number;
+  onSelectedIndexChange?: (index: number) => void;
 }
 
 // Main component
@@ -94,49 +96,14 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
   anchorRef,
   highlightQuery,
   isFileSuggestion = false,
+  selectedIndex = 0,
+  onSelectedIndexChange = () => undefined,
 }) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const [position, setPosition] = useState<{ top: number; left: number; width: number } | null>(
     null
   );
   const menuRef = useRef<HTMLDivElement>(null);
   const selectedRef = useRef<HTMLDivElement>(null);
-  const previousSuggestionsRef = useRef<SlashSuggestion[]>(suggestions);
-  const wasVisibleRef = useRef(isVisible);
-
-  // Keep selection stable while suggestions update (e.g. user keeps typing).
-  // We reset selection only when the menu becomes visible.
-  useLayoutEffect(() => {
-    const wasVisible = wasVisibleRef.current;
-    wasVisibleRef.current = isVisible;
-
-    const prevSuggestions = previousSuggestionsRef.current;
-    previousSuggestionsRef.current = suggestions;
-
-    if (!isVisible || suggestions.length === 0) {
-      setSelectedIndex(0);
-      return;
-    }
-
-    // Menu just opened: default to the first suggestion.
-    if (!wasVisible) {
-      setSelectedIndex(0);
-      return;
-    }
-
-    // Preserve the previously-selected suggestion if it still exists; otherwise clamp.
-    setSelectedIndex((prevIndex) => {
-      const prevSelected = prevSuggestions[prevIndex];
-      if (prevSelected) {
-        const nextIndex = suggestions.findIndex((s) => s.id === prevSelected.id);
-        if (nextIndex !== -1) {
-          return nextIndex;
-        }
-      }
-      return Math.min(prevIndex, suggestions.length - 1);
-    });
-  }, [isVisible, suggestions]);
-
   // Scroll selected item into view
   useLayoutEffect(() => {
     selectedRef.current?.scrollIntoView({ block: "nearest" });
@@ -173,44 +140,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
       window.removeEventListener("scroll", updatePosition, true);
     };
   }, [anchorRef, isVisible, suggestions]);
-
-  // Handle keyboard navigation
-  useEffect(() => {
-    if (!isVisible || suggestions.length === 0) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setSelectedIndex((i) => (i + 1) % suggestions.length);
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          setSelectedIndex((i) => (i - 1 + suggestions.length) % suggestions.length);
-          break;
-        case "Tab":
-          if (!e.shiftKey && suggestions.length > 0) {
-            e.preventDefault();
-            onSelectSuggestion(suggestions[selectedIndex]);
-          }
-          break;
-        case "Enter":
-          if (!e.shiftKey && suggestions.length > 0) {
-            e.preventDefault();
-            onSelectSuggestion(suggestions[selectedIndex]);
-          }
-          break;
-        case "Escape":
-          e.preventDefault();
-          e.stopPropagation();
-          onDismiss();
-          break;
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isVisible, suggestions, selectedIndex, onSelectSuggestion, onDismiss, isFileSuggestion]);
 
   // Click outside handler
   useEffect(() => {
@@ -264,7 +193,7 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
         <div
           key={suggestion.id}
           ref={index === selectedIndex ? selectedRef : undefined}
-          onMouseEnter={() => setSelectedIndex(index)}
+          onMouseEnter={() => onSelectedIndexChange(index)}
           onClick={() => onSelectSuggestion(suggestion)}
           id={`${resolvedListId}-option-${suggestion.id}`}
           role="option"

--- a/src/browser/features/ChatInput/CommandSuggestions.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.tsx
@@ -6,7 +6,8 @@ import { FileIcon } from "@/browser/components/FileIcon/FileIcon";
 
 export const COMMAND_SUGGESTION_KEYS = ["Tab", "Enter", "ArrowUp", "ArrowDown", "Escape"];
 
-export const FILE_SUGGESTION_KEYS = ["Tab", "Enter", "ArrowUp", "ArrowDown", "Escape"];
+export const FILE_SUGGESTION_KEYS = COMMAND_SUGGESTION_KEYS;
+
 function HighlightedText({
   text,
   query,
@@ -16,7 +17,7 @@ function HighlightedText({
   query?: string;
   className?: string;
 }) {
-  if (!query || query.length === 0) {
+  if (!query) {
     return <span className={className}>{text}</span>;
   }
 

--- a/src/browser/features/ChatInput/CommandSuggestions.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.tsx
@@ -4,19 +4,9 @@ import { cn } from "@/common/lib/utils";
 import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
 import { FileIcon } from "@/browser/components/FileIcon/FileIcon";
 
-// Keys for navigating slash command suggestions.
-// Enter or Tab accepts the highlighted suggestion; Shift+Enter inserts a newline.
 export const COMMAND_SUGGESTION_KEYS = ["Tab", "Enter", "ArrowUp", "ArrowDown", "Escape"];
 
-// Keys for navigating file path (@mention) suggestions.
-//
-// Enter accepts the selected file path (then a subsequent Enter sends the message).
 export const FILE_SUGGESTION_KEYS = ["Tab", "Enter", "ArrowUp", "ArrowDown", "Escape"];
-
-/**
- * Highlight matching portions of text based on a query.
- * Performs case-insensitive substring matching and highlights all occurrences.
- */
 function HighlightedText({
   text,
   query,
@@ -37,7 +27,6 @@ function HighlightedText({
   let matchIndex = lowerText.indexOf(lowerQuery);
 
   while (matchIndex !== -1) {
-    // Add non-matching prefix
     if (matchIndex > lastIndex) {
       parts.push(
         <span key={`text-${lastIndex}`} className="opacity-60">
@@ -45,7 +34,6 @@ function HighlightedText({
         </span>
       );
     }
-    // Add highlighted match
     parts.push(
       <span key={`match-${matchIndex}`} className="text-light">
         {text.slice(matchIndex, matchIndex + query.length)}
@@ -55,7 +43,6 @@ function HighlightedText({
     matchIndex = lowerText.indexOf(lowerQuery, lastIndex);
   }
 
-  // Add remaining non-matching suffix
   if (lastIndex < text.length) {
     parts.push(
       <span key={`text-${lastIndex}`} className="opacity-60">
@@ -67,7 +54,6 @@ function HighlightedText({
   return <span className={className}>{parts}</span>;
 }
 
-// Props interface
 interface CommandSuggestionsProps {
   suggestions: SlashSuggestion[];
   onSelectSuggestion: (suggestion: SlashSuggestion) => void;
@@ -75,17 +61,13 @@ interface CommandSuggestionsProps {
   isVisible: boolean;
   ariaLabel?: string;
   listId?: string;
-  /** Reference to the input element for portal positioning */
   anchorRef?: React.RefObject<HTMLElement | null>;
-  /** Query string to highlight in suggestions (for file path autocomplete) */
   highlightQuery?: string;
-  /** Whether suggestions are file paths (enables file icons) */
   isFileSuggestion?: boolean;
   selectedIndex?: number;
   onSelectedIndexChange?: (index: number) => void;
 }
 
-// Main component
 export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
   suggestions,
   onSelectSuggestion,
@@ -134,12 +116,10 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
     });
   }, [isSelectionControlled, isVisible, suggestions]);
 
-  // Scroll selected item into view
   useLayoutEffect(() => {
     selectedRef.current?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
-  // Calculate position when using portal mode
   useLayoutEffect(() => {
     if (!anchorRef?.current || !isVisible) {
       setPosition(null);
@@ -162,7 +142,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
 
     updatePosition();
 
-    // Update on resize/scroll
     window.addEventListener("resize", updatePosition);
     window.addEventListener("scroll", updatePosition, true);
     return () => {
@@ -194,7 +173,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isSelectionControlled, isVisible, onDismiss, onSelectSuggestion, selectedIndex, suggestions]);
 
-  // Click outside handler
   useEffect(() => {
     if (!isVisible) return;
 
@@ -228,7 +206,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
       data-command-suggestions
       className={cn(
         "bg-separator border-border-light z-[1010] flex max-h-[200px] flex-col overflow-y-auto rounded border shadow-[0_-4px_12px_rgba(0,0,0,0.4)]",
-        // Use absolute positioning relative to parent when not in portal mode
         !anchorRef && "absolute right-0 bottom-full left-0 mb-2"
       )}
       style={

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -498,7 +498,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
       setInput(next);
     },
-    [powerMode, setInput]
+    [latestInputValueRef, powerMode, setInput]
   );
 
   const { open } = useSettings();
@@ -596,14 +596,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       programmaticToolCalling: ptcExperimentEnabled,
     },
   });
-  const { agentSkillDescriptors, mcpPromptDescriptors } = composerSuggestions;
-  const handleComposerInputChange = useCallback(
-    (next: string, caret?: number) => {
-      composerSuggestions.handleInputCaretChange(caret, next.length);
-      handleInputChange(next, caret);
-    },
-    [composerSuggestions.handleInputCaretChange, handleInputChange]
-  );
+  const { agentSkillDescriptors, handleInputCaretChange, mcpPromptDescriptors } =
+    composerSuggestions;
+  const handleComposerInputChange = (next: string, caret?: number) => {
+    handleInputCaretChange(caret, next.length);
+    handleInputChange(next, caret);
+  };
   const additionalSystemContext = useAdditionalSystemContextSnapshot(
     variant === "workspace" ? props.workspaceId : ""
   );
@@ -1131,7 +1129,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const restorePreEditDraft = useCallback(() => {
     setDraft(preEditDraftRef.current);
     setDraftReviews(preEditReviewsRef.current);
-  }, [setDraft, setDraftReviews]);
+  }, [preEditDraftRef, preEditReviewsRef, setDraft, setDraftReviews]);
 
   // Method to restore text to input (used by compaction cancel)
   const restoreText = useCallback(
@@ -1432,7 +1430,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     window.addEventListener(CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER, handler as EventListener);
     return () =>
       window.removeEventListener(CUSTOM_EVENTS.CLEAR_CHAT_COMPOSER, handler as EventListener);
-  }, [onDetachAllReviewsForComposerClear, setAttachments, setInput, workspaceIdForComposerClear]);
+  }, [
+    onDetachAllReviewsForComposerClear,
+    setAttachments,
+    setDraftReviews,
+    setInput,
+    workspaceIdForComposerClear,
+  ]);
 
   // Allow external components to open the Model Selector
   useEffect(() => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -481,10 +481,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           el.selectionStart = newCursor;
           el.selectionEnd = newCursor;
         });
-        return;
+        return { text: converted.text, cursor: converted.cursor };
       }
 
       setInput(next);
+      return { text: next, cursor: caret };
     },
     [latestInputValueRef, powerMode, setInput]
   );
@@ -577,8 +578,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const { agentSkillDescriptors, handleInputCaretChange, mcpPromptDescriptors } =
     composerSuggestions;
   const handleComposerInputChange = (next: string, caret?: number) => {
-    handleInputCaretChange(caret, next);
-    handleInputChange(next, caret);
+    // Feed the suggestion seam the applied text/cursor: symbol auto-conversion
+    // can rewrite both, and caret state keyed to the pre-conversion text would
+    // fall back to end-of-input over the converted draft.
+    const applied = handleInputChange(next, caret);
+    handleInputCaretChange(applied.cursor, applied.text);
   };
   const additionalSystemContext = useAdditionalSystemContextSnapshot(
     variant === "workspace" ? props.workspaceId : ""

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -577,7 +577,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const { agentSkillDescriptors, handleInputCaretChange, mcpPromptDescriptors } =
     composerSuggestions;
   const handleComposerInputChange = (next: string, caret?: number) => {
-    handleInputCaretChange(caret, next.length);
+    handleInputCaretChange(caret, next);
     handleInputChange(next, caret);
   };
   const additionalSystemContext = useAdditionalSystemContextSnapshot(

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -143,6 +143,7 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   withAgentSkillRefs,
+  withMcpPromptRefs,
 } from "@/common/types/message";
 import {
   getModelCapabilities,
@@ -245,16 +246,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [thinkingLevel] = useThinkingLevel();
   const [reasoningMode] = useReasoningMode();
   const dynamicWorkflowsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
-  const workspaceHeartbeatsExperimentEnabled = useExperimentValue(
-    EXPERIMENT_IDS.WORKSPACE_HEARTBEATS
-  );
-  const memoryExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.MEMORY);
-  const agentPluginsExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_PLUGINS);
-  const memoryConsolidationExperimentEnabled = useExperimentValue(
-    EXPERIMENT_IDS.MEMORY_CONSOLIDATION
-  );
-  const rlmExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.RLM);
-  const ptcExperimentEnabled = useExperimentValue(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
   const atMentionProjectPath =
     variant === "creation" && props.kind !== "scratch" ? props.projectPath : null;
   const asyncCommandScopeRef = useRef<{ variant: typeof variant; workspaceId: string | null }>({
@@ -582,16 +573,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     workspaceId,
     projectPath: atMentionProjectPath,
     disableWorkspaceAgents: sendMessageOptions.disableWorkspaceAgents === true,
-    transferredDraftProjectDiscovery,
-    agentPluginsEnabled: agentPluginsExperimentEnabled,
-    experiments: {
-      workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
-      dynamicWorkflows: dynamicWorkflowsExperimentEnabled,
-      memory: memoryExperimentEnabled,
-      memoryConsolidation: memoryConsolidationExperimentEnabled,
-      rlm: rlmExperimentEnabled,
-      programmaticToolCalling: ptcExperimentEnabled,
-    },
   });
   const { agentSkillDescriptors, handleInputCaretChange, mcpPromptDescriptors } =
     composerSuggestions;
@@ -2124,6 +2105,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         if (editMessageForSend && actualMessageText.startsWith("/")) {
           const parsed = parseCommand(messageText);
           if (parsed?.type === "compact") {
+            // Inline refs ride the follow-up message so their snapshots
+            // materialize after compaction, not on the summarization turn.
+            const followUpMuxMetadata = withMcpPromptRefs(
+              withAgentSkillRefs(undefined, combinedSkillRefs),
+              combinedMcpPromptRefs
+            );
             const {
               messageText: regeneratedText,
               metadata,
@@ -2138,7 +2125,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                 parsed.continueMessage ||
                 sendFileParts?.length ||
                 reviewsData?.length ||
-                getStagedAttachments(sendAttachments).length
+                getStagedAttachments(sendAttachments).length ||
+                followUpMuxMetadata
                   ? {
                       text: appendStagedAttachmentNotice(
                         parsed.continueMessage ?? "",
@@ -2146,6 +2134,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                       ),
                       fileParts: sendFileParts,
                       reviews: reviewsData,
+                      ...(followUpMuxMetadata ? { muxMetadata: followUpMuxMetadata } : {}),
                     }
                   : undefined,
               model: parsed.model,

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -171,7 +171,7 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   withAgentSkillRefs,
-  withMcpPromptRefs,
+withMcpPromptRefs,
 } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
 import {
@@ -240,6 +240,8 @@ import {
   useComposerAttachments,
 } from "./useComposerAttachments";
 
+// Normal typing usually has no active suggestion menu. Reuse the existing empty array
+// so suggestion effects do not schedule an avoidable second render on every keypress.
 function clearSuggestions(prev: SlashSuggestion[]): SlashSuggestion[] {
   return prev.length === 0 ? prev : [];
 }

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -13,7 +13,6 @@ import {
 import {
   CommandSuggestions,
   COMMAND_SUGGESTION_KEYS,
-  FILE_SUGGESTION_KEYS,
 } from "@/browser/features/ChatInput/CommandSuggestions";
 import type { Toast } from "@/browser/features/ChatInput/ChatInputToast";
 import { ConnectionStatusToast } from "@/browser/components/ConnectionStatusToast/ConnectionStatusToast";
@@ -144,7 +143,6 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   withAgentSkillRefs,
-  withMcpPromptRefs,
 } from "@/common/types/message";
 import {
   getModelCapabilities,
@@ -419,7 +417,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   } = useComposerAttachments({
     variant,
     workspaceId,
-    attachments,
     setAttachments,
     editingMessage: editingMessageForUi != null,
     pushToast,
@@ -2121,12 +2118,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         // When editing a /compact command, regenerate the actual summarization request
         let actualMessageText = messageTextForSend;
         let muxMetadata: MuxMessageMetadata | undefined = skillMuxMetadata ?? promptMuxMetadata;
-        if (combinedSkillRefs.length > 0) {
-          muxMetadata = withAgentSkillRefs(muxMetadata, combinedSkillRefs);
-        }
-        if (combinedMcpPromptRefs.length > 0) {
-          muxMetadata = withMcpPromptRefs(muxMetadata, combinedMcpPromptRefs);
-        }
         let compactionOptions: Partial<SendMessageOptions> = {};
 
         let appendStagedNoticeToUserMessage = true;
@@ -2389,13 +2380,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     // Note: ESC handled by VimTextArea (for mode transitions) and CommandSuggestions (for dismissal)
 
-    if (
-      composerSuggestions.isVisible &&
-      (composerSuggestions.suppressionKeys === "command"
-        ? COMMAND_SUGGESTION_KEYS
-        : FILE_SUGGESTION_KEYS
-      ).includes(e.key)
-    ) {
+    if (composerSuggestions.isVisible && COMMAND_SUGGESTION_KEYS.includes(e.key)) {
       return;
     }
 
@@ -2654,11 +2639,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     onDrop={handleDrop}
                     onEscapeInNormalMode={handleEscapeInNormalMode}
                     suppressKeys={
-                      composerSuggestions.isVisible
-                        ? composerSuggestions.suppressionKeys === "command"
-                          ? COMMAND_SUGGESTION_KEYS
-                          : FILE_SUGGESTION_KEYS
-                        : undefined
+                      composerSuggestions.isVisible ? COMMAND_SUGGESTION_KEYS : undefined
                     }
                     placeholder={placeholder}
                     disabled={!editingMessageForUi && (disabled || sendInFlightBlocksInput)}

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -3,9 +3,7 @@ import React, {
   useRef,
   useCallback,
   useEffect,
-  useId,
   useMemo,
-  useLayoutEffect,
   useSyncExternalStore,
 } from "react";
 import {
@@ -24,7 +22,6 @@ import type { SendMessageError } from "@/common/types/errors";
 import { createErrorToast } from "@/browser/features/ChatInput/ChatInputToasts";
 import { ConfirmationModal } from "@/browser/components/ConfirmationModal/ConfirmationModal";
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
-import { subscribeAgentPluginsMutated } from "@/browser/utils/agentPluginMutations";
 import { parseCommand } from "@/browser/utils/slashCommands/parser";
 import {
   readPersistedState,
@@ -83,34 +80,17 @@ import {
 import { Button } from "@/browser/components/Button/Button";
 import { CUSTOM_EVENTS } from "@/common/constants/events";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
-import { findAtMentionAtCursor } from "@/common/utils/atMentions";
-import {
-  extractInlineSkillReferenceCandidates,
-  findInlineSkillReferenceAtCursor,
-} from "@/browser/utils/agentSkills/inlineSkillReferences";
+import { extractInlineSkillReferenceCandidates } from "@/browser/utils/agentSkills/inlineSkillReferences";
 import {
   convertSymbolCommandAtCursor,
   convertTerminatedSymbolCommand,
-  findSymbolCommandAtCursor,
-  getSymbolSuggestions,
 } from "@/browser/features/ChatInput/symbolShortcuts";
-import {
-  getInlineSkillInsertionTrailingText,
-  getInlineSkillSuggestions,
-  shouldRefreshInlineSkillSuggestions,
-} from "@/browser/utils/agentSkills/inlineSkillSuggestions";
 import {
   formatProjectHierarchyLabel,
   resolveWorkspaceCreationScope,
 } from "@/common/utils/subProjects";
 import { SCRATCH_PROJECT_CONFIG_KEY, SCRATCH_PROJECT_NAME } from "@/common/constants/scratch";
 import { CreationProjectSelect } from "./CreationProjectSelect";
-import { getCommandGhostHint } from "@/browser/utils/slashCommands/registry";
-import {
-  getSlashCommandSuggestions,
-  type SlashSuggestion,
-} from "@/browser/utils/slashCommands/suggestions";
-import { resolveSlashCommandExperimentValue } from "@/browser/utils/slashCommands/experimentVisibility";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { AgentModePicker } from "@/browser/components/AgentModePicker/AgentModePicker";
 import { ContextUsageIndicatorButton } from "@/browser/components/ContextUsageIndicatorButton/ContextUsageIndicatorButton";
@@ -152,9 +132,6 @@ import {
   type PendingUserMessage,
 } from "@/browser/utils/chatEditing";
 
-import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
-import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
-import type { PluginSlashCommandDescriptor } from "@/common/orpc/schemas/agentPlugins";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
 import { type OpenAIReasoningMode, type ThinkingLevel } from "@/common/types/thinking";
 import {
@@ -235,16 +212,7 @@ import {
   useComposerAttachments,
 } from "./useComposerAttachments";
 import { useComposerDraft } from "./useComposerDraft";
-
-// Normal typing usually has no active suggestion menu. Reuse the existing empty array
-// so suggestion effects do not schedule an avoidable second render on every keypress.
-function clearSuggestions(prev: SlashSuggestion[]): SlashSuggestion[] {
-  return prev.length === 0 ? prev : [];
-}
-
-function replaceSuggestions(prev: SlashSuggestion[], next: SlashSuggestion[]): SlashSuggestion[] {
-  return prev.length === 0 && next.length === 0 ? prev : next;
-}
+import { useComposerSuggestions } from "./useComposerSuggestions";
 
 export type { ChatInputProps, ChatInputAPI };
 
@@ -384,41 +352,8 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const isSending = sendingCount > 0;
   const sendModeMenuContainerRef = useRef<HTMLDivElement>(null);
   const [hideReviewsDuringSend, setHideReviewsDuringSend] = useState(false);
-  const [showAtMentionSuggestions, setShowAtMentionSuggestions] = useState(false);
-  const [atMentionSuggestions, setAtMentionSuggestions] = useState<SlashSuggestion[]>([]);
-  const [showSkillSuggestions, setShowSkillSuggestions] = useState(false);
-  const [skillSuggestions, setSkillSuggestions] = useState<SlashSuggestion[]>([]);
   const projectedWorkflowRunCardKeysRef = useRef(new Set<string>());
   const workflowsRequestIdRef = useRef(0);
-  const agentSkillsRequestIdRef = useRef(0);
-  const mcpPromptsRequestIdRef = useRef(0);
-  const mcpPromptsRequestRef = useRef<Promise<void> | null>(null);
-  const mcpPromptsLoadedAtRef = useRef(0);
-  const mcpPromptsWorkspaceRef = useRef<string | null>(null);
-  // Abandoned cold discovery would otherwise keep starting servers and
-  // waiting out prompts/list deadlines for a workspace we already left.
-  const mcpPromptsAbortRef = useRef<AbortController | null>(null);
-  const atMentionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const atMentionRequestIdRef = useRef(0);
-  const lastAtMentionScopeIdRef = useRef<string | null>(null);
-  const lastAtMentionQueryRef = useRef<string | null>(null);
-  const lastSkillInputRef = useRef<string | null>(null);
-  const lastSkillQueryRef = useRef<string | null>(null);
-  const lastSkillDescriptorsRef = useRef<AgentSkillDescriptor[] | null>(null);
-  const lastMcpPromptDescriptorsRef = useRef<MCPPromptDescriptor[] | null>(null);
-  const [showCommandSuggestions, setShowCommandSuggestions] = useState(false);
-
-  const [commandSuggestions, setCommandSuggestions] = useState<SlashSuggestion[]>([]);
-  // Backslash symbol-shortcut autocomplete (e.g. typing "\alpha" or "\leq").
-  const [showSymbolSuggestions, setShowSymbolSuggestions] = useState(false);
-  const [symbolSuggestions, setSymbolSuggestions] = useState<SlashSuggestion[]>([]);
-  const lastSymbolQueryRef = useRef<string>("");
-  const [agentSkillDescriptors, setAgentSkillDescriptors] = useState<AgentSkillDescriptor[]>([]);
-  const [mcpPromptDescriptors, setMcpPromptDescriptors] = useState<MCPPromptDescriptor[]>([]);
-  // Agent Plugins: manifest-contributed slash commands (empty when the experiment is off).
-  const [pluginCommandDescriptors, setPluginCommandDescriptors] = useState<
-    PluginSlashCommandDescriptor[]
-  >([]);
   const [toast, setToast] = useState<Toast | null>(null);
   // State for destructive command confirmation modal (currently only /clear).
   const [pendingDestructiveCommand, setPendingDestructiveCommand] = useState(false);
@@ -474,7 +409,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const { getDraft, setDraft, preEditDraftRef, preEditReviewsRef } = draft;
   const { reviewOverrideActive, reviewData, reviewIdsForCheck, reviewPanelItems } = draft;
   const { removeDraftReview, updateDraftReviewNote, storageKeys, latestInputValueRef } = draft;
-  const lastAtMentionInputRef = useRef<string>(input);
   const {
     processingAttachmentCount,
     handlePaste,
@@ -499,30 +433,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
-      mcpPromptsAbortRef.current?.abort();
-      mcpPromptsAbortRef.current = null;
     };
   }, []);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const modelSelectorRef = useRef<ModelSelectorRef>(null);
   const powerMode = usePowerMode();
-  const [atMentionCursorNonce, setAtMentionCursorNonce] = useState(0);
-  const lastAtMentionCursorRef = useRef<number | null>(null);
-  const handleAtMentionCursorActivity = useCallback(() => {
-    const el = inputRef.current;
-    if (!el) {
-      return;
-    }
-
-    const nextCursor = el.selectionStart ?? input.length;
-    if (lastAtMentionCursorRef.current === nextCursor) {
-      return;
-    }
-
-    lastAtMentionCursorRef.current = nextCursor;
-    setAtMentionCursorNonce((n) => n + 1);
-  }, [input.length]);
-
   const handleInputChange = useCallback(
     (next: string, caretFromEvent?: number) => {
       if (powerMode.enabled) {
@@ -612,10 +527,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       listener: true,
     }
   );
-  const atMentionListId = useId();
-  const skillListId = useId();
-  const commandListId = useId();
-  const symbolListId = useId();
   const telemetry = useTelemetry();
   const [vimEnabled, setVimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, {
     listener: true,
@@ -665,6 +576,33 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   // For creation variant, use project-scoped key; for workspace, use workspace ID
   const sendMessageOptions = useSendMessageOptions(
     variant === "workspace" ? props.workspaceId : getProjectScopeId(creationParentProjectPath)
+  );
+  const composerSuggestions = useComposerSuggestions({
+    input,
+    setInput,
+    inputRef,
+    variant,
+    workspaceId,
+    projectPath: atMentionProjectPath,
+    disableWorkspaceAgents: sendMessageOptions.disableWorkspaceAgents === true,
+    transferredDraftProjectDiscovery,
+    agentPluginsEnabled: agentPluginsExperimentEnabled,
+    experiments: {
+      workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
+      dynamicWorkflows: dynamicWorkflowsExperimentEnabled,
+      memory: memoryExperimentEnabled,
+      memoryConsolidation: memoryConsolidationExperimentEnabled,
+      rlm: rlmExperimentEnabled,
+      programmaticToolCalling: ptcExperimentEnabled,
+    },
+  });
+  const { agentSkillDescriptors, mcpPromptDescriptors } = composerSuggestions;
+  const handleComposerInputChange = useCallback(
+    (next: string, caret?: number) => {
+      composerSuggestions.handleInputCaretChange(caret, next.length);
+      handleInputChange(next, caret);
+    },
+    [composerSuggestions.handleInputCaretChange, handleInputChange]
   );
   const additionalSystemContext = useAdditionalSystemContextSnapshot(
     variant === "workspace" ? props.workspaceId : ""
@@ -1298,318 +1236,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when editingMessage changes
   }, [editingMessage, applyDraftFromPending]);
 
-  // Watch input/cursor for @file mentions
-  useEffect(() => {
-    if (atMentionDebounceRef.current) {
-      clearTimeout(atMentionDebounceRef.current);
-      atMentionDebounceRef.current = null;
-    }
-
-    const inputChanged = lastAtMentionInputRef.current !== input;
-    lastAtMentionInputRef.current = input;
-
-    const atMentionScopeId = variant === "workspace" ? workspaceId : atMentionProjectPath;
-
-    if (!api || !atMentionScopeId) {
-      // Invalidate any in-flight completion request.
-      atMentionRequestIdRef.current++;
-      lastAtMentionScopeIdRef.current = null;
-      lastAtMentionQueryRef.current = null;
-      setAtMentionSuggestions(clearSuggestions);
-      setShowAtMentionSuggestions(false);
-      return;
-    }
-
-    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-    const match = findAtMentionAtCursor(input, cursor);
-
-    if (!match) {
-      // Invalidate any in-flight completion request.
-      atMentionRequestIdRef.current++;
-      lastAtMentionScopeIdRef.current = null;
-      lastAtMentionQueryRef.current = null;
-      setAtMentionSuggestions(clearSuggestions);
-      setShowAtMentionSuggestions(false);
-      return;
-    }
-
-    // If the user is moving the caret and we aren't already showing suggestions, don't re-open.
-    if (!inputChanged && !showAtMentionSuggestions) {
-      return;
-    }
-
-    // Avoid refetching on caret movement within the same token/query.
-    if (
-      !inputChanged &&
-      lastAtMentionScopeIdRef.current === atMentionScopeId &&
-      lastAtMentionQueryRef.current === match.query
-    ) {
-      return;
-    }
-
-    lastAtMentionScopeIdRef.current = atMentionScopeId;
-    lastAtMentionQueryRef.current = match.query;
-
-    const requestId = ++atMentionRequestIdRef.current;
-    const runRequest = () => {
-      void (async () => {
-        try {
-          const result =
-            variant === "workspace"
-              ? await api.workspace.getFileCompletions({
-                  workspaceId: atMentionScopeId,
-                  query: match.query,
-                  limit: 20,
-                })
-              : await api.projects.getFileCompletions({
-                  projectPath: atMentionScopeId,
-                  query: match.query,
-                  limit: 20,
-                });
-
-          if (atMentionRequestIdRef.current !== requestId) {
-            return;
-          }
-
-          const nextSuggestions = result.paths
-            // File @mentions are whitespace-delimited (extractAtMentions uses /@(\S+)/), so
-            // suggestions containing spaces would be inserted incorrectly (e.g. "@foo bar.ts").
-            .filter((p) => !/\s/.test(p))
-            .map((p) => {
-              // Determine file type from extension or mark as directory
-              const getFileType = (path: string): string => {
-                if (path.endsWith("/")) return "Directory";
-                const lastDot = path.lastIndexOf(".");
-                const lastSlash = path.lastIndexOf("/");
-                // Only use extension if it's after the last slash (in the filename)
-                if (lastDot > lastSlash && lastDot < path.length - 1) {
-                  return path.slice(lastDot + 1).toUpperCase();
-                }
-                return "File";
-              };
-              return {
-                id: `file:${p}`,
-                display: p,
-                description: getFileType(p),
-                replacement: `@${p}`,
-              };
-            });
-
-          setAtMentionSuggestions(nextSuggestions);
-          setShowAtMentionSuggestions(nextSuggestions.length > 0);
-        } catch {
-          if (atMentionRequestIdRef.current === requestId) {
-            setAtMentionSuggestions(clearSuggestions);
-            setShowAtMentionSuggestions(false);
-          }
-        }
-      })();
-    };
-
-    // Our backend autocomplete is cheap (indexed) and cached, so update suggestions on every
-    // character rather than waiting for a debounce window.
-    runRequest();
-  }, [
-    api,
-    input,
-    showAtMentionSuggestions,
-    variant,
-    workspaceId,
-    atMentionProjectPath,
-    atMentionCursorNonce,
-  ]);
-
-  useEffect(() => {
-    if (!api || variant !== "workspace" || !workspaceId) {
-      if (mcpPromptsWorkspaceRef.current !== null) {
-        mcpPromptsWorkspaceRef.current = null;
-        mcpPromptsLoadedAtRef.current = 0;
-        mcpPromptsRequestIdRef.current++;
-        mcpPromptsRequestRef.current = null;
-        mcpPromptsAbortRef.current?.abort();
-        mcpPromptsAbortRef.current = null;
-        setMcpPromptDescriptors([]);
-      }
-      return;
-    }
-
-    if (mcpPromptsWorkspaceRef.current !== workspaceId) {
-      mcpPromptsWorkspaceRef.current = workspaceId;
-      mcpPromptsLoadedAtRef.current = 0;
-      mcpPromptsRequestIdRef.current++;
-      mcpPromptsRequestRef.current = null;
-      mcpPromptsAbortRef.current?.abort();
-      mcpPromptsAbortRef.current = null;
-      setMcpPromptDescriptors([]);
-    }
-
-    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-    const opensPromptSurface =
-      input.trimStart().startsWith("/") || findInlineSkillReferenceAtCursor(input, cursor) !== null;
-    if (!opensPromptSurface || Date.now() - mcpPromptsLoadedAtRef.current < 30_000) return;
-    if (mcpPromptsRequestRef.current) return;
-
-    const requestId = ++mcpPromptsRequestIdRef.current;
-    const abortController = new AbortController();
-    mcpPromptsAbortRef.current = abortController;
-    const request = api.workspace.mcp.prompts
-      .list({ workspaceId }, { signal: abortController.signal })
-      .then((prompts) => {
-        if (
-          mcpPromptsWorkspaceRef.current !== workspaceId ||
-          mcpPromptsRequestIdRef.current !== requestId
-        ) {
-          return;
-        }
-        setMcpPromptDescriptors(prompts);
-        mcpPromptsLoadedAtRef.current = Date.now();
-      })
-      .catch(() => {
-        if (
-          mcpPromptsWorkspaceRef.current === workspaceId &&
-          mcpPromptsRequestIdRef.current === requestId
-        ) {
-          mcpPromptsLoadedAtRef.current = Date.now();
-        }
-      })
-      .finally(() => {
-        if (mcpPromptsRequestRef.current === request) {
-          mcpPromptsRequestRef.current = null;
-        }
-        if (mcpPromptsAbortRef.current === abortController) {
-          mcpPromptsAbortRef.current = null;
-        }
-      });
-    mcpPromptsRequestRef.current = request;
-    // Caret movement must retrigger discovery when the input text is unchanged.
-  }, [api, input, variant, workspaceId, atMentionCursorNonce]);
-
-  useEffect(() => {
-    if (showAtMentionSuggestions) {
-      // File mentions win precedence if an edge-case token could match both menus.
-      setSkillSuggestions((prev) => (prev.length === 0 ? prev : []));
-      setShowSkillSuggestions(false);
-      lastSkillQueryRef.current = null;
-      return;
-    }
-
-    const inputChanged = lastSkillInputRef.current !== input;
-    lastSkillInputRef.current = input;
-
-    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-    const match = findInlineSkillReferenceAtCursor(input, cursor);
-
-    if (!match) {
-      setSkillSuggestions(clearSuggestions);
-      setShowSkillSuggestions(false);
-      lastSkillQueryRef.current = null;
-      return;
-    }
-
-    if (
-      !shouldRefreshInlineSkillSuggestions({
-        inputChanged,
-        previousPartial: lastSkillQueryRef.current,
-        partial: match.partial,
-        previousDescriptors: lastSkillDescriptorsRef.current,
-        descriptors: agentSkillDescriptors,
-        previousMcpPrompts: lastMcpPromptDescriptorsRef.current,
-        mcpPrompts: mcpPromptDescriptors,
-      })
-    ) {
-      return;
-    }
-
-    lastSkillQueryRef.current = match.partial;
-
-    const nextSuggestions = getInlineSkillSuggestions({
-      partial: match.partial,
-      descriptors: agentSkillDescriptors,
-      mcpPrompts: mcpPromptDescriptors,
-    });
-    lastSkillDescriptorsRef.current = agentSkillDescriptors;
-    lastMcpPromptDescriptorsRef.current = mcpPromptDescriptors;
-    setSkillSuggestions(nextSuggestions);
-    setShowSkillSuggestions(nextSuggestions.length > 0);
-  }, [
-    input,
-    showAtMentionSuggestions,
-    agentSkillDescriptors,
-    mcpPromptDescriptors,
-    atMentionCursorNonce,
-  ]);
-
-  // Keep slash suggestions current before Enter can accept a stale item.
-  useLayoutEffect(() => {
-    const suggestions = getSlashCommandSuggestions(input, {
-      agentSkills: agentSkillDescriptors,
-      mcpPrompts: mcpPromptDescriptors,
-      pluginCommands: pluginCommandDescriptors,
-      variant,
-      isExperimentEnabled: (experimentId) =>
-        resolveSlashCommandExperimentValue(experimentId, {
-          workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
-          dynamicWorkflows: dynamicWorkflowsExperimentEnabled,
-          memory: memoryExperimentEnabled,
-          memoryConsolidation: memoryConsolidationExperimentEnabled,
-          rlm: rlmExperimentEnabled,
-          programmaticToolCalling: ptcExperimentEnabled,
-        }),
-    });
-    setCommandSuggestions((prev) => replaceSuggestions(prev, suggestions));
-    setShowCommandSuggestions(suggestions.length > 0);
-  }, [
-    input,
-    agentSkillDescriptors,
-    mcpPromptDescriptors,
-    pluginCommandDescriptors,
-    variant,
-    workspaceHeartbeatsExperimentEnabled,
-    dynamicWorkflowsExperimentEnabled,
-    memoryExperimentEnabled,
-    memoryConsolidationExperimentEnabled,
-    rlmExperimentEnabled,
-    ptcExperimentEnabled,
-  ]);
-
-  // Watch input/cursor for `\symbol` backslash commands and surface the menu.
-  useLayoutEffect(() => {
-    if (showAtMentionSuggestions) {
-      // File mentions win precedence if an edge-case token could match both menus.
-      setSymbolSuggestions(clearSuggestions);
-      setShowSymbolSuggestions(false);
-      return;
-    }
-
-    const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-    const match = findSymbolCommandAtCursor(input, cursor);
-    if (!match) {
-      setSymbolSuggestions(clearSuggestions);
-      setShowSymbolSuggestions(false);
-      return;
-    }
-
-    const suggestions = getSymbolSuggestions(match.partial);
-    lastSymbolQueryRef.current = match.partial;
-    setSymbolSuggestions((prev) => replaceSuggestions(prev, suggestions));
-    setShowSymbolSuggestions(suggestions.length > 0);
-  }, [input, showAtMentionSuggestions, atMentionCursorNonce]);
-
-  // Derive ghost hint for slash-command argument syntax.
-  // Show only when suggestions are hidden and the input is exactly "/command " with no args yet.
-  const commandGhostHint = getCommandGhostHint(input, showCommandSuggestions, {
-    variant,
-    isExperimentEnabled: (experimentId) =>
-      resolveSlashCommandExperimentValue(experimentId, {
-        workspaceHeartbeats: workspaceHeartbeatsExperimentEnabled,
-        dynamicWorkflows: dynamicWorkflowsExperimentEnabled,
-        memory: memoryExperimentEnabled,
-        memoryConsolidation: memoryConsolidationExperimentEnabled,
-        rlm: rlmExperimentEnabled,
-        programmaticToolCalling: ptcExperimentEnabled,
-      }),
-  });
-
   // Project live workflow run cards for foreground slash invocations after reloads.
   useEffect(() => {
     let isMounted = true;
@@ -1666,114 +1292,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     isTranscriptCaughtUp,
     store,
   ]);
-
-  // Agent plugin installs/updates/uninstalls change contributed slash
-  // commands and skills while the composer stays mounted (palette and
-  // Settings flows never remount the workspace); bump a tick so both loader
-  // effects below re-query instead of serving descriptors from the old tree.
-  const [pluginMutationTick, setPluginMutationTick] = useState(0);
-  useEffect(
-    () =>
-      subscribeAgentPluginsMutated(() => {
-        setPluginMutationTick((tick) => tick + 1);
-      }),
-    []
-  );
-
-  // Load agent skills for suggestions
-  useEffect(() => {
-    let isMounted = true;
-    const requestId = ++agentSkillsRequestIdRef.current;
-
-    const loadAgentSkills = async () => {
-      if (!api) {
-        if (isMounted && agentSkillsRequestIdRef.current === requestId) {
-          setAgentSkillDescriptors([]);
-        }
-        return;
-      }
-
-      const discoveryInput =
-        variant === "workspace" && workspaceId
-          ? {
-              workspaceId,
-              disableWorkspaceAgents:
-                sendMessageOptions.disableWorkspaceAgents === true ||
-                transferredDraftProjectDiscovery,
-            }
-          : variant === "creation" && atMentionProjectPath
-            ? { projectPath: atMentionProjectPath }
-            : null;
-
-      if (!discoveryInput) {
-        if (isMounted && agentSkillsRequestIdRef.current === requestId) {
-          setAgentSkillDescriptors([]);
-        }
-        return;
-      }
-
-      try {
-        const skills = await api.agentSkills.list(discoveryInput);
-        if (!isMounted || agentSkillsRequestIdRef.current !== requestId) {
-          return;
-        }
-        if (Array.isArray(skills)) {
-          setAgentSkillDescriptors(skills);
-        }
-      } catch (error) {
-        console.error("Failed to load agent skills:", error);
-        if (!isMounted || agentSkillsRequestIdRef.current !== requestId) {
-          return;
-        }
-        setAgentSkillDescriptors([]);
-      }
-    };
-
-    void loadAgentSkills();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [
-    api,
-    variant,
-    workspaceId,
-    atMentionProjectPath,
-    sendMessageOptions.disableWorkspaceAgents,
-    transferredDraftProjectDiscovery,
-    // The backend gates plugin-contributed skills on this experiment, so a
-    // toggle must refetch /skill suggestions like it reloads plugin commands.
-    agentPluginsExperimentEnabled,
-    pluginMutationTick,
-  ]);
-
-  // Agent Plugins: load manifest-contributed slash commands for suggestions.
-  // Subscribes to the reactive experiment value so toggling agent-plugins in
-  // Settings immediately loads/clears commands without remounting the composer
-  // (the backend also returns [] while the experiment is disabled).
-  useEffect(() => {
-    let isMounted = true;
-
-    const loadPluginCommands = async () => {
-      if (!api || variant !== "workspace" || !workspaceId || !agentPluginsExperimentEnabled) {
-        if (isMounted) setPluginCommandDescriptors([]);
-        return;
-      }
-      try {
-        const commands = await api.workspace.plugins.slashCommands.list({ workspaceId });
-        if (isMounted) setPluginCommandDescriptors(commands);
-      } catch {
-        // Plugin command discovery must never break the composer.
-        if (isMounted) setPluginCommandDescriptors([]);
-      }
-    };
-
-    void loadPluginCommands();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [api, variant, workspaceId, agentPluginsExperimentEnabled, pluginMutationTick]);
 
   // Voice input: track transcription provider availability (subscribe to provider config changes)
   useEffect(() => {
@@ -2261,116 +1779,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const handleDestructiveCommandCancel = useCallback(() => {
     setPendingDestructiveCommand(false);
   }, []);
-
-  // Handle suggestion selection
-
-  const handleAtMentionSelect = useCallback(
-    (suggestion: SlashSuggestion) => {
-      const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-      const match = findAtMentionAtCursor(input, cursor);
-      if (!match) {
-        return;
-      }
-
-      // Add trailing space so user can continue typing naturally
-      const next =
-        input.slice(0, match.startIndex) +
-        suggestion.replacement +
-        " " +
-        input.slice(match.endIndex);
-
-      setInput(next);
-      setAtMentionSuggestions(clearSuggestions);
-      setShowAtMentionSuggestions(false);
-
-      requestAnimationFrame(() => {
-        const el = inputRef.current;
-        if (!el || el.disabled) {
-          return;
-        }
-
-        el.focus();
-        // +1 for the trailing space we added
-        const newCursor = match.startIndex + suggestion.replacement.length + 1;
-        el.selectionStart = newCursor;
-        el.selectionEnd = newCursor;
-      });
-    },
-    [input, setInput]
-  );
-  const handleSkillSelect = useCallback(
-    (suggestion: SlashSuggestion) => {
-      const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-      const match = findInlineSkillReferenceAtCursor(input, cursor);
-      if (!match) {
-        return;
-      }
-
-      // Add a separating space only when the following text does not already provide one.
-      const after = input.slice(match.endIndex);
-      const trailing = getInlineSkillInsertionTrailingText(after);
-      const next = input.slice(0, match.startIndex) + suggestion.replacement + trailing + after;
-
-      setInput(next);
-      setSkillSuggestions(clearSuggestions);
-      setShowSkillSuggestions(false);
-      lastSkillQueryRef.current = null;
-
-      requestAnimationFrame(() => {
-        const el = inputRef.current;
-        if (!el || el.disabled) {
-          return;
-        }
-
-        el.focus();
-        const newCursor = match.startIndex + suggestion.replacement.length + trailing.length;
-        el.selectionStart = newCursor;
-        el.selectionEnd = newCursor;
-      });
-    },
-    [input, setInput]
-  );
-
-  const handleCommandSelect = useCallback(
-    (suggestion: SlashSuggestion) => {
-      setInput(suggestion.replacement);
-      setShowCommandSuggestions(false);
-      inputRef.current?.focus();
-    },
-    [setInput]
-  );
-
-  const handleSymbolSelect = useCallback(
-    (suggestion: SlashSuggestion) => {
-      const cursor = Math.min(inputRef.current?.selectionStart ?? input.length, input.length);
-      const match = findSymbolCommandAtCursor(input, cursor);
-      if (!match) {
-        return;
-      }
-
-      // Replace the whole `\name` token with the symbol; no trailing space so the
-      // user can keep typing (e.g. another symbol, an exponent, or a number).
-      const next =
-        input.slice(0, match.startIndex) + suggestion.replacement + input.slice(match.endIndex);
-
-      setInput(next);
-      setSymbolSuggestions(clearSuggestions);
-      setShowSymbolSuggestions(false);
-
-      requestAnimationFrame(() => {
-        const el = inputRef.current;
-        if (!el || el.disabled) {
-          return;
-        }
-
-        el.focus();
-        const newCursor = match.startIndex + suggestion.replacement.length;
-        el.selectionStart = newCursor;
-        el.selectionEnd = newCursor;
-      });
-    },
-    [input, setInput]
-  );
 
   const handleSend = async (overrides?: InternalSendOverrides) => {
     if (!canSend) {
@@ -2977,20 +2385,14 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
     // Note: ESC handled by VimTextArea (for mode transitions) and CommandSuggestions (for dismissal)
 
-    const hasCommandSuggestionMenu = showCommandSuggestions && commandSuggestions.length > 0;
-    const hasAtMentionSuggestionMenu = showAtMentionSuggestions && atMentionSuggestions.length > 0;
-    const hasSkillSuggestionMenu = showSkillSuggestions && skillSuggestions.length > 0;
-    const hasSymbolSuggestionMenu = showSymbolSuggestions && symbolSuggestions.length > 0;
-
-    // Don't handle keys if suggestions are visible.
-    // Enter/Tab/arrows/Escape are handled by CommandSuggestions for slash, @file, $skill, and \symbol menus.
     if (
-      (hasCommandSuggestionMenu && COMMAND_SUGGESTION_KEYS.includes(e.key)) ||
-      (hasAtMentionSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key)) ||
-      (hasSkillSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key)) ||
-      (hasSymbolSuggestionMenu && FILE_SUGGESTION_KEYS.includes(e.key))
+      composerSuggestions.isVisible &&
+      (composerSuggestions.suppressionKeys === "command"
+        ? COMMAND_SUGGESTION_KEYS
+        : FILE_SUGGESTION_KEYS
+      ).includes(e.key)
     ) {
-      return; // Let CommandSuggestions handle it
+      return;
     }
 
     const hasOnlyQueuedMessage =
@@ -3197,53 +2599,18 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
             onOpenProviders={() => open("providers", { expandProvider: "openai" })}
           />
 
-          {/* File path suggestions (@src/foo.ts) */}
           <CommandSuggestions
-            suggestions={atMentionSuggestions}
-            onSelectSuggestion={handleAtMentionSelect}
-            onDismiss={() => setShowAtMentionSuggestions(false)}
-            isVisible={showAtMentionSuggestions}
-            ariaLabel="File path suggestions"
-            listId={atMentionListId}
+            suggestions={composerSuggestions.suggestions}
+            onSelectSuggestion={composerSuggestions.select}
+            onDismiss={composerSuggestions.dismiss}
+            isVisible={composerSuggestions.isVisible}
+            ariaLabel={composerSuggestions.ariaLabel}
+            listId={composerSuggestions.listId}
             anchorRef={variant === "creation" ? inputRef : undefined}
-            highlightQuery={lastAtMentionQueryRef.current ?? ""}
-            isFileSuggestion
-          />
-
-          {/* Skill suggestions ($deep-review) */}
-          <CommandSuggestions
-            suggestions={skillSuggestions}
-            onSelectSuggestion={handleSkillSelect}
-            onDismiss={() => setShowSkillSuggestions(false)}
-            isVisible={showSkillSuggestions}
-            ariaLabel="Skill suggestions"
-            listId={skillListId}
-            anchorRef={variant === "creation" ? inputRef : undefined}
-            highlightQuery={lastSkillQueryRef.current ?? ""}
-          />
-
-          {/* Slash command suggestions - available in both variants */}
-          {/* In creation mode, use portal (anchorRef) to escape overflow:hidden containers */}
-          <CommandSuggestions
-            suggestions={commandSuggestions}
-            onSelectSuggestion={handleCommandSelect}
-            onDismiss={() => setShowCommandSuggestions(false)}
-            isVisible={showCommandSuggestions}
-            ariaLabel="Slash command suggestions"
-            listId={commandListId}
-            anchorRef={variant === "creation" ? inputRef : undefined}
-          />
-
-          {/* Symbol shortcut suggestions (\alpha -> α, \leq -> ≤, \euro -> €) */}
-          <CommandSuggestions
-            suggestions={symbolSuggestions}
-            onSelectSuggestion={handleSymbolSelect}
-            onDismiss={() => setShowSymbolSuggestions(false)}
-            isVisible={showSymbolSuggestions}
-            ariaLabel="Symbol shortcuts"
-            listId={symbolListId}
-            anchorRef={variant === "creation" ? inputRef : undefined}
-            highlightQuery={lastSymbolQueryRef.current}
+            highlightQuery={composerSuggestions.highlightQuery}
+            isFileSuggestion={composerSuggestions.isFileSuggestion}
+            selectedIndex={composerSuggestions.selectedIndex}
+            onSelectedIndexChange={composerSuggestions.setSelectedIndex}
           />
 
           {/* Scope the focus border to the textarea so sibling controls do not trigger it. */}
@@ -3272,48 +2639,31 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
                     ref={inputRef}
                     data-escape-interrupts-stream="true"
                     value={input}
-                    ghostHint={commandGhostHint}
-                    onChange={handleInputChange}
+                    ghostHint={composerSuggestions.ghostHint}
+                    onChange={handleComposerInputChange}
                     onKeyDown={handleKeyDown}
                     onPaste={handlePaste}
-                    onKeyUp={handleAtMentionCursorActivity}
-                    onMouseUp={handleAtMentionCursorActivity}
-                    onSelect={handleAtMentionCursorActivity}
+                    onKeyUp={composerSuggestions.handleCursorActivity}
+                    onMouseUp={composerSuggestions.handleCursorActivity}
+                    onSelect={composerSuggestions.handleCursorActivity}
                     onDragOver={handleDragOver}
                     onDrop={handleDrop}
                     onEscapeInNormalMode={handleEscapeInNormalMode}
                     suppressKeys={
-                      showAtMentionSuggestions
-                        ? FILE_SUGGESTION_KEYS
-                        : showSkillSuggestions
-                          ? FILE_SUGGESTION_KEYS
-                          : showSymbolSuggestions
-                            ? FILE_SUGGESTION_KEYS
-                            : showCommandSuggestions
-                              ? COMMAND_SUGGESTION_KEYS
-                              : undefined
+                      composerSuggestions.isVisible
+                        ? composerSuggestions.suppressionKeys === "command"
+                          ? COMMAND_SUGGESTION_KEYS
+                          : FILE_SUGGESTION_KEYS
+                        : undefined
                     }
                     placeholder={placeholder}
                     disabled={!editingMessageForUi && (disabled || sendInFlightBlocksInput)}
                     aria-label={editingMessageForUi ? "Edit your last message" : "Message Claude"}
                     aria-autocomplete="list"
                     aria-controls={
-                      showAtMentionSuggestions && atMentionSuggestions.length > 0
-                        ? atMentionListId
-                        : showSkillSuggestions && skillSuggestions.length > 0
-                          ? skillListId
-                          : showSymbolSuggestions && symbolSuggestions.length > 0
-                            ? symbolListId
-                            : showCommandSuggestions && commandSuggestions.length > 0
-                              ? commandListId
-                              : undefined
+                      composerSuggestions.isVisible ? composerSuggestions.listId : undefined
                     }
-                    aria-expanded={
-                      (showCommandSuggestions && commandSuggestions.length > 0) ||
-                      (showAtMentionSuggestions && atMentionSuggestions.length > 0) ||
-                      (showSkillSuggestions && skillSuggestions.length > 0) ||
-                      (showSymbolSuggestions && symbolSuggestions.length > 0)
-                    }
+                    aria-expanded={composerSuggestions.isVisible}
                     // Creation favors prompt space; workspaces preserve transcript space. Mobile
                     // hides the shortcut hints the workspace floor exists for, so that room is
                     // dead space on a screen that has none to spare.

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -30,7 +30,6 @@ import {
   readPersistedState,
   usePersistedState,
   updatePersistedState,
-  subscribePersistedStateWrites,
 } from "@/browser/hooks/usePersistedState";
 import { useSettings } from "@/browser/contexts/SettingsContext";
 import { useWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
@@ -151,12 +150,7 @@ import { SendHorizontal } from "lucide-react";
 import { AttachFileButton } from "./AttachFileButton";
 import { VimTextArea } from "@/browser/components/VimTextArea/VimTextArea";
 import { ChatAttachments, type ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
-import {
-  extractAttachmentsFromClipboard,
-  extractAttachmentsFromDrop,
-  chatAttachmentsToFileParts,
-  processAttachmentFiles,
-} from "@/browser/utils/attachmentsHandling";
+import { chatAttachmentsToFileParts } from "@/browser/utils/attachmentsHandling";
 import {
   buildPendingFromRestoredInput,
   type PendingUserMessage,
@@ -177,7 +171,7 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   withAgentSkillRefs,
-withMcpPromptRefs,
+  withMcpPromptRefs,
 } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
 import {
@@ -207,11 +201,6 @@ import { useContextMenuPosition } from "@/browser/hooks/useContextMenuPosition";
 import { usePowerMode } from "@/browser/contexts/PowerModeContext";
 import { useVoiceInput } from "@/browser/hooks/useVoiceInput";
 import { VoiceInputButton } from "./VoiceInputButton";
-import {
-  estimatePersistedChatAttachmentsChars,
-  MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS,
-  readPersistedChatAttachments,
-} from "./draftAttachmentsStorage";
 import {
   formatPendingFileStagingError,
   getPendingFileAttachments,
@@ -245,12 +234,12 @@ import {
 } from "@/constants/layout";
 import { useChatDockColumnWidthClass } from "@/browser/components/ChatPane/chatDockColumn";
 import { prepareMessagePayload } from "./prepareMessagePayload";
+import {
+  estimateBase64DataUrlBytes,
+  isPdfAttachment,
+  useComposerAttachments,
+} from "./useComposerAttachments";
 
-// localStorage quotas are environment-dependent and relatively small.
-// Be conservative here so we can warn the user before writes start failing.
-
-// Normal typing usually has no active suggestion menu. Reuse the existing empty array
-// so suggestion effects do not schedule an avoidable second render on every keypress.
 function clearSuggestions(prev: SlashSuggestion[]): SlashSuggestion[] {
   return prev.length === 0 ? prev : [];
 }
@@ -258,30 +247,6 @@ function clearSuggestions(prev: SlashSuggestion[]): SlashSuggestion[] {
 function replaceSuggestions(prev: SlashSuggestion[], next: SlashSuggestion[]): SlashSuggestion[] {
   return prev.length === 0 && next.length === 0 ? prev : next;
 }
-
-const PDF_MEDIA_TYPE = "application/pdf";
-
-function getBaseMediaType(mediaType: string): string {
-  return mediaType.toLowerCase().trim().split(";")[0];
-}
-
-function estimateBase64DataUrlBytes(dataUrl: string): number | null {
-  if (!dataUrl.startsWith("data:")) return null;
-
-  const commaIndex = dataUrl.indexOf(",");
-  if (commaIndex === -1) return null;
-
-  const header = dataUrl.slice("data:".length, commaIndex);
-  if (!header.includes(";base64")) return null;
-
-  const base64 = dataUrl.slice(commaIndex + 1);
-  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
-  return Math.floor((base64.length * 3) / 4) - padding;
-}
-
-// Shared so the three "blocked while editing a message" attachment guards surface identical copy
-// and can't drift if one is reworded.
-const EDIT_MODE_ATTACHMENT_ERROR_MESSAGE = "Attachments cannot be added while editing a message.";
 
 export type { ChatInputProps, ChatInputAPI };
 
@@ -526,85 +491,24 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     setToast(null);
   }, []);
 
-  const attachmentDraftTooLargeToastKeyRef = useRef<string | null>(null);
-
-  const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() => {
-    return readPersistedChatAttachments(storageKeys.attachmentsKey);
+  const {
+    attachments,
+    setAttachments,
+    processingAttachmentCount,
+    handlePaste,
+    handleAttachFiles,
+    handleDragOver,
+    handleDrop,
+    handleRemoveAttachment,
+  } = useComposerAttachments({
+    variant,
+    workspaceId,
+    attachmentsKey: storageKeys.attachmentsKey,
+    editingMessage: editingMessageForUi != null,
+    pushToast,
   });
-  const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
   // Reviews restored from edits/queued drafts override attached review state while active.
   const [draftReviews, setDraftReviews] = useState<ReviewNoteDataForDisplay[] | null>(null);
-  // Distinguishes this component's own persisted writes from external ones
-  // (e.g. a creation-flow draft transfer landing after this composer mounted).
-  const selfAttachmentWriteRef = useRef(false);
-  const persistAttachments = useCallback(
-    (nextAttachments: ChatAttachment[]) => {
-      selfAttachmentWriteRef.current = true;
-      try {
-        if (nextAttachments.length === 0) {
-          attachmentDraftTooLargeToastKeyRef.current = null;
-          updatePersistedState<ChatAttachment[] | undefined>(storageKeys.attachmentsKey, undefined);
-          return;
-        }
-
-        const estimatedChars = estimatePersistedChatAttachmentsChars(nextAttachments);
-        if (estimatedChars > MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS) {
-          // Clear persisted value to avoid restoring stale attachments on restart.
-          updatePersistedState<ChatAttachment[] | undefined>(storageKeys.attachmentsKey, undefined);
-
-          if (attachmentDraftTooLargeToastKeyRef.current !== storageKeys.attachmentsKey) {
-            attachmentDraftTooLargeToastKeyRef.current = storageKeys.attachmentsKey;
-            pushToast({
-              type: "error",
-              message:
-                "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
-              duration: 5000,
-            });
-          }
-          return;
-        }
-
-        attachmentDraftTooLargeToastKeyRef.current = null;
-        updatePersistedState<ChatAttachment[] | undefined>(
-          storageKeys.attachmentsKey,
-          nextAttachments
-        );
-      } finally {
-        selfAttachmentWriteRef.current = false;
-      }
-    },
-    [storageKeys.attachmentsKey, pushToast]
-  );
-
-  // Keep attachment drafts in sync when the storage scope changes (e.g. switching creation projects).
-  useEffect(() => {
-    attachmentDraftTooLargeToastKeyRef.current = null;
-    setAttachmentsState(readPersistedChatAttachments(storageKeys.attachmentsKey));
-  }, [storageKeys.attachmentsKey]);
-
-  // Attachments live in local state (a too-large draft stays in memory after
-  // its persisted copy is cleared), so external writes to the draft key, such
-  // as a creation-flow transfer that lands after this composer mounted, must
-  // be synced in explicitly. Self-writes are skipped to keep that in-memory
-  // exception intact.
-  useEffect(() => {
-    return subscribePersistedStateWrites((event) => {
-      if (event.key !== storageKeys.attachmentsKey || selfAttachmentWriteRef.current) {
-        return;
-      }
-      setAttachmentsState(readPersistedChatAttachments(storageKeys.attachmentsKey));
-    });
-  }, [storageKeys.attachmentsKey]);
-  const setAttachments = useCallback(
-    (value: ChatAttachment[] | ((prev: ChatAttachment[]) => ChatAttachment[])) => {
-      setAttachmentsState((prev) => {
-        const next = value instanceof Function ? value(prev) : value;
-        persistAttachments(next);
-        return next;
-      });
-    },
-    [persistAttachments]
-  );
   // Attached reviews come from parent via props (persisted in pendingReviews state).
   const workspaceIdForComposerClear = variant === "workspace" ? props.workspaceId : null;
   const onDetachAllReviewsForComposerClear =
@@ -2272,140 +2176,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     };
   }, [variant, workspaceIdForFocus, focusMessageInput, setChatInputAutoFocusState]);
 
-  const showResizeToast = useCallback(
-    (nextAttachments: ChatAttachment[]) => {
-      const resized = nextAttachments.filter(
-        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
-          attachment.kind === "provider" && attachment.resizeInfo != null
-      );
-      if (resized.length === 0) {
-        return;
-      }
-
-      const firstResizeInfo = resized[0].resizeInfo;
-      if (!firstResizeInfo) {
-        return;
-      }
-
-      // Tell users when we auto-resize so the attachment dimensions are never surprising.
-      const message =
-        resized.length === 1
-          ? `Image resized from ${firstResizeInfo.originalWidth}×${firstResizeInfo.originalHeight} to ${firstResizeInfo.newWidth}×${firstResizeInfo.newHeight}`
-          : `${resized.length} images resized to fit provider limits`;
-
-      pushToast({ type: "info", message });
-    },
-    [pushToast]
-  );
-
-  const processAttachmentFilesForComposer = useCallback(
-    (files: File[]): Promise<ChatAttachment[]> => {
-      setProcessingAttachmentCount((count) => count + 1);
-      return processAttachmentFiles(files, {
-        stageAttachment:
-          variant === "workspace"
-            ? async (file, dataBase64) => {
-                if (!api) {
-                  throw new Error("Not connected to server");
-                }
-                if (workspaceId == null) {
-                  throw new Error("Files can be staged after opening a workspace.");
-                }
-                const result = await api.workspace.stageAttachment({
-                  workspaceId,
-                  filename: file.name,
-                  mediaType: file.type || null,
-                  sizeBytes: file.size,
-                  dataBase64,
-                });
-                if (!result.success) {
-                  throw new Error(result.error);
-                }
-                return result.data;
-              }
-            : undefined,
-        holdNonProviderFiles: variant === "creation",
-      }).finally(() => {
-        setProcessingAttachmentCount((count) => Math.max(0, count - 1));
-      });
-    },
-    [api, variant, workspaceId]
-  );
-
-  const attachFiles = useCallback(
-    (files: File[]) => {
-      const results = files.map((file) =>
-        processAttachmentFilesForComposer([file]).then(
-          (attachments) => ({ ok: true as const, attachments }),
-          (error: unknown) => ({ ok: false as const, error })
-        )
-      );
-      void Promise.all(results).then((outcomes) => {
-        const successes = outcomes.flatMap((outcome) => (outcome.ok ? outcome.attachments : []));
-        if (successes.length > 0) {
-          setAttachments((prev) => [...prev, ...successes]);
-          showResizeToast(successes);
-        }
-        for (const outcome of outcomes) {
-          if (!outcome.ok) {
-            const message =
-              outcome.error instanceof Error
-                ? outcome.error.message
-                : "Failed to process attachment";
-            console.error("Failed to process attached file:", outcome.error);
-            pushToast({ type: "error", message });
-          }
-        }
-      });
-    },
-    [processAttachmentFilesForComposer, pushToast, setAttachments, showResizeToast]
-  );
-
-  // Handle paste events to extract attachments
-  const handlePaste = useCallback(
-    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const items = e.clipboardData?.items;
-      if (!items) return;
-
-      const attachmentFiles = extractAttachmentsFromClipboard(items);
-      if (attachmentFiles.length === 0) return;
-
-      // When editing an existing message, we only allow changing the text.
-      // Don't preventDefault here so any clipboard text can still paste normally.
-      if (editingMessageForUi) {
-        pushToast({
-          type: "error",
-          message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE,
-        });
-        return;
-      }
-
-      e.preventDefault(); // Prevent default paste behavior for attachments
-
-      attachFiles(attachmentFiles);
-    },
-    [attachFiles, editingMessageForUi, pushToast]
-  );
-
-  // Handle removing an attachment
-  const handleRemoveAttachment = useCallback(
-    (id: string) => {
-      setAttachments((prev) => prev.filter((img) => img.id !== id));
-    },
-    [setAttachments]
-  );
-
-  const handleAttachFiles = (files: File[]) => {
-    if (editingMessageForUi) {
-      pushToast({
-        type: "error",
-        message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE,
-      });
-      return;
-    }
-    attachFiles(files);
-  };
-
   // Shared slash command execution for creation + workspace inputs.
   const commandWorkspaceId = variant === "workspace" ? props.workspaceId : undefined;
   const commandProjectPath =
@@ -2590,39 +2360,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const handleDestructiveCommandCancel = useCallback(() => {
     setPendingDestructiveCommand(false);
   }, []);
-
-  // Handle drag over to allow drop
-  const handleDragOver = useCallback(
-    (e: React.DragEvent<HTMLTextAreaElement>) => {
-      // Check if drag contains files
-      if (e.dataTransfer.types.includes("Files")) {
-        e.preventDefault();
-        e.dataTransfer.dropEffect = editingMessageForUi ? "none" : "copy";
-      }
-    },
-    [editingMessageForUi]
-  );
-
-  // Handle drop to extract attachments
-  const handleDrop = useCallback(
-    (e: React.DragEvent<HTMLTextAreaElement>) => {
-      e.preventDefault();
-
-      const attachmentFiles = extractAttachmentsFromDrop(e.dataTransfer);
-      if (attachmentFiles.length === 0) return;
-
-      if (editingMessageForUi) {
-        pushToast({
-          type: "error",
-          message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE,
-        });
-        return;
-      }
-
-      attachFiles(attachmentFiles);
-    },
-    [attachFiles, editingMessageForUi, pushToast]
-  );
 
   // Handle suggestion selection
 
@@ -3010,11 +2747,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       const policyModel = modelOverride ?? baseModel;
 
       // Preflight: if the message includes PDFs, ensure the selected model can accept them.
-      const pdfAttachments = attachments.filter(
-        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
-          attachment.kind === "provider" &&
-          getBaseMediaType(attachment.mediaType) === PDF_MEDIA_TYPE
-      );
+      const pdfAttachments = attachments.filter(isPdfAttachment);
       if (pdfAttachments.length > 0) {
         const caps = getModelCapabilitiesResolved(policyModel, providersConfig);
         if (caps && !caps.supportsPdfInput) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1147,19 +1147,26 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const onReady = props.onReady;
 
-  // Provide API to parent via callback
+  // Provide API to parent via callback. Latest-ref wrappers (see handleSendRef)
+  // keep the handed-out object stable even though the draft helpers are not
+  // identity-stable without manual memoization; re-invoking onReady per render
+  // would churn parent state.
+  const composerApiRef = useRef({ restoreText, restoreDraft, appendText, prependText });
+  useEffect(() => {
+    composerApiRef.current = { restoreText, restoreDraft, appendText, prependText };
+  });
   useEffect(() => {
     if (onReady) {
       onReady({
         focus: focusMessageInput,
         send,
-        restoreText,
-        restoreDraft,
-        appendText,
-        prependText,
+        restoreText: (text) => composerApiRef.current.restoreText(text),
+        restoreDraft: (pending) => composerApiRef.current.restoreDraft(pending),
+        appendText: (text) => composerApiRef.current.appendText(text),
+        prependText: (text) => composerApiRef.current.prependText(text),
       });
     }
-  }, [onReady, focusMessageInput, send, restoreText, restoreDraft, appendText, prependText]);
+  }, [onReady, focusMessageInput, send]);
 
   useEffect(() => {
     const handleGlobalKeyDown = (event: KeyboardEvent) => {
@@ -1209,8 +1216,11 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
       }, 0);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run when editingMessage changes
-  }, [editingMessage, applyDraftFromPending]);
+    // Key on the edit target only: function deps (applyDraftFromPending via the
+    // draft hook) are not identity-stable without manual memoization, and
+    // re-running would clobber the user's in-progress edit text every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingMessage?.id]);
 
   // Project live workflow run cards for foreground slash invocations after reloads.
   useEffect(() => {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -62,14 +62,10 @@ import {
   getReasoningModeKey,
   getThinkingLevelKey,
   getWorkspaceAISettingsByAgentKey,
-  getInputKey,
-  getInputAttachmentsKey,
   AGENT_AI_DEFAULTS_KEY,
   VIM_ENABLED_KEY,
   RUNTIME_ENABLEMENT_KEY,
   getProjectScopeId,
-  getPendingScopeId,
-  getDraftScopeId,
   getPendingDraftSkillDiscoveryKey,
   getPendingWorkspaceSendErrorKey,
   getWorkspaceLastReadKey,
@@ -149,7 +145,7 @@ import { useModelsFromSettings } from "@/browser/hooks/useModelsFromSettings";
 import { SendHorizontal } from "lucide-react";
 import { AttachFileButton } from "./AttachFileButton";
 import { VimTextArea } from "@/browser/components/VimTextArea/VimTextArea";
-import { ChatAttachments, type ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
+import { ChatAttachments } from "@/browser/features/ChatInput/ChatAttachments";
 import { chatAttachmentsToFileParts } from "@/browser/utils/attachmentsHandling";
 import {
   buildPendingFromRestoredInput,
@@ -171,9 +167,8 @@ import {
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
   withAgentSkillRefs,
-withMcpPromptRefs,
+  withMcpPromptRefs,
 } from "@/common/types/message";
-import type { Review } from "@/common/types/review";
 import {
   getModelCapabilities,
   getModelCapabilitiesResolved,
@@ -239,6 +234,7 @@ import {
   isPdfAttachment,
   useComposerAttachments,
 } from "./useComposerAttachments";
+import { useComposerDraft } from "./useComposerDraft";
 
 // Normal typing usually has no active suggestion menu. Reuse the existing empty array
 // so suggestion effects do not schedule an avoidable second render on every keypress.
@@ -373,26 +369,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   // Callback for model changes (both variants support this)
   const onModelChange = props.onModelChange;
 
-  // Storage keys differ by variant
-  const storageKeys = (() => {
-    if (variant === "creation") {
-      const pendingScopeId =
-        typeof props.pendingDraftId === "string" && props.pendingDraftId.trim().length > 0
-          ? getDraftScopeId(creationParentProjectPath, props.pendingDraftId)
-          : getPendingScopeId(creationParentProjectPath);
-      return {
-        inputKey: getInputKey(pendingScopeId),
-        attachmentsKey: getInputAttachmentsKey(pendingScopeId),
-        modelKey: getModelKey(getProjectScopeId(creationParentProjectPath)),
-      };
-    }
-    return {
-      inputKey: getInputKey(props.workspaceId),
-      attachmentsKey: getInputAttachmentsKey(props.workspaceId),
-      modelKey: getModelKey(props.workspaceId),
-    };
-  })();
-
   // User request: keep creation runtime controls synced with Settings enablement toggles.
   const [rawRuntimeEnablement] = usePersistedState(
     RUNTIME_ENABLEMENT_KEY,
@@ -401,12 +377,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   );
   const runtimeEnablement = normalizeRuntimeEnablement(rawRuntimeEnablement);
 
-  const [input, setInput] = usePersistedState(storageKeys.inputKey, "", { listener: true });
-
-  // Keep a stable reference to the latest input value so event handlers don't need to rebind
-  // on same-length edits (e.g. selection-replace) to know the previous value.
-  const latestInputValueRef = useRef(input);
-  latestInputValueRef.current = input;
   // Track concurrent sends with a counter (not boolean) to handle queued follow-ups correctly.
   // When a follow-up is queued during stream-start, it resolves immediately but shouldn't
   // clear the "in flight" state until all sends complete.
@@ -432,7 +402,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const atMentionRequestIdRef = useRef(0);
   const lastAtMentionScopeIdRef = useRef<string | null>(null);
   const lastAtMentionQueryRef = useRef<string | null>(null);
-  const lastAtMentionInputRef = useRef<string>(input);
   const lastSkillInputRef = useRef<string | null>(null);
   const lastSkillQueryRef = useRef<string | null>(null);
   const lastSkillDescriptorsRef = useRef<AgentSkillDescriptor[] | null>(null);
@@ -493,9 +462,36 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     setToast(null);
   }, []);
 
+  const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
   const {
+    storageKeys,
+    input,
+    setInput,
+    latestInputValueRef,
     attachments,
     setAttachments,
+    draftReviews,
+    setDraftReviews,
+    getDraft,
+    setDraft,
+    preEditDraftRef,
+    preEditReviewsRef,
+    reviewOverrideActive,
+    reviewData,
+    reviewIdsForCheck,
+    reviewPanelItems,
+    removeDraftReview,
+    updateDraftReviewNote,
+  } = useComposerDraft({
+    variant,
+    workspaceId,
+    creationProjectPath: creationParentProjectPath,
+    pendingDraftId: variant === "creation" ? (props.pendingDraftId ?? undefined) : undefined,
+    attachedReviews,
+    pushToast,
+  });
+  const lastAtMentionInputRef = useRef<string>(input);
+  const {
     processingAttachmentCount,
     handlePaste,
     handleAttachFiles,
@@ -505,58 +501,14 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   } = useComposerAttachments({
     variant,
     workspaceId,
-    attachmentsKey: storageKeys.attachmentsKey,
+    attachments,
+    setAttachments,
     editingMessage: editingMessageForUi != null,
     pushToast,
   });
-  // Reviews restored from edits/queued drafts override attached review state while active.
-  const [draftReviews, setDraftReviews] = useState<ReviewNoteDataForDisplay[] | null>(null);
-  // Attached reviews come from parent via props (persisted in pendingReviews state).
   const workspaceIdForComposerClear = variant === "workspace" ? props.workspaceId : null;
   const onDetachAllReviewsForComposerClear =
     variant === "workspace" ? props.onDetachAllReviews : undefined;
-
-  // draftReviews takes precedence when restoring or editing message drafts.
-  const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
-  const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
-  const nextDraftReviewIdRef = useRef(0);
-  const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
-    typeof value === "object" && value !== null;
-  const getDraftReviewId = (review: ReviewNoteDataForDisplay): string => {
-    const existingId = draftReviewIdsByValueRef.current.get(review);
-    if (existingId) return existingId;
-    const newId = `draft-review-${nextDraftReviewIdRef.current++}`;
-    draftReviewIdsByValueRef.current.set(review, newId);
-    return newId;
-  };
-
-  const withDraftReview = (
-    reviewId: string,
-    update: (reviews: ReviewNoteDataForDisplay[], reviewIndex: number) => ReviewNoteDataForDisplay[]
-  ) =>
-    setDraftReviews((prev) => {
-      if (prev === null) return prev;
-      const reviewIndex = prev.findIndex(
-        (review) => isDraftReviewData(review) && getDraftReviewId(review) === reviewId
-      );
-      return reviewIndex === -1 ? prev : update(prev, reviewIndex);
-    });
-
-  const removeDraftReview = (reviewId: string) =>
-    withDraftReview(reviewId, (prev, reviewIndex) =>
-      prev.filter((_, index) => index !== reviewIndex)
-    );
-
-  const updateDraftReviewNote = (reviewId: string, newNote: string) =>
-    withDraftReview(reviewId, (prev, reviewIndex) => {
-      const review = prev[reviewIndex];
-      if (!review || review.userNote === newNote) return prev;
-      const next = [...prev];
-      const updatedReview = { ...review, userNote: newNote };
-      draftReviewIdsByValueRef.current.set(updatedReview, reviewId);
-      next[reviewIndex] = updatedReview;
-      return next;
-    });
 
   // Creation sends can resolve after navigation; guard draft clears on unmounted inputs.
   const isMountedRef = useRef(true);
@@ -650,25 +602,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     [powerMode, setInput]
   );
 
-  // Draft state combines text input and attachments.
-  // Reviews are sourced separately via attachedReviews unless draftReviews overrides them.
-  interface DraftState {
-    text: string;
-    attachments: ChatAttachment[];
-  }
-  const getDraft = useCallback(
-    (): DraftState => ({ text: input, attachments }),
-    [input, attachments]
-  );
-  const setDraft = useCallback(
-    (draft: DraftState) => {
-      setInput(draft.text);
-      setAttachments(draft.attachments);
-    },
-    [setInput, setAttachments]
-  );
-  const preEditDraftRef = useRef<DraftState>({ text: "", attachments: [] });
-  const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
   const { open } = useSettings();
   const { selectedWorkspace, beginWorkspaceCreation } = useWorkspaceContext();
   const { agentId, currentAgent, agents } = useAgent();
@@ -1075,24 +1008,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       : null;
   const hasTypedText = input.trim().length > 0;
   const hasImages = attachments.length > 0;
-  const reviewOverrideActive = draftReviews !== null;
-  const draftReviewItems = (draftReviews ?? []).filter(isDraftReviewData);
-  const reviewData = reviewOverrideActive
-    ? draftReviewItems.length > 0
-      ? draftReviewItems
-      : undefined
-    : attachedReviews.length > 0
-      ? attachedReviews.map((review) => review.data)
-      : undefined;
-  const reviewIdsForCheck = reviewOverrideActive ? [] : attachedReviews.map((review) => review.id);
-  const reviewPanelItems: Review[] = reviewOverrideActive
-    ? draftReviewItems.map((data) => ({
-        id: getDraftReviewId(data),
-        data,
-        status: "attached",
-        createdAt: 0,
-      }))
-    : attachedReviews;
   const hasReviews = reviewData !== undefined;
   // Disable send while Coder presets are loading (user could bypass preset validation)
   const policyBlocksCreateSend = variant === "creation" && creationRuntimePolicyError != null;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -172,14 +172,12 @@ import {
   normalizeRuntimeEnablement,
   type CoderWorkspaceConfig,
 } from "@/common/types/runtime";
-import { resolveThinkingInput } from "@/common/utils/thinking/policy";
 import {
   type AgentSkillReference,
   type MuxMessageMetadata,
   type ReviewNoteDataForDisplay,
-  prepareUserMessageForSend,
   withAgentSkillRefs,
-  withMcpPromptRefs,
+withMcpPromptRefs,
 } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
 import {
@@ -246,6 +244,7 @@ import {
   CREATION_COLUMN_MAX_WIDTH_CLASS,
 } from "@/constants/layout";
 import { useChatDockColumnWidthClass } from "@/browser/components/ChatPane/chatDockColumn";
+import { prepareMessagePayload } from "./prepareMessagePayload";
 
 // localStorage quotas are environment-dependent and relatively small.
 // Be conservative here so we can warn the user before writes start failing.
@@ -3122,51 +3121,33 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           }
         }
 
-        const userMessageText = appendStagedNoticeToUserMessage
-          ? appendStagedAttachmentNotice(actualMessageText, sendAttachments)
-          : actualMessageText;
-        const { finalText: finalMessageText, metadata: reviewMetadata } = prepareUserMessageForSend(
-          { text: userMessageText, reviews: reviewsData },
-          muxMetadata
-        );
-        // When editing /compact, compactionOptions already includes the base sendMessageOptions.
-        // Avoid duplicating additionalSystemInstructions.
-        const additionalSystemInstructions =
-          compactionOptions.additionalSystemInstructions ??
-          sendMessageOptions.additionalSystemInstructions;
-
-        muxMetadata = reviewMetadata;
-
-        const effectiveModel = modelOverride ?? compactionOptions.model ?? sendMessageOptions.model;
-        // For one-shot overrides, store the original input as rawCommand so the
-        // command prefix (e.g., "/opus+high") stays visible in the user message.
-        const oneshotCommandPrefix = modelOneShot
-          ? messageText
-              .trim()
-              .slice(0, messageText.trim().length - modelOneShot.message.length)
-              .trimEnd()
-          : undefined;
-        const oneshotRawCommand = oneshotCommandPrefix
-          ? appendStagedAttachmentNotice(messageText.trim(), sendAttachments)
-          : undefined;
-        muxMetadata = muxMetadata
-          ? {
-              ...muxMetadata,
-              requestedModel: effectiveModel,
-              ...(oneshotRawCommand
-                ? { rawCommand: oneshotRawCommand, commandPrefix: oneshotCommandPrefix }
-                : {}),
-            }
-          : {
-              type: "normal",
-              requestedModel: effectiveModel,
-              ...(oneshotRawCommand
-                ? { rawCommand: oneshotRawCommand, commandPrefix: oneshotCommandPrefix }
-                : {}),
-            };
-
-        // Capture review IDs before clearing (for marking as checked on success)
-        const sentReviewIds = reviewIdsForCheck;
+        const preparedMessage = prepareMessagePayload({
+          messageText,
+          messageTextForSend,
+          attachments: sendAttachments,
+          fileParts,
+          reviews: reviewsData,
+          reviewIds: reviewIdsForCheck,
+          editMessageId: editMessageForSend?.id,
+          baseMetadata: muxMetadata,
+          agentSkillRefs: combinedSkillRefs,
+          mcpPromptRefs: combinedMcpPromptRefs,
+          sendMessageOptions,
+          compactionOptions,
+          compactionMessageText: actualMessageText,
+          appendStagedNotice: appendStagedNoticeToUserMessage,
+          modelOneShot,
+          policyModel,
+          transferredDraftProjectDiscovery,
+          additionalSystemContextHydrated,
+          additionalSystemContext,
+          goalInterventionPolicy: overrides?.goalInterventionPolicy,
+          queueDispatchMode: overrides?.queueDispatchMode,
+        });
+        const finalMessageText = preparedMessage.message;
+        const sendOptions = preparedMessage.options;
+        const effectiveModel = preparedMessage.effectiveModel;
+        const sentReviewIds = preparedMessage.sentReviewIds;
 
         if (editMessageForSend) {
           setOptimisticallyDismissedEditId(editMessageForSend.id);
@@ -3183,46 +3164,6 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         if (inputRef.current) {
           inputRef.current.style.height = "";
         }
-
-        // One-shot models/thinking shouldn't update the persisted session defaults.
-        // Resolve thinking level: numeric indices are model-relative (0 = model's lowest allowed level)
-        const rawThinkingOverride = modelOneShot?.thinkingLevel;
-        const thinkingOverride =
-          rawThinkingOverride != null
-            ? resolveThinkingInput(rawThinkingOverride, policyModel)
-            : undefined;
-        const goalInterventionPolicy = overrides?.goalInterventionPolicy;
-
-        const sendOptions = {
-          ...sendMessageOptions,
-          ...compactionOptions,
-          // Match the original creation send: project-scoped skill refs must
-          // resolve from the project path, not the new worktree.
-          ...(transferredDraftProjectDiscovery && hasProjectScopedSkillRef(combinedSkillRefs)
-            ? { disableWorkspaceAgents: true }
-            : {}),
-          ...(modelOverride ? { model: modelOverride } : {}),
-          ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
-          ...(modelOneShot ? { skipAiSettingsPersistence: true } : {}),
-          ...(goalInterventionPolicy ? { goalInterventionPolicy } : {}),
-          ...(overrides?.queueDispatchMode
-            ? { queueDispatchMode: overrides.queueDispatchMode }
-            : {}),
-          // Honor the per-workspace "Chat Instructions" toggle: when the user
-          // has disabled the scratchpad, send an empty string so the backend
-          // doesn't fall back to reading the durable content from disk.
-          ...(additionalSystemContextHydrated
-            ? {
-                additionalSystemContext: additionalSystemContext.enabled
-                  ? additionalSystemContext.content
-                  : "",
-              }
-            : {}),
-          additionalSystemInstructions,
-          editMessageId: editMessageForSend?.id,
-          fileParts: sendFileParts,
-          muxMetadata,
-        };
 
         props.onMessageSendStarted?.(overrides?.queueDispatchMode ?? "tool-end");
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -462,34 +462,18 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
     setToast(null);
   }, []);
 
-  const attachedReviews = variant === "workspace" ? (props.attachedReviews ?? []) : [];
-  const {
-    storageKeys,
-    input,
-    setInput,
-    latestInputValueRef,
-    attachments,
-    setAttachments,
-    draftReviews,
-    setDraftReviews,
-    getDraft,
-    setDraft,
-    preEditDraftRef,
-    preEditReviewsRef,
-    reviewOverrideActive,
-    reviewData,
-    reviewIdsForCheck,
-    reviewPanelItems,
-    removeDraftReview,
-    updateDraftReviewNote,
-  } = useComposerDraft({
+  const draft = useComposerDraft({
     variant,
     workspaceId,
     creationProjectPath: creationParentProjectPath,
     pendingDraftId: variant === "creation" ? (props.pendingDraftId ?? undefined) : undefined,
-    attachedReviews,
+    attachedReviews: variant === "workspace" ? (props.attachedReviews ?? []) : [],
     pushToast,
   });
+  const { input, setInput, attachments, setAttachments, draftReviews, setDraftReviews } = draft;
+  const { getDraft, setDraft, preEditDraftRef, preEditReviewsRef } = draft;
+  const { reviewOverrideActive, reviewData, reviewIdsForCheck, reviewPanelItems } = draft;
+  const { removeDraftReview, updateDraftReviewNote, storageKeys, latestInputValueRef } = draft;
   const lastAtMentionInputRef = useRef<string>(input);
   const {
     processingAttachmentCount,

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -3,62 +3,44 @@ import type { SendMessageOptions } from "@/common/orpc/types";
 import { prepareMessagePayload } from "./prepareMessagePayload";
 
 const model = "anthropic:claude-sonnet-4";
-const baseOptions = { model, thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
-const baseInput = {
-  ...{ messageText: "hello", messageTextForSend: "hello" },
-  ...{ attachments: [], reviewIds: [], agentSkillRefs: [], mcpPromptRefs: [] },
-  sendMessageOptions: baseOptions,
-  policyModel: model,
-  ...{ transferredDraftProjectDiscovery: false, additionalSystemContextHydrated: false },
-  additionalSystemContext: { enabled: false, content: "" },
-};
-const prepare = (input = {}) => prepareMessagePayload({ ...baseInput, ...input });
+const options = { model, thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
+const prepare = (input = {}) => prepareMessagePayload({
+  messageText: "hello", messageTextForSend: "hello", attachments: [], reviewIds: [],
+  agentSkillRefs: [], mcpPromptRefs: [], sendMessageOptions: options, policyModel: model,
+  transferredDraftProjectDiscovery: false, additionalSystemContextHydrated: false,
+  additionalSystemContext: { enabled: false, content: "" }, ...input,
+});
 const oneShot = {
-  type: "model-oneshot",
-  modelString: "anthropic:claude-opus-4-1",
-  thinkingLevel: "high",
-  message: "hello",
+  type: "model-oneshot", modelString: "anthropic:claude-opus-4-1",
+  thinkingLevel: "high", message: "hello",
 } as const;
 
 describe("prepareMessagePayload", () => {
   it.each([
-    ["normal message", {}, "hello", baseOptions.model, undefined],
-    [
-      "one-shot model",
-      { messageText: "/opus+high hello", modelOneShot: oneShot },
-      "hello",
-      oneShot.modelString,
-      undefined,
-    ],
-    ["empty edit attachments", { editMessageId: "message-1" }, "hello", baseOptions.model, 0],
-  ])("prepares %s", (_name, input, message, model, filePartCount) => {
+    ["normal message", {}, "hello", model, undefined],
+    ["one-shot model", { messageText: "/opus+high hello", modelOneShot: oneShot }, "hello", oneShot.modelString, undefined],
+    ["empty edit attachments", { editMessageId: "message-1" }, "hello", model, 0],
+  ])("prepares %s", (_name, input, message, effectiveModel, fileParts) => {
     const result = prepare(input);
-    expect(result.message).toBe(message);
-    expect(result.effectiveModel).toBe(model);
-    expect(result.options.fileParts?.length).toBe(filePartCount);
+    expect([result.message, result.effectiveModel, result.options.fileParts?.length])
+      .toEqual([message, effectiveModel, fileParts]);
   });
 
   it("applies compaction, context, and dispatch overrides", () => {
-    expect(
-      prepare({
-        compactionMessageText: "compact request",
-        appendStagedNotice: false,
-        compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
-        additionalSystemContextHydrated: true,
-        additionalSystemContext: { enabled: false, content: "ignored" },
-        queueDispatchMode: "turn-end",
-        goalInterventionPolicy: "pause",
-      })
-    ).toMatchObject({
-      message: "compact request",
-      effectiveModel: "openai:gpt-5",
-      options: {
-        model: "openai:gpt-5",
-        additionalSystemInstructions: "compact",
-        additionalSystemContext: "",
-        queueDispatchMode: "turn-end",
-        goalInterventionPolicy: "pause",
-      },
+    const result = prepare({
+      compactionMessageText: "compact request", appendStagedNotice: false,
+      compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
+      additionalSystemContextHydrated: true,
+      additionalSystemContext: { enabled: false, content: "ignored" },
+      queueDispatchMode: "turn-end", goalInterventionPolicy: "pause",
     });
+    expect([
+      result.message, result.effectiveModel, result.options.model,
+      result.options.additionalSystemInstructions, result.options.additionalSystemContext,
+      result.options.queueDispatchMode, result.options.goalInterventionPolicy,
+    ]).toEqual([
+      "compact request", "openai:gpt-5", "openai:gpt-5", "compact", "",
+      "turn-end", "pause",
+    ]);
   });
 });

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -4,43 +4,74 @@ import { prepareMessagePayload } from "./prepareMessagePayload";
 
 const model = "anthropic:claude-sonnet-4";
 const options = { model, thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
-const prepare = (input = {}) => prepareMessagePayload({
-  messageText: "hello", messageTextForSend: "hello", attachments: [], reviewIds: [],
-  agentSkillRefs: [], mcpPromptRefs: [], sendMessageOptions: options, policyModel: model,
-  transferredDraftProjectDiscovery: false, additionalSystemContextHydrated: false,
-  additionalSystemContext: { enabled: false, content: "" }, ...input,
-});
+const prepare = (input = {}) =>
+  prepareMessagePayload({
+    messageText: "hello",
+    messageTextForSend: "hello",
+    attachments: [],
+    reviewIds: [],
+    agentSkillRefs: [],
+    mcpPromptRefs: [],
+    sendMessageOptions: options,
+    policyModel: model,
+    transferredDraftProjectDiscovery: false,
+    additionalSystemContextHydrated: false,
+    additionalSystemContext: { enabled: false, content: "" },
+    ...input,
+  });
 const oneShot = {
-  type: "model-oneshot", modelString: "anthropic:claude-opus-4-1",
-  thinkingLevel: "high", message: "hello",
+  type: "model-oneshot",
+  modelString: "anthropic:claude-opus-4-1",
+  thinkingLevel: "high",
+  message: "hello",
 } as const;
 
 describe("prepareMessagePayload", () => {
   it.each([
     ["normal message", {}, "hello", model, undefined],
-    ["one-shot model", { messageText: "/opus+high hello", modelOneShot: oneShot }, "hello", oneShot.modelString, undefined],
+    [
+      "one-shot model",
+      { messageText: "/opus+high hello", modelOneShot: oneShot },
+      "hello",
+      oneShot.modelString,
+      undefined,
+    ],
     ["empty edit attachments", { editMessageId: "message-1" }, "hello", model, 0],
   ])("prepares %s", (_name, input, message, effectiveModel, fileParts) => {
     const result = prepare(input);
-    expect([result.message, result.effectiveModel, result.options.fileParts?.length])
-      .toEqual([message, effectiveModel, fileParts]);
+    expect([result.message, result.effectiveModel, result.options.fileParts?.length]).toEqual([
+      message,
+      effectiveModel,
+      fileParts,
+    ]);
   });
 
   it("applies compaction, context, and dispatch overrides", () => {
     const result = prepare({
-      compactionMessageText: "compact request", appendStagedNotice: false,
+      compactionMessageText: "compact request",
+      appendStagedNotice: false,
       compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
       additionalSystemContextHydrated: true,
       additionalSystemContext: { enabled: false, content: "ignored" },
-      queueDispatchMode: "turn-end", goalInterventionPolicy: "pause",
+      queueDispatchMode: "turn-end",
+      goalInterventionPolicy: "pause",
     });
     expect([
-      result.message, result.effectiveModel, result.options.model,
-      result.options.additionalSystemInstructions, result.options.additionalSystemContext,
-      result.options.queueDispatchMode, result.options.goalInterventionPolicy,
+      result.message,
+      result.effectiveModel,
+      result.options.model,
+      result.options.additionalSystemInstructions,
+      result.options.additionalSystemContext,
+      result.options.queueDispatchMode,
+      result.options.goalInterventionPolicy,
     ]).toEqual([
-      "compact request", "openai:gpt-5", "openai:gpt-5", "compact", "",
-      "turn-end", "pause",
+      "compact request",
+      "openai:gpt-5",
+      "openai:gpt-5",
+      "compact",
+      "",
+      "turn-end",
+      "pause",
     ]);
   });
 });

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import { prepareMessagePayload } from "./prepareMessagePayload";
 
-const baseOptions = { model: "anthropic:claude-sonnet-4", thinkingLevel: "off" } satisfies SendMessageOptions;
+const baseOptions = { model: "anthropic:claude-sonnet-4", thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
 
 const baseInput = {
   messageText: "hello",
@@ -16,7 +16,7 @@ const baseInput = {
   transferredDraftProjectDiscovery: false,
   additionalSystemContextHydrated: false,
   additionalSystemContext: { enabled: false, content: "" },
-} as const;
+};
 
 describe("prepareMessagePayload", () => {
   it.each([
@@ -26,7 +26,7 @@ describe("prepareMessagePayload", () => {
       expected: {
         message: "hello",
         effectiveModel: baseOptions.model,
-        fileParts: undefined,
+        filePartCount: undefined,
       },
     },
     {
@@ -43,7 +43,7 @@ describe("prepareMessagePayload", () => {
       expected: {
         message: "hello",
         effectiveModel: "anthropic:claude-opus-4-1",
-        fileParts: undefined,
+        filePartCount: undefined,
       },
     },
     {
@@ -52,14 +52,14 @@ describe("prepareMessagePayload", () => {
       expected: {
         message: "hello",
         effectiveModel: baseOptions.model,
-        fileParts: [],
+        filePartCount: 0,
       },
     },
   ])("prepares $name", ({ input, expected }) => {
     const result = prepareMessagePayload({ ...baseInput, ...input });
     expect(result.message).toBe(expected.message);
     expect(result.effectiveModel).toBe(expected.effectiveModel);
-    expect(result.options.fileParts).toEqual(expected.fileParts);
+    expect(result.options.fileParts?.length).toBe(expected.filePartCount);
   });
 
   it("applies compaction, context, and dispatch overrides", () => {

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { SendMessageOptions } from "@/common/orpc/types";
+import type { MuxMessageMetadata } from "@/common/types/message";
 import { prepareMessagePayload } from "./prepareMessagePayload";
 
 const model = "anthropic:claude-sonnet-4";
@@ -44,6 +45,27 @@ describe("prepareMessagePayload", () => {
       effectiveModel,
       fileParts,
     ]);
+  });
+
+  it.each([
+    ["normal", undefined, ["demo"]],
+    [
+      "compaction-request",
+      {
+        type: "compaction-request",
+        rawCommand: "/compact",
+        parsed: {},
+      } satisfies MuxMessageMetadata,
+      undefined,
+    ],
+  ])("attaches skill refs to %s metadata only", (_name, baseMetadata, expectedSkills) => {
+    const result = prepare({
+      baseMetadata,
+      agentSkillRefs: [{ skillName: "demo", scope: "project", source: "inline" }],
+    });
+    expect(result.options.muxMetadata?.agentSkillRefs?.map((ref) => ref.skillName)).toEqual(
+      expectedSkills
+    );
   });
 
   it("applies compaction, context, and dispatch overrides", () => {

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -2,86 +2,63 @@ import { describe, expect, it } from "bun:test";
 import type { SendMessageOptions } from "@/common/orpc/types";
 import { prepareMessagePayload } from "./prepareMessagePayload";
 
-const baseOptions = { model: "anthropic:claude-sonnet-4", thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
-
+const model = "anthropic:claude-sonnet-4";
+const baseOptions = { model, thinkingLevel: "off", agentId: "exec" } satisfies SendMessageOptions;
 const baseInput = {
-  messageText: "hello",
-  messageTextForSend: "hello",
-  attachments: [],
-  reviewIds: [],
-  agentSkillRefs: [],
-  mcpPromptRefs: [],
+  ...{ messageText: "hello", messageTextForSend: "hello" },
+  ...{ attachments: [], reviewIds: [], agentSkillRefs: [], mcpPromptRefs: [] },
   sendMessageOptions: baseOptions,
-  policyModel: baseOptions.model,
-  transferredDraftProjectDiscovery: false,
-  additionalSystemContextHydrated: false,
+  policyModel: model,
+  ...{ transferredDraftProjectDiscovery: false, additionalSystemContextHydrated: false },
   additionalSystemContext: { enabled: false, content: "" },
 };
+const prepare = (input = {}) => prepareMessagePayload({ ...baseInput, ...input });
+const oneShot = {
+  type: "model-oneshot",
+  modelString: "anthropic:claude-opus-4-1",
+  thinkingLevel: "high",
+  message: "hello",
+} as const;
 
 describe("prepareMessagePayload", () => {
   it.each([
-    {
-      name: "normal message",
-      input: {},
-      expected: {
-        message: "hello",
-        effectiveModel: baseOptions.model,
-        filePartCount: undefined,
-      },
-    },
-    {
-      name: "one-shot model",
-      input: {
-        messageText: "/opus+high hello",
-        modelOneShot: {
-          type: "model-oneshot" as const,
-          modelString: "anthropic:claude-opus-4-1",
-          thinkingLevel: "high" as const,
-          message: "hello",
-        },
-      },
-      expected: {
-        message: "hello",
-        effectiveModel: "anthropic:claude-opus-4-1",
-        filePartCount: undefined,
-      },
-    },
-    {
-      name: "empty edit attachments",
-      input: { editMessageId: "message-1" },
-      expected: {
-        message: "hello",
-        effectiveModel: baseOptions.model,
-        filePartCount: 0,
-      },
-    },
-  ])("prepares $name", ({ input, expected }) => {
-    const result = prepareMessagePayload({ ...baseInput, ...input });
-    expect(result.message).toBe(expected.message);
-    expect(result.effectiveModel).toBe(expected.effectiveModel);
-    expect(result.options.fileParts?.length).toBe(expected.filePartCount);
+    ["normal message", {}, "hello", baseOptions.model, undefined],
+    [
+      "one-shot model",
+      { messageText: "/opus+high hello", modelOneShot: oneShot },
+      "hello",
+      oneShot.modelString,
+      undefined,
+    ],
+    ["empty edit attachments", { editMessageId: "message-1" }, "hello", baseOptions.model, 0],
+  ])("prepares %s", (_name, input, message, model, filePartCount) => {
+    const result = prepare(input);
+    expect(result.message).toBe(message);
+    expect(result.effectiveModel).toBe(model);
+    expect(result.options.fileParts?.length).toBe(filePartCount);
   });
 
   it("applies compaction, context, and dispatch overrides", () => {
-    const result = prepareMessagePayload({
-      ...baseInput,
-      compactionMessageText: "compact request",
-      appendStagedNotice: false,
-      compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
-      additionalSystemContextHydrated: true,
-      additionalSystemContext: { enabled: false, content: "ignored" },
-      queueDispatchMode: "turn-end",
-      goalInterventionPolicy: "pause",
-    });
-
-    expect(result.message).toBe("compact request");
-    expect(result.effectiveModel).toBe("openai:gpt-5");
-    expect(result.options).toMatchObject({
-      model: "openai:gpt-5",
-      additionalSystemInstructions: "compact",
-      additionalSystemContext: "",
-      queueDispatchMode: "turn-end",
-      goalInterventionPolicy: "pause",
+    expect(
+      prepare({
+        compactionMessageText: "compact request",
+        appendStagedNotice: false,
+        compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
+        additionalSystemContextHydrated: true,
+        additionalSystemContext: { enabled: false, content: "ignored" },
+        queueDispatchMode: "turn-end",
+        goalInterventionPolicy: "pause",
+      })
+    ).toMatchObject({
+      message: "compact request",
+      effectiveModel: "openai:gpt-5",
+      options: {
+        model: "openai:gpt-5",
+        additionalSystemInstructions: "compact",
+        additionalSystemContext: "",
+        queueDispatchMode: "turn-end",
+        goalInterventionPolicy: "pause",
+      },
     });
   });
 });

--- a/src/browser/features/ChatInput/prepareMessagePayload.test.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import type { SendMessageOptions } from "@/common/orpc/types";
+import { prepareMessagePayload } from "./prepareMessagePayload";
+
+const baseOptions = { model: "anthropic:claude-sonnet-4", thinkingLevel: "off" } satisfies SendMessageOptions;
+
+const baseInput = {
+  messageText: "hello",
+  messageTextForSend: "hello",
+  attachments: [],
+  reviewIds: [],
+  agentSkillRefs: [],
+  mcpPromptRefs: [],
+  sendMessageOptions: baseOptions,
+  policyModel: baseOptions.model,
+  transferredDraftProjectDiscovery: false,
+  additionalSystemContextHydrated: false,
+  additionalSystemContext: { enabled: false, content: "" },
+} as const;
+
+describe("prepareMessagePayload", () => {
+  it.each([
+    {
+      name: "normal message",
+      input: {},
+      expected: {
+        message: "hello",
+        effectiveModel: baseOptions.model,
+        fileParts: undefined,
+      },
+    },
+    {
+      name: "one-shot model",
+      input: {
+        messageText: "/opus+high hello",
+        modelOneShot: {
+          type: "model-oneshot" as const,
+          modelString: "anthropic:claude-opus-4-1",
+          thinkingLevel: "high" as const,
+          message: "hello",
+        },
+      },
+      expected: {
+        message: "hello",
+        effectiveModel: "anthropic:claude-opus-4-1",
+        fileParts: undefined,
+      },
+    },
+    {
+      name: "empty edit attachments",
+      input: { editMessageId: "message-1" },
+      expected: {
+        message: "hello",
+        effectiveModel: baseOptions.model,
+        fileParts: [],
+      },
+    },
+  ])("prepares $name", ({ input, expected }) => {
+    const result = prepareMessagePayload({ ...baseInput, ...input });
+    expect(result.message).toBe(expected.message);
+    expect(result.effectiveModel).toBe(expected.effectiveModel);
+    expect(result.options.fileParts).toEqual(expected.fileParts);
+  });
+
+  it("applies compaction, context, and dispatch overrides", () => {
+    const result = prepareMessagePayload({
+      ...baseInput,
+      compactionMessageText: "compact request",
+      appendStagedNotice: false,
+      compactionOptions: { model: "openai:gpt-5", additionalSystemInstructions: "compact" },
+      additionalSystemContextHydrated: true,
+      additionalSystemContext: { enabled: false, content: "ignored" },
+      queueDispatchMode: "turn-end",
+      goalInterventionPolicy: "pause",
+    });
+
+    expect(result.message).toBe("compact request");
+    expect(result.effectiveModel).toBe("openai:gpt-5");
+    expect(result.options).toMatchObject({
+      model: "openai:gpt-5",
+      additionalSystemInstructions: "compact",
+      additionalSystemContext: "",
+      queueDispatchMode: "turn-end",
+      goalInterventionPolicy: "pause",
+    });
+  });
+});

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -18,7 +18,7 @@ import type { GoalInterventionPolicy, QueueDispatchMode } from "./types";
 
 type ModelOneShot = Extract<NonNullable<ParsedCommand>, { type: "model-oneshot" }>;
 
-export interface PrepareMessagePayloadInput {
+interface PrepareMessagePayloadInput {
   messageText: string;
   messageTextForSend: string;
   attachments: ChatAttachment[];
@@ -42,7 +42,7 @@ export interface PrepareMessagePayloadInput {
   queueDispatchMode?: QueueDispatchMode;
 }
 
-export interface PreparedMessagePayload {
+interface PreparedMessagePayload {
   message: string;
   options: SendMessageOptions & { fileParts?: FilePart[] };
   effectiveModel: string;

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -80,14 +80,14 @@ export function prepareMessagePayload(input: PrepareMessagePayloadInput): Prepar
     input.sendMessageOptions.additionalSystemInstructions;
   const effectiveModel =
     input.modelOneShot?.modelString ?? compactionOptions.model ?? input.sendMessageOptions.model;
+  const trimmedMessageText = input.messageText.trim();
   const commandPrefix = input.modelOneShot
-    ? input.messageText
-        .trim()
-        .slice(0, input.messageText.trim().length - input.modelOneShot.message.length)
+    ? trimmedMessageText
+        .slice(0, trimmedMessageText.length - input.modelOneShot.message.length)
         .trimEnd()
     : undefined;
   const rawCommand = commandPrefix
-    ? appendStagedAttachmentNotice(input.messageText.trim(), input.attachments)
+    ? appendStagedAttachmentNotice(trimmedMessageText, input.attachments)
     : undefined;
   metadata = {
     ...(prepared.metadata ?? { type: "normal" }),

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -1,0 +1,132 @@
+import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
+import type { ChatAttachment } from "./ChatAttachments";
+import { chatAttachmentsToFileParts } from "@/browser/utils/attachmentsHandling";
+import type { SendMessageOptions } from "@/common/orpc/types";
+import {
+  prepareUserMessageForSend,
+  type AgentSkillReference,
+  type MCPPromptReference,
+  type MuxMessageMetadata,
+  type ReviewNoteDataForDisplay,
+  withAgentSkillRefs,
+  withMcpPromptRefs,
+} from "@/common/types/message";
+import { resolveThinkingInput } from "@/common/utils/thinking/policy";
+import { appendStagedAttachmentNotice } from "./stagedAttachments";
+import { hasProjectScopedSkillRef } from "./utils";
+import type { GoalInterventionPolicy, QueueDispatchMode } from "./types";
+
+type ModelOneShot = Extract<NonNullable<ParsedCommand>, { type: "model-oneshot" }>;
+
+export interface PrepareMessagePayloadInput {
+  messageText: string;
+  messageTextForSend: string;
+  attachments: ChatAttachment[];
+  reviews?: ReviewNoteDataForDisplay[];
+  reviewIds: string[];
+  editMessageId?: string;
+  baseMetadata?: MuxMessageMetadata;
+  agentSkillRefs: AgentSkillReference[];
+  mcpPromptRefs: MCPPromptReference[];
+  sendMessageOptions: SendMessageOptions;
+  compactionOptions?: Partial<SendMessageOptions>;
+  compactionMessageText?: string;
+  appendStagedNotice?: boolean;
+  modelOneShot?: ModelOneShot | null;
+  policyModel: string;
+  transferredDraftProjectDiscovery: boolean;
+  additionalSystemContextHydrated: boolean;
+  additionalSystemContext: { enabled: boolean; content: string };
+  goalInterventionPolicy?: GoalInterventionPolicy;
+  queueDispatchMode?: QueueDispatchMode;
+}
+
+export interface PreparedMessagePayload {
+  message: string;
+  options: SendMessageOptions;
+  effectiveModel: string;
+  sentReviewIds: string[];
+}
+
+export function prepareMessagePayload(input: PrepareMessagePayloadInput): PreparedMessagePayload {
+  const fileParts = chatAttachmentsToFileParts(input.attachments, { validate: true });
+  const sendFileParts = input.editMessageId
+    ? fileParts
+    : fileParts.length > 0
+      ? fileParts
+      : undefined;
+  let metadata = input.baseMetadata;
+  if (input.agentSkillRefs.length > 0) {
+    metadata = withAgentSkillRefs(metadata, input.agentSkillRefs);
+  }
+  if (input.mcpPromptRefs.length > 0) {
+    metadata = withMcpPromptRefs(metadata, input.mcpPromptRefs);
+  }
+
+  const actualMessageText = input.compactionMessageText ?? input.messageTextForSend;
+  const userMessageText =
+    input.appendStagedNotice === false
+      ? actualMessageText
+      : appendStagedAttachmentNotice(actualMessageText, input.attachments);
+  const prepared = prepareUserMessageForSend(
+    { text: userMessageText, reviews: input.reviews },
+    metadata
+  );
+  const compactionOptions = input.compactionOptions ?? {};
+  const additionalSystemInstructions =
+    compactionOptions.additionalSystemInstructions ??
+    input.sendMessageOptions.additionalSystemInstructions;
+  const effectiveModel =
+    input.modelOneShot?.modelString ?? compactionOptions.model ?? input.sendMessageOptions.model;
+  const commandPrefix = input.modelOneShot
+    ? input.messageText
+        .trim()
+        .slice(0, input.messageText.trim().length - input.modelOneShot.message.length)
+        .trimEnd()
+    : undefined;
+  const rawCommand = commandPrefix
+    ? appendStagedAttachmentNotice(input.messageText.trim(), input.attachments)
+    : undefined;
+  metadata = {
+    ...(prepared.metadata ?? { type: "normal" }),
+    requestedModel: effectiveModel,
+    ...(rawCommand ? { rawCommand, commandPrefix } : {}),
+  };
+
+  const rawThinkingOverride = input.modelOneShot?.thinkingLevel;
+  const thinkingOverride =
+    rawThinkingOverride != null
+      ? resolveThinkingInput(rawThinkingOverride, input.policyModel)
+      : undefined;
+
+  return {
+    message: prepared.finalText,
+    effectiveModel,
+    sentReviewIds: input.reviewIds,
+    options: {
+      ...input.sendMessageOptions,
+      ...compactionOptions,
+      ...(input.transferredDraftProjectDiscovery && hasProjectScopedSkillRef(input.agentSkillRefs)
+        ? { disableWorkspaceAgents: true }
+        : {}),
+      ...(input.modelOneShot?.modelString ? { model: input.modelOneShot.modelString } : {}),
+      ...(thinkingOverride ? { thinkingLevel: thinkingOverride } : {}),
+      ...(input.modelOneShot ? { skipAiSettingsPersistence: true } : {}),
+      ...(input.goalInterventionPolicy
+        ? { goalInterventionPolicy: input.goalInterventionPolicy }
+        : {}),
+      ...(input.queueDispatchMode ? { queueDispatchMode: input.queueDispatchMode } : {}),
+      ...(input.additionalSystemContextHydrated
+        ? {
+            additionalSystemContext: input.additionalSystemContext.enabled
+              ? input.additionalSystemContext.content
+              : "",
+          }
+        : {}),
+      additionalSystemInstructions,
+      editMessageId: input.editMessageId,
+      fileParts: sendFileParts,
+      muxMetadata: metadata,
+    },
+  };
+}

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -50,7 +50,8 @@ export interface PreparedMessagePayload {
 }
 
 export function prepareMessagePayload(input: PrepareMessagePayloadInput): PreparedMessagePayload {
-  const fileParts = input.fileParts ?? chatAttachmentsToFileParts(input.attachments, { validate: true });
+  const fileParts =
+    input.fileParts ?? chatAttachmentsToFileParts(input.attachments, { validate: true });
   const sendFileParts = input.editMessageId
     ? fileParts
     : fileParts.length > 0

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -1,7 +1,7 @@
 import type { ParsedCommand } from "@/browser/utils/slashCommands/types";
 import type { ChatAttachment } from "./ChatAttachments";
 import { chatAttachmentsToFileParts } from "@/browser/utils/attachmentsHandling";
-import type { SendMessageOptions } from "@/common/orpc/types";
+import type { FilePart, SendMessageOptions } from "@/common/orpc/types";
 import {
   prepareUserMessageForSend,
   type AgentSkillReference,
@@ -22,6 +22,7 @@ export interface PrepareMessagePayloadInput {
   messageText: string;
   messageTextForSend: string;
   attachments: ChatAttachment[];
+  fileParts?: FilePart[];
   reviews?: ReviewNoteDataForDisplay[];
   reviewIds: string[];
   editMessageId?: string;
@@ -43,13 +44,13 @@ export interface PrepareMessagePayloadInput {
 
 export interface PreparedMessagePayload {
   message: string;
-  options: SendMessageOptions;
+  options: SendMessageOptions & { fileParts?: FilePart[] };
   effectiveModel: string;
   sentReviewIds: string[];
 }
 
 export function prepareMessagePayload(input: PrepareMessagePayloadInput): PreparedMessagePayload {
-  const fileParts = chatAttachmentsToFileParts(input.attachments, { validate: true });
+  const fileParts = input.fileParts ?? chatAttachmentsToFileParts(input.attachments, { validate: true });
   const sendFileParts = input.editMessageId
     ? fileParts
     : fileParts.length > 0

--- a/src/browser/features/ChatInput/prepareMessagePayload.ts
+++ b/src/browser/features/ChatInput/prepareMessagePayload.ts
@@ -44,7 +44,11 @@ interface PrepareMessagePayloadInput {
 
 interface PreparedMessagePayload {
   message: string;
-  options: SendMessageOptions & { fileParts?: FilePart[] };
+  // The schema leaves muxMetadata untyped (z.any()); narrow it at this seam.
+  options: Omit<SendMessageOptions, "muxMetadata"> & {
+    fileParts?: FilePart[];
+    muxMetadata?: MuxMessageMetadata;
+  };
   effectiveModel: string;
   sentReviewIds: string[];
 }
@@ -58,11 +62,15 @@ export function prepareMessagePayload(input: PrepareMessagePayloadInput): Prepar
       ? fileParts
       : undefined;
   let metadata = input.baseMetadata;
-  if (input.agentSkillRefs.length > 0) {
-    metadata = withAgentSkillRefs(metadata, input.agentSkillRefs);
-  }
-  if (input.mcpPromptRefs.length > 0) {
-    metadata = withMcpPromptRefs(metadata, input.mcpPromptRefs);
+  // Refs on a compaction request would make the summarization turn materialize
+  // skill snapshots; the caller carries them on the compaction follow-up instead.
+  if (metadata?.type !== "compaction-request") {
+    if (input.agentSkillRefs.length > 0) {
+      metadata = withAgentSkillRefs(metadata, input.agentSkillRefs);
+    }
+    if (input.mcpPromptRefs.length > 0) {
+      metadata = withMcpPromptRefs(metadata, input.mcpPromptRefs);
+    }
   }
 
   const actualMessageText = input.compactionMessageText ?? input.messageTextForSend;

--- a/src/browser/features/ChatInput/symbolShortcuts.test.ts
+++ b/src/browser/features/ChatInput/symbolShortcuts.test.ts
@@ -7,111 +7,62 @@ import {
 } from "@/browser/features/ChatInput/symbolShortcuts";
 
 const bs = String.fromCharCode(92);
-const cmd = (name: string) => `${bs}${name}`;
-const displays = (partial: string) =>
-  getSymbolSuggestions(partial).map((suggestion) => suggestion.display);
-const fenced = "```\n" + cmd("sum") + "\n```";
+const cmd = (name: string) => bs + name;
+const displays = (partial: string) => getSymbolSuggestions(partial).map(({ display }) => display);
+const fenced = `\`\`\`\n${cmd("sum")}\n\`\`\``;
 
-describe("findSymbolCommandAtCursor", () => {
+describe("symbol shortcuts", () => {
   test.each([
-    ["partial command", cmd("al"), 3, { partial: "al", startIndex: 0, endIndex: 3 }],
-    ["bare trigger", bs, 1, { partial: "", startIndex: 0, endIndex: 1 }],
-    ["caret in a token", cmd("alpha"), 3, { partial: "alpha", startIndex: 0, endIndex: 6 }],
-    ["no trigger", "alpha", 5, null],
-    ["escaped trigger", `${bs}${bs}alpha`, 7, null],
-    ["inline code", "`" + cmd("div") + "`", 5, null],
+    ["partial command", cmd("al"), 3, { partial: "al", startIndex: 0, endIndex: 3 }], ["bare trigger", bs, 1, { partial: "", startIndex: 0, endIndex: 1 }],
+    ["caret in a token", cmd("alpha"), 3, { partial: "alpha", startIndex: 0, endIndex: 6 }], ["no trigger", "alpha", 5, null],
+    ["escaped trigger", bs + cmd("alpha"), 7, null],
+    ["inline code", `${"\`"}${cmd("div")}${"\`"}`, 5, null],
     ["fenced code", fenced, fenced.indexOf("m") + 1, null],
     ["token outside code", cmd("div"), 4, { partial: "div", startIndex: 0, endIndex: 4 }],
-  ])("handles %s", (_name, text, cursor, expected) => {
+  ])("finds %s", (_name, text, cursor, expected) => {
     expect(findSymbolCommandAtCursor(text, cursor)).toEqual(expected);
   });
-});
 
-describe("getSymbolSuggestions", () => {
-  test.each([
-    ["a", ["alpha", "ast", "approx", "angle"], true],
-    ["A", ["Alpha"], true],
-    ["in", ["in", "infty", "int"], false],
-    ["sub", ["subset", "subseteq"], false],
-    ["R", ["R", "Rho", "Rightarrow"], false],
-  ])("lists %s commands in the intended order", (partial, names, ordered) => {
-    const actual = displays(partial);
-    expect(ordered ? actual : actual.sort()).toEqual(
-      ordered ? names.map(cmd) : names.map(cmd).sort()
-    );
-  });
-
-  test.each([
-    ["in", "in", "∈"],
-    ["to", "to", "→"],
-    ["subset", "subset", "⊂"],
-    ["a", "alpha", "α"],
-  ])("makes %s default to %s", (partial, name, replacement) => {
-    expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
-  });
-
-  test("keeps suggestion metadata and command names valid", () => {
+  test("orders suggestions, defaults collisions, and keeps metadata valid", () => {
+    expect(displays("a")).toEqual(["alpha", "ast", "approx", "angle"].map(cmd));
+    for (const [partial, names] of [
+      ["A", ["Alpha"]], ["in", ["in", "infty", "int"]], ["sub", ["subset", "subseteq"]],
+      ["R", ["R", "Rho", "Rightarrow"]],
+    ] as const) expect(displays(partial).sort()).toEqual(names.map(cmd).sort());
+    for (const [partial, name, replacement] of [
+      ["in", "in", "∈"], ["to", "to", "→"], ["subset", "subset", "⊂"], ["a", "alpha", "α"],
+    ] as const) expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
     const suggestions = getSymbolSuggestions("");
-    for (const suggestion of suggestions) {
-      expect(suggestion.replacement).toBe(suggestion.description);
-      expect(suggestion.display.startsWith(bs)).toBe(true);
-    }
+    expect(suggestions.map(({ display, replacement, description }) => [
+      display.startsWith(bs), replacement === description,
+    ])).toEqual(suggestions.map(() => [true, true]));
     expect(new Set(displays("")).size).toBe(suggestions.length);
-  });
-
-  test("returns no suggestions for an unknown prefix", () => {
     expect(getSymbolSuggestions("zzz")).toEqual([]);
   });
-});
 
-describe("convertSymbolCommandAtCursor", () => {
   test.each([
-    ["lowercase Greek", cmd("alpha"), 6, "α", 1],
-    ["uppercase Greek", cmd("Alpha"), 6, "Α", 1],
-    ["comparison", cmd("leq"), 4, "≤", 1],
-    ["multiplication", cmd("times"), 6, "×", 1],
-    ["set", cmd("subseteq"), 9, "⊆", 1],
-    ["logic", cmd("implies"), 8, "⟹", 1],
-    ["arrow", cmd("rightarrow"), 11, "→", 1],
-    ["currency", cmd("euro"), 5, "€", 1],
-    ["cryptocurrency", cmd("bitcoin"), 8, "₿", 1],
-    ["big operator", cmd("sum"), 4, "∑", 1],
-    ["surrounding text", `x ${cmd("geq")}`, 6, "x ≥", 3],
-    ["unambiguous prefix collision", cmd("int"), 4, "∫", 1],
-    ["unambiguous word", cmd("top"), 4, "⊤", 1],
-  ])("converts %s", (_name, input, cursor, text, nextCursor) => {
-    expect(convertSymbolCommandAtCursor(input, cursor)).toEqual({ text, cursor: nextCursor });
+    ["lowercase Greek", cmd("alpha"), 6, { text: "α", cursor: 1 }], ["uppercase Greek", cmd("Alpha"), 6, { text: "Α", cursor: 1 }],
+    ["comparison", cmd("leq"), 4, { text: "≤", cursor: 1 }], ["multiplication", cmd("times"), 6, { text: "×", cursor: 1 }],
+    ["set", cmd("subseteq"), 9, { text: "⊆", cursor: 1 }], ["logic", cmd("implies"), 8, { text: "⟹", cursor: 1 }],
+    ["arrow", cmd("rightarrow"), 11, { text: "→", cursor: 1 }], ["currency", cmd("euro"), 5, { text: "€", cursor: 1 }],
+    ["cryptocurrency", cmd("bitcoin"), 8, { text: "₿", cursor: 1 }], ["big operator", cmd("sum"), 4, { text: "∑", cursor: 1 }],
+    ["surrounding text", `x ${cmd("geq")}`, 6, { text: "x ≥", cursor: 3 }],
+    ["unambiguous prefix collision", cmd("int"), 4, { text: "∫", cursor: 1 }],
+    ["unambiguous word", cmd("top"), 4, { text: "⊤", cursor: 1 }],
+    ["ambiguous in", cmd("in"), 3, null], ["ambiguous to", cmd("to"), 3, null],
+    ["ambiguous subset", cmd("subset"), 7, null], ["ambiguous R", cmd("R"), 2, null],
+    ["partial name", cmd("alph"), 5, null], ["unknown name", cmd("alphax"), 7, null],
+    ["mid-token caret", cmd("alpha"), 3, null], ["escaped command", bs + cmd("alpha"), 7, null],
+  ])("converts at cursor: %s", (_name, input, cursor, expected) => {
+    expect(convertSymbolCommandAtCursor(input, cursor)).toEqual(expected);
   });
 
   test.each([
-    ["ambiguous in", cmd("in"), 3],
-    ["ambiguous to", cmd("to"), 3],
-    ["ambiguous subset", cmd("subset"), 7],
-    ["ambiguous R", cmd("R"), 2],
-    ["partial name", cmd("alph"), 5],
-    ["unknown name", cmd("alphax"), 7],
-    ["mid-token caret", cmd("alpha"), 3],
-    ["escaped command", `${bs}${bs}alpha`, 7],
-  ])("does not convert %s", (_name, input, cursor) => {
-    expect(convertSymbolCommandAtCursor(input, cursor)).toBeNull();
-  });
-});
-
-describe("convertTerminatedSymbolCommand", () => {
-  test.each([
-    ["ambiguous name", cmd("in") + " ", 4, "∈ ", 2],
-    ["set name", cmd("subset") + ")", 8, "⊂)", 2],
-    ["single-letter set", cmd("R") + ")", 3, "ℝ)", 2],
-    ["pasted unambiguous run", cmd("alpha") + " ", 7, "α ", 2],
-  ])("converts %s", (_name, input, cursor, text, nextCursor) => {
-    expect(convertTerminatedSymbolCommand(input, cursor)).toEqual({ text, cursor: nextCursor });
-  });
-
-  test.each([
-    ["unterminated name", cmd("in"), 3],
-    ["unknown name", cmd("nope") + " ", 6],
-    ["escaped command", `${bs}${bs}in `, 5],
-  ])("does not convert %s", (_name, input, cursor) => {
-    expect(convertTerminatedSymbolCommand(input, cursor)).toBeNull();
+    ["ambiguous name", cmd("in") + " ", 4, { text: "∈ ", cursor: 2 }], ["set name", cmd("subset") + ")", 8, { text: "⊂)", cursor: 2 }],
+    ["single-letter set", cmd("R") + ")", 3, { text: "ℝ)", cursor: 2 }], ["pasted unambiguous run", cmd("alpha") + " ", 7, { text: "α ", cursor: 2 }],
+    ["unterminated name", cmd("in"), 3, null], ["unknown name", cmd("nope") + " ", 6, null],
+    ["escaped command", bs + cmd("in") + " ", 5, null],
+  ])("converts terminated command: %s", (_name, input, cursor, expected) => {
+    expect(convertTerminatedSymbolCommand(input, cursor)).toEqual(expected);
   });
 });

--- a/src/browser/features/ChatInput/symbolShortcuts.test.ts
+++ b/src/browser/features/ChatInput/symbolShortcuts.test.ts
@@ -8,15 +8,18 @@ import {
 
 const bs = String.fromCharCode(92);
 const cmd = (name: string) => bs + name;
+const tick = String.fromCharCode(96);
 const displays = (partial: string) => getSymbolSuggestions(partial).map(({ display }) => display);
-const fenced = `\`\`\`\n${cmd("sum")}\n\`\`\``;
+const fenced = `${tick.repeat(3)}\n${cmd("sum")}\n${tick.repeat(3)}`;
 
 describe("symbol shortcuts", () => {
   test.each([
-    ["partial command", cmd("al"), 3, { partial: "al", startIndex: 0, endIndex: 3 }], ["bare trigger", bs, 1, { partial: "", startIndex: 0, endIndex: 1 }],
-    ["caret in a token", cmd("alpha"), 3, { partial: "alpha", startIndex: 0, endIndex: 6 }], ["no trigger", "alpha", 5, null],
+    ["partial command", cmd("al"), 3, { partial: "al", startIndex: 0, endIndex: 3 }],
+    ["bare trigger", bs, 1, { partial: "", startIndex: 0, endIndex: 1 }],
+    ["caret in a token", cmd("alpha"), 3, { partial: "alpha", startIndex: 0, endIndex: 6 }],
+    ["no trigger", "alpha", 5, null],
     ["escaped trigger", bs + cmd("alpha"), 7, null],
-    ["inline code", `${"\`"}${cmd("div")}${"\`"}`, 5, null],
+    ["inline code", `${tick}${cmd("div")}${tick}`, 5, null],
     ["fenced code", fenced, fenced.indexOf("m") + 1, null],
     ["token outside code", cmd("div"), 4, { partial: "div", startIndex: 0, endIndex: 4 }],
   ])("finds %s", (_name, text, cursor, expected) => {
@@ -26,41 +29,63 @@ describe("symbol shortcuts", () => {
   test("orders suggestions, defaults collisions, and keeps metadata valid", () => {
     expect(displays("a")).toEqual(["alpha", "ast", "approx", "angle"].map(cmd));
     for (const [partial, names] of [
-      ["A", ["Alpha"]], ["in", ["in", "infty", "int"]], ["sub", ["subset", "subseteq"]],
+      ["A", ["Alpha"]],
+      ["in", ["in", "infty", "int"]],
+      ["sub", ["subset", "subseteq"]],
       ["R", ["R", "Rho", "Rightarrow"]],
-    ] as const) expect(displays(partial).sort()).toEqual(names.map(cmd).sort());
+    ] as const)
+      expect(displays(partial).sort()).toEqual(names.map(cmd).sort());
     for (const [partial, name, replacement] of [
-      ["in", "in", "∈"], ["to", "to", "→"], ["subset", "subset", "⊂"], ["a", "alpha", "α"],
-    ] as const) expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
+      ["in", "in", "∈"],
+      ["to", "to", "→"],
+      ["subset", "subset", "⊂"],
+      ["a", "alpha", "α"],
+    ] as const)
+      expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
     const suggestions = getSymbolSuggestions("");
-    expect(suggestions.map(({ display, replacement, description }) => [
-      display.startsWith(bs), replacement === description,
-    ])).toEqual(suggestions.map(() => [true, true]));
+    expect(
+      suggestions.map(({ display, replacement, description }) => [
+        display.startsWith(bs),
+        replacement === description,
+      ])
+    ).toEqual(suggestions.map(() => [true, true]));
     expect(new Set(displays("")).size).toBe(suggestions.length);
     expect(getSymbolSuggestions("zzz")).toEqual([]);
   });
 
   test.each([
-    ["lowercase Greek", cmd("alpha"), 6, { text: "α", cursor: 1 }], ["uppercase Greek", cmd("Alpha"), 6, { text: "Α", cursor: 1 }],
-    ["comparison", cmd("leq"), 4, { text: "≤", cursor: 1 }], ["multiplication", cmd("times"), 6, { text: "×", cursor: 1 }],
-    ["set", cmd("subseteq"), 9, { text: "⊆", cursor: 1 }], ["logic", cmd("implies"), 8, { text: "⟹", cursor: 1 }],
-    ["arrow", cmd("rightarrow"), 11, { text: "→", cursor: 1 }], ["currency", cmd("euro"), 5, { text: "€", cursor: 1 }],
-    ["cryptocurrency", cmd("bitcoin"), 8, { text: "₿", cursor: 1 }], ["big operator", cmd("sum"), 4, { text: "∑", cursor: 1 }],
+    ["lowercase Greek", cmd("alpha"), 6, { text: "α", cursor: 1 }],
+    ["uppercase Greek", cmd("Alpha"), 6, { text: "Α", cursor: 1 }],
+    ["comparison", cmd("leq"), 4, { text: "≤", cursor: 1 }],
+    ["multiplication", cmd("times"), 6, { text: "×", cursor: 1 }],
+    ["set", cmd("subseteq"), 9, { text: "⊆", cursor: 1 }],
+    ["logic", cmd("implies"), 8, { text: "⟹", cursor: 1 }],
+    ["arrow", cmd("rightarrow"), 11, { text: "→", cursor: 1 }],
+    ["currency", cmd("euro"), 5, { text: "€", cursor: 1 }],
+    ["cryptocurrency", cmd("bitcoin"), 8, { text: "₿", cursor: 1 }],
+    ["big operator", cmd("sum"), 4, { text: "∑", cursor: 1 }],
     ["surrounding text", `x ${cmd("geq")}`, 6, { text: "x ≥", cursor: 3 }],
     ["unambiguous prefix collision", cmd("int"), 4, { text: "∫", cursor: 1 }],
     ["unambiguous word", cmd("top"), 4, { text: "⊤", cursor: 1 }],
-    ["ambiguous in", cmd("in"), 3, null], ["ambiguous to", cmd("to"), 3, null],
-    ["ambiguous subset", cmd("subset"), 7, null], ["ambiguous R", cmd("R"), 2, null],
-    ["partial name", cmd("alph"), 5, null], ["unknown name", cmd("alphax"), 7, null],
-    ["mid-token caret", cmd("alpha"), 3, null], ["escaped command", bs + cmd("alpha"), 7, null],
+    ["ambiguous in", cmd("in"), 3, null],
+    ["ambiguous to", cmd("to"), 3, null],
+    ["ambiguous subset", cmd("subset"), 7, null],
+    ["ambiguous R", cmd("R"), 2, null],
+    ["partial name", cmd("alph"), 5, null],
+    ["unknown name", cmd("alphax"), 7, null],
+    ["mid-token caret", cmd("alpha"), 3, null],
+    ["escaped command", bs + cmd("alpha"), 7, null],
   ])("converts at cursor: %s", (_name, input, cursor, expected) => {
     expect(convertSymbolCommandAtCursor(input, cursor)).toEqual(expected);
   });
 
   test.each([
-    ["ambiguous name", cmd("in") + " ", 4, { text: "∈ ", cursor: 2 }], ["set name", cmd("subset") + ")", 8, { text: "⊂)", cursor: 2 }],
-    ["single-letter set", cmd("R") + ")", 3, { text: "ℝ)", cursor: 2 }], ["pasted unambiguous run", cmd("alpha") + " ", 7, { text: "α ", cursor: 2 }],
-    ["unterminated name", cmd("in"), 3, null], ["unknown name", cmd("nope") + " ", 6, null],
+    ["ambiguous name", cmd("in") + " ", 4, { text: "∈ ", cursor: 2 }],
+    ["set name", cmd("subset") + ")", 8, { text: "⊂)", cursor: 2 }],
+    ["single-letter set", cmd("R") + ")", 3, { text: "ℝ)", cursor: 2 }],
+    ["pasted unambiguous run", cmd("alpha") + " ", 7, { text: "α ", cursor: 2 }],
+    ["unterminated name", cmd("in"), 3, null],
+    ["unknown name", cmd("nope") + " ", 6, null],
     ["escaped command", bs + cmd("in") + " ", 5, null],
   ])("converts terminated command: %s", (_name, input, cursor, expected) => {
     expect(convertTerminatedSymbolCommand(input, cursor)).toEqual(expected);

--- a/src/browser/features/ChatInput/symbolShortcuts.test.ts
+++ b/src/browser/features/ChatInput/symbolShortcuts.test.ts
@@ -6,180 +6,112 @@ import {
   getSymbolSuggestions,
 } from "@/browser/features/ChatInput/symbolShortcuts";
 
-// Build backslash-prefixed inputs without literal backslashes in source.
 const bs = String.fromCharCode(92);
 const cmd = (name: string) => `${bs}${name}`;
+const displays = (partial: string) =>
+  getSymbolSuggestions(partial).map((suggestion) => suggestion.display);
+const fenced = "```\n" + cmd("sum") + "\n```";
 
 describe("findSymbolCommandAtCursor", () => {
-  test("matches a partial command at the cursor", () => {
-    expect(findSymbolCommandAtCursor(cmd("al"), 3)).toEqual({
-      partial: "al",
-      startIndex: 0,
-      endIndex: 3,
-    });
-  });
-
-  test("matches the bare trigger with an empty partial", () => {
-    expect(findSymbolCommandAtCursor(bs, 1)).toEqual({ partial: "", startIndex: 0, endIndex: 1 });
-  });
-
-  test("captures the full token even when the caret is mid-word", () => {
-    expect(findSymbolCommandAtCursor(cmd("alpha"), 3)).toEqual({
-      partial: "alpha",
-      startIndex: 0,
-      endIndex: 6,
-    });
-  });
-
-  test("returns null without a trigger and ignores escaped triggers", () => {
-    expect(findSymbolCommandAtCursor("alpha", 5)).toBeNull();
-    expect(findSymbolCommandAtCursor(`${bs}${bs}alpha`, 7)).toBeNull();
-  });
-
-  test("does not match inside inline code or fenced blocks", () => {
-    // Inline code span: `\div`
-    expect(findSymbolCommandAtCursor("`" + cmd("div") + "`", 5)).toBeNull();
-    // Fenced block
-    const fenced = "```\n" + cmd("sum") + "\n```";
-    const cursorInFence = fenced.indexOf("m") + 1;
-    expect(findSymbolCommandAtCursor(fenced, cursorInFence)).toBeNull();
-    // Same token outside code still matches
-    expect(findSymbolCommandAtCursor(cmd("div"), 4)?.partial).toBe("div");
+  test.each([
+    ["partial command", cmd("al"), 3, { partial: "al", startIndex: 0, endIndex: 3 }],
+    ["bare trigger", bs, 1, { partial: "", startIndex: 0, endIndex: 1 }],
+    ["caret in a token", cmd("alpha"), 3, { partial: "alpha", startIndex: 0, endIndex: 6 }],
+    ["no trigger", "alpha", 5, null],
+    ["escaped trigger", `${bs}${bs}alpha`, 7, null],
+    ["inline code", "`" + cmd("div") + "`", 5, null],
+    ["fenced code", fenced, fenced.indexOf("m") + 1, null],
+    ["token outside code", cmd("div"), 4, { partial: "div", startIndex: 0, endIndex: 4 }],
+  ])("handles %s", (_name, text, cursor, expected) => {
+    expect(findSymbolCommandAtCursor(text, cursor)).toEqual(expected);
   });
 });
 
 describe("getSymbolSuggestions", () => {
-  test("filtering is case-sensitive so name case picks glyph case", () => {
-    const lower = getSymbolSuggestions("a");
-    expect(lower.map((s) => s.display)).toEqual([
-      cmd("alpha"),
-      cmd("ast"),
-      cmd("approx"),
-      cmd("angle"),
-    ]);
-    const upper = getSymbolSuggestions("A");
-    expect(upper.map((s) => s.display)).toEqual([cmd("Alpha")]);
+  test.each([
+    ["a", ["alpha", "ast", "approx", "angle"], true],
+    ["A", ["Alpha"], true],
+    ["in", ["in", "infty", "int"], false],
+    ["sub", ["subset", "subseteq"], false],
+    ["R", ["R", "Rho", "Rightarrow"], false],
+  ])("lists %s commands in the intended order", (partial, names, ordered) => {
+    const actual = displays(partial);
+    expect(ordered ? actual : actual.sort()).toEqual(
+      ordered ? names.map(cmd) : names.map(cmd).sort()
+    );
   });
 
-  test("an exact match is the default (first) suggestion so Tab accepts it", () => {
-    // Regression: typing "\in" + Tab must yield ∈, not ∞/∫ — the exact match
-    // floats above its longer prefix-completions.
-    expect(getSymbolSuggestions("in")[0]?.display).toBe(cmd("in"));
-    expect(getSymbolSuggestions("in")[0]?.replacement).toBe("∈");
-    expect(getSymbolSuggestions("to")[0]?.display).toBe(cmd("to"));
-    expect(getSymbolSuggestions("subset")[0]?.display).toBe(cmd("subset"));
+  test.each([
+    ["in", "in", "∈"],
+    ["to", "to", "→"],
+    ["subset", "subset", "⊂"],
+    ["a", "alpha", "α"],
+  ])("makes %s default to %s", (partial, name, replacement) => {
+    expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
   });
 
-  test("non-exact queries keep curated order (no shorter-sibling hijack)", () => {
-    // "\a" has no exact match, so the curated Greek-first ordering stands and
-    // \alpha remains the default rather than the shorter \ast.
-    expect(getSymbolSuggestions("a")[0]?.display).toBe(cmd("alpha"));
-  });
-
-  test("prefix-colliding names all appear in the menu", () => {
-    expect(
-      getSymbolSuggestions("in")
-        .map((s) => s.display)
-        .sort()
-    ).toEqual([cmd("in"), cmd("infty"), cmd("int")].sort());
-    expect(
-      getSymbolSuggestions("sub")
-        .map((s) => s.display)
-        .sort()
-    ).toEqual([cmd("subset"), cmd("subseteq")].sort());
-    // Single-letter set names collide with capitalized Greek + arrows.
-    expect(
-      getSymbolSuggestions("R")
-        .map((s) => s.display)
-        .sort()
-    ).toEqual([cmd("R"), cmd("Rho"), cmd("Rightarrow")].sort());
-  });
-
-  test("each suggestion's replacement matches its glyph", () => {
-    for (const s of getSymbolSuggestions("")) {
-      expect(s.replacement).toBe(s.description);
-      expect(s.display.startsWith(bs)).toBe(true);
+  test("keeps suggestion metadata and command names valid", () => {
+    const suggestions = getSymbolSuggestions("");
+    for (const suggestion of suggestions) {
+      expect(suggestion.replacement).toBe(suggestion.description);
+      expect(suggestion.display.startsWith(bs)).toBe(true);
     }
+    expect(new Set(displays("")).size).toBe(suggestions.length);
   });
 
-  test("command names are unique", () => {
-    const names = getSymbolSuggestions("").map((s) => s.display);
-    expect(new Set(names).size).toBe(names.length);
-  });
-
-  test("no match yields no suggestions", () => {
+  test("returns no suggestions for an unknown prefix", () => {
     expect(getSymbolSuggestions("zzz")).toEqual([]);
   });
 });
 
-describe("convertSymbolCommandAtCursor (eager, unambiguous only)", () => {
-  test("converts completed Greek commands by case", () => {
-    expect(convertSymbolCommandAtCursor(cmd("alpha"), 6)).toEqual({ text: "α", cursor: 1 });
-    expect(convertSymbolCommandAtCursor(cmd("Alpha"), 6)).toEqual({ text: "Α", cursor: 1 });
+describe("convertSymbolCommandAtCursor", () => {
+  test.each([
+    ["lowercase Greek", cmd("alpha"), 6, "α", 1],
+    ["uppercase Greek", cmd("Alpha"), 6, "Α", 1],
+    ["comparison", cmd("leq"), 4, "≤", 1],
+    ["multiplication", cmd("times"), 6, "×", 1],
+    ["set", cmd("subseteq"), 9, "⊆", 1],
+    ["logic", cmd("implies"), 8, "⟹", 1],
+    ["arrow", cmd("rightarrow"), 11, "→", 1],
+    ["currency", cmd("euro"), 5, "€", 1],
+    ["cryptocurrency", cmd("bitcoin"), 8, "₿", 1],
+    ["big operator", cmd("sum"), 4, "∑", 1],
+    ["surrounding text", `x ${cmd("geq")}`, 6, "x ≥", 3],
+    ["unambiguous prefix collision", cmd("int"), 4, "∫", 1],
+    ["unambiguous word", cmd("top"), 4, "⊤", 1],
+  ])("converts %s", (_name, input, cursor, text, nextCursor) => {
+    expect(convertSymbolCommandAtCursor(input, cursor)).toEqual({ text, cursor: nextCursor });
   });
 
-  test("converts representative symbols across categories", () => {
-    expect(convertSymbolCommandAtCursor(cmd("leq"), 4)?.text).toBe("≤"); // math
-    expect(convertSymbolCommandAtCursor(cmd("times"), 6)?.text).toBe("×"); // math
-    expect(convertSymbolCommandAtCursor(cmd("subseteq"), 9)?.text).toBe("⊆"); // set
-    expect(convertSymbolCommandAtCursor(cmd("implies"), 8)?.text).toBe("⟹"); // logic
-    expect(convertSymbolCommandAtCursor(cmd("rightarrow"), 11)?.text).toBe("→"); // arrow
-    expect(convertSymbolCommandAtCursor(cmd("euro"), 5)?.text).toBe("€"); // currency
-    expect(convertSymbolCommandAtCursor(cmd("bitcoin"), 8)?.text).toBe("₿"); // currency
-    expect(convertSymbolCommandAtCursor(cmd("sum"), 4)?.text).toBe("∑"); // bigop
-  });
-
-  test("converts in place within surrounding text", () => {
-    expect(convertSymbolCommandAtCursor(`x ${cmd("geq")}`, 6)).toEqual({ text: "x ≥", cursor: 3 });
-  });
-
-  test("does NOT eager-convert a name that is a prefix of another", () => {
-    expect(convertSymbolCommandAtCursor(cmd("in"), 3)).toBeNull(); // prefix of int/infty
-    expect(convertSymbolCommandAtCursor(cmd("to"), 3)).toBeNull(); // prefix of top
-    expect(convertSymbolCommandAtCursor(cmd("subset"), 7)).toBeNull(); // prefix of subseteq
-    expect(convertSymbolCommandAtCursor(cmd("R"), 2)).toBeNull(); // prefix of Rho/Rightarrow
-  });
-
-  test("eager-converts once the name becomes unambiguous", () => {
-    expect(convertSymbolCommandAtCursor(cmd("int"), 4)).toEqual({ text: "∫", cursor: 1 });
-    expect(convertSymbolCommandAtCursor(cmd("top"), 4)).toEqual({ text: "⊤", cursor: 1 });
-    expect(convertSymbolCommandAtCursor(cmd("subseteq"), 9)).toEqual({ text: "⊆", cursor: 1 });
-  });
-
-  test("does not convert a partial, unknown, or mid-token name", () => {
-    expect(convertSymbolCommandAtCursor(cmd("alph"), 5)).toBeNull();
-    expect(convertSymbolCommandAtCursor(cmd("alphax"), 7)).toBeNull();
-    expect(convertSymbolCommandAtCursor(cmd("alpha"), 3)).toBeNull();
-  });
-
-  test("does not convert an escaped command", () => {
-    expect(convertSymbolCommandAtCursor(`${bs}${bs}alpha`, 7)).toBeNull();
+  test.each([
+    ["ambiguous in", cmd("in"), 3],
+    ["ambiguous to", cmd("to"), 3],
+    ["ambiguous subset", cmd("subset"), 7],
+    ["ambiguous R", cmd("R"), 2],
+    ["partial name", cmd("alph"), 5],
+    ["unknown name", cmd("alphax"), 7],
+    ["mid-token caret", cmd("alpha"), 3],
+    ["escaped command", `${bs}${bs}alpha`, 7],
+  ])("does not convert %s", (_name, input, cursor) => {
+    expect(convertSymbolCommandAtCursor(input, cursor)).toBeNull();
   });
 });
 
-describe("convertTerminatedSymbolCommand (accept on space/punctuation)", () => {
-  test("converts an ambiguous name when a terminator follows", () => {
-    expect(convertTerminatedSymbolCommand(cmd("in") + " ", 4)).toEqual({ text: "∈ ", cursor: 2 });
-    expect(convertTerminatedSymbolCommand(cmd("subset") + ")", 8)).toEqual({
-      text: "⊂)",
-      cursor: 2,
-    });
-    expect(convertTerminatedSymbolCommand(cmd("R") + ")", 3)).toEqual({ text: "ℝ)", cursor: 2 });
+describe("convertTerminatedSymbolCommand", () => {
+  test.each([
+    ["ambiguous name", cmd("in") + " ", 4, "∈ ", 2],
+    ["set name", cmd("subset") + ")", 8, "⊂)", 2],
+    ["single-letter set", cmd("R") + ")", 3, "ℝ)", 2],
+    ["pasted unambiguous run", cmd("alpha") + " ", 7, "α ", 2],
+  ])("converts %s", (_name, input, cursor, text, nextCursor) => {
+    expect(convertTerminatedSymbolCommand(input, cursor)).toEqual({ text, cursor: nextCursor });
   });
 
-  test("converts a pasted unambiguous run ending in a terminator", () => {
-    expect(convertTerminatedSymbolCommand(cmd("alpha") + " ", 7)).toEqual({
-      text: "α ",
-      cursor: 2,
-    });
-  });
-
-  test("does nothing without a terminator or for unknown names", () => {
-    expect(convertTerminatedSymbolCommand(cmd("in"), 3)).toBeNull(); // no terminator
-    expect(convertTerminatedSymbolCommand(cmd("nope") + " ", 6)).toBeNull();
-  });
-
-  test("does not convert an escaped command on terminator", () => {
-    expect(convertTerminatedSymbolCommand(`${bs}${bs}in `, 5)).toBeNull();
+  test.each([
+    ["unterminated name", cmd("in"), 3],
+    ["unknown name", cmd("nope") + " ", 6],
+    ["escaped command", `${bs}${bs}in `, 5],
+  ])("does not convert %s", (_name, input, cursor) => {
+    expect(convertTerminatedSymbolCommand(input, cursor)).toBeNull();
   });
 });

--- a/src/browser/features/ChatInput/symbolShortcuts.test.ts
+++ b/src/browser/features/ChatInput/symbolShortcuts.test.ts
@@ -44,11 +44,11 @@ describe("symbol shortcuts", () => {
       expect(getSymbolSuggestions(partial)[0]).toMatchObject({ display: cmd(name), replacement });
     const suggestions = getSymbolSuggestions("");
     expect(
-      suggestions.map(({ display, replacement, description }) => [
-        display.startsWith(bs),
-        replacement === description,
-      ])
-    ).toEqual(suggestions.map(() => [true, true]));
+      suggestions.every(
+        ({ display, replacement, description }) =>
+          display.startsWith(bs) && replacement === description
+      )
+    ).toBe(true);
     expect(new Set(displays("")).size).toBe(suggestions.length);
     expect(getSymbolSuggestions("zzz")).toEqual([]);
   });

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -1,10 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import type React from "react";
 import { useAPI } from "@/browser/contexts/API";
-import {
-  subscribePersistedStateWrites,
-  updatePersistedState,
-} from "@/browser/hooks/usePersistedState";
 import {
   extractAttachmentsFromClipboard,
   extractAttachmentsFromDrop,
@@ -12,11 +8,6 @@ import {
 } from "@/browser/utils/attachmentsHandling";
 import type { ChatAttachment } from "./ChatAttachments";
 import type { Toast } from "./ChatInputToast";
-import {
-  estimatePersistedChatAttachmentsChars,
-  MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS,
-  readPersistedChatAttachments,
-} from "./draftAttachmentsStorage";
 
 const PDF_MEDIA_TYPE = "application/pdf";
 const EDIT_MODE_ATTACHMENT_ERROR_MESSAGE = "Attachments cannot be added while editing a message.";
@@ -26,7 +17,10 @@ type PushToast = (toast: Omit<Toast, "id" | "type"> & { type: Toast["type"] | "i
 interface UseComposerAttachmentsOptions {
   variant: "creation" | "workspace";
   workspaceId: string | null;
-  attachmentsKey: string;
+  attachments: ChatAttachment[];
+  setAttachments: (
+    value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])
+  ) => void;
   editingMessage: boolean;
   pushToast: PushToast;
 }
@@ -52,70 +46,8 @@ export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
 }
 export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { api } = useAPI();
-  const tooLargeToastKeyRef = useRef<string | null>(null);
-  // External draft transfers must not replace an oversized attachment kept only in memory.
-  const selfWriteRef = useRef(false);
-  const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
-    readPersistedChatAttachments(options.attachmentsKey)
-  );
+  const { attachments, setAttachments } = options;
   const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
-
-  const persistAttachments = useCallback(
-    (next: ChatAttachment[]) => {
-      selfWriteRef.current = true;
-      try {
-        if (next.length === 0) {
-          tooLargeToastKeyRef.current = null;
-          updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, undefined);
-          return;
-        }
-        if (estimatePersistedChatAttachmentsChars(next) > MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS) {
-          updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, undefined);
-          if (tooLargeToastKeyRef.current !== options.attachmentsKey) {
-            tooLargeToastKeyRef.current = options.attachmentsKey;
-            options.pushToast({
-              type: "error",
-              message:
-                "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
-              duration: 5000,
-            });
-          }
-          return;
-        }
-        tooLargeToastKeyRef.current = null;
-        updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, next);
-      } finally {
-        selfWriteRef.current = false;
-      }
-    },
-    [options.attachmentsKey, options.pushToast]
-  );
-
-  useEffect(() => {
-    tooLargeToastKeyRef.current = null;
-    setAttachmentsState(readPersistedChatAttachments(options.attachmentsKey));
-  }, [options.attachmentsKey]);
-
-  useEffect(
-    () =>
-      subscribePersistedStateWrites((event) => {
-        if (event.key === options.attachmentsKey && !selfWriteRef.current) {
-          setAttachmentsState(readPersistedChatAttachments(options.attachmentsKey));
-        }
-      }),
-    [options.attachmentsKey]
-  );
-
-  const setAttachments = useCallback(
-    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) => {
-      setAttachmentsState((previous) => {
-        const next = value instanceof Function ? value(previous) : value;
-        persistAttachments(next);
-        return next;
-      });
-    },
-    [persistAttachments]
-  );
 
   const showResizeToast = useCallback(
     (next: ChatAttachment[]) => {

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type React from "react";
+import { useAPI } from "@/browser/contexts/API";
+import {
+  subscribePersistedStateWrites,
+  updatePersistedState,
+} from "@/browser/hooks/usePersistedState";
+import {
+  extractAttachmentsFromClipboard,
+  extractAttachmentsFromDrop,
+  processAttachmentFiles,
+} from "@/browser/utils/attachmentsHandling";
+import type { ChatAttachment } from "./ChatAttachments";
+import type { Toast } from "./ChatInputToast";
+import {
+  estimatePersistedChatAttachmentsChars,
+  MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS,
+  readPersistedChatAttachments,
+} from "./draftAttachmentsStorage";
+
+const PDF_MEDIA_TYPE = "application/pdf";
+const EDIT_MODE_ATTACHMENT_ERROR_MESSAGE = "Attachments cannot be added while editing a message.";
+
+type PushToast = (toast: Omit<Toast, "id" | "type"> & { type: Toast["type"] | "info" }) => void;
+
+interface UseComposerAttachmentsOptions {
+  variant: "creation" | "workspace";
+  workspaceId: string | null;
+  attachmentsKey: string;
+  editingMessage: boolean;
+  pushToast: PushToast;
+}
+
+export function getBaseMediaType(mediaType: string): string {
+  return mediaType.toLowerCase().trim().split(";")[0];
+}
+
+export function isPdfAttachment(
+  attachment: ChatAttachment
+): attachment is Extract<ChatAttachment, { kind: "provider" }> {
+  return (
+    attachment.kind === "provider" && getBaseMediaType(attachment.mediaType) === PDF_MEDIA_TYPE
+  );
+}
+
+export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
+  if (!dataUrl.startsWith("data:")) return null;
+  const commaIndex = dataUrl.indexOf(",");
+  if (commaIndex === -1) return null;
+  const header = dataUrl.slice("data:".length, commaIndex);
+  if (!header.includes(";base64")) return null;
+  const base64 = dataUrl.slice(commaIndex + 1);
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
+
+export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
+  const { api } = useAPI();
+  const tooLargeToastKeyRef = useRef<string | null>(null);
+  const selfWriteRef = useRef(false);
+  const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
+    readPersistedChatAttachments(options.attachmentsKey)
+  );
+  const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
+
+  const persistAttachments = useCallback(
+    (next: ChatAttachment[]) => {
+      selfWriteRef.current = true;
+      try {
+        if (next.length === 0) {
+          tooLargeToastKeyRef.current = null;
+          updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, undefined);
+          return;
+        }
+        if (estimatePersistedChatAttachmentsChars(next) > MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS) {
+          updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, undefined);
+          if (tooLargeToastKeyRef.current !== options.attachmentsKey) {
+            tooLargeToastKeyRef.current = options.attachmentsKey;
+            options.pushToast({
+              type: "error",
+              message:
+                "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
+              duration: 5000,
+            });
+          }
+          return;
+        }
+        tooLargeToastKeyRef.current = null;
+        updatePersistedState<ChatAttachment[] | undefined>(options.attachmentsKey, next);
+      } finally {
+        selfWriteRef.current = false;
+      }
+    },
+    [options.attachmentsKey, options.pushToast]
+  );
+
+  useEffect(() => {
+    tooLargeToastKeyRef.current = null;
+    setAttachmentsState(readPersistedChatAttachments(options.attachmentsKey));
+  }, [options.attachmentsKey]);
+
+  useEffect(
+    () =>
+      subscribePersistedStateWrites((event) => {
+        if (event.key === options.attachmentsKey && !selfWriteRef.current) {
+          setAttachmentsState(readPersistedChatAttachments(options.attachmentsKey));
+        }
+      }),
+    [options.attachmentsKey]
+  );
+
+  const setAttachments = useCallback(
+    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) => {
+      setAttachmentsState((previous) => {
+        const next = value instanceof Function ? value(previous) : value;
+        persistAttachments(next);
+        return next;
+      });
+    },
+    [persistAttachments]
+  );
+
+  const showResizeToast = useCallback(
+    (next: ChatAttachment[]) => {
+      const resized = next.filter(
+        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
+          attachment.kind === "provider" && attachment.resizeInfo != null
+      );
+      const resizeInfo = resized[0]?.resizeInfo;
+      if (!resizeInfo) return;
+      options.pushToast({
+        type: "info",
+        message:
+          resized.length === 1
+            ? `Image resized from ${resizeInfo.originalWidth}×${resizeInfo.originalHeight} to ${resizeInfo.newWidth}×${resizeInfo.newHeight}`
+            : `${resized.length} images resized to fit provider limits`,
+      });
+    },
+    [options.pushToast]
+  );
+
+  const processFiles = useCallback(
+    (files: File[]) => {
+      setProcessingAttachmentCount((count) => count + 1);
+      return processAttachmentFiles(files, {
+        stageAttachment:
+          options.variant === "workspace"
+            ? async (file, dataBase64) => {
+                if (!api) throw new Error("Not connected to server");
+                if (options.workspaceId == null)
+                  throw new Error("Files can be staged after opening a workspace.");
+                const result = await api.workspace.stageAttachment({
+                  workspaceId: options.workspaceId,
+                  filename: file.name,
+                  mediaType: file.type || null,
+                  sizeBytes: file.size,
+                  dataBase64,
+                });
+                if (!result.success) throw new Error(result.error);
+                return result.data;
+              }
+            : undefined,
+        holdNonProviderFiles: options.variant === "creation",
+      }).finally(() => setProcessingAttachmentCount((count) => Math.max(0, count - 1)));
+    },
+    [api, options.variant, options.workspaceId]
+  );
+
+  const attachFiles = useCallback(
+    (files: File[]) => {
+      void Promise.all(
+        files.map((file) =>
+          processFiles([file]).then(
+            (processed) => ({ ok: true as const, attachments: processed }),
+            (error: unknown) => ({ ok: false as const, error })
+          )
+        )
+      ).then((outcomes) => {
+        const successes = outcomes.flatMap((outcome) => (outcome.ok ? outcome.attachments : []));
+        if (successes.length > 0) {
+          setAttachments((previous) => [...previous, ...successes]);
+          showResizeToast(successes);
+        }
+        for (const outcome of outcomes) {
+          if (outcome.ok) continue;
+          console.error("Failed to process attached file:", outcome.error);
+          options.pushToast({
+            type: "error",
+            message:
+              outcome.error instanceof Error
+                ? outcome.error.message
+                : "Failed to process attachment",
+          });
+        }
+      });
+    },
+    [options.pushToast, processFiles, setAttachments, showResizeToast]
+  );
+
+  const rejectEditAttachment = useCallback(() => {
+    options.pushToast({ type: "error", message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE });
+  }, [options.pushToast]);
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const files = event.clipboardData?.items
+        ? extractAttachmentsFromClipboard(event.clipboardData.items)
+        : [];
+      if (files.length === 0) return;
+      if (options.editingMessage) {
+        rejectEditAttachment();
+        return;
+      }
+      event.preventDefault();
+      attachFiles(files);
+    },
+    [attachFiles, options.editingMessage, rejectEditAttachment]
+  );
+
+  const handleAttachFiles = useCallback(
+    (files: File[]) => {
+      if (options.editingMessage) rejectEditAttachment();
+      else attachFiles(files);
+    },
+    [attachFiles, options.editingMessage, rejectEditAttachment]
+  );
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLTextAreaElement>) => {
+      if (!event.dataTransfer.types.includes("Files")) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = options.editingMessage ? "none" : "copy";
+    },
+    [options.editingMessage]
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLTextAreaElement>) => {
+      event.preventDefault();
+      const files = extractAttachmentsFromDrop(event.dataTransfer);
+      if (files.length === 0) return;
+      if (options.editingMessage) rejectEditAttachment();
+      else attachFiles(files);
+    },
+    [attachFiles, options.editingMessage, rejectEditAttachment]
+  );
+
+  const handleRemoveAttachment = useCallback(
+    (id: string) => {
+      setAttachments((previous) => previous.filter((item) => item.id !== id));
+    },
+    [setAttachments]
+  );
+
+  return {
+    attachments,
+    setAttachments,
+    processingAttachmentCount,
+    handlePaste,
+    handleAttachFiles,
+    handleDragOver,
+    handleDrop,
+    handleRemoveAttachment,
+  };
+}

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -53,7 +53,7 @@ export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
 export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { api } = useAPI();
   const tooLargeToastKeyRef = useRef<string | null>(null);
-  // External draft transfers must not overwrite an oversized attachment kept only in memory.
+  // External draft transfers must not replace an oversized attachment kept only in memory.
   const selfWriteRef = useRef(false);
   const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
     readPersistedChatAttachments(options.attachmentsKey)

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -24,7 +24,7 @@ interface UseComposerAttachmentsOptions {
   editingMessage: boolean;
   pushToast: PushToast;
 }
-export function getBaseMediaType(mediaType: string): string {
+function getBaseMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
 }
 export function isPdfAttachment(

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import type React from "react";
 import { useAPI } from "@/browser/contexts/API";
 import {
@@ -48,137 +48,111 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { setAttachments, editingMessage, pushToast, variant, workspaceId } = options;
   const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
 
-  const showResizeToast = useCallback(
-    (next: ChatAttachment[]) => {
-      const resized = next.filter(
-        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
-          attachment.kind === "provider" && attachment.resizeInfo != null
-      );
-      const resizeInfo = resized[0]?.resizeInfo;
-      if (!resizeInfo) return;
-      pushToast({
-        type: "info",
-        message:
-          resized.length === 1
-            ? `Image resized from ${resizeInfo.originalWidth}×${resizeInfo.originalHeight} to ${resizeInfo.newWidth}×${resizeInfo.newHeight}`
-            : `${resized.length} images resized to fit provider limits`,
-      });
-    },
-    [pushToast]
-  );
+  const showResizeToast = (next: ChatAttachment[]) => {
+    const resized = next.filter(
+      (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
+        attachment.kind === "provider" && attachment.resizeInfo != null
+    );
+    const resizeInfo = resized[0]?.resizeInfo;
+    if (!resizeInfo) return;
+    pushToast({
+      type: "info",
+      message:
+        resized.length === 1
+          ? `Image resized from ${resizeInfo.originalWidth}×${resizeInfo.originalHeight} to ${resizeInfo.newWidth}×${resizeInfo.newHeight}`
+          : `${resized.length} images resized to fit provider limits`,
+    });
+  };
 
-  const processFiles = useCallback(
-    (files: File[]) => {
-      setProcessingAttachmentCount((count) => count + 1);
-      return processAttachmentFiles(files, {
-        stageAttachment:
-          variant === "workspace"
-            ? async (file, dataBase64) => {
-                if (!api) throw new Error("Not connected to server");
-                if (workspaceId == null)
-                  throw new Error("Files can be staged after opening a workspace.");
-                const result = await api.workspace.stageAttachment({
-                  workspaceId,
-                  filename: file.name,
-                  mediaType: file.type || null,
-                  sizeBytes: file.size,
-                  dataBase64,
-                });
-                if (!result.success) throw new Error(result.error);
-                return result.data;
-              }
-            : undefined,
-        holdNonProviderFiles: variant === "creation",
-      }).finally(() => setProcessingAttachmentCount((count) => Math.max(0, count - 1)));
-    },
-    [api, variant, workspaceId]
-  );
+  const processFiles = (files: File[]) => {
+    setProcessingAttachmentCount((count) => count + 1);
+    return processAttachmentFiles(files, {
+      stageAttachment:
+        variant === "workspace"
+          ? async (file, dataBase64) => {
+              if (!api) throw new Error("Not connected to server");
+              if (workspaceId == null)
+                throw new Error("Files can be staged after opening a workspace.");
+              const result = await api.workspace.stageAttachment({
+                workspaceId,
+                filename: file.name,
+                mediaType: file.type || null,
+                sizeBytes: file.size,
+                dataBase64,
+              });
+              if (!result.success) throw new Error(result.error);
+              return result.data;
+            }
+          : undefined,
+      holdNonProviderFiles: variant === "creation",
+    }).finally(() => setProcessingAttachmentCount((count) => Math.max(0, count - 1)));
+  };
 
-  const attachFiles = useCallback(
-    (files: File[]) => {
-      void Promise.all(
-        files.map((file) =>
-          processFiles([file]).then(
-            (processed) => ({ ok: true as const, attachments: processed }),
-            (error: unknown) => ({ ok: false as const, error })
-          )
+  const attachFiles = (files: File[]) => {
+    void Promise.all(
+      files.map((file) =>
+        processFiles([file]).then(
+          (processed) => ({ ok: true as const, attachments: processed }),
+          (error: unknown) => ({ ok: false as const, error })
         )
-      ).then((outcomes) => {
-        const successes = outcomes.flatMap((outcome) => (outcome.ok ? outcome.attachments : []));
-        if (successes.length > 0) {
-          setAttachments((previous) => [...previous, ...successes]);
-          showResizeToast(successes);
-        }
-        for (const outcome of outcomes) {
-          if (outcome.ok) continue;
-          console.error("Failed to process attached file:", outcome.error);
-          pushToast({
-            type: "error",
-            message:
-              outcome.error instanceof Error
-                ? outcome.error.message
-                : "Failed to process attachment",
-          });
-        }
-      });
-    },
-    [pushToast, processFiles, setAttachments, showResizeToast]
-  );
-
-  const rejectEditAttachment = useCallback(() => {
-    pushToast({ type: "error", message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE });
-  }, [pushToast]);
-
-  const handlePaste = useCallback(
-    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const files = event.clipboardData?.items
-        ? extractAttachmentsFromClipboard(event.clipboardData.items)
-        : [];
-      if (files.length === 0) return;
-      if (editingMessage) {
-        rejectEditAttachment();
-        return;
+      )
+    ).then((outcomes) => {
+      const successes = outcomes.flatMap((outcome) => (outcome.ok ? outcome.attachments : []));
+      if (successes.length > 0) {
+        setAttachments((previous) => [...previous, ...successes]);
+        showResizeToast(successes);
       }
-      event.preventDefault();
-      attachFiles(files);
-    },
-    [attachFiles, editingMessage, rejectEditAttachment]
-  );
+      for (const outcome of outcomes) {
+        if (outcome.ok) continue;
+        console.error("Failed to process attached file:", outcome.error);
+        pushToast({
+          type: "error",
+          message:
+            outcome.error instanceof Error ? outcome.error.message : "Failed to process attachment",
+        });
+      }
+    });
+  };
 
-  const handleAttachFiles = useCallback(
-    (files: File[]) => {
-      if (editingMessage) rejectEditAttachment();
-      else attachFiles(files);
-    },
-    [attachFiles, editingMessage, rejectEditAttachment]
-  );
+  const rejectEditAttachment = () => {
+    pushToast({ type: "error", message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE });
+  };
 
-  const handleDragOver = useCallback(
-    (event: React.DragEvent<HTMLTextAreaElement>) => {
-      if (!event.dataTransfer.types.includes("Files")) return;
-      event.preventDefault();
-      event.dataTransfer.dropEffect = editingMessage ? "none" : "copy";
-    },
-    [editingMessage]
-  );
+  const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const files = event.clipboardData?.items
+      ? extractAttachmentsFromClipboard(event.clipboardData.items)
+      : [];
+    if (files.length === 0) return;
+    if (editingMessage) {
+      rejectEditAttachment();
+      return;
+    }
+    event.preventDefault();
+    attachFiles(files);
+  };
 
-  const handleDrop = useCallback(
-    (event: React.DragEvent<HTMLTextAreaElement>) => {
-      event.preventDefault();
-      const files = extractAttachmentsFromDrop(event.dataTransfer);
-      if (files.length === 0) return;
-      if (editingMessage) rejectEditAttachment();
-      else attachFiles(files);
-    },
-    [attachFiles, editingMessage, rejectEditAttachment]
-  );
+  const handleAttachFiles = (files: File[]) => {
+    if (editingMessage) rejectEditAttachment();
+    else attachFiles(files);
+  };
 
-  const handleRemoveAttachment = useCallback(
-    (id: string) => {
-      setAttachments((previous) => previous.filter((item) => item.id !== id));
-    },
-    [setAttachments]
-  );
+  const handleDragOver = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    if (!event.dataTransfer.types.includes("Files")) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = editingMessage ? "none" : "copy";
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLTextAreaElement>) => {
+    event.preventDefault();
+    const files = extractAttachmentsFromDrop(event.dataTransfer);
+    if (files.length === 0) return;
+    if (editingMessage) rejectEditAttachment();
+    else attachFiles(files);
+  };
+
+  const handleRemoveAttachment = (id: string) => {
+    setAttachments((previous) => previous.filter((item) => item.id !== id));
+  };
 
   return {
     processingAttachmentCount,

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -30,11 +30,9 @@ interface UseComposerAttachmentsOptions {
   editingMessage: boolean;
   pushToast: PushToast;
 }
-
 export function getBaseMediaType(mediaType: string): string {
   return mediaType.toLowerCase().trim().split(";")[0];
 }
-
 export function isPdfAttachment(
   attachment: ChatAttachment
 ): attachment is Extract<ChatAttachment, { kind: "provider" }> {
@@ -42,7 +40,6 @@ export function isPdfAttachment(
     attachment.kind === "provider" && getBaseMediaType(attachment.mediaType) === PDF_MEDIA_TYPE
   );
 }
-
 export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
   if (!dataUrl.startsWith("data:")) return null;
   const commaIndex = dataUrl.indexOf(",");
@@ -53,10 +50,10 @@ export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
   const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
   return Math.floor((base64.length * 3) / 4) - padding;
 }
-
 export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { api } = useAPI();
   const tooLargeToastKeyRef = useRef<string | null>(null);
+  // External draft transfers must not overwrite an oversized attachment kept only in memory.
   const selfWriteRef = useRef(false);
   const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
     readPersistedChatAttachments(options.attachmentsKey)

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -46,7 +46,7 @@ export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
 }
 export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { api } = useAPI();
-  const { attachments, setAttachments } = options;
+  const { attachments, setAttachments, editingMessage, pushToast, variant, workspaceId } = options;
   const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
 
   const showResizeToast = useCallback(
@@ -57,7 +57,7 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
       );
       const resizeInfo = resized[0]?.resizeInfo;
       if (!resizeInfo) return;
-      options.pushToast({
+      pushToast({
         type: "info",
         message:
           resized.length === 1
@@ -65,7 +65,7 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
             : `${resized.length} images resized to fit provider limits`,
       });
     },
-    [options.pushToast]
+    [pushToast]
   );
 
   const processFiles = useCallback(
@@ -73,13 +73,13 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
       setProcessingAttachmentCount((count) => count + 1);
       return processAttachmentFiles(files, {
         stageAttachment:
-          options.variant === "workspace"
+          variant === "workspace"
             ? async (file, dataBase64) => {
                 if (!api) throw new Error("Not connected to server");
-                if (options.workspaceId == null)
+                if (workspaceId == null)
                   throw new Error("Files can be staged after opening a workspace.");
                 const result = await api.workspace.stageAttachment({
-                  workspaceId: options.workspaceId,
+                  workspaceId: workspaceId,
                   filename: file.name,
                   mediaType: file.type || null,
                   sizeBytes: file.size,
@@ -89,10 +89,10 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
                 return result.data;
               }
             : undefined,
-        holdNonProviderFiles: options.variant === "creation",
+        holdNonProviderFiles: variant === "creation",
       }).finally(() => setProcessingAttachmentCount((count) => Math.max(0, count - 1)));
     },
-    [api, options.variant, options.workspaceId]
+    [api, variant, workspaceId]
   );
 
   const attachFiles = useCallback(
@@ -113,7 +113,7 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
         for (const outcome of outcomes) {
           if (outcome.ok) continue;
           console.error("Failed to process attached file:", outcome.error);
-          options.pushToast({
+          pushToast({
             type: "error",
             message:
               outcome.error instanceof Error
@@ -123,12 +123,12 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
         }
       });
     },
-    [options.pushToast, processFiles, setAttachments, showResizeToast]
+    [pushToast, processFiles, setAttachments, showResizeToast]
   );
 
   const rejectEditAttachment = useCallback(() => {
-    options.pushToast({ type: "error", message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE });
-  }, [options.pushToast]);
+    pushToast({ type: "error", message: EDIT_MODE_ATTACHMENT_ERROR_MESSAGE });
+  }, [pushToast]);
 
   const handlePaste = useCallback(
     (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -136,31 +136,31 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
         ? extractAttachmentsFromClipboard(event.clipboardData.items)
         : [];
       if (files.length === 0) return;
-      if (options.editingMessage) {
+      if (editingMessage) {
         rejectEditAttachment();
         return;
       }
       event.preventDefault();
       attachFiles(files);
     },
-    [attachFiles, options.editingMessage, rejectEditAttachment]
+    [attachFiles, editingMessage, rejectEditAttachment]
   );
 
   const handleAttachFiles = useCallback(
     (files: File[]) => {
-      if (options.editingMessage) rejectEditAttachment();
+      if (editingMessage) rejectEditAttachment();
       else attachFiles(files);
     },
-    [attachFiles, options.editingMessage, rejectEditAttachment]
+    [attachFiles, editingMessage, rejectEditAttachment]
   );
 
   const handleDragOver = useCallback(
     (event: React.DragEvent<HTMLTextAreaElement>) => {
       if (!event.dataTransfer.types.includes("Files")) return;
       event.preventDefault();
-      event.dataTransfer.dropEffect = options.editingMessage ? "none" : "copy";
+      event.dataTransfer.dropEffect = editingMessage ? "none" : "copy";
     },
-    [options.editingMessage]
+    [editingMessage]
   );
 
   const handleDrop = useCallback(
@@ -168,10 +168,10 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
       event.preventDefault();
       const files = extractAttachmentsFromDrop(event.dataTransfer);
       if (files.length === 0) return;
-      if (options.editingMessage) rejectEditAttachment();
+      if (editingMessage) rejectEditAttachment();
       else attachFiles(files);
     },
-    [attachFiles, options.editingMessage, rejectEditAttachment]
+    [attachFiles, editingMessage, rejectEditAttachment]
   );
 
   const handleRemoveAttachment = useCallback(

--- a/src/browser/features/ChatInput/useComposerAttachments.ts
+++ b/src/browser/features/ChatInput/useComposerAttachments.ts
@@ -17,7 +17,6 @@ type PushToast = (toast: Omit<Toast, "id" | "type"> & { type: Toast["type"] | "i
 interface UseComposerAttachmentsOptions {
   variant: "creation" | "workspace";
   workspaceId: string | null;
-  attachments: ChatAttachment[];
   setAttachments: (
     value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])
   ) => void;
@@ -46,7 +45,7 @@ export function estimateBase64DataUrlBytes(dataUrl: string): number | null {
 }
 export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   const { api } = useAPI();
-  const { attachments, setAttachments, editingMessage, pushToast, variant, workspaceId } = options;
+  const { setAttachments, editingMessage, pushToast, variant, workspaceId } = options;
   const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
 
   const showResizeToast = useCallback(
@@ -79,7 +78,7 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
                 if (workspaceId == null)
                   throw new Error("Files can be staged after opening a workspace.");
                 const result = await api.workspace.stageAttachment({
-                  workspaceId: workspaceId,
+                  workspaceId,
                   filename: file.name,
                   mediaType: file.type || null,
                   sizeBytes: file.size,
@@ -182,8 +181,6 @@ export function useComposerAttachments(options: UseComposerAttachmentsOptions) {
   );
 
   return {
-    attachments,
-    setAttachments,
     processingAttachmentCount,
     handlePaste,
     handleAttachFiles,

--- a/src/browser/features/ChatInput/useComposerDraft.ts
+++ b/src/browser/features/ChatInput/useComposerDraft.ts
@@ -8,9 +8,7 @@ import {
   getDraftScopeId,
   getInputAttachmentsKey,
   getInputKey,
-  getModelKey,
   getPendingScopeId,
-  getProjectScopeId,
 } from "@/common/constants/storage";
 import type { ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { Review } from "@/common/types/review";
@@ -42,9 +40,6 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
         : getPendingScopeId(creationProjectPath);
   const inputKey = getInputKey(scopeId);
   const attachmentsKey = getInputAttachmentsKey(scopeId);
-  const modelKey = getModelKey(
-    variant === "creation" ? getProjectScopeId(creationProjectPath) : scopeId
-  );
   const [input, setInput] = usePersistedState(inputKey, "", { listener: true });
   const latestInputValueRef = useRef(input);
   latestInputValueRef.current = input;
@@ -145,7 +140,7 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
   const preEditDraftRef = useRef<ReturnType<typeof getDraft>>({ text: "", attachments: [] });
   const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
   return {
-    storageKeys: { inputKey, modelKey },
+    storageKeys: { inputKey },
     input,
     setInput,
     latestInputValueRef,

--- a/src/browser/features/ChatInput/useComposerDraft.ts
+++ b/src/browser/features/ChatInput/useComposerDraft.ts
@@ -32,16 +32,18 @@ interface UseComposerDraftOptions {
 }
 
 export function useComposerDraft(options: UseComposerDraftOptions) {
+  const { attachedReviews, creationProjectPath, pendingDraftId, pushToast, variant, workspaceId } =
+    options;
   const scopeId =
-    options.variant === "workspace"
-      ? (options.workspaceId ?? "")
-      : options.pendingDraftId?.trim().length
-        ? getDraftScopeId(options.creationProjectPath, options.pendingDraftId)
-        : getPendingScopeId(options.creationProjectPath);
+    variant === "workspace"
+      ? (workspaceId ?? "")
+      : pendingDraftId?.trim().length
+        ? getDraftScopeId(creationProjectPath, pendingDraftId)
+        : getPendingScopeId(creationProjectPath);
   const inputKey = getInputKey(scopeId);
   const attachmentsKey = getInputAttachmentsKey(scopeId);
   const modelKey = getModelKey(
-    options.variant === "creation" ? getProjectScopeId(options.creationProjectPath) : scopeId
+    variant === "creation" ? getProjectScopeId(creationProjectPath) : scopeId
   );
   const [input, setInput] = usePersistedState(inputKey, "", { listener: true });
   const latestInputValueRef = useRef(input);
@@ -70,7 +72,7 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
         if (persists || next.length === 0) tooLargeToastKeyRef.current = null;
         else if (tooLargeToastKeyRef.current !== attachmentsKey) {
           tooLargeToastKeyRef.current = attachmentsKey;
-          options.pushToast({
+          pushToast({
             type: "error",
             message:
               "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
@@ -79,7 +81,7 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
         }
         return next;
       }),
-    [attachmentsKey, options.pushToast]
+    [attachmentsKey, pushToast]
   );
   useEffect(() => {
     tooLargeToastKeyRef.current = null;
@@ -121,9 +123,9 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
   const draftReviewItems = (draftReviews ?? []).filter(isDraftReviewData);
   const reviews = reviewOverrideActive
     ? draftReviewItems
-    : options.attachedReviews.map((review) => review.data);
+    : attachedReviews.map((review) => review.data);
   const reviewData = reviews.length > 0 ? reviews : undefined;
-  const reviewIdsForCheck = reviewOverrideActive ? [] : options.attachedReviews.map(({ id }) => id);
+  const reviewIdsForCheck = reviewOverrideActive ? [] : attachedReviews.map(({ id }) => id);
   const reviewPanelItems = reviewOverrideActive
     ? draftReviewItems.map((data) => ({
         id: idForReview(data),
@@ -131,7 +133,7 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
         status: "attached" as const,
         createdAt: 0,
       }))
-    : options.attachedReviews;
+    : attachedReviews;
   const getDraft = useCallback(() => ({ text: input, attachments }), [input, attachments]);
   const setDraft = useCallback(
     (draft: { text: string; attachments: ChatAttachment[] }) => {

--- a/src/browser/features/ChatInput/useComposerDraft.ts
+++ b/src/browser/features/ChatInput/useComposerDraft.ts
@@ -22,11 +22,6 @@ import {
   readPersistedChatAttachments,
 } from "./draftAttachmentsStorage";
 
-interface DraftState {
-  text: string;
-  attachments: ChatAttachment[];
-}
-
 interface UseComposerDraftOptions {
   variant: "creation" | "workspace";
   workspaceId: string | null;
@@ -37,10 +32,12 @@ interface UseComposerDraftOptions {
 }
 
 export function useComposerDraft(options: UseComposerDraftOptions) {
-  const pendingScopeId = options.pendingDraftId?.trim().length
-    ? getDraftScopeId(options.creationProjectPath, options.pendingDraftId)
-    : getPendingScopeId(options.creationProjectPath);
-  const scopeId = options.variant === "creation" ? pendingScopeId : (options.workspaceId ?? "");
+  const scopeId =
+    options.variant === "workspace"
+      ? (options.workspaceId ?? "")
+      : options.pendingDraftId?.trim().length
+        ? getDraftScopeId(options.creationProjectPath, options.pendingDraftId)
+        : getPendingScopeId(options.creationProjectPath);
   const inputKey = getInputKey(scopeId);
   const attachmentsKey = getInputAttachmentsKey(scopeId);
   const modelKey = getModelKey(
@@ -49,142 +46,104 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
   const [input, setInput] = usePersistedState(inputKey, "", { listener: true });
   const latestInputValueRef = useRef(input);
   latestInputValueRef.current = input;
-
   const tooLargeToastKeyRef = useRef<string | null>(null);
   const selfWriteRef = useRef(false);
   const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
     readPersistedChatAttachments(attachmentsKey)
   );
-  const persistAttachments = useCallback(
-    (next: ChatAttachment[]) => {
-      selfWriteRef.current = true;
-      try {
-        if (next.length === 0) {
-          tooLargeToastKeyRef.current = null;
-          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, undefined);
-        } else if (
-          estimatePersistedChatAttachmentsChars(next) > MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS
-        ) {
-          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, undefined);
-          if (tooLargeToastKeyRef.current !== attachmentsKey) {
-            tooLargeToastKeyRef.current = attachmentsKey;
-            options.pushToast({
-              type: "error",
-              message:
-                "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
-              duration: 5000,
-            });
-          }
-        } else {
-          tooLargeToastKeyRef.current = null;
-          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, next);
-        }
-      } finally {
-        selfWriteRef.current = false;
-      }
-    },
-    [attachmentsKey, options.pushToast]
-  );
   const setAttachments = useCallback(
-    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) => {
+    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) =>
       setAttachmentsState((previous) => {
         const next = value instanceof Function ? value(previous) : value;
-        persistAttachments(next);
+        const persists =
+          next.length > 0 &&
+          estimatePersistedChatAttachmentsChars(next) <= MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS;
+        selfWriteRef.current = true;
+        try {
+          updatePersistedState<ChatAttachment[] | undefined>(
+            attachmentsKey,
+            persists ? next : undefined
+          );
+        } finally {
+          selfWriteRef.current = false;
+        }
+        if (persists || next.length === 0) tooLargeToastKeyRef.current = null;
+        else if (tooLargeToastKeyRef.current !== attachmentsKey) {
+          tooLargeToastKeyRef.current = attachmentsKey;
+          options.pushToast({
+            type: "error",
+            message:
+              "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
+            duration: 5000,
+          });
+        }
         return next;
-      });
-    },
-    [persistAttachments]
+      }),
+    [attachmentsKey, options.pushToast]
   );
-
   useEffect(() => {
     tooLargeToastKeyRef.current = null;
     setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
+    return subscribePersistedStateWrites((event) => {
+      if (event.key === attachmentsKey && !selfWriteRef.current) {
+        setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
+      }
+    });
   }, [attachmentsKey]);
-  useEffect(
-    () =>
-      subscribePersistedStateWrites((event) => {
-        if (event.key === attachmentsKey && !selfWriteRef.current) {
-          setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
-        }
-      }),
-    [attachmentsKey]
-  );
-
   const [draftReviews, setDraftReviews] = useState<ReviewNoteDataForDisplay[] | null>(null);
-  const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
+  const draftReviewIdsRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
   const nextDraftReviewIdRef = useRef(0);
   const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
     typeof value === "object" && value !== null;
-  const getDraftReviewId = (review: ReviewNoteDataForDisplay): string => {
-    const existingId = draftReviewIdsByValueRef.current.get(review);
+  const idForReview = (review: ReviewNoteDataForDisplay) => {
+    const existingId = draftReviewIdsRef.current.get(review);
     if (existingId) return existingId;
     const newId = "draft-review-" + nextDraftReviewIdRef.current++;
-    draftReviewIdsByValueRef.current.set(review, newId);
+    draftReviewIdsRef.current.set(review, newId);
     return newId;
   };
-  const withDraftReview = (
-    reviewId: string,
-    update: (reviews: ReviewNoteDataForDisplay[], reviewIndex: number) => ReviewNoteDataForDisplay[]
-  ) =>
+  const mutateDraftReview = (reviewId: string, userNote?: string) =>
     setDraftReviews((previous) => {
       if (previous === null) return previous;
-      const reviewIndex = previous.findIndex(
-        (review) => isDraftReviewData(review) && getDraftReviewId(review) === reviewId
+      const index = previous.findIndex(
+        (review) => isDraftReviewData(review) && idForReview(review) === reviewId
       );
-      return reviewIndex === -1 ? previous : update(previous, reviewIndex);
-    });
-  const removeDraftReview = (reviewId: string) =>
-    withDraftReview(reviewId, (previous, reviewIndex) =>
-      previous.filter((_, index) => index !== reviewIndex)
-    );
-  const updateDraftReviewNote = (reviewId: string, userNote: string) =>
-    withDraftReview(reviewId, (previous, reviewIndex) => {
-      const review = previous[reviewIndex];
+      if (index === -1) return previous;
+      if (userNote === undefined) return previous.filter((_, itemIndex) => itemIndex !== index);
+      const review = previous[index];
       if (!review || review.userNote === userNote) return previous;
       const next = [...previous];
-      const updatedReview = { ...review, userNote };
-      draftReviewIdsByValueRef.current.set(updatedReview, reviewId);
-      next[reviewIndex] = updatedReview;
+      next[index] = { ...review, userNote };
+      draftReviewIdsRef.current.set(next[index], reviewId);
       return next;
     });
-
   const reviewOverrideActive = draftReviews !== null;
   const draftReviewItems = (draftReviews ?? []).filter(isDraftReviewData);
-  const reviewData = reviewOverrideActive
-    ? draftReviewItems.length > 0
-      ? draftReviewItems
-      : undefined
-    : options.attachedReviews.length > 0
-      ? options.attachedReviews.map((review) => review.data)
-      : undefined;
-  const reviewIdsForCheck = reviewOverrideActive
-    ? []
-    : options.attachedReviews.map((review) => review.id);
-  const reviewPanelItems: Review[] = reviewOverrideActive
+  const reviews = reviewOverrideActive
+    ? draftReviewItems
+    : options.attachedReviews.map((review) => review.data);
+  const reviewData = reviews.length > 0 ? reviews : undefined;
+  const reviewIdsForCheck = reviewOverrideActive ? [] : options.attachedReviews.map(({ id }) => id);
+  const reviewPanelItems = reviewOverrideActive
     ? draftReviewItems.map((data) => ({
-        id: getDraftReviewId(data),
+        id: idForReview(data),
         data,
-        status: "attached",
+        status: "attached" as const,
         createdAt: 0,
       }))
     : options.attachedReviews;
-
-  const getDraft = useCallback(
-    (): DraftState => ({ text: input, attachments }),
-    [input, attachments]
-  );
+  const getDraft = useCallback(() => ({ text: input, attachments }), [input, attachments]);
   const setDraft = useCallback(
-    (draft: DraftState) => {
+    (draft: { text: string; attachments: ChatAttachment[] }) => {
       setInput(draft.text);
       setAttachments(draft.attachments);
     },
     [setAttachments, setInput]
   );
-  const preEditDraftRef = useRef<DraftState>({ text: "", attachments: [] });
+  const preEditDraftRef = useRef<ReturnType<typeof getDraft>>({ text: "", attachments: [] });
   const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
-
   return {
-    storageKeys: { inputKey, attachmentsKey, modelKey },
+    storageKeys: { inputKey, modelKey },
     input,
     setInput,
     latestInputValueRef,
@@ -200,7 +159,7 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
     reviewData,
     reviewIdsForCheck,
     reviewPanelItems,
-    removeDraftReview,
-    updateDraftReviewNote,
+    removeDraftReview: (reviewId: string) => mutateDraftReview(reviewId),
+    updateDraftReviewNote: mutateDraftReview,
   };
 }

--- a/src/browser/features/ChatInput/useComposerDraft.ts
+++ b/src/browser/features/ChatInput/useComposerDraft.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  subscribePersistedStateWrites,
+  updatePersistedState,
+  usePersistedState,
+} from "@/browser/hooks/usePersistedState";
+import {
+  getDraftScopeId,
+  getInputAttachmentsKey,
+  getInputKey,
+  getModelKey,
+  getPendingScopeId,
+  getProjectScopeId,
+} from "@/common/constants/storage";
+import type { ReviewNoteDataForDisplay } from "@/common/types/message";
+import type { Review } from "@/common/types/review";
+import type { ChatAttachment } from "./ChatAttachments";
+import type { Toast } from "./ChatInputToast";
+import {
+  estimatePersistedChatAttachmentsChars,
+  MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS,
+  readPersistedChatAttachments,
+} from "./draftAttachmentsStorage";
+
+interface DraftState {
+  text: string;
+  attachments: ChatAttachment[];
+}
+
+interface UseComposerDraftOptions {
+  variant: "creation" | "workspace";
+  workspaceId: string | null;
+  creationProjectPath: string;
+  pendingDraftId?: string;
+  attachedReviews: Review[];
+  pushToast: (toast: Omit<Toast, "id" | "type"> & { type: Toast["type"] | "info" }) => void;
+}
+
+export function useComposerDraft(options: UseComposerDraftOptions) {
+  const pendingScopeId = options.pendingDraftId?.trim().length
+    ? getDraftScopeId(options.creationProjectPath, options.pendingDraftId)
+    : getPendingScopeId(options.creationProjectPath);
+  const scopeId = options.variant === "creation" ? pendingScopeId : (options.workspaceId ?? "");
+  const inputKey = getInputKey(scopeId);
+  const attachmentsKey = getInputAttachmentsKey(scopeId);
+  const modelKey = getModelKey(
+    options.variant === "creation" ? getProjectScopeId(options.creationProjectPath) : scopeId
+  );
+  const [input, setInput] = usePersistedState(inputKey, "", { listener: true });
+  const latestInputValueRef = useRef(input);
+  latestInputValueRef.current = input;
+
+  const tooLargeToastKeyRef = useRef<string | null>(null);
+  const selfWriteRef = useRef(false);
+  const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
+    readPersistedChatAttachments(attachmentsKey)
+  );
+  const persistAttachments = useCallback(
+    (next: ChatAttachment[]) => {
+      selfWriteRef.current = true;
+      try {
+        if (next.length === 0) {
+          tooLargeToastKeyRef.current = null;
+          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, undefined);
+        } else if (
+          estimatePersistedChatAttachmentsChars(next) > MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS
+        ) {
+          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, undefined);
+          if (tooLargeToastKeyRef.current !== attachmentsKey) {
+            tooLargeToastKeyRef.current = attachmentsKey;
+            options.pushToast({
+              type: "error",
+              message:
+                "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
+              duration: 5000,
+            });
+          }
+        } else {
+          tooLargeToastKeyRef.current = null;
+          updatePersistedState<ChatAttachment[] | undefined>(attachmentsKey, next);
+        }
+      } finally {
+        selfWriteRef.current = false;
+      }
+    },
+    [attachmentsKey, options.pushToast]
+  );
+  const setAttachments = useCallback(
+    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) => {
+      setAttachmentsState((previous) => {
+        const next = value instanceof Function ? value(previous) : value;
+        persistAttachments(next);
+        return next;
+      });
+    },
+    [persistAttachments]
+  );
+
+  useEffect(() => {
+    tooLargeToastKeyRef.current = null;
+    setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
+  }, [attachmentsKey]);
+  useEffect(
+    () =>
+      subscribePersistedStateWrites((event) => {
+        if (event.key === attachmentsKey && !selfWriteRef.current) {
+          setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
+        }
+      }),
+    [attachmentsKey]
+  );
+
+  const [draftReviews, setDraftReviews] = useState<ReviewNoteDataForDisplay[] | null>(null);
+  const draftReviewIdsByValueRef = useRef(new WeakMap<ReviewNoteDataForDisplay, string>());
+  const nextDraftReviewIdRef = useRef(0);
+  const isDraftReviewData = (value: unknown): value is ReviewNoteDataForDisplay =>
+    typeof value === "object" && value !== null;
+  const getDraftReviewId = (review: ReviewNoteDataForDisplay): string => {
+    const existingId = draftReviewIdsByValueRef.current.get(review);
+    if (existingId) return existingId;
+    const newId = "draft-review-" + nextDraftReviewIdRef.current++;
+    draftReviewIdsByValueRef.current.set(review, newId);
+    return newId;
+  };
+  const withDraftReview = (
+    reviewId: string,
+    update: (reviews: ReviewNoteDataForDisplay[], reviewIndex: number) => ReviewNoteDataForDisplay[]
+  ) =>
+    setDraftReviews((previous) => {
+      if (previous === null) return previous;
+      const reviewIndex = previous.findIndex(
+        (review) => isDraftReviewData(review) && getDraftReviewId(review) === reviewId
+      );
+      return reviewIndex === -1 ? previous : update(previous, reviewIndex);
+    });
+  const removeDraftReview = (reviewId: string) =>
+    withDraftReview(reviewId, (previous, reviewIndex) =>
+      previous.filter((_, index) => index !== reviewIndex)
+    );
+  const updateDraftReviewNote = (reviewId: string, userNote: string) =>
+    withDraftReview(reviewId, (previous, reviewIndex) => {
+      const review = previous[reviewIndex];
+      if (!review || review.userNote === userNote) return previous;
+      const next = [...previous];
+      const updatedReview = { ...review, userNote };
+      draftReviewIdsByValueRef.current.set(updatedReview, reviewId);
+      next[reviewIndex] = updatedReview;
+      return next;
+    });
+
+  const reviewOverrideActive = draftReviews !== null;
+  const draftReviewItems = (draftReviews ?? []).filter(isDraftReviewData);
+  const reviewData = reviewOverrideActive
+    ? draftReviewItems.length > 0
+      ? draftReviewItems
+      : undefined
+    : options.attachedReviews.length > 0
+      ? options.attachedReviews.map((review) => review.data)
+      : undefined;
+  const reviewIdsForCheck = reviewOverrideActive
+    ? []
+    : options.attachedReviews.map((review) => review.id);
+  const reviewPanelItems: Review[] = reviewOverrideActive
+    ? draftReviewItems.map((data) => ({
+        id: getDraftReviewId(data),
+        data,
+        status: "attached",
+        createdAt: 0,
+      }))
+    : options.attachedReviews;
+
+  const getDraft = useCallback(
+    (): DraftState => ({ text: input, attachments }),
+    [input, attachments]
+  );
+  const setDraft = useCallback(
+    (draft: DraftState) => {
+      setInput(draft.text);
+      setAttachments(draft.attachments);
+    },
+    [setAttachments, setInput]
+  );
+  const preEditDraftRef = useRef<DraftState>({ text: "", attachments: [] });
+  const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
+
+  return {
+    storageKeys: { inputKey, attachmentsKey, modelKey },
+    input,
+    setInput,
+    latestInputValueRef,
+    attachments,
+    setAttachments,
+    draftReviews,
+    setDraftReviews,
+    getDraft,
+    setDraft,
+    preEditDraftRef,
+    preEditReviewsRef,
+    reviewOverrideActive,
+    reviewData,
+    reviewIdsForCheck,
+    reviewPanelItems,
+    removeDraftReview,
+    updateDraftReviewNote,
+  };
+}

--- a/src/browser/features/ChatInput/useComposerDraft.ts
+++ b/src/browser/features/ChatInput/useComposerDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   subscribePersistedStateWrites,
   updatePersistedState,
@@ -48,36 +48,35 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
   const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() =>
     readPersistedChatAttachments(attachmentsKey)
   );
-  const setAttachments = useCallback(
-    (value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])) =>
-      setAttachmentsState((previous) => {
-        const next = value instanceof Function ? value(previous) : value;
-        const persists =
-          next.length > 0 &&
-          estimatePersistedChatAttachmentsChars(next) <= MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS;
-        selfWriteRef.current = true;
-        try {
-          updatePersistedState<ChatAttachment[] | undefined>(
-            attachmentsKey,
-            persists ? next : undefined
-          );
-        } finally {
-          selfWriteRef.current = false;
-        }
-        if (persists || next.length === 0) tooLargeToastKeyRef.current = null;
-        else if (tooLargeToastKeyRef.current !== attachmentsKey) {
-          tooLargeToastKeyRef.current = attachmentsKey;
-          pushToast({
-            type: "error",
-            message:
-              "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
-            duration: 5000,
-          });
-        }
-        return next;
-      }),
-    [attachmentsKey, pushToast]
-  );
+  const setAttachments = (
+    value: ChatAttachment[] | ((previous: ChatAttachment[]) => ChatAttachment[])
+  ) =>
+    setAttachmentsState((previous) => {
+      const next = value instanceof Function ? value(previous) : value;
+      const persists =
+        next.length > 0 &&
+        estimatePersistedChatAttachmentsChars(next) <= MAX_PERSISTED_ATTACHMENT_DRAFT_CHARS;
+      selfWriteRef.current = true;
+      try {
+        updatePersistedState<ChatAttachment[] | undefined>(
+          attachmentsKey,
+          persists ? next : undefined
+        );
+      } finally {
+        selfWriteRef.current = false;
+      }
+      if (persists || next.length === 0) tooLargeToastKeyRef.current = null;
+      else if (tooLargeToastKeyRef.current !== attachmentsKey) {
+        tooLargeToastKeyRef.current = attachmentsKey;
+        pushToast({
+          type: "error",
+          message:
+            "This draft attachment is too large to save. It will be lost when you switch workspaces or restart.",
+          duration: 5000,
+        });
+      }
+      return next;
+    });
   useEffect(() => {
     tooLargeToastKeyRef.current = null;
     setAttachmentsState(readPersistedChatAttachments(attachmentsKey));
@@ -129,14 +128,11 @@ export function useComposerDraft(options: UseComposerDraftOptions) {
         createdAt: 0,
       }))
     : attachedReviews;
-  const getDraft = useCallback(() => ({ text: input, attachments }), [input, attachments]);
-  const setDraft = useCallback(
-    (draft: { text: string; attachments: ChatAttachment[] }) => {
-      setInput(draft.text);
-      setAttachments(draft.attachments);
-    },
-    [setAttachments, setInput]
-  );
+  const getDraft = () => ({ text: input, attachments });
+  const setDraft = (draft: { text: string; attachments: ChatAttachment[] }) => {
+    setInput(draft.text);
+    setAttachments(draft.attachments);
+  };
   const preEditDraftRef = useRef<ReturnType<typeof getDraft>>({ text: "", attachments: [] });
   const preEditReviewsRef = useRef<ReviewNoteDataForDisplay[] | null>(null);
   return {

--- a/src/browser/features/ChatInput/useComposerSuggestions.test.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.test.ts
@@ -8,23 +8,34 @@ import {
 } from "./useComposerSuggestions";
 
 const context = {
-  agentSkills: [{ name: "deep-review", description: "Review code", scope: "global" }] satisfies AgentSkillDescriptor[],
+  agentSkills: [
+    { name: "deep-review", description: "Review code", scope: "global" },
+  ] satisfies AgentSkillDescriptor[],
   mcpPrompts: [],
   pluginCommands: [],
   variant: "workspace" as const,
   experiments: {
-    workspaceHeartbeats: false, dynamicWorkflows: false, memory: false,
-    memoryConsolidation: false, rlm: false, programmaticToolCalling: false,
+    workspaceHeartbeats: false,
+    dynamicWorkflows: false,
+    memory: false,
+    memoryConsolidation: false,
+    rlm: false,
+    programmaticToolCalling: false,
   },
 };
 const suggestion = (replacement: string): SlashSuggestion => ({
-  id: replacement, display: replacement, description: "", replacement,
+  id: replacement,
+  display: replacement,
+  description: "",
+  replacement,
 });
 
 describe("composer suggestion seams", () => {
   test.each([
-    ["/ask @src/fo", 12, "file", "src/fo"], ["/ask $deep", 10, "inline", "deep"],
-    [String.raw`/ask \alp`, 9, "symbol", "alp"], ["/clear", 6, "slash", "/clear"],
+    ["/ask @src/fo", 12, "file", "src/fo"],
+    ["/ask $deep", 10, "inline", "deep"],
+    [String.raw`/ask \alp`, 9, "symbol", "alp"],
+    ["/clear", 6, "slash", "/clear"],
     ["plain text", 10, null, null],
   ] as const)("detects the active token in %s", (input, cursor, kind, query) => {
     const token = detectActiveComposerToken(input, cursor);
@@ -32,22 +43,27 @@ describe("composer suggestion seams", () => {
   });
 
   test.each([
-    ["$deep", 5, "$deep-review"], [String.raw`\alpha`, 6, String.raw`\alpha`],
+    ["$deep", 5, "$deep-review"],
+    [String.raw`\alpha`, 6, String.raw`\alpha`],
     ["/cl", 3, "/clear"],
   ] as const)("derives matches for %s during render", (input, cursor, expected) => {
     const token = detectActiveComposerToken(input, cursor);
-    expect(getSynchronousComposerSuggestions(token, context).map(({ display }) => display)).toContain(expected);
+    expect(
+      getSynchronousComposerSuggestions(token, context).map(({ display }) => display)
+    ).toContain(expected);
   });
 
   test.each([
     ["see @sr now", 7, "@src/file.ts", "see @src/file.ts  now", 17],
     ["use $de, now", 7, "$deep-review", "use $deep-review, now", 16],
-    [String.raw`x \alp2`, 6, "α", "x α2", 3], ["/cl", 3, "/clear", "/clear", 6],
+    [String.raw`x \alp2`, 6, "α", "x α2", 3],
+    ["/cl", 3, "/clear", "/clear", 6],
   ] as const)("applies a selection for %s", (input, cursor, replacement, expected, nextCursor) => {
     const token = detectActiveComposerToken(input, cursor);
     if (!token) throw new Error("expected active token");
     expect(applyComposerSuggestion(input, token, suggestion(replacement))).toEqual({
-      input: expected, cursor: nextCursor,
+      input: expected,
+      cursor: nextCursor,
     });
   });
 });

--- a/src/browser/features/ChatInput/useComposerSuggestions.test.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
+import {
+  applyComposerSuggestion,
+  detectActiveComposerToken,
+  getSynchronousComposerSuggestions,
+} from "./useComposerSuggestions";
+
+const experiments = {
+  workspaceHeartbeats: false,
+  dynamicWorkflows: false,
+  memory: false,
+  memoryConsolidation: false,
+  rlm: false,
+  programmaticToolCalling: false,
+};
+const context = {
+  agentSkills: [
+    { name: "deep-review", description: "Review code", scope: "global" },
+  ] satisfies AgentSkillDescriptor[],
+  mcpPrompts: [],
+  pluginCommands: [],
+  variant: "workspace" as const,
+  experiments,
+};
+const suggestion = (replacement: string): SlashSuggestion => ({
+  id: replacement,
+  display: replacement,
+  description: "",
+  replacement,
+});
+
+describe("detectActiveComposerToken", () => {
+  test.each([
+    ["/ask @src/fo", 12, "file", "src/fo"],
+    ["/ask $deep", 10, "inline", "deep"],
+    [String.raw`/ask \alp`, 9, "symbol", "alp"],
+    ["/clear", 6, "slash", "/clear"],
+    ["plain text", 10, null, null],
+  ] as const)("detects the active token in %s", (input, cursor, kind, query) => {
+    const token = detectActiveComposerToken(input, cursor);
+    expect(token?.kind ?? null).toBe(kind);
+    expect(token?.query ?? null).toBe(query);
+  });
+});
+
+describe("getSynchronousComposerSuggestions", () => {
+  test.each([
+    ["$deep", 5, "$deep-review"],
+    [String.raw`\alpha`, 6, String.raw`\alpha`],
+    ["/cl", 3, "/clear"],
+  ] as const)("derives matches for %s during render", (input, cursor, expected) => {
+    const token = detectActiveComposerToken(input, cursor);
+    expect(getSynchronousComposerSuggestions(token, context).map((item) => item.display)).toContain(
+      expected
+    );
+  });
+});
+
+describe("applyComposerSuggestion", () => {
+  test.each([
+    ["see @sr now", 7, "@src/file.ts", "see @src/file.ts  now", 17],
+    ["use $de, now", 7, "$deep-review", "use $deep-review, now", 16],
+    [String.raw`x \alp2`, 6, "α", "x α2", 3],
+    ["/cl", 3, "/clear", "/clear", 6],
+  ] as const)("applies a selection for %s", (input, cursor, replacement, expected, nextCursor) => {
+    const token = detectActiveComposerToken(input, cursor);
+    expect(token).not.toBeNull();
+    if (!token) return;
+    expect(applyComposerSuggestion(input, token, suggestion(replacement))).toEqual({
+      input: expected,
+      cursor: nextCursor,
+    });
+  });
+});

--- a/src/browser/features/ChatInput/useComposerSuggestions.test.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.test.ts
@@ -7,70 +7,47 @@ import {
   getSynchronousComposerSuggestions,
 } from "./useComposerSuggestions";
 
-const experiments = {
-  workspaceHeartbeats: false,
-  dynamicWorkflows: false,
-  memory: false,
-  memoryConsolidation: false,
-  rlm: false,
-  programmaticToolCalling: false,
-};
 const context = {
-  agentSkills: [
-    { name: "deep-review", description: "Review code", scope: "global" },
-  ] satisfies AgentSkillDescriptor[],
+  agentSkills: [{ name: "deep-review", description: "Review code", scope: "global" }] satisfies AgentSkillDescriptor[],
   mcpPrompts: [],
   pluginCommands: [],
   variant: "workspace" as const,
-  experiments,
+  experiments: {
+    workspaceHeartbeats: false, dynamicWorkflows: false, memory: false,
+    memoryConsolidation: false, rlm: false, programmaticToolCalling: false,
+  },
 };
 const suggestion = (replacement: string): SlashSuggestion => ({
-  id: replacement,
-  display: replacement,
-  description: "",
-  replacement,
+  id: replacement, display: replacement, description: "", replacement,
 });
 
-describe("detectActiveComposerToken", () => {
+describe("composer suggestion seams", () => {
   test.each([
-    ["/ask @src/fo", 12, "file", "src/fo"],
-    ["/ask $deep", 10, "inline", "deep"],
-    [String.raw`/ask \alp`, 9, "symbol", "alp"],
-    ["/clear", 6, "slash", "/clear"],
+    ["/ask @src/fo", 12, "file", "src/fo"], ["/ask $deep", 10, "inline", "deep"],
+    [String.raw`/ask \alp`, 9, "symbol", "alp"], ["/clear", 6, "slash", "/clear"],
     ["plain text", 10, null, null],
   ] as const)("detects the active token in %s", (input, cursor, kind, query) => {
     const token = detectActiveComposerToken(input, cursor);
-    expect(token?.kind ?? null).toBe(kind);
-    expect(token?.query ?? null).toBe(query);
+    expect([token?.kind ?? null, token?.query ?? null]).toEqual([kind, query]);
   });
-});
 
-describe("getSynchronousComposerSuggestions", () => {
   test.each([
-    ["$deep", 5, "$deep-review"],
-    [String.raw`\alpha`, 6, String.raw`\alpha`],
+    ["$deep", 5, "$deep-review"], [String.raw`\alpha`, 6, String.raw`\alpha`],
     ["/cl", 3, "/clear"],
   ] as const)("derives matches for %s during render", (input, cursor, expected) => {
     const token = detectActiveComposerToken(input, cursor);
-    expect(getSynchronousComposerSuggestions(token, context).map((item) => item.display)).toContain(
-      expected
-    );
+    expect(getSynchronousComposerSuggestions(token, context).map(({ display }) => display)).toContain(expected);
   });
-});
 
-describe("applyComposerSuggestion", () => {
   test.each([
     ["see @sr now", 7, "@src/file.ts", "see @src/file.ts  now", 17],
     ["use $de, now", 7, "$deep-review", "use $deep-review, now", 16],
-    [String.raw`x \alp2`, 6, "α", "x α2", 3],
-    ["/cl", 3, "/clear", "/clear", 6],
+    [String.raw`x \alp2`, 6, "α", "x α2", 3], ["/cl", 3, "/clear", "/clear", 6],
   ] as const)("applies a selection for %s", (input, cursor, replacement, expected, nextCursor) => {
     const token = detectActiveComposerToken(input, cursor);
-    expect(token).not.toBeNull();
-    if (!token) return;
+    if (!token) throw new Error("expected active token");
     expect(applyComposerSuggestion(input, token, suggestion(replacement))).toEqual({
-      input: expected,
-      cursor: nextCursor,
+      input: expected, cursor: nextCursor,
     });
   });
 });

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -20,7 +20,7 @@ import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
 import type { PluginSlashCommandDescriptor } from "@/common/orpc/schemas/agentPlugins";
 
-export type ComposerSuggestionToken =
+type ComposerSuggestionToken =
   | { kind: "file"; startIndex: number; endIndex: number; query: string }
   | { kind: "inline"; startIndex: number; endIndex: number; query: string }
   | { kind: "symbol"; startIndex: number; endIndex: number; query: string }

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -407,11 +407,13 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     workspaceId,
   ]);
 
+  // Dismissal drops the stored selection so a menu reopened for the same
+  // channel starts back at the first result instead of the pre-Escape row.
   const dismiss = () => {
     setSelection({
-      channelKey: activeChannelKey,
-      index: selectedIndex,
-      selectedId: suggestions[selectedIndex]?.id ?? null,
+      channelKey: "",
+      index: 0,
+      selectedId: null,
       dismissedTokenKey: activeTokenKey,
     });
   };

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { RefObject } from "react";
 import { useAPI } from "@/browser/contexts/API";
+import { useExperimentValue } from "@/browser/hooks/useExperiments";
+import { usePersistedState } from "@/browser/hooks/usePersistedState";
+import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import { getPendingDraftSkillDiscoveryKey } from "@/common/constants/storage";
 import { subscribeAgentPluginsMutated } from "@/browser/utils/agentPluginMutations";
 import { findAtMentionAtCursor } from "@/common/utils/atMentions";
 import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
@@ -151,25 +155,38 @@ interface UseComposerSuggestionsOptions {
   workspaceId: string | null;
   projectPath: string | null;
   disableWorkspaceAgents: boolean;
-  transferredDraftProjectDiscovery: boolean;
-  agentPluginsEnabled: boolean;
-  experiments: SuggestionExperiments;
 }
 
 export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
-  const {
-    agentPluginsEnabled,
-    disableWorkspaceAgents,
-    experiments,
-    input,
-    inputRef,
-    projectPath,
-    setInput,
-    transferredDraftProjectDiscovery,
-    variant,
-    workspaceId,
-  } = options;
+  const { disableWorkspaceAgents, input, inputRef, projectPath, setInput, variant, workspaceId } =
+    options;
   const { api } = useAPI();
+  const agentPluginsEnabled = useExperimentValue(EXPERIMENT_IDS.AGENT_PLUGINS);
+  const workspaceHeartbeatsEnabled = useExperimentValue(EXPERIMENT_IDS.WORKSPACE_HEARTBEATS);
+  const dynamicWorkflowsEnabled = useExperimentValue(EXPERIMENT_IDS.DYNAMIC_WORKFLOWS);
+  const memoryEnabled = useExperimentValue(EXPERIMENT_IDS.MEMORY);
+  const memoryConsolidationEnabled = useExperimentValue(EXPERIMENT_IDS.MEMORY_CONSOLIDATION);
+  const rlmEnabled = useExperimentValue(EXPERIMENT_IDS.RLM);
+  const ptcEnabled = useExperimentValue(EXPERIMENT_IDS.PROGRAMMATIC_TOOL_CALLING);
+  const experiments: SuggestionExperiments = {
+    workspaceHeartbeats: workspaceHeartbeatsEnabled,
+    dynamicWorkflows: dynamicWorkflowsEnabled,
+    memory: memoryEnabled,
+    memoryConsolidation: memoryConsolidationEnabled,
+    rlm: rlmEnabled,
+    programmaticToolCalling: ptcEnabled,
+  };
+  // A draft transferred from a failed creation send may have resolved its
+  // slash skill against the project path; honor that choice on the retry.
+  // listener keeps the descriptor reload in sync when the transfer lands
+  // after mount and when a successful send clears the key.
+  const [transferredDraftProjectDiscovery] = usePersistedState<boolean>(
+    variant === "workspace" && workspaceId
+      ? getPendingDraftSkillDiscoveryKey(workspaceId)
+      : "__unused__",
+    false,
+    { listener: true }
+  );
   const [cursor, setCursor] = useState(input.length);
   const [selection, setSelection] = useState({
     channelKey: "",
@@ -329,9 +346,19 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   }, [api, activeToken?.kind, activeTokenKey, variant, workspaceId]);
 
   useEffect(() => {
-    if (!api || activeToken?.kind !== "file") return;
     const scope = variant === "workspace" ? workspaceId : projectPath;
-    if (!scope) return;
+    if (!api || activeToken?.kind !== "file" || !scope) {
+      // Invalidate in-flight requests and drop the cached completion when the
+      // file token or its scope goes away, so a stale response (e.g. from a
+      // previous workspace) cannot resurface for a later identical token.
+      fileRequestId.current++;
+      setFileCompletion((prev) =>
+        prev.tokenKey === "" && prev.suggestions.length === 0
+          ? prev
+          : { tokenKey: "", suggestions: [] }
+      );
+      return;
+    }
     const requestId = ++fileRequestId.current;
     const requestedTokenKey = activeTokenKey;
     const request =
@@ -376,52 +403,49 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     workspaceId,
   ]);
 
-  const dismiss = useCallback(() => {
+  const dismiss = () => {
     setSelection({
       channelKey: activeChannelKey,
       index: selectedIndex,
       selectedId: suggestions[selectedIndex]?.id ?? null,
       dismissedTokenKey: activeTokenKey,
     });
-  }, [activeChannelKey, activeTokenKey, selectedIndex, suggestions]);
+  };
 
-  const setSelectedIndex = useCallback(
-    (index: number) =>
-      setSelection({
-        channelKey: activeChannelKey,
-        index,
-        selectedId: suggestions[index]?.id ?? null,
-        dismissedTokenKey: "",
-      }),
-    [activeChannelKey, suggestions]
-  );
+  const setSelectedIndex = (index: number) =>
+    setSelection({
+      channelKey: activeChannelKey,
+      index,
+      selectedId: suggestions[index]?.id ?? null,
+      dismissedTokenKey: "",
+    });
 
-  const select = useCallback(
-    (suggestion: SlashSuggestion) => {
-      if (!activeToken) return;
-      const applied = applyComposerSuggestion(input, activeToken, suggestion);
-      setInput(applied.input);
-      setCursor(applied.cursor);
-      setSelection({
-        channelKey: activeChannelKey,
-        index: 0,
-        selectedId: null,
-        dismissedTokenKey: tokenKey(detectActiveComposerToken(applied.input, applied.cursor)) ?? "",
-      });
-      requestAnimationFrame(() => {
-        const element = inputRef.current;
-        if (!element || element.disabled) return;
-        element.focus();
-        element.selectionStart = applied.cursor;
-        element.selectionEnd = applied.cursor;
-      });
-    },
-    [activeChannelKey, activeToken, input, inputRef, setInput]
-  );
+  const select = (suggestion: SlashSuggestion) => {
+    if (!activeToken) return;
+    const applied = applyComposerSuggestion(input, activeToken, suggestion);
+    setInput(applied.input);
+    setCursor(applied.cursor);
+    setSelection({
+      channelKey: activeChannelKey,
+      index: 0,
+      selectedId: null,
+      dismissedTokenKey: tokenKey(detectActiveComposerToken(applied.input, applied.cursor)) ?? "",
+    });
+    requestAnimationFrame(() => {
+      const element = inputRef.current;
+      if (!element || element.disabled) return;
+      element.focus();
+      element.selectionStart = applied.cursor;
+      element.selectionEnd = applied.cursor;
+    });
+  };
 
+  // Latest-ref listener: the document handler reads fresh state per event so
+  // attaching only depends on visibility, without useCallback dependency lists
+  // (manual memoization is banned; React Compiler owns stabilization).
+  const keydownHandlerRef = useRef<((event: KeyboardEvent) => void) | null>(null);
   useEffect(() => {
-    if (!isVisible) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
+    keydownHandlerRef.current = (event: KeyboardEvent) => {
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         event.preventDefault();
         const delta = event.key === "ArrowDown" ? 1 : -1;
@@ -436,20 +460,24 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         dismiss();
       }
     };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [dismiss, isVisible, select, selectedIndex, setSelectedIndex, suggestions]);
+  });
+  useEffect(() => {
+    if (!isVisible) return;
+    const listener = (event: KeyboardEvent) => keydownHandlerRef.current?.(event);
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, [isVisible]);
 
   useEffect(() => () => mcpAbort.current?.abort(), []);
 
-  const handleCursorActivity = useCallback(() => {
+  const handleCursorActivity = () => {
     const element = inputRef.current;
     if (element) setCursor(element.selectionStart ?? input.length);
-  }, [input.length, inputRef]);
+  };
 
-  const handleInputCaretChange = useCallback((caret: number | undefined, inputLength: number) => {
+  const handleInputCaretChange = (caret: number | undefined, inputLength: number) => {
     setCursor(caret ?? inputLength);
-  }, []);
+  };
 
   const ghostHint = getCommandGhostHint(input, isVisible && activeToken?.kind === "slash", {
     variant,

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -1,0 +1,452 @@
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { RefObject } from "react";
+import { useAPI } from "@/browser/contexts/API";
+import { subscribeAgentPluginsMutated } from "@/browser/utils/agentPluginMutations";
+import { findAtMentionAtCursor } from "@/common/utils/atMentions";
+import { findInlineSkillReferenceAtCursor } from "@/browser/utils/agentSkills/inlineSkillReferences";
+import {
+  getInlineSkillInsertionTrailingText,
+  getInlineSkillSuggestions,
+} from "@/browser/utils/agentSkills/inlineSkillSuggestions";
+import {
+  findSymbolCommandAtCursor,
+  getSymbolSuggestions,
+} from "@/browser/features/ChatInput/symbolShortcuts";
+import { getCommandGhostHint } from "@/browser/utils/slashCommands/registry";
+import { getSlashCommandSuggestions } from "@/browser/utils/slashCommands/suggestions";
+import { resolveSlashCommandExperimentValue } from "@/browser/utils/slashCommands/experimentVisibility";
+import type { SlashSuggestion } from "@/browser/utils/slashCommands/types";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import type { MCPPromptDescriptor } from "@/common/orpc/schemas/mcp";
+import type { PluginSlashCommandDescriptor } from "@/common/orpc/schemas/agentPlugins";
+
+export type ComposerSuggestionToken =
+  | { kind: "file"; startIndex: number; endIndex: number; query: string }
+  | { kind: "inline"; startIndex: number; endIndex: number; query: string }
+  | { kind: "symbol"; startIndex: number; endIndex: number; query: string }
+  | { kind: "slash"; startIndex: 0; endIndex: number; query: string };
+
+interface SuggestionExperiments {
+  workspaceHeartbeats: boolean;
+  dynamicWorkflows: boolean;
+  memory: boolean;
+  memoryConsolidation: boolean;
+  rlm: boolean;
+  programmaticToolCalling: boolean;
+}
+
+interface SynchronousSuggestionContext {
+  agentSkills: AgentSkillDescriptor[];
+  mcpPrompts: MCPPromptDescriptor[];
+  pluginCommands: PluginSlashCommandDescriptor[];
+  variant: "creation" | "workspace";
+  experiments: SuggestionExperiments;
+}
+
+export function detectActiveComposerToken(
+  input: string,
+  cursor: number
+): ComposerSuggestionToken | null {
+  const boundedCursor = Math.min(Math.max(cursor, 0), input.length);
+  const file = findAtMentionAtCursor(input, boundedCursor);
+  if (file) {
+    return {
+      kind: "file",
+      startIndex: file.startIndex,
+      endIndex: file.endIndex,
+      query: file.query,
+    };
+  }
+
+  const inline = findInlineSkillReferenceAtCursor(input, boundedCursor);
+  if (inline) {
+    return {
+      kind: "inline",
+      startIndex: inline.startIndex,
+      endIndex: inline.endIndex,
+      query: inline.partial,
+    };
+  }
+
+  const symbol = findSymbolCommandAtCursor(input, boundedCursor);
+  if (symbol) {
+    return {
+      kind: "symbol",
+      startIndex: symbol.startIndex,
+      endIndex: symbol.endIndex,
+      query: symbol.partial,
+    };
+  }
+
+  if (input.trimStart().startsWith("/")) {
+    return { kind: "slash", startIndex: 0, endIndex: input.length, query: input };
+  }
+  return null;
+}
+
+export function getSynchronousComposerSuggestions(
+  token: ComposerSuggestionToken | null,
+  context: SynchronousSuggestionContext
+): SlashSuggestion[] {
+  if (!token || token.kind === "file") return [];
+  if (token.kind === "inline") {
+    return getInlineSkillSuggestions({
+      partial: token.query,
+      descriptors: context.agentSkills,
+      mcpPrompts: context.mcpPrompts,
+    });
+  }
+  if (token.kind === "symbol") return getSymbolSuggestions(token.query);
+  return getSlashCommandSuggestions(token.query, {
+    agentSkills: context.agentSkills,
+    mcpPrompts: context.mcpPrompts,
+    pluginCommands: context.pluginCommands,
+    variant: context.variant,
+    isExperimentEnabled: (experimentId) =>
+      resolveSlashCommandExperimentValue(experimentId, context.experiments),
+  });
+}
+
+export function applyComposerSuggestion(
+  input: string,
+  token: ComposerSuggestionToken,
+  suggestion: SlashSuggestion
+): { input: string; cursor: number } {
+  if (token.kind === "slash") {
+    return { input: suggestion.replacement, cursor: suggestion.replacement.length };
+  }
+
+  const after = input.slice(token.endIndex);
+  const trailing =
+    token.kind === "file"
+      ? " "
+      : token.kind === "inline"
+        ? getInlineSkillInsertionTrailingText(after)
+        : "";
+  const next = input.slice(0, token.startIndex) + suggestion.replacement + trailing + after;
+  return {
+    input: next,
+    cursor: token.startIndex + suggestion.replacement.length + trailing.length,
+  };
+}
+
+function tokenKey(token: ComposerSuggestionToken | null): string | null {
+  return token ? [token.kind, token.startIndex, token.endIndex, token.query].join(":") : null;
+}
+
+function fileType(path: string): string {
+  if (path.endsWith("/")) return "Directory";
+  const lastDot = path.lastIndexOf(".");
+  const lastSlash = path.lastIndexOf("/");
+  return lastDot > lastSlash && lastDot < path.length - 1
+    ? path.slice(lastDot + 1).toUpperCase()
+    : "File";
+}
+
+interface UseComposerSuggestionsOptions {
+  input: string;
+  setInput: (input: string) => void;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  variant: "creation" | "workspace";
+  workspaceId: string | null;
+  projectPath: string | null;
+  disableWorkspaceAgents: boolean;
+  transferredDraftProjectDiscovery: boolean;
+  agentPluginsEnabled: boolean;
+  experiments: SuggestionExperiments;
+}
+
+export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
+  const { api } = useAPI();
+  const [cursor, setCursor] = useState(options.input.length);
+  const [selection, setSelection] = useState({ tokenKey: "", index: 0, dismissed: false });
+  const [fileCompletion, setFileCompletion] = useState<{
+    tokenKey: string;
+    suggestions: SlashSuggestion[];
+  }>({ tokenKey: "", suggestions: [] });
+  const [agentSkills, setAgentSkills] = useState<AgentSkillDescriptor[]>([]);
+  const [mcpPrompts, setMcpPrompts] = useState<MCPPromptDescriptor[]>([]);
+  const [pluginCommands, setPluginCommands] = useState<PluginSlashCommandDescriptor[]>([]);
+  const [pluginMutationTick, setPluginMutationTick] = useState(0);
+  const fileRequestId = useRef(0);
+  const skillRequestId = useRef(0);
+  const mcpRequestId = useRef(0);
+  const mcpRequest = useRef<Promise<void> | null>(null);
+  const mcpLoadedAt = useRef(0);
+  const mcpWorkspace = useRef<string | null>(null);
+  const mcpAbort = useRef<AbortController | null>(null);
+  const listId = useId();
+
+  const activeToken = detectActiveComposerToken(options.input, cursor);
+  const activeTokenKey = tokenKey(activeToken) ?? "";
+  const synchronousSuggestions = getSynchronousComposerSuggestions(activeToken, {
+    agentSkills,
+    mcpPrompts,
+    pluginCommands,
+    variant: options.variant,
+    experiments: options.experiments,
+  });
+  const suggestions =
+    activeToken?.kind === "file" && fileCompletion.tokenKey === activeTokenKey
+      ? fileCompletion.suggestions
+      : synchronousSuggestions;
+  const dismissed = selection.tokenKey === activeTokenKey && selection.dismissed;
+  const isVisible = !dismissed && suggestions.length > 0;
+  const selectedIndex =
+    selection.tokenKey === activeTokenKey
+      ? Math.min(selection.index, Math.max(0, suggestions.length - 1))
+      : 0;
+
+  useEffect(
+    () => subscribeAgentPluginsMutated(() => setPluginMutationTick((tick) => tick + 1)),
+    []
+  );
+
+  useEffect(() => {
+    let mounted = true;
+    const requestId = ++skillRequestId.current;
+    const discovery =
+      options.variant === "workspace" && options.workspaceId
+        ? {
+            workspaceId: options.workspaceId,
+            disableWorkspaceAgents:
+              options.disableWorkspaceAgents || options.transferredDraftProjectDiscovery,
+          }
+        : options.variant === "creation" && options.projectPath
+          ? { projectPath: options.projectPath }
+          : null;
+    if (!api || !discovery) {
+      setAgentSkills([]);
+      return;
+    }
+    api.agentSkills
+      .list(discovery)
+      .then((skills) => {
+        if (mounted && skillRequestId.current === requestId) setAgentSkills(skills);
+      })
+      .catch((error: unknown) => {
+        console.error("Failed to load agent skills:", error);
+        if (mounted && skillRequestId.current === requestId) setAgentSkills([]);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [
+    api,
+    options.variant,
+    options.workspaceId,
+    options.projectPath,
+    options.disableWorkspaceAgents,
+    options.transferredDraftProjectDiscovery,
+    options.agentPluginsEnabled,
+    pluginMutationTick,
+  ]);
+
+  useEffect(() => {
+    let mounted = true;
+    if (
+      !api ||
+      options.variant !== "workspace" ||
+      !options.workspaceId ||
+      !options.agentPluginsEnabled
+    ) {
+      setPluginCommands([]);
+      return;
+    }
+    api.workspace.plugins.slashCommands
+      .list({ workspaceId: options.workspaceId })
+      .then((commands) => {
+        if (mounted) setPluginCommands(commands);
+      })
+      .catch(() => {
+        if (mounted) setPluginCommands([]);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [api, options.variant, options.workspaceId, options.agentPluginsEnabled, pluginMutationTick]);
+
+  useEffect(() => {
+    const workspaceId = options.workspaceId;
+    if (!api || options.variant !== "workspace" || !workspaceId) {
+      mcpWorkspace.current = null;
+      mcpLoadedAt.current = 0;
+      mcpRequestId.current++;
+      mcpRequest.current = null;
+      mcpAbort.current?.abort();
+      mcpAbort.current = null;
+      setMcpPrompts([]);
+      return;
+    }
+    if (mcpWorkspace.current !== workspaceId) {
+      mcpWorkspace.current = workspaceId;
+      mcpLoadedAt.current = 0;
+      mcpRequestId.current++;
+      mcpRequest.current = null;
+      mcpAbort.current?.abort();
+      mcpAbort.current = null;
+      setMcpPrompts([]);
+    }
+    if (activeToken?.kind !== "slash" && activeToken?.kind !== "inline") return;
+    if (Date.now() - mcpLoadedAt.current < 30_000 || mcpRequest.current) return;
+
+    const requestId = ++mcpRequestId.current;
+    const controller = new AbortController();
+    mcpAbort.current = controller;
+    const request = api.workspace.mcp.prompts
+      .list({ workspaceId }, { signal: controller.signal })
+      .then((prompts) => {
+        if (mcpWorkspace.current === workspaceId && mcpRequestId.current === requestId) {
+          setMcpPrompts(prompts);
+          mcpLoadedAt.current = Date.now();
+        }
+      })
+      .catch(() => {
+        if (mcpWorkspace.current === workspaceId && mcpRequestId.current === requestId) {
+          mcpLoadedAt.current = Date.now();
+        }
+      })
+      .finally(() => {
+        if (mcpRequest.current === request) mcpRequest.current = null;
+        if (mcpAbort.current === controller) mcpAbort.current = null;
+      });
+    mcpRequest.current = request;
+  }, [api, activeToken?.kind, options.variant, options.workspaceId]);
+
+  useEffect(() => {
+    if (!api || activeToken?.kind !== "file") return;
+    const scope = options.variant === "workspace" ? options.workspaceId : options.projectPath;
+    if (!scope) return;
+    const requestId = ++fileRequestId.current;
+    const requestedTokenKey = activeTokenKey;
+    const request =
+      options.variant === "workspace"
+        ? api.workspace.getFileCompletions({
+            workspaceId: scope,
+            query: activeToken.query,
+            limit: 20,
+          })
+        : api.projects.getFileCompletions({
+            projectPath: scope,
+            query: activeToken.query,
+            limit: 20,
+          });
+    request
+      .then((result) => {
+        if (fileRequestId.current !== requestId) return;
+        setFileCompletion({
+          tokenKey: requestedTokenKey,
+          suggestions: result.paths
+            .filter((path) => !/\s/.test(path))
+            .map((path) => ({
+              id: `file:${path}`,
+              display: path,
+              description: fileType(path),
+              replacement: `@${path}`,
+            })),
+        });
+      })
+      .catch(() => {
+        if (fileRequestId.current === requestId) {
+          setFileCompletion({ tokenKey: requestedTokenKey, suggestions: [] });
+        }
+      });
+  }, [api, activeTokenKey, options.variant, options.workspaceId, options.projectPath]);
+
+  const dismiss = useCallback(() => {
+    setSelection({ tokenKey: activeTokenKey, index: selectedIndex, dismissed: true });
+  }, [activeTokenKey, selectedIndex]);
+
+  const setSelectedIndex = useCallback(
+    (index: number) => setSelection({ tokenKey: activeTokenKey, index, dismissed: false }),
+    [activeTokenKey]
+  );
+
+  const select = useCallback(
+    (suggestion: SlashSuggestion) => {
+      if (!activeToken) return;
+      const applied = applyComposerSuggestion(options.input, activeToken, suggestion);
+      options.setInput(applied.input);
+      setCursor(applied.cursor);
+      setSelection({ tokenKey: activeTokenKey, index: 0, dismissed: true });
+      requestAnimationFrame(() => {
+        const element = options.inputRef.current;
+        if (!element || element.disabled) return;
+        element.focus();
+        element.selectionStart = applied.cursor;
+        element.selectionEnd = applied.cursor;
+      });
+    },
+    [activeToken, activeTokenKey, options.input, options.inputRef, options.setInput]
+  );
+
+  useEffect(() => {
+    if (!isVisible) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        const delta = event.key === "ArrowDown" ? 1 : -1;
+        setSelectedIndex((selectedIndex + delta + suggestions.length) % suggestions.length);
+      } else if ((event.key === "Tab" || event.key === "Enter") && !event.shiftKey) {
+        event.preventDefault();
+        const suggestion = suggestions[selectedIndex];
+        if (suggestion) select(suggestion);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        dismiss();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [dismiss, isVisible, select, selectedIndex, setSelectedIndex, suggestions]);
+
+  useEffect(() => () => mcpAbort.current?.abort(), []);
+
+  const handleCursorActivity = useCallback(() => {
+    const element = options.inputRef.current;
+    if (element) setCursor(element.selectionStart ?? options.input.length);
+  }, [options.input.length, options.inputRef]);
+
+  const handleInputCaretChange = useCallback((caret: number | undefined, inputLength: number) => {
+    setCursor(caret ?? inputLength);
+  }, []);
+
+  const ghostHint = getCommandGhostHint(options.input, isVisible && activeToken?.kind === "slash", {
+    variant: options.variant,
+    isExperimentEnabled: (experimentId) =>
+      resolveSlashCommandExperimentValue(experimentId, options.experiments),
+  });
+
+  return {
+    activeToken,
+    suggestions,
+    selectedIndex,
+    setSelectedIndex,
+    select,
+    dismiss,
+    isVisible,
+    listId,
+    ariaLabel:
+      activeToken?.kind === "file"
+        ? "File path suggestions"
+        : activeToken?.kind === "inline"
+          ? "Skill suggestions"
+          : activeToken?.kind === "symbol"
+            ? "Symbol shortcuts"
+            : "Slash command suggestions",
+    highlightQuery:
+      activeToken?.kind === "file" ||
+      activeToken?.kind === "inline" ||
+      activeToken?.kind === "symbol"
+        ? activeToken.query
+        : undefined,
+    isFileSuggestion: activeToken?.kind === "file",
+    suppressionKeys: activeToken?.kind === "slash" ? "command" : "file",
+    ghostHint,
+    handleCursorActivity,
+    handleInputCaretChange,
+    agentSkillDescriptors: agentSkills,
+    mcpPromptDescriptors: mcpPrompts,
+  };
+}

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -157,8 +157,20 @@ interface UseComposerSuggestionsOptions {
 }
 
 export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
+  const {
+    agentPluginsEnabled,
+    disableWorkspaceAgents,
+    experiments,
+    input,
+    inputRef,
+    projectPath,
+    setInput,
+    transferredDraftProjectDiscovery,
+    variant,
+    workspaceId,
+  } = options;
   const { api } = useAPI();
-  const [cursor, setCursor] = useState(options.input.length);
+  const [cursor, setCursor] = useState(input.length);
   const [selection, setSelection] = useState({
     channelKey: "",
     index: 0,
@@ -182,15 +194,15 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   const mcpAbort = useRef<AbortController | null>(null);
   const listId = useId();
 
-  const activeToken = detectActiveComposerToken(options.input, cursor);
+  const activeToken = detectActiveComposerToken(input, cursor);
   const activeTokenKey = tokenKey(activeToken) ?? "";
   const activeChannelKey = activeToken ? `${activeToken.kind}:${activeToken.startIndex}` : "";
   const synchronousSuggestions = getSynchronousComposerSuggestions(activeToken, {
     agentSkills,
     mcpPrompts,
     pluginCommands,
-    variant: options.variant,
-    experiments: options.experiments,
+    variant,
+    experiments,
   });
   const suggestions =
     activeToken?.kind === "file" && fileCompletion.tokenKey === activeTokenKey
@@ -216,14 +228,13 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     let mounted = true;
     const requestId = ++skillRequestId.current;
     const discovery =
-      options.variant === "workspace" && options.workspaceId
+      variant === "workspace" && workspaceId
         ? {
-            workspaceId: options.workspaceId,
-            disableWorkspaceAgents:
-              options.disableWorkspaceAgents || options.transferredDraftProjectDiscovery,
+            workspaceId: workspaceId,
+            disableWorkspaceAgents: disableWorkspaceAgents || transferredDraftProjectDiscovery,
           }
-        : options.variant === "creation" && options.projectPath
-          ? { projectPath: options.projectPath }
+        : variant === "creation" && projectPath
+          ? { projectPath }
           : null;
     if (!api || !discovery) {
       setAgentSkills([]);
@@ -243,28 +254,23 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     };
   }, [
     api,
-    options.variant,
-    options.workspaceId,
-    options.projectPath,
-    options.disableWorkspaceAgents,
-    options.transferredDraftProjectDiscovery,
-    options.agentPluginsEnabled,
+    variant,
+    workspaceId,
+    projectPath,
+    disableWorkspaceAgents,
+    transferredDraftProjectDiscovery,
+    agentPluginsEnabled,
     pluginMutationTick,
   ]);
 
   useEffect(() => {
     let mounted = true;
-    if (
-      !api ||
-      options.variant !== "workspace" ||
-      !options.workspaceId ||
-      !options.agentPluginsEnabled
-    ) {
+    if (!api || variant !== "workspace" || !workspaceId || !agentPluginsEnabled) {
       setPluginCommands([]);
       return;
     }
     api.workspace.plugins.slashCommands
-      .list({ workspaceId: options.workspaceId })
+      .list({ workspaceId: workspaceId })
       .then((commands) => {
         if (mounted) setPluginCommands(commands);
       })
@@ -274,11 +280,10 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     return () => {
       mounted = false;
     };
-  }, [api, options.variant, options.workspaceId, options.agentPluginsEnabled, pluginMutationTick]);
+  }, [api, variant, workspaceId, agentPluginsEnabled, pluginMutationTick]);
 
   useEffect(() => {
-    const workspaceId = options.workspaceId;
-    if (!api || options.variant !== "workspace" || !workspaceId) {
+    if (!api || variant !== "workspace" || !workspaceId) {
       mcpWorkspace.current = null;
       mcpLoadedAt.current = 0;
       mcpRequestId.current++;
@@ -321,16 +326,16 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         if (mcpAbort.current === controller) mcpAbort.current = null;
       });
     mcpRequest.current = request;
-  }, [api, activeToken?.kind, activeTokenKey, options.variant, options.workspaceId]);
+  }, [api, activeToken?.kind, activeTokenKey, variant, workspaceId]);
 
   useEffect(() => {
     if (!api || activeToken?.kind !== "file") return;
-    const scope = options.variant === "workspace" ? options.workspaceId : options.projectPath;
+    const scope = variant === "workspace" ? workspaceId : projectPath;
     if (!scope) return;
     const requestId = ++fileRequestId.current;
     const requestedTokenKey = activeTokenKey;
     const request =
-      options.variant === "workspace"
+      variant === "workspace"
         ? api.workspace.getFileCompletions({
             workspaceId: scope,
             query: activeToken.query,
@@ -361,7 +366,15 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
           setFileCompletion({ tokenKey: requestedTokenKey, suggestions: [] });
         }
       });
-  }, [api, activeTokenKey, options.variant, options.workspaceId, options.projectPath]);
+  }, [
+    api,
+    activeToken?.kind,
+    activeToken?.query,
+    activeTokenKey,
+    projectPath,
+    variant,
+    workspaceId,
+  ]);
 
   const dismiss = useCallback(() => {
     setSelection({
@@ -386,8 +399,8 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   const select = useCallback(
     (suggestion: SlashSuggestion) => {
       if (!activeToken) return;
-      const applied = applyComposerSuggestion(options.input, activeToken, suggestion);
-      options.setInput(applied.input);
+      const applied = applyComposerSuggestion(input, activeToken, suggestion);
+      setInput(applied.input);
       setCursor(applied.cursor);
       setSelection({
         channelKey: activeChannelKey,
@@ -396,14 +409,14 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         dismissedTokenKey: tokenKey(detectActiveComposerToken(applied.input, applied.cursor)) ?? "",
       });
       requestAnimationFrame(() => {
-        const element = options.inputRef.current;
+        const element = inputRef.current;
         if (!element || element.disabled) return;
         element.focus();
         element.selectionStart = applied.cursor;
         element.selectionEnd = applied.cursor;
       });
     },
-    [activeChannelKey, activeToken, options.input, options.inputRef, options.setInput]
+    [activeChannelKey, activeToken, input, inputRef, setInput]
   );
 
   useEffect(() => {
@@ -430,18 +443,18 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   useEffect(() => () => mcpAbort.current?.abort(), []);
 
   const handleCursorActivity = useCallback(() => {
-    const element = options.inputRef.current;
-    if (element) setCursor(element.selectionStart ?? options.input.length);
-  }, [options.input.length, options.inputRef]);
+    const element = inputRef.current;
+    if (element) setCursor(element.selectionStart ?? input.length);
+  }, [input.length, inputRef]);
 
   const handleInputCaretChange = useCallback((caret: number | undefined, inputLength: number) => {
     setCursor(caret ?? inputLength);
   }, []);
 
-  const ghostHint = getCommandGhostHint(options.input, isVisible && activeToken?.kind === "slash", {
-    variant: options.variant,
+  const ghostHint = getCommandGhostHint(input, isVisible && activeToken?.kind === "slash", {
+    variant,
     isExperimentEnabled: (experimentId) =>
-      resolveSlashCommandExperimentValue(experimentId, options.experiments),
+      resolveSlashCommandExperimentValue(experimentId, experiments),
   });
 
   return {

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -187,7 +187,11 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     false,
     { listener: true }
   );
-  const [cursor, setCursor] = useState(input.length);
+  // A measured caret is only valid for the input it was measured against;
+  // external input changes (draft restore, persisted-state writes) fall back
+  // to end-of-text, matching the pre-extraction selectionStart ?? length read.
+  const [caretState, setCaretState] = useState<{ input: string; cursor: number } | null>(null);
+  const cursor = caretState?.input === input ? caretState.cursor : input.length;
   const [selection, setSelection] = useState({
     channelKey: "",
     index: 0,
@@ -424,7 +428,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     if (!activeToken) return;
     const applied = applyComposerSuggestion(input, activeToken, suggestion);
     setInput(applied.input);
-    setCursor(applied.cursor);
+    setCaretState({ input: applied.input, cursor: applied.cursor });
     setSelection({
       channelKey: activeChannelKey,
       index: 0,
@@ -472,11 +476,11 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
 
   const handleCursorActivity = () => {
     const element = inputRef.current;
-    if (element) setCursor(element.selectionStart ?? input.length);
+    if (element) setCaretState({ input, cursor: element.selectionStart ?? input.length });
   };
 
-  const handleInputCaretChange = (caret: number | undefined, inputLength: number) => {
-    setCursor(caret ?? inputLength);
+  const handleInputCaretChange = (caret: number | undefined, nextInput: string) => {
+    setCaretState({ input: nextInput, cursor: caret ?? nextInput.length });
   };
 
   const ghostHint = getCommandGhostHint(input, isVisible && activeToken?.kind === "slash", {

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -111,7 +111,7 @@ export function applyComposerSuggestion(
   input: string,
   token: ComposerSuggestionToken,
   suggestion: SlashSuggestion
-): { input: string; cursor: number } {
+) {
   if (token.kind === "slash") {
     return { input: suggestion.replacement, cursor: suggestion.replacement.length };
   }
@@ -230,7 +230,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     const discovery =
       variant === "workspace" && workspaceId
         ? {
-            workspaceId: workspaceId,
+            workspaceId,
             disableWorkspaceAgents: disableWorkspaceAgents || transferredDraftProjectDiscovery,
           }
         : variant === "creation" && projectPath
@@ -270,7 +270,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
       return;
     }
     api.workspace.plugins.slashCommands
-      .list({ workspaceId: workspaceId })
+      .list({ workspaceId })
       .then((commands) => {
         if (mounted) setPluginCommands(commands);
       })
@@ -458,7 +458,6 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   });
 
   return {
-    activeToken,
     suggestions,
     selectedIndex,
     setSelectedIndex,
@@ -481,7 +480,6 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         ? activeToken.query
         : undefined,
     isFileSuggestion: activeToken?.kind === "file",
-    suppressionKeys: activeToken?.kind === "slash" ? "command" : "file",
     ghostHint,
     handleCursorActivity,
     handleInputCaretChange,

--- a/src/browser/features/ChatInput/useComposerSuggestions.ts
+++ b/src/browser/features/ChatInput/useComposerSuggestions.ts
@@ -159,7 +159,12 @@ interface UseComposerSuggestionsOptions {
 export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   const { api } = useAPI();
   const [cursor, setCursor] = useState(options.input.length);
-  const [selection, setSelection] = useState({ tokenKey: "", index: 0, dismissed: false });
+  const [selection, setSelection] = useState({
+    channelKey: "",
+    index: 0,
+    selectedId: null as string | null,
+    dismissedTokenKey: "",
+  });
   const [fileCompletion, setFileCompletion] = useState<{
     tokenKey: string;
     suggestions: SlashSuggestion[];
@@ -179,6 +184,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
 
   const activeToken = detectActiveComposerToken(options.input, cursor);
   const activeTokenKey = tokenKey(activeToken) ?? "";
+  const activeChannelKey = activeToken ? `${activeToken.kind}:${activeToken.startIndex}` : "";
   const synchronousSuggestions = getSynchronousComposerSuggestions(activeToken, {
     agentSkills,
     mcpPrompts,
@@ -190,11 +196,15 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
     activeToken?.kind === "file" && fileCompletion.tokenKey === activeTokenKey
       ? fileCompletion.suggestions
       : synchronousSuggestions;
-  const dismissed = selection.tokenKey === activeTokenKey && selection.dismissed;
-  const isVisible = !dismissed && suggestions.length > 0;
+  const isVisible = selection.dismissedTokenKey !== activeTokenKey && suggestions.length > 0;
+  const preservedIndex = selection.selectedId
+    ? suggestions.findIndex((suggestion) => suggestion.id === selection.selectedId)
+    : -1;
   const selectedIndex =
-    selection.tokenKey === activeTokenKey
-      ? Math.min(selection.index, Math.max(0, suggestions.length - 1))
+    selection.channelKey === activeChannelKey
+      ? preservedIndex >= 0
+        ? preservedIndex
+        : Math.min(selection.index, Math.max(0, suggestions.length - 1))
       : 0;
 
   useEffect(
@@ -311,7 +321,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         if (mcpAbort.current === controller) mcpAbort.current = null;
       });
     mcpRequest.current = request;
-  }, [api, activeToken?.kind, options.variant, options.workspaceId]);
+  }, [api, activeToken?.kind, activeTokenKey, options.variant, options.workspaceId]);
 
   useEffect(() => {
     if (!api || activeToken?.kind !== "file") return;
@@ -354,12 +364,23 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
   }, [api, activeTokenKey, options.variant, options.workspaceId, options.projectPath]);
 
   const dismiss = useCallback(() => {
-    setSelection({ tokenKey: activeTokenKey, index: selectedIndex, dismissed: true });
-  }, [activeTokenKey, selectedIndex]);
+    setSelection({
+      channelKey: activeChannelKey,
+      index: selectedIndex,
+      selectedId: suggestions[selectedIndex]?.id ?? null,
+      dismissedTokenKey: activeTokenKey,
+    });
+  }, [activeChannelKey, activeTokenKey, selectedIndex, suggestions]);
 
   const setSelectedIndex = useCallback(
-    (index: number) => setSelection({ tokenKey: activeTokenKey, index, dismissed: false }),
-    [activeTokenKey]
+    (index: number) =>
+      setSelection({
+        channelKey: activeChannelKey,
+        index,
+        selectedId: suggestions[index]?.id ?? null,
+        dismissedTokenKey: "",
+      }),
+    [activeChannelKey, suggestions]
   );
 
   const select = useCallback(
@@ -368,7 +389,12 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
       const applied = applyComposerSuggestion(options.input, activeToken, suggestion);
       options.setInput(applied.input);
       setCursor(applied.cursor);
-      setSelection({ tokenKey: activeTokenKey, index: 0, dismissed: true });
+      setSelection({
+        channelKey: activeChannelKey,
+        index: 0,
+        selectedId: null,
+        dismissedTokenKey: tokenKey(detectActiveComposerToken(applied.input, applied.cursor)) ?? "",
+      });
       requestAnimationFrame(() => {
         const element = options.inputRef.current;
         if (!element || element.disabled) return;
@@ -377,7 +403,7 @@ export function useComposerSuggestions(options: UseComposerSuggestionsOptions) {
         element.selectionEnd = applied.cursor;
       });
     },
-    [activeToken, activeTokenKey, options.input, options.inputRef, options.setInput]
+    [activeChannelKey, activeToken, options.input, options.inputRef, options.setInput]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Decomposes the 4,011-line `ChatInput` composer (`ChatInputInner`: 27 useState / 37 useRef / 32 useEffect conflating 7 concerns) into three deep hooks plus a pure send-preflight function, with a net **-142 LOC** delta. Behavior-preserving: no UX, keybind, or feature changes.

## Background

Refactor #7 from the 2026-08-29 architecture review (evidence at `f04e0f8a3`). Every keystroke re-evaluated all 32 effects; the ~570-line send preflight and the four suggestion channels were untestable without DOM, and the four channels duplicated the same cursor/token logic.

## Implementation

- `useComposerSuggestions` (~500 lines): unifies the four suggestion channels (slash command, @-mention, skill, symbol) behind a single cursor/token seam. Self-contained per repo guidance: derives experiments, plugin enablement, and draft-discovery state internally; the boundary is the input seam plus identity. The token matcher is a pure exported function with DOM-free tests.
- `useComposerAttachments` (~190): attachment state, processing counts, PDF/media-type validation, paste/drop/pick entry points, and draft-attachment persistence.
- `useComposerDraft` (~160): storage-key scoping (workspace/creation/pending-draft), input persistence and restore across workspace switches, draft-review lifecycle.
- `prepareMessagePayload` (~140): pure payload assembly extracted from `handleSend`; the remaining orchestrator is guard, async resolution, prepare, dispatch. Covered by table-driven unit tests, including the compaction-metadata ref gate (proven red-green).
- `index.tsx`: 4,011 to 2,924 lines; effects reduced (32 to ~22). No manual memoization anywhere in the new hooks (React Compiler convention); the two effects that previously leaned on `useCallback` identity now key on data (`editingMessage?.id`) or hand out latest-ref wrappers (`onReady` API), and the document keydown listener uses a latest-ref handler attached only on visibility.
- Caret state is keyed to the input it was measured against, falling back to end-of-text for external input changes (draft restores, persisted-state writes), preserving pre-extraction semantics; symbol auto-conversion propagates the converted text/cursor into the seam.

## Net LOC

- Production: +1,170 / -1,309 (**-139**)
- Tests: +294 / -297 (**-3**)

Irreducible additions: `useComposerSuggestions` consolidates four previously duplicated channel implementations behind one seam (replacing ~640 deleted lines from `index.tsx`/`CommandSuggestions.tsx`); `prepareMessagePayload` + its tests (+211) make the send preflight unit-testable for the first time, offset by pruning mock-heavy structure-asserting tests (`CommandSuggestions.test.tsx` -79, `symbolShortcuts.test.ts` -92 net, collapsed into table-driven cases).

## Validation

- Remote dogfood UAT (regression-focused): 27 scenarios at desktop and 375 px widths, endorsed PASS covering typing, all four suggestion channels, attachments (image + PDF, button/paste/drag-drop), draft save/restore across workspace switches, edit mode + boundary confirm, destructive-command modal, Escape/Enter keybinds, and send/queue during a live stream. Both anomalies found were proven pre-existing via target-vs-base comparison.
- Review-round hardening: CI caught two real regressions that were bisected and fixed with deterministic local repros: a stale suggestion caret when input is written externally (jest `fileMentionsWithSlashCommands`) and an edit-populate effect that clobbered in-progress edit text once draft helpers lost `useCallback` identity (e2e `review.spec`). Both suites now pass locally and in CI, alongside `make static-check` and whole-file bun runs of all touched test files.

## Risks

Highest-traffic UI surface in the app. The riskiest moves are the unified suggestion token seam (channel trigger/filter/selection semantics), the send preflight extraction, and the effect re-keying described above. Mitigated by the new pure unit tests, the full UAT regression pass, the e2e/jest coverage that already caught the two regressions, and keeping `ChatInputProps`/`ChatInputAPI` unchanged.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$155.26`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=155.26 -->

## Stack

Layer 8/10 of the architecture refactor stack (net -5,101 LOC overall). This PR's diff is only this layer, against `mike/arch-turn-context-assembler`.
