### PR TITLE
🤖 refactor: convert retryManager and muxGatewayOauthService internals to Effect

### DIFF
--- a/src/node/services/muxGatewayOauthService.ts
+++ b/src/node/services/muxGatewayOauthService.ts
@@ -1,4 +1,22 @@
+/**
+ * Xum Gateway OAuth + balance service.
+ *
+ * Internals are Effect-native: each fallible pipeline is an `Effect.gen`
+ * program whose error channel carries typed domain errors, and the public
+ * Promise methods are thin `Effect.runPromise` facades that fold those errors
+ * back into the wire `Result<_, string>` shape, so pre-Effect callers (oRPC
+ * routes, tests) keep working unchanged. Only `MuxGatewaySessionExpiredError`
+ * gets its own tag because a caller genuinely branches on it (clearing stored
+ * credentials); every other failure is a `MuxGatewayOAuthError` whose `reason`
+ * is already the exact user-facing string.
+ *
+ * Desktop flow bookkeeping (deferreds, loopback server lifetime, timeouts)
+ * stays promise-based in `OAuthFlowManager`, which is shared with the other
+ * OAuth services — converting that lifecycle to Effect `Scope` is deferred
+ * until the shared manager itself migrates.
+ */
 import * as crypto from "crypto";
+import { Effect, Schema } from "effect";
 import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
 import {
@@ -26,6 +44,38 @@ interface ServerFlow {
   expiresAtMs: number;
 }
 
+/**
+ * Typed failure: the gateway rejected the stored credential (HTTP 401).
+ * `getAccountStatus` branches on this tag to clear the stored credentials
+ * before surfacing the fixed session-expired message.
+ */
+export class MuxGatewaySessionExpiredError extends Schema.TaggedError<MuxGatewaySessionExpiredError>()(
+  "MuxGatewaySessionExpiredError",
+  {}
+) {}
+
+/**
+ * Typed failure for every other gateway/OAuth error. `reason` carries the
+ * exact user-facing string the wire `Result` contract expects, so facades map
+ * it 1:1 onto `Err(reason)` without reformatting.
+ */
+export class MuxGatewayOAuthError extends Schema.TaggedError<MuxGatewayOAuthError>()(
+  "MuxGatewayOAuthError",
+  { reason: Schema.String }
+) {}
+
+/** Fold the typed failure channel back into the wire `Result` shape. */
+function toWireResult<A>(
+  effect: Effect.Effect<A, MuxGatewayOAuthError>
+): Effect.Effect<Result<A, string>> {
+  return effect.pipe(
+    Effect.map((value): Result<A, string> => Ok(value)),
+    Effect.catchTag("MuxGatewayOAuthError", (error) =>
+      Effect.succeed<Result<A, string>>(Err(error.reason))
+    )
+  );
+}
+
 export class MuxGatewayOauthService {
   private readonly desktopFlows = new OAuthFlowManager();
   private readonly serverFlows = new Map<string, ServerFlow>();
@@ -45,135 +95,212 @@ export class MuxGatewayOauthService {
       string
     >
   > {
-    const providersConfig = this.providersConfigStore.loadProvidersConfig() ?? {};
-    const muxConfig = (providersConfig["mux-gateway"] ?? {}) as Record<string, unknown>;
-    const creds = resolveProviderCredentials("mux-gateway", {
-      couponCode: typeof muxConfig.couponCode === "string" ? muxConfig.couponCode : undefined,
-      voucher: typeof muxConfig.voucher === "string" ? muxConfig.voucher : undefined,
-    });
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.runPromise(
+      toWireResult(
+        this.getAccountStatusEffect().pipe(
+          Effect.catchTag("MuxGatewaySessionExpiredError", () =>
+            Effect.gen(function* () {
+              yield* self.clearStoredCredentials();
+              return yield* Effect.fail(
+                new MuxGatewayOAuthError({ reason: MUX_GATEWAY_SESSION_EXPIRED_MESSAGE })
+              );
+            })
+          )
+        )
+      )
+    );
+  }
 
-    if (!creds.isConfigured || !creds.couponCode) {
-      return Err("Xum Gateway is not logged in");
-    }
-
-    let response: Awaited<ReturnType<typeof fetch>>;
-    try {
-      response = await fetch(`${MUX_GATEWAY_ORIGIN}/api/v1/balance`, {
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${creds.couponCode}`,
-        },
+  private getAccountStatusEffect(): Effect.Effect<
+    { remaining_microdollars: number; ai_gateway_concurrent_requests_per_user: number },
+    MuxGatewaySessionExpiredError | MuxGatewayOAuthError
+  > {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const providersConfig = self.providersConfigStore.loadProvidersConfig() ?? {};
+      const muxConfig = (providersConfig["mux-gateway"] ?? {}) as Record<string, unknown>;
+      const creds = resolveProviderCredentials("mux-gateway", {
+        couponCode: typeof muxConfig.couponCode === "string" ? muxConfig.couponCode : undefined,
+        voucher: typeof muxConfig.voucher === "string" ? muxConfig.voucher : undefined,
       });
-    } catch (error) {
-      return Err(`Xum Gateway balance request failed: ${getErrorMessage(error)}`);
-    }
 
-    if (response.status === 401) {
+      if (!creds.isConfigured || !creds.couponCode) {
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({ reason: "Xum Gateway is not logged in" })
+        );
+      }
+      // Captured after the guard: the narrowing does not survive into the thunk closure.
+      const couponCode = creds.couponCode;
+
+      const response = yield* Effect.tryPromise({
+        // async thunk: mirrors the old `await fetch(...)`, which coerces
+        // non-Promise returns (e.g. a test's synchronous fetch mock).
+        try: async () =>
+          fetch(`${MUX_GATEWAY_ORIGIN}/api/v1/balance`, {
+            headers: {
+              Accept: "application/json",
+              Authorization: `Bearer ${couponCode}`,
+            },
+          }),
+        catch: (error) =>
+          new MuxGatewayOAuthError({
+            reason: `Xum Gateway balance request failed: ${getErrorMessage(error)}`,
+          }),
+      });
+
+      if (response.status === 401) {
+        return yield* Effect.fail(new MuxGatewaySessionExpiredError());
+      }
+
+      if (!response.ok) {
+        // Preserve the HTTP status fallback when the response body is unreadable.
+        const body = yield* Effect.promise(() => response.text().catch(() => ""));
+        const prefix = body.trim().slice(0, 200);
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({
+            reason: `Xum Gateway balance request failed (HTTP ${response.status}): ${
+              prefix || response.statusText
+            }`,
+          })
+        );
+      }
+
+      const json = yield* Effect.tryPromise({
+        try: async (): Promise<unknown> => response.json(),
+        catch: (error) =>
+          new MuxGatewayOAuthError({
+            reason: `Xum Gateway balance response was not valid JSON: ${getErrorMessage(error)}`,
+          }),
+      });
+
+      const payload = json as {
+        remaining_microdollars?: unknown;
+        ai_gateway_concurrent_requests_per_user?: unknown;
+      };
+      const remaining = payload.remaining_microdollars;
+      const concurrency = payload.ai_gateway_concurrent_requests_per_user;
+
+      if (
+        typeof remaining !== "number" ||
+        !Number.isFinite(remaining) ||
+        !Number.isInteger(remaining) ||
+        remaining < 0 ||
+        typeof concurrency !== "number" ||
+        !Number.isFinite(concurrency) ||
+        !Number.isInteger(concurrency) ||
+        concurrency < 0
+      ) {
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({ reason: "Xum Gateway returned an invalid balance payload" })
+        );
+      }
+
+      return {
+        remaining_microdollars: remaining,
+        ai_gateway_concurrent_requests_per_user: concurrency,
+      };
+    });
+  }
+
+  /**
+   * Best-effort credential clearing on session expiry: failures are swallowed
+   * so the session-expired message still reaches the caller. Mirrors the
+   * pre-Effect behavior exactly (sequential awaits under a single catch, so a
+   * couponCode rejection also skips the voucher clear).
+   */
+  private clearStoredCredentials(): Effect.Effect<void> {
+    return Effect.promise(async () => {
       try {
         await this.providerService.setConfig("mux-gateway", ["couponCode"], "");
         await this.providerService.setConfig("mux-gateway", ["voucher"], "");
       } catch {
         // Credential clearing is best-effort; session expiry still reaches the caller.
       }
-
-      return Err(MUX_GATEWAY_SESSION_EXPIRED_MESSAGE);
-    }
-
-    if (!response.ok) {
-      let body = "";
-      try {
-        body = await response.text();
-      } catch {
-        // Preserve the HTTP status fallback when the response body is unreadable.
-      }
-      const prefix = body.trim().slice(0, 200);
-      return Err(
-        `Xum Gateway balance request failed (HTTP ${response.status}): ${
-          prefix || response.statusText
-        }`
-      );
-    }
-
-    let json: unknown;
-    try {
-      json = await response.json();
-    } catch (error) {
-      return Err(`Xum Gateway balance response was not valid JSON: ${getErrorMessage(error)}`);
-    }
-
-    const payload = json as {
-      remaining_microdollars?: unknown;
-      ai_gateway_concurrent_requests_per_user?: unknown;
-    };
-    const remaining = payload.remaining_microdollars;
-    const concurrency = payload.ai_gateway_concurrent_requests_per_user;
-
-    if (
-      typeof remaining !== "number" ||
-      !Number.isFinite(remaining) ||
-      !Number.isInteger(remaining) ||
-      remaining < 0 ||
-      typeof concurrency !== "number" ||
-      !Number.isFinite(concurrency) ||
-      !Number.isInteger(concurrency) ||
-      concurrency < 0
-    ) {
-      return Err("Xum Gateway returned an invalid balance payload");
-    }
-
-    return Ok({
-      remaining_microdollars: remaining,
-      ai_gateway_concurrent_requests_per_user: concurrency,
     });
   }
 
   async startDesktopFlow(): Promise<
     Result<{ flowId: string; authorizeUrl: string; redirectUri: string }, string>
   > {
-    const flowId = crypto.randomUUID();
-    const resultDeferred = createDeferred<Result<void, string>>();
+    return Effect.runPromise(toWireResult(this.startDesktopFlowEffect()));
+  }
 
-    let loopback;
-    try {
-      loopback = await startLoopbackServer({
-        expectedState: flowId,
-        deferSuccessResponse: true,
-        renderHtml: (r) =>
-          renderOAuthCallbackHtml({
-            title: r.success ? "Login complete" : "Login failed",
-            message: r.success
-              ? "You can return to Xum. You may now close this tab."
-              : (r.error ?? "Unknown error"),
-            success: r.success,
-            extraHead:
-              '<meta name="theme-color" content="#0e0e0e" />\n    <link rel="stylesheet" href="https://gateway.mux.coder.com/static/css/site.css" />',
+  private startDesktopFlowEffect(): Effect.Effect<
+    { flowId: string; authorizeUrl: string; redirectUri: string },
+    MuxGatewayOAuthError
+  > {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const flowId = crypto.randomUUID();
+      const resultDeferred = createDeferred<Result<void, string>>();
+
+      const loopback = yield* Effect.tryPromise({
+        try: () =>
+          startLoopbackServer({
+            expectedState: flowId,
+            deferSuccessResponse: true,
+            renderHtml: (r) =>
+              renderOAuthCallbackHtml({
+                title: r.success ? "Login complete" : "Login failed",
+                message: r.success
+                  ? "You can return to Xum. You may now close this tab."
+                  : (r.error ?? "Unknown error"),
+                success: r.success,
+                extraHead:
+                  '<meta name="theme-color" content="#0e0e0e" />\n    <link rel="stylesheet" href="https://gateway.mux.coder.com/static/css/site.css" />',
+              }),
+          }),
+        catch: (error) =>
+          new MuxGatewayOAuthError({
+            reason: `Failed to start OAuth callback listener: ${getErrorMessage(error)}`,
           }),
       });
-    } catch (error) {
-      const message = getErrorMessage(error);
-      return Err(`Failed to start OAuth callback listener: ${message}`);
-    }
 
-    const authorizeUrl = buildAuthorizeUrl({ redirectUri: loopback.redirectUri, state: flowId });
+      const authorizeUrl = buildAuthorizeUrl({ redirectUri: loopback.redirectUri, state: flowId });
 
-    this.desktopFlows.register(flowId, {
-      server: loopback.server,
-      resultDeferred,
-      // Keep server-side timeout tied to flow lifetime so abandoned flows
-      // (e.g. callers that never invoke waitForDesktopFlow) still self-clean.
-      timeoutHandle: setTimeout(() => {
-        void this.desktopFlows.finish(flowId, Err("Timed out waiting for OAuth callback"));
-      }, DEFAULT_DESKTOP_TIMEOUT_MS),
+      self.desktopFlows.register(flowId, {
+        server: loopback.server,
+        resultDeferred,
+        // Keep server-side timeout tied to flow lifetime so abandoned flows
+        // (e.g. callers that never invoke waitForDesktopFlow) still self-clean.
+        timeoutHandle: setTimeout(() => {
+          void self.desktopFlows.finish(flowId, Err("Timed out waiting for OAuth callback"));
+        }, DEFAULT_DESKTOP_TIMEOUT_MS),
+      });
+
+      // Background fiber: await loopback callback, do token exchange, finish
+      // flow. Cancellation/timeout still flow through resultDeferred (the
+      // promise-native OAuthFlowManager lifecycle), so the fiber exits via the
+      // race below rather than interruption.
+      Effect.runFork(self.desktopCallbackPipeline(flowId, loopback, resultDeferred));
+
+      log.debug(`Xum Gateway OAuth desktop flow started (flowId=${flowId})`);
+
+      return { flowId, authorizeUrl, redirectUri: loopback.redirectUri };
     });
+  }
 
-    // Background task: await loopback callback, do token exchange, finish flow.
-    // Race against resultDeferred so that if the flow is cancelled/timed out
-    // externally, this task exits cleanly instead of dangling on loopback.result.
-    void (async () => {
-      const callbackOrDone = await Promise.race([
-        loopback.result,
-        resultDeferred.promise.then((): null => null),
-      ]);
+  /**
+   * Desktop-flow completion pipeline, forked from `startDesktopFlowEffect`.
+   * Races the loopback callback against resultDeferred so that if the flow is
+   * cancelled/timed out externally, this fiber exits cleanly instead of
+   * dangling on loopback.result.
+   */
+  private desktopCallbackPipeline(
+    flowId: string,
+    loopback: Awaited<ReturnType<typeof startLoopbackServer>>,
+    resultDeferred: ReturnType<typeof createDeferred<Result<void, string>>>
+  ): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const callbackOrDone = yield* Effect.promise(() =>
+        Promise.race([loopback.result, resultDeferred.promise.then((): null => null)])
+      );
 
       // Flow was already finished externally (timeout or cancel).
       if (callbackOrDone === null) return;
@@ -182,11 +309,13 @@ export class MuxGatewayOauthService {
 
       let result: Result<void, string>;
       if (callbackOrDone.success) {
-        result = await this.handleCallbackAndExchange({
-          state: callbackOrDone.data.state,
-          code: callbackOrDone.data.code,
-          error: null,
-        });
+        result = yield* toWireResult(
+          self.handleCallbackAndExchange({
+            state: callbackOrDone.data.state,
+            code: callbackOrDone.data.code,
+            error: null,
+          })
+        );
 
         if (result.success) {
           loopback.sendSuccessResponse();
@@ -197,12 +326,8 @@ export class MuxGatewayOauthService {
         result = Err(`Xum Gateway OAuth error: ${callbackOrDone.error}`);
       }
 
-      await this.desktopFlows.finish(flowId, result);
-    })();
-
-    log.debug(`Xum Gateway OAuth desktop flow started (flowId=${flowId})`);
-
-    return Ok({ flowId, authorizeUrl, redirectUri: loopback.redirectUri });
+      yield* Effect.promise(() => self.desktopFlows.finish(flowId, result));
+    });
   }
 
   async waitForDesktopFlow(
@@ -246,30 +371,38 @@ export class MuxGatewayOauthService {
     error: string | null;
     errorDescription?: string;
   }): Promise<Result<void, string>> {
-    const state = input.state;
-    if (!state) {
-      return Err("Missing OAuth state");
-    }
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.runPromise(
+      toWireResult(
+        Effect.gen(function* () {
+          const state = input.state;
+          if (!state) {
+            return yield* Effect.fail(new MuxGatewayOAuthError({ reason: "Missing OAuth state" }));
+          }
 
-    const flow = this.serverFlows.get(state);
-    if (!flow) {
-      return Err("Unknown OAuth state");
-    }
+          const flow = self.serverFlows.get(state);
+          if (!flow) {
+            return yield* Effect.fail(new MuxGatewayOAuthError({ reason: "Unknown OAuth state" }));
+          }
 
-    if (Date.now() > flow.expiresAtMs) {
-      this.serverFlows.delete(state);
-      return Err("OAuth flow expired");
-    }
+          if (Date.now() > flow.expiresAtMs) {
+            self.serverFlows.delete(state);
+            return yield* Effect.fail(new MuxGatewayOAuthError({ reason: "OAuth flow expired" }));
+          }
 
-    // Regardless of outcome, this flow should not be reused.
-    this.serverFlows.delete(state);
+          // Regardless of outcome, this flow should not be reused.
+          self.serverFlows.delete(state);
 
-    return this.handleCallbackAndExchange({
-      state,
-      code: input.code,
-      error: input.error,
-      errorDescription: input.errorDescription,
-    });
+          yield* self.handleCallbackAndExchange({
+            state,
+            code: input.code,
+            error: input.error,
+            errorDescription: input.errorDescription,
+          });
+        })
+      )
+    );
   }
 
   async dispose(): Promise<void> {
@@ -277,70 +410,86 @@ export class MuxGatewayOauthService {
     this.serverFlows.clear();
   }
 
-  private async handleCallbackAndExchange(input: {
+  private handleCallbackAndExchange(input: {
     state: string;
     code: string | null;
     error: string | null;
     errorDescription?: string;
-  }): Promise<Result<void, string>> {
-    if (input.error) {
-      const message = input.errorDescription
-        ? `${input.error}: ${input.errorDescription}`
-        : input.error;
-      return Err(`Xum Gateway OAuth error: ${message}`);
-    }
+  }): Effect.Effect<void, MuxGatewayOAuthError> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      if (input.error) {
+        const message = input.errorDescription
+          ? `${input.error}: ${input.errorDescription}`
+          : input.error;
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({ reason: `Xum Gateway OAuth error: ${message}` })
+        );
+      }
 
-    if (!input.code) {
-      return Err("Missing OAuth code");
-    }
+      if (!input.code) {
+        return yield* Effect.fail(new MuxGatewayOAuthError({ reason: "Missing OAuth code" }));
+      }
 
-    const tokenResult = await this.exchangeCodeForToken(input.code);
-    if (!tokenResult.success) {
-      return Err(tokenResult.error);
-    }
+      const token = yield* self.exchangeCodeForToken(input.code);
 
-    const persistResult = await this.providerService.setConfig(
-      "mux-gateway",
-      ["couponCode"],
-      tokenResult.data
-    );
-    if (!persistResult.success) {
-      return Err(persistResult.error);
-    }
+      // setConfig resolves with a wire Result; a rejection stays a defect,
+      // matching the previously un-caught await.
+      const persistResult = yield* Effect.promise(() =>
+        self.providerService.setConfig("mux-gateway", ["couponCode"], token)
+      );
+      if (!persistResult.success) {
+        return yield* Effect.fail(new MuxGatewayOAuthError({ reason: persistResult.error }));
+      }
 
-    log.debug(`Xum Gateway OAuth exchange completed (state=${input.state})`);
+      log.debug(`Xum Gateway OAuth exchange completed (state=${input.state})`);
 
-    this.windowService?.focusMainWindow();
-
-    return Ok(undefined);
+      self.windowService?.focusMainWindow();
+    });
   }
 
-  private async exchangeCodeForToken(code: string): Promise<Result<string, string>> {
-    try {
-      const response = await fetch(MUX_GATEWAY_EXCHANGE_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-        },
-        body: buildExchangeBody({ code }),
+  private exchangeCodeForToken(code: string): Effect.Effect<string, MuxGatewayOAuthError> {
+    return Effect.gen(function* () {
+      const response = yield* Effect.tryPromise({
+        // async thunk: mirrors the old `await fetch(...)` coercion (see above).
+        try: async () =>
+          fetch(MUX_GATEWAY_EXCHANGE_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: buildExchangeBody({ code }),
+          }),
+        catch: (error) =>
+          new MuxGatewayOAuthError({
+            reason: `Xum Gateway exchange failed: ${getErrorMessage(error)}`,
+          }),
       });
 
       if (!response.ok) {
-        const errorText = await response.text().catch(() => "");
+        const errorText = yield* Effect.promise(() => response.text().catch(() => ""));
         const prefix = `Xum Gateway exchange failed (${response.status})`;
-        return Err(errorText ? `${prefix}: ${errorText}` : prefix);
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({ reason: errorText ? `${prefix}: ${errorText}` : prefix })
+        );
       }
 
-      const json = (await response.json()) as { access_token?: unknown };
+      const json = yield* Effect.tryPromise({
+        try: async () => (await response.json()) as { access_token?: unknown },
+        catch: (error) =>
+          new MuxGatewayOAuthError({
+            reason: `Xum Gateway exchange failed: ${getErrorMessage(error)}`,
+          }),
+      });
       const token = typeof json.access_token === "string" ? json.access_token : null;
       if (!token) {
-        return Err("Xum Gateway exchange response missing access_token");
+        return yield* Effect.fail(
+          new MuxGatewayOAuthError({ reason: "Xum Gateway exchange response missing access_token" })
+        );
       }
 
-      return Ok(token);
-    } catch (error) {
-      const message = getErrorMessage(error);
-      return Err(`Xum Gateway exchange failed: ${message}`);
-    }
+      return token;
+    });
   }
 }

--- a/src/node/services/retryManager.ts
+++ b/src/node/services/retryManager.ts
@@ -1,3 +1,4 @@
+import { Duration, Effect, Fiber } from "effect";
 import assert from "@/common/utils/assert";
 import {
   calculateBackoffDelay,
@@ -37,8 +38,25 @@ export type RetryStatusEvent =
 
 export class RetryManager {
   private state: RetryState<RetryFailureError>;
-  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The forked retry fiber: sleeps for the backoff delay (Effect's clock
+   * registers a plain `setTimeout` under the hood), then emits
+   * `auto-retry-starting` and runs the onRetry callback. Fiber interruption
+   * replaces hand-rolled `clearTimeout` bookkeeping: interrupting a sleeping
+   * fiber cancels its timer, and interrupting a fiber awaiting onRetry
+   * discards the (now stale) settlement so late rejections cannot emit events.
+   */
+  private retryFiber: Fiber.Fiber<void> | null = null;
+  /** True only while the backoff sleep is pending (scheduled, not yet fired). */
+  private retryPending = false;
   private enabled = true;
+  /**
+   * Guard for re-entrant synchronous cancellation: a status callback may call
+   * cancel()/setEnabled(false) while the retry fiber is executing
+   * synchronously, and fiber interruption only lands at the next yield point.
+   * The fiber therefore re-checks its generation after every callback it
+   * invokes, mirroring interruption for purely synchronous re-entrancy.
+   */
   private retryGeneration = 0;
   private pendingScheduledEvent: AutoRetryScheduledEvent | null = null;
 
@@ -71,7 +89,7 @@ export class RetryManager {
     // Cancel any pending retry first — a retryable error may have scheduled
     // a timer, but a later non-retryable error supersedes it.
     if (isNonRetryableSendError(error) || isNonRetryableStreamError(error)) {
-      this.cancelPendingTimer();
+      this.interruptRetryFiber();
       this.pendingScheduledEvent = null;
       this.retryGeneration += 1;
       this.onStatusChange({ type: "auto-retry-abandoned", reason: error.type });
@@ -80,7 +98,7 @@ export class RetryManager {
 
     // If a retry is already pending, cancel it and reschedule with updated backoff.
     // This can happen when multiple error events arrive before the timer fires.
-    this.cancelPendingTimer();
+    this.interruptRetryFiber();
 
     this.state = createFailedRetryState(this.state.attempt, error);
     const delay = calculateBackoffDelay(this.state.attempt);
@@ -96,36 +114,67 @@ export class RetryManager {
     this.pendingScheduledEvent = scheduledEvent;
     this.onStatusChange(scheduledEvent);
 
-    this.retryTimer = setTimeout(() => {
-      this.retryTimer = null;
-      this.pendingScheduledEvent = null;
+    this.scheduleRetry(delay, scheduledGeneration);
+  }
 
-      // Guard against stale timers or stop requests that race with callback execution.
-      if (!this.enabled || scheduledGeneration !== this.retryGeneration) {
-        return;
-      }
+  /**
+   * Fork the retry fiber. `Effect.runFork` executes synchronously up to the
+   * sleep, so the backoff timer is registered before this method returns —
+   * the same observable ordering as the previous `setTimeout` call.
+   *
+   * The backoff policy itself stays the hand-rolled pure
+   * `calculateBackoffDelay`: attempts are driven by external stream events
+   * (not by retrying an effect), so an Effect `Schedule` would only re-encode
+   * the same shared one-liner behind effectful stepping machinery.
+   */
+  private scheduleRetry(delayMs: number, scheduledGeneration: number): void {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    this.retryPending = true;
+    this.retryFiber = Effect.runFork(
+      Effect.gen(function* () {
+        yield* Effect.sleep(Duration.millis(delayMs));
+        self.retryPending = false;
+        self.pendingScheduledEvent = null;
 
-      this.onStatusChange({ type: "auto-retry-starting", attempt: this.state.attempt });
-
-      // Re-check after status emission so a synchronous stop handler can cancel
-      // before we attempt to resume the stream.
-      if (!this.enabled || scheduledGeneration !== this.retryGeneration) {
-        return;
-      }
-
-      this.onRetry().catch((retryError: unknown) => {
-        // Ignore stale retry callbacks from superseded/disabled generations.
-        if (!this.enabled || scheduledGeneration !== this.retryGeneration) {
+        // Guard against stale wake-ups or stop requests that race with fiber
+        // resumption (e.g. a cancel() issued re-entrantly while the scheduled
+        // event was still being emitted, before this fiber was forked).
+        if (!self.enabled || scheduledGeneration !== self.retryGeneration) {
           return;
         }
 
-        const reason =
-          retryError instanceof Error && retryError.message.length > 0
-            ? retryError.message
-            : "retry_callback_failed";
-        this.onStatusChange({ type: "auto-retry-abandoned", reason });
-      });
-    }, delay);
+        self.onStatusChange({ type: "auto-retry-starting", attempt: self.state.attempt });
+
+        // Re-check after status emission so a synchronous stop handler can cancel
+        // before we attempt to resume the stream.
+        if (!self.enabled || scheduledGeneration !== self.retryGeneration) {
+          return;
+        }
+
+        yield* Effect.tryPromise({
+          try: () => self.onRetry(),
+          catch: (retryError) => retryError,
+        }).pipe(
+          Effect.catch((retryError) =>
+            Effect.sync(() => {
+              // Ignore stale retry callbacks from superseded/disabled generations.
+              // Interruption already discards most stale settlements; this guard
+              // covers synchronous re-entrancy that raced the interrupt.
+              if (!self.enabled || scheduledGeneration !== self.retryGeneration) {
+                return;
+              }
+
+              const reason =
+                retryError instanceof Error && retryError.message.length > 0
+                  ? retryError.message
+                  : "retry_callback_failed";
+              self.onStatusChange({ type: "auto-retry-abandoned", reason });
+            })
+          )
+        );
+      })
+    );
   }
 
   handleStreamSuccess(): void {
@@ -134,16 +183,24 @@ export class RetryManager {
     this.cancel();
   }
 
-  /** Cancel any pending retry timer without resetting state. */
-  private cancelPendingTimer(): void {
-    if (this.retryTimer !== null) {
-      clearTimeout(this.retryTimer);
-      this.retryTimer = null;
+  /**
+   * Interrupt any in-flight retry fiber without resetting state. Interruption
+   * of a sleeping fiber clears its backoff timer synchronously; a fiber
+   * already awaiting onRetry is discarded at settlement.
+   */
+  private interruptRetryFiber(): void {
+    if (this.retryFiber !== null) {
+      const fiber = this.retryFiber;
+      this.retryFiber = null;
+      this.retryPending = false;
+      // Fire-and-forget: the interrupt signal lands synchronously; awaiting
+      // full fiber exit is unnecessary (and impossible from sync callers).
+      Effect.runFork(Fiber.interrupt(fiber));
     }
   }
 
   cancel(): void {
-    this.cancelPendingTimer();
+    this.interruptRetryFiber();
     this.pendingScheduledEvent = null;
     this.retryGeneration += 1;
     this.state = createFreshRetryState<RetryFailureError>();
@@ -166,7 +223,7 @@ export class RetryManager {
   }
 
   get isRetryPending(): boolean {
-    return this.retryTimer !== null;
+    return this.retryPending;
   }
 
   getScheduledStatusSnapshot(): AutoRetryScheduledEvent | null {


### PR DESCRIPTION
## Summary

Phase 2a of the progressive Effect migration: converts the internals of `RetryManager` and `MuxGatewayOauthService` to Effect while keeping their public APIs and observable behavior byte-identical via thin facades. Both existing test suites pass **unchanged**.

## Background

Follows #4022 (Effect v4-rc + oRPC 1.14 spike, `effectBridge`/`handlerGen`) and #4025 (memory subsystem conversion). Same house pattern: `Effect.gen` internals, `Schema.TaggedError` domain errors where callers branch, `Effect.runPromise` Promise facades so pre-Effect callers (`agentSession`, `taskService`, oRPC routes) stay untouched. Later phases own `providerService`, `providerModelFactory`, and `streamManager`.

## Implementation

**`retryManager.ts`** — the hand-rolled `setTimeout`/`clearTimeout` timer bookkeeping is replaced by a forked retry fiber: `Effect.sleep` for the backoff delay, `Fiber.interrupt` for cancellation. `Effect.runFork` executes synchronously up to the sleep and interruption clears the timer synchronously, so the exact observable ordering (synchronous event emission, timer registration/cancellation) is preserved — verified by the pre-existing tests, which mock global `setTimeout`/`clearTimeout` and assert synchronous sequencing. The generation guard is retained for purely synchronous re-entrancy (a status callback cancelling mid-emission), which fiber interruption alone cannot cover because interrupts only land at yield points.

**On `Schedule`** (informs Phase 2b/2c/3): Effect `Schedule` did **not** fit here and was deliberately not used. `Schedule` drives *the runtime retrying an effect it owns*; `RetryManager` is an externally-driven state machine — attempts are triggered by stream failure/success events arriving from outside, and the "retry" is a fire-and-forget callback whose outcome arrives as a later event. The backoff policy is already a pure shared one-liner (`calculateBackoffDelay`, also used by the frontend types), so expressing it as a `Schedule` would mean effectful stepping machinery to recompute `min(1000·2^n, 60000)`. Schedule remains the right tool where the effect being retried lives inside the Effect world (e.g. Phase 3 background workers/heartbeats).

**`muxGatewayOauthService.ts`** — every fallible pipeline (`getAccountStatus`, `startDesktopFlow`, server/desktop callback exchange, token exchange) is now an `Effect.gen` program with typed errors:

- `MuxGatewaySessionExpiredError` — the one tag a caller genuinely branches on: `getAccountStatus` catches it to clear stored credentials before surfacing the fixed session-expired message.
- `MuxGatewayOAuthError` — everything else; `reason` carries the exact user-facing string, folded back onto the wire `Result<_, string>` by a single `toWireResult` helper at the facades.

The desktop background task (callback → exchange → finish) is now a forked fiber. `Scope` was **not** forced in: flow lifetime (loopback server, timeout, cancellation) is owned by the shared promise-based `OAuthFlowManager` (used by 4 OAuth services), so an acquire/release conversion belongs to a later phase that migrates that shared manager, not to this leaf.

One subtlety: `Effect.tryPromise` thunks around `fetch` are `async` so non-Promise returns (tests' synchronous fetch mocks) coerce exactly like the old `await` did.

## Validation

- `bun test src/node/services/retryManager.test.ts` — 14/14 pass, file untouched.
- `bun test src/node/services/muxGatewayOauthService.test.ts` — 10/10 pass, file untouched.
- `agentSession.preStreamError`, `agentSession.startupAutoRetry`, `streamManager` suites green.
- `make static-check` green locally.
- `taskService.test.ts`: 2 failures reproduce identically on unmodified `main` in this environment (pre-existing baseline, unrelated terminal-recovery mock plumbing); the suite is otherwise green.
- No new tests: the error-channel tags are exercised through the existing exact-error-string assertions; adding tag-only tests would be tautological.

## Risks

Low-to-moderate: `RetryManager` sequencing is intricate (re-entrant cancellation, stale-generation guards) and regressions would affect stream auto-retry UX. Mitigated by the unchanged test suite that pins synchronous ordering, timer counts, and exact delays, plus a probe verifying Effect v4's runtime registers/clears plain `setTimeout` timers synchronously under `runFork`/interrupt. The OAuth service conversion is mechanical: every error string and branch is preserved 1:1.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$9.79`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=9.79 -->
