### PR TITLE
🤖 refactor: convert memory operations to Effect internals behind Promise facades

### DIFF
--- a/src/node/orpc/context.ts
+++ b/src/node/orpc/context.ts
@@ -63,8 +63,8 @@ import type { WithEffectContext } from "@orpc/experimental-effect";
 import type { OrpcEffectServices } from "@/node/orpc/effectContext";
 
 /**
- * Effect-migration spike: `WithEffectContext` adds the `"effect/context"` key
- * carrying the Effect services available to Effect-native handlers (built via
+ * `WithEffectContext` adds the `"effect/context"` key carrying the Effect
+ * services available to Effect-native handlers (built via
  * `buildOrpcEffectContext` in the service container).
  */
 export interface ORPCContext extends WithEffectContext<OrpcEffectServices> {

--- a/src/node/orpc/effectBridge.test.ts
+++ b/src/node/orpc/effectBridge.test.ts
@@ -1,5 +1,5 @@
 /**
- * Validates the Effect ↔ oRPC bridge end-to-end (see effectSpike.ts):
+ * Validates the Effect ↔ oRPC bridge end-to-end (see effectBridge.ts):
  * service injection through "effect/context", Effect Schema input validation,
  * Schema.TaggedError → defined oRPC error propagation, abort-driven fiber
  * interruption with scope finalizers, and router-level auth middleware
@@ -10,7 +10,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { ORPCError, createRouterClient, os as orpcBase } from "@orpc/server";
-import { effectSpike, scopeProbe } from "./effectSpike";
+import { effectBridge, scopeProbe } from "./effectBridge";
 import { buildOrpcEffectContext } from "./effectContext";
 import { createAuthMiddleware } from "./authMiddleware";
 import { createOpenAPIGenerator } from "./server";
@@ -22,7 +22,7 @@ let memoryMetaService: MemoryMetaService;
 let client: ReturnType<typeof createClient>;
 
 function makeContext(service: MemoryMetaService): ORPCContext {
-  // Spike procedures only consume Effect services; the remaining ~60 context
+  // Bridge probe procedures only consume Effect services; the remaining ~60 context
   // fields are irrelevant here (same partial-context pattern as router.test.ts).
   return {
     "effect/context": buildOrpcEffectContext({ memoryMetaService: service }),
@@ -30,7 +30,7 @@ function makeContext(service: MemoryMetaService): ORPCContext {
 }
 
 function createClient(service: MemoryMetaService) {
-  return createRouterClient(effectSpike, { context: makeContext(service) });
+  return createRouterClient(effectBridge, { context: makeContext(service) });
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
@@ -42,7 +42,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
 }
 
 beforeEach(async () => {
-  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "effect-spike-"));
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "effect-bridge-"));
   memoryMetaService = new MemoryMetaService(tmpDir);
   client = createClient(memoryMetaService);
   scopeProbe.reset();
@@ -135,19 +135,19 @@ describe("cancellation + resource scoping", () => {
 
 describe("router-level middleware over Effect handlers", () => {
   test("auth middleware applies to handlerGen procedures mounted under it", async () => {
-    // The spike namespace is deliberately NOT part of the production router
+    // The effectBridge namespace is deliberately NOT part of the production router
     // (codex review on #4022); compose it the same way router() composes its
     // procedures to prove middleware still wraps Effect handlers.
     const authedRouter = orpcBase
       .$context<ORPCContext>()
       .use(createAuthMiddleware("secret-token"))
-      .router({ effectSpike });
+      .router({ effectBridge });
     const unauthedClient = createRouterClient(authedRouter, {
       context: { headers: {} } as unknown as ORPCContext,
     });
 
     try {
-      await unauthedClient.effectSpike.echoAsync({ n: 1 });
+      await unauthedClient.effectBridge.echoAsync({ n: 1 });
       expect.unreachable();
     } catch (error) {
       expect(error).toBeInstanceOf(ORPCError);
@@ -162,14 +162,14 @@ describe("OpenAPI generation for Effect Schema inputs", () => {
     // the generator silently drops the requestBody for Effect Schema inputs,
     // shipping a lossy spec (fields missing from /api/docs and generated clients).
     const spec = await createOpenAPIGenerator().generate(
-      orpcBase.$context<ORPCContext>().router({ effectSpike }),
-      { base: { info: { title: "spike", version: "0" } } }
+      orpcBase.$context<ORPCContext>().router({ effectBridge }),
+      { base: { info: { title: "effect-bridge", version: "0" } } }
     );
     const paths = (spec.paths ?? {}) as Record<
       string,
       { post?: { requestBody?: { content?: Record<string, unknown> } } }
     >;
-    const operation = paths["/effectSpike/pinnedCount"]?.post;
+    const operation = paths["/effectBridge/pinnedCount"]?.post;
     expect(operation).toBeDefined();
     const requestSchema = JSON.stringify(operation?.requestBody?.content ?? {});
     expect(requestSchema).toContain('"prefix"');
@@ -194,9 +194,9 @@ describe("benchmark: async handler vs Effect handler (informational)", () => {
     for (let i = 0; i < iterations; i++) await client.echoEffect({ n: i });
     const effectMs = performance.now() - effectStart;
 
-    // Informational output consumed by the spike findings doc.
+    // Informational output: tracks Effect runtime per-call overhead over time.
     console.log(
-      `[effect-spike bench] ${iterations} sequential calls — ` +
+      `[effect-bridge bench] ${iterations} sequential calls — ` +
         `async: ${asyncMs.toFixed(1)}ms (${((asyncMs / iterations) * 1000).toFixed(1)}µs/call), ` +
         `effect: ${effectMs.toFixed(1)}ms (${((effectMs / iterations) * 1000).toFixed(1)}µs/call), ` +
         `overhead: ${(((effectMs - asyncMs) / iterations) * 1000).toFixed(1)}µs/call`

--- a/src/node/orpc/effectBridge.ts
+++ b/src/node/orpc/effectBridge.ts
@@ -1,8 +1,10 @@
 /**
- * Effect-migration spike procedures (`effectSpike.*` namespace).
+ * Effect ↔ oRPC bridge regression procedures (`effectBridge.*` namespace).
  *
- * These procedures exist to validate the `@orpc/experimental-effect` bridge
- * end-to-end and are exercised by effectSpike.test.ts:
+ * Production handlers (router.ts `memory.*`) ride the
+ * `@orpc/experimental-effect` bridge; these probe procedures pin down the
+ * bridge behaviors those handlers rely on, and are exercised only by
+ * effectBridge.test.ts (never mounted on the production router):
  *
  * - `pinnedCount`: Effect service injection via the oRPC context's
  *   `"effect/context"` key + an Effect `Schema` input schema coexisting with
@@ -40,7 +42,7 @@ export const scopeProbe = {
   },
 };
 
-export const effectSpike = {
+export const effectBridge = {
   /** Count pinned memory keys matching a prefix (service via Effect context). */
   pinnedCount: t
     .input(toStandardSchema(Schema.Struct({ prefix: Schema.String })))

--- a/src/node/orpc/effectContext.ts
+++ b/src/node/orpc/effectContext.ts
@@ -1,6 +1,6 @@
 /**
- * Effect-migration spike: bridges xum services into the Effect runtime for
- * oRPC handlers written with `@orpc/experimental-effect`.
+ * Bridges xum services into the Effect runtime for oRPC handlers written
+ * with `@orpc/experimental-effect`.
  *
  * `ORPCContext` carries a pre-built `Context.Context` under the well-known
  * `"effect/context"` key (see `WithEffectContext`). `handlerGen` provides it to

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -11,12 +11,12 @@ import {
 import { handlerGen } from "@orpc/experimental-effect";
 import {
   assertMemoryEnabled,
-  consolidateMemory,
-  deleteMemory,
-  getMemoryConsolidationStatus,
-  listMemory,
-  readMemory,
-  saveMemory,
+  consolidateMemoryEffect,
+  deleteMemoryEffect,
+  getMemoryConsolidationStatusEffect,
+  listMemoryEffect,
+  readMemoryEffect,
+  saveMemoryEffect,
   setMemoryPinnedEffect,
 } from "@/node/services/memoryOperations";
 import {
@@ -1134,25 +1134,41 @@ export const router = (authToken?: string) => {
         .output(schemas.coder.listWorkspaces.output)
         .handler(async ({ context }) => context.coderService.listWorkspaces()),
     },
+    // Memory handlers run Effect generators via handlerGen (client aborts
+    // interrupt the fiber); the wire contracts are unchanged.
     memory: {
       list: t
         .input(schemas.memory.list.input)
         .output(schemas.memory.list.output)
-        .handler(({ context, input }) => listMemory(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* listMemoryEffect(context, input);
+          })
+        ),
       read: t
         .input(schemas.memory.read.input)
         .output(schemas.memory.read.output)
-        .handler(({ context, input }) => readMemory(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* readMemoryEffect(context, input);
+          })
+        ),
       save: t
         .input(schemas.memory.save.input)
         .output(schemas.memory.save.output)
-        .handler(({ context, input }) => saveMemory(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* saveMemoryEffect(context, input);
+          })
+        ),
       delete: t
         .input(schemas.memory.delete.input)
         .output(schemas.memory.delete.output)
-        .handler(({ context, input }) => deleteMemory(context, input)),
-      // Effect-migration spike: this handler runs an Effect generator via
-      // handlerGen; the wire contract is unchanged.
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* deleteMemoryEffect(context, input);
+          })
+        ),
       setPinned: t
         .input(schemas.memory.setPinned.input)
         .output(schemas.memory.setPinned.output)
@@ -1164,11 +1180,22 @@ export const router = (authToken?: string) => {
       consolidationStatus: t
         .input(schemas.memory.consolidationStatus.input)
         .output(schemas.memory.consolidationStatus.output)
-        .handler(({ context, input }) => getMemoryConsolidationStatus(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* getMemoryConsolidationStatusEffect(context, input);
+          })
+        ),
       consolidate: t
         .input(schemas.memory.consolidate.input)
         .output(schemas.memory.consolidate.output)
-        .handler(({ context, input }) => consolidateMemory(context, input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            return yield* consolidateMemoryEffect(context, input);
+          })
+        ),
+      // Subscription, not a unary call: the handler returns an event iterator,
+      // which handlerGen cannot produce. Streams stay Promise/AsyncGenerator
+      // until an Effect Stream bridge exists (later migration phase).
       onChange: t
         .input(schemas.memory.onChange.input)
         .output(schemas.memory.onChange.output)

--- a/src/node/orpc/server.ts
+++ b/src/node/orpc/server.ts
@@ -19,8 +19,8 @@ import { ZodToJsonSchemaConverter } from "@orpc/zod";
 import { EffectSchemaToJsonSchemaConverter } from "@orpc/experimental-effect";
 
 /**
- * Effect-migration spike: Effect Schema inputs need their own JSON-schema
- * converter; without it the generator silently emits operations with no
+ * Effect Schema inputs need their own JSON-schema converter alongside Zod's;
+ * without it the generator silently emits operations with no
  * requestBody, producing a lossy /api/spec.json. Exported so tests can verify
  * the production converter set against Effect Schema procedures.
  */

--- a/src/node/services/memoryMeta.ts
+++ b/src/node/services/memoryMeta.ts
@@ -124,9 +124,9 @@ function sanitizeMetaFile(raw: unknown): MemoryMetaFile {
  * conflicts). Reads never fail — malformed or missing data self-heals to
  * empty — so writes are the only failure channel this service exposes.
  *
- * Effect-migration spike: `Schema.TaggedError` gives us an `Error` subclass
- * that is simultaneously a schema (usable in oRPC error payloads), a tagged
- * union member (usable with `Effect.catchTag`), and yieldable in `Effect.gen`.
+ * `Schema.TaggedError` gives us an `Error` subclass that is simultaneously a
+ * schema (usable in oRPC error payloads), a tagged union member (usable with
+ * `Effect.catchTag`), and yieldable in `Effect.gen`.
  */
 export class MemoryMetaWriteError extends Schema.TaggedError<MemoryMetaWriteError>()(
   "MemoryMetaWriteError",
@@ -140,19 +140,19 @@ export class MemoryMetaService {
   private readonly metaPath: string;
   /**
    * Serializes read-modify-write cycles against the (single) sidecar file.
-   * Effect-migration spike: an Effect `Semaphore` replaces the promise-based
-   * MutexMap so lock acquisition participates in interruption — a fiber
-   * cancelled while waiting for the permit never runs its critical section.
+   * An Effect `Semaphore` rather than a promise-based mutex so lock
+   * acquisition participates in interruption — a fiber cancelled while
+   * waiting for the permit never runs its critical section.
    */
   private readonly writeLock = Semaphore.makeUnsafe(1);
   private cache: MemoryMetaFile | null = null;
 
   /**
-   * Effect-native API (the migration target surface). The legacy Promise
-   * methods below are thin `Effect.runPromise` facades over these, so existing
-   * callers keep working unchanged while new Effect callers (oRPC `.effect`
-   * handlers, other migrated services) compose these directly and see typed
-   * errors in the `E` channel instead of untyped rejections.
+   * Effect-native API. The Promise methods below are thin `Effect.runPromise`
+   * facades over these, so pre-Effect callers keep working unchanged while
+   * Effect callers (oRPC `handlerGen` handlers, other migrated services)
+   * compose these directly and see typed errors in the `E` channel instead of
+   * untyped rejections.
    */
   readonly effects = {
     /** Logical keys of all pinned memory files. */
@@ -240,6 +240,12 @@ export class MemoryMetaService {
     this.metaPath = path.join(xumHome, "memory-meta.json");
   }
 
+  /**
+   * Load + cache the sidecar. The error channel is `never` by design, not an
+   * oversight: per the self-healing rule, a missing or unreadable sidecar must
+   * never brick memory routes, so read failures degrade to "no metadata"
+   * (logged for diagnosis) and only writes can fail.
+   */
   private load(): Effect.Effect<MemoryMetaFile> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;

--- a/src/node/services/memoryOperations.ts
+++ b/src/node/services/memoryOperations.ts
@@ -1,5 +1,18 @@
+/**
+ * Memory route operations (Memory tab + Settings → Memory).
+ *
+ * Internals are Effect-native: each operation is an `Effect.gen` pipeline
+ * (the `*Effect` exports) that the router runs via `handlerGen`; a thin
+ * `Effect.runPromise` facade keeps the Promise signatures for pre-Effect
+ * callers. Failures the client renders (workspace not found, scope
+ * unavailable, path errors) stay in the success channel as the wire
+ * `{ success: false }` unions. The Effect error channel carries only typed
+ * domain errors a caller can branch on (`MemoryWorkspaceNotFoundError`,
+ * `MemoryMetaWriteError`), and every operation handles them before the
+ * effect reaches the router, so the exported effects never fail.
+ */
 import { ORPCError } from "@orpc/server";
-import { Effect, Result } from "effect";
+import { Effect, Result, Schema } from "effect";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import type * as schemas from "@/common/orpc/schemas";
 import { getErrorMessage } from "@/common/utils/errors";
@@ -28,103 +41,160 @@ export function assertMemoryEnabled(context: MemoryContext): void {
   }
 }
 
-async function resolveMemoryScopeContext(
-  context: MemoryContext,
-  workspaceId: string | null | undefined
-): Promise<{ projectPath: string; scopeCtx: MemoryScopeContext } | null> {
-  if (workspaceId == null)
-    return {
-      projectPath: "",
-      scopeCtx: { runtime: null, checkoutCwd: "", workspaceId: "", projectPath: "" },
-    };
-  const metadata = await context.workspaceService.getInfo(workspaceId);
-  if (!metadata) return null;
-  const projectPath = resolveMemoryProjectIdentity(metadata);
-  return {
-    projectPath,
-    scopeCtx: {
-      runtime: createRuntimeForWorkspace(metadata),
-      checkoutCwd: "",
-      workspaceId,
-      projectPath,
-    },
-  };
-}
+/**
+ * Typed failure: the request named a workspaceId that no longer resolves to a
+ * live workspace. Operations branch on the tag to map it onto their route's
+ * `{ success: false }` union (plain string vs MemorySaveError shape).
+ */
+export class MemoryWorkspaceNotFoundError extends Schema.TaggedError<MemoryWorkspaceNotFoundError>()(
+  "MemoryWorkspaceNotFoundError",
+  { workspaceId: Schema.NullOr(Schema.String) }
+) {}
 
 function workspaceNotFound(workspaceId: string | null | undefined): string {
   return "Workspace not found: " + (workspaceId ?? "<none>");
 }
 
-export async function listMemory(context: MemoryContext, input: Input<typeof schemas.memory.list>) {
-  assertMemoryEnabled(context);
-  const resolved = await resolveMemoryScopeContext(context, input.workspaceId);
-  if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
-  const entries = await context.memoryService.listIndexEntries(resolved.scopeCtx);
-  const meta = await context.memoryMetaService.getEntries();
-  const ids = { projectPath: resolved.projectPath, workspaceId: input.workspaceId ?? "" };
-  return {
-    success: true as const,
-    data: {
-      files: entries.map((entry) => {
-        const stats = meta.get(memoryLogicalKey(entry.scope, entry.relPath, ids));
-        return {
-          path: entry.path,
-          scope: entry.scope,
-          description: entry.description,
-          pinned: stats?.pinned ?? false,
-          accessCount: stats?.accessCount ?? 0,
-          lastAccessedAt: stats?.lastAccessedAt ?? null,
-        };
-      }),
-    },
-  };
+interface ResolvedMemoryScope {
+  projectPath: string;
+  scopeCtx: MemoryScopeContext;
 }
 
-export async function readMemory(context: MemoryContext, input: Input<typeof schemas.memory.read>) {
-  assertMemoryEnabled(context);
-  const resolved = await resolveMemoryScopeContext(context, input.workspaceId);
-  if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
-  return context.memoryService.readFileWithSha(resolved.scopeCtx, input.path);
-}
-
-export async function saveMemory(context: MemoryContext, input: Input<typeof schemas.memory.save>) {
-  assertMemoryEnabled(context);
-  const resolved = await resolveMemoryScopeContext(context, input.workspaceId);
-  if (!resolved)
+/**
+ * Resolve the scope context that maps virtual /memories paths onto physical
+ * roots. A null/undefined workspaceId is the Settings → Memory case (global
+ * scope only), not an error; an unknown workspaceId is the typed failure.
+ */
+function resolveMemoryScope(
+  context: MemoryContext,
+  workspaceId: string | null | undefined
+): Effect.Effect<ResolvedMemoryScope, MemoryWorkspaceNotFoundError> {
+  return Effect.gen(function* () {
+    if (workspaceId == null)
+      return {
+        projectPath: "",
+        scopeCtx: { runtime: null, checkoutCwd: "", workspaceId: "", projectPath: "" },
+      };
+    const metadata = yield* Effect.promise(() => context.workspaceService.getInfo(workspaceId));
+    if (!metadata) return yield* Effect.fail(new MemoryWorkspaceNotFoundError({ workspaceId }));
+    const projectPath = resolveMemoryProjectIdentity(metadata);
     return {
-      success: false as const,
-      error: { kind: "error" as const, message: workspaceNotFound(input.workspaceId) },
+      projectPath,
+      scopeCtx: {
+        runtime: createRuntimeForWorkspace(metadata),
+        checkoutCwd: "",
+        workspaceId,
+        projectPath,
+      },
     };
-  return context.memoryService.saveFile(
-    resolved.scopeCtx,
-    input.path,
-    input.content,
-    input.expectedSha256,
-    "user"
+  });
+}
+
+/** Map the typed workspace failure onto the routes' plain string error union. */
+const workspaceNotFoundAsStringError = (error: MemoryWorkspaceNotFoundError) =>
+  Effect.succeed({ success: false as const, error: workspaceNotFound(error.workspaceId) });
+
+export function listMemoryEffect(context: MemoryContext, input: Input<typeof schemas.memory.list>) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const resolved = yield* resolveMemoryScope(context, input.workspaceId);
+    const entries = yield* Effect.promise(() =>
+      context.memoryService.listIndexEntries(resolved.scopeCtx)
+    );
+    const meta = yield* context.memoryMetaService.effects.getEntries();
+    const ids = { projectPath: resolved.projectPath, workspaceId: input.workspaceId ?? "" };
+    return {
+      success: true as const,
+      data: {
+        files: entries.map((entry) => {
+          const stats = meta.get(memoryLogicalKey(entry.scope, entry.relPath, ids));
+          return {
+            path: entry.path,
+            scope: entry.scope,
+            description: entry.description,
+            pinned: stats?.pinned ?? false,
+            accessCount: stats?.accessCount ?? 0,
+            lastAccessedAt: stats?.lastAccessedAt ?? null,
+          };
+        }),
+      },
+    };
+  }).pipe(Effect.catchTag("MemoryWorkspaceNotFoundError", workspaceNotFoundAsStringError));
+}
+
+/** Promise facade over {@link listMemoryEffect} for pre-Effect callers. */
+export async function listMemory(context: MemoryContext, input: Input<typeof schemas.memory.list>) {
+  return Effect.runPromise(listMemoryEffect(context, input));
+}
+
+export function readMemoryEffect(context: MemoryContext, input: Input<typeof schemas.memory.read>) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const resolved = yield* resolveMemoryScope(context, input.workspaceId);
+    return yield* Effect.promise(() =>
+      context.memoryService.readFileWithSha(resolved.scopeCtx, input.path)
+    );
+  }).pipe(Effect.catchTag("MemoryWorkspaceNotFoundError", workspaceNotFoundAsStringError));
+}
+
+/** Promise facade over {@link readMemoryEffect} for pre-Effect callers. */
+export async function readMemory(context: MemoryContext, input: Input<typeof schemas.memory.read>) {
+  return Effect.runPromise(readMemoryEffect(context, input));
+}
+
+export function saveMemoryEffect(context: MemoryContext, input: Input<typeof schemas.memory.save>) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const resolved = yield* resolveMemoryScope(context, input.workspaceId);
+    return yield* Effect.promise(() =>
+      context.memoryService.saveFile(
+        resolved.scopeCtx,
+        input.path,
+        input.content,
+        input.expectedSha256,
+        "user"
+      )
+    );
+  }).pipe(
+    // save's wire error is MemorySaveError, not a plain string.
+    Effect.catchTag("MemoryWorkspaceNotFoundError", (error) =>
+      Effect.succeed({
+        success: false as const,
+        error: { kind: "error" as const, message: workspaceNotFound(error.workspaceId) },
+      })
+    )
   );
 }
 
