### PR TITLE
🤖 refactor: convert OAuthFlowManager flow lifecycle to Effect per-flow Scope

### DIFF
--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -579,7 +579,7 @@ export const router = (authToken?: string) => {
       // startDesktopFlow rides handlerGen; its service pipeline is
       // uninterruptible (see startDesktopFlowEffect) so a client abort cannot
       // leak the loopback server. waitFor/cancel stay plain handlers until the
-      // promise-native OAuthFlowManager grows an Effect surface.
+      // batch OAuth-service conversion migrates the remaining procedures.
       startDesktopFlow: t
         .input(schemas.muxGatewayOauth.startDesktopFlow.input)
         .output(schemas.muxGatewayOauth.startDesktopFlow.output)

--- a/src/node/services/muxGatewayOauthService.ts
+++ b/src/node/services/muxGatewayOauthService.ts
@@ -11,9 +11,9 @@
  * is already the exact user-facing string.
  *
  * Desktop flow bookkeeping (deferreds, loopback server lifetime, timeouts)
- * stays promise-based in `OAuthFlowManager`, which is shared with the other
- * OAuth services — converting that lifecycle to Effect `Scope` is deferred
- * until the shared manager itself migrates.
+ * lives in `OAuthFlowManager`, which is shared with the other OAuth services
+ * and is itself Effect-native (per-flow `Scope` lifecycle) — Effect callers
+ * here use its `*Effect` surface directly.
  */
 import * as crypto from "crypto";
 import { Effect, Schema } from "effect";
@@ -295,7 +295,9 @@ export class MuxGatewayOauthService {
         // Keep server-side timeout tied to flow lifetime so abandoned flows
         // (e.g. callers that never invoke waitForDesktopFlow) still self-clean.
         timeoutHandle: setTimeout(() => {
-          void self.desktopFlows.finish(flowId, Err("Timed out waiting for OAuth callback"));
+          Effect.runFork(
+            self.desktopFlows.finishEffect(flowId, Err("Timed out waiting for OAuth callback"))
+          );
         }, DEFAULT_DESKTOP_TIMEOUT_MS),
       });
 
@@ -353,7 +355,7 @@ export class MuxGatewayOauthService {
         result = Err(`Xum Gateway OAuth error: ${callbackOrDone.error}`);
       }
 
-      yield* Effect.promise(() => self.desktopFlows.finish(flowId, result));
+      yield* self.desktopFlows.finishEffect(flowId, result);
     });
   }
 

--- a/src/node/utils/oauthFlowManager.test.ts
+++ b/src/node/utils/oauthFlowManager.test.ts
@@ -293,6 +293,74 @@ describe("OAuthFlowManager", () => {
   });
 
   // -----------------------------------------------------------------------
