### PR TITLE
🤖 refactor: convert periodic-worker scheduling to Effect Schedule + Scope

### DIFF
--- a/src/node/services/heartbeatService.test.ts
+++ b/src/node/services/heartbeatService.test.ts
@@ -591,8 +591,11 @@ describe("HeartbeatService", () => {
       const emitter = new EventEmitter();
       let failListenerRegistration = true;
       const realOn = emitter.on.bind(emitter);
+      // Fail only the SECOND listener registration ("metadata") so the test
+      // also covers partial-acquisition rollback: the already-registered
+      // "activity" listener must be released, not leaked across retries.
       emitter.on = ((event: string, listener: (...args: unknown[]) => void) => {
-        if (failListenerRegistration) {
+        if (failListenerRegistration && event === "metadata") {
           throw new Error("listener registration failed");
         }
         return realOn(event, listener);
@@ -612,6 +615,11 @@ describe("HeartbeatService", () => {
       );
 
       expect(() => failingService.start()).toThrow();
+
+      // The "activity" listener registered before the failing "metadata"
+      // registration must have been rolled back — a leak here would double up
+      // event handling after a successful retry.
+      expect(emitter.listenerCount("activity")).toBe(0);
 
       // The idle-consumer registration acquired before the failing step must
       // have been released: re-registering the same consumer name would

--- a/src/node/services/heartbeatService.test.ts
+++ b/src/node/services/heartbeatService.test.ts
@@ -18,6 +18,7 @@ import type { BackgroundProcessManager } from "./backgroundProcessManager";
 import type { ExtensionMetadataService } from "./ExtensionMetadataService";
 import { advanceAnchoredDeadline, HeartbeatService } from "./heartbeatService";
 import type { HistoryService } from "./historyService";
+import { IdleDispatcher } from "./idleDispatcher";
 import type { InitStateManager } from "./initStateManager";
 import type { TaskService } from "./taskService";
 import { makeAgentTaskIntegrationFake } from "./taskWorkspaceSeam.testUtils";
@@ -583,6 +584,52 @@ describe("HeartbeatService", () => {
 
       expect(internals.queuedWorkspaceIds.size).toBe(0);
       expect(executeHeartbeatMock).not.toHaveBeenCalled();
+    });
+
+    test("start failure releases earlier acquisitions and leaves the service restartable", () => {
+      const dispatcher = new IdleDispatcher();
+      const emitter = new EventEmitter();
+      let failListenerRegistration = true;
+      const realOn = emitter.on.bind(emitter);
+      emitter.on = ((event: string, listener: (...args: unknown[]) => void) => {
+        if (failListenerRegistration) {
+          throw new Error("listener registration failed");
+        }
+        return realOn(event, listener);
+      }) as typeof emitter.on;
+      const failingWorkspaceService = Object.assign(emitter, {
+        getChatHistory: getChatHistoryMock,
+        executeHeartbeat: executeHeartbeatMock,
+        isBusyForMessage: isBusyForMessageMock,
+      }) as unknown as WorkspaceService;
+
+      const failingService = new HeartbeatService(
+        mockConfig,
+        mockExtensionMetadata,
+        failingWorkspaceService,
+        mockTaskService,
+        dispatcher
+      );
+
+      expect(() => failingService.start()).toThrow();
+
+      // The idle-consumer registration acquired before the failing step must
+      // have been released: re-registering the same consumer name would
+      // otherwise trip the dispatcher's duplicate-registration assert.
+      const disposeProbe = dispatcher.registerConsumer({
+        name: "heartbeat",
+        priority: 50,
+        buildPayload: () => Promise.resolve(null),
+      });
+      disposeProbe();
+
+      // The rollback restores the stopped state, so start() succeeds once the
+      // failure cause is fixed.
+      failListenerRegistration = false;
+      failingService.start();
+      expect(emitter.listenerCount("activity")).toBe(1);
+      failingService.stop();
+      expect(emitter.listenerCount("activity")).toBe(0);
     });
   });
 

--- a/src/node/services/heartbeatService.ts
+++ b/src/node/services/heartbeatService.ts
@@ -170,14 +170,25 @@ export class HeartbeatService {
             self.heartbeatConsumerDisposer = null;
           })
       );
+      // One acquireRelease per listener: a combined acquisition would install
+      // its finalizer only after BOTH .on() calls succeed, so a throw from the
+      // second registration (e.g. a `newListener` hook) would leak the first
+      // listener across start() retries (Codex P2 on #4031).
       yield* Effect.acquireRelease(
         Effect.sync(() => {
           self.workspaceService.on("activity", self.onActivity);
-          self.workspaceService.on("metadata", self.onMetadata);
         }),
         () =>
           Effect.sync(() => {
             self.workspaceService.off("activity", self.onActivity);
+          })
+      );
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          self.workspaceService.on("metadata", self.onMetadata);
+        }),
+        () =>
+          Effect.sync(() => {
             self.workspaceService.off("metadata", self.onMetadata);
           })
       );