+/** Promise facade over {@link saveMemoryEffect} for pre-Effect callers. */
+export async function saveMemory(context: MemoryContext, input: Input<typeof schemas.memory.save>) {
+  return Effect.runPromise(saveMemoryEffect(context, input));
+}
+
+export function deleteMemoryEffect(
+  context: MemoryContext,
+  input: Input<typeof schemas.memory.delete>
+) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const resolved = yield* resolveMemoryScope(context, input.workspaceId);
+    const result = yield* Effect.promise(() =>
+      context.memoryService.deletePath(resolved.scopeCtx, input.path, "user")
+    );
+    return result.success
+      ? { success: true as const, data: undefined }
+      : { success: false as const, error: result.error };
+  }).pipe(Effect.catchTag("MemoryWorkspaceNotFoundError", workspaceNotFoundAsStringError));
+}
+
+/** Promise facade over {@link deleteMemoryEffect} for pre-Effect callers. */
 export async function deleteMemory(
   context: MemoryContext,
   input: Input<typeof schemas.memory.delete>
 ) {
-  assertMemoryEnabled(context);
-  const resolved = await resolveMemoryScopeContext(context, input.workspaceId);
-  if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
-  const result = await context.memoryService.deletePath(resolved.scopeCtx, input.path, "user");
-  return result.success
-    ? { success: true as const, data: undefined }
-    : { success: false as const, error: result.error };
+  return Effect.runPromise(deleteMemoryEffect(context, input));
 }
 
