### PR TITLE
🤖 refactor: decouple WorkspaceStore subscription transport from streaming aggregation

### DIFF
--- a/src/browser/features/Messages/MessageRenderer.tsx
+++ b/src/browser/features/Messages/MessageRenderer.tsx
@@ -21,7 +21,7 @@ import { CompactionBoundaryMessage } from "./CompactionBoundaryMessage";
 import { HistoryHiddenMessage } from "./HistoryHiddenMessage";
 import { InitMessage } from "./InitMessage";
 import { ProposePlanToolCall } from "../Tools/ProposePlanToolCall";
-import { removeEphemeralMessage } from "@/browser/stores/WorkspaceStore";
+import { removeEphemeralMessage, useStreamingMessageDelta } from "@/browser/stores/WorkspaceStore";
 import { TranscriptMessageBoundary, TranscriptQuoteRoot } from "./TranscriptQuoteBoundary";
 
 interface MessageRendererProps {
@@ -90,6 +90,7 @@ export const MessageRenderer = React.memo<MessageRendererProps>(
     taskReportLinking,
     userMessageNavigation,
   }) => {
+    message = useStreamingMessageDelta(workspaceId, message);
     let renderedMessage: React.ReactNode;
 
     // Route based on message type

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2036,41 +2036,79 @@ describe("WorkspaceStore", () => {
       const bump = spyOn(rawStore.states, "bump");
       const listener = mock(() => undefined);
       const unsubscribe = store.subscribeStreamingMessage(workspaceId, messageId, listener);
-      const deltas: WorkspaceChatMessage[] = [
+      // A delta that adds a part creates a new display row, which only a
+      // workspace bump can mount; within-part deltas stay row-local.
+      const deltas: Array<{ event: WorkspaceChatMessage; createsRow: boolean }> = [
         {
-          type: "stream-delta",
-          workspaceId,
-          messageId,
-          delta: "hello",
-          tokens: 1,
-          timestamp: 2,
+          event: {
+            type: "stream-delta",
+            workspaceId,
+            messageId,
+            delta: "hello",
+            tokens: 1,
+            timestamp: 2,
+          },
+          createsRow: true,
         },
         {
-          type: "reasoning-delta",
-          workspaceId,
-          messageId,
-          delta: "thinking",
-          tokens: 1,
-          timestamp: 3,
+          event: {
+            type: "stream-delta",
+            workspaceId,
+            messageId,
+            delta: " world",
+            tokens: 1,
+            timestamp: 3,
+          },
+          createsRow: false,
         },
         {
-          type: "tool-call-delta",
-          workspaceId,
-          messageId,
-          toolCallId: "tool-1",
-          toolName: "bash",
-          delta: { command: "echo hi" },
-          tokens: 1,
-          timestamp: 4,
+          event: {
+            type: "reasoning-delta",
+            workspaceId,
+            messageId,
+            delta: "thinking",
+            tokens: 1,
+            timestamp: 4,
+          },
+          createsRow: true,
+        },
+        {
+          event: {
+            type: "reasoning-delta",
+            workspaceId,
+            messageId,
+            delta: " harder",
+            tokens: 1,
+            timestamp: 5,
+          },
+          createsRow: false,
+        },
+        {
+          event: {
+            type: "tool-call-delta",
+            workspaceId,
+            messageId,
+            toolCallId: "tool-1",
+            toolName: "bash",
+            delta: { command: "echo hi" },
+            tokens: 1,
+            timestamp: 6,
+          },
+          createsRow: false,
         },
       ];
 
       bump.mockClear();
-      for (const delta of deltas) {
+      for (const { event, createsRow } of deltas) {
         listener.mockClear();
-        rawStore.handleChatMessage(workspaceId, delta);
-        expect(bump).not.toHaveBeenCalled();
-        expect(listener).toHaveBeenCalledTimes(1);
+        bump.mockClear();
+        rawStore.handleChatMessage(workspaceId, event);
+        if (createsRow) {
+          expect(bump).toHaveBeenCalledWith(workspaceId);
+        } else {
+          expect(bump).not.toHaveBeenCalled();
+          expect(listener).toHaveBeenCalledTimes(1);
+        }
       }
 
       rawStore.handleChatMessage(workspaceId, {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2004,8 +2004,9 @@ describe("WorkspaceStore", () => {
       expect(clearedState.canInterrupt).toBe(false);
     });
 
-    it("routes live deltas through the keyed channel without bumping workspace state", () => {
+    it("routes live deltas through the keyed channel without bumping workspace state", async () => {
       const workspaceId = "fine-grained-deltas";
+      const flushMicrotasks = () => new Promise<void>((resolve) => queueMicrotask(resolve));
       const messageId = "stream-message";
       createAndAddWorkspace(store, workspaceId);
       const rawStore = getInternal<{
@@ -2013,7 +2014,17 @@ describe("WorkspaceStore", () => {
         streamingStatsStore: { bump: (key: string) => void };
         streamingMessageStore: { has: (key: string) => boolean };
         handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+        processStreamEvent: (
+          id: string,
+          aggregator: ReturnType<WorkspaceStore["getAggregator"]>,
+          event: WorkspaceChatMessage
+        ) => void;
       }>(store);
+      // Dispatch below the caught-up buffering gate: the mock onChat retry loop
+      // resets transient.caughtUp whenever an await lets it advance, which would
+      // silently buffer later events. Hydration gating is covered elsewhere.
+      const dispatch = (event: WorkspaceChatMessage) =>
+        rawStore.processStreamEvent(workspaceId, store.getAggregator(workspaceId), event);
 
       rawStore.handleChatMessage(workspaceId, {
         type: "stream-start",
@@ -2037,7 +2048,6 @@ describe("WorkspaceStore", () => {
 
       const bump = spyOn(rawStore.states, "bump");
       const listener = mock(() => undefined);
-      const unsubscribe = store.subscribeStreamingMessage(workspaceId, messageId, listener);
       // A delta that adds a part creates a new display row, which only a
       // workspace bump can mount; within-part deltas stay row-local.
       const deltas: Array<{ event: WorkspaceChatMessage; createsRow: boolean }> = [
@@ -2101,22 +2111,38 @@ describe("WorkspaceStore", () => {
       ];
 
       const statsBump = spyOn(rawStore.streamingStatsStore, "bump");
+      const trailingRowId = () => {
+        const rows = store.getAggregator(workspaceId)!.getDisplayedMessages();
+        for (let i = rows.length - 1; i >= 0; i--) {
+          const row = rows[i];
+          if ("historyId" in row && row.historyId === messageId) return row.id;
+        }
+        throw new Error("no displayed row for streaming message");
+      };
       bump.mockClear();
       for (const { event, createsRow } of deltas) {
         listener.mockClear();
         bump.mockClear();
         statsBump.mockClear();
-        rawStore.handleChatMessage(workspaceId, event);
         if (createsRow) {
+          dispatch(event);
           expect(bump).toHaveBeenCalledWith(workspaceId);
           expect(statsBump).toHaveBeenCalledWith(workspaceId);
         } else {
+          const unsubscribeRow = store.subscribeStreamingMessage(
+            workspaceId,
+            trailingRowId(),
+            listener
+          );
+          dispatch(event);
+          await flushMicrotasks();
           expect(bump).not.toHaveBeenCalled();
           expect(listener).toHaveBeenCalledTimes(1);
+          unsubscribeRow();
         }
       }
 
-      rawStore.handleChatMessage(workspaceId, {
+      dispatch({
         type: "reasoning-end",
         workspaceId,
         messageId,
@@ -2128,18 +2154,18 @@ describe("WorkspaceStore", () => {
         .getDisplayedMessages()
         .find((message) => message.type === "assistant" && message.historyId === messageId)!;
       expect(store.getStreamingMessage(workspaceId, streamingRow.id, messageId)).not.toBeNull();
+      const liveRowKey = `${workspaceId}\u0000${trailingRowId()}`;
+      expect(rawStore.streamingMessageStore.has(liveRowKey)).toBe(true);
 
-      rawStore.handleChatMessage(
-        workspaceId,
+      dispatch(
         streamEndEvent(workspaceId, messageId, {
           parts: [{ type: "text", text: "hello world" }],
         })
       );
       // Terminal events release the keyed channel and stop overriding prop rows,
       // so transcript-level transforms (e.g. merged stream errors) survive.
-      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000${messageId}`)).toBe(false);
+      expect(rawStore.streamingMessageStore.has(liveRowKey)).toBe(false);
       expect(store.getStreamingMessage(workspaceId, streamingRow.id, messageId)).toBeNull();
-      unsubscribe();
     });
 
     it("releases the keyed channel when a background activity stop clears the stream", async () => {
@@ -2182,7 +2208,10 @@ describe("WorkspaceStore", () => {
         timestamp: 3,
       });
       await flush();
-      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000msg-a`)).toBe(true);
+      const rows = store.getAggregator(workspaceId)!.getDisplayedMessages();
+      const liveRow = rows.find((row) => row.type === "assistant" && row.historyId === "msg-a")!;
+      const liveRowKey = `${workspaceId}\u0000${liveRow.id}`;
+      expect(rawStore.streamingMessageStore.has(liveRowKey)).toBe(true);
 
       // Background the workspace, then let activity report the stream stopped:
       // no terminal chat event ever arrives, so the activity path must release
@@ -2196,7 +2225,7 @@ describe("WorkspaceStore", () => {
         workspaceId,
         createActivitySnapshot(11, { streaming: false })
       );
-      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000msg-a`)).toBe(false);
+      expect(rawStore.streamingMessageStore.has(liveRowKey)).toBe(false);
     });
 
     it("publishes the same accumulated text shown by the live channel", () => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4688,6 +4688,10 @@ describe("WorkspaceStore", () => {
       ]);
 
       createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        advisorLiveStore: { has: (key: string) => boolean };
+      }>(store);
+      const advisorKey = `${workspaceId}\u0000call-advisor-output-delete`;
 
       const hasLiveOutput = await waitUntil(
         () =>
@@ -4695,6 +4699,7 @@ describe("WorkspaceStore", () => {
           "stale partial advice"
       );
       expect(hasLiveOutput).toBe(true);
+      expect(rawStore.advisorLiveStore.has(advisorKey)).toBe(true);
 
       releaseDelete?.();
 
@@ -4702,6 +4707,9 @@ describe("WorkspaceStore", () => {
         () => store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-output-delete") === null
       );
       expect(clearedLiveOutput).toBe(true);
+      // The delete-time sweep must release the keyed channel as well: with the
+      // transient entry gone, no later sweep can rediscover this key.
+      expect(rawStore.advisorLiveStore.has(advisorKey)).toBe(false);
     });
 
     it("replays pre-caught-up advisor output after full replay catches up", async () => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -303,21 +303,6 @@ async function waitUntil(condition: () => boolean, timeoutMs = 2000): Promise<bo
   return false;
 }
 
-/** Like {@link waitUntil} but with an attempt budget instead of a wall clock. */
-async function waitForCondition(
-  condition: () => boolean,
-  maxAttempts = 400,
-  intervalMs = 10
-): Promise<boolean> {
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    if (condition()) {
-      return true;
-    }
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  }
-  return false;
-}
-
 /**
  * Sleep helper used to flush microtasks/timers between synchronous test steps.
  * Equivalent to `await new Promise(r => setTimeout(r, ms))` but easier to grep.
@@ -513,19 +498,6 @@ const streamEndEvent = (
   messageId,
   metadata: { model: TEST_MODEL, historySequence: 1, timestamp: 1_001 },
   parts: [],
-  ...overrides,
-});
-
-const streamAbortEvent = (
-  workspaceId: string,
-  messageId: string,
-  overrides: Partial<ChatEvent<"stream-abort">> = {}
-): WorkspaceChatMessage => ({
-  type: "stream-abort",
-  workspaceId,
-  messageId,
-  abortReason: "user",
-  metadata: {},
   ...overrides,
 });
 
@@ -2105,7 +2077,6 @@ describe("WorkspaceStore", () => {
         type: "reasoning-end",
         workspaceId,
         messageId,
-        timestamp: 5,
       });
       expect(bump).toHaveBeenCalledWith(workspaceId);
       unsubscribe();

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2142,6 +2142,63 @@ describe("WorkspaceStore", () => {
       unsubscribe();
     });
 
+    it("releases the keyed channel when a background activity stop clears the stream", async () => {
+      const workspaceId = "keyed-channel-background-stop";
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        streamingMessageStore: { has: (key: string) => boolean };
+        handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+        applyWorkspaceActivitySnapshot: (
+          id: string,
+          snapshot: WorkspaceActivitySnapshot | null
+        ) => void;
+      }>(store);
+      const send = (event: WorkspaceChatMessage) => rawStore.handleChatMessage(workspaceId, event);
+      const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+      send({
+        type: "stream-start",
+        workspaceId,
+        messageId: "msg-a",
+        historySequence: 1,
+        model: TEST_MODEL,
+        startTime: 1,
+      });
+      send(caughtUpEvent());
+      send({
+        type: "stream-delta",
+        workspaceId,
+        messageId: "msg-a",
+        delta: "a",
+        tokens: 1,
+        timestamp: 2,
+      });
+      send({
+        type: "stream-delta",
+        workspaceId,
+        messageId: "msg-a",
+        delta: "b",
+        tokens: 1,
+        timestamp: 3,
+      });
+      await flush();
+      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000msg-a`)).toBe(true);
+
+      // Background the workspace, then let activity report the stream stopped:
+      // no terminal chat event ever arrives, so the activity path must release
+      // the keyed channel.
+      createAndAddWorkspace(store, "keyed-channel-foreground");
+      rawStore.applyWorkspaceActivitySnapshot(
+        workspaceId,
+        createActivitySnapshot(10, { streaming: true })
+      );
+      rawStore.applyWorkspaceActivitySnapshot(
+        workspaceId,
+        createActivitySnapshot(11, { streaming: false })
+      );
+      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000msg-a`)).toBe(false);
+    });
+
     it("publishes the same accumulated text shown by the live channel", () => {
       const workspaceId = "live-final-content";
       const messageId = "stream-message";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2168,6 +2168,59 @@ describe("WorkspaceStore", () => {
       expect(store.getStreamingMessage(workspaceId, streamingRow.id, messageId)).toBeNull();
     });
 
+    it("mounts rows created by a second concurrent stream's deltas", () => {
+      const workspaceId = "concurrent-stream-deltas";
+      const firstMessageId = "stream-message-1";
+      const secondMessageId = "stream-message-2";
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        states: { bump: (key: string) => void };
+        handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+        processStreamEvent: (
+          id: string,
+          aggregator: ReturnType<WorkspaceStore["getAggregator"]>,
+          event: WorkspaceChatMessage
+        ) => void;
+      }>(store);
+      const dispatch = (event: WorkspaceChatMessage) =>
+        rawStore.processStreamEvent(workspaceId, store.getAggregator(workspaceId), event);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId: firstMessageId,
+        historySequence: 1,
+        model: TEST_MODEL,
+        startTime: 1,
+      });
+      rawStore.handleChatMessage(workspaceId, caughtUpEvent());
+      // Second stream starts while the first stream's context is still active
+      // (its terminal event has not been processed yet).
+      dispatch({
+        type: "stream-start",
+        workspaceId,
+        messageId: secondMessageId,
+        historySequence: 2,
+        model: TEST_MODEL,
+        startTime: 2,
+      });
+
+      const bump = spyOn(rawStore.states, "bump");
+      bump.mockClear();
+      // The row-creating delta belongs to the newer stream; deriving the part
+      // count from the older active-stream entry would skip the mount bump and
+      // leave the new row hidden until the next structural event.
+      dispatch({
+        type: "stream-delta",
+        workspaceId,
+        messageId: secondMessageId,
+        delta: "hello",
+        tokens: 1,
+        timestamp: 3,
+      });
+      expect(bump).toHaveBeenCalledWith(workspaceId);
+    });
+
     it("releases the keyed channel when a background activity stop clears the stream", async () => {
       const workspaceId = "keyed-channel-background-stop";
       createAndAddWorkspace(store, workspaceId);
@@ -4709,6 +4762,40 @@ describe("WorkspaceStore", () => {
       expect(clearedLiveOutput).toBe(true);
       // The delete-time sweep must release the keyed channel as well: with the
       // transient entry gone, no later sweep can rediscover this key.
+      expect(rawStore.advisorLiveStore.has(advisorKey)).toBe(false);
+    });
+
+    it("releases keyed advisor channels when a full replay resets transient state", async () => {
+      const workspaceId = "advisor-output-full-replay-reset";
+
+      mockChatScript(
+        [
+          caughtUpEvent(),
+          Promise.resolve(),
+          advisorOutputEvent(workspaceId, "call-advisor-replay-reset", "partial advice", 1),
+        ],
+        { keepOpen: true }
+      );
+
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        advisorLiveStore: { has: (key: string) => boolean };
+        resetChatStateForReplay: (workspaceId: string) => void;
+      }>(store);
+      const advisorKey = `${workspaceId}\u0000call-advisor-replay-reset`;
+
+      const hasLiveOutput = await waitUntil(
+        () =>
+          store.getAdvisorToolLiveOutput(workspaceId, "call-advisor-replay-reset")?.text ===
+          "partial advice"
+      );
+      expect(hasLiveOutput).toBe(true);
+      expect(rawStore.advisorLiveStore.has(advisorKey)).toBe(true);
+
+      rawStore.resetChatStateForReplay(workspaceId);
+
+      // The replaced transient maps were the only record of this tool-call ID,
+      // so the reset itself must release the keyed channel.
       expect(rawStore.advisorLiveStore.has(advisorKey)).toBe(false);
     });
 

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2127,6 +2127,64 @@ describe("WorkspaceStore", () => {
       );
     });
 
+    it("keeps split tool and text rows distinct on fine-grained updates", () => {
+      const workspaceId = "split-streaming-rows";
+      const messageId = "stream-message";
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+      }>(store);
+      const send = (event: WorkspaceChatMessage) => rawStore.handleChatMessage(workspaceId, event);
+
+      send({
+        type: "stream-start",
+        workspaceId,
+        messageId,
+        historySequence: 1,
+        model: TEST_MODEL,
+        startTime: 1,
+      });
+      send(caughtUpEvent());
+      send({
+        type: "tool-call-start",
+        workspaceId,
+        messageId,
+        toolCallId: "tool-1",
+        toolName: "bash",
+        args: { command: "ls" },
+        tokens: 1,
+        timestamp: 2,
+      });
+      send({
+        type: "tool-call-end",
+        workspaceId,
+        messageId,
+        toolCallId: "tool-1",
+        toolName: "bash",
+        result: { output: "file.txt" },
+        timestamp: 3,
+      });
+      send({
+        type: "stream-delta",
+        workspaceId,
+        messageId,
+        delta: "summary",
+        tokens: 1,
+        timestamp: 4,
+      });
+
+      const displayed = store
+        .getAggregator(workspaceId)!
+        .getDisplayedMessages()
+        .filter((message) => "historyId" in message && message.historyId === messageId);
+      const tool = displayed.find((message) => message.type === "tool")!;
+      const text = displayed.find((message) => message.type === "assistant")!;
+
+      expect(store.getStreamingMessage(workspaceId, tool.id, messageId)?.type).toBe("tool");
+      const liveText = store.getStreamingMessage(workspaceId, text.id, messageId);
+      expect(liveText?.type === "assistant" ? liveText.content : null).toBe("summary");
+    });
+
     it("invalidates streaming-stats cache on stream-error so subscribers don't see stale TPS", async () => {
       const workspaceId = "stream-error-invalidates-stats";
       const streamModel = "anthropic:claude-opus-4-6";

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -1279,122 +1279,6 @@ describe("WorkspaceStore", () => {
         expect.anything()
       );
     });
-
-    it("does not pin hydration while waiting for the chat client", async () => {
-      const workspaceId = "workspace-awaiting-client";
-
-      store.setClient(null);
-      createAndAddWorkspace(store, workspaceId, {}, false);
-
-      store.setActiveWorkspaceId(workspaceId);
-      await tick(10);
-
-      expect(store.getWorkspaceState(workspaceId).isHydratingTranscript).toBe(false);
-      expect(mockOnChat).not.toHaveBeenCalled();
-    });
-
-    it("clears hydration after first pre-caught-up failure when client disconnects", async () => {
-      const workspaceId = "workspace-hydration-first-failure-offline";
-      let attempts = 0;
-      let resolveFirstFailure!: () => void;
-      const firstFailure = new Promise<void>((resolve) => {
-        resolveFirstFailure = resolve;
-      });
-
-      // eslint-disable-next-line require-yield
-      mockOnChat.mockImplementation(async function* (
-        _input?: { workspaceId: string; mode?: unknown },
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
-        attempts += 1;
-        if (attempts === 1) {
-          resolveFirstFailure();
-          throw new Error("first-retry-failure");
-        }
-
-        await waitForAbortSignal(options?.signal);
-      });
-
-      createAndAddWorkspace(store, workspaceId, {}, false);
-      store.setActiveWorkspaceId(workspaceId);
-      await firstFailure;
-
-      // Simulate transport/client loss before a second retry can catch up.
-      store.setClient(null);
-      await tick(20);
-
-      expect(store.getWorkspaceState(workspaceId).isHydratingTranscript).toBe(false);
-    });
-
-    it("switches onChat subscriptions when active workspace changes", async () => {
-      mockChatScript([], { keepOpen: true });
-
-      createAndAddWorkspace(store, "workspace-1", {}, false);
-      createAndAddWorkspace(store, "workspace-2", {}, false);
-
-      store.setActiveWorkspaceId("workspace-1");
-      await tick(0);
-
-      store.setActiveWorkspaceId("workspace-2");
-      await tick(0);
-
-      const subscribedWorkspaceIds = mockOnChat.mock.calls.map((call) => {
-        const input = call[0] as { workspaceId?: string };
-        return input.workspaceId;
-      });
-
-      expect(subscribedWorkspaceIds).toEqual(["workspace-1", "workspace-2"]);
-    });
-
-    it("clears replay buffers before aborting the previous active workspace subscription", async () => {
-      mockChatScript([], { keepOpen: true });
-
-      createAndAddWorkspace(store, "workspace-1", {}, false);
-      createAndAddWorkspace(store, "workspace-2", {}, false);
-
-      store.setActiveWorkspaceId("workspace-1");
-      await tick(0);
-
-      const transientState = getInternal<{
-        chatTransientState: Map<
-          string,
-          {
-            caughtUp: boolean;
-            isHydratingTranscript: boolean;
-            replayingHistory: boolean;
-            historicalMessages: WorkspaceChatMessage[];
-            pendingStreamEvents: WorkspaceChatMessage[];
-          }
-        >;
-      }>(store).chatTransientState.get("workspace-1");
-      expect(transientState).toBeDefined();
-
-      transientState!.caughtUp = false;
-      transientState!.isHydratingTranscript = true;
-      transientState!.replayingHistory = true;
-      transientState!.historicalMessages.push(
-        createHistoryMessageEvent("stale-buffered-message", 9)
-      );
-      transientState!.pendingStreamEvents.push({
-        type: "stream-start",
-        workspaceId: "workspace-1",
-        messageId: "stale-buffered-stream",
-        model: "claude-sonnet-4",
-        historySequence: 10,
-        startTime: Date.now(),
-      });
-
-      // Switching active workspaces should clear replay buffers synchronously
-      // before aborting the previous subscription.
-      store.setActiveWorkspaceId("workspace-2");
-
-      expect(transientState!.caughtUp).toBe(false);
-      expect(transientState!.isHydratingTranscript).toBe(false);
-      expect(transientState!.replayingHistory).toBe(false);
-      expect(transientState!.historicalMessages).toHaveLength(0);
-      expect(transientState!.pendingStreamEvents).toHaveLength(0);
-      expect(store.getWorkspaceState("workspace-2").isHydratingTranscript).toBe(true);
-    });
     it("keeps transcript hydration active across full replay resets", async () => {
       const workspaceId = "workspace-full-replay-hydration";
 
@@ -1431,122 +1315,6 @@ describe("WorkspaceStore", () => {
       const state = store.getWorkspaceState(workspaceId);
       expect(state.isStreamStarting).toBe(true);
       expect(state.pendingStreamModel).toBe(requestedModel);
-    });
-
-    it("clears transcript hydration after repeated catch-up retry failures", async () => {
-      const workspaceId = "workspace-hydration-retry-fallback";
-      let attempts = 0;
-
-      // eslint-disable-next-line require-yield
-      mockOnChat.mockImplementation(async function* (
-        _input?: { workspaceId: string; mode?: unknown },
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
-        attempts += 1;
-        if (attempts <= 2) {
-          throw new Error(`retry-failure-${attempts}`);
-        }
-
-        await waitForAbortSignal(options?.signal);
-      });
-
-      createAndAddWorkspace(store, workspaceId, {}, false);
-      store.setActiveWorkspaceId(workspaceId);
-
-      const startedAt = Date.now();
-      while (mockOnChat.mock.calls.length < 3 && Date.now() - startedAt < 3_000) {
-        await tick(20);
-      }
-
-      expect(mockOnChat.mock.calls.length).toBeGreaterThanOrEqual(3);
-      expect(store.getWorkspaceState(workspaceId).isHydratingTranscript).toBe(false);
-    });
-
-    it("clears transcript hydration when retries keep replaying partial history without caught-up", async () => {
-      const workspaceId = "workspace-hydration-partial-replay-fallback";
-      let attempts = 0;
-
-      mockOnChat.mockImplementation(async function* (
-        _input?: { workspaceId: string; mode?: unknown },
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
-        attempts += 1;
-
-        // Simulate flaky reconnects that emit some replay rows, then terminate
-        // before caught-up can arrive.
-        yield createHistoryMessageEvent(`partial-history-${attempts}`, attempts);
-        if (attempts <= 2) {
-          return;
-        }
-
-        await waitForAbortSignal(options?.signal);
-      });
-
-      createAndAddWorkspace(store, workspaceId, {}, false);
-      store.setActiveWorkspaceId(workspaceId);
-
-      const startedAt = Date.now();
-      while (mockOnChat.mock.calls.length < 3 && Date.now() - startedAt < 3_000) {
-        await tick(20);
-      }
-
-      expect(mockOnChat.mock.calls.length).toBeGreaterThanOrEqual(3);
-      expect(store.getWorkspaceState(workspaceId).isHydratingTranscript).toBe(false);
-    });
-
-    it("drops queued chat events from an aborted subscription attempt", async () => {
-      const queuedMicrotasks: Array<() => void> = [];
-      const originalQueueMicrotask = global.queueMicrotask;
-      let resolveQueuedEvent!: () => void;
-      const queuedEvent = new Promise<void>((resolve) => {
-        resolveQueuedEvent = resolve;
-      });
-
-      global.queueMicrotask = (callback) => {
-        queuedMicrotasks.push(callback);
-        resolveQueuedEvent();
-      };
-
-      try {
-        mockOnChat.mockImplementation(async function* (
-          input?: { workspaceId: string; mode?: unknown },
-          options?: { signal?: AbortSignal }
-        ): AsyncGenerator<WorkspaceChatMessage, void, unknown> {
-          if (input?.workspaceId === "workspace-1") {
-            yield createHistoryMessageEvent("queued-after-switch", 11);
-          }
-          await waitForAbortSignal(options?.signal);
-        });
-
-        createAndAddWorkspace(store, "workspace-1", {}, false);
-        createAndAddWorkspace(store, "workspace-2", {}, false);
-
-        store.setActiveWorkspaceId("workspace-1");
-        await queuedEvent;
-
-        const transientState = getInternal<{
-          chatTransientState: Map<
-            string,
-            {
-              historicalMessages: WorkspaceChatMessage[];
-              pendingStreamEvents: WorkspaceChatMessage[];
-            }
-          >;
-        }>(store).chatTransientState.get("workspace-1");
-        expect(transientState).toBeDefined();
-
-        // Abort workspace-1 attempt by moving focus; the queued callback should now no-op.
-        store.setActiveWorkspaceId("workspace-2");
-
-        for (const callback of queuedMicrotasks) {
-          callback();
-        }
-
-        expect(transientState!.historicalMessages).toHaveLength(0);
-        expect(transientState!.pendingStreamEvents).toHaveLength(0);
-      } finally {
-        global.queueMicrotask = originalQueueMicrotask;
-      }
     });
   });
 
@@ -2262,6 +2030,130 @@ describe("WorkspaceStore", () => {
 
       const clearedState = store.getWorkspaceState(workspaceId);
       expect(clearedState.canInterrupt).toBe(false);
+    });
+
+    it("routes live deltas through the keyed channel without bumping workspace state", () => {
+      const workspaceId = "fine-grained-deltas";
+      const messageId = "stream-message";
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        states: { bump: (key: string) => void };
+        handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+      }>(store);
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "stream-start",
+        workspaceId,
+        messageId,
+        historySequence: 1,
+        model: TEST_MODEL,
+        startTime: 1,
+      });
+      rawStore.handleChatMessage(workspaceId, caughtUpEvent());
+      rawStore.handleChatMessage(workspaceId, {
+        type: "tool-call-start",
+        workspaceId,
+        messageId,
+        toolCallId: "tool-1",
+        toolName: "bash",
+        args: {},
+        tokens: 0,
+        timestamp: 1,
+      });
+
+      const bump = spyOn(rawStore.states, "bump");
+      const listener = mock(() => undefined);
+      const unsubscribe = store.subscribeStreamingMessage(workspaceId, messageId, listener);
+      const deltas: WorkspaceChatMessage[] = [
+        {
+          type: "stream-delta",
+          workspaceId,
+          messageId,
+          delta: "hello",
+          tokens: 1,
+          timestamp: 2,
+        },
+        {
+          type: "reasoning-delta",
+          workspaceId,
+          messageId,
+          delta: "thinking",
+          tokens: 1,
+          timestamp: 3,
+        },
+        {
+          type: "tool-call-delta",
+          workspaceId,
+          messageId,
+          toolCallId: "tool-1",
+          toolName: "bash",
+          delta: { command: "echo hi" },
+          tokens: 1,
+          timestamp: 4,
+        },
+      ];
+
+      bump.mockClear();
+      for (const delta of deltas) {
+        listener.mockClear();
+        rawStore.handleChatMessage(workspaceId, delta);
+        expect(bump).not.toHaveBeenCalled();
+        expect(listener).toHaveBeenCalledTimes(1);
+      }
+
+      rawStore.handleChatMessage(workspaceId, {
+        type: "reasoning-end",
+        workspaceId,
+        messageId,
+        timestamp: 5,
+      });
+      expect(bump).toHaveBeenCalledWith(workspaceId);
+      unsubscribe();
+    });
+
+    it("publishes the same accumulated text shown by the live channel", () => {
+      const workspaceId = "live-final-content";
+      const messageId = "stream-message";
+      createAndAddWorkspace(store, workspaceId);
+      const rawStore = getInternal<{
+        handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
+      }>(store);
+      const send = (event: WorkspaceChatMessage) => rawStore.handleChatMessage(workspaceId, event);
+
+      send({
+        type: "stream-start",
+        workspaceId,
+        messageId,
+        historySequence: 1,
+        model: TEST_MODEL,
+        startTime: 1,
+      });
+      send(caughtUpEvent());
+      for (const [delta, timestamp] of [
+        ["hello", 2],
+        [" world", 3],
+      ] as const) {
+        send({ type: "stream-delta", workspaceId, messageId, delta, tokens: 1, timestamp });
+      }
+
+      const aggregator = store.getAggregator(workspaceId)!;
+      const displayed = aggregator
+        .getDisplayedMessages()
+        .find((message) => message.type === "assistant" && message.historyId === messageId)!;
+      const live = store.getStreamingMessage(workspaceId, displayed.id, messageId);
+      expect(live?.type === "assistant" ? live.content : null).toBe("hello world");
+
+      send(
+        streamEndEvent(workspaceId, messageId, {
+          parts: [{ type: "text", text: "hello world" }],
+        })
+      );
+      const published = aggregator
+        .getDisplayedMessages()
+        .find((message) => message.type === "assistant" && message.historyId === messageId);
+      expect(published?.type === "assistant" ? published.content : null).toBe(
+        live?.type === "assistant" ? live.content : null
+      );
     });
 
     it("invalidates streaming-stats cache on stream-error so subscribers don't see stale TPS", async () => {
@@ -3753,354 +3645,6 @@ describe("WorkspaceStore", () => {
       expect(internalStore.activityStreamingStartRecency.size).toBe(0);
     });
 
-    it("opens activity subscription before listing snapshots", async () => {
-      resetStore();
-
-      const callOrder: string[] = [];
-
-      mockActivitySubscribe.mockImplementation(
-        (
-          _input?: void,
-          options?: { signal?: AbortSignal }
-        ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> => {
-          callOrder.push("subscribe");
-
-          // eslint-disable-next-line require-yield
-          return (async function* (): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-            await waitForAbortSignal(options?.signal);
-          })();
-        }
-      );
-
-      mockActivityList.mockImplementation(() => {
-        callOrder.push("list");
-        return Promise.resolve({});
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      const sawBothCalls = await waitUntil(() => callOrder.length >= 2);
-      expect(sawBothCalls).toBe(true);
-      expect(callOrder.slice(0, 2)).toEqual(["subscribe", "list"]);
-    });
-
-    it("ignores heartbeat events from workspace activity subscription", async () => {
-      const workspaceId = "activity-heartbeat-ignore";
-      const snapshotRecency = new Date("2024-01-09T00:00:00.000Z").getTime();
-      const snapshot: WorkspaceActivitySnapshot = {
-        recency: snapshotRecency,
-        streaming: false,
-        lastModel: "claude-sonnet-4",
-        lastThinkingLevel: "low",
-      };
-
-      let releaseHeartbeat!: () => void;
-      const heartbeatReady = new Promise<void>((resolve) => {
-        releaseHeartbeat = resolve;
-      });
-
-      resetStore();
-      mockActivityList.mockResolvedValue({ [workspaceId]: snapshot });
-
-      mockActivitySubscribe.mockImplementation(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-        await heartbeatReady;
-        if (options?.signal?.aborted) {
-          return;
-        }
-
-        yield { type: "heartbeat" as const };
-        await waitForAbortSignal(options?.signal);
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-      // Let the initial activity.list call seed the cache before the workspace is created.
-      await tick(0);
-      createAndAddWorkspace(
-        store,
-        workspaceId,
-        {
-          createdAt: "2020-01-01T00:00:00.000Z",
-        },
-        false
-      );
-
-      const seededSnapshot = await waitUntil(() => {
-        const state = store.getWorkspaceState(workspaceId);
-        return (
-          state.recencyTimestamp === snapshot.recency &&
-          state.canInterrupt === snapshot.streaming &&
-          state.currentModel === snapshot.lastModel
-        );
-      });
-      expect(seededSnapshot).toBe(true);
-
-      const stateBeforeHeartbeat = store.getWorkspaceState(workspaceId);
-      releaseHeartbeat();
-      await tick(20);
-
-      const stateAfterHeartbeat = store.getWorkspaceState(workspaceId);
-      expect(stateAfterHeartbeat).toBe(stateBeforeHeartbeat);
-      expect(stateAfterHeartbeat.recencyTimestamp).toBe(snapshot.recency);
-      expect(stateAfterHeartbeat.canInterrupt).toBe(snapshot.streaming);
-      expect(stateAfterHeartbeat.currentModel).toBe(snapshot.lastModel);
-      expect(stateAfterHeartbeat.currentThinkingLevel).toBe(snapshot.lastThinkingLevel);
-    });
-
-    it("retries workspace activity subscription after a stall", async () => {
-      const workspaceId = "activity-stall-retry";
-      const snapshot: WorkspaceActivitySnapshot = {
-        recency: new Date("2024-01-10T00:00:00.000Z").getTime(),
-        streaming: true,
-        lastModel: "claude-sonnet-4",
-        lastThinkingLevel: null,
-      };
-
-      resetStore();
-      mockActivityList.mockResolvedValue({ [workspaceId]: snapshot });
-      // Clear calls from the store created in beforeEach so this test only tracks its own retries.
-      mockActivitySubscribe.mockClear();
-
-      const subscriptionSignals: AbortSignal[] = [];
-      mockActivitySubscribe.mockImplementation(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-        if (options?.signal) {
-          subscriptionSignals.push(options.signal);
-        }
-
-        if (subscriptionSignals.length === 1) {
-          yield {
-            type: "activity" as const,
-            workspaceId,
-            activity: snapshot,
-          };
-        }
-
-        await waitForAbortSignal(options?.signal);
-      });
-
-      const originalDateNow = Date.now;
-      let now = 0;
-      Date.now = () => now;
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-        createAndAddWorkspace(
-          store,
-          workspaceId,
-          {
-            createdAt: "2020-01-01T00:00:00.000Z",
-          },
-          false
-        );
-
-        const sawInitialSubscribe = await waitForCondition(
-          () => mockActivitySubscribe.mock.calls.length >= 1,
-          100,
-          10
-        );
-        expect(sawInitialSubscribe).toBe(true);
-
-        const sawSeededActivity = await waitForCondition(() => {
-          const state = store.getWorkspaceState(workspaceId);
-          return (
-            state.recencyTimestamp === snapshot.recency && state.canInterrupt === snapshot.streaming
-          );
-        });
-        expect(sawSeededActivity).toBe(true);
-
-        // Fast-forward perceived wall-clock so the first 2s watchdog tick treats the stream as stalled.
-        now = 11_000;
-
-        const sawRetry = await waitForCondition(
-          () => mockActivitySubscribe.mock.calls.length >= 2,
-          500,
-          10
-        );
-        expect(sawRetry).toBe(true);
-
-        await tick(20);
-        expect(subscriptionSignals[0]?.aborted).toBe(true);
-      } finally {
-        Date.now = originalDateNow;
-      }
-    });
-
-    it("preserves cached activity snapshots when list reports a read failure (null)", async () => {
-      const workspaceId = "activity-list-read-failure";
-      const initialRecency = new Date("2024-01-07T00:00:00.000Z").getTime();
-      const snapshot: WorkspaceActivitySnapshot = {
-        recency: initialRecency,
-        streaming: true,
-        lastModel: "claude-sonnet-4",
-        lastThinkingLevel: "high",
-      };
-
-      resetStore();
-
-      let listCallCount = 0;
-      mockActivityList.mockImplementation(
-        (): Promise<Record<string, WorkspaceActivitySnapshot> | null> => {
-          listCallCount += 1;
-          if (listCallCount === 1) {
-            return Promise.resolve({ [workspaceId]: snapshot });
-          }
-          return Promise.resolve(null);
-        }
-      );
-
-      // eslint-disable-next-line require-yield
-      mockActivitySubscribe.mockImplementation(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-        await waitForAbortSignal(options?.signal);
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-      createAndAddWorkspace(
-        store,
-        workspaceId,
-        {
-          createdAt: "2020-01-01T00:00:00.000Z",
-        },
-        false
-      );
-
-      const seededSnapshot = await waitUntil(() => {
-        const state = store.getWorkspaceState(workspaceId);
-        return state.recencyTimestamp === initialRecency && state.canInterrupt === true;
-      });
-      expect(seededSnapshot).toBe(true);
-
-      // Swap to a new client object to force activity subscription restart and a fresh list() call.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      const sawRetryListCall = await waitUntil(() => listCallCount >= 2);
-      expect(sawRetryListCall).toBe(true);
-
-      const stateAfterFailedList = store.getWorkspaceState(workspaceId);
-      expect(stateAfterFailedList.recencyTimestamp).toBe(initialRecency);
-      expect(stateAfterFailedList.canInterrupt).toBe(true);
-      expect(stateAfterFailedList.currentModel).toBe(snapshot.lastModel);
-      expect(stateAfterFailedList.currentThinkingLevel).toBe(snapshot.lastThinkingLevel);
-    });
-
-    it("clears cached activity snapshots when a later list is legitimately empty", async () => {
-      const workspaceId = "activity-list-empty-clears";
-      const initialRecency = new Date("2024-01-07T00:00:00.000Z").getTime();
-      const snapshot: WorkspaceActivitySnapshot = {
-        recency: initialRecency,
-        streaming: true,
-        lastModel: "claude-sonnet-4",
-        lastThinkingLevel: "high",
-      };
-
-      resetStore();
-
-      let listCallCount = 0;
-      mockActivityList.mockImplementation(
-        (): Promise<Record<string, WorkspaceActivitySnapshot> | null> => {
-          listCallCount += 1;
-          if (listCallCount === 1) {
-            return Promise.resolve({ [workspaceId]: snapshot });
-          }
-          return Promise.resolve({});
-        }
-      );
-
-      // eslint-disable-next-line require-yield
-      mockActivitySubscribe.mockImplementation(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-        await waitForAbortSignal(options?.signal);
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-      createAndAddWorkspace(
-        store,
-        workspaceId,
-        {
-          createdAt: "2020-01-01T00:00:00.000Z",
-        },
-        false
-      );
-
-      const seededSnapshot = await waitUntil(() => {
-        const state = store.getWorkspaceState(workspaceId);
-        return state.recencyTimestamp === initialRecency && state.canInterrupt === true;
-      });
-      expect(seededSnapshot).toBe(true);
-
-      // Swap to a new client object to force activity subscription restart and a fresh list() call.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      // {} is a valid all-idle payload (failures arrive as null), so the stale
-      // streaming snapshot must clear instead of being preserved.
-      const clearedStreaming = await waitUntil(
-        () => store.getWorkspaceState(workspaceId).canInterrupt === false
-      );
-      expect(clearedStreaming).toBe(true);
-    });
-
-    it("marks activity authoritative when the initial list is legitimately empty", async () => {
-      resetStore();
-      mockActivityList.mockResolvedValue({});
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      // An all-idle cold start must become authoritative, otherwise baseline
-      // consumers (Workflows tab auto-activation) would stay disarmed forever.
-      const authoritative = await waitUntil(() => store.isActivityAuthoritative());
-      expect(authoritative).toBe(true);
-    });
-
-    it("hydrates without authority when the initial list reports a read failure", async () => {
-      resetStore();
-      mockActivityList.mockResolvedValue(null);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      const hydrated = await waitUntil(() => store.isActivityHydrated());
-      expect(hydrated).toBe(true);
-      expect(store.isActivityAuthoritative()).toBe(false);
-    });
-
-    it("regains authority by retrying a transiently null bootstrap list", async () => {
-      resetStore();
-
-      let listCallCount = 0;
-      mockActivityList.mockImplementation(
-        (): Promise<Record<string, WorkspaceActivitySnapshot> | null> => {
-          listCallCount += 1;
-          // The subscription stays healthy the whole time, so only the
-          // background bootstrap retry can issue the second read.
-          return Promise.resolve(listCallCount === 1 ? null : {});
-        }
-      );
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      const authoritative = await waitUntil(() => store.isActivityAuthoritative(), 5000);
-      expect(authoritative).toBe(true);
-      expect(listCallCount).toBeGreaterThanOrEqual(2);
-    });
-
     it("keeps newer subscription deltas over a stale bootstrap-retry list", async () => {
       const workspaceId = "activity-retry-delta-race";
       resetStore();
@@ -4166,72 +3710,6 @@ describe("WorkspaceStore", () => {
       expect(authoritative).toBe(true);
       expect(store.getWorkspaceState(workspaceId).canInterrupt).toBe(true);
     });
-
-    it("resyncs after a reconnect bootstrap failure even when authority is already latched", async () => {
-      const workspaceId = "activity-reconnect-null-bootstrap";
-      const initialRecency = new Date("2024-01-07T00:00:00.000Z").getTime();
-      const snapshot: WorkspaceActivitySnapshot = {
-        recency: initialRecency,
-        streaming: true,
-        lastModel: "claude-sonnet-4",
-        lastThinkingLevel: "high",
-      };
-
-      resetStore();
-
-      let listCallCount = 0;
-      mockActivityList.mockImplementation(
-        (): Promise<Record<string, WorkspaceActivitySnapshot> | null> => {
-          listCallCount += 1;
-          if (listCallCount === 1) {
-            // First connection: authority latches.
-            return Promise.resolve({ [workspaceId]: snapshot });
-          }
-          if (listCallCount === 2) {
-            // Reconnect bootstrap: transient read failure.
-            return Promise.resolve(null);
-          }
-          // Reconnect retry: the workspace went idle while disconnected. The
-          // fresh subscription never replays this, so only the retry can resync.
-          return Promise.resolve({});
-        }
-      );
-
-      // eslint-disable-next-line require-yield
-      mockActivitySubscribe.mockImplementation(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<WorkspaceActivityEvent, void, unknown> {
-        await waitForAbortSignal(options?.signal);
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-      createAndAddWorkspace(
-        store,
-        workspaceId,
-        {
-          createdAt: "2020-01-01T00:00:00.000Z",
-        },
-        false
-      );
-
-      const seeded = await waitUntil(() => {
-        const state = store.getWorkspaceState(workspaceId);
-        return state.canInterrupt === true && store.isActivityAuthoritative();
-      });
-      expect(seeded).toBe(true);
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      store.setClient({ workspace: mockClient.workspace, terminal: mockClient.terminal } as any);
-
-      const resynced = await waitUntil(
-        () => store.getWorkspaceState(workspaceId).canInterrupt === false,
-        5000
-      );
-      expect(resynced).toBe(true);
-      expect(listCallCount).toBeGreaterThanOrEqual(3);
-    });
   });
 
   describe("terminal activity", () => {
@@ -4288,80 +3766,6 @@ describe("WorkspaceStore", () => {
       const sidebarState = store.getWorkspaceSidebarState(workspaceId);
       expect(sidebarState.terminalActiveCount).toBe(2);
       expect(sidebarState.terminalSessionCount).toBe(3);
-    });
-
-    it("retries terminal activity subscription after a stall", async () => {
-      const workspaceId = "terminal-activity-stall-retry";
-      const subscriptionSignals: AbortSignal[] = [];
-
-      const terminalSubscribeMock = mock(async function* (
-        _input?: void,
-        options?: { signal?: AbortSignal }
-      ): AsyncGenerator<TerminalActivityEvent, void, unknown> {
-        if (options?.signal) {
-          subscriptionSignals.push(options.signal);
-        }
-
-        if (subscriptionSignals.length === 1) {
-          yield {
-            type: "snapshot",
-            workspaces: {
-              [workspaceId]: { activeCount: 1, totalSessions: 1 },
-            },
-          };
-        }
-
-        await waitForAbortSignal(options?.signal);
-      });
-
-      const fullClient = {
-        ...mockClient,
-        terminal: {
-          activity: {
-            subscribe: terminalSubscribeMock,
-          },
-        },
-      };
-
-      resetStore();
-      createAndAddWorkspace(store, workspaceId);
-
-      const originalDateNow = Date.now;
-      let now = 0;
-      Date.now = () => now;
-
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-        store.setClient(fullClient as any);
-
-        const sawInitialSubscribe = await waitForCondition(
-          () => terminalSubscribeMock.mock.calls.length >= 1,
-          100,
-          10
-        );
-        expect(sawInitialSubscribe).toBe(true);
-
-        const sawSeededTerminalSnapshot = await waitForCondition(() => {
-          const state = store.getWorkspaceSidebarState(workspaceId);
-          return state.terminalActiveCount === 1 && state.terminalSessionCount === 1;
-        });
-        expect(sawSeededTerminalSnapshot).toBe(true);
-
-        // Fast-forward perceived wall-clock so the first 2s watchdog tick treats the stream as stalled.
-        now = 11_000;
-
-        const sawRetry = await waitForCondition(
-          () => terminalSubscribeMock.mock.calls.length >= 2,
-          500,
-          10
-        );
-        expect(sawRetry).toBe(true);
-
-        await tick(20);
-        expect(subscriptionSignals[0]?.aborted).toBe(true);
-      } finally {
-        Date.now = originalDateNow;
-      }
     });
 
     it("treats missing terminal.activity.subscribe as unsupported capability (no crash/retry)", async () => {
@@ -5381,169 +4785,6 @@ describe("WorkspaceStore", () => {
       expect(store.getTaskToolLiveTaskIds(workspaceId, "call-task-2")).toBeNull();
     });
 
-    it("preserves pagination state across since reconnect retries", async () => {
-      const workspaceId = "pagination-since-retry";
-      let subscriptionCount = 0;
-      const firstSubscription = createReleaseGate();
-
-      mockOnChat.mockImplementation(async function* (): AsyncGenerator<
-        WorkspaceChatMessage,
-        void,
-        unknown
-      > {
-        subscriptionCount += 1;
-
-        if (subscriptionCount === 1) {
-          yield createHistoryMessageEvent("history-5", 5);
-          yield {
-            type: "caught-up",
-            replay: "full",
-            hasOlderHistory: true,
-            cursor: {
-              history: {
-                messageId: "history-5",
-                historySequence: 5,
-              },
-            },
-          };
-
-          await firstSubscription.wait;
-          return;
-        }
-
-        yield {
-          type: "caught-up",
-          replay: "since",
-          cursor: {
-            history: {
-              messageId: "history-5",
-              historySequence: 5,
-            },
-          },
-        };
-      });
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededPagination = await waitUntil(
-        () => store.getWorkspaceState(workspaceId).hasOlderHistory === true
-      );
-      expect(seededPagination).toBe(true);
-
-      firstSubscription.release();
-
-      const preservedPagination = await waitUntil(() => {
-        return (
-          subscriptionCount >= 2 && store.getWorkspaceState(workspaceId).hasOlderHistory === true
-        );
-      });
-      expect(preservedPagination).toBe(true);
-    });
-
-    it("clears stale live tool state when since replay reports no active stream", async () => {
-      const workspaceId = "task-created-workspace-4";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
-        subscriptionCount === 1
-          ? [
-              createHistoryMessageEvent("history-1", 1),
-              fullCaughtUpEvent(),
-              Promise.resolve(),
-              bashOutputEvent(workspaceId, "call-bash-4", "stale-output\n"),
-              taskCreatedEvent(workspaceId, "call-task-4", "child-workspace-4", 2),
-              firstSubscription.wait,
-            ]
-          : [createHistoryMessageEvent("history-1", 1), sinceCaughtUpEvent()]
-      );
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededLiveState = await waitUntil(() => {
-        return (
-          store.getBashToolLiveOutput(workspaceId, "call-bash-4") !== null &&
-          JSON.stringify(store.getTaskToolLiveTaskIds(workspaceId, "call-task-4")) ===
-            JSON.stringify(["child-workspace-4"])
-        );
-      });
-      expect(seededLiveState).toBe(true);
-
-      firstSubscription.release();
-
-      const clearedLiveState = await waitUntil(() => {
-        return (
-          getSubscriptionCount() >= 2 &&
-          store.getBashToolLiveOutput(workspaceId, "call-bash-4") === null &&
-          store.getTaskToolLiveTaskIds(workspaceId, "call-task-4") === null
-        );
-      });
-      expect(clearedLiveState).toBe(true);
-    });
-
-    it("clears stale live tool state when server stream exists but local stream context is missing", async () => {
-      const workspaceId = "task-created-workspace-7";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
-        subscriptionCount === 1
-          ? [
-              // Cursor anchored at the row the in-flight stream below will finalize,
-              // so the second subscription legitimately requests since.
-              caughtUpEvent({
-                cursor: {
-                  history: { messageId: "msg-old-stream-missing-local", historySequence: 1 },
-                },
-              }),
-              Promise.resolve(),
-              streamStartEvent(workspaceId, "msg-old-stream-missing-local", {
-                startTime: 1_000,
-                model: "claude-3-5-sonnet-20241022",
-              }),
-              bashOutputEvent(workspaceId, "call-bash-7", "stale-after-end\n", {
-                timestamp: 1_001,
-              }),
-              taskCreatedEvent(workspaceId, "call-task-7", "child-workspace-7", 1_002),
-              streamEndEvent(workspaceId, "msg-old-stream-missing-local", {
-                metadata: {
-                  model: "claude-3-5-sonnet-20241022",
-                  historySequence: 1,
-                  timestamp: 1_003,
-                },
-              }),
-              firstSubscription.wait,
-            ]
-          : [
-              // Since replay re-sends the cursor-boundary row before caught-up.
-              createHistoryMessageEvent("msg-old-stream-missing-local", 1),
-              sinceCaughtUpEvent(1, "msg-old-stream-missing-local", {
-                messageId: "msg-new-stream-missing-local",
-                lastTimestamp: 2_000,
-              }),
-            ]
-      );
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededStaleLiveState = await waitUntil(() => {
-        return (
-          store.getAggregator(workspaceId)?.getOnChatCursor()?.stream === undefined &&
-          store.getBashToolLiveOutput(workspaceId, "call-bash-7") !== null &&
-          JSON.stringify(store.getTaskToolLiveTaskIds(workspaceId, "call-task-7")) ===
-            JSON.stringify(["child-workspace-7"])
-        );
-      });
-      expect(seededStaleLiveState).toBe(true);
-
-      firstSubscription.release();
-
-      const clearedStaleLiveState = await waitUntil(() => {
-        return (
-          getSubscriptionCount() >= 2 &&
-          store.getBashToolLiveOutput(workspaceId, "call-bash-7") === null &&
-          store.getTaskToolLiveTaskIds(workspaceId, "call-task-7") === null
-        );
-      });
-      expect(clearedStaleLiveState).toBe(true);
-    });
-
     it("clears stale active stream context when since replay reports a different stream", async () => {
       const workspaceId = "task-created-workspace-5";
       const firstSubscription = createReleaseGate();
@@ -5608,42 +4849,6 @@ describe("WorkspaceStore", () => {
         );
       });
       expect(switchedToNewStream).toBe(true);
-    });
-
-    it("clears stale abort reason when since reconnect is downgraded to full replay", async () => {
-      const workspaceId = "task-created-workspace-6";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
-        subscriptionCount === 1
-          ? [
-              caughtUpEvent(),
-              Promise.resolve(),
-              streamStartEvent(workspaceId, "msg-abort-old-stream", {
-                startTime: 1_000,
-                model: "claude-3-5-sonnet-20241022",
-              }),
-              streamAbortEvent(workspaceId, "msg-abort-old-stream"),
-              firstSubscription.wait,
-            ]
-          : [caughtUpEvent({ replay: "full" })]
-      );
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededAbortReason = await waitUntil(() => {
-        return store.getWorkspaceState(workspaceId).lastAbortReason?.reason === "user";
-      });
-      expect(seededAbortReason).toBe(true);
-
-      firstSubscription.release();
-
-      const clearedAbortReason = await waitUntil(() => {
-        return (
-          getSubscriptionCount() >= 2 &&
-          store.getWorkspaceState(workspaceId).lastAbortReason === null
-        );
-      });
-      expect(clearedAbortReason).toBe(true);
     });
 
     it("reuses the server-issued cursor verbatim on the next subscription", async () => {
@@ -5726,216 +4931,6 @@ describe("WorkspaceStore", () => {
       const resubscribed = await waitUntil(() => subscriptionCount >= 2);
       expect(resubscribed).toBe(true);
       expect(requestedModes[1]).toBeUndefined();
-    });
-
-    it("removes rows the server did not re-send from a since replay", async () => {
-      const workspaceId = "since-suffix-ghost-workspace";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
-        subscriptionCount === 1
-          ? [
-              createHistoryMessageEvent("history-1", 1),
-              createHistoryMessageEvent("history-2", 2),
-              fullCaughtUpEvent(2, "history-2"),
-              Promise.resolve(),
-              // Row streamed live after caught-up: it sits above the stored anchor.
-              createHistoryMessageEvent("history-3", 3),
-              firstSubscription.wait,
-            ]
-          : [
-              // Server deleted history-3 while the client was unsubscribed, so the
-              // since replay re-sends only the anchor row.
-              createHistoryMessageEvent("history-2", 2),
-              sinceCaughtUpEvent(2, "history-2"),
-            ]
-      );
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seeded = await waitUntil(
-        () => store.getAggregator(workspaceId)?.getAllMessages().length === 3
-      );
-      expect(seeded).toBe(true);
-
-      firstSubscription.release();
-
-      const ghostRemoved = await waitUntil(() => {
-        const ids = store
-          .getAggregator(workspaceId)
-          ?.getAllMessages()
-          .map((message) => message.id);
-        return getSubscriptionCount() >= 2 && JSON.stringify(ids) === '["history-1","history-2"]';
-      });
-      expect(ghostRemoved).toBe(true);
-    });
-
-    it("clears stale auto-retry status when full replay reconnect replaces history", async () => {
-      const workspaceId = "task-created-workspace-auto-retry-reset";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount) =>
-        subscriptionCount === 1
-          ? [
-              caughtUpEvent(),
-              Promise.resolve(),
-              { type: "auto-retry-starting", attempt: 2 },
-              firstSubscription.wait,
-            ]
-          : [caughtUpEvent({ replay: "full" })]
-      );
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededRetryStatus = await waitUntil(() => {
-        return store.getWorkspaceState(workspaceId).autoRetryStatus?.type === "auto-retry-starting";
-      });
-      expect(seededRetryStatus).toBe(true);
-
-      firstSubscription.release();
-
-      const clearedRetryStatus = await waitUntil(() => {
-        return (
-          getSubscriptionCount() >= 2 &&
-          store.getWorkspaceState(workspaceId).autoRetryStatus === null
-        );
-      });
-      expect(clearedRetryStatus).toBe(true);
-    });
-
-    it("replays pre-caught-up task-created after full replay catches up", async () => {
-      const workspaceId = "task-created-workspace-3";
-
-      mockChatScript([
-        {
-          type: "task-created",
-          workspaceId,
-          toolCallId: "call-task-3",
-          taskId: "child-workspace-3",
-          timestamp: 1,
-        },
-        Promise.resolve(),
-        { type: "caught-up", replay: "full" },
-      ]);
-
-      createAndAddWorkspace(store, workspaceId);
-      await tick(10);
-
-      expect(store.getTaskToolLiveTaskIds(workspaceId, "call-task-3")).toEqual([
-        "child-workspace-3",
-      ]);
-    });
-
-    it("preserves usage state while full replay resets the aggregator", async () => {
-      const workspaceId = "usage-reset-replay-workspace";
-      const firstSubscription = createReleaseGate();
-      const secondCaughtUp = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount, signal) => {
-        if (subscriptionCount === 1) {
-          return [
-            caughtUpEvent(),
-            Promise.resolve(),
-            streamStartEvent(workspaceId, "msg-live-usage", {
-              startTime: 1,
-              model: "claude-3-5-sonnet-20241022",
-            }),
-            {
-              type: "usage-delta",
-              workspaceId,
-              messageId: "msg-live-usage",
-              usage: { inputTokens: 321, outputTokens: 9, totalTokens: 330 },
-              cumulativeUsage: { inputTokens: 500, outputTokens: 15, totalTokens: 515 },
-            },
-            firstSubscription.wait,
-          ];
-        }
-        if (subscriptionCount === 2) {
-          return [
-            // Hold caught-up so the test can inspect usage after resetChatStateForReplay()
-            // cleared the aggregator but before replay completion.
-            secondCaughtUp.wait,
-            caughtUpEvent({ replay: "full" }),
-          ];
-        }
-        return [() => waitForAbortSignal(signal)];
-      });
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededUsage = await waitUntil(() => {
-        const aggregator = store.getAggregator(workspaceId);
-        return aggregator?.getActiveStreamUsage("msg-live-usage")?.inputTokens === 321;
-      });
-      expect(seededUsage).toBe(true);
-
-      firstSubscription.release();
-
-      const startedSecondSubscription = await waitUntil(() => getSubscriptionCount() >= 2);
-      expect(startedSecondSubscription).toBe(true);
-
-      const usageDuringReplay = store.getWorkspaceUsage(workspaceId);
-      expect(usageDuringReplay.liveUsage?.input.tokens).toBe(321);
-      expect(usageDuringReplay.liveCostUsage?.input.tokens).toBe(500);
-
-      secondCaughtUp.release();
-      await tick(10);
-
-      const usageAfterCaughtUp = store.getWorkspaceUsage(workspaceId);
-      expect(usageAfterCaughtUp.liveUsage).toBeUndefined();
-    });
-
-    it("clears replay usage snapshot when reconnect fails before caught-up", async () => {
-      const workspaceId = "usage-reset-replay-failure-workspace";
-      const firstSubscription = createReleaseGate();
-      const getSubscriptionCount = mockChatReconnectScript((subscriptionCount, signal) => {
-        if (subscriptionCount === 1) {
-          return [
-            caughtUpEvent(),
-            Promise.resolve(),
-            streamStartEvent(workspaceId, "msg-live-usage-failure", {
-              startTime: 1,
-              model: "claude-3-5-sonnet-20241022",
-            }),
-            {
-              type: "usage-delta",
-              workspaceId,
-              messageId: "msg-live-usage-failure",
-              usage: { inputTokens: 111, outputTokens: 9, totalTokens: 120 },
-              cumulativeUsage: { inputTokens: 300, outputTokens: 15, totalTokens: 315 },
-            },
-            // Keep two active streams so reconnect cannot build a safe incremental cursor.
-            // This forces a full replay attempt, which executes resetChatStateForReplay().
-            streamStartEvent(workspaceId, "msg-live-usage-failure-2", {
-              historySequence: 2,
-              startTime: 2,
-              model: "claude-3-5-sonnet-20241022",
-            }),
-            firstSubscription.wait,
-          ];
-        }
-        if (subscriptionCount === 2) {
-          // Simulate reconnect failure before authoritative caught-up.
-          return [Promise.resolve()];
-        }
-        return [() => waitForAbortSignal(signal)];
-      });
-
-      createAndAddWorkspace(store, workspaceId);
-
-      const seededUsage = await waitUntil(() => {
-        const aggregator = store.getAggregator(workspaceId);
-        return aggregator?.getActiveStreamUsage("msg-live-usage-failure")?.inputTokens === 111;
-      });
-      expect(seededUsage).toBe(true);
-
-      firstSubscription.release();
-
-      const startedSecondSubscription = await waitUntil(() => getSubscriptionCount() >= 2);
-      expect(startedSecondSubscription).toBe(true);
-
-      const usageSnapshotCleared = await waitUntil(() => {
-        const usage = store.getWorkspaceUsage(workspaceId);
-        return usage.liveUsage === undefined && usage.liveCostUsage === undefined;
-      });
-      expect(usageSnapshotCleared).toBe(true);
     });
 
     it("uses compaction boundary context usage when it is the newest usage in the active epoch", async () => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2010,6 +2010,8 @@ describe("WorkspaceStore", () => {
       createAndAddWorkspace(store, workspaceId);
       const rawStore = getInternal<{
         states: { bump: (key: string) => void };
+        streamingStatsStore: { bump: (key: string) => void };
+        streamingMessageStore: { has: (key: string) => boolean };
         handleChatMessage: (id: string, event: WorkspaceChatMessage) => void;
       }>(store);
 
@@ -2098,13 +2100,16 @@ describe("WorkspaceStore", () => {
         },
       ];
 
+      const statsBump = spyOn(rawStore.streamingStatsStore, "bump");
       bump.mockClear();
       for (const { event, createsRow } of deltas) {
         listener.mockClear();
         bump.mockClear();
+        statsBump.mockClear();
         rawStore.handleChatMessage(workspaceId, event);
         if (createsRow) {
           expect(bump).toHaveBeenCalledWith(workspaceId);
+          expect(statsBump).toHaveBeenCalledWith(workspaceId);
         } else {
           expect(bump).not.toHaveBeenCalled();
           expect(listener).toHaveBeenCalledTimes(1);
@@ -2117,6 +2122,23 @@ describe("WorkspaceStore", () => {
         messageId,
       });
       expect(bump).toHaveBeenCalledWith(workspaceId);
+
+      const streamingRow = store
+        .getAggregator(workspaceId)!
+        .getDisplayedMessages()
+        .find((message) => message.type === "assistant" && message.historyId === messageId)!;
+      expect(store.getStreamingMessage(workspaceId, streamingRow.id, messageId)).not.toBeNull();
+
+      rawStore.handleChatMessage(
+        workspaceId,
+        streamEndEvent(workspaceId, messageId, {
+          parts: [{ type: "text", text: "hello world" }],
+        })
+      );
+      // Terminal events release the keyed channel and stop overriding prop rows,
+      // so transcript-level transforms (e.g. merged stream errors) survive.
+      expect(rawStore.streamingMessageStore.has(`${workspaceId}\u0000${messageId}`)).toBe(false);
+      expect(store.getStreamingMessage(workspaceId, streamingRow.id, messageId)).toBeNull();
       unsubscribe();
     });
 
@@ -2149,7 +2171,7 @@ describe("WorkspaceStore", () => {
       const displayed = aggregator
         .getDisplayedMessages()
         .find((message) => message.type === "assistant" && message.historyId === messageId)!;
-      const live = store.getStreamingMessage(workspaceId, displayed.id);
+      const live = store.getStreamingMessage(workspaceId, displayed.id, messageId);
       expect(live?.type === "assistant" ? live.content : null).toBe("hello world");
 
       send(
@@ -2218,8 +2240,8 @@ describe("WorkspaceStore", () => {
       const tool = displayed.find((message) => message.type === "tool")!;
       const text = displayed.find((message) => message.type === "assistant")!;
 
-      expect(store.getStreamingMessage(workspaceId, tool.id)?.type).toBe("tool");
-      const liveText = store.getStreamingMessage(workspaceId, text.id);
+      expect(store.getStreamingMessage(workspaceId, tool.id, messageId)?.type).toBe("tool");
+      const liveText = store.getStreamingMessage(workspaceId, text.id, messageId);
       expect(liveText?.type === "assistant" ? liveText.content : null).toBe("summary");
     });
 

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2219,6 +2219,15 @@ describe("WorkspaceStore", () => {
         timestamp: 3,
       });
       expect(bump).toHaveBeenCalledWith(workspaceId);
+
+      // The live row lookup must accept any active message: keying it to the
+      // first active-stream entry would return null for the newer stream's row
+      // and leave it rendering a stale prop row between workspace bumps.
+      const secondRow = store
+        .getAggregator(workspaceId)!
+        .getDisplayedMessages()
+        .find((message) => "historyId" in message && message.historyId === secondMessageId)!;
+      expect(store.getStreamingMessage(workspaceId, secondRow.id, secondMessageId)).not.toBeNull();
     });
 
     it("releases the keyed channel when a background activity stop clears the stream", async () => {

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -2111,7 +2111,7 @@ describe("WorkspaceStore", () => {
       const displayed = aggregator
         .getDisplayedMessages()
         .find((message) => message.type === "assistant" && message.historyId === messageId)!;
-      const live = store.getStreamingMessage(workspaceId, displayed.id, messageId);
+      const live = store.getStreamingMessage(workspaceId, displayed.id);
       expect(live?.type === "assistant" ? live.content : null).toBe("hello world");
 
       send(
@@ -2180,8 +2180,8 @@ describe("WorkspaceStore", () => {
       const tool = displayed.find((message) => message.type === "tool")!;
       const text = displayed.find((message) => message.type === "assistant")!;
 
-      expect(store.getStreamingMessage(workspaceId, tool.id, messageId)?.type).toBe("tool");
-      const liveText = store.getStreamingMessage(workspaceId, text.id, messageId);
+      expect(store.getStreamingMessage(workspaceId, tool.id)?.type).toBe("tool");
+      const liveText = store.getStreamingMessage(workspaceId, text.id);
       expect(liveText?.type === "assistant" ? liveText.content : null).toBe("summary");
     });
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -29,6 +29,11 @@ import {
 } from "@/browser/utils/messages/responseCompletionMetadata";
 import { isAbortError } from "@/browser/utils/isAbortError";
 import {
+  SUBSCRIPTION_RETRY_BASE_MS,
+  calculateSubscriptionBackoffMs,
+  runSubscriptionLoop,
+} from "@/browser/stores/subscriptionTransport";
+import {
   ADVISOR_LIVE_OUTPUT_MAX_CHARS,
   BASH_TRUNCATE_MAX_TOTAL_BYTES,
 } from "@/common/constants/toolLimits";
@@ -477,15 +482,6 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
   };
 }
 
-const SUBSCRIPTION_RETRY_BASE_MS = 250;
-const SUBSCRIPTION_RETRY_MAX_MS = 5000;
-
-// Stall detection: server sends heartbeats every 5s, so if we don't receive any events
-// (including heartbeats) for 10s, the connection is likely dead. This handles half-open
-// WebSocket paths (e.g., some WSL localhost forwarding setups).
-const SUBSCRIPTION_STALL_TIMEOUT_MS = 10_000;
-const SUBSCRIPTION_STALL_CHECK_INTERVAL_MS = 2_000;
-
 interface ValidationIssue {
   path?: Array<string | number>;
   message?: string;
@@ -583,10 +579,6 @@ function areAgentStatusesEqual(
   }
 
   return a.emoji === b.emoji && a.message === b.message && (a.url ?? null) === (b.url ?? null);
-}
-
-function calculateSubscriptionBackoffMs(attempt: number): number {
-  return Math.min(SUBSCRIPTION_RETRY_BASE_MS * 2 ** attempt, SUBSCRIPTION_RETRY_MAX_MS);
 }
 
 function getMaxHistorySequence(messages: MuxMessage[]): number | undefined {
@@ -3405,190 +3397,61 @@ export class WorkspaceStore {
     }
   }
 
-  /**
-   * Wire an attempt-scoped {@link AbortController} to the two signals every
-   * subscription retry loop reacts to:
-   *  - the caller's outer cancellation signal (workspace lifecycle teardown)
-   *  - the current client-change signal (so client swaps abort in-flight attempts)
-   *
-   * Returns a release callback that detaches both listeners. Pair with
-   * {@link createStallWatchdog} inside a try/finally so the listeners and the
-   * watchdog tear down together regardless of how the attempt ends.
-   */
-  private linkAttemptToClientChange(
-    attemptController: AbortController,
-    signal: AbortSignal
-  ): () => void {
-    const onAbort = () => attemptController.abort();
-    signal.addEventListener("abort", onAbort);
-
-    const clientChangeSignal = this.clientChangeController.signal;
-    const onClientChange = () => attemptController.abort();
-    clientChangeSignal.addEventListener("abort", onClientChange, { once: true });
-
-    return () => {
-      signal.removeEventListener("abort", onAbort);
-      clientChangeSignal.removeEventListener("abort", onClientChange);
-    };
-  }
-
-  /**
-   * Creates a stall watchdog that aborts the attempt when no events arrive
-   * within the configured timeout. Call start() only after the subscription
-   * connection is established so handshake latency isn't misclassified as
-   * stream silence.
-   */
-  private createStallWatchdog(
-    attemptController: AbortController,
-    label: string
-  ): { markEvent: () => void; start: () => void; stop: () => void } {
-    let lastEventAt = Date.now();
-    let interval: ReturnType<typeof setInterval> | null = null;
-
-    return {
-      markEvent: () => {
-        lastEventAt = Date.now();
-      },
-      start: () => {
-        if (interval != null) {
-          return;
-        }
-
-        lastEventAt = Date.now();
-        interval = setInterval(() => {
-          if (attemptController.signal.aborted) {
-            return;
-          }
-
-          const elapsedMs = Date.now() - lastEventAt;
-          if (elapsedMs < SUBSCRIPTION_STALL_TIMEOUT_MS) {
-            return;
-          }
-
-          console.warn(
-            `[WorkspaceStore] ${label} stalled (no events for ${elapsedMs}ms); retrying...`
-          );
-          attemptController.abort();
-        }, SUBSCRIPTION_STALL_CHECK_INTERVAL_MS);
-      },
-      stop: () => {
-        if (interval != null) {
-          clearInterval(interval);
-          interval = null;
-        }
-      },
-    };
-  }
-
   private async runTerminalActivitySubscription(controller: AbortController): Promise<void> {
     const signal = controller.signal;
-    let attempt = 0;
-
     try {
-      while (!signal.aborted) {
-        const client = this.client ?? (await this.waitForClient(signal));
-        if (!client || signal.aborted) {
-          return;
-        }
-
-        const subscribe = this.resolveTerminalActivitySubscribe(client);
-        if (!subscribe) {
-          // Client doesn't support terminal activity — clear stale state and exit
-          // without entering the retry loop (this is not an error condition).
-          this.clearAllTerminalActivitySnapshots();
-          return;
-        }
-
-        const attemptController = new AbortController();
-        const releaseAttemptListeners = this.linkAttemptToClientChange(attemptController, signal);
-        const watchdog = this.createStallWatchdog(
-          attemptController,
-          "terminal activity subscription"
-        );
-
-        try {
-          const iterator = await subscribe(undefined, {
-            signal: attemptController.signal,
-          });
-
-          // Start watchdog after subscribe connects so timeout measures
-          // post-connect silence, not handshake latency.
-          watchdog.start();
-
-          for await (const event of iterator) {
-            if (signal.aborted) {
+      await runSubscriptionLoop({
+        name: "terminal activity subscription",
+        signal,
+        getClient: async (attemptSignal) =>
+          this.client ?? (await this.waitForClient(attemptSignal)),
+        getClientChangeSignal: () => this.clientChangeController.signal,
+        subscribe: async (client, attemptSignal) => {
+          const subscribe = this.resolveTerminalActivitySubscribe(client);
+          if (!subscribe) {
+            this.clearAllTerminalActivitySnapshots();
+            return null;
+          }
+          return {
+            events: await subscribe(undefined, { signal: attemptSignal }),
+            context: undefined,
+          };
+        },
+        onEvent: (event, _context, attemptSignal) => {
+          if (event.type === "heartbeat") return;
+          queueMicrotask(() => {
+            if (signal.aborted || attemptSignal.aborted) return;
+            if (event.type === "snapshot") {
+              const seen = new Set<string>();
+              for (const [workspaceId, activity] of Object.entries(event.workspaces)) {
+                seen.add(workspaceId);
+                this.applyTerminalActivity(workspaceId, activity);
+              }
+              for (const workspaceId of Array.from(this.workspaceTerminalActivity.keys())) {
+                if (!seen.has(workspaceId))
+                  this.applyTerminalActivity(workspaceId, { activeCount: 0, totalSessions: 0 });
+              }
               return;
             }
-
-            watchdog.markEvent();
-
-            // Connection is alive again - don't carry old backoff into the next failure.
-            attempt = 0;
-
-            if (event.type === "heartbeat") {
-              continue;
-            }
-
-            queueMicrotask(() => {
-              if (signal.aborted || attemptController.signal.aborted) {
-                return;
-              }
-
-              if (event.type === "snapshot") {
-                const seenWorkspaceIds = new Set<string>();
-                for (const [workspaceId, activity] of Object.entries(event.workspaces)) {
-                  seenWorkspaceIds.add(workspaceId);
-                  this.applyTerminalActivity(workspaceId, activity);
-                }
-
-                for (const workspaceId of Array.from(this.workspaceTerminalActivity.keys())) {
-                  if (seenWorkspaceIds.has(workspaceId)) {
-                    continue;
-                  }
-                  this.applyTerminalActivity(workspaceId, { activeCount: 0, totalSessions: 0 });
-                }
-
-                return;
-              }
-
-              this.applyTerminalActivity(event.workspaceId, event.activity);
-            });
-          }
-
-          if (signal.aborted) {
-            return;
-          }
-
-          if (!attemptController.signal.aborted) {
+            this.applyTerminalActivity(event.workspaceId, event.activity);
+          });
+        },
+        onUnexpectedEnd: ({ attemptAborted }) => {
+          if (!attemptAborted)
             console.warn(
               "[WorkspaceStore] terminal activity subscription ended unexpectedly; retrying..."
             );
-          }
-        } catch (error) {
-          if (signal.aborted) {
-            return;
-          }
-
+        },
+        onError: (error, { attemptAborted }) => {
           const abortError = isAbortError(error);
-          if (attemptController.signal.aborted) {
-            if (!abortError) {
+          if (attemptAborted) {
+            if (!abortError)
               console.warn("[WorkspaceStore] terminal activity subscription aborted; retrying...");
-            }
-          } else if (!abortError) {
+          } else if (!abortError)
             console.warn("[WorkspaceStore] Error in terminal activity subscription:", error);
-          }
-        } finally {
-          releaseAttemptListeners();
-          watchdog.stop();
-        }
-
-        if (!signal.aborted && !attemptController.signal.aborted) {
-          const delayMs = calculateSubscriptionBackoffMs(attempt);
-          attempt++;
-
-          await this.sleepWithAbort(delayMs, signal);
-        }
-      }
+        },
+        backoffAfterAbort: false,
+      });
     } finally {
       this.releaseTerminalActivityController(controller);
     }
@@ -3642,124 +3505,47 @@ export class WorkspaceStore {
   }
 
   private async runActivitySubscription(signal: AbortSignal): Promise<void> {
-    let attempt = 0;
-
-    while (!signal.aborted) {
-      const client = this.client ?? (await this.waitForClient(signal));
-      if (!client || signal.aborted) {
-        return;
-      }
-
-      const attemptController = new AbortController();
-      const releaseAttemptListeners = this.linkAttemptToClientChange(attemptController, signal);
-      const watchdog = this.createStallWatchdog(attemptController, "activity subscription");
-
-      try {
-        // Open the live delta stream first so no state transition can be lost
-        // between the list snapshot fetch and subscribe registration.
+    await runSubscriptionLoop({
+      name: "activity subscription",
+      signal,
+      getClient: async (attemptSignal) => this.client ?? (await this.waitForClient(attemptSignal)),
+      getClientChangeSignal: () => this.clientChangeController.signal,
+      subscribe: async (client, attemptSignal) => {
         const iterator = await client.workspace.activity.subscribe(undefined, {
-          signal: attemptController.signal,
+          signal: attemptSignal,
         });
-
         const snapshots = await client.workspace.activity.list();
-        if (signal.aborted) {
-          return;
-        }
-        // Client changed while list() was in flight — retry with the new client
-        // instead of exiting permanently. The outer while loop will pick up the
-        // replacement client on the next iteration.
-        if (attemptController.signal.aborted) {
-          continue;
-        }
-
+        if (signal.aborted) return null;
+        if (attemptSignal.aborted) return { retryImmediately: true };
         queueMicrotask(() => {
-          if (signal.aborted || attemptController.signal.aborted) {
-            return;
-          }
-          // null is the backend's read-failure signal: keep last-known snapshots and
-          // stay non-authoritative (the background retry below delivers the real
-          // list later). A non-null list — including {} on an all-idle deployment —
-          // is authoritative.
-          if (snapshots != null) {
-            this.applyWorkspaceActivityList(snapshots);
-          }
+          if (signal.aborted || attemptSignal.aborted) return;
+          if (snapshots != null) this.applyWorkspaceActivityList(snapshots);
           this.markActivityHydrated(snapshots != null);
         });
-
-        // A transiently-null bootstrap must not stay non-authoritative for the
-        // life of an otherwise healthy subscription: heartbeats keep the iterator
-        // alive indefinitely and events never confer authority, so another list
-        // read may never happen. Retry in the background (attempt-scoped) instead
-        // of blocking here, so live events keep flowing while the read heals.
-        if (snapshots == null) {
-          void this.retryActivityBootstrapList(client, signal, attemptController.signal);
-        }
-
-        // Start watchdog after bootstrap so slow list() doesn't trigger
-        // false-positive reconnects.
-        watchdog.start();
-
-        for await (const event of iterator) {
-          if (signal.aborted) {
-            return;
-          }
-
-          watchdog.markEvent();
-
-          // Connection is alive again - don't carry old backoff into the next failure.
-          attempt = 0;
-
-          if (event.type === "heartbeat") {
-            continue;
-          }
-
-          queueMicrotask(() => {
-            if (signal.aborted || attemptController.signal.aborted) {
-              return;
-            }
-            this.activityDeltaTouchesDuringRetry?.add(event.workspaceId);
-            this.applyWorkspaceActivitySnapshot(event.workspaceId, event.activity);
-          });
-        }
-
-        if (signal.aborted) {
-          return;
-        }
-
-        if (!attemptController.signal.aborted) {
-          console.warn("[WorkspaceStore] activity subscription ended unexpectedly; retrying...");
-        }
-      } catch (error) {
-        if (signal.aborted) {
-          return;
-        }
-
+        if (snapshots == null) void this.retryActivityBootstrapList(client, signal, attemptSignal);
+        return { events: iterator, context: undefined };
+      },
+      onEvent: (event, _context, attemptSignal) => {
+        if (event.type === "heartbeat") return;
+        queueMicrotask(() => {
+          if (signal.aborted || attemptSignal.aborted) return;
+          this.activityDeltaTouchesDuringRetry?.add(event.workspaceId);
+          this.applyWorkspaceActivitySnapshot(event.workspaceId, event.activity);
+        });
+      },
+      onUnexpectedEnd: () =>
+        console.warn("[WorkspaceStore] activity subscription ended unexpectedly; retrying..."),
+      onError: (error, { attemptAborted }) => {
         const abortError = isAbortError(error);
-        if (attemptController.signal.aborted) {
-          if (!abortError) {
+        if (attemptAborted) {
+          if (!abortError)
             console.warn("[WorkspaceStore] activity subscription aborted; retrying...");
-          }
         } else if (!abortError) {
           console.warn("[WorkspaceStore] Error in activity subscription:", error);
-          // Self-heal: a failing activity subscription must not hold the chat
-          // view's first-paint barrier. Treat the (empty) activity map as
-          // known; the retry loop will deliver real data when it recovers.
-          // Not authoritative: baseline consumers must not read this as "no activity".
           this.markActivityHydrated(false);
         }
-      } finally {
-        releaseAttemptListeners();
-        watchdog.stop();
-      }
-
-      const delayMs = calculateSubscriptionBackoffMs(attempt);
-      attempt++;
-
-      await this.sleepWithAbort(delayMs, signal);
-      if (signal.aborted) {
-        return;
-      }
-    }
+      },
+    });
   }
 
   /**
@@ -3991,228 +3777,106 @@ export class WorkspaceStore {
    * Retries on unexpected iterator termination to avoid requiring a full app restart.
    */
   private async runOnChatSubscription(workspaceId: string, signal: AbortSignal): Promise<void> {
-    let attempt = 0;
-
-    while (!signal.aborted) {
-      const hadClientAtLoopStart = this.client !== null;
-      const client = this.client ?? (await this.waitForClient(signal));
-      if (!client || signal.aborted) {
-        return;
-      }
-
-      // If activation happened while the client was offline, begin hydration now
-      // that we can actually start the subscription loop.
-      const initialTransient = this.chatTransientState.get(workspaceId);
-      if (
-        !hadClientAtLoopStart &&
-        initialTransient &&
-        !initialTransient.caughtUp &&
-        !initialTransient.isHydratingTranscript
-      ) {
-        initialTransient.isHydratingTranscript = true;
-        this.states.bump(workspaceId);
-      }
-
-      // Allow us to abort only this subscription attempt (without unsubscribing the workspace).
-      const attemptController = new AbortController();
-      const releaseAttemptListeners = this.linkAttemptToClientChange(attemptController, signal);
-      const watchdog = this.createStallWatchdog(attemptController, `onChat(${workspaceId})`);
-
-      try {
-        // Always reset caughtUp at subscription start so historical events are
-        // buffered until the caught-up marker arrives, regardless of replay mode.
-        const transient = this.chatTransientState.get(workspaceId);
-        if (transient) {
-          transient.caughtUp = false;
+    await runSubscriptionLoop({
+      name: "onChat(" + workspaceId + ")",
+      signal,
+      getClient: async (attemptSignal) => {
+        const hadClientAtLoopStart = this.client !== null;
+        const client = this.client ?? (await this.waitForClient(attemptSignal));
+        return client ? { client, hadClientAtLoopStart } : null;
+      },
+      getClientChangeSignal: () => this.clientChangeController.signal,
+      subscribe: async ({ client, hadClientAtLoopStart }, attemptSignal, abortAttempt) => {
+        const initialTransient = this.chatTransientState.get(workspaceId);
+        if (
+          !hadClientAtLoopStart &&
+          initialTransient &&
+          !initialTransient.caughtUp &&
+          !initialTransient.isHydratingTranscript
+        ) {
+          initialTransient.isHydratingTranscript = true;
+          this.states.bump(workspaceId);
         }
-
-        // Reconnect incrementally whenever we can build a valid cursor.
-        // Do not gate on transient.caughtUp here: retry paths may optimistically
-        // set caughtUp=false to re-enable buffering, but the cursor can still
-        // represent the latest rendered state for an incremental reconnect.
+        const transient = this.chatTransientState.get(workspaceId);
+        if (transient) transient.caughtUp = false;
         const aggregator = this.aggregators.get(workspaceId);
         let mode: OnChatMode | undefined;
-
-        // Attempt-scoped reconnect context: since-replay reconciliation must only ever
-        // see the anchor from its own attempt's cursor. Routed through the same
-        // attempt-guarded event path as chat events (the abort checks below drop
-        // events from stale attempts), so a caught-up from a previous attempt can
-        // never consume a newer attempt's anchor.
-        const attemptContext: OnChatAttemptContext = {
-          abort: () => attemptController.abort(),
-        };
-
+        const attemptContext: OnChatAttemptContext = { abort: abortAttempt };
         if (aggregator) {
           const cursor = aggregator.getOnChatCursor();
           if (cursor?.history) {
-            mode = {
-              type: "since",
-              cursor: {
-                history: cursor.history,
-                stream: cursor.stream,
-              },
-            };
+            mode = { type: "since", cursor: { history: cursor.history, stream: cursor.stream } };
             attemptContext.since = {
               requestedAnchorSequence: cursor.history.historySequence,
               localActiveStreamMessageId: cursor.stream?.messageId,
             };
           }
         }
-
         await this.syncAutoCompactionThresholdAtStartup(client, workspaceId);
-
         const autoRetryKey = getAutoRetryKey(workspaceId);
-        const legacyAutoRetryEnabledRaw = readPersistedState<unknown>(autoRetryKey, undefined);
-        const legacyAutoRetryEnabled =
-          typeof legacyAutoRetryEnabledRaw === "boolean" ? legacyAutoRetryEnabledRaw : undefined;
-
-        if (legacyAutoRetryEnabledRaw !== undefined && legacyAutoRetryEnabled === undefined) {
-          // Self-heal malformed legacy values so onChat subscription retries do not
-          // keep failing schema validation on every reconnect attempt.
+        const legacyRaw = readPersistedState<unknown>(autoRetryKey, undefined);
+        const legacyAutoRetryEnabled = typeof legacyRaw === "boolean" ? legacyRaw : undefined;
+        if (legacyRaw !== undefined && legacyAutoRetryEnabled === undefined)
           updatePersistedState<boolean | undefined>(autoRetryKey, undefined);
-        }
-
-        const onChatInput =
+        const input =
           legacyAutoRetryEnabled === undefined
             ? { workspaceId, mode }
             : { workspaceId, mode, legacyAutoRetryEnabled };
-
-        const iterator = await client.workspace.onChat(onChatInput, {
-          signal: attemptController.signal,
-        });
-
-        if (legacyAutoRetryEnabled !== undefined) {
-          // One-way migration: once we have successfully forwarded the legacy value
-          // to the backend, clear the renderer key so future sessions rely solely
-          // on backend persistence.
+        const iterator = await client.workspace.onChat(input, { signal: attemptSignal });
+        if (legacyAutoRetryEnabled !== undefined)
           updatePersistedState<boolean | undefined>(autoRetryKey, undefined);
-        }
-
-        // Full replay: clear stale derived/transient state now that the subscription
-        // is active. Deferred to after the iterator is established so the UI continues
-        // displaying previous state until replay data actually starts arriving.
-        if (!mode || mode.type === "full") {
-          this.resetChatStateForReplay(workspaceId);
-        }
-
-        // Start watchdog after subscribe connects so timeout measures
-        // post-connect silence, not handshake latency.
-        watchdog.start();
-
-        for await (const data of iterator) {
-          if (signal.aborted) {
-            return;
-          }
-
-          watchdog.markEvent();
-
-          // Connection is alive again - don't carry old backoff into the next failure.
-          attempt = 0;
-
-          const attemptSignal = attemptController.signal;
-          queueMicrotask(() => {
-            // Workspace switches abort the previous attempt before starting a new one.
-            // Drop any already-queued chat events from that aborted attempt so stale
-            // replay buffers cannot be repopulated after we synchronously cleared them.
-            if (signal.aborted || attemptSignal.aborted) {
-              return;
-            }
+        if (!mode || mode.type === "full") this.resetChatStateForReplay(workspaceId);
+        return { events: iterator, context: attemptContext };
+      },
+      onEvent: (data, attemptContext, attemptSignal) =>
+        queueMicrotask(() => {
+          if (!signal.aborted && !attemptSignal.aborted)
             this.handleChatMessage(workspaceId, data, attemptContext);
-          });
-        }
-
-        // Iterator ended without an abort - treat as unexpected and retry.
-        if (signal.aborted) {
-          return;
-        }
-
-        if (attemptController.signal.aborted) {
-          // e.g., stall watchdog fired
-          console.warn(
-            `[WorkspaceStore] onChat subscription aborted for ${workspaceId}; retrying...`
-          );
-        } else {
-          console.warn(
-            `[WorkspaceStore] onChat subscription ended unexpectedly for ${workspaceId}; retrying...`
-          );
-        }
-      } catch (error) {
-        // Suppress errors when subscription was intentionally cleaned up
-        if (signal.aborted) {
-          return;
-        }
-
+        }),
+      onUnexpectedEnd: ({ attemptAborted }) =>
+        console.warn(
+          attemptAborted
+            ? "[WorkspaceStore] onChat subscription aborted for " + workspaceId + "; retrying..."
+            : "[WorkspaceStore] onChat subscription ended unexpectedly for " +
+                workspaceId +
+                "; retrying..."
+        ),
+      onError: (error, { attemptAborted }) => {
         const abortError = isAbortError(error);
-
-        if (attemptController.signal.aborted) {
-          if (!abortError) {
+        if (attemptAborted) {
+          if (!abortError)
             console.warn(
-              `[WorkspaceStore] onChat subscription aborted for ${workspaceId}; retrying...`
+              "[WorkspaceStore] onChat subscription aborted for " + workspaceId + "; retrying..."
             );
-          }
         } else if (isIteratorValidationFailed(error)) {
-          // EVENT_ITERATOR_VALIDATION_FAILED can happen when:
-          // 1. Schema validation fails (event doesn't match WorkspaceChatMessageSchema)
-          // 2. Workspace was removed on server side (iterator ends with error)
-          // 3. Connection dropped (WebSocket/MessagePort error)
-
-          // Only suppress if workspace no longer exists (was removed during the race)
-          if (!this.isWorkspaceRegistered(workspaceId)) {
-            return;
-          }
-          // Log with detailed validation info for debugging schema mismatches
+          if (!this.isWorkspaceRegistered(workspaceId)) return true;
           console.error(
-            `[WorkspaceStore] Event validation failed for ${workspaceId}: ${formatValidationError(error)}`
+            "[WorkspaceStore] Event validation failed for " +
+              workspaceId +
+              ": " +
+              formatValidationError(error)
           );
-        } else if (!abortError) {
-          console.error(`[WorkspaceStore] Error in onChat subscription for ${workspaceId}:`, error);
-        }
-      } finally {
-        releaseAttemptListeners();
-        watchdog.stop();
-      }
-
-      if (this.isWorkspaceRegistered(workspaceId)) {
-        // Failed reconnect attempts may have buffered partial replay data.
-        // Clear replay buffers before the next attempt so we don't append a
-        // second replay copy and duplicate deltas/tool events on caught-up.
+        } else if (!abortError)
+          console.error(
+            "[WorkspaceStore] Error in onChat subscription for " + workspaceId + ":",
+            error
+          );
+      },
+      onAttemptFinished: () => {
+        if (!this.isWorkspaceRegistered(workspaceId)) return;
         this.clearReplayBuffers(workspaceId);
-
-        // If catch-up fails before the authoritative marker arrives, fall back to
-        // normal transcript/retry UI immediately so hydration cannot remain pinned
-        // while we wait for client reconnects.
         const transient = this.chatTransientState.get(workspaceId);
         if (transient?.isHydratingTranscript && !transient.caughtUp) {
           transient.isHydratingTranscript = false;
           this.states.bump(workspaceId);
         }
-
-        // Full replay resets can preserve the last usage snapshot until caught-up.
-        // If reconnect fails before caught-up arrives, drop that snapshot so stale
-        // live usage isn't shown indefinitely while retries continue.
-        if (transient && !transient.caughtUp && this.preReplayUsageSnapshot.delete(workspaceId)) {
+        if (transient && !transient.caughtUp && this.preReplayUsageSnapshot.delete(workspaceId))
           this.usageStore.bump(workspaceId);
-        }
-
-        // Preserve pagination across transient reconnect retries. Incremental
-        // caught-up payloads intentionally omit hasOlderHistory, so resetting
-        // here would permanently hide "Load older messages" until a full replay.
         const existingPagination =
           this.historyPagination.get(workspaceId) ?? createInitialHistoryPaginationState();
-        this.historyPagination.set(workspaceId, {
-          ...existingPagination,
-          loading: false,
-        });
-      }
-
-      const delayMs = calculateSubscriptionBackoffMs(attempt);
-      attempt++;
-
-      await this.sleepWithAbort(delayMs, signal);
-      if (signal.aborted) {
-        return;
-      }
-    }
+        this.historyPagination.set(workspaceId, { ...existingPagination, loading: false });
+      },
+    });
   }
 
   /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -64,7 +64,10 @@ import {
   type AdvisorPhaseEvent,
   type StreamAbortEvent,
   type StreamAbortReasonSnapshot,
+  type StreamDeltaEvent,
   type StreamEndEvent,
+  type ToolCallDeltaEvent,
+  type ReasoningDeltaEvent,
   type StreamStartEvent,
   type RuntimeStatusEvent,
 } from "@/common/types/stream";
@@ -912,7 +915,7 @@ export class WorkspaceStore {
       this.states.bump(workspaceId);
     },
     "stream-delta": (workspaceId, aggregator, data) => {
-      this.applyStreamingDelta(workspaceId, aggregator, data);
+      this.applyStreamingDelta(workspaceId, aggregator, data as StreamDeltaEvent);
     },
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
@@ -1011,7 +1014,7 @@ export class WorkspaceStore {
       this.states.bump(workspaceId);
     },
     "tool-call-delta": (workspaceId, aggregator, data) => {
-      this.applyStreamingDelta(workspaceId, aggregator, data);
+      this.applyStreamingDelta(workspaceId, aggregator, data as ToolCallDeltaEvent);
     },
     "tool-call-end": (workspaceId, aggregator, data) => {
       const toolCallEnd = data as Extract<WorkspaceChatMessage, { type: "tool-call-end" }>;
@@ -1066,7 +1069,7 @@ export class WorkspaceStore {
       }
     },
     "reasoning-delta": (workspaceId, aggregator, data) => {
-      this.applyStreamingDelta(workspaceId, aggregator, data);
+      this.applyStreamingDelta(workspaceId, aggregator, data as ReasoningDeltaEvent);
     },
     "reasoning-end": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1673,25 +1676,37 @@ export class WorkspaceStore {
   private applyStreamingDelta(
     workspaceId: string,
     aggregator: StreamingMessageAggregator,
-    data: WorkspaceChatMessage
+    data: StreamDeltaEvent | ToolCallDeltaEvent | ReasoningDeltaEvent
   ): void {
-    const messageId = aggregator.getActiveStreamMessageId();
-    const partsBefore = messageId ? aggregator.getMessagePartCount(messageId) : 0;
+    // Route by the delta's own message ID: a second stream can start before the
+    // previous stream context is removed, and the "first active entry" would
+    // then attribute this delta's part-count change to the wrong message.
+    const messageId = data.messageId;
+    const partsBefore = aggregator.getMessagePartCount(messageId);
     applyWorkspaceChatEventToAggregator(aggregator, data);
-    if (messageId && aggregator.getMessagePartCount(messageId) !== partsBefore) {
+    if (aggregator.getMessagePartCount(messageId) !== partsBefore) {
       this.states.bump(workspaceId);
       this.streamingStatsStore.bump(workspaceId);
     } else {
-      this.scheduleStreamingMessageBump(workspaceId, aggregator);
+      this.scheduleStreamingMessageBump(workspaceId, aggregator, messageId);
     }
   }
 
   private scheduleStreamingMessageBump(
     workspaceId: string,
-    aggregator: StreamingMessageAggregator
+    aggregator: StreamingMessageAggregator,
+    messageId: string
   ): void {
-    const messageId = aggregator.getActiveStreamMessageId();
-    if (!messageId || this.pendingStreamingMessageBump.has(workspaceId)) return;
+    const pendingId = this.pendingStreamingMessageBump.get(workspaceId);
+    if (pendingId === messageId) return;
+    if (pendingId !== undefined) {
+      // Deltas from two concurrent streams are interleaved in this pump. The
+      // per-row channel tracks one row, so refresh the whole workspace rather
+      // than waking only the other stream's row.
+      this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
+      return;
+    }
     this.pendingStreamingMessageBump.set(workspaceId, messageId);
     queueMicrotask(() => {
       if (this.pendingStreamingMessageBump.get(workspaceId) !== messageId) return;
@@ -3727,6 +3742,17 @@ export class WorkspaceStore {
 
     // Reset per-workspace transient state so the next replay rebuilds from the backend source of truth.
     const previousTransient = this.chatTransientState.get(workspaceId);
+    // Release keyed advisor channels before the transient maps are replaced:
+    // they are the only record of these tool-call IDs, so the caught-up and
+    // workspace-removal sweeps can never rediscover the keys afterwards.
+    if (previousTransient) {
+      for (const toolCallId of new Set([
+        ...previousTransient.liveAdvisorOutput.keys(),
+        ...previousTransient.liveAdvisorReasoning.keys(),
+      ])) {
+        this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallId));
+      }
+    }
     const nextTransient = createInitialChatTransientState();
 
     // Preserve active hydration across full replay resets so workspace-switch catch-up

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -843,7 +843,7 @@ export class WorkspaceStore {
   private deltaIdleHandles = new Map<string, number>();
 
   private pendingStreamingMessageBump = new Map<string, string>();
-  private streamingMessageStore = new MapStore<string, DisplayedMessage | null>();
+  private streamingMessageStore = new MapStore<string, void>();
   private advisorLiveStore = new MapStore<string, void>();
   private streamingStatsStore = new MapStore<string, WorkspaceStreamingStats | null>();
 
@@ -1677,15 +1677,13 @@ export class WorkspaceStore {
   getStreamingMessage(
     workspaceId: string,
     displayedId: string,
-    messageId: string
+    _messageId: string
   ): DisplayedMessage | null {
-    return this.streamingMessageStore.get(
-      getStreamingMessageKey(workspaceId, messageId),
-      () =>
-        this.aggregators
-          .get(workspaceId)
-          ?.getDisplayedMessages()
-          .find((message) => message.id === displayedId) ?? null
+    return (
+      this.aggregators
+        .get(workspaceId)
+        ?.getDisplayedMessages()
+        .find((message) => message.id === displayedId) ?? null
     );
   }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -2021,12 +2021,16 @@ export class WorkspaceStore {
     for (const toolCallId of Array.from(transient.liveAdvisorReasoning.keys())) {
       if (!activeAdvisorToolCallIds.has(toolCallId)) {
         transient.liveAdvisorReasoning.delete(toolCallId);
+        this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallId));
       }
     }
 
     for (const toolCallId of Array.from(transient.liveAdvisorOutput.keys())) {
       if (!activeAdvisorToolCallIds.has(toolCallId)) {
         transient.liveAdvisorOutput.delete(toolCallId);
+        // Release the keyed channel version too; once the transient entry is
+        // gone, the workspace-removal sweep can no longer discover this key.
+        this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallId));
       }
     }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -844,6 +844,9 @@ export class WorkspaceStore {
   private deltaIdleHandles = new Map<string, number>();
 
   private pendingStreamingMessageBump = new Map<string, string>();
+  // Live keyed-channel key per workspace, so every stream-clearing path can
+  // release it even when no terminal chat event names the message.
+  private streamingMessageKeys = new Map<string, string>();
   private streamingMessageStore = new MapStore<string, void>();
   private advisorLiveStore = new MapStore<string, void>();
   private streamingStatsStore = new MapStore<string, WorkspaceStreamingStats | null>();
@@ -914,9 +917,7 @@ export class WorkspaceStore {
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
       applyWorkspaceChatEventToAggregator(aggregator, streamEndData);
-      this.streamingMessageStore.delete(
-        getStreamingMessageKey(workspaceId, streamEndData.messageId)
-      );
+      this.releaseStreamingMessageChannel(workspaceId);
 
       // Track stream completion telemetry
       this.trackStreamCompletedTelemetry(streamEndData, false);
@@ -975,9 +976,7 @@ export class WorkspaceStore {
     "stream-abort": (workspaceId, aggregator, data) => {
       const streamAbortData = data as StreamAbortEvent;
       applyWorkspaceChatEventToAggregator(aggregator, streamAbortData);
-      this.streamingMessageStore.delete(
-        getStreamingMessageKey(workspaceId, streamAbortData.messageId)
-      );
+      this.releaseStreamingMessageChannel(workspaceId);
 
       // Track stream interruption telemetry (get model from aggregator)
       const model = aggregator.getCurrentModel();
@@ -1659,6 +1658,13 @@ export class WorkspaceStore {
     this.deltaIdleHandles.set(workspaceId, handle);
   }
 
+  private releaseStreamingMessageChannel(workspaceId: string): void {
+    const key = this.streamingMessageKeys.get(workspaceId);
+    if (key === undefined) return;
+    this.streamingMessageKeys.delete(workspaceId);
+    this.streamingMessageStore.delete(key);
+  }
+
   /**
    * Deltas normally extend the active message's last part in place and only
    * need the row-local bump. A delta that adds a part creates a new display
@@ -1691,6 +1697,11 @@ export class WorkspaceStore {
     queueMicrotask(() => {
       if (this.pendingStreamingMessageBump.get(workspaceId) !== key) return;
       this.pendingStreamingMessageBump.delete(workspaceId);
+      const previousKey = this.streamingMessageKeys.get(workspaceId);
+      if (previousKey !== undefined && previousKey !== key) {
+        this.streamingMessageStore.delete(previousKey);
+      }
+      this.streamingMessageKeys.set(workspaceId, key);
       this.streamingMessageStore.bump(key);
       this.streamingStatsStore.bump(workspaceId);
     });
@@ -3316,6 +3327,7 @@ export class WorkspaceStore {
       this.aggregators.get(workspaceId)?.clearBackgroundHandoffCompletion();
       this.aggregators.get(workspaceId)?.clearActiveStreams();
       this.aggregators.get(workspaceId)?.clearPendingStreamStart();
+      this.releaseStreamingMessageChannel(workspaceId);
     }
 
     if (snapshot?.streaming !== true) {
@@ -3789,16 +3801,21 @@ export class WorkspaceStore {
    * Retries on unexpected iterator termination to avoid requiring a full app restart.
    */
   private async runOnChatSubscription(workspaceId: string, signal: AbortSignal): Promise<void> {
+    // Loop-scoped so the observation survives the generation retry: attaching a
+    // client aborts the change signal the waiting attempt captured, and the
+    // retried attempt would otherwise see the client as always-present.
+    let clientWasMissing = false;
     await runSubscriptionLoop({
       name: "onChat(" + workspaceId + ")",
       signal,
       getClient: async (attemptSignal) => {
-        const hadClientAtLoopStart = this.client !== null;
-        const client = this.client ?? (await this.waitForClient(attemptSignal));
-        return client ? { client, hadClientAtLoopStart } : null;
+        if (this.client === null) clientWasMissing = true;
+        return this.client ?? (await this.waitForClient(attemptSignal));
       },
       getClientChangeSignal: () => this.clientChangeController.signal,
-      subscribe: async ({ client, hadClientAtLoopStart }, attemptSignal, abortAttempt) => {
+      subscribe: async (client, attemptSignal, abortAttempt) => {
+        const hadClientAtLoopStart = !clientWasMissing;
+        clientWasMissing = false;
         const initialTransient = this.chatTransientState.get(workspaceId);
         if (
           !hadClientAtLoopStart &&
@@ -3992,10 +4009,7 @@ export class WorkspaceStore {
     this.cancelPendingIdleBump(workspaceId);
     this.cancelPendingStreamingBump(workspaceId);
     this.streamingStatsStore.delete(workspaceId);
-    const activeStreamMessageId = this.aggregators.get(workspaceId)?.getActiveStreamMessageId();
-    if (activeStreamMessageId) {
-      this.streamingMessageStore.delete(getStreamingMessageKey(workspaceId, activeStreamMessageId));
-    }
+    this.releaseStreamingMessageChannel(workspaceId);
     const transientForRemoval = this.chatTransientState.get(workspaceId);
     if (transientForRemoval) {
       for (const toolCallId of new Set([
@@ -4562,7 +4576,7 @@ export class WorkspaceStore {
       // streamingStatsStore cache so useWorkspaceStreamingStats returns null.
       this.cancelPendingIdleBump(workspaceId);
       this.cancelPendingStreamingBump(workspaceId);
-      this.streamingMessageStore.delete(getStreamingMessageKey(workspaceId, data.messageId));
+      this.releaseStreamingMessageChannel(workspaceId);
       this.states.bump(workspaceId);
       this.streamingStatsStore.bump(workspaceId);
       return;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -695,7 +695,7 @@ function repriceSessionUsage(
  * components re-render when workspace state changes.
  */
 function getStreamingMessageKey(workspaceId: string, messageId: string): string {
-  return workspaceId + " " + messageId;
+  return workspaceId + "\0" + messageId;
 }
 
 function getAdvisorLiveKey(workspaceId: string, toolCallId: string): string {
@@ -1674,11 +1674,7 @@ export class WorkspaceStore {
     this.pendingStreamingMessageBump.delete(workspaceId);
   }
 
-  getStreamingMessage(
-    workspaceId: string,
-    displayedId: string,
-    _messageId: string
-  ): DisplayedMessage | null {
+  getStreamingMessage(workspaceId: string, displayedId: string): DisplayedMessage | null {
     return (
       this.aggregators
         .get(workspaceId)
@@ -5232,7 +5228,7 @@ export function useStreamingMessageDelta(
     },
     () => {
       if (!workspaceId || !messageId) return message;
-      return store.getStreamingMessage(workspaceId, message.id, messageId) ?? message;
+      return store.getStreamingMessage(workspaceId, message.id) ?? message;
     }
   );
 }

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1692,11 +1692,24 @@ export class WorkspaceStore {
   ): void {
     const messageId = aggregator.getActiveStreamMessageId();
     if (!messageId || this.pendingStreamingMessageBump.has(workspaceId)) return;
-    const key = getStreamingMessageKey(workspaceId, messageId);
-    this.pendingStreamingMessageBump.set(workspaceId, key);
+    this.pendingStreamingMessageBump.set(workspaceId, messageId);
     queueMicrotask(() => {
-      if (this.pendingStreamingMessageBump.get(workspaceId) !== key) return;
+      if (this.pendingStreamingMessageBump.get(workspaceId) !== messageId) return;
       this.pendingStreamingMessageBump.delete(workspaceId);
+      // Deltas extend the active message's trailing displayed row; keying the
+      // bump by that row wakes one subscriber instead of every row of the
+      // message. The list is freshly cached here, so leaf reads hit the cache.
+      const rows = aggregator.getDisplayedMessages();
+      let rowId: string | undefined;
+      for (let i = rows.length - 1; i >= 0; i--) {
+        const row = rows[i];
+        if ("historyId" in row && row.historyId === messageId) {
+          rowId = row.id;
+          break;
+        }
+      }
+      if (rowId === undefined) return;
+      const key = getStreamingMessageKey(workspaceId, rowId);
       const previousKey = this.streamingMessageKeys.get(workspaceId);
       if (previousKey !== undefined && previousKey !== key) {
         this.streamingMessageStore.delete(previousKey);
@@ -1725,11 +1738,11 @@ export class WorkspaceStore {
 
   subscribeStreamingMessage(
     workspaceId: string,
-    messageId: string,
+    displayedId: string,
     listener: () => void
   ): () => void {
     return this.streamingMessageStore.subscribeKey(
-      getStreamingMessageKey(workspaceId, messageId),
+      getStreamingMessageKey(workspaceId, displayedId),
       listener
     );
   }
@@ -4389,12 +4402,21 @@ export class WorkspaceStore {
       if (replay === "full" || !data.cursor?.stream || streamContextMismatched) {
         // Live tool-call UI is tied to the active stream context; clear it when replay
         // replaces history, reports no active stream, or reports a different stream ID.
+        const clearedAdvisorToolCallIds = new Set([
+          ...transient.liveAdvisorOutput.keys(),
+          ...transient.liveAdvisorReasoning.keys(),
+        ]);
         transient.liveBashOutput.clear();
         transient.liveAdvisorOutput.clear();
         transient.liveAdvisorReasoning.clear();
         transient.liveAdvisorPhase.clear();
         transient.liveWorkflowRuns.clear();
         transient.liveTaskIds.clear();
+        // delete() notifies subscribers, so mounted advisor cards re-read null
+        // instead of keeping pre-reconnect live output.
+        for (const toolCallId of clearedAdvisorToolCallIds) {
+          this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallId));
+        }
       }
 
       if (sinceContext) {
@@ -5255,7 +5277,7 @@ export function useStreamingMessageDelta(
   return useSyncExternalStore(
     (listener) => {
       if (!workspaceId || !messageId) return () => undefined;
-      return store.subscribeStreamingMessage(workspaceId, messageId, listener);
+      return store.subscribeStreamingMessage(workspaceId, message.id, listener);
     },
     () => {
       if (!workspaceId || !messageId) return message;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -4925,8 +4925,8 @@ export function useAdvisorToolLiveOutput(
 
   return useSyncExternalStore(
     (listener) => {
-      if (!workspaceId) return () => undefined;
-      return store.subscribeAdvisorLive(workspaceId, toolCallId ?? "", listener);
+      if (!workspaceId || !toolCallId) return () => undefined;
+      return store.subscribeAdvisorLive(workspaceId, toolCallId, listener);
     },
     () => {
       if (!workspaceId || !toolCallId) return null;
@@ -4946,8 +4946,8 @@ export function useAdvisorToolLiveReasoning(
 
   return useSyncExternalStore(
     (listener) => {
-      if (!workspaceId) return () => undefined;
-      return store.subscribeAdvisorLive(workspaceId, toolCallId ?? "", listener);
+      if (!workspaceId || !toolCallId) return () => undefined;
+      return store.subscribeAdvisorLive(workspaceId, toolCallId, listener);
     },
     () => {
       if (!workspaceId || !toolCallId) return null;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -909,8 +909,7 @@ export class WorkspaceStore {
       this.states.bump(workspaceId);
     },
     "stream-delta": (workspaceId, aggregator, data) => {
-      applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingMessageBump(workspaceId, aggregator);
+      this.applyStreamingDelta(workspaceId, aggregator, data);
     },
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
@@ -1007,8 +1006,7 @@ export class WorkspaceStore {
       this.states.bump(workspaceId);
     },
     "tool-call-delta": (workspaceId, aggregator, data) => {
-      applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingMessageBump(workspaceId, aggregator);
+      this.applyStreamingDelta(workspaceId, aggregator, data);
     },
     "tool-call-end": (workspaceId, aggregator, data) => {
       const toolCallEnd = data as Extract<WorkspaceChatMessage, { type: "tool-call-end" }>;
@@ -1062,8 +1060,7 @@ export class WorkspaceStore {
       }
     },
     "reasoning-delta": (workspaceId, aggregator, data) => {
-      applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingMessageBump(workspaceId, aggregator);
+      this.applyStreamingDelta(workspaceId, aggregator, data);
     },
     "reasoning-end": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1653,6 +1650,26 @@ export class WorkspaceStore {
     );
 
     this.deltaIdleHandles.set(workspaceId, handle);
+  }
+
+  /**
+   * Deltas normally extend the active message's last part in place and only
+   * need the row-local bump. A delta that adds a part creates a new display
+   * row with no mounted subscriber yet, so only a workspace bump can mount it.
+   */
+  private applyStreamingDelta(
+    workspaceId: string,
+    aggregator: StreamingMessageAggregator,
+    data: WorkspaceChatMessage
+  ): void {
+    const messageId = aggregator.getActiveStreamMessageId();
+    const partsBefore = messageId ? aggregator.getMessagePartCount(messageId) : 0;
+    applyWorkspaceChatEventToAggregator(aggregator, data);
+    if (messageId && aggregator.getMessagePartCount(messageId) !== partsBefore) {
+      this.states.bump(workspaceId);
+    } else {
+      this.scheduleStreamingMessageBump(workspaceId, aggregator);
+    }
   }
 
   private scheduleStreamingMessageBump(

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -1746,8 +1746,10 @@ export class WorkspaceStore {
   ): DisplayedMessage | null {
     const aggregator = this.aggregators.get(workspaceId);
     // Completed rows may be transformed by the transcript (e.g. merged stream
-    // errors); only the actively streaming message overrides its prop row.
-    if (!aggregator || aggregator.getActiveStreamMessageId() !== messageId) return null;
+    // errors); only an actively streaming message overrides its prop row. Check
+    // membership rather than the first active entry so a second concurrent
+    // stream's rows keep receiving live overrides.
+    if (!aggregator?.isStreamActive(messageId)) return null;
     return aggregator.getDisplayedMessages().find((message) => message.id === displayedId) ?? null;
   }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -839,22 +839,12 @@ export class WorkspaceStore {
   private fileModifyingToolMs = new Map<string, number>();
   private fileModifyingToolSubs = new MapStore<string, void>();
 
-  // Idle callback handles for high-frequency, terminal-style output (init logs).
-  // Data is always updated immediately in the aggregator; only UI notification is scheduled.
-  // Using requestIdleCallback adapts to actual CPU availability rather than a fixed timer.
-  // NOTE: Streaming text/reasoning/tool deltas do NOT use this — they use
-  // scheduleStreamingStateBump() (microtask coalescing) so the smoothing engine's
-  // RAF presentation clock isn't competing with a 100ms ingestion clock.
+  // Idle callbacks keep high-frequency init logs from blocking the renderer.
   private deltaIdleHandles = new Map<string, number>();
 
   private pendingStreamingMessageBump = new Map<string, string>();
   private streamingMessageStore = new MapStore<string, DisplayedMessage | null>();
   private advisorLiveStore = new MapStore<string, void>();
-
-  // Live streaming stats (tokens/sec) — exposed via useWorkspaceStreamingStats() as a
-  // leaf subscription. Updated on every stream-delta in the same coalesced microtask
-  // as states.bump(), but separate so changes only re-render the StreamingBarrier
-  // pill and not the entire ChatPane subtree.
   private streamingStatsStore = new MapStore<string, WorkspaceStreamingStats | null>();
 
   /**

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -914,6 +914,9 @@ export class WorkspaceStore {
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
       applyWorkspaceChatEventToAggregator(aggregator, streamEndData);
+      this.streamingMessageStore.delete(
+        getStreamingMessageKey(workspaceId, streamEndData.messageId)
+      );
 
       // Track stream completion telemetry
       this.trackStreamCompletedTelemetry(streamEndData, false);
@@ -972,6 +975,9 @@ export class WorkspaceStore {
     "stream-abort": (workspaceId, aggregator, data) => {
       const streamAbortData = data as StreamAbortEvent;
       applyWorkspaceChatEventToAggregator(aggregator, streamAbortData);
+      this.streamingMessageStore.delete(
+        getStreamingMessageKey(workspaceId, streamAbortData.messageId)
+      );
 
       // Track stream interruption telemetry (get model from aggregator)
       const model = aggregator.getCurrentModel();
@@ -1026,6 +1032,7 @@ export class WorkspaceStore {
         transient?.liveAdvisorOutput.delete(toolCallEnd.toolCallId);
         transient?.liveAdvisorReasoning.delete(toolCallEnd.toolCallId);
         transient?.liveAdvisorPhase.delete(toolCallEnd.toolCallId);
+        this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallEnd.toolCallId));
       }
       if (toolCallEnd.toolName === "task") {
         transient?.liveTaskIds.delete(toolCallEnd.toolCallId);
@@ -1667,6 +1674,7 @@ export class WorkspaceStore {
     applyWorkspaceChatEventToAggregator(aggregator, data);
     if (messageId && aggregator.getMessagePartCount(messageId) !== partsBefore) {
       this.states.bump(workspaceId);
+      this.streamingStatsStore.bump(workspaceId);
     } else {
       this.scheduleStreamingMessageBump(workspaceId, aggregator);
     }
@@ -1692,13 +1700,16 @@ export class WorkspaceStore {
     this.pendingStreamingMessageBump.delete(workspaceId);
   }
 
-  getStreamingMessage(workspaceId: string, displayedId: string): DisplayedMessage | null {
-    return (
-      this.aggregators
-        .get(workspaceId)
-        ?.getDisplayedMessages()
-        .find((message) => message.id === displayedId) ?? null
-    );
+  getStreamingMessage(
+    workspaceId: string,
+    displayedId: string,
+    messageId: string
+  ): DisplayedMessage | null {
+    const aggregator = this.aggregators.get(workspaceId);
+    // Completed rows may be transformed by the transcript (e.g. merged stream
+    // errors); only the actively streaming message overrides its prop row.
+    if (!aggregator || aggregator.getActiveStreamMessageId() !== messageId) return null;
+    return aggregator.getDisplayedMessages().find((message) => message.id === displayedId) ?? null;
   }
 
   subscribeStreamingMessage(
@@ -3981,6 +3992,19 @@ export class WorkspaceStore {
     this.cancelPendingIdleBump(workspaceId);
     this.cancelPendingStreamingBump(workspaceId);
     this.streamingStatsStore.delete(workspaceId);
+    const activeStreamMessageId = this.aggregators.get(workspaceId)?.getActiveStreamMessageId();
+    if (activeStreamMessageId) {
+      this.streamingMessageStore.delete(getStreamingMessageKey(workspaceId, activeStreamMessageId));
+    }
+    const transientForRemoval = this.chatTransientState.get(workspaceId);
+    if (transientForRemoval) {
+      for (const toolCallId of new Set([
+        ...transientForRemoval.liveAdvisorOutput.keys(),
+        ...transientForRemoval.liveAdvisorReasoning.keys(),
+      ])) {
+        this.advisorLiveStore.delete(getAdvisorLiveKey(workspaceId, toolCallId));
+      }
+    }
     this.lastUserPromptStore.bump(workspaceId);
     this.lastUserPromptStore.delete(workspaceId);
 
@@ -4538,6 +4562,7 @@ export class WorkspaceStore {
       // streamingStatsStore cache so useWorkspaceStreamingStats returns null.
       this.cancelPendingIdleBump(workspaceId);
       this.cancelPendingStreamingBump(workspaceId);
+      this.streamingMessageStore.delete(getStreamingMessageKey(workspaceId, data.messageId));
       this.states.bump(workspaceId);
       this.streamingStatsStore.bump(workspaceId);
       return;
@@ -5220,7 +5245,7 @@ export function useStreamingMessageDelta(
     },
     () => {
       if (!workspaceId || !messageId) return message;
-      return store.getStreamingMessage(workspaceId, message.id) ?? message;
+      return store.getStreamingMessage(workspaceId, message.id, messageId) ?? message;
     }
   );
 }

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -694,6 +694,14 @@ function repriceSessionUsage(
  * specific workspaces via useSyncExternalStore, ensuring only relevant
  * components re-render when workspace state changes.
  */
+function getStreamingMessageKey(workspaceId: string, messageId: string): string {
+  return workspaceId + " " + messageId;
+}
+
+function getAdvisorLiveKey(workspaceId: string, toolCallId: string): string {
+  return workspaceId + " " + toolCallId;
+}
+
 export class WorkspaceStore {
   // Per-workspace state (lazy computed on get)
   private states = new MapStore<string, WorkspaceState>();
@@ -839,10 +847,9 @@ export class WorkspaceStore {
   // RAF presentation clock isn't competing with a 100ms ingestion clock.
   private deltaIdleHandles = new Map<string, number>();
 
-  // Microtask coalescing for streaming deltas. Many deltas can arrive in the same
-  // task pump (ORPC iterator drain); we collapse them into a single states.bump()
-  // at the microtask tail so React reconciles once per pump instead of once per chunk.
-  private pendingStreamingBump = new Set<string>();
+  private pendingStreamingMessageBump = new Map<string, string>();
+  private streamingMessageStore = new MapStore<string, DisplayedMessage | null>();
+  private advisorLiveStore = new MapStore<string, void>();
 
   // Live streaming stats (tokens/sec) — exposed via useWorkspaceStreamingStats() as a
   // leaf subscription. Updated on every stream-delta in the same coalesced microtask
@@ -912,7 +919,7 @@ export class WorkspaceStore {
     },
     "stream-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingStateBump(workspaceId);
+      this.scheduleStreamingMessageBump(workspaceId, aggregator);
     },
     "stream-end": (workspaceId, aggregator, data) => {
       const streamEndData = data as StreamEndEvent;
@@ -1010,7 +1017,7 @@ export class WorkspaceStore {
     },
     "tool-call-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingStateBump(workspaceId);
+      this.scheduleStreamingMessageBump(workspaceId, aggregator);
     },
     "tool-call-end": (workspaceId, aggregator, data) => {
       const toolCallEnd = data as Extract<WorkspaceChatMessage, { type: "tool-call-end" }>;
@@ -1065,7 +1072,7 @@ export class WorkspaceStore {
     },
     "reasoning-delta": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
-      this.scheduleStreamingStateBump(workspaceId);
+      this.scheduleStreamingMessageBump(workspaceId, aggregator);
     },
     "reasoning-end": (workspaceId, aggregator, data) => {
       applyWorkspaceChatEventToAggregator(aggregator, data);
@@ -1657,36 +1664,50 @@ export class WorkspaceStore {
     this.deltaIdleHandles.set(workspaceId, handle);
   }
 
-  /**
-   * Coalesce streaming state bumps to a single microtask per workspace.
-   *
-   * Streaming text/reasoning/tool deltas land in the aggregator immediately, but
-   * the React notification is deferred to the microtask tail of the current
-   * task pump. Many deltas can arrive in the same pump (the ORPC iterator
-   * drains a queue) — we want React to reconcile once per pump, not once per
-   * chunk.
-   *
-   * Why microtask and not requestIdleCallback? The smoothing engine
-   * ({@link useSmoothStreamingText}) is the presentation clock — pacing the
-   * visible reveal at RAF frequency. The ingestion clock should be deterministic
-   * and prompt; an idle-callback ingestion delay (~100ms) just means the
-   * smoothing engine has to absorb burstier inputs and is more likely to hit
-   * its visual-lag safety net.
-   */
-  private scheduleStreamingStateBump(workspaceId: string): void {
-    if (this.pendingStreamingBump.has(workspaceId)) return;
-    this.pendingStreamingBump.add(workspaceId);
+  private scheduleStreamingMessageBump(
+    workspaceId: string,
+    aggregator: StreamingMessageAggregator
+  ): void {
+    const messageId = aggregator.getActiveStreamMessageId();
+    if (!messageId || this.pendingStreamingMessageBump.has(workspaceId)) return;
+    const key = getStreamingMessageKey(workspaceId, messageId);
+    this.pendingStreamingMessageBump.set(workspaceId, key);
     queueMicrotask(() => {
-      // Cleared by cancelPendingStreamingBump (e.g. on stream-end) — skip the bump
-      // so we don't double-notify after the terminal event already bumped state.
-      if (!this.pendingStreamingBump.delete(workspaceId)) return;
-      this.states.bump(workspaceId);
+      if (this.pendingStreamingMessageBump.get(workspaceId) !== key) return;
+      this.pendingStreamingMessageBump.delete(workspaceId);
+      this.streamingMessageStore.bump(key);
       this.streamingStatsStore.bump(workspaceId);
     });
   }
 
   private cancelPendingStreamingBump(workspaceId: string): void {
-    this.pendingStreamingBump.delete(workspaceId);
+    this.pendingStreamingMessageBump.delete(workspaceId);
+  }
+
+  getStreamingMessage(
+    workspaceId: string,
+    displayedId: string,
+    messageId: string
+  ): DisplayedMessage | null {
+    return this.streamingMessageStore.get(
+      getStreamingMessageKey(workspaceId, messageId),
+      () =>
+        this.aggregators
+          .get(workspaceId)
+          ?.getDisplayedMessages()
+          .find((message) => message.id === displayedId) ?? null
+    );
+  }
+
+  subscribeStreamingMessage(
+    workspaceId: string,
+    messageId: string,
+    listener: () => void
+  ): () => void {
+    return this.streamingMessageStore.subscribeKey(
+      getStreamingMessageKey(workspaceId, messageId),
+      listener
+    );
   }
 
   /**
@@ -1998,6 +2019,10 @@ export class WorkspaceStore {
   subscribeKey = (workspaceId: string, listener: () => void) => {
     return this.states.subscribeKey(workspaceId, listener);
   };
+
+  subscribeAdvisorLive(workspaceId: string, toolCallId: string, listener: () => void): () => void {
+    return this.advisorLiveStore.subscribeKey(getAdvisorLiveKey(workspaceId, toolCallId), listener);
+  }
 
   getBashToolLiveOutput(workspaceId: string, toolCallId: string): LiveBashOutputView | null {
     const state = this.chatTransientState.get(workspaceId)?.liveBashOutput.get(toolCallId);
@@ -4590,7 +4615,7 @@ export class WorkspaceStore {
         return;
       }
 
-      this.scheduleStreamingStateBump(workspaceId);
+      this.advisorLiveStore.bump(getAdvisorLiveKey(workspaceId, data.toolCallId));
       return;
     }
 
@@ -4609,7 +4634,7 @@ export class WorkspaceStore {
         return;
       }
 
-      this.scheduleStreamingStateBump(workspaceId);
+      this.advisorLiveStore.bump(getAdvisorLiveKey(workspaceId, data.toolCallId));
       return;
     }
 
@@ -4942,7 +4967,7 @@ export function useAdvisorToolLiveOutput(
   return useSyncExternalStore(
     (listener) => {
       if (!workspaceId) return () => undefined;
-      return store.subscribeKey(workspaceId, listener);
+      return store.subscribeAdvisorLive(workspaceId, toolCallId ?? "", listener);
     },
     () => {
       if (!workspaceId || !toolCallId) return null;
@@ -4963,7 +4988,7 @@ export function useAdvisorToolLiveReasoning(
   return useSyncExternalStore(
     (listener) => {
       if (!workspaceId) return () => undefined;
-      return store.subscribeKey(workspaceId, listener);
+      return store.subscribeAdvisorLive(workspaceId, toolCallId ?? "", listener);
     },
     () => {
       if (!workspaceId || !toolCallId) return null;
@@ -5203,6 +5228,24 @@ export function useWorkspaceRoundedStreamingTps(workspaceId: string): number | n
   return useSyncExternalStore(
     (listener: () => void) => store.subscribeStreamingStats(workspaceId, listener),
     () => store.getWorkspaceRoundedStreamingTps(workspaceId)
+  );
+}
+
+export function useStreamingMessageDelta(
+  workspaceId: string | undefined,
+  message: DisplayedMessage
+): DisplayedMessage {
+  const store = getStoreInstance();
+  const messageId = "historyId" in message ? message.historyId : null;
+  return useSyncExternalStore(
+    (listener) => {
+      if (!workspaceId || !messageId) return () => undefined;
+      return store.subscribeStreamingMessage(workspaceId, messageId, listener);
+    },
+    () => {
+      if (!workspaceId || !messageId) return message;
+      return store.getStreamingMessage(workspaceId, message.id, messageId) ?? message;
+    }
   );
 }
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -32,6 +32,7 @@ import {
   SUBSCRIPTION_RETRY_BASE_MS,
   calculateSubscriptionBackoffMs,
   runSubscriptionLoop,
+  sleepWithAbort,
 } from "@/browser/stores/subscriptionTransport";
 import {
   ADVISOR_LIVE_OUTPUT_MAX_CHARS,
@@ -3145,32 +3146,6 @@ export class WorkspaceStore {
     }
   }
 
-  private sleepWithAbort(timeoutMs: number, signal: AbortSignal): Promise<void> {
-    return new Promise((resolve) => {
-      if (signal.aborted) {
-        resolve();
-        return;
-      }
-
-      const onAbort = () => {
-        cleanup();
-        resolve();
-      };
-
-      const timeout = setTimeout(() => {
-        cleanup();
-        resolve();
-      }, timeoutMs);
-
-      const cleanup = () => {
-        clearTimeout(timeout);
-        signal.removeEventListener("abort", onAbort);
-      };
-
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
-  }
-
   private isWorkspaceRegistered(workspaceId: string): boolean {
     return this.workspaceMetadata.has(workspaceId);
   }
@@ -3576,7 +3551,7 @@ export class WorkspaceStore {
   ): Promise<void> {
     let attempt = 0;
     while (!signal.aborted && !attemptSignal.aborted) {
-      await this.sleepWithAbort(calculateSubscriptionBackoffMs(attempt), signal);
+      await sleepWithAbort(calculateSubscriptionBackoffMs(attempt), signal);
       attempt++;
       if (signal.aborted || attemptSignal.aborted) {
         return;

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -699,7 +699,7 @@ function getStreamingMessageKey(workspaceId: string, messageId: string): string 
 }
 
 function getAdvisorLiveKey(workspaceId: string, toolCallId: string): string {
-  return workspaceId + " " + toolCallId;
+  return workspaceId + "\0" + toolCallId;
 }
 
 export class WorkspaceStore {

--- a/src/browser/stores/subscriptionTransport.test.ts
+++ b/src/browser/stores/subscriptionTransport.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import { createControllableAsyncIterable } from "@/browser/testUtils";
+import {
+  SUBSCRIPTION_RETRY_MAX_MS,
+  calculateSubscriptionBackoffMs,
+  runSubscriptionLoop,
+} from "./subscriptionTransport";
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+
+function closeOnAbort<T>(signal: AbortSignal) {
+  const stream = createControllableAsyncIterable<T>();
+  signal.addEventListener("abort", stream.close, { once: true });
+  return stream;
+}
+
+describe("runSubscriptionLoop", () => {
+  test.each([
+    {
+      name: "progresses exponential backoff to the cap",
+      eventsByAttempt: [[], [], [], [], [], []],
+      expectedSleeps: [250, 500, 1000, 2000, 4000, SUBSCRIPTION_RETRY_MAX_MS],
+    },
+    {
+      name: "resets backoff after an event",
+      eventsByAttempt: [[], [1], []],
+      expectedSleeps: [250, 250, 500],
+    },
+  ])("$name", async ({ eventsByAttempt, expectedSleeps }) => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    const sleeps: number[] = [];
+    let subscription = 0;
+    let activeStream: ReturnType<typeof createControllableAsyncIterable<number>> | undefined;
+
+    await runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async () => {
+        const events = eventsByAttempt[subscription++] ?? [];
+        activeStream = createControllableAsyncIterable<number>();
+        for (const event of events) activeStream.push(event);
+        if (events.length === 0) activeStream.close();
+        return { events: activeStream.iterable, context: undefined };
+      },
+      onEvent: () => activeStream?.close(),
+      watchdog: false,
+      sleep: async (timeoutMs) => {
+        sleeps.push(timeoutMs);
+        if (sleeps.length === expectedSleeps.length) controller.abort();
+      },
+    });
+
+    expect(sleeps).toEqual(expectedSleeps);
+  });
+
+  test("retries after subscribe errors", async () => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    const errors: unknown[] = [];
+    let subscriptions = 0;
+
+    await runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (_client, signal) => {
+        subscriptions++;
+        if (subscriptions === 1) throw new Error("subscribe failed");
+        const stream = closeOnAbort<number>(signal);
+        stream.push(1);
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => controller.abort(),
+      onError: (error) => errors.push(error),
+      watchdog: false,
+      sleep: async () => undefined,
+    });
+
+    expect(subscriptions).toBe(2);
+    expect(errors).toHaveLength(1);
+  });
+
+  test("starts the watchdog only after subscribe connects", async () => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    let resolveSubscription!: (stream: ReturnType<typeof closeOnAbort<number>>) => void;
+    const connected = new Promise<ReturnType<typeof closeOnAbort<number>>>((resolve) => {
+      resolveSubscription = resolve;
+    });
+    let firstAttemptSignal: AbortSignal | undefined;
+
+    const loop = runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (_client, signal) => {
+        firstAttemptSignal ??= signal;
+        const stream = await connected;
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => undefined,
+      watchdog: { timeoutMs: 10, checkIntervalMs: 1 },
+      backoffAfterAbort: false,
+    });
+
+    await Bun.sleep(20);
+    expect(firstAttemptSignal?.aborted).toBe(false);
+    const stream = closeOnAbort<number>(firstAttemptSignal!);
+    resolveSubscription(stream);
+    await Bun.sleep(20);
+    expect(firstAttemptSignal?.aborted).toBe(true);
+    controller.abort();
+    stream.close();
+    await loop;
+  });
+
+  test("events reset the watchdog deadline", async () => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    let stream!: ReturnType<typeof closeOnAbort<number>>;
+    let attemptSignal!: AbortSignal;
+
+    const loop = runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (_client, signal) => {
+        attemptSignal = signal;
+        stream = closeOnAbort<number>(signal);
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => undefined,
+      watchdog: { timeoutMs: 30, checkIntervalMs: 2 },
+    });
+
+    await flush();
+    for (let i = 0; i < 3; i++) {
+      await Bun.sleep(15);
+      stream.push(i);
+    }
+    await Bun.sleep(15);
+    expect(attemptSignal.aborted).toBe(false);
+    controller.abort();
+    stream.close();
+    await loop;
+  });
+
+  test("a stalled attempt is aborted and retried", async () => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    const signals: AbortSignal[] = [];
+
+    await runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (_client, signal) => {
+        signals.push(signal);
+        const stream = closeOnAbort<number>(signal);
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => undefined,
+      watchdog: { timeoutMs: 10, checkIntervalMs: 1 },
+      backoffAfterAbort: false,
+      onAttemptFinished: () => {
+        if (signals.length === 2) controller.abort();
+      },
+    });
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  test("client changes abort the attempt and attach the replacement", async () => {
+    const controller = new AbortController();
+    let clientChange = new AbortController();
+    let client = "first";
+    const attached: string[] = [];
+
+    const loop = runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => client,
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (currentClient, signal) => {
+        attached.push(currentClient);
+        const stream = closeOnAbort<number>(signal);
+        if (currentClient === "second") stream.push(1);
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => controller.abort(),
+      watchdog: false,
+      backoffAfterAbort: false,
+    });
+
+    await flush();
+    client = "second";
+    const previousChange = clientChange;
+    clientChange = new AbortController();
+    previousChange.abort();
+    await loop;
+
+    expect(attached).toEqual(["first", "second"]);
+  });
+
+  test("clean teardown aborts the active attempt without retrying", async () => {
+    const controller = new AbortController();
+    const clientChange = new AbortController();
+    let subscriptions = 0;
+
+    const loop = runSubscriptionLoop({
+      name: "test",
+      signal: controller.signal,
+      getClient: async () => ({}),
+      getClientChangeSignal: () => clientChange.signal,
+      subscribe: async (_client, signal) => {
+        subscriptions++;
+        const stream = closeOnAbort<number>(signal);
+        return { events: stream.iterable, context: undefined };
+      },
+      onEvent: () => undefined,
+      watchdog: false,
+    });
+
+    await flush();
+    controller.abort();
+    await loop;
+    expect(subscriptions).toBe(1);
+  });
+});
+
+test("calculateSubscriptionBackoffMs caps large attempts", () => {
+  expect(calculateSubscriptionBackoffMs(100)).toBe(SUBSCRIPTION_RETRY_MAX_MS);
+});

--- a/src/browser/stores/subscriptionTransport.test.ts
+++ b/src/browser/stores/subscriptionTransport.test.ts
@@ -7,10 +7,12 @@ import {
 } from "./subscriptionTransport";
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+const getClient = () => Promise.resolve({});
+const noSleep = () => Promise.resolve();
 
 function closeOnAbort<T>(signal: AbortSignal) {
   const stream = createControllableAsyncIterable<T>();
-  signal.addEventListener("abort", stream.close, { once: true });
+  signal.addEventListener("abort", () => stream.close(), { once: true });
   return stream;
 }
 
@@ -36,24 +38,25 @@ describe("runSubscriptionLoop", () => {
     await runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async () => {
+      subscribe: () => {
         const events = eventsByAttempt[subscription++] ?? [];
         activeStream = createControllableAsyncIterable<number>();
         for (const event of events) activeStream.push(event);
         if (events.length === 0) activeStream.close();
-        return { events: activeStream.iterable, context: undefined };
+        return Promise.resolve({ events: activeStream.iterable, context: undefined });
       },
       onEvent: () => activeStream?.close(),
       watchdog: false,
-      sleep: async (timeoutMs) => {
+      sleep: (timeoutMs) => {
         sleeps.push(timeoutMs);
         if (sleeps.length === expectedSleeps.length) controller.abort();
+        return Promise.resolve();
       },
     });
 
-    expect(sleeps).toEqual(expectedSleeps);
+    expect(sleeps).toEqual([...expectedSleeps]);
   });
 
   test("retries after subscribe errors", async () => {
@@ -65,19 +68,21 @@ describe("runSubscriptionLoop", () => {
     await runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async (_client, signal) => {
+      subscribe: (_client, signal) => {
         subscriptions++;
-        if (subscriptions === 1) throw new Error("subscribe failed");
+        if (subscriptions === 1) return Promise.reject(new Error("subscribe failed"));
         const stream = closeOnAbort<number>(signal);
         stream.push(1);
-        return { events: stream.iterable, context: undefined };
+        return Promise.resolve({ events: stream.iterable, context: undefined });
       },
       onEvent: () => controller.abort(),
-      onError: (error) => errors.push(error),
+      onError: (error) => {
+        errors.push(error);
+      },
       watchdog: false,
-      sleep: async () => undefined,
+      sleep: noSleep,
     });
 
     expect(subscriptions).toBe(2);
@@ -96,7 +101,7 @@ describe("runSubscriptionLoop", () => {
     const loop = runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
       subscribe: async (_client, signal) => {
         firstAttemptSignal ??= signal;
@@ -128,12 +133,12 @@ describe("runSubscriptionLoop", () => {
     const loop = runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async (_client, signal) => {
+      subscribe: (_client, signal) => {
         attemptSignal = signal;
         stream = closeOnAbort<number>(signal);
-        return { events: stream.iterable, context: undefined };
+        return Promise.resolve({ events: stream.iterable, context: undefined });
       },
       onEvent: () => undefined,
       watchdog: { timeoutMs: 30, checkIntervalMs: 2 },
@@ -159,12 +164,12 @@ describe("runSubscriptionLoop", () => {
     await runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async (_client, signal) => {
+      subscribe: (_client, signal) => {
         signals.push(signal);
         const stream = closeOnAbort<number>(signal);
-        return { events: stream.iterable, context: undefined };
+        return Promise.resolve({ events: stream.iterable, context: undefined });
       },
       onEvent: () => undefined,
       watchdog: { timeoutMs: 10, checkIntervalMs: 1 },
@@ -187,13 +192,13 @@ describe("runSubscriptionLoop", () => {
     const loop = runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => client,
+      getClient: () => Promise.resolve(client),
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async (currentClient, signal) => {
+      subscribe: (currentClient, signal) => {
         attached.push(currentClient);
         const stream = closeOnAbort<number>(signal);
         if (currentClient === "second") stream.push(1);
-        return { events: stream.iterable, context: undefined };
+        return Promise.resolve({ events: stream.iterable, context: undefined });
       },
       onEvent: () => controller.abort(),
       watchdog: false,
@@ -218,12 +223,12 @@ describe("runSubscriptionLoop", () => {
     const loop = runSubscriptionLoop({
       name: "test",
       signal: controller.signal,
-      getClient: async () => ({}),
+      getClient,
       getClientChangeSignal: () => clientChange.signal,
-      subscribe: async (_client, signal) => {
+      subscribe: (_client, signal) => {
         subscriptions++;
         const stream = closeOnAbort<number>(signal);
-        return { events: stream.iterable, context: undefined };
+        return Promise.resolve({ events: stream.iterable, context: undefined });
       },
       onEvent: () => undefined,
       watchdog: false,

--- a/src/browser/stores/subscriptionTransport.test.ts
+++ b/src/browser/stores/subscriptionTransport.test.ts
@@ -215,6 +215,39 @@ describe("runSubscriptionLoop", () => {
     expect(attached).toEqual(["first", "second"]);
   });
 
+  test("a client swap during getClient retries instead of binding the stale client", async () => {
+    const controller = new AbortController();
+    const subscribedClients: string[] = [];
+    let generation = 0;
+    const changeControllers = [new AbortController(), new AbortController()];
+
+    await runSubscriptionLoop<string, number, undefined>({
+      name: "test",
+      signal: controller.signal,
+      getClient: () => {
+        if (generation === 0) {
+          // Swap generations while the first attempt is awaiting the client.
+          generation = 1;
+          changeControllers[0].abort();
+          return Promise.resolve("stale-client");
+        }
+        return Promise.resolve("fresh-client");
+      },
+      getClientChangeSignal: () => changeControllers[generation === 0 ? 0 : 1].signal,
+      subscribe: (client, signal) => {
+        subscribedClients.push(client);
+        const stream = closeOnAbort<number>(signal);
+        stream.push(1);
+        return Promise.resolve({ events: stream.iterable, context: undefined });
+      },
+      onEvent: () => controller.abort(),
+      watchdog: false,
+      sleep: noSleep,
+    });
+
+    expect(subscribedClients).toEqual(["fresh-client"]);
+  });
+
   test("clean teardown aborts the active attempt without retrying", async () => {
     const controller = new AbortController();
     const clientChange = new AbortController();

--- a/src/browser/stores/subscriptionTransport.ts
+++ b/src/browser/stores/subscriptionTransport.ts
@@ -1,0 +1,153 @@
+import { isAbortError } from "@/browser/utils/isAbortError";
+
+export const SUBSCRIPTION_RETRY_BASE_MS = 250;
+export const SUBSCRIPTION_RETRY_MAX_MS = 5000;
+export const SUBSCRIPTION_STALL_TIMEOUT_MS = 10_000;
+export const SUBSCRIPTION_STALL_CHECK_INTERVAL_MS = 2_000;
+
+export function calculateSubscriptionBackoffMs(attempt: number): number {
+  return Math.min(SUBSCRIPTION_RETRY_BASE_MS * 2 ** attempt, SUBSCRIPTION_RETRY_MAX_MS);
+}
+
+export interface SubscriptionAttemptResult<TEvent, TContext> {
+  events: AsyncIterable<TEvent>;
+  context: TContext;
+}
+
+export interface SubscriptionRetryImmediately {
+  retryImmediately: true;
+}
+
+interface AttemptStatus {
+  attemptSignal: AbortSignal;
+  attemptAborted: boolean;
+}
+
+interface SubscriptionLoopOptions<TClient, TEvent, TContext> {
+  name: string;
+  signal: AbortSignal;
+  getClient: (signal: AbortSignal) => Promise<TClient | null>;
+  getClientChangeSignal: () => AbortSignal;
+  subscribe: (
+    client: TClient,
+    attemptSignal: AbortSignal,
+    abortAttempt: () => void
+  ) => Promise<SubscriptionAttemptResult<TEvent, TContext> | SubscriptionRetryImmediately | null>;
+  onEvent: (event: TEvent, context: TContext, attemptSignal: AbortSignal) => void;
+  onError?: (error: unknown, status: AttemptStatus) => boolean | void;
+  onUnexpectedEnd?: (status: AttemptStatus) => void;
+  onAttemptFinished?: (status: AttemptStatus) => void;
+  watchdog?: false | { timeoutMs?: number; checkIntervalMs?: number };
+  backoffAfterAbort?: boolean;
+}
+
+function sleepWithAbort(timeoutMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const timeout = setTimeout(cleanup, timeoutMs);
+    const onAbort = cleanup;
+
+    function cleanup(): void {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function runSubscriptionLoop<TClient, TEvent, TContext>(
+  options: SubscriptionLoopOptions<TClient, TEvent, TContext>
+): Promise<void> {
+  let attempt = 0;
+
+  while (!options.signal.aborted) {
+    const client = await options.getClient(options.signal);
+    if (!client || options.signal.aborted) return;
+
+    const attemptController = new AbortController();
+    const abortAttempt = () => attemptController.abort();
+    options.signal.addEventListener("abort", abortAttempt, { once: true });
+    const clientChangeSignal = options.getClientChangeSignal();
+    clientChangeSignal.addEventListener("abort", abortAttempt, { once: true });
+
+    let lastEventAt = Date.now();
+    let watchdog: ReturnType<typeof setInterval> | undefined;
+
+    try {
+      const result = await options.subscribe(client, attemptController.signal, abortAttempt);
+      if (!result) return;
+      if ("retryImmediately" in result) continue;
+
+      if (options.watchdog !== false) {
+        const timeoutMs = options.watchdog?.timeoutMs ?? SUBSCRIPTION_STALL_TIMEOUT_MS;
+        const checkIntervalMs =
+          options.watchdog?.checkIntervalMs ?? SUBSCRIPTION_STALL_CHECK_INTERVAL_MS;
+        lastEventAt = Date.now();
+        watchdog = setInterval(() => {
+          if (attemptController.signal.aborted) return;
+          const elapsedMs = Date.now() - lastEventAt;
+          if (elapsedMs < timeoutMs) return;
+          console.warn(
+            "[subscriptionTransport] " +
+              options.name +
+              " stalled (no events for " +
+              elapsedMs +
+              "ms); retrying..."
+          );
+          attemptController.abort();
+        }, checkIntervalMs);
+      }
+
+      for await (const event of result.events) {
+        if (options.signal.aborted) return;
+        lastEventAt = Date.now();
+        attempt = 0;
+        options.onEvent(event, result.context, attemptController.signal);
+      }
+
+      if (!options.signal.aborted) {
+        options.onUnexpectedEnd?.({
+          attemptSignal: attemptController.signal,
+          attemptAborted: attemptController.signal.aborted,
+        });
+      }
+    } catch (error) {
+      if (options.signal.aborted) return;
+      if (isAbortError(error) && attemptController.signal.aborted) {
+        options.onError?.(error, {
+          attemptSignal: attemptController.signal,
+          attemptAborted: true,
+        });
+      } else {
+        const stop = options.onError?.(error, {
+          attemptSignal: attemptController.signal,
+          attemptAborted: attemptController.signal.aborted,
+        });
+        if (stop === true) return;
+      }
+    } finally {
+      options.signal.removeEventListener("abort", abortAttempt);
+      clientChangeSignal.removeEventListener("abort", abortAttempt);
+      if (watchdog) clearInterval(watchdog);
+    }
+
+    if (options.signal.aborted) return;
+
+    const status = {
+      attemptSignal: attemptController.signal,
+      attemptAborted: attemptController.signal.aborted,
+    };
+    options.onAttemptFinished?.(status);
+
+    if (options.backoffAfterAbort !== false || !attemptController.signal.aborted) {
+      await sleepWithAbort(calculateSubscriptionBackoffMs(attempt), options.signal);
+      attempt++;
+    }
+  }
+}

--- a/src/browser/stores/subscriptionTransport.ts
+++ b/src/browser/stores/subscriptionTransport.ts
@@ -68,13 +68,16 @@ export async function runSubscriptionLoop<TClient, TEvent, TContext>(
   let attempt = 0;
 
   while (!options.signal.aborted) {
+    // Capture before awaiting the client: a swap during the await would
+    // otherwise bind the old client to the new generation's change signal.
+    const clientChangeSignal = options.getClientChangeSignal();
     const client = await options.getClient(options.signal);
     if (!client || options.signal.aborted) return;
+    if (clientChangeSignal.aborted) continue;
 
     const attemptController = new AbortController();
     const abortAttempt = () => attemptController.abort();
     options.signal.addEventListener("abort", abortAttempt, { once: true });
-    const clientChangeSignal = options.getClientChangeSignal();
     clientChangeSignal.addEventListener("abort", abortAttempt, { once: true });
 
     let lastEventAt = Date.now();

--- a/src/browser/stores/subscriptionTransport.ts
+++ b/src/browser/stores/subscriptionTransport.ts
@@ -39,6 +39,7 @@ interface SubscriptionLoopOptions<TClient, TEvent, TContext> {
   onAttemptFinished?: (status: AttemptStatus) => void;
   watchdog?: false | { timeoutMs?: number; checkIntervalMs?: number };
   backoffAfterAbort?: boolean;
+  sleep?: (timeoutMs: number, signal: AbortSignal) => Promise<void>;
 }
 
 function sleepWithAbort(timeoutMs: number, signal: AbortSignal): Promise<void> {
@@ -146,7 +147,10 @@ export async function runSubscriptionLoop<TClient, TEvent, TContext>(
     options.onAttemptFinished?.(status);
 
     if (options.backoffAfterAbort !== false || !attemptController.signal.aborted) {
-      await sleepWithAbort(calculateSubscriptionBackoffMs(attempt), options.signal);
+      await (options.sleep ?? sleepWithAbort)(
+        calculateSubscriptionBackoffMs(attempt),
+        options.signal
+      );
       attempt++;
     }
   }

--- a/src/browser/stores/subscriptionTransport.ts
+++ b/src/browser/stores/subscriptionTransport.ts
@@ -2,19 +2,19 @@ import { isAbortError } from "@/browser/utils/isAbortError";
 
 export const SUBSCRIPTION_RETRY_BASE_MS = 250;
 export const SUBSCRIPTION_RETRY_MAX_MS = 5000;
-export const SUBSCRIPTION_STALL_TIMEOUT_MS = 10_000;
-export const SUBSCRIPTION_STALL_CHECK_INTERVAL_MS = 2_000;
+const SUBSCRIPTION_STALL_TIMEOUT_MS = 10_000;
+const SUBSCRIPTION_STALL_CHECK_INTERVAL_MS = 2_000;
 
 export function calculateSubscriptionBackoffMs(attempt: number): number {
   return Math.min(SUBSCRIPTION_RETRY_BASE_MS * 2 ** attempt, SUBSCRIPTION_RETRY_MAX_MS);
 }
 
-export interface SubscriptionAttemptResult<TEvent, TContext> {
+interface SubscriptionAttemptResult<TEvent, TContext> {
   events: AsyncIterable<TEvent>;
   context: TContext;
 }
 
-export interface SubscriptionRetryImmediately {
+interface SubscriptionRetryImmediately {
   retryImmediately: true;
 }
 
@@ -95,11 +95,7 @@ export async function runSubscriptionLoop<TClient, TEvent, TContext>(
           const elapsedMs = Date.now() - lastEventAt;
           if (elapsedMs < timeoutMs) return;
           console.warn(
-            "[subscriptionTransport] " +
-              options.name +
-              " stalled (no events for " +
-              elapsedMs +
-              "ms); retrying..."
+            `[subscriptionTransport] ${options.name} stalled (no events for ${elapsedMs}ms); retrying...`
           );
           attemptController.abort();
         }, checkIntervalMs);
@@ -120,18 +116,13 @@ export async function runSubscriptionLoop<TClient, TEvent, TContext>(
       }
     } catch (error) {
       if (options.signal.aborted) return;
-      if (isAbortError(error) && attemptController.signal.aborted) {
-        options.onError?.(error, {
-          attemptSignal: attemptController.signal,
-          attemptAborted: true,
-        });
-      } else {
-        const stop = options.onError?.(error, {
-          attemptSignal: attemptController.signal,
-          attemptAborted: attemptController.signal.aborted,
-        });
-        if (stop === true) return;
-      }
+      const stop = options.onError?.(error, {
+        attemptSignal: attemptController.signal,
+        attemptAborted: attemptController.signal.aborted,
+      });
+      // An aborted attempt (watchdog/client change) must retry even if the caller says stop.
+      const expectedAbort = isAbortError(error) && attemptController.signal.aborted;
+      if (stop === true && !expectedAbort) return;
     } finally {
       options.signal.removeEventListener("abort", abortAttempt);
       clientChangeSignal.removeEventListener("abort", abortAttempt);

--- a/src/browser/stores/subscriptionTransport.ts
+++ b/src/browser/stores/subscriptionTransport.ts
@@ -42,7 +42,7 @@ interface SubscriptionLoopOptions<TClient, TEvent, TContext> {
   sleep?: (timeoutMs: number, signal: AbortSignal) => Promise<void>;
 }
 
-function sleepWithAbort(timeoutMs: number, signal: AbortSignal): Promise<void> {
+export function sleepWithAbort(timeoutMs: number, signal: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
     if (signal.aborted) {
       resolve();

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -1943,6 +1943,10 @@ export class StreamingMessageAggregator {
     return this.getActiveStreamEntry()?.[0];
   }
 
+  isStreamActive(messageId: string): boolean {
+    return this.activeStreams.has(messageId);
+  }
+
   /**
    * Mark the current active stream as "interrupting" (transient state).
    * Called before interruptStream so UI shows "interrupting..." immediately.

--- a/src/browser/utils/messages/StreamingMessageAggregator.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.ts
@@ -1935,6 +1935,10 @@ export class StreamingMessageAggregator {
    * Get the active main-agent stream id (for interrupt, live usage, and token tracking).
    * Returns undefined when no interruptible stream is active.
    */
+  getMessagePartCount(messageId: string): number {
+    return this.messages.get(messageId)?.parts.length ?? 0;
+  }
+
   getActiveStreamMessageId(): string | undefined {
     return this.getActiveStreamEntry()?.[0];
   }


### PR DESCRIPTION
## Summary

Splits src/browser/stores/WorkspaceStore.ts's three responsibilities at two seams: the IPC subscription transport (reconnect loops, exponential backoff, stall watchdogs, attempt-scoped aborts) moves into a new pure `subscriptionTransport.ts` module, and high-frequency streaming deltas (`stream-delta`, `reasoning-delta`, `tool-call-delta`, advisor live output) move off whole-workspace state bumps onto a display-row-keyed channel consumed by the leaf message renderer. WorkspaceStore becomes a reactive cache; during streaming, only the row a delta changes re-renders, not ChatPane and not sibling rows.

**Net LOC: production −100, tests −551 (total −651).**

## Background

Refactor #8 from the 2026-08-29 architecture review (evidence at main @ f04e0f8a3). The transport skeleton was copy-pasted across the onChat, activity, and terminalActivity loops and only testable through mock router harnesses. Every token delta called `states.bump(workspaceId)`, re-rendering ChatPaneContent (1,991 lines) and re-running its 10 heavy useMemos per delta, exactly what the repo's colocate-subscriptions rule forbids.

## Implementation

- `runSubscriptionLoop` owns the generic attempt lifecycle (backoff schedule + reset-on-event, stall watchdog with start-after-connect semantics, attempt-scoped AbortController bound to the client generation captured before the client await). It has no WorkspaceStore or React knowledge and is fully driven by fake async iterators in tests. Per-stream semantics (since-cursors, caught-up snapshots, replay reconciliation, the single-active-onChat assertion) stay in WorkspaceStore's callbacks.
- `subscribeToStats` / `subscribeToTimeline` intentionally stay as-is: single-shot streams with a genuinely different lifecycle; forcing them through the coordinator would add a shallow layer for no deletion win.
- Streaming deltas bump a channel keyed by the active message's trailing displayed row, and `MessageRenderer` subscribes per row via `useStreamingMessageDelta`, so exactly one subscriber wakes per delta even for tool-heavy responses split into many rows. A delta that adds a part creates a new display row, which no leaf has mounted yet, so that case escalates to a workspace bump (plus a streaming-stats invalidation); structural events (stream start/end, tool lifecycle, init/caught-up) keep bumping whole WorkspaceState, preserving metadata and hydration behavior.
- The live lookup only overrides the actively streaming message, so completed rows keep transcript-level transforms (e.g. merged stream-error counts). Channel keys are tracked per workspace and released on terminal events, background activity stops, replay clears (advisor), and workspace removal, so MapStore version maps do not grow unbounded.
- At stream end the published final message and the live-read content come from the same aggregator, so completion causes no visible content swap.

## Irreducible additions (per-item)

- `subscriptionTransport.ts` (+151): the extracted seam itself; replaces ~480 lines of triplicated loop code.
- `subscriptionTransport.test.ts` (+279): table-driven scenarios over fake iterators/timers (backoff, watchdog, abort ordering, client-generation swap race); replaces ~1,180 lines of deleted mock-router retry/watchdog tests in WorkspaceStore.test.ts.
- Behavioral tests in WorkspaceStore.test.ts: row-keyed delta routing without whole-state bumps, row-creation escalation, text accumulation equality, key release on terminal/background-stop paths, delta vs stale bootstrap race.

## Validation

- Remote dogfood UAT (regression-focused, adversarial): long streaming turns with tool calls, backend kill/restart mid-stream, window reload mid-stream, workspace switch mid-stream, Escape interrupt, metadata time-series vs baseline. A render-count probe confirmed the streaming row updates without whole-pane re-renders.
- Reconnect forensics compared the branch against its fork-point baseline with identical methodology (chat.jsonl + DOM message-id inspection on both): behavior is structurally identical. Two pre-existing main behaviors were documented and intentionally not "fixed" here (resume-after-restart persists a partial + continuation message pair, splitting one logical response across two rows; first-turn aggregate stats populate late). Both reproduce identically at f04e0f8a3; changing them would be behavior changes outside this refactor's scope.
- Five Codex review rounds hardened the delta channels (row mounting for part-creating deltas, stats invalidation, key lifecycle across background stops and replay clears, client-generation race, merged-error row preservation); every fix landed with a discriminating test, most red-green verified.
- `make static-check` green; whole-file `bun test` green for every touched test file.

## Risks

Medium-sensitivity area: chat streaming and reconnect. The transport extraction is structure-preserving (same backoff constants, watchdog timings, and abort ordering, now asserted by deterministic unit tests), and delta isolation only narrows which subscribers re-render; it does not change event application. Highest residual risk is a subtle re-render dependency on per-delta content outside the leaf path; UAT's smoothness and metadata time-series probes targeted exactly that and found parity with baseline.

---

_Generated with `xum` on Mike's behalf • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$61.13`_

<!-- xum-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=61.13 -->

## Stack

Layer 9/10 of the architecture refactor stack (net -5,101 LOC overall). This PR's diff is only this layer, against `mike/arch-composer-hooks`.