+  // guaranteed cleanup (per-flow scope)
+  // -----------------------------------------------------------------------
+
+  describe("guaranteed cleanup", () => {
+    it("closes the server and clears the timeout even when the deferred resolve throws", async () => {
+      // Per-flow scope guarantee: each resource has an independent release, so
+      // a defect while settling the deferred cannot leak the loopback server
+      // or the registration timeout. (The pre-Effect implementation skipped
+      // the server close when resolve threw.)
+      let serverClosed = false;
+      const mockServer = {
+        close: (cb?: (err?: Error) => void) => {
+          serverClosed = true;
+          if (cb) cb();
+          return mockServer;
+        },
+      } as unknown as http.Server;
+
+      let timeoutFired = false;
+      const entry: OAuthFlowEntry = {
+        server: mockServer,
+        resultDeferred: {
+          promise: createDeferred<Result<void, string>>().promise,
+          resolve: () => {
+            throw new Error("resolve exploded");
+          },
+        },
+        timeoutHandle: setTimeout(() => {
+          timeoutFired = true;
+        }, 10),
+      };
+      manager.register("f1", entry);
+
+      // Must not reject despite the resolve defect.
+      await manager.finish("f1", Ok(undefined));
+
+      expect(manager.has("f1")).toBe(false);
+      expect(serverClosed).toBe(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(timeoutFired).toBe(false);
+    });
+
+    it("closes the loopback server after a waitFor timeout even though waitFor already returned", async () => {
+      // The timeout-path cleanup is fire-and-forget (waitFor resolves without
+      // waiting for the server close); the detached release fiber must still
+      // complete after waitFor's own fiber has exited.
+      let serverClosed = false;
+      const mockServer = {
+        close: (cb?: (err?: Error) => void) => {
+          serverClosed = true;
+          if (cb) cb();
+          return mockServer;
+        },
+      } as unknown as http.Server;
+
+      manager.register("f1", createFlowEntry(mockServer));
+
+      const result = await manager.waitFor("f1", 10);
+      expect(result.success).toBe(false);
+      expect(manager.has("f1")).toBe(false);
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(serverClosed).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // shutdownAll
   // -----------------------------------------------------------------------
 

--- a/src/node/utils/oauthFlowManager.ts
+++ b/src/node/utils/oauthFlowManager.ts
@@ -1,4 +1,5 @@
 import type http from "node:http";
+import { Duration, Effect, Exit, Scope } from "effect";
 import type { Result } from "@/common/types/result";
 import { Err } from "@/common/types/result";
 import { closeServer } from "@/node/utils/oauthUtils";
@@ -11,6 +12,16 @@ import { log } from "@/node/services/log";
  * flows with an identical `Map<string, DesktopFlow>` + `waitFor`/`cancel`/
  * `finish`/`shutdownAll` pattern. This class extracts that shared lifecycle
  * so each service can delegate flow bookkeeping here.
+ *
+ * Internals are Effect-native: every registered flow owns a per-flow
+ * `Scope` holding one release finalizer per resource (registration timeout,
+ * deferred settlement, loopback server close), so cleanup is guaranteed on
+ * every termination path — finish, cancel, caller-timeout race, duplicate
+ * registration, shutdownAll, and defects while releasing a sibling resource.
+ * The Promise-based public API is preserved as thin `Effect.runPromise`
+ * facades so the not-yet-converted OAuth services and existing tests keep
+ * working unchanged; Effect-native callers (muxGatewayOauthService) can use
+ * the `*Effect` surface directly without runPromise round-trips.
  */
 
 // ---------------------------------------------------------------------------
@@ -29,6 +40,25 @@ export interface OAuthFlowEntry {
   timeoutHandle: ReturnType<typeof setTimeout> | null;
 }
 
+interface ActiveFlow {
+  entry: OAuthFlowEntry;
+  /**
+   * Owns the flow's resources. Closing it runs the release finalizers in
+   * reverse acquisition order: clear the registration timeout, settle the
+   * deferred, then close the loopback server (awaited).
+   */
+  scope: Scope.Closeable;
+  /**
+   * Result the deferred-settle finalizer resolves `resultDeferred` with.
+   * Mutable so every termination path (finish/cancel/shutdown/replace) routes
+   * its result through the same scope-guaranteed finalizer instead of ad-hoc
+   * resolve calls. The initial value is a defensive fallback for the
+   * (should-be-impossible) case of the scope closing before any path staged
+   * a real result — waiters must never hang on an unsettled deferred.
+   */
+  finalResult: Result<void, string>;
+}
+
 interface CompletedOAuthFlowEntry {
   result: Result<void, string>;
   cleanupTimeout: ReturnType<typeof setTimeout> | null;
@@ -37,11 +67,71 @@ interface CompletedOAuthFlowEntry {
 const DEFAULT_COMPLETED_FLOW_TTL_MS = 60_000;
 
 // ---------------------------------------------------------------------------
+// Per-flow resource scope
+// ---------------------------------------------------------------------------
+
+/**
+ * Move ownership of the caller-acquired flow resources into the per-flow
+ * scope. One `acquireRelease` per resource: a combined acquisition would
+ * install its finalizer only after every step succeeded, so a defect in a
+ * later step would leak the earlier resources (Codex P2 on #4031).
+ *
+ * Resource state (`server`, `timeoutHandle`, `finalResult`) is read at
+ * release time, not captured at acquisition, matching the pre-Effect code
+ * that read the entry fields inside `finish`.
+ *
+ * Release order (reverse acquisition) preserves the pre-Effect `finish`
+ * ordering: clear the registration timeout, settle the deferred (so waiters
+ * unblock before the async close), then close the loopback server.
+ */
+function acquireFlowResources(flow: ActiveFlow): Effect.Effect<void, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    yield* Effect.acquireRelease(Effect.void, () => {
+      const server = flow.entry.server;
+      if (server === null) {
+        return Effect.void;
+      }
+      // Stop accepting new connections and wait for the (bounded) drain.
+      return Effect.promise(async () => closeServer(server));
+    });
+    yield* Effect.acquireRelease(Effect.void, () =>
+      Effect.sync(() => {
+        flow.entry.resultDeferred.resolve(flow.finalResult);
+      })
+    );
+    yield* Effect.acquireRelease(Effect.void, () =>
+      Effect.sync(() => {
+        if (flow.entry.timeoutHandle !== null) {
+          clearTimeout(flow.entry.timeoutHandle);
+        }
+      })
+    );
+  });
+}
+
+/**
+ * Close a flow's scope, releasing its resources. A defect while releasing one
+ * resource cannot skip the others (each finalizer is independent), and the
+ * aggregated defect must never escape — flow teardown runs on shutdown paths
+ * that must not crash the app — so it is logged at debug level like the
+ * pre-Effect try/catch did.
+ */
+function closeFlowScope(scope: Scope.Closeable, failureLogMessage: string): Effect.Effect<void> {
+  return Scope.close(scope, Exit.void).pipe(
+    Effect.catchDefect((defect) =>
+      Effect.sync(() => {
+        log.debug(failureLogMessage, defect);
+      })
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Manager
 // ---------------------------------------------------------------------------
 
 export class OAuthFlowManager {
-  private readonly flows = new Map<string, OAuthFlowEntry>();
+  private readonly flows = new Map<string, ActiveFlow>();
   private readonly completed = new Map<string, CompletedOAuthFlowEntry>();
 
   constructor(private readonly completedFlowTtlMs = DEFAULT_COMPLETED_FLOW_TTL_MS) {}
@@ -57,27 +147,32 @@ export class OAuthFlowManager {
       // Defensive: avoid silently overwriting an active flow entry.
       //
       // This can happen if a provider accidentally re-uses a flow ID, or if a
-      // stale in-flight start attempt races a newer one. Best-effort cleanup to
-      // avoid leaking timeouts, deferred promises, or loopback servers.
+      // stale in-flight start attempt races a newer one. Clean up to avoid
+      // leaking timeouts, deferred promises, or loopback servers.
       log.debug(`[OAuthFlowManager] Duplicate register — replacing active flow (flowId=${flowId})`);
 
-      if (existing.timeoutHandle !== null) {
-        clearTimeout(existing.timeoutHandle);
-      }
-
-      try {
-        existing.resultDeferred.resolve(Err("OAuth flow replaced"));
-
-        if (existing.server) {
-          // Stop accepting new connections.
-          void closeServer(existing.server);
-        }
-      } catch (error) {
-        log.debug("Failed to clean up replaced OAuth flow:", error);
-      }
+      this.flows.delete(flowId);
+      existing.finalResult = Err("OAuth flow replaced");
+      // register must stay synchronous while the replaced flow's server close
+      // is async, so run the release in a detached fiber. runFork executes it
+      // synchronously up to the first suspension: the old timeout is cleared
+      // and the old deferred settles before register returns (same observable
+      // ordering as before); only the server close continues in background.
+      Effect.runFork(closeFlowScope(existing.scope, "Failed to clean up replaced OAuth flow:"));
     }
 
-    this.flows.set(flowId, entry);
+    const scope = Scope.makeUnsafe();
+    const flow: ActiveFlow = { entry, scope, finalResult: Err("OAuth flow terminated") };
+    try {
+      Effect.runSync(Scope.provide(scope)(acquireFlowResources(flow)));
+    } catch (error) {
+      // Defensive: the acquisition steps are infallible ownership handovers,
+      // but if one ever defects, release whatever was acquired so a partial
+      // registration cannot leak resources.
+      Effect.runFork(closeFlowScope(scope, "Failed to clean up partially registered OAuth flow:"));
+      throw error;
+    }
+    this.flows.set(flowId, flow);
   }
 
   private clearCompleted(flowId: string): void {
@@ -91,92 +186,14 @@ export class OAuthFlowManager {
     this.completed.delete(flowId);
   }
 
-  /** Get a flow entry by ID, or undefined if not found. */
-  get(flowId: string): OAuthFlowEntry | undefined {
-    return this.flows.get(flowId);
-  }
-
-  /** Check whether a flow exists. */
-  has(flowId: string): boolean {
-    return this.flows.has(flowId);
-  }
-
   /**
-   * Wait for a flow to complete with a caller-facing timeout race.
+   * Preserve the final result briefly so late waiters can still retrieve it.
    *
-   * Mirrors the `waitForDesktopFlow` pattern shared across all four services:
-   * - Creates a local timeout promise for this wait call only.
-   * - Races that local timeout against `flow.resultDeferred.promise`.
-   * - Registration-time timeout remains on `flow.timeoutHandle` and is cleared in `finish`.
-   * - On any error result (caller timeout or flow error), calls `finish` for shared cleanup.
+   * Old per-service DesktopFlow implementations kept completed flows around for
+   * ~60s (cleanupTimeout) to avoid a race where the OAuth callback finishes
+   * before the frontend begins `waitFor`-ing.
    */
-  async waitFor(flowId: string, timeoutMs: number): Promise<Result<void, string>> {
-    const flow = this.flows.get(flowId);
-    if (!flow) {
-      const completed = this.completed.get(flowId);
-      if (completed) {
-        return completed.result;
-      }
-
-      return Err("OAuth flow not found");
-    }
-
-    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-    const timeoutPromise = new Promise<Result<void, string>>((resolve) => {
-      timeoutHandle = setTimeout(() => {
-        resolve(Err("Timed out waiting for OAuth callback"));
-      }, timeoutMs);
-    });
-
-    const result = await Promise.race([flow.resultDeferred.promise, timeoutPromise]);
-
-    if (timeoutHandle !== null) {
-      clearTimeout(timeoutHandle);
-    }
-
-    if (!result.success) {
-      // Ensure listener is closed on timeout/errors.
-      void this.finish(flowId, result);
-    }
-
-    return result;
-  }
-
-  /**
-   * Cancel a flow — resolves the deferred with an error and cleans up.
-   *
-   * Mirrors the `cancelDesktopFlow` pattern.
-   */
-  async cancel(flowId: string): Promise<void> {
-    const flow = this.flows.get(flowId);
-    if (!flow) return;
-
-    await this.finish(flowId, Err("OAuth flow cancelled"));
-  }
-
-  /**
-   * Finish a flow: resolve the deferred, clear the timeout, close the server,
-   * and remove the entry from the map.
-   *
-   * Idempotent — no-op if the flow was already removed. Mirrors the
-   * `finishDesktopFlow` pattern.
-   */
-  async finish(flowId: string, result: Result<void, string>): Promise<void> {
-    const flow = this.flows.get(flowId);
-    if (!flow) return;
-
-    // Remove from map first to make re-entrant calls no-ops.
-    this.flows.delete(flowId);
-
-    if (flow.timeoutHandle !== null) {
-      clearTimeout(flow.timeoutHandle);
-    }
-
-    // Preserve the final result briefly so late waiters can still retrieve it.
-    //
-    // Old per-service DesktopFlow implementations kept completed flows around for
-    // ~60s (cleanupTimeout) to avoid a race where the OAuth callback finishes
-    // before the frontend begins `waitFor`-ing.
+  private recordCompleted(flowId: string, result: Result<void, string>): void {
     this.clearCompleted(flowId);
     const cleanupTimeout = setTimeout(() => {
       this.completed.delete(flowId);
@@ -188,17 +205,133 @@ export class OAuthFlowManager {
     }
 
     this.completed.set(flowId, { result, cleanupTimeout });
+  }
 
-    try {
-      flow.resultDeferred.resolve(result);
+  /** Get a flow entry by ID, or undefined if not found. */
+  get(flowId: string): OAuthFlowEntry | undefined {
+    return this.flows.get(flowId)?.entry;
+  }
 
-      if (flow.server) {
-        // Stop accepting new connections.
-        await closeServer(flow.server);
+  /** Check whether a flow exists. */
+  has(flowId: string): boolean {
+    return this.flows.has(flowId);
+  }
+
+  /**
+   * Synchronous head of `finish`: remove the flow from the active map (so
+   * re-entrant calls and `has` liveness checks observe the removal
+   * immediately), record the completed result for late waiters, and stage the
+   * final result for the deferred-settle finalizer. Returns the async release
+   * (scope close) for the caller to run — awaited by `finishEffect`,
+   * fire-and-forget in a detached fiber on the `waitFor` error path.
+   */
+  private beginFinish(flowId: string, result: Result<void, string>): Effect.Effect<void> | null {
+    const flow = this.flows.get(flowId);
+    if (!flow) return null;
+
+    this.flows.delete(flowId);
+    this.recordCompleted(flowId, result);
+
+    flow.finalResult = result;
+    return closeFlowScope(flow.scope, "Failed to close OAuth callback listener:");
+  }
+
+  /**
+   * Wait for a flow to complete with a caller-facing timeout race.
+   *
+   * Mirrors the `waitForDesktopFlow` pattern shared across all four services:
+   * - `Effect.timeout` bounds this wait call only; on timeout it interrupts
+   *   the promise-wait fiber (the shared deferred is unaffected for other
+   *   waiters) and its own timer is cleared by the interruption when the
+   *   deferred wins.
+   * - Registration-time timeout remains on `flow.timeoutHandle` and is cleared
+   *   by the flow scope's release.
+   * - On any error result (caller timeout or flow error), runs `finish` for
+   *   shared cleanup.
+   */
+  waitForEffect(flowId: string, timeoutMs: number): Effect.Effect<Result<void, string>> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const flow = self.flows.get(flowId);
+      if (!flow) {
+        const completed = self.completed.get(flowId);
+        if (completed) {
+          return completed.result;
+        }
+
+        return Err("OAuth flow not found");
       }
-    } catch (error) {
-      log.debug("Failed to close OAuth callback listener:", error);
-    }
+
+      const result: Result<void, string> = yield* Effect.promise(
+        async () => flow.entry.resultDeferred.promise
+      ).pipe(
+        Effect.timeout(Duration.millis(timeoutMs)),
+        Effect.catch(() =>
+          Effect.succeed<Result<void, string>>(Err("Timed out waiting for OAuth callback"))
+        )
+      );
+
+      if (!result.success) {
+        // Ensure listener is closed on timeout/errors. Bookkeeping runs
+        // synchronously (the flow is unregistered before waitFor resolves);
+        // the async release runs in a detached fiber so waiters aren't held
+        // up by the server close — same fire-and-forget shape as the
+        // pre-Effect `void this.finish(...)`, but as a supervised fiber that
+        // survives this effect's completion.
+        const release = self.beginFinish(flowId, result);
+        if (release !== null) {
+          yield* Effect.forkDetach(release);
+        }
+      }
+
+      return result;
+    });
+  }
+
+  async waitFor(flowId: string, timeoutMs: number): Promise<Result<void, string>> {
+    return Effect.runPromise(this.waitForEffect(flowId, timeoutMs));
+  }
+
+  /**
+   * Cancel a flow — resolves the deferred with an error and cleans up.
+   *
+   * Mirrors the `cancelDesktopFlow` pattern.
+   */
+  cancelEffect(flowId: string): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      if (!self.flows.has(flowId)) return;
+
+      yield* self.finishEffect(flowId, Err("OAuth flow cancelled"));
+    });
+  }
+
+  async cancel(flowId: string): Promise<void> {
+    return Effect.runPromise(this.cancelEffect(flowId));
+  }
+
+  /**
+   * Finish a flow: resolve the deferred, clear the timeout, close the server
+   * (all via the flow scope's release), and remove the entry from the map.
+   *
+   * Idempotent — no-op if the flow was already removed. Mirrors the
+   * `finishDesktopFlow` pattern. Never fails: release defects are logged.
+   */
+  finishEffect(flowId: string, result: Result<void, string>): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const release = self.beginFinish(flowId, result);
+      if (release !== null) {
+        yield* release;
+      }
+    });
+  }
+
+  async finish(flowId: string, result: Result<void, string>): Promise<void> {
+    return Effect.runPromise(this.finishEffect(flowId, result));
   }
 
   /**
@@ -208,19 +341,43 @@ export class OAuthFlowManager {
    * cleared). Each flow is removed from the manager before this resolves,
    * so commit-path liveness checks (`has`) fail for the cancelled flows.
    */
+  cancelAllEffect(): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const flowIds = [...self.flows.keys()];
+      yield* Effect.all(
+        flowIds.map((id) => self.cancelEffect(id)),
+        { concurrency: "unbounded", discard: true }
+      );
+    });
+  }
+
   async cancelAll(): Promise<void> {
-    const flowIds = [...this.flows.keys()];
-    await Promise.all(flowIds.map((id) => this.cancel(id)));
+    return Effect.runPromise(this.cancelAllEffect());
   }
 
   /**
    * Shut down all active flows — resolves each with an error.
    *
-   * Mirrors the `dispose` pattern where services iterate all flows
-   * and finish them with `Err("App shutting down")`.
+   * Mirrors the `dispose` pattern where services iterate all flows and finish
+   * them with `Err("App shutting down")`. Stays async (callers' `dispose`
+   * awaits the loopback-server closes, which are bounded by the server's
+   * force-finish socket handling) and never rejects.
    */