-/**
- * Effect-migration spike: `setMemoryPinned` converted to `Effect.gen`. The
- * wire contract (ResultSchema(z.void(), z.string())) is unchanged; the router
- * runs this via `handlerGen`, and the Promise wrapper below keeps pre-Effect
- * callers (tests) working. Sidecar write failures arrive as the typed
- * `MemoryMetaWriteError` and are mapped to the legacy string error channel
- * instead of escaping as an untyped INTERNAL_SERVER_ERROR rejection.
- */
 export function setMemoryPinnedEffect(
   context: MemoryContext,
   input: Input<typeof schemas.memory.setPinned>
@@ -133,10 +203,7 @@ export function setMemoryPinnedEffect(
     // Sync ORPCError throw stays a runtime defect and reaches the client as
     // the same BAD_REQUEST it does today from async handlers.
     assertMemoryEnabled(context);
-    const resolved = yield* Effect.promise(() =>
-      resolveMemoryScopeContext(context, input.workspaceId)
-    );
-    if (!resolved) return { success: false as const, error: workspaceNotFound(input.workspaceId) };
+    const resolved = yield* resolveMemoryScope(context, input.workspaceId);
     const parsedResult = yield* Effect.result(
       Effect.try({
         try: () => parseMemoryPath(input.path),
@@ -170,6 +237,9 @@ export function setMemoryPinnedEffect(
       )
       .pipe(
         Effect.map(() => ({ success: true as const, data: undefined })),
+        // Sidecar write failures (disk full, permissions) arrive as the typed
+        // MemoryMetaWriteError and map onto the legacy string error channel
+        // instead of escaping as an untyped INTERNAL_SERVER_ERROR rejection.
         Effect.catchTag("MemoryMetaWriteError", (error) =>
           Effect.succeed({
             success: false as const,
@@ -177,7 +247,7 @@ export function setMemoryPinnedEffect(
           })
         )
       );
-  });
+  }).pipe(Effect.catchTag("MemoryWorkspaceNotFoundError", workspaceNotFoundAsStringError));
 }
 
 /** Promise facade over {@link setMemoryPinnedEffect} for pre-Effect callers. */
@@ -188,24 +258,46 @@ export async function setMemoryPinned(
   return Effect.runPromise(setMemoryPinnedEffect(context, input));
 }
 
+export function getMemoryConsolidationStatusEffect(
+  context: MemoryContext,
+  input: Input<typeof schemas.memory.consolidationStatus>
+) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const data = yield* Effect.promise(() =>
+      context.memoryConsolidationService.getStatus(input.workspaceId)
+    );
+    return { success: true as const, data };
+  });
+}
+
+/** Promise facade over {@link getMemoryConsolidationStatusEffect} for pre-Effect callers. */
 export async function getMemoryConsolidationStatus(
   context: MemoryContext,
   input: Input<typeof schemas.memory.consolidationStatus>
 ) {
-  assertMemoryEnabled(context);
-  return {
-    success: true as const,
-    data: await context.memoryConsolidationService.getStatus(input.workspaceId),
-  };
+  return Effect.runPromise(getMemoryConsolidationStatusEffect(context, input));
 }
 
