### PR TITLE
🤖 feat: Effect + oRPC integration spike (oRPC 1.14, effect v4-rc, handlerGen bridge)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,28 +1,33 @@
 function transformImportMetaForJest({ types: t }) {
+  // Shared by MemberExpression and OptionalMemberExpression (`import.meta?.env`,
+  // used by the ESM-only `effect` package) so both spellings rewrite identically.
+  function rewriteImportMetaMember(path) {
+    if (!t.isMetaProperty(path.node.object)) return;
+
+    const meta = path.node.object;
+    if (meta.meta.name !== "import" || meta.property.name !== "meta") return;
+    if (!t.isIdentifier(path.node.property)) return;
+
+    if (path.node.property.name === "env") {
+      path.replaceWith(t.memberExpression(t.identifier("process"), t.identifier("env")));
+      return;
+    }
+
+    if (path.node.property.name === "url") {
+      // `import.meta.url` -> `require("url").pathToFileURL(__filename).toString()`
+      const requireUrl = t.callExpression(t.identifier("require"), [t.stringLiteral("url")]);
+      const pathToFileURL = t.memberExpression(requireUrl, t.identifier("pathToFileURL"));
+      const fileUrl = t.callExpression(pathToFileURL, [t.identifier("__filename")]);
+      const toString = t.memberExpression(fileUrl, t.identifier("toString"));
+      path.replaceWith(t.callExpression(toString, []));
+    }
+  }
+
   return {
     name: "transform-import-meta-for-jest",
     visitor: {
-      MemberExpression(path) {
-        if (!t.isMetaProperty(path.node.object)) return;
-
-        const meta = path.node.object;
-        if (meta.meta.name !== "import" || meta.property.name !== "meta") return;
-        if (!t.isIdentifier(path.node.property)) return;
-
-        if (path.node.property.name === "env") {
-          path.replaceWith(t.memberExpression(t.identifier("process"), t.identifier("env")));
-          return;
-        }
-
-        if (path.node.property.name === "url") {
-          // `import.meta.url` -> `require("url").pathToFileURL(__filename).toString()`
-          const requireUrl = t.callExpression(t.identifier("require"), [t.stringLiteral("url")]);
-          const pathToFileURL = t.memberExpression(requireUrl, t.identifier("pathToFileURL"));
-          const fileUrl = t.callExpression(pathToFileURL, [t.identifier("__filename")]);
-          const toString = t.memberExpression(fileUrl, t.identifier("toString"));
-          path.replaceWith(t.callExpression(toString, []));
-        }
-      },
+      MemberExpression: rewriteImportMetaMember,
+      OptionalMemberExpression: rewriteImportMetaMember,
     },
   };
 }

--- a/bun.lock
+++ b/bun.lock
@@ -26,10 +26,11 @@
         "@mozilla/readability": "^0.6.0",
         "@novnc/novnc": "^1.6.0",
         "@openrouter/ai-sdk-provider": "^3.0.0",
-        "@orpc/client": "^1.11.3",
-        "@orpc/openapi": "^1.12.2",
-        "@orpc/server": "^1.11.3",
-        "@orpc/zod": "^1.11.3",
+        "@orpc/client": "1.14.11",
+        "@orpc/experimental-effect": "1.14.11",
+        "@orpc/openapi": "1.14.11",
+        "@orpc/server": "1.14.11",
+        "@orpc/zod": "1.14.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -58,6 +59,7 @@
         "crc-32": "^1.2.2",
         "diff": "^8.0.2",
         "disposablestack": "^1.1.7",
+        "effect": "4.0.0-rc.112",
         "electron-updater": "^6.6.2",
         "electron-window-state": "^5.0.3",
         "express": "^5.1.0",
@@ -210,6 +212,7 @@
   ],
   "patchedDependencies": {
     "@ai-sdk/xai@4.0.37": "patches/@ai-sdk%2Fxai@4.0.37.patch",
+    "trpc-cli@0.12.1": "patches/trpc-cli@0.12.1.patch",
   },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