+  shutdownAllEffect(): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const flowIds = [...self.flows.keys()];
+      yield* Effect.all(
+        flowIds.map((id) => self.finishEffect(id, Err("App shutting down"))),
+        { concurrency: "unbounded", discard: true }
+      );
+    });
+  }
+
   async shutdownAll(): Promise<void> {
-    const flowIds = [...this.flows.keys()];
-    await Promise.all(flowIds.map((id) => this.finish(id, Err("App shutting down"))));
+    return Effect.runPromise(this.shutdownAllEffect());
   }
 }


### PR DESCRIPTION
## Summary

Phase 5 of the progressive Effect migration (first phase of Wave 2, the wave's gating item deferred since #4027): converts `OAuthFlowManager` internals to Effect with real resource safety. Every registered desktop OAuth flow now owns a per-flow `Scope` whose release finalizers guarantee cleanup (registration-timeout clear, deferred settlement, loopback-server close) on every termination path — finish, cancel, caller-timeout race, duplicate registration, `shutdownAll`, and defects. The Promise-based public API is preserved as thin `Effect.runPromise` facades, so the three not-yet-converted OAuth services (`coderOauthService`, `codexOauthService`, `muxGovernorOauthService`) and all existing tests work unchanged.

## Background

Wave 1 (#4022, #4025, #4027, #4028, #4030, #4031, #4032) established the house pattern: `Effect.gen` internals, thin `runPromise` facades, `handlerGen` for oRPC procedures. #4027 converted `muxGatewayOauthService` but explicitly deferred the shared flow-lifecycle manager: its resources (loopback `http.Server`, registration `setTimeout`, result deferred) were cleaned up via ad-hoc `try/catch` + fire-and-forget `void closeServer(...)`, and a defect while resolving the deferred silently skipped the server close. This PR is the acquire/release case that deferral pointed at, and unblocks Phase 6 (batch conversion of the sibling OAuth services).

## Implementation

**Per-flow Scope design** — `register` creates a `Scope.makeUnsafe()` per flow and moves ownership of the caller-acquired resources into it via one `Effect.acquireRelease` per resource (a combined acquisition would install its finalizer only after every step succeeded, leaking earlier resources on a later defect — the #4031 Codex P2 lesson). Release runs in reverse acquisition order, preserving the pre-Effect `finish` ordering: clear registration timeout → settle deferred (waiters unblock before the async close) → close loopback server (awaited).

**Deferred settlement via finalizer** — each `ActiveFlow` carries a mutable `finalResult` staged by the terminating path (finish/cancel/shutdown/replace); the settle finalizer resolves the caller's deferred with it. Settlement is therefore scope-guaranteed rather than an ad-hoc `resolve` call, with a defensive fallback result so waiters can never hang.

**Caller-facing timeout race** — `waitFor` maps to `Effect.timeout` over `Effect.promise` on the shared deferred: the local wait timer is fiber-managed (interruption clears it), stays separate from the registration-time timeout, and on any error result runs `finish` for shared cleanup. The cleanup's synchronous bookkeeping (map removal, completed-result recording) runs before `waitFor` resolves — exact parity with the old sync prefix — while the async release runs in an `Effect.forkDetach` fiber, replacing the old `void this.finish(...)` fire-and-forget with a supervised fiber that survives the caller's completion (verified by a live-runtime probe: detached fibers outlive the parent, `runFork`/`runPromise` execute synchronously to first suspension, and a throwing finalizer does not skip its siblings).

**shutdownAll contract** — preserved as async (`Promise<void>` facade): `serviceContainer.dispose` awaits it, and loopback-server closes are bounded by the server's force-finish socket handling. It never rejects; release defects are caught (`Effect.catchDefect`) and logged at debug level, per the startup/shutdown-must-never-crash rule.

**Effect-native surface** — `waitForEffect` / `cancelEffect` / `finishEffect` / `cancelAllEffect` / `shutdownAllEffect` are public (wire-shaped, never-failing — same shape as #4032's Effect surfaces). `muxGatewayOauthService`'s Effect pipeline now yields `finishEffect` directly instead of `Effect.promise(() => …finish(...))`, and its registration-timeout callback uses `Effect.runFork(finishEffect(...))` instead of `void finish(...)`.

**Not converted to Effect `Deferred`** — the result deferred's identity is part of the public caller-owned `OAuthFlowEntry` (the three unconverted services construct entries with `createDeferred`), so swapping it would break the "existing callers unchanged" contract; revisit when Phase 6 converts entry construction.

## Validation

- All 18 pre-existing `oauthFlowManager` tests pass byte-identical, plus all OAuth service suites (194 tests: coder/codex/muxGateway/muxGovernor/mcp/copilot/codexOauthAuth) and loopback-server/oauthUtils suites.
- Two new behavioral tests for the genuinely-new guarantees: (1) server close + timeout clear still happen when the deferred `resolve` throws (the pre-Effect code skipped the close — this test fails on the old implementation), and (2) the detached cleanup fiber completes after `waitFor` has already returned on the timeout path (guards against accidental child-fiber supervision, where the release would be interrupted with the caller).
- A standalone Effect v4 runtime probe validated the semantics the design relies on (finalizer independence under defects, reverse sequential release order, eager sync-prefix execution of `runPromise`/`runFork`, `forkDetach` outliving the parent, `Effect.timeout` + `Effect.catch` over `Effect.promise`).
- `make static-check` green.

## Risks

Low-to-moderate: this is shared lifecycle code under four OAuth login flows (Gateway, Governor, Codex, Coder). The public API, observable ordering (map removal before `finish` resolves, deferred settlement before server close, synchronous `register`), and error strings are preserved exactly; regressions would surface as leaked loopback listeners, hung `waitFor` calls, or unsettled deferreds — all covered by the existing + new suites.

## Lessons for Phase 6

Phase 6 is the batch conversion of `coderOauthService`, `codexOauthService`, `muxGovernorOauthService`, `copilotOauthService`, plus their ~20 router sites. Notes to make it mechanical:

- The manager now exposes never-failing, wire-shaped `waitForEffect`/`cancelEffect`/`finishEffect`/`shutdownAllEffect`, so converted service pipelines can yield them directly (see `desktopCallbackPipeline` in `muxGatewayOauthService` as the template), and registration-timeout callbacks should use `Effect.runFork(manager.finishEffect(...))`.
- `beginFinish`'s sync-bookkeeping/async-release split is the pattern to reach for wherever a service needs "unregister now, release in background" semantics.
- Each sibling's `startDesktopFlow` should become uninterruptible like the gateway's (#4032): a client abort between loopback acquisition and `register` would otherwise leak the server.
- `coderOauthService` is the outlier: it has extra commit-path liveness checks (`has`) and multi-step persist/commit finish calls (~10 `desktopFlows.*` sites vs ~5 in the others) — expect most of the Phase 6 effort there.
- **Recommendation: two PRs.** PR A: codex + governor + copilot service internals (near-identical DesktopFlow shape, mechanical) together with their router procedures moving to `handlerGen` (the `waitFor`/`cancel` handlers for the gateway can join here — the router comment at `muxGatewayOauth` already points at this). PR B: `coderOauthService` alone — its commit/persist liveness semantics deserve isolated review, and a combined PR would bury it under the mechanical churn.
---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `anthropic:claude-fable-5` • Thinking: `xhigh`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh -->