+export function consolidateMemoryEffect(
+  context: MemoryContext,
+  input: Input<typeof schemas.memory.consolidate>
+) {
+  return Effect.gen(function* () {
+    assertMemoryEnabled(context);
+    const result = yield* Effect.promise(() =>
+      context.memoryConsolidationService.maybeRun(input.workspaceId, "manual")
+    );
+    return result.success
+      ? { success: true as const, data: result.data }
+      : { success: false as const, error: result.error };
+  });
+}
+
+/** Promise facade over {@link consolidateMemoryEffect} for pre-Effect callers. */
 export async function consolidateMemory(
   context: MemoryContext,
   input: Input<typeof schemas.memory.consolidate>
 ) {
-  assertMemoryEnabled(context);
-  const result = await context.memoryConsolidationService.maybeRun(input.workspaceId, "manual");
-  return result.success
-    ? { success: true as const, data: result.data }
-    : { success: false as const, error: result.error };
+  return Effect.runPromise(consolidateMemoryEffect(context, input));
 }

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -646,8 +646,8 @@ export class ServiceContainer {
    */
   toORPCContext(): Omit<ORPCContext, "headers"> {
     return {
-      // Effect-migration spike: pre-built Effect service context consumed by
-      // Effect-native oRPC handlers (see src/node/orpc/effectContext.ts).
+      // Pre-built Effect service context consumed by Effect-native oRPC
+      // handlers (see src/node/orpc/effectContext.ts).
       "effect/context": buildOrpcEffectContext({ memoryMetaService: this.memoryMetaService }),
       workflowRuntimeFactory: this.workflowRuntimeFactory,
       config: this.config,


### PR DESCRIPTION
## Summary

Phase 1 of the progressive Effect migration: the memory subsystem's route operations are now Effect-native end-to-end — `Effect.gen` internals, typed domain errors, and all unary `memory.*` oRPC procedures running through the `@orpc/experimental-effect` `handlerGen` bridge — while every pre-Effect caller and existing test keeps working unchanged through thin `Effect.runPromise` facades.

## Background

The Effect + oRPC spike (#4022) landed the bridge (`handlerGen`, `WithEffectContext`, `EffectSchemaToJsonSchemaConverter`), converted `MemoryMetaService` internals, and proved the pattern on a single procedure (`memory.setPinned`). This PR completes the memory subsystem (Phase 1 scope): the remaining `memoryOperations.ts` functions, the remaining `memory.*` router handlers, and promotion of spike-era naming/comments to durable production docs. Providers/gateway/streaming (Phase 2) and background workers (Phase 3) are untouched.

## Implementation

- **`memoryOperations.ts`** — every operation (`list`, `read`, `save`, `delete`, `setPinned`, `consolidationStatus`, `consolidate`) is an `Effect.gen` pipeline exported as `*Effect`, plus a Promise facade with the original name/signature. Failures the client renders stay in the success channel as the unchanged wire `{ success: false }` unions; the Effect error channel carries only typed errors a caller can branch on:
  - `MemoryWorkspaceNotFoundError` (new, `Schema.TaggedError`): raised by the shared `resolveMemoryScope` helper; each route catches the tag and maps it onto its own union shape (plain string vs `MemorySaveError`).
  - `MemoryMetaWriteError` (existing): still mapped to the legacy string error in `setPinned`.
  - Every exported effect is fully handled (`Effect.Effect<A, never>`), so `handlerGen` handlers are one-line delegations.
- **`router.ts`** — all unary memory procedures now run via `handlerGen` (client aborts interrupt the handler fiber; wire contracts unchanged). `memory.onChange` intentionally stays an AsyncGenerator subscription: it returns an event iterator, which `handlerGen` cannot produce — an Effect `Stream` bridge is a later-phase concern (comment in code).
- **`memoryMeta.ts`** — spike-era comments reframed as durable docs; `load()`'s never-failing error channel is now explicitly documented as the AGENTS.md self-healing contract (malformed/unreadable sidecar degrades to "no metadata", logged, never bricks memory routes). No `Scope` was forced in: the service has no real acquire/release lifecycle.
- **`effectSpike.{ts,test.ts}` → `effectBridge.{ts,test.ts}`** (`git mv`, history retained) — the spike procedures are promoted to a permanent bridge regression harness pinning down the behaviors production handlers rely on (service injection, `Schema.TaggedError` → defined error, abort → fiber interruption + scope finalizers, middleware compatibility, OpenAPI generation for Effect Schema inputs). Still test-only, never mounted on the production router.

## Validation

- Existing tests pass **unchanged** (facade contract): `memoryOperations.test.ts`, `memoryMeta.test.ts`, `effectBridge.test.ts` (35 tests), full `src/node/orpc/` suite (71 tests), and the memory service suites.
- No new tests: the only new error-channel branch (workspace-not-found → per-route union shape) is already covered by the existing "routes fail cleanly for unknown workspaces" behavior test.
- `make static-check` green locally. One `memoryConsolidationService.test.ts` timing flake reproduces identically on clean `origin/main` (pre-existing host flake, file untouched by this diff).

## Risks

Low-to-moderate: wire contracts, schemas, and error strings are byte-identical; the change is internal control-flow plumbing. The main behavioral delta is intentional: client aborts now interrupt memory handler fibers instead of letting orphaned promises run to completion. Memory writes stay safe under interruption because `MemoryMetaService.mutate` performs the disk write + cache update in one `Effect.uninterruptible` region under the write semaphore (spike-era invariant, unchanged). Affected area is gated behind the `memory` experiment.

## Follow-ups (deliberately deferred)

- Effect `Stream` bridging for subscription procedures (`memory.onChange`).
- Phase 2: LLM provider/gateway leaf services; Phase 3: background workers (`Schedule`/`Scope`).

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