@@ -684,6 +687,10 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
+    "@hey-api/spec-types": ["@hey-api/spec-types@0.0.0-next-20260408030107", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-P5DKr4dpZ7lmZpZt2bc2KWuzU9vl4GZcN7VrjchZF1WWKNGZFnwWhBxZo1t6P2muOCopIvqD2Fvp5os4QiitKA=="],
+
+    "@hey-api/types": ["@hey-api/types@0.1.4", "", {}, "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg=="],
+
     "@homebridge/ciao": ["@homebridge/ciao@1.3.4", "", { "dependencies": { "debug": "^4.4.1", "fast-deep-equal": "^3.1.3", "source-map-support": "^0.5.21", "tslib": "^2.8.1" }, "bin": { "ciao-bcs": "lib/bonjour-conformance-testing.js" } }, "sha512-qK6ZgGx0wwOubq/MY6eTbhApQHBUQCvCOsTYpQE01uLvfA2/Prm6egySHlZouKaina1RPuDwfLhCmsRCxwHj3Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
@@ -848,6 +855,18 @@
 
     "@mozilla/readability": ["@mozilla/readability@0.6.0", "", {}, "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@next/env": ["@next/env@16.0.6", "", {}, "sha512-PFTK/G/vM3UJwK5XDYMFOqt8QW42mmhSgdKDapOlCqBUAOfJN2dyOnASR/xUR/JRrro0pLohh/zOJ77xUQWQAg=="],
@@ -880,35 +899,21 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
-    "@orpc/client": ["@orpc/client@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "@orpc/standard-server-fetch": "1.12.2", "@orpc/standard-server-peer": "1.12.2" } }, "sha512-3MTFnWRYYjcyzhtcYpodvkaYQlqsxKd5xGv+7PPJSpjCgFg9wcp7mZmRKy7hK0sCwUlkyi7AKs1Q19aUVUFIGA=="],
+    "@orpc/client": ["@orpc/client@1.14.11", "", { "dependencies": { "@orpc/shared": "1.14.11", "@standardserver/core": "^0.5.0", "@standardserver/fetch": "^0.5.0", "@standardserver/peer": "^0.5.0" } }, "sha512-ZD2r8x07bycoqI/nGGFmIR1n4m/Mf2TsfVTPtuo5djKfWfSXmQPPAXhZsO6CN3eF+sl6g4sa5/fe1/T5zQoE1w=="],
 
-    "@orpc/contract": ["@orpc/contract@1.12.2", "", { "dependencies": { "@orpc/client": "1.12.2", "@orpc/shared": "1.12.2", "@standard-schema/spec": "^1.0.0", "openapi-types": "^12.1.3" } }, "sha512-eleSbF7WgfkWz+7jl1b9t3C3DWn127694+yEdR3j6EiBjb9mzHMIeOMRTXsclIP4gWj13wD1NtXp1Qlv8m7oZw=="],
+    "@orpc/contract": ["@orpc/contract@1.14.11", "", { "dependencies": { "@orpc/client": "1.14.11", "@orpc/shared": "1.14.11", "@standard-schema/spec": "^1.1.0" } }, "sha512-TM5Bw5adKuxMUJWENYzVwaDVN8eamwF/+PV5xkCGCaKuyZXHlWCDFhoGOQN8ybbrEtlReT/QPUtDclLhM9Ny1A=="],
 
-    "@orpc/interop": ["@orpc/interop@1.12.2", "", {}, "sha512-whHawJ8XZBzxngqOZKRzkI6HaFZcFSdbaK0//LmqOdSKXBeuveHF+kprCcpr8C6rH2N5i9nKMdnt0RetjPvxCg=="],
+    "@orpc/experimental-effect": ["@orpc/experimental-effect@1.14.11", "", { "dependencies": { "@orpc/contract": "1.14.11", "@orpc/json-schema": "1.14.11", "@orpc/server": "1.14.11", "@orpc/shared": "1.14.11" }, "peerDependencies": { "effect": ">=4.0.0-beta.90" } }, "sha512-M+aEyA6OscZ9gMWOv7BkEFJWW/ZhFJyHhWrvPue/gNrIp4dIjQh1dmek4ACUqdgHMn0rJdQtS6pnSK42MXMi8g=="],
 
-    "@orpc/json-schema": ["@orpc/json-schema@1.12.2", "", { "dependencies": { "@orpc/contract": "1.12.2", "@orpc/interop": "1.12.2", "@orpc/openapi": "1.12.2", "@orpc/server": "1.12.2", "@orpc/shared": "1.12.2", "json-schema-typed": "^8.0.2" } }, "sha512-b1SFH8d5lSKDPNcgK3fD3OvKKdO4eSjLilWmWUSQxqgfTEBckOIIMTfczDRQEkJIg/IyN++tYSwmjPFEI+dM3w=="],
+    "@orpc/json-schema": ["@orpc/json-schema@1.14.11", "", { "dependencies": { "@orpc/client": "1.14.11", "@orpc/contract": "1.14.11", "@orpc/server": "1.14.11", "@orpc/shared": "1.14.11", "@standard-schema/spec": "^1.1.0", "json-schema-typed": "^8.0.2" } }, "sha512-2t1F0k17vvnQ1ZcF7ab9XCGGpS2UippPU0ZlSRBd+RKwn+LwUmdRBng27w+XfIMKv/OiRj2K/ZL6mm2Q3h5ing=="],
 
-    "@orpc/openapi": ["@orpc/openapi@1.12.2", "", { "dependencies": { "@orpc/client": "1.12.2", "@orpc/contract": "1.12.2", "@orpc/interop": "1.12.2", "@orpc/openapi-client": "1.12.2", "@orpc/server": "1.12.2", "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "json-schema-typed": "^8.0.2", "rou3": "^0.7.10" } }, "sha512-21aB1uxNvzxnWBI/Y9pbhGL9i/w/kF62Zxiindopcy6PO+jjNhmHRCvJte70Rb+8rieoRMqn7m1d6yMC2B6NtQ=="],
+    "@orpc/openapi": ["@orpc/openapi@1.14.11", "", { "dependencies": { "@hey-api/spec-types": "0.0.0-next-20260408030107", "@orpc/client": "1.14.11", "@orpc/contract": "1.14.11", "@orpc/json-schema": "1.14.11", "@orpc/server": "1.14.11", "@orpc/shared": "1.14.11", "@standardserver/core": "^0.5.0", "@standardserver/fetch": "^0.5.0", "rou3": "^0.9.1" }, "peerDependencies": { "@scalar/api-reference": ">=1.57.2", "@types/swagger-ui": ">=5.32.0", "swagger-ui": ">=5.32.6" }, "optionalPeers": ["@scalar/api-reference", "@types/swagger-ui", "swagger-ui"] }, "sha512-X3PxQYbFYCS4CHOZWlSEOgECC1z69kjZu04hnZ/mQ2J+WTSIS3emjddfvNEgA4VkfWlCO0M2oOI8VW6HPx0KPQ=="],
 
-    "@orpc/openapi-client": ["@orpc/openapi-client@1.12.2", "", { "dependencies": { "@orpc/client": "1.12.2", "@orpc/contract": "1.12.2", "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2" } }, "sha512-Ci0TT4eSjRAMmBEwF9RBYrVWGEa/OALp6dKjM28FErqEqxQ5hdI5HMnNmFqGl5neIt05qtYEZRqhVv3jagOIcg=="],
+    "@orpc/server": ["@orpc/server@1.14.11", "", { "dependencies": { "@orpc/client": "1.14.11", "@orpc/contract": "1.14.11", "@orpc/shared": "1.14.11", "@standardserver/core": "^0.5.0", "@standardserver/fetch": "^0.5.0", "@standardserver/node": "^0.5.0", "@standardserver/peer": "^0.5.0", "cookie": "^2.0.1" }, "peerDependencies": { "crossws": ">=0.3.4" }, "optionalPeers": ["crossws"] }, "sha512-CVGdu2T0RtFKq5kNHZLLNYvRw2hXzqE+b8GDVx+MWwqoNJEDPLQHYCoByt0lBvK32TPLG61p6Y87gkEDlhbaRg=="],
 
-    "@orpc/server": ["@orpc/server@1.12.2", "", { "dependencies": { "@orpc/client": "1.12.2", "@orpc/contract": "1.12.2", "@orpc/interop": "1.12.2", "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "@orpc/standard-server-aws-lambda": "1.12.2", "@orpc/standard-server-fastify": "1.12.2", "@orpc/standard-server-fetch": "1.12.2", "@orpc/standard-server-node": "1.12.2", "@orpc/standard-server-peer": "1.12.2", "cookie": "^1.0.2" }, "peerDependencies": { "crossws": ">=0.3.4", "ws": ">=8.18.1" }, "optionalPeers": ["crossws", "ws"] }, "sha512-lgT3VR+yXsCcgzbZ2d1fXtqaf1RbgUJHMDWQ4J22LBYH1P8pi0Nk+EYi9/w3YNFIr1WuUmVu4Pm6Dg6l92oiQA=="],
+    "@orpc/shared": ["@orpc/shared@1.14.11", "", { "dependencies": { "@standardserver/shared": "^0.5.0", "radash": "^12.1.1", "type-fest": "^5.3.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-TNDa578Deju+vrCWEE/IbnDDsE/x2aEfOYVLUy+YPusZ9gx3FagcS9uxaBkJ2bdMrHEo1n5P0SjKdiEQttj9CQ=="],
 
-    "@orpc/shared": ["@orpc/shared@1.12.2", "", { "dependencies": { "radash": "^12.1.1", "type-fest": "^5.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-aITtDnmkofoG/GY6897AOPLnFMkLpQpM7ljzaqsG8QMbL6oovO427G/9Tr9Y3DDSyrsxA7FQ8+rwV03ZDG7gfQ=="],
-
-    "@orpc/standard-server": ["@orpc/standard-server@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2" } }, "sha512-8ZNhL3CRJmoJ7uFjOZB4U7NVGdcbGIOKLRTP0i/yhi51QL5Lw+56f/hNqztrCPVZolhJWif86HjyQhuixizrVg=="],
-
-    "@orpc/standard-server-aws-lambda": ["@orpc/standard-server-aws-lambda@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "@orpc/standard-server-fetch": "1.12.2", "@orpc/standard-server-node": "1.12.2" } }, "sha512-2gpM0ipl3YvE6/bJKTE6Oga4EROo2zuRiOzwY21F/3q38xyQ344Lk1smHzUv20lYZEIBDWP0FRR0OPhBQYLwNQ=="],
-
-    "@orpc/standard-server-fastify": ["@orpc/standard-server-fastify@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "@orpc/standard-server-node": "1.12.2" }, "peerDependencies": { "fastify": ">=5.6.1" }, "optionalPeers": ["fastify"] }, "sha512-O1IsvytsK1j6cbuztreE5sJHL3OyvDMn1lSWKO16YoLBK47W8XRHCVBKDDV+1gk4f4Q74bSJOvNGQh1OUcNbkg=="],
-
-    "@orpc/standard-server-fetch": ["@orpc/standard-server-fetch@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2" } }, "sha512-gjqZgD8uiW3dVaf+bo9Gj0GXTQ4B/vXkaHPmat+11AE+34UsOZJqZJzEuUi+P4qkmNOm6ZXAsb8roz6H3izPrg=="],
-
-    "@orpc/standard-server-node": ["@orpc/standard-server-node@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2", "@orpc/standard-server-fetch": "1.12.2" } }, "sha512-st9yjw3i+xFJu8YHeKcCBchMkRKyobBNqstR8yUelrLE/+rC0qKX+AwrmP6xq6gP6BQqFk+RSfIManaIruKuuQ=="],
-
-    "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.12.2", "", { "dependencies": { "@orpc/shared": "1.12.2", "@orpc/standard-server": "1.12.2" } }, "sha512-O51FDFAHgK5uG5EhIG5PYWrkpnwBSVIKih2yYtNzLVYsU3y8EkE07UHRWixJFjUDJ7YeGy16ud3M8oNqt2bE4g=="],
-
-    "@orpc/zod": ["@orpc/zod@1.12.2", "", { "dependencies": { "@orpc/json-schema": "1.12.2", "@orpc/openapi": "1.12.2", "@orpc/shared": "1.12.2", "escape-string-regexp": "^5.0.0", "wildcard-match": "^5.1.3" }, "peerDependencies": { "@orpc/contract": "1.12.2", "@orpc/server": "1.12.2", "zod": ">=3.25.0" } }, "sha512-U2XQyxsONPeSPY0rJ3JHXZhicS5KD5zJADj6p9h98TywO7qH/8a/u8tc8oB3f0qUiILY7crdGQBVw34MkuT44A=="],
+    "@orpc/zod": ["@orpc/zod@1.14.11", "", { "dependencies": { "@orpc/json-schema": "1.14.11", "json-schema-typed": "^8.0.2" }, "peerDependencies": { "zod": ">=4.3.5" } }, "sha512-ZhULfbgJhPXci/hWk6hvQkwPEs2zH5A/hFk+TGWgl7YRqfViVWi7c+QqpCh5VXRGOInG8bKJSeGFg9xP0RGipg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1169,6 +1174,16 @@
     "@smithy/uuid": ["@smithy/uuid@1.1.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standardserver/core": ["@standardserver/core@0.5.0", "", { "dependencies": { "@standardserver/shared": "0.5.0" } }, "sha512-c6vIXiJtQNVHm0G8vJCCdZ7G4ObgWj71n89HvKvVR5RnajxEEb+wVcIn10rvrMJmd9sR9RtHR6HCubeCFY214A=="],
+
+    "@standardserver/fetch": ["@standardserver/fetch@0.5.0", "", { "dependencies": { "@standardserver/core": "0.5.0", "@standardserver/shared": "0.5.0" } }, "sha512-0Sosn0v2Cl2Vhcc1st2FKGxwdK0qPq84K40TtZFAePLGq+Zu6hJZ4VsrwOWfm3S7iZ0EeRo9OByp0oUhm8NiPw=="],
+
+    "@standardserver/node": ["@standardserver/node@0.5.0", "", { "dependencies": { "@standardserver/core": "0.5.0", "@standardserver/fetch": "0.5.0", "@standardserver/shared": "0.5.0" } }, "sha512-4OYFeVyVUZzWOjw9g2qf1lpWTNtjOYTr68w0zOy+AXEq3BiXoQweepoP7WgdYVJ4kmpmOwk1LOrJRqeqPrpTcQ=="],
+
+    "@standardserver/peer": ["@standardserver/peer@0.5.0", "", { "dependencies": { "@standardserver/core": "0.5.0", "@standardserver/shared": "0.5.0" } }, "sha512-gsOgvknhj8XirAqJksDZlrzkppGU2WH4PyxzISwfG8Ug3TJyOYwWvNCY81HNe5PJWjDdelIkgHSyjb2apkN2CA=="],
+
+    "@standardserver/shared": ["@standardserver/shared@0.5.0", "", {}, "sha512-YPkkdqyKQ+6tvtP2pPLzIIrvhjrsvnI006tTTSWqFc2US6X8r1zfYVhfHf9Zpn4HsdhyhwpWwF4fIsN+nlr1Ow=="],
 
     "@storybook/addon-docs": ["@storybook/addon-docs@10.3.3", "", { "dependencies": { "@mdx-js/react": "^3.0.0", "@storybook/csf-plugin": "10.3.3", "@storybook/icons": "^2.0.1", "@storybook/react-dom-shim": "10.3.3", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.3" } }, "sha512-trJQTpOtuOEuNv1Rn8X2Sopp5hSPpb0u0soEJ71BZAbxe4d2Y1d/1MYcxBdRKwncum6sCTsnxTpqQ/qvSJKlTQ=="],
 
@@ -1852,7 +1867,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -2066,6 +2081,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
+
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
     "electron": ["electron@40.9.3", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-rDcJOT6BBE689Ada+4jD3rVr05pMv9MZOgT0x/rIMVDF9c4ttx4RTb6lVARTyxZC7uqpirttCtcli1eg1DX5qg=="],
@@ -2197,6 +2214,8 @@
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -2918,6 +2937,10 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
 
     "nan": ["nan@2.24.0", "", {}, "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg=="],
@@ -2943,6 +2966,8 @@
     "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
 
     "node-gyp": ["node-gyp@12.3.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
@@ -2995,8 +3020,6 @@
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "openai": ["openai@6.18.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-odLRYyz9rlzz6g8gKn61RM2oP5UUm428sE2zOxZqS9MzVfD5/XW8UoEjpnRkzTuScXP7ZbP/m7fC+bl8jCOZZw=="],
-
-    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -3292,7 +3315,7 @@
 
     "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
 
-    "rou3": ["rou3@0.7.10", "", {}, "sha512-aoFj6f7MJZ5muJ+Of79nrhs9N3oLGqi2VEMe94Zbkjb6Wupha46EuoYgpWSOZlXww3bbd8ojgXTAA2mzimX5Ww=="],
+    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
@@ -3686,8 +3709,6 @@
 
     "which-typed-array": ["which-typed-array@1.1.19", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw=="],
 
-    "wildcard-match": ["wildcard-match@5.1.4", "", {}, "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="],
-
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
@@ -3858,11 +3879,7 @@
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "@orpc/contract/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
-
-    "@orpc/shared/type-fest": ["type-fest@5.3.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-d9CwU93nN0IA1QL+GSNDdwLAu1Ew5ZjTwupvedwg3WdfoH6pIDvYQ2hV0Uc2nKBLPq7NB5apCx57MLS5qlmO5g=="],
-
-    "@orpc/zod/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+    "@orpc/shared/type-fest": ["type-fest@5.9.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-yANm3Jr3GiJ1qgJlxGAVxTOIcEOk1rhQHamlXtnrCK7EHP4HeM9OGxtMg/W7HFdrVzw/ZWJKGVIJusVH85sLtw=="],
 
     "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
@@ -4074,6 +4091,8 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "fast-check/pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
@@ -4247,6 +4266,8 @@
     "raw-body/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 
     "react-docgen/doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "read-config-file/dotenv": ["dotenv@9.0.2", "", {}, "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             outputHashMode = "recursive";
             # Marker used by scripts/update_flake_hash.sh to update this hash in place.
-            outputHash = "sha256-qZmS1EPW+0IU6S8cQGuj+wjHTgBRB0HhLkM0cJDgoc8="; # xum-offline-cache-hash
+            outputHash = "sha256-sO6bGZQoHXmiS/lMgKy/p0/nTa8WByUFIUAz8V6WiBU="; # xum-offline-cache-hash
           };
 
           configurePhase = ''

--- a/package.json
+++ b/package.json
@@ -70,10 +70,11 @@
     "@mozilla/readability": "^0.6.0",
     "@novnc/novnc": "^1.6.0",
     "@openrouter/ai-sdk-provider": "^3.0.0",
-    "@orpc/client": "^1.11.3",
-    "@orpc/openapi": "^1.12.2",
-    "@orpc/server": "^1.11.3",
-    "@orpc/zod": "^1.11.3",
+    "@orpc/client": "1.14.11",
+    "@orpc/experimental-effect": "1.14.11",
+    "@orpc/openapi": "1.14.11",
+    "@orpc/server": "1.14.11",
+    "@orpc/zod": "1.14.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -102,6 +103,7 @@
     "crc-32": "^1.2.2",
     "diff": "^8.0.2",
     "disposablestack": "^1.1.7",
+    "effect": "4.0.0-rc.112",
     "electron-updater": "^6.6.2",
     "electron-window-state": "^5.0.3",
     "express": "^5.1.0",
@@ -338,6 +340,7 @@
     "unrs-resolver"
   ],
   "patchedDependencies": {
-    "@ai-sdk/xai@4.0.37": "patches/@ai-sdk%2Fxai@4.0.37.patch"
+    "@ai-sdk/xai@4.0.37": "patches/@ai-sdk%2Fxai@4.0.37.patch",
+    "trpc-cli@0.12.1": "patches/trpc-cli@0.12.1.patch"
   }
 }

--- a/patches/trpc-cli@0.12.1.patch
+++ b/patches/trpc-cli@0.12.1.patch
@@ -1,0 +1,50 @@
+diff --git a/dist/index.js b/dist/index.js
+index 476387edaa6d28a0d1bc6ce519fad894b0bbf154..3762c504650a52e2bd2e30580db145ddf668e1c7 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -64,7 +64,21 @@ const parseTrpcRouter = ({ router, ...params }) => {
+ // eslint-disable-next-line @typescript-eslint/no-explicit-any
+ const parseOrpcRouter = (params) => {
+     const entries = [];
+-    const { traverseContractProcedures, isProcedure } = getOrpcServerModule();
++    // xum patch: oRPC >=1.14 removed `traverseContractProcedures` and `isProcedure`
++    // from @orpc/server. Duck-type procedures by their '~orpc' definition and walk
++    // the router locally. Lazy routers are not used by xum, so lazyRoutes stays [].
++    const isProcedure = (value) => Boolean(value) && typeof value === 'object' && typeof value['~orpc'] === 'object' && typeof value['~orpc'].handler === 'function';
++    const traverseContractProcedures = ({ path, router }, visit) => {
++        for (const [key, value] of Object.entries(router)) {
++            if (!value || typeof value !== 'object')
++                continue;
++            if (isProcedure(value))
++                visit({ contract: value, path: [...path, key] });
++            else
++                traverseContractProcedures({ path: [...path, key], router: value }, visit);
++        }
++        return [];
++    };
+     const router = params.router;
+     const lazyRoutes = traverseContractProcedures({ path: [], router }, ({ contract, path }) => {
+         let procedure = params.router;
+@@ -72,7 +86,7 @@ const parseOrpcRouter = (params) => {
+             procedure = procedure[p];
+         if (!isProcedure(procedure))
+             return; // if it's contract-only, we can't run it via CLI (user may have passed an implemented contract router? should we tell them? it's undefined behaviour so kinda on them)
+-        const procedureInputsResult = parseProcedureInputs([contract['~orpc'].inputSchema], {
++        const procedureInputsResult = parseProcedureInputs([contract['~orpc'].inputSchema ?? contract['~orpc'].inputSchemas?.[0]], {
+             '@valibot/to-json-schema': params['@valibot/to-json-schema'],
+             effect: params.effect,
+         });
+diff --git a/dist/trpc-compat.d.ts b/dist/trpc-compat.d.ts
+index 9278e603fc3c71c4a2ffc6751c5423bfd57000da..8d264e2bf4f928a78a98b915a0b7eea29ee56a0a 100644
+--- a/dist/trpc-compat.d.ts
++++ b/dist/trpc-compat.d.ts
+@@ -57,6 +57,9 @@ export type OrpcProcedureLike<Ctx> = {
+     '~orpc': {
+         __initialContext?: (context: Ctx) => unknown;
+         inputSchema?: StandardSchemaV1;
++        /** xum patch: oRPC >=1.14 renamed the context brand and pluralized schemas. */
++        __TInitialContext?: (type: Ctx) => unknown;
++        inputSchemas?: StandardSchemaV1<any, any>[];
+     };
+ };
+ export type OrpcRouterLike<Ctx> = {

--- a/rfc/20260831_effect-orpc-spike.md
+++ b/rfc/20260831_effect-orpc-spike.md
@@ -1,0 +1,203 @@
+---
+author: @mux
+date: 2026-08-31
+---
+
+# Spike Findings: Progressive Effect Migration via oRPC Integration
+
+Status: Spike report (branch `effect-orpc-spike`, not intended to merge as-is)
+
+## Objective
+
+Evaluate a progressive migration of xum's backend to [Effect](https://effect.website/),
+anchored on the existing oRPC layer:
+
+1. Wire `@orpc/experimental-effect` into the oRPC context/router.
+2. Convert a representative leaf, I/O-heavy service and its procedures to `Effect.gen`.
+3. Validate `Schema.TaggedError` → typed oRPC error propagation without untyped catch blocks.
+4. Evaluate resource scoping (`Scope`/finalizers) and cancellation for long-lived operations.
+5. Recommend an incremental adoption architecture.
+
+Everything below was validated by code in this branch (`src/node/orpc/effectSpike.ts`,
+`src/node/orpc/effectSpike.test.ts`, converted `MemoryMetaService`/`setMemoryPinned`),
+with all affected suites green: 128 tests across oRPC/memory/CLI files plus 7 new spike tests.
+
+## TL;DR
+
+- **The integration works and is remarkably small.** `@orpc/experimental-effect` is a
+  ~40-line runtime bridge: handlers become generators that `yield*` Effects, services are
+  injected via a pre-built `Context` on the oRPC context, `AbortSignal` maps to fiber
+  interruption, and `ORPCError` instances in the failure channel become _typed, defined_
+  oRPC errors. Typed error propagation, scoped finalizers under client aborts, and Effect
+  Schema inputs all behave exactly as advertised.
+- **The version prerequisites are the real cost.** The official package requires
+  **Effect v4 (currently RC)** and pins **oRPC 1.14.x** exactly. Migrating xum from oRPC
+  1.12→1.14 was bounded (~12 files, this branch did it) but breaks `trpc-cli`'s oRPC
+  support (fixed here with a bun patch). Effect v4 RC is pre-stable.
+- **Overhead is negligible for xum's workloads:** ~3–4µs per call added by the Effect
+  runtime on a no-op procedure (in-process router client, Bun; 8.8µs/call async vs
+  12.2µs/call Effect). Any real I/O dwarfs this.
+- **Recommendation: adopt in narrow slices, gated on Effect v4 stable.** The
+  service-internal conversion pattern (Effect core + thin Promise facade) is immediately
+  usable and low-risk; the oRPC bridge layer is a one-file change once versions align. If
+  we want to start before v4 stabilizes, a hand-rolled `handlerGen` (the bridge is ~40
+  lines, MIT) against stable Effect 3.x is a viable interim path.
+
+## What was built
+
+### 1. Bridge wiring (objective 1)
+
+- `ORPCContext` now `extends WithEffectContext<OrpcEffectServices>`: one well-known key,
+  `"effect/context"`, carrying a pre-built `Context.Context` of Effect services
+  (`src/node/orpc/effectContext.ts`, built in `ServiceContainer.toORPCContext()`).
+- Handlers use `handlerGen` directly (`.handler(handlerGen(function* ({ context, errors, signal }, input) { ... }))`).
+  The `.effect()` builder sugar exists but requires a side-effect import that patches
+  `Builder.prototype` globally; `handlerGen` has zero global footprint and was preferred.
+- The optional `"effect/wrap"` hook wraps every Effect handler per request with
+  `{ path, procedure, signal }` — the natural future seam for tracing/metrics
+  (`@effect/opentelemetry`) without touching individual handlers.
+
+### 2. Leaf service conversion (objective 2)
+
+`MemoryMetaService` (host-local JSON sidecar; pure disk I/O, one write lock) was converted:
+
+- Internals are `Effect.gen`; the promise `MutexMap` became an Effect `Semaphore`, so lock
+  acquisition participates in interruption (a fiber cancelled while waiting never runs its
+  critical section — a real correctness upgrade over the promise mutex).
+- The public API is preserved by a **thin Promise facade** (`Effect.runPromise` per method)
+  plus a new Effect-native `effects` surface for migrated callers. All 12 pre-existing
+  service tests pass unchanged — the facade pattern demonstrably de-risks conversion.
+- One real procedure chain was converted end-to-end: `memory.setPinned` →
+  `setMemoryPinnedEffect` (Effect.gen with `Effect.result`/`Effect.try` replacing try/catch)
+  → `handlerGen` in the router. The zod wire contract is untouched.
+
+### 3. Typed errors (objective 3)
+
+`MemoryMetaWriteError` is a `Schema.TaggedError` — simultaneously an `Error` subclass, a
+schema, a tagged-union member, and yieldable. The spike procedure declares
+`.errors({ MEMORY_META_WRITE_FAILED: { data: z.object({ metaPath, reason }) } })` and maps:
+
+```ts
+yield *
+  memoryMeta.effects
+    .setPinned(key, pinned)
+    .pipe(
+      Effect.catchTag("MemoryMetaWriteError", (e) =>
+        Effect.fail(
+          errors.MEMORY_META_WRITE_FAILED({ data: { metaPath: e.metaPath, reason: e.reason } })
+        )
+      )
+    );
+```
+
+Validated: the client receives `ORPCError` with `code: "MEMORY_META_WRITE_FAILED"`,
+`defined: true`, and schema-validated `data`. No untyped catch anywhere on the path — the
+failure is typed from `writeFileAtomic` all the way to the wire.
+
+**Caveat found:** the bridge's types do _not_ force exhaustive error handling. Yielded
+effects may carry any `E`; only `ORPCError` members become typed returns, and everything
+else silently remains a runtime throw (squashed cause), exactly like today's untyped
+rejections. Exhaustiveness is opt-in: teams must adopt a convention (or a lint) that
+handler-yielded effects satisfy `E extends AnyORPCError | never`. Worth building a tiny
+`yieldStrict` helper or ESLint rule during real adoption.
+
+### 4. Scoping + cancellation (objective 4)
+
+`effectSpike.scopedHold` acquires a resource with `Effect.acquireRelease` inside
+`Effect.scoped` and sleeps. Validated by test:
+
+- Client `AbortController.abort()` interrupts the fiber **promptly** (60s hold aborted in
+  <5s wall including test overhead; actual interruption is immediate).
+- The release finalizer runs **exactly once**, both on abort and on normal completion.
+- The bridge maps interruption back to the abort reason (`options.signal.reason`), so oRPC
+  reports the abort exactly like an async handler would.
+
+This is the headline win for xum: today's long-lived operations thread `AbortSignal`
+manually through every layer (e.g. `cloneWithProgress(input, signal)`) and clean up in
+ad-hoc try/finally. Structured concurrency makes "cancellation propagates + resources
+release" the default instead of a per-call discipline. Prime future candidates:
+`routerSubscriptions.ts` teardown, process spawns, MCP server lifecycles, stream managers.
+
+### 5. Performance & ergonomics (objective 5)
+
+- Micro-benchmark (in-process router client, 2k sequential calls each, warmed):
+  no-op async handler ≈ **8.8µs/call**; identical `handlerGen` handler ≈ **12.2µs/call**;
+  Effect runtime overhead ≈ **3.4µs/call**. Noise-level for anything touching disk,
+  network, or an LLM.
+- Ergonomics that worked well: `yield*` reads like `await`; service tags double as
+  Effects (`const svc = yield* MemoryMeta`); `catchTag` gives compiler-checked error
+  narrowing; existing zod schemas coexist with Effect Schema inputs per-procedure
+  (`toStandardSchema`), so there is no forced schema migration.
+- Frictions: `this` is not available inside `Effect.gen` generators (self-alias needed,
+  plus an eslint-disable for `no-this-alias`); sync throws inside generators become
+  defects rather than typed failures (fine for `ORPCError` gates like
+  `assertMemoryEnabled`, but a subtle trap); `require-yield` lint fires on yield-free
+  generator handlers; Effect v4 renames significant v3 API (`Effect.catch`,
+  `Context.Service`, `Semaphore.make*`, `Effect.result`/`Result`), so most public
+  Effect v3 documentation and LLM training data does not directly apply.
+
+## Version compatibility findings (the hard constraints)
+
+| Constraint                       | Detail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@orpc/experimental-effect` peer | `effect >= 4.0.0-beta.90` — **Effect v4 only** (v4 is at RC today; v3 stable is not supported)                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `@orpc/experimental-effect` deps | Exact-pinned `@orpc/{server,shared,contract,json-schema}@1.14.11` — repo must move to oRPC 1.14 in lockstep or ship duplicate oRPC copies (breaks `instanceof ORPCError` and prototype patches; bun kept stale nested copies until a forced reinstall)                                                                                                                                                                                                                                                   |
+| oRPC 1.12→1.14 breaks            | `@orpc/server/ws`→`/websocket`; `@orpc/zod/zod4`→`@orpc/zod`; client links split `url` into `origin` + path-only `url`; websocket links take `connect: () => ws`; `OpenAPIGenerator` options (`converters`, `base`); `ValidationError.data`→`invalidData`; `ORPCError.status` removed; `isProcedure`/`traverseContractProcedures` removed (use `instanceof Procedure`); procedure defs store `inputSchemas[]` + `orderedMiddlewares`; `.use()` no longer accepts unions of differently-typed middlewares |
+| Ecosystem fallout                | **No released `trpc-cli` (≤0.16.0) supports oRPC 1.14** — `xum api` would crash at startup. This branch carries a bun patch (`patches/trpc-cli@0.12.1.patch`: local router traversal + duck-typed `isProcedure` + def-shape shims). Upstreaming or replacing trpc-cli is a prerequisite for a real upgrade.                                                                                                                                                                                              |
+| Package maturity                 | The `experimental-` prefix is explicit; v1 line exists (1.14.11) plus 2.0.0 betas tracking oRPC v2. API surface is tiny, so forking/vendoring is a realistic escape hatch.                                                                                                                                                                                                                                                                                                                               |
+
+## Recommended incremental adoption architecture
+
+Phased, each phase independently shippable and reversible:
+
+**Phase 0 — prerequisites (before any Effect code ships):**
+oRPC 1.14 upgrade as its own PR (this branch's first commit is that migration, validated);
+resolve trpc-cli (upstream a 1.14-compat PR, keep the bun patch, or replace with a thin
+custom CLI walker — we already own `proxifyOrpc`). Hold production Effect adoption until
+Effect v4 stable unless we vendor a v3-compatible `handlerGen` (~40 lines).
+
+**Phase 1 — services adopt Effect internally (no oRPC coupling, can start anytime):**
+convert leaf, I/O-heavy services with the pattern proven here — Effect-native `effects`
+surface + Promise facade, existing tests untouched. Best next candidates:
+`HistoryService` (locks + atomic writes + self-healing reads), config stores,
+`workspaceFileLocks` users. Each conversion upgrades error typing and interruption safety
+without any caller changes.
+
+**Phase 2 — bridge layer on (one-file switch):**
+`ORPCContext extends WithEffectContext<...>` + `ServiceContainer` builds the service
+`Context` (done in this branch). New/converted procedures use `handlerGen`; the rest stay
+async. Both styles coexist indefinitely — this is the core progressive-migration property.
+
+**Phase 3 — typed errors at the wire:**
+migrate high-value procedures from `ResultSchema({success:false,error:string})` toward
+`.errors()` maps fed by `Schema.TaggedError` (`isDefinedError` gives clients typed
+narrowing). Do this per-procedure; frontend consumes `error.defined`/`error.data`.
+Adopt an exhaustiveness convention/lint for handler `E` channels (see caveat above).
+
+**Phase 4 — structured concurrency for long-lived ops:**
+move subscriptions (`routerSubscriptions.ts`), process spawns, and stream lifecycles onto
+`Scope`/`acquireRelease`, replacing manual `AbortSignal` threading. Add an
+`"effect/wrap"` hook for tracing/metrics across all Effect handlers.
+
+**Non-goals for now:** full `Layer`-based dependency graph (ServiceContainer already does
+this job; revisit only if service construction becomes Effect-native), Effect on the
+renderer/browser side, and Effect Schema replacing zod wholesale (coexistence works).
+
+## Key risks
+
+1. **Effect v4 RC churn** — APIs may still shift before stable; don't merge v4 to main yet.
+2. **Two mental models during migration** — mitigated by the facade pattern (callers never
+   see Effect until their own conversion) and by keeping `handlerGen` opt-in per procedure.
+3. **Untyped-failure escape hatch** — the bridge tolerates non-ORPCError failures silently
+   (runtime throw); needs a lint/convention to realize the "no untyped errors" promise.
+4. **Ecosystem lag on oRPC 1.14** (trpc-cli today; audit other oRPC-adjacent deps before
+   upgrading main).
+
+## Validation record
+
+- `make typecheck` green (both tsconfigs).
+- `bun test src/node/orpc/ src/node/services/memoryMeta.test.ts src/node/services/memoryOperations.test.ts src/cli/cli.test.ts src/cli/server.test.ts` → 125 pass / 3 skip / 0 fail.
+- `bun test src/node/orpc/effectSpike.test.ts` → 7/7: service injection, Effect Schema
+  validation, typed error round-trip (success + failure with `defined:true` + data),
+  abort-interruption with exactly-once finalizers, normal-completion finalizers, benchmark.
+- ESLint clean on all touched files.

--- a/rfc/20260831_effect-orpc-spike.md
+++ b/rfc/20260831_effect-orpc-spike.md
@@ -19,7 +19,9 @@ anchored on the existing oRPC layer:
 5. Recommend an incremental adoption architecture.
 
 Everything below was validated by code in this branch (`src/node/orpc/effectSpike.ts`,
-`src/node/orpc/effectSpike.test.ts`, converted `MemoryMetaService`/`setMemoryPinned`),
+`src/node/orpc/effectSpike.test.ts`, converted `MemoryMetaService`/`setMemoryPinned`).
+The `effectSpike.*` validation namespace is mounted only by its tests — it is
+deliberately not part of the production router (codex review),
 with all affected suites green: 128 tests across oRPC/memory/CLI files plus 7 new spike tests.
 
 ## TL;DR
@@ -197,7 +199,8 @@ renderer/browser side, and Effect Schema replacing zod wholesale (coexistence wo
 
 - `make typecheck` green (both tsconfigs).
 - `bun test src/node/orpc/ src/node/services/memoryMeta.test.ts src/node/services/memoryOperations.test.ts src/cli/cli.test.ts src/cli/server.test.ts` → 125 pass / 3 skip / 0 fail.
-- `bun test src/node/orpc/effectSpike.test.ts` → 7/7: service injection, Effect Schema
+- `bun test src/node/orpc/effectSpike.test.ts` → 9/9: service injection, Effect Schema
   validation, typed error round-trip (success + failure with `defined:true` + data),
-  abort-interruption with exactly-once finalizers, normal-completion finalizers, benchmark.
+  abort-interruption with exactly-once finalizers, normal-completion finalizers,
+  auth-middleware-over-handlerGen composition, OpenAPI converter regression, benchmark.
 - ESLint clean on all touched files.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -240,15 +240,17 @@ const { RPCLink } = require('@orpc/client/fetch');
 const { createORPCClient } = require('@orpc/client');
 const WebSocket = require('ws');
 
-const ORPC_URL = 'http://${SERVER_HOST}:${SERVER_PORT}/orpc';
+const ORPC_ORIGIN = 'http://${SERVER_HOST}:${SERVER_PORT}';
 const WS_URL = 'ws://${SERVER_HOST}:${SERVER_PORT}/orpc/ws';
 const PROJECT_DIR = '$PROJECT_DIR';
 
 async function runTests() {
   // Test 1: HTTP oRPC client - create project
   console.log('Testing oRPC project creation via HTTP...');
+  // oRPC >=1.14 splits the request URL into origin + path-only url.
   const httpLink = new RPCLink({
-    url: ORPC_URL,
+    origin: ORPC_ORIGIN,
+    url: '/orpc',
     headers: { 'Authorization': 'Bearer ${AUTH_TOKEN}' }
   });
   const client = createORPCClient(httpLink);

--- a/src/browser/contexts/API.tsx
+++ b/src/browser/contexts/API.tsx
@@ -172,7 +172,8 @@ function createBrowserClient(
   }
 
   const ws = createWebSocket(wsUrl.toString());
-  const link = new WebSocketLink({ websocket: ws });
+  // oRPC >=1.14 replaced the `websocket` option with a `connect` factory.
+  const link = new WebSocketLink({ connect: () => ws });
 
   return {
     client: createClient(link),

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -168,7 +168,8 @@ function renderAnalyticsHook<TResult>(callback: () => TResult) {
 
 function createHttpClient(baseUrl: string): RouterClient<AppRouter> {
   const link = new HTTPRPCLink({
-    url: `${baseUrl}/orpc`,
+    origin: baseUrl,
+    url: "/orpc",
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- typed test helper

--- a/src/browser/hooks/useAnalytics.test.tsx
+++ b/src/browser/hooks/useAnalytics.test.tsx
@@ -656,7 +656,11 @@ describe("useAnalytics hooks", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.error).toBe("Internal server error");
+    // The behavioral contract is "generic error, no infrastructure detail leak".
+    // Match case-insensitively: oRPC changed its default INTERNAL_SERVER_ERROR
+    // message casing in 1.14 ("Internal server error" -> "Internal Server Error").
+    expect(result.current.error ?? "").toMatch(/^internal server error$/i);
+    expect(result.current.error).not.toContain("Analytics worker");
     expect(result.current.data).toBeNull();
   });
 });

--- a/src/cli/proxifyOrpc.ts
+++ b/src/cli/proxifyOrpc.ts
@@ -10,7 +10,7 @@
 
 import { RPCLink as HTTPRPCLink } from "@orpc/client/fetch";
 import { createORPCClient } from "@orpc/client";
-import { isProcedure } from "@orpc/server";
+import { Procedure } from "@orpc/server";
 import { z } from "zod";
 import type { AppRouter } from "@/node/orpc/router";
 import type { RouterClient } from "@orpc/server";
@@ -26,9 +26,15 @@ export interface ProxifyOrpcOptions {
 }
 
 interface OrpcDef {
+  /** Legacy (<1.14) singular schema field; still read by trpc-cli. */
   inputSchema?: unknown;
   outputSchema?: unknown;
+  /** oRPC >=1.14 stores merged schema chains as arrays. */
+  inputSchemas?: unknown[];
+  outputSchemas?: unknown[];
   middlewares?: unknown[];
+  /** oRPC >=1.14 replaced `middlewares` + validation indexes with this. */
+  orderedMiddlewares?: unknown[];
   inputValidationIndex?: number;
   outputValidationIndex?: number;
   errorMap?: unknown;
@@ -567,8 +573,10 @@ type ClientFactory = () => RouterClient<AppRouter>;
 export function proxifyOrpc(router: AppRouter, options: ProxifyOrpcOptions): AppRouter {
   // Client factory - creates a new client on each procedure invocation
   const createClient: ClientFactory = () => {
+    // oRPC >=1.14 splits the request URL into `origin` (base) + `url` (path).
     const link = new HTTPRPCLink({
-      url: `${options.baseUrl}/orpc`,
+      origin: options.baseUrl,
+      url: "/orpc",
       headers: options.authToken ? { Authorization: `Bearer ${options.authToken}` } : undefined,
     });
     return createORPCClient(link);
@@ -593,7 +601,8 @@ function createRouterProxy(
   for (const [key, value] of Object.entries(router)) {
     const newPath = [...path, key];
 
-    if (isProcedure(value)) {
+    // oRPC >=1.14 removed `isProcedure`; `Procedure` implements `Symbol.hasInstance`.
+    if (value instanceof Procedure) {
       result[key] = createProcedureProxy(
         // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
         value as unknown as OrpcProcedureLike,
@@ -614,7 +623,9 @@ function createProcedureProxy(
   path: string[]
 ): OrpcProcedureLike {
   const originalDef = procedure["~orpc"];
-  const originalInputSchema = originalDef.inputSchema;
+  // oRPC >=1.14 stores `.input()` schemas as an array; xum procedures declare at
+  // most one input schema, so the head is the whole story.
+  const originalInputSchema = originalDef.inputSchema ?? originalDef.inputSchemas?.[0];
 
   // Check if the original schema was void/undefined - trpc-cli sends {} but server expects undefined
   const isVoidInput = isVoidOrUndefinedSchema(originalInputSchema);
@@ -641,11 +652,14 @@ function createProcedureProxy(
   const proxy: OrpcProcedureLike = {
     "~orpc": {
       ...originalDef,
-      // Use enhanced schema for CLI help generation
+      // Use enhanced schema for CLI help generation. Both spellings are set:
+      // trpc-cli reads the legacy singular field, oRPC >=1.14 `call()` reads the array.
       inputSchema: enhancedInputSchema,
+      inputSchemas: enhancedInputSchema === undefined ? undefined : [enhancedInputSchema],
       // Keep the original middlewares empty for the proxy - we don't need them
       // since the server will run its own middleware chain
       middlewares: [],
+      orderedMiddlewares: [],
       // The handler that will be called by @orpc/server's `call()` function
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       handler: async (opts: { input: unknown }): Promise<any> => {

--- a/src/cli/server.test.ts
+++ b/src/cli/server.test.ts
@@ -85,7 +85,8 @@ async function createTestServer(): Promise<TestServerHandle> {
 
 function createHttpClient(baseUrl: string): RouterClient<AppRouter> {
   const link = new HTTPRPCLink({
-    url: `${baseUrl}/orpc`,
+    origin: baseUrl,
+    url: "/orpc",
   });
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for tsgo typecheck
   return createORPCClient(link) as RouterClient<AppRouter>;
@@ -107,7 +108,8 @@ async function createWebSocketClient(wsUrl: string): Promise<WebSocketClientHand
     ws.on("error", reject);
   });
 
-  const link = new WebSocketRPCLink({ websocket: ws as unknown as globalThis.WebSocket });
+  // oRPC >=1.14 replaced the `websocket` option with a `connect` factory.
+  const link = new WebSocketRPCLink({ connect: () => ws as unknown as globalThis.WebSocket });
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for tsgo typecheck
   const client = createORPCClient(link) as RouterClient<AppRouter>;
 

--- a/src/node/acp/serverConnection.ts
+++ b/src/node/acp/serverConnection.ts
@@ -229,9 +229,10 @@ async function connectViaWebSocket(
   await waitForWebSocketOpen(websocket, wsUrl);
 
   // oRPC expects a browser-like WebSocket surface; ws is compatible at runtime.
+  // oRPC >=1.14 replaced the `websocket` option with a `connect` factory.
   const link = new WebSocketRPCLink({
     // eslint-disable-next-line local/no-chained-type-assertions -- grandfathered when the rule was introduced; fix the underlying type instead of copying this pattern
-    websocket: websocket as unknown as globalThis.WebSocket,
+    connect: () => websocket as unknown as globalThis.WebSocket,
   });
   const client = createTypedClient(link);
 

--- a/src/node/orpc/authMiddleware.ts
+++ b/src/node/orpc/authMiddleware.ts
@@ -112,11 +112,10 @@ export function extractCookieValues(
 
 /** Create auth middleware that validates Authorization header or session cookie from context */
 export function createAuthMiddleware(authToken?: string) {
-  if (!authToken?.trim()) {
-    return os.middleware(({ next }) => next());
-  }
-
-  const expectedToken = authToken.trim();
+  // oRPC >=1.14 no longer accepts a union of differently-typed middlewares in
+  // `.use()`, so the "no token configured" case is folded into a single
+  // middleware instead of returning a separately-typed pass-through.
+  const expectedToken = authToken?.trim();
 
   return os
     .$context<ORPCContext>()
@@ -126,6 +125,10 @@ export function createAuthMiddleware(authToken?: string) {
       },
     })
     .middleware(async ({ context, errors, next }) => {
+      if (!expectedToken) {
+        return next();
+      }
+
       const presentedToken = extractBearerToken(context.headers?.authorization);
 
       if (presentedToken && safeEq(presentedToken, expectedToken)) {

--- a/src/node/orpc/context.ts
+++ b/src/node/orpc/context.ts
@@ -59,8 +59,15 @@ import type { AnalyticsService } from "@/node/services/analytics/analyticsServic
 import type { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer";
 import type { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
 import type { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
+import type { WithEffectContext } from "@orpc/experimental-effect";
+import type { OrpcEffectServices } from "@/node/orpc/effectContext";
 
-export interface ORPCContext {
+/**
+ * Effect-migration spike: `WithEffectContext` adds the `"effect/context"` key
+ * carrying the Effect services available to Effect-native handlers (built via
+ * `buildOrpcEffectContext` in the service container).
+ */
+export interface ORPCContext extends WithEffectContext<OrpcEffectServices> {
   config: Config;
   sessionLocator: WorkspaceSessionLocator;
   providersConfigStore: ProvidersConfigStore;

--- a/src/node/orpc/effectContext.ts
+++ b/src/node/orpc/effectContext.ts
@@ -1,0 +1,32 @@
+/**
+ * Effect-migration spike: bridges xum services into the Effect runtime for
+ * oRPC handlers written with `@orpc/experimental-effect`.
+ *
+ * `ORPCContext` carries a pre-built `Context.Context` under the well-known
+ * `"effect/context"` key (see `WithEffectContext`). `handlerGen` provides it to
+ * every effect a handler yields, so Effect-native handlers resolve services by
+ * yielding tags instead of reaching through the oRPC context object. During
+ * the incremental migration both styles coexist:
+ *
+ * - Effect-native handlers: `const meta = yield* MemoryMeta;`
+ * - Transitional handlers: `context.memoryMetaService.effects.…` (same
+ *   instances, no Effect context required).
+ *
+ * Grow `OrpcEffectServices` as more services gain Effect surfaces.
+ */
+import { Context } from "effect";
+import type { MemoryMetaService } from "@/node/services/memoryMeta";
+
+/** Effect service tag for the memory metadata sidecar service. */
+export class MemoryMeta extends Context.Service<MemoryMeta, MemoryMetaService>()(
+  "xum/MemoryMeta"
+) {}
+
+/** Union of all services available to Effect-native oRPC handlers. */
+export type OrpcEffectServices = MemoryMeta;
+
+export function buildOrpcEffectContext(services: {
+  memoryMetaService: MemoryMetaService;
+}): Context.Context<OrpcEffectServices> {
+  return Context.make(MemoryMeta, services.memoryMetaService);
+}

--- a/src/node/orpc/effectSpike.test.ts
+++ b/src/node/orpc/effectSpike.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Validates the Effect ↔ oRPC bridge end-to-end (see effectSpike.ts):
+ * service injection through "effect/context", Effect Schema input validation,
+ * Schema.TaggedError → defined oRPC error propagation, abort-driven fiber
+ * interruption with scope finalizers, and router-level auth middleware
+ * compatibility with Effect handlers.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ORPCError, createRouterClient } from "@orpc/server";
+import { effectSpike, scopeProbe } from "./effectSpike";
+import { buildOrpcEffectContext } from "./effectContext";
+import { MemoryMetaService } from "@/node/services/memoryMeta";
+import type { ORPCContext } from "./context";
+
+let tmpDir: string;
+let memoryMetaService: MemoryMetaService;
+let client: ReturnType<typeof createClient>;
+
+function makeContext(service: MemoryMetaService): ORPCContext {
+  // Spike procedures only consume Effect services; the remaining ~60 context
+  // fields are irrelevant here (same partial-context pattern as router.test.ts).
+  return {
+    "effect/context": buildOrpcEffectContext({ memoryMetaService: service }),
+  } as unknown as ORPCContext;
+}
+
+function createClient(service: MemoryMetaService) {
+  return createRouterClient(effectSpike, { context: makeContext(service) });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "effect-spike-"));
+  memoryMetaService = new MemoryMetaService(tmpDir);
+  client = createClient(memoryMetaService);
+  scopeProbe.reset();
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("effect/context service injection", () => {
+  test("handler resolves MemoryMeta service and reads real disk state", async () => {
+    await memoryMetaService.setPinned("global:prefs.md", true);
+    await memoryMetaService.setPinned("workspace:ws1:notes.md", true);
+
+    const result = await client.pinnedCount({ prefix: "global:" });
+    expect(result).toEqual({ count: 1 });
+  });
+
+  test("Effect Schema input schema validates like any standard schema", async () => {
+    try {
+      await client.pinnedCount({ prefix: 42 as unknown as string });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ORPCError);
+      expect((error as ORPCError<string, unknown>).code).toBe("BAD_REQUEST");
+    }
+  });
+});
+
+describe("Schema.TaggedError → defined oRPC error", () => {
+  test("success path round-trips", async () => {
+    const result = await client.setPinned({ logicalKey: "global:a.md", pinned: true });
+    expect(result).toEqual({ ok: true });
+    expect(await memoryMetaService.getPinnedKeys()).toEqual(new Set(["global:a.md"]));
+  });
+
+  test("write failure surfaces as typed error with schema-validated data", async () => {
+    // Make the sidecar unwritable: a directory occupies its path, so
+    // write-file-atomic's rename step fails deterministically.
+    await fs.mkdir(path.join(tmpDir, "memory-meta.json"));
+
+    try {
+      await client.setPinned({ logicalKey: "global:a.md", pinned: true });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ORPCError);
+      const orpcError = error as ORPCError<string, { metaPath: string; reason: string }>;
+      expect(orpcError.code).toBe("MEMORY_META_WRITE_FAILED");
+      // `defined: true` = matched the procedure's .errors() map (not a fallback).
+      expect(orpcError.defined).toBe(true);
+      expect(orpcError.data.metaPath).toContain("memory-meta.json");
+      expect(orpcError.data.reason.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("cancellation + resource scoping", () => {
+  test("client abort interrupts the fiber and still runs scope finalizers", async () => {
+    const controller = new AbortController();
+    const startedAt = Date.now();
+
+    const pending = client.scopedHold({ holdMs: 60_000 }, { signal: controller.signal });
+    // Swallow the expected rejection so bun's unhandled-rejection detection
+    // stays quiet between abort() and the assertion below.
+    const settled = pending.then(
+      () => ({ rejected: false as const, error: undefined as unknown }),
+      (error: unknown) => ({ rejected: true as const, error })
+    );
+
+    await waitFor(() => scopeProbe.acquired === 1);
+    controller.abort();
+
+    const outcome = await settled;
+    expect(outcome.rejected).toBe(true);
+
+    // Interruption must be prompt (not the 60s hold) and release exactly once.
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+    await waitFor(() => scopeProbe.released === 1);
+    expect(scopeProbe.acquired).toBe(1);
+    expect(scopeProbe.released).toBe(1);
+  });
+
+  test("uncancelled hold completes and releases normally", async () => {
+    const result = await client.scopedHold({ holdMs: 10 });
+    expect(result).toEqual({ held: true });
+    expect(scopeProbe.acquired).toBe(1);
+    expect(scopeProbe.released).toBe(1);
+  });
+});
+
+describe("benchmark: async handler vs Effect handler (informational)", () => {
+  test("logs per-call overhead of the Effect runtime", async () => {
+    const iterations = 2_000;
+
+    // Warmup both paths.
+    for (let i = 0; i < 200; i++) {
+      await client.echoAsync({ n: i });
+      await client.echoEffect({ n: i });
+    }
+
+    const asyncStart = performance.now();
+    for (let i = 0; i < iterations; i++) await client.echoAsync({ n: i });
+    const asyncMs = performance.now() - asyncStart;
+
+    const effectStart = performance.now();
+    for (let i = 0; i < iterations; i++) await client.echoEffect({ n: i });
+    const effectMs = performance.now() - effectStart;
+
+    // Informational output consumed by the spike findings doc.
+    console.log(
+      `[effect-spike bench] ${iterations} sequential calls — ` +
+        `async: ${asyncMs.toFixed(1)}ms (${((asyncMs / iterations) * 1000).toFixed(1)}µs/call), ` +
+        `effect: ${effectMs.toFixed(1)}ms (${((effectMs / iterations) * 1000).toFixed(1)}µs/call), ` +
+        `overhead: ${(((effectMs - asyncMs) / iterations) * 1000).toFixed(1)}µs/call`
+    );
+
+    expect(asyncMs).toBeGreaterThan(0);
+    expect(effectMs).toBeGreaterThan(0);
+  });
+});

--- a/src/node/orpc/effectSpike.test.ts
+++ b/src/node/orpc/effectSpike.test.ts
@@ -9,10 +9,11 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ORPCError, createRouterClient } from "@orpc/server";
+import { ORPCError, createRouterClient, os as orpcBase } from "@orpc/server";
 import { effectSpike, scopeProbe } from "./effectSpike";
 import { buildOrpcEffectContext } from "./effectContext";
-import { router } from "./router";
+import { createAuthMiddleware } from "./authMiddleware";
+import { createOpenAPIGenerator } from "./server";
 import { MemoryMetaService } from "@/node/services/memoryMeta";
 import type { ORPCContext } from "./context";
 
@@ -133,8 +134,14 @@ describe("cancellation + resource scoping", () => {
 });
 
 describe("router-level middleware over Effect handlers", () => {
-  test("effectSpike procedures inherit the router's auth middleware", async () => {
-    const authedRouter = router("secret-token");
+  test("auth middleware applies to handlerGen procedures mounted under it", async () => {
+    // The spike namespace is deliberately NOT part of the production router
+    // (codex review on #4022); compose it the same way router() composes its
+    // procedures to prove middleware still wraps Effect handlers.
+    const authedRouter = orpcBase
+      .$context<ORPCContext>()
+      .use(createAuthMiddleware("secret-token"))
+      .router({ effectSpike });
     const unauthedClient = createRouterClient(authedRouter, {
       context: { headers: {} } as unknown as ORPCContext,
     });
@@ -146,6 +153,26 @@ describe("router-level middleware over Effect handlers", () => {
       expect(error).toBeInstanceOf(ORPCError);
       expect((error as ORPCError<string, unknown>).code).toBe("UNAUTHORIZED");
     }
+  });
+});
+
+describe("OpenAPI generation for Effect Schema inputs", () => {
+  test("production converter set emits request bodies for Effect Schema inputs", async () => {
+    // Regression (codex P1 on #4022): without EffectSchemaToJsonSchemaConverter
+    // the generator silently drops the requestBody for Effect Schema inputs,
+    // shipping a lossy spec (fields missing from /api/docs and generated clients).
+    const spec = await createOpenAPIGenerator().generate(
+      orpcBase.$context<ORPCContext>().router({ effectSpike }),
+      { base: { info: { title: "spike", version: "0" } } }
+    );
+    const paths = (spec.paths ?? {}) as Record<
+      string,
+      { post?: { requestBody?: { content?: Record<string, unknown> } } }
+    >;
+    const operation = paths["/effectSpike/pinnedCount"]?.post;
+    expect(operation).toBeDefined();
+    const requestSchema = JSON.stringify(operation?.requestBody?.content ?? {});
+    expect(requestSchema).toContain('"prefix"');
   });
 });
 

--- a/src/node/orpc/effectSpike.test.ts
+++ b/src/node/orpc/effectSpike.test.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import { ORPCError, createRouterClient } from "@orpc/server";
 import { effectSpike, scopeProbe } from "./effectSpike";
 import { buildOrpcEffectContext } from "./effectContext";
+import { router } from "./router";
 import { MemoryMetaService } from "@/node/services/memoryMeta";
 import type { ORPCContext } from "./context";
 
@@ -128,6 +129,23 @@ describe("cancellation + resource scoping", () => {
     expect(result).toEqual({ held: true });
     expect(scopeProbe.acquired).toBe(1);
     expect(scopeProbe.released).toBe(1);
+  });
+});
+
+describe("router-level middleware over Effect handlers", () => {
+  test("effectSpike procedures inherit the router's auth middleware", async () => {
+    const authedRouter = router("secret-token");
+    const unauthedClient = createRouterClient(authedRouter, {
+      context: { headers: {} } as unknown as ORPCContext,
+    });
+
+    try {
+      await unauthedClient.effectSpike.echoAsync({ n: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ORPCError);
+      expect((error as ORPCError<string, unknown>).code).toBe("UNAUTHORIZED");
+    }
   });
 });
 

--- a/src/node/orpc/effectSpike.ts
+++ b/src/node/orpc/effectSpike.ts
@@ -1,0 +1,135 @@
+/**
+ * Effect-migration spike procedures (`effectSpike.*` namespace).
+ *
+ * These procedures exist to validate the `@orpc/experimental-effect` bridge
+ * end-to-end and are exercised by effectSpike.test.ts:
+ *
+ * - `pinnedCount`: Effect service injection via the oRPC context's
+ *   `"effect/context"` key + an Effect `Schema` input schema coexisting with
+ *   Zod outputs in the same procedure.
+ * - `setPinned`: `Schema.TaggedError` failures surfaced as *defined* oRPC
+ *   errors (`.errors()` map) without any untyped catch block.
+ * - `scopedHold`: scoped resource acquisition whose finalizers must run when
+ *   the client aborts the request (AbortSignal → fiber interruption).
+ * - `echoAsync`/`echoEffect`: identical no-op procedures used to measure the
+ *   per-call overhead of the Effect runtime vs a plain async handler.
+ *
+ * `handlerGen` is used directly instead of the `.effect()` builder extension:
+ * the extension patches `Builder.prototype` globally via a side-effect import,
+ * while `handlerGen` is a plain function wrapper with zero global footprint.
+ */
+import { os } from "@orpc/server";
+import { handlerGen, toStandardSchema } from "@orpc/experimental-effect";
+import { Effect, Schema } from "effect";
+import { z } from "zod";
+import type { ORPCContext } from "./context";
+import { MemoryMeta } from "./effectContext";
+
+const t = os.$context<ORPCContext>();
+
+/**
+ * Observable side-channel for tests: proves that scope finalizers run exactly
+ * once, including when the handler fiber is interrupted by a client abort.
+ */
+export const scopeProbe = {
+  acquired: 0,
+  released: 0,
+  reset(): void {
+    this.acquired = 0;
+    this.released = 0;
+  },
+};
+
+export const effectSpike = {
+  /** Count pinned memory keys matching a prefix (service via Effect context). */
+  pinnedCount: t
+    .input(toStandardSchema(Schema.Struct({ prefix: Schema.String })))
+    .output(z.object({ count: z.number() }))
+    .handler(
+      handlerGen(function* (_opts, input) {
+        // Service resolution: the tag is itself an Effect; `handlerGen`
+        // provides the "effect/context" services to everything yielded here.
+        const memoryMeta = yield* MemoryMeta;
+        const keys = yield* memoryMeta.effects.getPinnedKeys();
+        let count = 0;
+        for (const key of keys) if (key.startsWith(input.prefix)) count += 1;
+        return { count };
+      })
+    ),
+
+  /**
+   * Pin/unpin by raw logical key. Demonstrates the typed error path:
+   * MemoryMetaWriteError (Schema.TaggedError) → errors.MEMORY_META_WRITE_FAILED
+   * (defined oRPC error with schema-validated payload). After `catchTag` the
+   * only failure left in the E channel is the ORPCError itself.
+   */
+  setPinned: t
+    .input(z.object({ logicalKey: z.string(), pinned: z.boolean() }))
+    .errors({
+      MEMORY_META_WRITE_FAILED: {
+        message: "Failed to persist memory pin state",
+        data: z.object({ metaPath: z.string(), reason: z.string() }),
+      },
+    })
+    .output(z.object({ ok: z.literal(true) }))
+    .handler(
+      handlerGen(function* ({ errors }, input) {
+        const memoryMeta = yield* MemoryMeta;
+        yield* memoryMeta.effects.setPinned(input.logicalKey, input.pinned).pipe(
+          Effect.catchTag("MemoryMetaWriteError", (error) =>
+            Effect.fail(
+              errors.MEMORY_META_WRITE_FAILED({
+                data: { metaPath: error.metaPath, reason: error.reason },
+              })
+            )
+          )
+        );
+        return { ok: true as const };
+      })
+    ),
+
+  /**
+   * Hold a scoped resource for `holdMs`. When the client aborts, oRPC's
+   * AbortSignal interrupts the fiber and the scope's release finalizer must
+   * still run (observable via scopeProbe).
+   */
+  scopedHold: t
+    .input(z.object({ holdMs: z.number() }))
+    .output(z.object({ held: z.boolean() }))
+    .handler(
+      handlerGen(function* (_opts, input) {
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* Effect.acquireRelease(
+              Effect.sync(() => {
+                scopeProbe.acquired += 1;
+              }),
+              () =>
+                Effect.sync(() => {
+                  scopeProbe.released += 1;
+                })
+            );
+            yield* Effect.sleep(input.holdMs);
+          })
+        );
+        return { held: true };
+      })
+    ),
+
+  /** Plain async no-op — benchmark baseline. */
+  echoAsync: t
+    .input(z.object({ n: z.number() }))
+    .output(z.object({ n: z.number() }))
+    .handler(({ input }) => ({ n: input.n })),
+
+  /** Effect no-op — measures handlerGen + runtime overhead per call. */
+  echoEffect: t
+    .input(z.object({ n: z.number() }))
+    .output(z.object({ n: z.number() }))
+    .handler(
+      // eslint-disable-next-line require-yield -- deliberately yield-free: benchmarks the bare Effect.gen wrapper cost
+      handlerGen(function* (_opts, input) {
+        return { n: input.n };
+      })
+    ),
+};

--- a/src/node/orpc/formatOrpcError.test.ts
+++ b/src/node/orpc/formatOrpcError.test.ts
@@ -12,7 +12,7 @@ describe("formatOrpcError", () => {
           path: ["slots", 0, "preset"],
         },
       ],
-      data: { version: 2, slots: [] },
+      invalidData: { version: 2, slots: [] },
     });
 
     const error = new ORPCError("INTERNAL_SERVER_ERROR", {

--- a/src/node/orpc/formatOrpcError.ts
+++ b/src/node/orpc/formatOrpcError.ts
@@ -1,4 +1,5 @@
 import { ORPCError, ValidationError } from "@orpc/server";
+import { COMMON_ERROR_STATUS_MAP } from "@orpc/client";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { inspect } from "node:util";
 import { DYNAMIC_WORKFLOWS_DISABLED_ERROR_MESSAGE } from "@/node/services/workflows/WorkflowService";
@@ -274,7 +275,8 @@ function getValidationErrorInfo(
     return {
       message: cause.message,
       issues: cause.issues,
-      data: cause.data,
+      // oRPC >=1.14 renamed `ValidationError.data` to `invalidData`.
+      data: cause.invalidData,
     };
   }
 
@@ -315,7 +317,10 @@ export function formatOrpcError(error: unknown, interceptorOptions?: unknown): F
 
     if (error instanceof ORPCError) {
       const code = typeof error.code === "string" ? error.code : String(error.code);
-      const status = typeof error.status === "number" ? error.status : undefined;
+      // oRPC >=1.14 removed `ORPCError.status`; derive the HTTP status from the
+      // shared code→status table (custom codes have no fixed status).
+      const statusFromCode = (COMMON_ERROR_STATUS_MAP as Record<string, number>)[code];
+      const status = typeof statusFromCode === "number" ? statusFromCode : undefined;
 
       debugDump.error = {
         type: "ORPCError",

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -8,6 +8,7 @@ import {
   listWorkspacePluginSlashCommands,
   setWorkspaceMcpOverrides,
 } from "@/node/services/agentPlugins/workspacePluginOperations";
+import { handlerGen } from "@orpc/experimental-effect";
 import {
   assertMemoryEnabled,
   consolidateMemory,
@@ -16,8 +17,9 @@ import {
   listMemory,
   readMemory,
   saveMemory,
-  setMemoryPinned,
+  setMemoryPinnedEffect,
 } from "@/node/services/memoryOperations";
+import { effectSpike } from "@/node/orpc/effectSpike";
 import {
   controlBrowser,
   getBrowserBootstrap,
@@ -1150,10 +1152,16 @@ export const router = (authToken?: string) => {
         .input(schemas.memory.delete.input)
         .output(schemas.memory.delete.output)
         .handler(({ context, input }) => deleteMemory(context, input)),
+      // Effect-migration spike: this handler runs an Effect generator via
+      // handlerGen; the wire contract is unchanged.
       setPinned: t
         .input(schemas.memory.setPinned.input)
         .output(schemas.memory.setPinned.output)
-        .handler(({ context, input }) => setMemoryPinned(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* setMemoryPinnedEffect(context, input);
+          })
+        ),
       consolidationStatus: t
         .input(schemas.memory.consolidationStatus.input)
         .output(schemas.memory.consolidationStatus.output)
@@ -1172,6 +1180,8 @@ export const router = (authToken?: string) => {
           )
         ),
     },
+    // Effect-migration spike namespace (see src/node/orpc/effectSpike.ts).
+    effectSpike,
     refinements: {
       // /refine trajectory distillation (RLM r11). Gating lives in the
       // service: it refuses when the rlm-mode machine overrides are off.

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -19,7 +19,6 @@ import {
   saveMemory,
   setMemoryPinnedEffect,
 } from "@/node/services/memoryOperations";
-import { effectSpike } from "@/node/orpc/effectSpike";
 import {
   controlBrowser,
   getBrowserBootstrap,
@@ -1180,8 +1179,6 @@ export const router = (authToken?: string) => {
           )
         ),
     },
-    // Effect-migration spike namespace (see src/node/orpc/effectSpike.ts).
-    effectSpike,
     refinements: {
       // /refine trajectory distillation (RLM r11). Gating lives in the
       // service: it refuses when the rlm-mode machine overrides are off.

--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -103,7 +103,8 @@ function createHttpClient(
   headers?: Record<string, string>
 ): RouterClient<AppRouter> {
   const link = new HTTPRPCLink({
-    url: `${baseUrl}/orpc`,
+    origin: baseUrl,
+    url: "/orpc",
     headers,
   });
 

--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -296,25 +296,6 @@ async function expectWebSocketOriginCase(input: {
   );
 }
 
-describe("OpenAPI spec generation", () => {
-  test("emits request bodies for Effect Schema inputs (converter registered)", async () => {
-    await withTestOrpcServer(async (server) => {
-      const response = await fetch(`${server.baseUrl}/api/spec.json`);
-      expect(response.status).toBe(200);
-      const spec = (await response.json()) as {
-        paths?: Record<string, { post?: { requestBody?: { content?: Record<string, unknown> } } }>;
-      };
-      // Regression: without EffectSchemaToJsonSchemaConverter the generator
-      // silently drops the requestBody for Effect Schema inputs, shipping a
-      // lossy spec (fields missing from /api/docs and generated clients).
-      const operation = spec.paths?.["/effectSpike/pinnedCount"]?.post;
-      expect(operation).toBeDefined();
-      const requestSchema = JSON.stringify(operation?.requestBody?.content ?? {});
-      expect(requestSchema).toContain('"prefix"');
-    });
-  });
-});
-
 describe("createOrpcServer", () => {
   test("serveStatic fallback does not swallow /api routes", async () => {
     // Minimal context stub - router won't be exercised by this test.

--- a/src/node/orpc/server.test.ts
+++ b/src/node/orpc/server.test.ts
@@ -296,6 +296,25 @@ async function expectWebSocketOriginCase(input: {
   );
 }
 
+describe("OpenAPI spec generation", () => {
+  test("emits request bodies for Effect Schema inputs (converter registered)", async () => {
+    await withTestOrpcServer(async (server) => {
+      const response = await fetch(`${server.baseUrl}/api/spec.json`);
+      expect(response.status).toBe(200);
+      const spec = (await response.json()) as {
+        paths?: Record<string, { post?: { requestBody?: { content?: Record<string, unknown> } } }>;
+      };
+      // Regression: without EffectSchemaToJsonSchemaConverter the generator
+      // silently drops the requestBody for Effect Schema inputs, shipping a
+      // lossy spec (fields missing from /api/docs and generated clients).
+      const operation = spec.paths?.["/effectSpike/pinnedCount"]?.post;
+      expect(operation).toBeDefined();
+      const requestSchema = JSON.stringify(operation?.requestBody?.content ?? {});
+      expect(requestSchema).toContain('"prefix"');
+    });
+  });
+});
+
 describe("createOrpcServer", () => {
   test("serveStatic fallback does not swallow /api routes", async () => {
     // Minimal context stub - router won't be exercised by this test.

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -11,11 +11,11 @@ import * as http from "http";
 import * as path from "path";
 import { WebSocketServer, type WebSocket } from "ws";
 import { RPCHandler } from "@orpc/server/node";
-import { RPCHandler as ORPCWebSocketServerHandler } from "@orpc/server/ws";
+import { RPCHandler as ORPCWebSocketServerHandler } from "@orpc/server/websocket";
 import { ORPCError, onError } from "@orpc/server";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/node";
-import { ZodToJsonSchemaConverter } from "@orpc/zod/zod4";
+import { ZodToJsonSchemaConverter } from "@orpc/zod";
 import { router, type AppRouter } from "@/node/orpc/router";
 import type { ORPCContext } from "@/node/orpc/context";
 import { extractCookieValues, extractWsHeaders, safeEq } from "@/node/orpc/authMiddleware";
@@ -1468,7 +1468,7 @@ export async function createOrpcServer({
 
   // OpenAPI generator for spec endpoint
   const openAPIGenerator = new OpenAPIGenerator({
-    schemaConverters: [new ZodToJsonSchemaConverter()],
+    converters: [new ZodToJsonSchemaConverter()],
   });
 
   // OpenAPI spec endpoint
@@ -1481,24 +1481,27 @@ export async function createOrpcServer({
       "/api"
     );
 
+    // oRPC >=1.14 nests document fields under `base` instead of top-level options.
     const spec = await openAPIGenerator.generate(orpcRouter, {
-      info: {
-        title: "Xum API",
-        version: gitDescribe,
-        description: "API for Xum",
-      },
-      servers: [{ url: publicApiPath }],
-      security: authToken ? [{ bearerAuth: [] }] : undefined,
-      components: authToken
-        ? {
-            securitySchemes: {
-              bearerAuth: {
-                type: "http",
-                scheme: "bearer",
+      base: {
+        info: {
+          title: "Xum API",
+          version: gitDescribe,
+          description: "API for Xum",
+        },
+        servers: [{ url: publicApiPath }],
+        security: authToken ? [{ bearerAuth: [] }] : undefined,
+        components: authToken
+          ? {
+              securitySchemes: {
+                bearerAuth: {
+                  type: "http",
+                  scheme: "bearer",
+                },
               },
-            },
-          }
-        : undefined,
+            }
+          : undefined,
+      },
     });
     varyPublicBasePathHeaders(res);
     res.json(spec);

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -17,6 +17,18 @@ import { OpenAPIGenerator } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/node";
 import { ZodToJsonSchemaConverter } from "@orpc/zod";
 import { EffectSchemaToJsonSchemaConverter } from "@orpc/experimental-effect";
+
+/**
+ * Effect-migration spike: Effect Schema inputs need their own JSON-schema
+ * converter; without it the generator silently emits operations with no
+ * requestBody, producing a lossy /api/spec.json. Exported so tests can verify
+ * the production converter set against Effect Schema procedures.
+ */
+export function createOpenAPIGenerator(): OpenAPIGenerator {
+  return new OpenAPIGenerator({
+    converters: [new ZodToJsonSchemaConverter(), new EffectSchemaToJsonSchemaConverter()],
+  });
+}
 import { router, type AppRouter } from "@/node/orpc/router";
 import type { ORPCContext } from "@/node/orpc/context";
 import { extractCookieValues, extractWsHeaders, safeEq } from "@/node/orpc/authMiddleware";
@@ -1468,12 +1480,7 @@ export async function createOrpcServer({
   const orpcRouter = existingRouter ?? router(authToken);
 
   // OpenAPI generator for spec endpoint
-  // Effect-migration spike: Effect Schema inputs (effectSpike.pinnedCount) need
-  // their own JSON-schema converter; without it the generator silently emits
-  // operations with no requestBody, producing a lossy /api/spec.json.
-  const openAPIGenerator = new OpenAPIGenerator({
-    converters: [new ZodToJsonSchemaConverter(), new EffectSchemaToJsonSchemaConverter()],
-  });
+  const openAPIGenerator = createOpenAPIGenerator();
 
   // OpenAPI spec endpoint
   app.get("/api/spec.json", async (req, res) => {

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -16,6 +16,7 @@ import { ORPCError, onError } from "@orpc/server";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/node";
 import { ZodToJsonSchemaConverter } from "@orpc/zod";
+import { EffectSchemaToJsonSchemaConverter } from "@orpc/experimental-effect";
 import { router, type AppRouter } from "@/node/orpc/router";
 import type { ORPCContext } from "@/node/orpc/context";
 import { extractCookieValues, extractWsHeaders, safeEq } from "@/node/orpc/authMiddleware";
@@ -1467,8 +1468,11 @@ export async function createOrpcServer({
   const orpcRouter = existingRouter ?? router(authToken);
 
   // OpenAPI generator for spec endpoint
+  // Effect-migration spike: Effect Schema inputs (effectSpike.pinnedCount) need
+  // their own JSON-schema converter; without it the generator silently emits
+  // operations with no requestBody, producing a lossy /api/spec.json.
   const openAPIGenerator = new OpenAPIGenerator({
-    converters: [new ZodToJsonSchemaConverter()],
+    converters: [new ZodToJsonSchemaConverter(), new EffectSchemaToJsonSchemaConverter()],
   });
 
   // OpenAPI spec endpoint

--- a/src/node/services/memoryMeta.test.ts
+++ b/src/node/services/memoryMeta.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "bun:test";
+import { Effect } from "effect";
 
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
@@ -216,6 +217,36 @@ describe("MemoryMetaService", () => {
       });
       // Entirely-default entries are dropped.
       expect(entries.has("global:all-defaults.md")).toBe(false);
+    });
+  });
+
+  describe("interruption safety", () => {
+    // Regression (codex P2 on #4022): a fiber interrupted mid-write must not
+    // leave the in-memory cache diverged from disk — the write + cache update
+    // are one uninterruptible unit. Race aborts at varied delays and assert
+    // cache and disk agree after every settled attempt; this can never
+    // false-fail, and any divergence is a real interruption-safety bug.
+    it("keeps cache and disk consistent when writes race with interruption", async () => {
+      using tempDir = new TestTempDir("test-memory-meta");
+      const service = new MemoryMetaService(tempDir.path);
+
+      for (let i = 0; i < 25; i++) {
+        const controller = new AbortController();
+        const attempt = Effect.runPromise(service.effects.setPinned(`global:race-${i}.md`, true), {
+          signal: controller.signal,
+        }).then(
+          () => undefined,
+          () => undefined // interruption/abort rejections are expected here
+        );
+        if (i % 5 === 0) controller.abort();
+        else setTimeout(() => controller.abort(), i % 5);
+        await attempt;
+
+        // Fresh instance = authoritative disk state; original = cached state.
+        const diskEntries = await new MemoryMetaService(tempDir.path).getEntries();
+        const cachedEntries = await service.getEntries();
+        expect(cachedEntries).toEqual(diskEntries);
+      }
     });
   });
 });

--- a/src/node/services/memoryMeta.ts
+++ b/src/node/services/memoryMeta.ts
@@ -282,13 +282,27 @@ export class MemoryMetaService {
           if (isEmptyEntry(entry)) delete entries[key];
         }
         const next: MemoryMetaFile = { entries };
-        yield* Effect.tryPromise({
-          try: () =>
-            writeFileAtomic(self.metaPath, JSON.stringify(next, null, 2), { encoding: "utf-8" }),
-          catch: (cause) =>
-            new MemoryMetaWriteError({ metaPath: self.metaPath, reason: getErrorMessage(cause) }),
-        });
-        self.cache = next;
+        // The atomic write cannot be cancelled once started, so the write and
+        // the cache update form one uninterruptible unit: a fiber interrupted
+        // mid-write (e.g. client abort) must still reconcile the in-memory
+        // cache with what landed on disk. Otherwise the next mutation would
+        // rebuild disk state from a stale cache and silently lose this write.
+        yield* Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* Effect.tryPromise({
+              try: () =>
+                writeFileAtomic(self.metaPath, JSON.stringify(next, null, 2), {
+                  encoding: "utf-8",
+                }),
+              catch: (cause) =>
+                new MemoryMetaWriteError({
+                  metaPath: self.metaPath,
+                  reason: getErrorMessage(cause),
+                }),
+            });
+            self.cache = next;
+          })
+        );
       })
     );
   }

--- a/src/node/services/memoryMeta.ts
+++ b/src/node/services/memoryMeta.ts
@@ -13,8 +13,9 @@
 import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import writeFileAtomic from "write-file-atomic";
+import { Effect, Schema, Semaphore } from "effect";
 import type { MemoryScope } from "@/common/constants/memory";
-import { MutexMap } from "@/node/utils/concurrency/mutexMap";
+import { getErrorMessage } from "@/common/utils/errors";
 import { log } from "@/node/services/log";
 
 /**
@@ -118,97 +119,201 @@ function sanitizeMetaFile(raw: unknown): MemoryMetaFile {
   return { entries };
 }
 
+/**
+ * Typed failure for sidecar persistence (disk full, permissions, path
+ * conflicts). Reads never fail — malformed or missing data self-heals to
+ * empty — so writes are the only failure channel this service exposes.
+ *
+ * Effect-migration spike: `Schema.TaggedError` gives us an `Error` subclass
+ * that is simultaneously a schema (usable in oRPC error payloads), a tagged
+ * union member (usable with `Effect.catchTag`), and yieldable in `Effect.gen`.
+ */
+export class MemoryMetaWriteError extends Schema.TaggedError<MemoryMetaWriteError>()(
+  "MemoryMetaWriteError",
+  {
+    metaPath: Schema.String,
+    reason: Schema.String,
+  }
+) {}
+
 export class MemoryMetaService {
   private readonly metaPath: string;
-  /** Serializes read-modify-write cycles against the (single) sidecar file. */
-  private readonly lock = new MutexMap<"meta">();
+  /**
+   * Serializes read-modify-write cycles against the (single) sidecar file.
+   * Effect-migration spike: an Effect `Semaphore` replaces the promise-based
+   * MutexMap so lock acquisition participates in interruption — a fiber
+   * cancelled while waiting for the permit never runs its critical section.
+   */
+  private readonly writeLock = Semaphore.makeUnsafe(1);
   private cache: MemoryMetaFile | null = null;
+
+  /**
+   * Effect-native API (the migration target surface). The legacy Promise
+   * methods below are thin `Effect.runPromise` facades over these, so existing
+   * callers keep working unchanged while new Effect callers (oRPC `.effect`
+   * handlers, other migrated services) compose these directly and see typed
+   * errors in the `E` channel instead of untyped rejections.
+   */
+  readonly effects = {
+    /** Logical keys of all pinned memory files. */
+    getPinnedKeys: (): Effect.Effect<Set<string>> =>
+      Effect.map(
+        this.load(),
+        (meta) =>
+          new Set(
+            Object.entries(meta.entries)
+              .filter(([, entry]) => entry.pinned)
+              .map(([key]) => key)
+          )
+      ),
+
+    /** All entries (pins + usage stats) keyed by logical memory identity. */
+    getEntries: (): Effect.Effect<Map<string, MemoryMetaEntry>> =>
+      Effect.map(
+        this.load(),
+        (meta) => new Map(Object.entries(meta.entries).map(([key, entry]) => [key, { ...entry }]))
+      ),
+
+    setPinned: (logicalKey: string, pinned: boolean): Effect.Effect<void, MemoryMetaWriteError> =>
+      this.mutate((entries) => {
+        const current = entries[logicalKey] ?? EMPTY_ENTRY;
+        if (pinned) {
+          // Pinning counts as a use: it is an explicit signal the file matters,
+          // and it feeds the same recency/frequency ranking as reads/writes.
+          entries[logicalKey] = {
+            ...current,
+            pinned: true,
+            accessCount: current.accessCount + 1,
+            lastAccessedAt: Date.now(),
+          };
+        } else {
+          // Unpinning preserves usage stats; mutate() drops the entry if empty.
+          entries[logicalKey] = { ...current, pinned: false };
+        }
+      }),
+
+    /** Record a use (read or write) of a memory file at the MemoryService chokepoint. */
+    recordAccess: (
+      logicalKey: string,
+      options: { write: boolean }
+    ): Effect.Effect<void, MemoryMetaWriteError> =>
+      this.mutate((entries) => {
+        const current = entries[logicalKey] ?? EMPTY_ENTRY;
+        const now = Date.now();
+        entries[logicalKey] = {
+          ...current,
+          accessCount: current.accessCount + 1,
+          lastAccessedAt: now,
+          lastWriteAt: options.write ? now : current.lastWriteAt,
+        };
+      }),
+
+    /**
+     * Move all entries for a renamed file or directory subtree so pins and
+     * stats follow the file. Stale entries at the destination are overwritten.
+     */
+    renameKeys: (
+      oldLogicalKey: string,
+      newLogicalKey: string
+    ): Effect.Effect<void, MemoryMetaWriteError> =>
+      this.mutate((entries) => {
+        for (const [key, entry] of Object.entries(entries)) {
+          if (!keyInSubtree(key, oldLogicalKey)) continue;
+          delete entries[key];
+          entries[`${newLogicalKey}${key.slice(oldLogicalKey.length)}`] = entry;
+        }
+      }),
+
+    /**
+     * Drop all entries for a deleted file or directory subtree so a future file
+     * at the same path never resurrects stale pins or stats.
+     */
+    removeKeys: (logicalKey: string): Effect.Effect<void, MemoryMetaWriteError> =>
+      this.mutate((entries) => {
+        for (const key of Object.keys(entries)) {
+          if (keyInSubtree(key, logicalKey)) delete entries[key];
+        }
+      }),
+  };
 
   constructor(xumHome: string) {
     this.metaPath = path.join(xumHome, "memory-meta.json");
   }
 
-  private async load(): Promise<MemoryMetaFile> {
-    if (this.cache !== null) return this.cache;
-    let parsed: unknown = null;
-    try {
-      parsed = JSON.parse(await fsPromises.readFile(this.metaPath, "utf-8"));
-    } catch (error) {
-      // Missing file is the normal first-run case; anything else is healed to empty.
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        log.debug("[MemoryMetaService] healing unreadable sidecar", { error });
-      }
-    }
-    this.cache = sanitizeMetaFile(parsed);
-    return this.cache;
-  }
-
-  /**
-   * Read-modify-write cycle under the sidecar mutex. Persists before updating
-   * the in-memory cache so observers never see state that didn't make it to
-   * disk. Entries that end up entirely default are dropped.
-   */
-  private async mutate(update: (entries: Record<string, MemoryMetaEntry>) => void): Promise<void> {
-    await this.lock.withLock("meta", async () => {
-      const meta = await this.load();
-      const entries = { ...meta.entries };
-      update(entries);
-      for (const [key, entry] of Object.entries(entries)) {
-        if (isEmptyEntry(entry)) delete entries[key];
-      }
-      const next: MemoryMetaFile = { entries };
-      await writeFileAtomic(this.metaPath, JSON.stringify(next, null, 2), { encoding: "utf-8" });
-      this.cache = next;
+  private load(): Effect.Effect<MemoryMetaFile> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      if (self.cache !== null) return self.cache;
+      const parsed = yield* Effect.tryPromise({
+        try: async (): Promise<unknown> =>
+          JSON.parse(await fsPromises.readFile(self.metaPath, "utf-8")),
+        catch: (error) => error,
+      }).pipe(
+        Effect.catch((error) => {
+          // Missing file is the normal first-run case; anything else is healed to empty.
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            log.debug("[MemoryMetaService] healing unreadable sidecar", { error });
+          }
+          return Effect.succeed<unknown>(null);
+        })
+      );
+      self.cache = sanitizeMetaFile(parsed);
+      return self.cache;
     });
   }
 
+  /**
+   * Read-modify-write cycle under the sidecar semaphore. Persists before
+   * updating the in-memory cache so observers never see state that didn't make
+   * it to disk. Entries that end up entirely default are dropped.
+   */
+  private mutate(
+    update: (entries: Record<string, MemoryMetaEntry>) => void
+  ): Effect.Effect<void, MemoryMetaWriteError> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return this.writeLock.withPermit(
+      Effect.gen(function* () {
+        const meta = yield* self.load();
+        const entries = { ...meta.entries };
+        update(entries);
+        for (const [key, entry] of Object.entries(entries)) {
+          if (isEmptyEntry(entry)) delete entries[key];
+        }
+        const next: MemoryMetaFile = { entries };
+        yield* Effect.tryPromise({
+          try: () =>
+            writeFileAtomic(self.metaPath, JSON.stringify(next, null, 2), { encoding: "utf-8" }),
+          catch: (cause) =>
+            new MemoryMetaWriteError({ metaPath: self.metaPath, reason: getErrorMessage(cause) }),
+        });
+        self.cache = next;
+      })
+    );
+  }
+
+  // Legacy Promise facade — signatures unchanged for pre-Effect callers.
+  // Failures reject with MemoryMetaWriteError (an Error subclass), matching the
+  // old behavior of surfacing the underlying write rejection.
+
   /** Logical keys of all pinned memory files. */
   async getPinnedKeys(): Promise<Set<string>> {
-    const meta = await this.load();
-    return new Set(
-      Object.entries(meta.entries)
-        .filter(([, entry]) => entry.pinned)
-        .map(([key]) => key)
-    );
+    return Effect.runPromise(this.effects.getPinnedKeys());
   }
 
   /** All entries (pins + usage stats) keyed by logical memory identity. */
   async getEntries(): Promise<Map<string, MemoryMetaEntry>> {
-    const meta = await this.load();
-    return new Map(Object.entries(meta.entries).map(([key, entry]) => [key, { ...entry }]));
+    return Effect.runPromise(this.effects.getEntries());
   }
 
   async setPinned(logicalKey: string, pinned: boolean): Promise<void> {
-    await this.mutate((entries) => {
-      const current = entries[logicalKey] ?? EMPTY_ENTRY;
-      if (pinned) {
-        // Pinning counts as a use: it is an explicit signal the file matters,
-        // and it feeds the same recency/frequency ranking as reads/writes.
-        entries[logicalKey] = {
-          ...current,
-          pinned: true,
-          accessCount: current.accessCount + 1,
-          lastAccessedAt: Date.now(),
-        };
-      } else {
-        // Unpinning preserves usage stats; mutate() drops the entry if empty.
-        entries[logicalKey] = { ...current, pinned: false };
-      }
-    });
+    await Effect.runPromise(this.effects.setPinned(logicalKey, pinned));
   }
 
   /** Record a use (read or write) of a memory file at the MemoryService chokepoint. */
   async recordAccess(logicalKey: string, options: { write: boolean }): Promise<void> {
-    await this.mutate((entries) => {
-      const current = entries[logicalKey] ?? EMPTY_ENTRY;
-      const now = Date.now();
-      entries[logicalKey] = {
-        ...current,
-        accessCount: current.accessCount + 1,
-        lastAccessedAt: now,
-        lastWriteAt: options.write ? now : current.lastWriteAt,
-      };
-    });
+    await Effect.runPromise(this.effects.recordAccess(logicalKey, options));
   }
 
   /**
@@ -216,13 +321,7 @@ export class MemoryMetaService {
    * stats follow the file. Stale entries at the destination are overwritten.
    */
   async renameKeys(oldLogicalKey: string, newLogicalKey: string): Promise<void> {
-    await this.mutate((entries) => {
-      for (const [key, entry] of Object.entries(entries)) {
-        if (!keyInSubtree(key, oldLogicalKey)) continue;
-        delete entries[key];
-        entries[`${newLogicalKey}${key.slice(oldLogicalKey.length)}`] = entry;
-      }
-    });
+    await Effect.runPromise(this.effects.renameKeys(oldLogicalKey, newLogicalKey));
   }
 
   /**
@@ -230,10 +329,6 @@ export class MemoryMetaService {
    * at the same path never resurrects stale pins or stats.
    */
   async removeKeys(logicalKey: string): Promise<void> {
-    await this.mutate((entries) => {
-      for (const key of Object.keys(entries)) {
-        if (keyInSubtree(key, logicalKey)) delete entries[key];
-      }
-    });
+    await Effect.runPromise(this.effects.removeKeys(logicalKey));
   }
 }

--- a/src/node/services/memoryOperations.ts
+++ b/src/node/services/memoryOperations.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from "@orpc/server";
+import { Effect, Result } from "effect";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import type * as schemas from "@/common/orpc/schemas";
 import { getErrorMessage } from "@/common/utils/errors";
@@ -116,42 +117,75 @@ export async function deleteMemory(
     : { success: false as const, error: result.error };
 }
 
+/**
+ * Effect-migration spike: `setMemoryPinned` converted to `Effect.gen`. The
+ * wire contract (ResultSchema(z.void(), z.string())) is unchanged; the router
+ * runs this via `handlerGen`, and the Promise wrapper below keeps pre-Effect
+ * callers (tests) working. Sidecar write failures arrive as the typed
+ * `MemoryMetaWriteError` and are mapped to the legacy string error channel
+ * instead of escaping as an untyped INTERNAL_SERVER_ERROR rejection.
+ */
+export function setMemoryPinnedEffect(
+  context: MemoryContext,
+  input: Input<typeof schemas.memory.setPinned>
+): Effect.Effect<{ success: true; data: undefined } | { success: false; error: string }> {
+  return Effect.gen(function* () {
+    // Sync ORPCError throw stays a runtime defect and reaches the client as
+    // the same BAD_REQUEST it does today from async handlers.
+    assertMemoryEnabled(context);
+    const resolved = yield* Effect.promise(() =>
+      resolveMemoryScopeContext(context, input.workspaceId)
+    );
+    if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
+    const parsedResult = yield* Effect.result(
+      Effect.try({
+        try: () => parseMemoryPath(input.path),
+        catch: (error) => getErrorMessage(error),
+      })
+    );
+    if (Result.isFailure(parsedResult))
+      return { success: false as const, error: parsedResult.failure };
+    const { scope, relPath } = parsedResult.success;
+    if (scope === null || relPath === "")
+      return { success: false as const, error: "Cannot pin a directory: " + input.path };
+    if (input.workspaceId == null && scope !== "global")
+      return {
+        success: false as const,
+        error:
+          (scope === "project" ? "Project" : "Workspace") +
+          " memory is unavailable: no workspace is associated with this request",
+      };
+    if (scope === "project" && resolved.projectPath === "")
+      return {
+        success: false as const,
+        error: "Project memory is unavailable: no project is associated with this session",
+      };
+    return yield* context.memoryMetaService.effects
+      .setPinned(
+        memoryLogicalKey(scope, relPath, {
+          projectPath: resolved.projectPath,
+          workspaceId: input.workspaceId ?? "",
+        }),
+        input.pinned
+      )
+      .pipe(
+        Effect.map(() => ({ success: true as const, data: undefined })),
+        Effect.catchTag("MemoryMetaWriteError", (error) =>
+          Effect.succeed({
+            success: false as const,
+            error: `Failed to persist pin state: ${error.reason}`,
+          })
+        )
+      );
+  });
+}
+
+/** Promise facade over {@link setMemoryPinnedEffect} for pre-Effect callers. */
 export async function setMemoryPinned(
   context: MemoryContext,
   input: Input<typeof schemas.memory.setPinned>
 ) {
-  assertMemoryEnabled(context);
-  const resolved = await resolveMemoryScopeContext(context, input.workspaceId);
-  if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
-  let parsed: ReturnType<typeof parseMemoryPath>;
-  try {
-    parsed = parseMemoryPath(input.path);
-  } catch (error) {
-    return { success: false as const, error: getErrorMessage(error) };
-  }
-  const { scope, relPath } = parsed;
-  if (scope === null || relPath === "")
-    return { success: false as const, error: "Cannot pin a directory: " + input.path };
-  if (input.workspaceId == null && scope !== "global")
-    return {
-      success: false as const,
-      error:
-        (scope === "project" ? "Project" : "Workspace") +
-        " memory is unavailable: no workspace is associated with this request",
-    };
-  if (scope === "project" && resolved.projectPath === "")
-    return {
-      success: false as const,
-      error: "Project memory is unavailable: no project is associated with this session",
-    };
-  await context.memoryMetaService.setPinned(
-    memoryLogicalKey(scope, relPath, {
-      projectPath: resolved.projectPath,
-      workspaceId: input.workspaceId ?? "",
-    }),
-    input.pinned
-  );
-  return { success: true as const, data: undefined };
+  return Effect.runPromise(setMemoryPinnedEffect(context, input));
 }
 
 export async function getMemoryConsolidationStatus(

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -81,6 +81,7 @@ import { DesktopBridgeServer } from "@/node/services/desktop/DesktopBridgeServer
 import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionManager";
 import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
+import { buildOrpcEffectContext } from "@/node/orpc/effectContext";
 /**
  * ServiceContainer - Central dependency container for all backend services.
  *
@@ -645,6 +646,9 @@ export class ServiceContainer {
    */
   toORPCContext(): Omit<ORPCContext, "headers"> {
     return {
+      // Effect-migration spike: pre-built Effect service context consumed by
+      // Effect-native oRPC handlers (see src/node/orpc/effectContext.ts).
+      "effect/context": buildOrpcEffectContext({ memoryMetaService: this.memoryMetaService }),
       workflowRuntimeFactory: this.workflowRuntimeFactory,
       config: this.config,
       sessionLocator: this.sessionLocator,

--- a/tests/ipc/streaming/queuedMessages.test.ts
+++ b/tests/ipc/streaming/queuedMessages.test.ts
@@ -26,53 +26,52 @@ if (shouldRunIntegrationTests()) {
   validateApiKeys(["ANTHROPIC_API_KEY"]);
 }
 
-// Helper: Get queued messages from latest queued-message-changed event
-// If wait=true, waits for a new event first (use when expecting a change)
-// If wait=false, returns current state immediately (use when checking final state)
-async function getQueuedMessages(
-  collector: StreamCollector,
-  options: { wait?: boolean; timeoutMs?: number } = {}
-): Promise<string[]> {
-  const { wait = true, timeoutMs = 5000 } = options;
-
-  if (wait) {
-    await waitForQueuedMessageEvent(collector, timeoutMs);
-  }
-
-  const events = collector.getEvents();
-  const queuedEvents = events.filter(isQueuedMessageChanged);
-
-  if (queuedEvents.length === 0) {
-    return [];
-  }
-
-  // Return messages from the most recent event
-  const latestEvent = queuedEvents[queuedEvents.length - 1];
-  return latestEvent.queuedMessages;
+// Helper: Latest queued-message-changed state observed by the collector.
+function getQueuedMessages(collector: StreamCollector): string[] {
+  const queuedEvents = collector.getEvents().filter(isQueuedMessageChanged);
+  const latest = queuedEvents[queuedEvents.length - 1];
+  return latest ? latest.queuedMessages : [];
 }
 
-// Helper: Wait for a NEW queued-message-changed event (one that wasn't seen before)
+// Helper: Wait until a queued-message-changed event matching `predicate` exists
+// anywhere in the collector history. Scanning history (instead of waiting for
+// "the next new event" past a count snapshot) is required for determinism:
+// oRPC >=1.14 can deliver the queued event before the sendMessage promise
+// resolves, so a count snapshot taken after the send already includes it and a
+// new-event wait then observes the later queue-drain event instead (#4023).
 async function waitForQueuedMessageEvent(
+  collector: StreamCollector,
+  predicate: (event: QueuedMessageChangedEvent) => boolean,
+  timeoutMs = 5000
+): Promise<QueuedMessageChangedEvent | null> {
+  const startTime = Date.now();
+  for (;;) {
+    const match = collector.getEvents().filter(isQueuedMessageChanged).find(predicate);
+    if (match) return match;
+    if (Date.now() - startTime >= timeoutMs) return null;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+// Helper: Wait until the LATEST queued-message-changed event shows an empty,
+// part-free queue (the post-drain state). Latest-state convergence is safe for
+// drain waits because these tests never re-queue after draining; requiring
+// empty fileParts distinguishes the drain event from an image-only queued
+// event (which also has empty queuedMessages).
+async function waitForQueueDrained(
   collector: StreamCollector,
   timeoutMs = 5000
 ): Promise<QueuedMessageChangedEvent | null> {
-  // Get current count of queued-message-changed events
-  const currentEvents = collector.getEvents().filter(isQueuedMessageChanged);
-  const currentCount = currentEvents.length;
-
-  // Wait for a new event
   const startTime = Date.now();
-  while (Date.now() - startTime < timeoutMs) {
-    const events = collector.getEvents().filter(isQueuedMessageChanged);
-    if (events.length > currentCount) {
-      // Return the newest event
-      return events[events.length - 1];
+  for (;;) {
+    const queuedEvents = collector.getEvents().filter(isQueuedMessageChanged);
+    const latest = queuedEvents[queuedEvents.length - 1];
+    if (latest && latest.queuedMessages.length === 0 && (latest.fileParts ?? []).length === 0) {
+      return latest;
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    if (Date.now() - startTime >= timeoutMs) return null;
+    await new Promise((resolve) => setTimeout(resolve, 50));
   }
-
-  // Timeout - return null
-  return null;
 }
 
 // Helper: Wait for restore-to-input event
@@ -118,8 +117,10 @@ describeIntegration("Queued messages", () => {
         expect(queueResult.success).toBe(true);
 
         // Verify message was queued (not sent directly)
-        const queuedEvent = await waitForQueuedMessageEvent(collector1);
-        expect(queuedEvent).toBeDefined();
+        const queuedEvent = await waitForQueuedMessageEvent(collector1, (e) =>
+          e.queuedMessages.includes("Say 'SECOND' and nothing else")
+        );
+        expect(queuedEvent).not.toBeNull();
         expect(queuedEvent?.queuedMessages).toEqual(["Say 'SECOND' and nothing else"]);
         expect(queuedEvent?.displayText).toBe("Say 'SECOND' and nothing else");
 
@@ -128,7 +129,7 @@ describeIntegration("Queued messages", () => {
 
         // Wait for queue to be cleared (happens before auto-send starts new stream)
         // The sendQueuedMessages() clears queue and emits event before sending
-        const clearEvent = await waitForQueuedMessageEvent(collector1, 5000);
+        const clearEvent = await waitForQueueDrained(collector1, 5000);
         expect(clearEvent?.queuedMessages).toEqual([]);
 
         // Wait for auto-send to emit second user message (happens async after stream-end)
@@ -139,8 +140,7 @@ describeIntegration("Queued messages", () => {
         await collector1.waitForEvent("stream-end", 15000);
 
         // Verify queue is still empty (check current state)
-        const queuedAfter = await getQueuedMessages(collector1, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector1)).toEqual([]);
         collector1.stop();
       } finally {
         await cleanup();
@@ -175,12 +175,10 @@ describeIntegration("Queued messages", () => {
         );
 
         // Verify message was queued
-        const queued = await getQueuedMessages(collector);
-        expect(queued).toEqual(["This message should be restored"]);
-
-        // Capture event count BEFORE interrupt to avoid race condition
-        // (clear event may arrive before or with stream-abort)
-        const preInterruptEventCount = collector.getEvents().filter(isQueuedMessageChanged).length;
+        const queuedEvent = await waitForQueuedMessageEvent(collector, (e) =>
+          e.queuedMessages.includes("This message should be restored")
+        );
+        expect(queuedEvent?.queuedMessages).toEqual(["This message should be restored"]);
 
         // Interrupt the stream
         const client = resolveOrpcClient(env);
@@ -190,18 +188,8 @@ describeIntegration("Queued messages", () => {
         // Wait for stream abort
         await collector.waitForEvent("stream-abort", 5000);
 
-        // Wait for queue to be cleared (may have already arrived with stream-abort)
-        // Use preInterruptEventCount as baseline since clear event races with stream-abort
-        const startTime = Date.now();
-        let clearEvent: QueuedMessageChangedEvent | null = null;
-        while (Date.now() - startTime < 5000) {
-          const events = collector.getEvents().filter(isQueuedMessageChanged);
-          if (events.length > preInterruptEventCount) {
-            clearEvent = events[events.length - 1];
-            break;
-          }
-          await new Promise((resolve) => setTimeout(resolve, 100));
-        }
+        // Wait for queue to be cleared (may arrive before or with stream-abort)
+        const clearEvent = await waitForQueueDrained(collector, 5000);
         expect(clearEvent?.queuedMessages).toEqual([]);
 
         // Wait for restore-to-input event
@@ -211,8 +199,7 @@ describeIntegration("Queued messages", () => {
         expect(restoreEvent?.workspaceId).toBe(workspaceId);
 
         // Verify queue is still empty
-        const queuedAfter = await getQueuedMessages(collector, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector)).toEqual([]);
         collector.stop();
       } finally {
         await cleanup();
@@ -251,8 +238,10 @@ describeIntegration("Queued messages", () => {
         );
 
         // Verify message was queued
-        const queued = await getQueuedMessages(collector);
-        expect(queued).toEqual(["This message should be sent immediately"]);
+        const queuedEvent = await waitForQueuedMessageEvent(collector, (e) =>
+          e.queuedMessages.includes("This message should be sent immediately")
+        );
+        expect(queuedEvent?.queuedMessages).toEqual(["This message should be sent immediately"]);
 
         // Interrupt the stream with sendQueuedImmediately flag
         const client = resolveOrpcClient(env);
@@ -276,8 +265,7 @@ describeIntegration("Queued messages", () => {
         expect(autoSendHappened).toBe(true);
 
         // Verify queue was cleared
-        const queuedAfter = await getQueuedMessages(collector, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector)).toEqual([]);
 
         // Wait for the immediately-sent message's stream to start and complete
         await collector.waitForEvent("stream-start", 5000);
@@ -313,17 +301,19 @@ describeIntegration("Queued messages", () => {
 
         // Queue multiple messages, waiting for each queued-message-changed event
         await sendMessage(env, workspaceId, "Message 1");
-        await waitForQueuedMessageEvent(collector1);
+        await waitForQueuedMessageEvent(collector1, (e) => e.queuedMessages.includes("Message 1"));
 
         await sendMessage(env, workspaceId, "Message 2");
-        await waitForQueuedMessageEvent(collector1);
+        await waitForQueuedMessageEvent(collector1, (e) => e.queuedMessages.includes("Message 2"));
 
         await sendMessage(env, workspaceId, "Message 3");
-        await waitForQueuedMessageEvent(collector1);
 
-        // Verify all messages queued (check current state, don't wait for new event)
-        const queued = await getQueuedMessages(collector1, { wait: false });
-        expect(queued).toEqual(["Message 1", "Message 2", "Message 3"]);
+        // Verify all messages queued
+        const allQueued = await waitForQueuedMessageEvent(
+          collector1,
+          (e) => e.queuedMessages.length === 3
+        );
+        expect(allQueued?.queuedMessages).toEqual(["Message 1", "Message 2", "Message 3"]);
 
         // Wait for first stream to complete (this triggers auto-send)
         await collector1.waitForEvent("stream-end", 15000);
@@ -367,7 +357,9 @@ describeIntegration("Queued messages", () => {
         });
 
         // Verify queued with image
-        const queuedEvent = await waitForQueuedMessageEvent(collector1);
+        const queuedEvent = await waitForQueuedMessageEvent(collector1, (e) =>
+          e.queuedMessages.includes("Describe this image")
+        );
         expect(queuedEvent?.queuedMessages).toEqual(["Describe this image"]);
         expect(queuedEvent?.fileParts).toHaveLength(1);
         expect(queuedEvent?.fileParts?.[0]).toMatchObject(TEST_IMAGES.RED_PIXEL);
@@ -376,7 +368,7 @@ describeIntegration("Queued messages", () => {
         await collector1.waitForEvent("stream-end", 15000);
 
         // Wait for queue to be cleared
-        const clearEvent = await waitForQueuedMessageEvent(collector1, 5000);
+        const clearEvent = await waitForQueueDrained(collector1, 5000);
         expect(clearEvent?.queuedMessages).toEqual([]);
 
         // Wait for auto-send stream to start and complete
@@ -384,8 +376,7 @@ describeIntegration("Queued messages", () => {
         await collector1.waitForEvent("stream-end", 15000);
 
         // Verify queue is still empty
-        const queuedAfter = await getQueuedMessages(collector1, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector1)).toEqual([]);
         collector1.stop();
       } finally {
         await cleanup();
@@ -418,7 +409,10 @@ describeIntegration("Queued messages", () => {
         });
 
         // Verify queued (no text messages, but has image)
-        const queuedEvent = await waitForQueuedMessageEvent(collector1);
+        const queuedEvent = await waitForQueuedMessageEvent(
+          collector1,
+          (e) => (e.fileParts ?? []).length > 0
+        );
         expect(queuedEvent?.queuedMessages).toEqual([]);
         expect(queuedEvent?.displayText).toBe("");
         expect(queuedEvent?.fileParts).toHaveLength(1);
@@ -431,9 +425,7 @@ describeIntegration("Queued messages", () => {
         await collector1.waitForEvent("stream-end", 15000);
 
         // Verify queue was cleared after auto-send
-        // Use wait: false since the queue-clearing event already happened
-        const queuedAfter = await getQueuedMessages(collector1, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector1)).toEqual([]);
         collector1.stop();
       } finally {
         await cleanup();
@@ -517,14 +509,17 @@ describeIntegration("Queued messages", () => {
         });
 
         // Wait for queued-message-changed event
-        const queuedEvent = await waitForQueuedMessageEvent(collector1);
-        expect(queuedEvent?.displayText).toBe("/compact -t 3000");
+        const queuedEvent = await waitForQueuedMessageEvent(
+          collector1,
+          (e) => e.displayText === "/compact -t 3000"
+        );
+        expect(queuedEvent).not.toBeNull();
 
         // Wait for first stream to complete (this triggers auto-send)
         await collector1.waitForEvent("stream-end", 15000);
 
         // Wait for queue to be cleared
-        const clearEvent = await waitForQueuedMessageEvent(collector1, 5000);
+        const clearEvent = await waitForQueueDrained(collector1, 5000);
         expect(clearEvent?.queuedMessages).toEqual([]);
 
         // Wait for auto-send stream to start and complete
@@ -532,8 +527,7 @@ describeIntegration("Queued messages", () => {
         await collector1.waitForEvent("stream-end", 15000);
 
         // Verify queue is still empty
-        const queuedAfter = await getQueuedMessages(collector1, { wait: false });
-        expect(queuedAfter).toEqual([]);
+        expect(getQueuedMessages(collector1)).toEqual([]);
         collector1.stop();
       } finally {
         await cleanup();

--- a/vscode/src/api/client.ts
+++ b/vscode/src/api/client.ts
@@ -30,20 +30,20 @@ export function createApiClient(config: ApiClientConfig): ApiClient {
 
   const normalizedBaseUrl = normalizeBaseUrl(config.baseUrl);
 
+  // oRPC >=1.14 splits the request URL into `origin` + path-only `url`, and the
+  // fetch override now receives (url, init) instead of a Request object.
   const link = new RPCLink({
-    url: `${normalizedBaseUrl}/orpc`,
-    async fetch(request, init) {
-      const headers = new Headers(request.headers);
+    origin: normalizedBaseUrl,
+    url: "/orpc",
+    async fetch(url, init) {
+      const headers = new Headers(init.headers);
       if (config.authToken) {
         headers.set("Authorization", `Bearer ${config.authToken}`);
       }
 
-      return fetch(request.url, {
-        body: await request.blob(),
-        headers,
-        method: request.method,
-        signal: request.signal,
+      return fetch(url, {
         ...init,
+        headers,
       });
     },
   });


### PR DESCRIPTION
## Summary

Spike evaluating progressive [Effect](https://effect.website/) adoption anchored on the oRPC layer, plus the dependency upgrades it forces. The Effect ↔ oRPC bridge (`@orpc/experimental-effect`) is wired into `ORPCContext`, one real leaf service (`MemoryMetaService`) and one real procedure chain (`memory.setPinned`) are converted to `Effect.gen`, and a validation namespace (`effectSpike.*`) proves typed error propagation, Effect Schema inputs, and abort-driven cancellation with exactly-once scope finalizers. Full findings + phased adoption plan: `rfc/20260831_effect-orpc-spike.md`.

> [!WARNING]
> **Spike caveat, per the RFC's own recommendation:** this PR adds `effect@4.0.0-rc.112` (a pre-stable RC) as a production dependency and carries a local `trpc-cli` compatibility patch (no released trpc-cli supports oRPC 1.14). Merging adopts those risks on main; the conservative alternative is to land the oRPC 1.14 migration alone and hold the Effect bridge until v4 stabilizes. Merge-on-green was explicitly requested by @ThomasK33.

## Background

We want typed error channels, structured concurrency (cancellation + resource scoping), and dependency-injected services for backend code. oRPC ships an official-but-experimental Effect integration; this spike answers whether it fits xum's existing router/context architecture and what incremental adoption would look like. Findings validated by tests in `src/node/orpc/effectSpike.test.ts`.

## Dependency upgrades

| Change                                                        | Why                                                                                                                                                                                                                                              |
| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `@orpc/{client,server,openapi,zod}` `^1.11/^1.12` → `1.14.11` | `@orpc/experimental-effect` exact-pins its oRPC deps at 1.14.11; mixed versions ship duplicate classes and break `instanceof ORPCError`                                                                                                          |
| `@orpc/experimental-effect@1.14.11` (new)                     | The Effect bridge under evaluation (~40-line runtime; `handlerGen`, `WithEffectContext`, `toStandardSchema`)                                                                                                                                     |
| `effect@4.0.0-rc.112` (new)                                   | Peer requirement of the bridge (`>=4.0.0-beta.90`); v3 stable is not supported                                                                                                                                                                   |
| `patches/trpc-cli@0.12.1.patch` (new)                         | oRPC 1.14 removed `isProcedure`/`traverseContractProcedures`, which every released trpc-cli uses — `xum api` would crash at startup. Patch adds a local router walk, duck-typed procedure detection, and 1.14 def-shape shims (`inputSchemas[]`) |

oRPC 1.12→1.14 app migration included: `@orpc/server/ws`→`/websocket`, `@orpc/zod/zod4`→`@orpc/zod`, client fetch links split `url` into `origin` + path-only `url`, websocket links take `connect: () => ws`, `OpenAPIGenerator` `converters`/`base` options, `ValidationError.invalidData`, removed `ORPCError.status` (now derived from `COMMON_ERROR_STATUS_MAP`), `instanceof Procedure`, and `createAuthMiddleware` collapsed to a single typed middleware (1.14 `.use()` rejects unions of differently-typed middlewares).

## Implementation

- **Bridge wiring:** `ORPCContext extends WithEffectContext<OrpcEffectServices>`; `ServiceContainer.toORPCContext()` pre-builds the Effect service `Context` under `"effect/context"` (`src/node/orpc/effectContext.ts`). Handlers opt in per-procedure via `handlerGen` (no global `Builder.prototype` patching); async handlers coexist untouched.
- **Leaf-service conversion pattern:** `MemoryMetaService` internals are `Effect.gen` with an Effect `Semaphore` write lock (interruption-safe) and a `Schema.TaggedError` (`MemoryMetaWriteError`) failure channel — behind an unchanged Promise facade, so all pre-existing callers and tests work unmodified.
- **Real procedure conversion:** `memory.setPinned` → `setMemoryPinnedEffect` (Effect.gen; `Effect.result`/`Effect.try` replace try/catch; typed write failures map into the existing `ResultSchema` string error). Wire contract unchanged.
- **Validation namespace `effectSpike.*`:** service injection via Effect context, Effect Schema input (`toStandardSchema`) coexisting with Zod outputs, `Schema.TaggedError` → **defined** oRPC error (`.errors()` map + `catchTag`, no untyped catch), scoped hold with acquire/release probe, and an async-vs-effect echo pair for overhead measurement (~3.4µs/call Effect overhead).

## Validation

- 7 new spike tests prove the headline claims: typed error round-trip with `defined: true` + schema-validated `data`; client abort interrupts the handler fiber promptly with the release finalizer running exactly once; Effect Schema inputs reject bad payloads as `BAD_REQUEST`.
- Existing suites green after both the 1.14 migration and the Effect conversion: `src/node/orpc/*` (62), `memoryMeta`/`memoryOperations`, `cli.test.ts`/`server.test.ts` (31, exercising the patched trpc-cli end-to-end) — 125 pass / 3 skip / 0 fail.
- `make typecheck` green on both tsconfigs; ESLint + prettier clean on touched files.
- **`tests/ipc/streaming/queuedMessages.test.ts` determinism fix (CI `Test / Integration`):** oRPC 1.14's in-process iterator delivers `queued-message-changed` before the `sendMessage` promise resolves, so the suite's count-snapshot helper (`wait for the next NEW event`) already contained the queued event and observed the later drain `[]` instead — failing all 8 tests deterministically on this branch (confirmed via event-history dump: `[[], ["Say 'SECOND'..."], []]`). Replaced count-snapshot waits with predicate-based history scans (queued assertions) and latest-state convergence (drain waits). 2× 8/8 green locally against the live API. Supersedes the #4023 triage — that issue's "fails on unmodified main" local repro was contaminated by a provider-auth env issue.

## Risks

- **Effect v4 RC churn (medium):** APIs may shift before v4 stable; confined to `MemoryMetaService`, `memory.setPinned`, and the spike namespace — all revertible without wire-contract changes.
- **oRPC 1.14 behavioral surface (medium):** the upgrade touches every RPC link (HTTP/WS, browser/CLI/ACP) and the OpenAPI generator. Covered by existing server/CLI/analytics tests, but transport edge cases (proxy prefixes, WS reconnects) get their real soak only in use.
- **trpc-cli patch (low):** local patch must be maintained until upstream supports oRPC 1.14; `cli.test.ts` covers the patched paths.
- **`memory.setPinned` failure mode change (low, intentional):** sidecar write failures now return `{success:false, error}` instead of an untyped `INTERNAL_SERVER_ERROR` rejection.

---

<details>
<summary>📋 Spike findings RFC (rfc/20260831_effect-orpc-spike.md)</summary>

---

author: @mux
date: 2026-08-31

---

# Spike Findings: Progressive Effect Migration via oRPC Integration

Status: Spike report (branch `effect-orpc-spike`, not intended to merge as-is)

## Objective

Evaluate a progressive migration of xum's backend to [Effect](https://effect.website/),
anchored on the existing oRPC layer:

1. Wire `@orpc/experimental-effect` into the oRPC context/router.
2. Convert a representative leaf, I/O-heavy service and its procedures to `Effect.gen`.
3. Validate `Schema.TaggedError` → typed oRPC error propagation without untyped catch blocks.
4. Evaluate resource scoping (`Scope`/finalizers) and cancellation for long-lived operations.
5. Recommend an incremental adoption architecture.

Everything below was validated by code in this branch (`src/node/orpc/effectSpike.ts`,
`src/node/orpc/effectSpike.test.ts`, converted `MemoryMetaService`/`setMemoryPinned`),
with all affected suites green: 128 tests across oRPC/memory/CLI files plus 7 new spike tests.

## TL;DR

- **The integration works and is remarkably small.** `@orpc/experimental-effect` is a
  ~40-line runtime bridge: handlers become generators that `yield*` Effects, services are
  injected via a pre-built `Context` on the oRPC context, `AbortSignal` maps to fiber
  interruption, and `ORPCError` instances in the failure channel become _typed, defined_
  oRPC errors. Typed error propagation, scoped finalizers under client aborts, and Effect
  Schema inputs all behave exactly as advertised.
- **The version prerequisites are the real cost.** The official package requires
  **Effect v4 (currently RC)** and pins **oRPC 1.14.x** exactly. Migrating xum from oRPC
  1.12→1.14 was bounded (~12 files, this branch did it) but breaks `trpc-cli`'s oRPC
  support (fixed here with a bun patch). Effect v4 RC is pre-stable.
- **Overhead is negligible for xum's workloads:** ~3–4µs per call added by the Effect
  runtime on a no-op procedure (in-process router client, Bun; 8.8µs/call async vs
  12.2µs/call Effect). Any real I/O dwarfs this.
- **Recommendation: adopt in narrow slices, gated on Effect v4 stable.** The
  service-internal conversion pattern (Effect core + thin Promise facade) is immediately
  usable and low-risk; the oRPC bridge layer is a one-file change once versions align. If
  we want to start before v4 stabilizes, a hand-rolled `handlerGen` (the bridge is ~40
  lines, MIT) against stable Effect 3.x is a viable interim path.

## What was built

### 1. Bridge wiring (objective 1)

- `ORPCContext` now `extends WithEffectContext<OrpcEffectServices>`: one well-known key,
  `"effect/context"`, carrying a pre-built `Context.Context` of Effect services
  (`src/node/orpc/effectContext.ts`, built in `ServiceContainer.toORPCContext()`).
- Handlers use `handlerGen` directly (`.handler(handlerGen(function* ({ context, errors, signal }, input) { ... }))`).
  The `.effect()` builder sugar exists but requires a side-effect import that patches
  `Builder.prototype` globally; `handlerGen` has zero global footprint and was preferred.
- The optional `"effect/wrap"` hook wraps every Effect handler per request with
  `{ path, procedure, signal }` — the natural future seam for tracing/metrics
  (`@effect/opentelemetry`) without touching individual handlers.

### 2. Leaf service conversion (objective 2)

`MemoryMetaService` (host-local JSON sidecar; pure disk I/O, one write lock) was converted:

- Internals are `Effect.gen`; the promise `MutexMap` became an Effect `Semaphore`, so lock
  acquisition participates in interruption (a fiber cancelled while waiting never runs its
  critical section — a real correctness upgrade over the promise mutex).
- The public API is preserved by a **thin Promise facade** (`Effect.runPromise` per method)
  plus a new Effect-native `effects` surface for migrated callers. All 12 pre-existing
  service tests pass unchanged — the facade pattern demonstrably de-risks conversion.
- One real procedure chain was converted end-to-end: `memory.setPinned` →
  `setMemoryPinnedEffect` (Effect.gen with `Effect.result`/`Effect.try` replacing try/catch)
  → `handlerGen` in the router. The zod wire contract is untouched.

### 3. Typed errors (objective 3)

`MemoryMetaWriteError` is a `Schema.TaggedError` — simultaneously an `Error` subclass, a
schema, a tagged-union member, and yieldable. The spike procedure declares
`.errors({ MEMORY_META_WRITE_FAILED: { data: z.object({ metaPath, reason }) } })` and maps:

```ts
yield *
  memoryMeta.effects
    .setPinned(key, pinned)
    .pipe(
      Effect.catchTag("MemoryMetaWriteError", (e) =>
        Effect.fail(
          errors.MEMORY_META_WRITE_FAILED({
            data: { metaPath: e.metaPath, reason: e.reason },
          }),
        ),
      ),
    );
```

Validated: the client receives `ORPCError` with `code: "MEMORY_META_WRITE_FAILED"`,
`defined: true`, and schema-validated `data`. No untyped catch anywhere on the path — the
failure is typed from `writeFileAtomic` all the way to the wire.

**Caveat found:** the bridge's types do _not_ force exhaustive error handling. Yielded
effects may carry any `E`; only `ORPCError` members become typed returns, and everything
else silently remains a runtime throw (squashed cause), exactly like today's untyped
rejections. Exhaustiveness is opt-in: teams must adopt a convention (or a lint) that
handler-yielded effects satisfy `E extends AnyORPCError | never`. Worth building a tiny
`yieldStrict` helper or ESLint rule during real adoption.

### 4. Scoping + cancellation (objective 4)

`effectSpike.scopedHold` acquires a resource with `Effect.acquireRelease` inside
`Effect.scoped` and sleeps. Validated by test:

- Client `AbortController.abort()` interrupts the fiber **promptly** (60s hold aborted in
  <5s wall including test overhead; actual interruption is immediate).
- The release finalizer runs **exactly once**, both on abort and on normal completion.
- The bridge maps interruption back to the abort reason (`options.signal.reason`), so oRPC
  reports the abort exactly like an async handler would.

This is the headline win for xum: today's long-lived operations thread `AbortSignal`
manually through every layer (e.g. `cloneWithProgress(input, signal)`) and clean up in
ad-hoc try/finally. Structured concurrency makes "cancellation propagates + resources
release" the default instead of a per-call discipline. Prime future candidates:
`routerSubscriptions.ts` teardown, process spawns, MCP server lifecycles, stream managers.

### 5. Performance & ergonomics (objective 5)

- Micro-benchmark (in-process router client, 2k sequential calls each, warmed):
  no-op async handler ≈ **8.8µs/call**; identical `handlerGen` handler ≈ **12.2µs/call**;
  Effect runtime overhead ≈ **3.4µs/call**. Noise-level for anything touching disk,
  network, or an LLM.
- Ergonomics that worked well: `yield*` reads like `await`; service tags double as
  Effects (`const svc = yield* MemoryMeta`); `catchTag` gives compiler-checked error
  narrowing; existing zod schemas coexist with Effect Schema inputs per-procedure
  (`toStandardSchema`), so there is no forced schema migration.
- Frictions: `this` is not available inside `Effect.gen` generators (self-alias needed,
  plus an eslint-disable for `no-this-alias`); sync throws inside generators become
  defects rather than typed failures (fine for `ORPCError` gates like
  `assertMemoryEnabled`, but a subtle trap); `require-yield` lint fires on yield-free
  generator handlers; Effect v4 renames significant v3 API (`Effect.catch`,
  `Context.Service`, `Semaphore.make*`, `Effect.result`/`Result`), so most public
  Effect v3 documentation and LLM training data does not directly apply.

## Version compatibility findings (the hard constraints)

| Constraint                       | Detail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `@orpc/experimental-effect` peer | `effect >= 4.0.0-beta.90` — **Effect v4 only** (v4 is at RC today; v3 stable is not supported)                                                                                                                                                                                                                                                                                                                                                                                                           |
| `@orpc/experimental-effect` deps | Exact-pinned `@orpc/{server,shared,contract,json-schema}@1.14.11` — repo must move to oRPC 1.14 in lockstep or ship duplicate oRPC copies (breaks `instanceof ORPCError` and prototype patches; bun kept stale nested copies until a forced reinstall)                                                                                                                                                                                                                                                   |
| oRPC 1.12→1.14 breaks            | `@orpc/server/ws`→`/websocket`; `@orpc/zod/zod4`→`@orpc/zod`; client links split `url` into `origin` + path-only `url`; websocket links take `connect: () => ws`; `OpenAPIGenerator` options (`converters`, `base`); `ValidationError.data`→`invalidData`; `ORPCError.status` removed; `isProcedure`/`traverseContractProcedures` removed (use `instanceof Procedure`); procedure defs store `inputSchemas[]` + `orderedMiddlewares`; `.use()` no longer accepts unions of differently-typed middlewares |
| Ecosystem fallout                | **No released `trpc-cli` (≤0.16.0) supports oRPC 1.14** — `xum api` would crash at startup. This branch carries a bun patch (`patches/trpc-cli@0.12.1.patch`: local router traversal + duck-typed `isProcedure` + def-shape shims). Upstreaming or replacing trpc-cli is a prerequisite for a real upgrade.                                                                                                                                                                                              |
| Package maturity                 | The `experimental-` prefix is explicit; v1 line exists (1.14.11) plus 2.0.0 betas tracking oRPC v2. API surface is tiny, so forking/vendoring is a realistic escape hatch.                                                                                                                                                                                                                                                                                                                               |

## Recommended incremental adoption architecture

Phased, each phase independently shippable and reversible:

**Phase 0 — prerequisites (before any Effect code ships):**
oRPC 1.14 upgrade as its own PR (this branch's first commit is that migration, validated);
resolve trpc-cli (upstream a 1.14-compat PR, keep the bun patch, or replace with a thin
custom CLI walker — we already own `proxifyOrpc`). Hold production Effect adoption until
Effect v4 stable unless we vendor a v3-compatible `handlerGen` (~40 lines).

**Phase 1 — services adopt Effect internally (no oRPC coupling, can start anytime):**
convert leaf, I/O-heavy services with the pattern proven here — Effect-native `effects`
surface + Promise facade, existing tests untouched. Best next candidates:
`HistoryService` (locks + atomic writes + self-healing reads), config stores,
`workspaceFileLocks` users. Each conversion upgrades error typing and interruption safety
without any caller changes.

**Phase 2 — bridge layer on (one-file switch):**
`ORPCContext extends WithEffectContext<...>` + `ServiceContainer` builds the service
`Context` (done in this branch). New/converted procedures use `handlerGen`; the rest stay
async. Both styles coexist indefinitely — this is the core progressive-migration property.

**Phase 3 — typed errors at the wire:**
migrate high-value procedures from `ResultSchema({success:false,error:string})` toward
`.errors()` maps fed by `Schema.TaggedError` (`isDefinedError` gives clients typed
narrowing). Do this per-procedure; frontend consumes `error.defined`/`error.data`.
Adopt an exhaustiveness convention/lint for handler `E` channels (see caveat above).

**Phase 4 — structured concurrency for long-lived ops:**
move subscriptions (`routerSubscriptions.ts`), process spawns, and stream lifecycles onto
`Scope`/`acquireRelease`, replacing manual `AbortSignal` threading. Add an
`"effect/wrap"` hook for tracing/metrics across all Effect handlers.

**Non-goals for now:** full `Layer`-based dependency graph (ServiceContainer already does
this job; revisit only if service construction becomes Effect-native), Effect on the
renderer/browser side, and Effect Schema replacing zod wholesale (coexistence works).

## Key risks

1. **Effect v4 RC churn** — APIs may still shift before stable; don't merge v4 to main yet.
2. **Two mental models during migration** — mitigated by the facade pattern (callers never
   see Effect until their own conversion) and by keeping `handlerGen` opt-in per procedure.
3. **Untyped-failure escape hatch** — the bridge tolerates non-ORPCError failures silently
   (runtime throw); needs a lint/convention to realize the "no untyped errors" promise.
4. **Ecosystem lag on oRPC 1.14** (trpc-cli today; audit other oRPC-adjacent deps before
   upgrading main).

## Validation record

- `make typecheck` green (both tsconfigs).
- `bun test src/node/orpc/ src/node/services/memoryMeta.test.ts src/node/services/memoryOperations.test.ts src/cli/cli.test.ts src/cli/server.test.ts` → 125 pass / 3 skip / 0 fail.
- `bun test src/node/orpc/effectSpike.test.ts` → 7/7: service injection, Effect Schema
  validation, typed error round-trip (success + failure with `defined:true` + data),
  abort-interruption with exactly-once finalizers, normal-completion finalizers, benchmark.
- ESLint clean on all touched files.

</details>

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$35.81`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=35.81 -->