--- a/src/node/services/heartbeatService.ts
+++ b/src/node/services/heartbeatService.ts
@@ -1,3 +1,4 @@
+import { Duration, Effect, Exit, Schedule, Scope, type Fiber } from "effect";
 import assert from "@/common/utils/assert";
 import type { MuxMessage } from "@/common/types/message";
 import type { ProjectsConfig, Workspace } from "@/common/types/project";
@@ -61,8 +62,22 @@ export class HeartbeatService {
 
   private timelineRecorder: TimelineRecorder = NOOP_TIMELINE_RECORDER;
 
-  private startupTimeout: ReturnType<typeof setTimeout> | null = null;
-  private checkInterval: ReturnType<typeof setInterval> | null = null;
+  // The scheduler runs as a single Effect fiber forked into `lifecycleScope`:
+  // sleep(STARTUP_DELAY_MS), then tick immediately and every CHECK_INTERVAL_MS.
+  // The legacy two-field shape is preserved because it is the observable
+  // lifecycle contract (tests pin the null/non-null progression):
+  // `startupTimeout` holds the fiber while the startup delay is pending and
+  // `checkInterval` holds it once the periodic ticker is live.
+  private startupTimeout: Fiber.Fiber<void> | null = null;
+  private checkInterval: Fiber.Fiber<void> | null = null;
+  /**
+   * Owns every resource start() acquires — idle-consumer registration,
+   * workspace event listeners, and the scheduler fiber. Closing it releases
+   * them in reverse acquisition order (fiber interrupt, listeners off,
+   * consumer dispose — the same order the hand-rolled stop() used) and is
+   * guaranteed to run them even when a later startup step throws.
+   */
+  private lifecycleScope: Scope.Closeable | null = null;
   private stopped = true;
 
   private readonly nextEligibleAtByWorkspaceId = new Map<string, number>();
@@ -114,25 +129,79 @@ export class HeartbeatService {
     this.stopped = false;
     this.lifecycleVersion += 1;
 
-    this.heartbeatConsumerDisposer = this.idleDispatcher.registerConsumer({
-      name: HEARTBEAT_IDLE_CONSUMER_NAME,
-      priority: HEARTBEAT_IDLE_CONSUMER_PRIORITY,
-      buildPayload: (workspaceId) => this.buildHeartbeatDispatchPayload(workspaceId),
-    });
-    this.workspaceService.on("activity", this.onActivity);
-    this.workspaceService.on("metadata", this.onMetadata);
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    const scope = Scope.makeUnsafe();
+    this.lifecycleScope = scope;
 
-    this.startupTimeout = setTimeout(() => {
-      if (this.stopped) {
+    const scheduler = Effect.gen(function* () {
+      yield* Effect.sleep(Duration.millis(STARTUP_DELAY_MS));
+      // Defensive parity with the legacy setTimeout callback: interruption via
+      // stop() already prevents this resumption, so a stopped service must
+      // never transition into the ticking phase even if a wake-up raced it.
+      if (self.stopped) {
         return;
       }
 
+      // Startup delay elapsed: the same fiber now becomes the periodic ticker.
+      self.checkInterval = self.startupTimeout;
+      self.startupTimeout = null;
+      // Effect.repeat runs the first tick immediately (matching the legacy
+      // direct tick() call when the startup timer fired), then Schedule.fixed
+      // reproduces setInterval cadence: wall-clock anchored, no burst catch-up.
+      // tick() is synchronous fire-and-forget, so the body never delays a slot.
+      yield* Effect.sync(() => self.tick()).pipe(
+        Effect.repeat(Schedule.fixed(Duration.millis(CHECK_INTERVAL_MS)))
+      );
+    });
+
+    const acquireResources = Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          self.heartbeatConsumerDisposer = self.idleDispatcher.registerConsumer({
+            name: HEARTBEAT_IDLE_CONSUMER_NAME,
+            priority: HEARTBEAT_IDLE_CONSUMER_PRIORITY,
+            buildPayload: (workspaceId) => self.buildHeartbeatDispatchPayload(workspaceId),
+          });
+        }),
+        () =>
+          Effect.sync(() => {
+            self.heartbeatConsumerDisposer?.();
+            self.heartbeatConsumerDisposer = null;
+          })
+      );
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          self.workspaceService.on("activity", self.onActivity);
+          self.workspaceService.on("metadata", self.onMetadata);
+        }),
+        () =>
+          Effect.sync(() => {
+            self.workspaceService.off("activity", self.onActivity);
+            self.workspaceService.off("metadata", self.onMetadata);
+          })
+      );
+      self.startupTimeout = yield* Effect.forkIn(scheduler, scope);
+    });
+
+    try {
+      // Runs synchronously: acquisitions are Effect.sync and forkIn executes
+      // the scheduler up to its first sleep before returning, so the startup
+      // timer is registered before start() returns (same observable ordering
+      // as the previous setTimeout call).
+      Effect.runSync(Scope.provide(scope)(acquireResources));
+    } catch (error) {
+      // Guaranteed cleanup on partial startup failure: close the scope so the
+      // finalizers registered before the failing step run (the hand-rolled
+      // version leaked earlier acquisitions here), restore the stopped state
+      // so a later start() retry is possible, then surface the error.
+      this.lifecycleScope = null;
       this.startupTimeout = null;
-      this.tick();
-      this.checkInterval = setInterval(() => {
-        this.tick();
-      }, CHECK_INTERVAL_MS);
-    }, STARTUP_DELAY_MS);
+      this.checkInterval = null;
+      this.stopped = true;
+      Effect.runSync(Scope.close(scope, Exit.void));
+      throw error;
+    }
 
     log.info("HeartbeatService started", {
       startupDelayMs: STARTUP_DELAY_MS,
@@ -144,19 +213,25 @@ export class HeartbeatService {
     this.stopped = true;
     this.lifecycleVersion += 1;
 
-    if (this.startupTimeout) {
-      clearTimeout(this.startupTimeout);
-      this.startupTimeout = null;
-    }
-    if (this.checkInterval) {
-      clearInterval(this.checkInterval);
-      this.checkInterval = null;
-    }
+    // Captured before teardown for the shutdown log below.
+    const schedulerPhase =
+      this.checkInterval != null
+        ? "ticking"
+        : this.startupTimeout != null
+          ? "startup_delay"
+          : "not_started";
 
-    this.workspaceService.off("activity", this.onActivity);
-    this.workspaceService.off("metadata", this.onMetadata);
-    this.heartbeatConsumerDisposer?.();
-    this.heartbeatConsumerDisposer = null;
+    if (this.lifecycleScope) {
+      const scope = this.lifecycleScope;
+      this.lifecycleScope = null;
+      // Releases everything start() acquired, in reverse acquisition order:
+      // scheduler fiber interrupt (synchronously clearing its pending timer),
+      // listeners off, consumer disposer — completing synchronously because
+      // the fiber only ever suspends on its clock timer.
+      Effect.runSync(Scope.close(scope, Exit.void));
+    }
+    this.startupTimeout = null;
+    this.checkInterval = null;
 
     this.nextEligibleAtByWorkspaceId.clear();
     this.trackedIntervalMsByWorkspaceId.clear();
@@ -166,7 +241,7 @@ export class HeartbeatService {
     this.isProcessingQueue = false;
     this.tickInFlight = false;
 
-    log.info("HeartbeatService stopped");
+    log.info("HeartbeatService stopped", { schedulerPhase });
   }
 
   private tick(): void {

--- a/src/node/services/idleCompactionService.ts
+++ b/src/node/services/idleCompactionService.ts
@@ -1,3 +1,4 @@
+import { Duration, Effect, Exit, Schedule, Scope } from "effect";
 import assert from "@/common/utils/assert";
 import type { Config } from "@/node/config";
 import type { HistoryService } from "./historyService";
@@ -44,8 +45,12 @@ export class IdleCompactionService {
   private readonly historyService: HistoryService;
   private readonly extensionMetadata: ExtensionMetadataService;
   private readonly executeIdleCompaction: (workspaceId: string) => Promise<void>;
-  private initialTimeout: ReturnType<typeof setTimeout> | null = null;
-  private checkInterval: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Owns the checker fiber forked by start(): sleep(INITIAL_CHECK_DELAY_MS),
+   * then check immediately and every CHECK_INTERVAL_MS. Closing the scope in
+   * stop() interrupts the fiber, synchronously clearing its pending timer.
+   */
+  private lifecycleScope: Scope.Closeable | null = null;
   private readonly queue: QueuedIdleCompaction[] = [];
   private readonly queuedWorkspaceIds = new Set<string>();
   private readonly activeWorkspaceIds = new Set<string>();
@@ -76,14 +81,27 @@ export class IdleCompactionService {
   start(): void {
     this.stopped = false;
 
-    // First check after delay to let startup settle.
-    this.initialTimeout = setTimeout(() => {
-      void this.checkAllWorkspaces();
-      // Then periodically.
-      this.checkInterval = setInterval(() => {
-        void this.checkAllWorkspaces();
-      }, CHECK_INTERVAL_MS);
-    }, INITIAL_CHECK_DELAY_MS);
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    const scope = Scope.makeUnsafe();
+    this.lifecycleScope = scope;
+
+    const checker = Effect.gen(function* () {
+      // First check after delay to let startup settle.
+      yield* Effect.sleep(Duration.millis(INITIAL_CHECK_DELAY_MS));
+      // Effect.repeat runs the first check immediately (matching the legacy
+      // direct call when the initial timer fired), then Schedule.fixed
+      // reproduces setInterval cadence. The check stays fire-and-forget so a
+      // slow sweep never delays the next cadence slot (same as setInterval).
+      yield* Effect.sync(() => {
+        void self.checkAllWorkspaces();
+      }).pipe(Effect.repeat(Schedule.fixed(Duration.millis(CHECK_INTERVAL_MS))));
+    });
+    // Runs synchronously up to the checker's first sleep, so the initial-delay
+    // timer is registered before start() returns (same as the previous
+    // setTimeout call).
+    Effect.runSync(Effect.forkIn(checker, scope));
+
     log.info("IdleCompactionService started", {
       initialDelayMs: INITIAL_CHECK_DELAY_MS,
       intervalMs: CHECK_INTERVAL_MS,
@@ -96,13 +114,12 @@ export class IdleCompactionService {
   stop(): void {
     this.stopped = true;
 
-    if (this.initialTimeout) {
-      clearTimeout(this.initialTimeout);
-      this.initialTimeout = null;
-    }
-    if (this.checkInterval) {
-      clearInterval(this.checkInterval);
-      this.checkInterval = null;
+    if (this.lifecycleScope) {
+      const scope = this.lifecycleScope;
+      this.lifecycleScope = null;
+      // Interrupts the checker fiber, synchronously clearing its pending
+      // timer — the fiber only ever suspends on its clock timer.
+      Effect.runSync(Scope.close(scope, Exit.void));
     }
 
     // Best-effort queue reset: do not start new compactions after stop().

--- a/src/node/services/idleDispatcher.ts
+++ b/src/node/services/idleDispatcher.ts
@@ -1,3 +1,4 @@
+import { Duration, Effect, type Fiber } from "effect";
 import assert from "@/common/utils/assert";
 import { log } from "./log";
 
@@ -29,7 +30,13 @@ interface IdleDispatcherOptions {
 interface PendingDispatchRequest {
   readonly sources: Set<string>;
   readonly resolvers: Array<() => void>;
-  debounceTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Debounce fiber: sleeps for `debounceMs` (Effect's clock registers a plain
+   * `setTimeout` under the hood), then marks the workspace ready. Non-null
+   * exactly while the debounce window is open — later requests for the same
+   * workspace coalesce into this pending entry instead of re-arming it.
+   */
+  debounceFiber: Fiber.Fiber<void> | null;
 }
 
 export class IdleDispatcher {
@@ -89,14 +96,24 @@ export class IdleDispatcher {
       pending.sources.add(source);
       pending.resolvers.push(resolve);
 
-      if (pending.debounceTimer != null) {
+      if (pending.debounceFiber != null) {
         return;
       }
 
-      pending.debounceTimer = setTimeout(() => {
-        pending.debounceTimer = null;
-        this.markWorkspaceReady(workspaceId);
-      }, this.debounceMs);
+      // Effect.runFork executes synchronously up to the sleep, so the debounce
+      // timer is registered before this callback returns (same observable
+      // ordering as the previous setTimeout call); a zero-duration sleep still
+      // defers to a timer tick rather than firing inline.
+      pending.debounceFiber = Effect.runFork(
+        Effect.sleep(Duration.millis(this.debounceMs)).pipe(
+          Effect.flatMap(() =>
+            Effect.sync(() => {
+              pending.debounceFiber = null;
+              this.markWorkspaceReady(workspaceId);
+            })
+          )
+        )
+      );
     });
   }
 
@@ -109,7 +126,7 @@ export class IdleDispatcher {
     const pending: PendingDispatchRequest = {
       sources: new Set<string>(),
       resolvers: [],
-      debounceTimer: null,
+      debounceFiber: null,
     };
     this.pendingByWorkspaceId.set(workspaceId, pending);
     return pending;


### PR DESCRIPTION
## Summary

Phase 3 of the progressive Effect migration: the periodic-worker internals of `heartbeatService`, `idleCompactionService`, and `idleDispatcher` now run on Effect fibers — `Schedule`-driven loops for the two interval services and forked sleep fibers for per-workspace debounce — with service start/stop lifecycles owned by an Effect `Scope` (the first real `Scope` use in the migration). Public APIs are unchanged and all pre-existing tests pass unchanged.

## Background

Follows #4022 (spike), #4025 (memory ops), #4027 (retryManager + gateway OAuth), #4028 (providerService), #4030 (providerModelFactory). #4027 established that Effect `Schedule` fits runtime-owned loops (the repeated effect lives inside the Effect world) rather than externally-driven state machines — these three services are exactly the runtime-owned case: hand-rolled `setTimeout` startup delays chained into `setInterval` ticks, plus per-workspace debounce timers.

## Implementation

**heartbeatService** — the `startupTimeout` + `checkInterval` timer pair becomes one scheduler fiber: `Effect.sleep(STARTUP_DELAY_MS)` → first tick → `Effect.repeat(Schedule.fixed(CHECK_INTERVAL_MS))`. `Schedule.fixed` is the `setInterval` analogue (wall-clock anchored, no burst catch-up; probe-verified). `start()` acquires the idle-consumer registration and workspace event listeners via `Effect.acquireRelease` and forks the scheduler with `Effect.forkIn`, all inside a `Scope.makeUnsafe()` lifecycle scope; `stop()` closes the scope, which releases everything in reverse acquisition order — fiber interrupt (synchronously clearing the pending timer), listeners off, consumer dispose — the exact order the hand-rolled `stop()` used. The legacy `startupTimeout`/`checkInterval` field pair is kept (now holding the fiber) because the null/non-null phase progression is the observable lifecycle contract that tests pin.

**idleCompactionService** — same shape: `sleep(INITIAL_CHECK_DELAY_MS)` → immediate first check → `Schedule.fixed(CHECK_INTERVAL_MS)`, forked into a lifecycle scope; checks stay fire-and-forget so a slow sweep never delays a cadence slot (matching `setInterval`).

**idleDispatcher** — each per-workspace debounce `setTimeout` becomes a forked fiber (`Effect.sleep(debounceMs)` → mark ready). `Effect.runFork` executes synchronously up to the sleep, so timer registration ordering relative to `requestDispatch` is unchanged, and a zero-duration sleep still defers to a timer tick rather than firing inline (probe-verified).

**Behavioral improvement (one new test)** — under the hand-rolled version, a throw partway through `heartbeatService.start()` leaked earlier acquisitions (idle-consumer registration) and left the service permanently wedged (`stopped=false`, so both retry-`start()` and the duplicate-consumer assert would fire). Scope finalizers now guarantee release on partial startup failure and the rollback restores the stopped state, so a retry succeeds. This is the only new test; no other test files changed beyond that addition.

### Runtime semantics probe (verified against effect 4.0.0-rc.112 before implementation)

- `Scope.makeUnsafe` + `Effect.acquireRelease` + `Effect.forkIn` under `Effect.runSync` execute fully synchronously; the forked fiber runs to its first `sleep` before fork returns.
- `Effect.runSync(Scope.close(...))` completes synchronously while the fiber is suspended on its clock timer, runs finalizers in reverse order, and no late ticks fire afterward.
- `Effect.repeat` runs the first execution immediately; `Schedule.fixed` re-anchors after a slow body without bursting (`[0, 30, {50ms body}, immediate, 120, 150, 180]`).
- Forked `Effect.sleep(0)` defers like `setTimeout(0)` rather than firing inline.

### Explicitly out of scope (fit assessment)

- **memoryConsolidationService**: not converted here. Its loop is a fit for the same Schedule/Scope pattern *if* it is a plain delay+interval worker, but it also participates in memory-file locking; conversion should be planned together with its lock-ordering constraints rather than ride along in a scheduling PR.
- **workspaceStatusGenerator**: not converted. Its regeneration is event/debounce-driven off workspace activity rather than a fixed-cadence loop; the idleDispatcher debounce-fiber pattern from this PR is the right template when it is converted.
- Proactive OAuth token-refresh worker (suggested by #4030): new functionality, not migration — remains backlog.

## Lessons for Phase 4 (core router progressive conversion + streamManager placement)

1. `Scope` + `acquireRelease` + `forkIn` composes cleanly with **synchronous** start/stop facades: everything runs under `runSync` because acquisitions are `Effect.sync` and fibers only suspend on clock timers. Phase 4's streamManager owns fibers that suspend on **I/O**, where `Scope.close` cannot complete synchronously — plan async `close` (or `runFork` + stopped-flag latching) for those lifecycles before converting.
2. `Schedule.fixed` vs `Schedule.spaced`: `fixed` is the honest `setInterval` replacement (wall-clock anchor, no burst); `spaced` drifts by body duration. Pick per legacy timer type, and probe — repeat's first execution is immediate, which conveniently matches the "fire once when the startup timer lands, then every interval" idiom.
3. Fields that tests pin (`startupTimeout`/`checkInterval`) can survive a mechanism swap by re-typing them as fiber/phase markers rather than editing tests; document that the null/non-null progression is the contract. The core router has many more internals-pinning tests — budget for this.
4. TS6133 trap: a phase-marker field written only from inside the fiber counts as "never read" — give it a genuine read (e.g. a shutdown debug log) instead of suppressing.
5. `type Fiber` import: fibers held only as fields trip `consistent-type-imports`; import the namespace as type.

## Validation

- Probe scripts against effect 4.0.0-rc.112 validated all timing/interruption assumptions before implementation (results above).
- `bun test` on the three service suites: 100 pass / 0 fail (99 pre-existing unchanged + 1 new). Consumer suites (workspaceGoalService, agentSession.goalAutoPause, agentSession.waitForIdle, workspaceService.heartbeatSettings, tools/heartbeat, timelineMapper, tools): all green. The single `workspaceService.test.ts` failure ("bash monitor wakes > accepted history suppresses redelivery…") reproduces identically on unmodified `main` in this environment (baseline, unrelated).
- `make static-check` green.

## Risks

Low-to-moderate: heartbeat and idle-compaction scheduling drive background automation for every workspace, so a cadence regression would be user-visible but not data-destructive. The queue/eligibility business logic is untouched — only the timer skeletons moved. The main semantic risk (synchronous stop ordering) is pinned by existing lifecycle tests and was probe-verified; interruption of a sleeping fiber clears its timer synchronously, matching `clearTimeout`/`clearInterval`.
---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=0.00 -->
