### PR TITLE
🤖 refactor: convert Config service mutation surface to Effect Semaphore pipeline and config router sites to handlerGen

### DIFF
--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as crypto from "crypto";
 import { EventEmitter } from "events";
 import writeFileAtomic from "write-file-atomic";
+import { Effect, Semaphore } from "effect";
 import { resolveXumEnvironmentValue } from "@/common/compat/legacyMux";
 import { log } from "@/node/services/log";
 import { ProvidersConfigStore } from "./providersConfigStore";
@@ -906,8 +907,14 @@ export class Config {
    */
   private readonly legacyTaskVariantGroups = new Map<string, LegacyTaskVariantWorkspace>();
   private readonly legacyTaskVariantMetadataOnlyIds = new Set<string>();
-  /** Serializes editConfig calls; see editConfig for why. */
-  private editConfigQueue: Promise<void> = Promise.resolve();
+  /**
+   * Serializes editConfig calls; see editConfig for why. An Effect Semaphore (FIFO
+   * permits) replaces the old promise-chain queue 1:1: each edit holds the single
+   * permit for its whole read-modify-write cycle, and a failed edit releases its
+   * permit on the way out, which preserves the old queue-keep-alive behavior (one
+   * edit's failure never wedges later edits).
+   */
+  private readonly editSemaphore = Semaphore.makeUnsafe(1);
   /** One-shot guard for the queued load-time migration persist; see loadConfigOrDefault. */
   private migrationPersist: Promise<void> | null = null;
 
@@ -1806,11 +1813,16 @@ export class Config {
    * removeWorkspace() and written after it resurrected the removed workspace entry
    * as a permanent sidebar ghost. All mutations must go through editConfig so each
    * write is derived from a fresh serialized read.
+   *
+   * Never fails: the whole pipeline folds every failure and defect into the same
+   * log-and-swallow the old try/catch applied (total catch discipline).
    */
-  private async saveConfig(config: ProjectsConfig): Promise<void> {
-    try {
-      if (!fs.existsSync(this.rootDir)) {
-        ensurePrivateDirSync(this.rootDir);
+  private saveConfig(config: ProjectsConfig): Effect.Effect<void> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      if (!fs.existsSync(self.rootDir)) {
+        ensurePrivateDirSync(self.rootDir);
       }
 
       const data: Partial<Record<keyof AppConfigOnDisk, unknown>> & {
@@ -1824,7 +1836,7 @@ export class Config {
           };
           for (const workspace of persistedProjectConfig.workspaces) {
             const workspaceId = parseOptionalNonEmptyString(workspace.id);
-            const legacy = workspaceId ? this.legacyTaskVariantGroups.get(workspaceId) : undefined;
+            const legacy = workspaceId ? self.legacyTaskVariantGroups.get(workspaceId) : undefined;
             if (legacy && workspace.bestOf == null) {
               // Keep downgrade-only metadata on disk without exposing it to current runtime types,
               // UI grouping, or provider-facing task schemas.
@@ -2084,22 +2096,29 @@ export class Config {
           }
         }
       }
-      await writeFileAtomic(this.configFile, JSON.stringify(data, null, 2), "utf-8");
-      for (const workspaceId of this.legacyTaskVariantGroups.keys()) {
+      yield* Effect.tryPromise({
+        try: async () => writeFileAtomic(self.configFile, JSON.stringify(data, null, 2), "utf-8"),
+        catch: (error) => error,
+      });
+      for (const workspaceId of self.legacyTaskVariantGroups.keys()) {
         if (!persistedWorkspaceIds.has(workspaceId)) {
           // A load-time settings migration can save before getAllWorkspaceMetadata's queued
           // identity migration adds this legacy workspace ID. Keep metadata-only entries alive
           // until a later save can attach them to the migrated config record.
-          if (!this.legacyTaskVariantMetadataOnlyIds.has(workspaceId)) {
-            this.legacyTaskVariantGroups.delete(workspaceId);
+          if (!self.legacyTaskVariantMetadataOnlyIds.has(workspaceId)) {
+            self.legacyTaskVariantGroups.delete(workspaceId);
           }
         } else {
-          this.legacyTaskVariantMetadataOnlyIds.delete(workspaceId);
+          self.legacyTaskVariantMetadataOnlyIds.delete(workspaceId);
         }
       }
-    } catch (error) {
-      log.error("Error saving config:", error);
-    }
+    }).pipe(
+      // Mirror the old whole-pipeline try/catch: fold both the typed write failure and
+      // any defect thrown by the synchronous serialization above into the same
+      // log-and-swallow, so this pipeline never fails.
+      Effect.catch((error) => Effect.sync(() => log.error("Error saving config:", error))),
+      Effect.catchDefect((error) => Effect.sync(() => log.error("Error saving config:", error)))
+    );
   }
 
   /**
@@ -2418,57 +2437,90 @@ export class Config {
    * detail rather than a caller-initiated mutation.
    */
   private enqueueConfigEdit(fn: (config: ProjectsConfig) => ProjectsConfig): Promise<void> {
-    const run = this.editConfigQueue.then(async () => {
-      const config = this.loadConfigOrDefault();
-      const newConfig = fn(config);
-      // If that load failed, writing would replace the corrupt file with defaults. Only
-      // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
-      // no confirmed backup, a concurrent replacement since the load, or an unreadable
-      // file all reject the edit so callers do not treat the mutation as durable (unlike
-      // saveConfig's log-and-swallow of unexpected I/O errors, this skip is deliberate).
-      // A missing file is safe to overwrite. This cannot fully close the cross-process
-      // race (that needs file locking, which editConfig has never had); it binds the
-      // approval to the current bytes and shrinks the window to the atomic write itself.
-      const failureState = configLoadFailureStates.get(this.configFile);
-      if (failureState) {
-        const rejectEdit = (reason: string): never => {
-          const message = `Skipping config write to ${this.configFile}: ${reason}`;
-          log.error(message);
-          throw new Error(message);
-        };
-        if (failureState.backupSignature === null) {
-          rejectEdit(
-            "the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry."
-          );
-        }
-        let currentSignature: string | null = null;
-        try {
-          const currentBytes = fs.readFileSync(this.configFile);
-          currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
-        } catch (readError) {
-          if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
-            rejectEdit(
-              `the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
-            );
-          }
-        }
-        if (currentSignature !== null && currentSignature !== failureState.backupSignature) {
-          rejectEdit(
-            "the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change."
-          );
-        }
-      }
-      await this.saveConfig(newConfig);
-      // Backend-initiated config edits (for example gateway auth changes) use this signal
-      // so frontend subscribers can refresh derived state without polling.
-      this.notifyConfigChanged();
-    });
-    // Keep the queue alive when an edit fails; the failure still propagates to this caller.
-    this.editConfigQueue = run.then(
-      () => undefined,
-      () => undefined
+    // Defer the fiber start to a microtask: Effect.runPromise executes fibers
+    // synchronously on the caller's stack until the first async boundary, but the old
+    // promise-chain queue always ran edit bodies on a later microtask.
+    // loadConfigOrDefault's one-shot migrationPersist guard depends on that ordering:
+    // the edit body's own loadConfigOrDefault must observe the `this.migrationPersist`
+    // assignment, or a load-time migration would schedule its persist twice.
+    // Effect failures reject this promise with the raw error (v4 runPromise does not
+    // wrap causes), so callers observe the same rejections as before.
+    return Promise.resolve().then(() => Effect.runPromise(this.enqueueConfigEditEffect(fn)));
+  }
+
+  /**
+   * Semaphore(1)-serialized edit pipeline: FIFO permits guarantee each edit's read
+   * happens only after the previous edit's write has landed, replacing the old
+   * promise-chain queue 1:1. The body is uninterruptible so an interruption can never
+   * separate the corrupt-file gate from the write it approves, or drop the change
+   * notification after a write landed; waiting for the permit stays interruptible (a
+   * fiber cancelled while waiting never runs its edit).
+   */
+  private enqueueConfigEditEffect(
+    fn: (config: ProjectsConfig) => ProjectsConfig
+  ): Effect.Effect<void, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return this.editSemaphore.withPermits(1)(
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          // Effect.try keeps the pre-Effect contract: a throwing transform or a rejected
+          // corrupt-file gate reaches the caller as the raw original error.
+          const newConfig = yield* Effect.try({
+            try: () => {
+              const config = self.loadConfigOrDefault();
+              const newConfig = fn(config);
+              // If that load failed, writing would replace the corrupt file with defaults. Only
+              // proceed when the bytes on disk right now are the ones with a confirmed sidecar:
+              // no confirmed backup, a concurrent replacement since the load, or an unreadable
+              // file all reject the edit so callers do not treat the mutation as durable (unlike
+              // saveConfig's log-and-swallow of unexpected I/O errors, this skip is deliberate).
+              // A missing file is safe to overwrite. This cannot fully close the cross-process
+              // race (that needs file locking, which editConfig has never had); it binds the
+              // approval to the current bytes and shrinks the window to the atomic write itself.
+              const failureState = configLoadFailureStates.get(self.configFile);
+              if (failureState) {
+                const rejectEdit = (reason: string): never => {
+                  const message = `Skipping config write to ${self.configFile}: ${reason}`;
+                  log.error(message);
+                  throw new Error(message);
+                };
+                if (failureState.backupSignature === null) {
+                  rejectEdit(
+                    "the existing corrupt config has no confirmed backup yet. Fix the reported backup failure or move the corrupt file aside, then retry."
+                  );
+                }
+                let currentSignature: string | null = null;
+                try {
+                  const currentBytes = fs.readFileSync(self.configFile);
+                  currentSignature = crypto.createHash("sha256").update(currentBytes).digest("hex");
+                } catch (readError) {
+                  if ((readError as NodeJS.ErrnoException).code !== "ENOENT") {
+                    rejectEdit(
+                      `the file could not be re-read before writing (${readError instanceof Error ? readError.message : String(readError)}). Retry the settings change.`
+                    );
+                  }
+                }
+                if (
+                  currentSignature !== null &&
+                  currentSignature !== failureState.backupSignature
+                ) {
+                  rejectEdit(
+                    "the file changed after this edit loaded it and the new content has no confirmed backup. Retry the settings change."
+                  );
+                }
+              }
+              return newConfig;
+            },
+            catch: (error) => error,
+          });
+          yield* self.saveConfig(newConfig);
+          // Backend-initiated config edits (for example gateway auth changes) use this signal
+          // so frontend subscribers can refresh derived state without polling.
+          self.notifyConfigChanged();
+        })
+      )
     );
-    return run;
   }
 
   getUpdateChannel(): UpdateChannel {

--- a/src/node/config/index.ts
+++ b/src/node/config/index.ts
@@ -1814,10 +1814,18 @@ export class Config {
    * as a permanent sidebar ghost. All mutations must go through editConfig so each
    * write is derived from a fresh serialized read.
    *
+   * Kept as a Promise facade (tests spy on it with Promise mocks to simulate
+   * swallowed writes); saveConfigEffect below holds the actual pipeline.
+   */
+  private saveConfig(config: ProjectsConfig): Promise<void> {
+    return Effect.runPromise(this.saveConfigEffect(config));
+  }
+
+  /**
    * Never fails: the whole pipeline folds every failure and defect into the same
    * log-and-swallow the old try/catch applied (total catch discipline).
    */
-  private saveConfig(config: ProjectsConfig): Effect.Effect<void> {
+  private saveConfigEffect(config: ProjectsConfig): Effect.Effect<void> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
     const self = this;
     return Effect.gen(function* () {
@@ -2514,7 +2522,9 @@ export class Config {
             },
             catch: (error) => error,
           });
-          yield* self.saveConfig(newConfig);
+          // Route through the saveConfig Promise facade (not saveConfigEffect) so test
+          // spies on saveConfig keep intercepting the serialized write.
+          yield* Effect.promise(async () => self.saveConfig(newConfig));
           // Backend-initiated config edits (for example gateway auth changes) use this signal
           // so frontend subscribers can refresh derived state without polling.
           self.notifyConfigChanged();

--- a/src/node/config/providersConfigStore.ts
+++ b/src/node/config/providersConfigStore.ts
@@ -2,6 +2,7 @@ import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import * as jsonc from "jsonc-parser";
+import { Effect } from "effect";
 import writeFileAtomic from "write-file-atomic";
 import { getXumHome } from "@/common/constants/paths";
 import type {
@@ -23,16 +24,31 @@ export class ProvidersConfigStore {
   }
 
   loadProvidersConfig(): ProvidersConfig | null {
-    try {
-      if (fs.existsSync(this.providersFile)) {
-        const data = fs.readFileSync(this.providersFile, "utf-8");
-        return jsonc.parse(data) as ProvidersConfig;
-      }
-    } catch (error) {
-      log.error("Error loading providers config:", error);
-    }
+    return Effect.runSync(this.loadProvidersConfigEffect());
+  }
 
-    return null;
+  /**
+   * Total pre-Effect catch discipline: any read/parse failure folds to `null`
+   * (logged), matching the old whole-body try/catch.
+   */
+  private loadProvidersConfigEffect(): Effect.Effect<ProvidersConfig | null> {
+    return Effect.try({
+      try: (): ProvidersConfig | null => {
+        if (fs.existsSync(this.providersFile)) {
+          const data = fs.readFileSync(this.providersFile, "utf-8");
+          return jsonc.parse(data) as ProvidersConfig;
+        }
+        return null;
+      },
+      catch: (error) => error,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          log.error("Error loading providers config:", error);
+          return null;
+        })
+      )
+    );
   }
 
   /**
@@ -50,12 +66,15 @@ export class ProvidersConfigStore {
    * write signal.
    */
   getProvidersFileFingerprint(): string | null {
-    try {
+    return Effect.runSync(this.getProvidersFileFingerprintEffect());
+  }
+
+  /** Total pre-Effect catch discipline: any read failure folds silently to `null`. */
+  private getProvidersFileFingerprintEffect(): Effect.Effect<string | null> {
+    return Effect.try((): string | null => {
       const contents = fs.readFileSync(this.providersFile);
       return crypto.createHash("sha256").update(contents).digest("hex");
-    } catch {
-      return null;
-    }
+    }).pipe(Effect.catch(() => Effect.succeed(null)));
   }
 
   /**
@@ -144,14 +163,25 @@ export class ProvidersConfigStore {
   }
 
   saveProvidersConfig(config: ProvidersConfig): void {
-    try {
-      if (!fs.existsSync(this.rootDir)) {
-        ensurePrivateDirSync(this.rootDir);
-      }
+    // runSync rethrows the raw typed failure, so callers observe the same throw as
+    // before the Effect conversion.
+    Effect.runSync(this.saveProvidersConfigEffect(config));
+  }
 
-      const jsonString = JSON.stringify(config, null, 2);
+  /**
+   * Log-then-rethrow pre-Effect catch discipline: failures are logged and pass
+   * through raw to the caller in the typed failure channel.
+   */
+  private saveProvidersConfigEffect(config: ProvidersConfig): Effect.Effect<void, unknown> {
+    return Effect.try({
+      try: () => {
+        if (!fs.existsSync(this.rootDir)) {
+          ensurePrivateDirSync(this.rootDir);
+        }
 
-      const contentWithComments = `// Providers configuration for xum
+        const jsonString = JSON.stringify(config, null, 2);
+
+        const contentWithComments = `// Providers configuration for xum
 // Configure your AI providers here
 // Example:
 // {
@@ -170,13 +200,16 @@ export class ProvidersConfigStore {
 // }
 ${jsonString}`;
 
-      writeFileAtomic.sync(this.providersFile, contentWithComments, {
-        encoding: "utf-8",
-        mode: 0o600,
-      });
-    } catch (error) {
-      log.error("Error saving providers config:", error);
-      throw error; // Re-throw to let caller handle
-    }
+        writeFileAtomic.sync(this.providersFile, contentWithComments, {
+          encoding: "utf-8",
+          mode: 0o600,
+        });
+      },
+      catch: (error) => error,
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() => log.error("Error saving providers config:", error))
+      )
+    );
   }
 }

--- a/src/node/config/secretsStore.ts
+++ b/src/node/config/secretsStore.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { Effect } from "effect";
 import writeFileAtomic from "write-file-atomic";
 import { getXumHome } from "@/common/constants/paths";
 import { isSecretReferenceValue, type Secret, type SecretsConfig } from "@/common/types/secrets";
@@ -149,17 +150,32 @@ export class SecretsStore {
   }
 
   loadSecretsConfig(): SecretsConfig {
-    try {
-      if (fs.existsSync(this.secretsFile)) {
-        const data = fs.readFileSync(this.secretsFile, "utf-8");
-        const parsed = JSON.parse(data) as unknown;
-        return SecretsStore.normalizeSecretsConfig(parsed);
-      }
-    } catch (error) {
-      log.error("Error loading secrets config:", error);
-    }
+    return Effect.runSync(this.loadSecretsConfigEffect());
+  }
 
-    return {};
+  /**
+   * Total pre-Effect catch discipline: any read/parse failure folds to `{}` (logged),
+   * matching the old whole-body try/catch.
+   */
+  private loadSecretsConfigEffect(): Effect.Effect<SecretsConfig> {
+    return Effect.try({
+      try: (): SecretsConfig => {
+        if (fs.existsSync(this.secretsFile)) {
+          const data = fs.readFileSync(this.secretsFile, "utf-8");
+          const parsed = JSON.parse(data) as unknown;
+          return SecretsStore.normalizeSecretsConfig(parsed);
+        }
+        return {};
+      },
+      catch: (error) => error,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          log.error("Error loading secrets config:", error);
+          return {};
+        })
+      )
+    );
   }
 
   /**
@@ -167,19 +183,27 @@ export class SecretsStore {
    * paths so unsupported legacy entries survive round-trips to disk instead of
    * being silently deleted when an unrelated secret is saved.
    */
-  private loadRawSecretsConfig(): Record<string, unknown> {
-    try {
-      if (fs.existsSync(this.secretsFile)) {
-        const parsed = JSON.parse(fs.readFileSync(this.secretsFile, "utf-8")) as unknown;
-        if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return { ...(parsed as Record<string, unknown>) };
+  private loadRawSecretsConfigEffect(): Effect.Effect<Record<string, unknown>> {
+    return Effect.try({
+      try: (): Record<string, unknown> => {
+        if (fs.existsSync(this.secretsFile)) {
+          const parsed = JSON.parse(fs.readFileSync(this.secretsFile, "utf-8")) as unknown;
+          if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return { ...(parsed as Record<string, unknown>) };
+          }
         }
-      }
-    } catch (error) {
-      log.error("Error loading secrets config:", error);
-    }
-
-    return {};
+        return {};
+      },
+      catch: (error) => error,
+    }).pipe(
+      // Total pre-Effect catch discipline: any read/parse failure folds to `{}` (logged).
+      Effect.catch((error) =>
+        Effect.sync(() => {
+          log.error("Error loading secrets config:", error);
+          return {};
+        })
+      )
+    );
   }
 
   /**
@@ -187,47 +211,72 @@ export class SecretsStore {
    * project path) while leaving every other bucket byte-for-byte intact and
    * preserving unsupported legacy entries within the target bucket.
    */
-  private async updateSecretsBucket(bucketKey: string, secrets: Secret[]): Promise<void> {
-    const raw = this.loadRawSecretsConfig();
+  private updateSecretsBucketEffect(
+    bucketKey: string,
+    secrets: Secret[]
+  ): Effect.Effect<void, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias -- Effect.gen generator bodies do not inherit `this`
+    const self = this;
+    return Effect.gen(function* () {
+      const raw = yield* self.loadRawSecretsConfigEffect();
 
-    // Project paths may be persisted with trailing slashes; fold every raw key
-    // that maps to this bucket so preserved entries aren't left in a shadowed
-    // duplicate bucket.
-    const rawBucketEntries: unknown[] = [];
-    for (const [rawKey, rawValue] of Object.entries(raw)) {
-      const mappedKey =
-        rawKey === SecretsStore.GLOBAL_SECRETS_KEY
-          ? rawKey
-          : SecretsStore.normalizeSecretsProjectPath(rawKey) || rawKey;
-      if (mappedKey !== bucketKey) {
-        continue;
+      // Project paths may be persisted with trailing slashes; fold every raw key
+      // that maps to this bucket so preserved entries aren't left in a shadowed
+      // duplicate bucket.
+      const rawBucketEntries: unknown[] = [];
+      for (const [rawKey, rawValue] of Object.entries(raw)) {
+        const mappedKey =
+          rawKey === SecretsStore.GLOBAL_SECRETS_KEY
+            ? rawKey
+            : SecretsStore.normalizeSecretsProjectPath(rawKey) || rawKey;
+        if (mappedKey !== bucketKey) {
+          continue;
+        }
+
+        if (Array.isArray(rawValue)) {
+          // Array.isArray narrows unknown to any[]; retype to unknown[] for safe handling.
+          rawBucketEntries.push(...(rawValue as unknown[]));
+        }
+        delete raw[rawKey];
       }
 
-      if (Array.isArray(rawValue)) {
-        // Array.isArray narrows unknown to any[]; retype to unknown[] for safe handling.
-        rawBucketEntries.push(...(rawValue as unknown[]));
-      }
-      delete raw[rawKey];
-    }
-
-    raw[bucketKey] = SecretsStore.mergeSecretsPreservingUnsupported(rawBucketEntries, secrets);
-    await this.saveSecretsConfig(raw);
+      raw[bucketKey] = SecretsStore.mergeSecretsPreservingUnsupported(rawBucketEntries, secrets);
+      yield* self.saveSecretsConfigEffect(raw);
+    });
   }
 
-  async saveSecretsConfig(config: SecretsConfig | Record<string, unknown>): Promise<void> {
-    try {
-      if (!fs.existsSync(this.rootDir)) {
-        ensurePrivateDirSync(this.rootDir);
-      }
+  saveSecretsConfig(config: SecretsConfig | Record<string, unknown>): Promise<void> {
+    // runPromise rejects with the raw typed failure, so callers observe the same
+    // rejection as before the Effect conversion.
+    return Effect.runPromise(this.saveSecretsConfigEffect(config));
+  }
 
-      await writeFileAtomic(this.secretsFile, JSON.stringify(config, null, 2), {
-        encoding: "utf-8",
-        mode: 0o600,
-      });
-    } catch (error) {
-      log.error("Error saving secrets config:", error);
-      throw error;
-    }
+  /**
+   * Log-then-rethrow pre-Effect catch discipline: failures are logged and pass
+   * through raw to the caller in the typed failure channel. The thunk is async so a
+   * synchronous throw (e.g. from ensurePrivateDirSync) follows the same rejection
+   * path the old `await`-based body produced.
+   */
+  private saveSecretsConfigEffect(
+    config: SecretsConfig | Record<string, unknown>
+  ): Effect.Effect<void, unknown> {
+    return Effect.tryPromise({
+      try: async () => {
+        if (!fs.existsSync(this.rootDir)) {
+          ensurePrivateDirSync(this.rootDir);
+        }
+
+        await writeFileAtomic(this.secretsFile, JSON.stringify(config, null, 2), {
+          encoding: "utf-8",
+          mode: 0o600,
+        });
+      },
+      catch: (error) => error,
+    }).pipe(
+      Effect.tapError((error) =>
+        Effect.sync(() => log.error("Error saving secrets config:", error))
+      )
+    );
   }
 
   /**
@@ -241,8 +290,10 @@ export class SecretsStore {
   }
 
   /** Update global secrets (not project-scoped). */
-  async updateGlobalSecrets(secrets: Secret[]): Promise<void> {
-    await this.updateSecretsBucket(SecretsStore.GLOBAL_SECRETS_KEY, secrets);
+  updateGlobalSecrets(secrets: Secret[]): Promise<void> {
+    return Effect.runPromise(
+      this.updateSecretsBucketEffect(SecretsStore.GLOBAL_SECRETS_KEY, secrets)
+    );
   }
 
   /**
@@ -394,9 +445,9 @@ export class SecretsStore {
     return config[normalizedProjectPath] ?? [];
   }
 
-  async updateProjectSecrets(projectPath: string, secrets: Secret[]): Promise<void> {
+  updateProjectSecrets(projectPath: string, secrets: Secret[]): Promise<void> {
     const normalizedProjectPath =
       SecretsStore.normalizeSecretsProjectPath(projectPath) || projectPath;
-    await this.updateSecretsBucket(normalizedProjectPath, secrets);
+    return Effect.runPromise(this.updateSecretsBucketEffect(normalizedProjectPath, secrets));
   }
 }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -28,6 +28,7 @@ import {
   setWorkspaceMcpOverrides,
 } from "@/node/services/agentPlugins/workspacePluginOperations";
 import { handlerGen } from "@orpc/experimental-effect";
+import { Effect } from "effect";
 import {
   assertMemoryEnabled,
   consolidateMemoryEffect,
@@ -189,18 +190,36 @@ export const router = (authToken?: string) => {
         .output(schemas.tokenizer.calculateStats.output)
         .handler(({ context, input }) => context.tokenizerService.calculateWorkspaceStats(input)),
     },
+    // Config-backed procedures ride handlerGen. Interruption posture (also applies to
+    // the `config` and `uiLayouts` namespaces below): reads are single Effect.sync
+    // steps (interruption is a don't-care); mutations wrap the whole pre-Effect
+    // handler body in one Effect.promise thunk, so they are uninterruptible by
+    // construction — a client abort interrupts the handler fiber, never the in-flight
+    // Semaphore(1)-serialized config edit, and multi-step bodies (mutate + notify)
+    // cannot be torn apart. Rejections become defects, surfacing as the same internal
+    // error the old async handlers produced.
     splashScreens: {
       getViewedSplashScreens: t
         .input(schemas.splashScreens.getViewedSplashScreens.input)
         .output(schemas.splashScreens.getViewedSplashScreens.output)
-        .handler(({ context }) => {
-          const config = context.config.loadConfigOrDefault();
-          return config.viewedSplashScreens ?? [];
-        }),
+        .handler(
+          handlerGen(function* ({ context }) {
+            return yield* Effect.sync(() => {
+              const config = context.config.loadConfigOrDefault();
+              return config.viewedSplashScreens ?? [];
+            });
+          })
+        ),
       markSplashScreenViewed: t
         .input(schemas.splashScreens.markSplashScreenViewed.input)
         .output(schemas.splashScreens.markSplashScreenViewed.output)
-        .handler(({ context, input }) => context.config.markSplashScreenViewed(input.splashId)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.markSplashScreenViewed(input.splashId)
+            );
+          })
+        ),
     },
     server: {
       getLaunchProject: t
@@ -253,7 +272,13 @@ export const router = (authToken?: string) => {
       getConfig: t
         .input(schemas.config.getConfig.input)
         .output(schemas.config.getConfig.output)
-        .handler(({ context }) => context.config.getClientConfig()),
+        .handler(
+          handlerGen(function* ({ context }) {
+            return yield* Effect.sync(() => context.config.getClientConfig());
+          })
+        ),
+      // Event-iterator subscription: stays on the plain handler until the Effect
+      // Stream bridge phase converts event subscriptions wholesale.
       onConfigChanged: t
         .input(schemas.config.onConfigChanged.input)
         .output(schemas.config.onConfigChanged.output)
@@ -261,89 +286,155 @@ export const router = (authToken?: string) => {
       updateAgentAiDefaults: t
         .input(schemas.config.updateAgentAiDefaults.input)
         .output(schemas.config.updateAgentAiDefaults.output)
-        .handler(({ context, input }) =>
-          context.config.updateAgentAiDefaults(input.agentAiDefaults)
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateAgentAiDefaults(input.agentAiDefaults)
+            );
+          })
         ),
 
       updateMuxGatewayPrefs: t
         .input(schemas.config.updateMuxGatewayPrefs.input)
         .output(schemas.config.updateMuxGatewayPrefs.output)
-        .handler(async ({ context, input }) => {
-          await context.config.updateMuxGatewayPrefs(input);
-          context.providerService.notifyConfigChanged();
-        }),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => {
+              await context.config.updateMuxGatewayPrefs(input);
+              context.providerService.notifyConfigChanged();
+            });
+          })
+        ),
       updateRoutePreferences: t
         .input(schemas.config.updateRoutePreferences.input)
         .output(schemas.config.updateRoutePreferences.output)
-        .handler(({ context, input }) => context.providerService.updateRoutePreferences(input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.providerService.updateRoutePreferences(input)
+            );
+          })
+        ),
 
       updateMinThinkingLevels: t
         .input(schemas.config.updateMinThinkingLevels.input)
         .output(schemas.config.updateMinThinkingLevels.output)
-        .handler(({ context, input }) =>
-          context.config.updateMinThinkingLevels(input.minThinkingLevelByModel)
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateMinThinkingLevels(input.minThinkingLevelByModel)
+            );
+          })
         ),
 
       updateModelFallbacks: t
         .input(schemas.config.updateModelFallbacks.input)
         .output(schemas.config.updateModelFallbacks.output)
-        .handler(({ context, input }) => context.config.updateModelFallbacks(input.modelFallbacks)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateModelFallbacks(input.modelFallbacks)
+            );
+          })
+        ),
 
       updateModelPreferences: t
         .input(schemas.config.updateModelPreferences.input)
         .output(schemas.config.updateModelPreferences.output)
-        .handler(({ context, input }) => context.config.updateModelPreferences(input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => context.config.updateModelPreferences(input));
+          })
+        ),
 
       updateCoderPrefs: t
         .input(schemas.config.updateCoderPrefs.input)
         .output(schemas.config.updateCoderPrefs.output)
-        .handler(({ context, input }) => context.config.updateCoderPrefs(input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => context.config.updateCoderPrefs(input));
+          })
+        ),
       updateRuntimeEnablement: t
         .input(schemas.config.updateRuntimeEnablement.input)
         .output(schemas.config.updateRuntimeEnablement.output)
-        .handler(({ context, input }) => context.config.updateRuntimeEnablement(input)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => context.config.updateRuntimeEnablement(input));
+          })
+        ),
 
       saveConfig: t
         .input(schemas.config.saveConfig.input)
         .output(schemas.config.saveConfig.output)
-        .handler(async ({ context, input }) => {
-          await context.config.saveUserConfig(input);
-          await context.taskService.maybeStartQueuedTasks();
-        }),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => {
+              await context.config.saveUserConfig(input);
+              await context.taskService.maybeStartQueuedTasks();
+            });
+          })
+        ),
 
       updateChatTranscriptFullWidth: t
         .input(schemas.config.updateChatTranscriptFullWidth.input)
         .output(schemas.config.updateChatTranscriptFullWidth.output)
-        .handler(({ context, input }) =>
-          context.config.updateChatTranscriptFullWidth(input.enabled)
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateChatTranscriptFullWidth(input.enabled)
+            );
+          })
         ),
       updateLlmDebugLogs: t
         .input(schemas.config.updateLlmDebugLogs.input)
         .output(schemas.config.updateLlmDebugLogs.output)
-        .handler(({ context, input }) => context.config.updateLlmDebugLogs(input.enabled)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () => context.config.updateLlmDebugLogs(input.enabled));
+          })
+        ),
       updateHeartbeatDefaultPrompt: t
         .input(schemas.config.updateHeartbeatDefaultPrompt.input)
         .output(schemas.config.updateHeartbeatDefaultPrompt.output)
-        .handler(({ context, input }) =>
-          context.config.updateHeartbeatDefaultPrompt(input.defaultPrompt)
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateHeartbeatDefaultPrompt(input.defaultPrompt)
+            );
+          })
         ),
       updateHeartbeatDefaultIntervalMs: t
         .input(schemas.config.updateHeartbeatDefaultIntervalMs.input)
         .output(schemas.config.updateHeartbeatDefaultIntervalMs.output)
-        .handler(({ context, input }) =>
-          context.config.updateHeartbeatDefaultIntervalMs(input.intervalMs)
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateHeartbeatDefaultIntervalMs(input.intervalMs)
+            );
+          })
         ),
       updateGoalDefaults: t
         .input(schemas.config.updateGoalDefaults.input)
         .output(schemas.config.updateGoalDefaults.output)
-        .handler(({ context, input }) => context.config.updateGoalDefaults(input.goalDefaults)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.updateGoalDefaults(input.goalDefaults)
+            );
+          })
+        ),
       unenrollMuxGovernor: t
         .input(schemas.config.unenrollMuxGovernor.input)
         .output(schemas.config.unenrollMuxGovernor.output)
-        .handler(async ({ context }) => {
-          await context.config.unenrollMuxGovernor();
-          await context.policyService.refreshNow();
-        }),
+        .handler(
+          handlerGen(function* ({ context }) {
+            yield* Effect.promise(async () => {
+              await context.config.unenrollMuxGovernor();
+              await context.policyService.refreshNow();
+            });
+          })
+        ),
     },
     devtools: {
       getRuns: t
@@ -404,14 +495,24 @@ export const router = (authToken?: string) => {
       getAll: t
         .input(schemas.uiLayouts.getAll.input)
         .output(schemas.uiLayouts.getAll.output)
-        .handler(({ context }) => {
-          const config = context.config.loadConfigOrDefault();
-          return config.layoutPresets ?? DEFAULT_LAYOUT_PRESETS_CONFIG;
-        }),
+        .handler(
+          handlerGen(function* ({ context }) {
+            return yield* Effect.sync(() => {
+              const config = context.config.loadConfigOrDefault();
+              return config.layoutPresets ?? DEFAULT_LAYOUT_PRESETS_CONFIG;
+            });
+          })
+        ),
       saveAll: t
         .input(schemas.uiLayouts.saveAll.input)
         .output(schemas.uiLayouts.saveAll.output)
-        .handler(({ context, input }) => context.config.saveLayoutPresets(input.layoutPresets)),
+        .handler(
+          handlerGen(function* ({ context }, input) {
+            yield* Effect.promise(async () =>
+              context.config.saveLayoutPresets(input.layoutPresets)
+            );
+          })
+        ),
     },
     agents: {
       list: t


### PR DESCRIPTION
## Summary

Phase 7 of the progressive Effect migration (Wave 2): converts the Config service mutation surface to an Effect `Semaphore(1)`-serialized pipeline, converts the fallible read/write pipelines in `ProvidersConfigStore`/`SecretsStore` to Effect per their pre-Effect catch discipline, and moves all 20 config-backed unary router procedures (`splashScreens`, `config`, `uiLayouts`) to `handlerGen`. All public Promise/sync APIs are preserved by thin `runPromise`/`runSync` facades; existing tests pass unchanged.

## Background

Follows #4033 (OAuthFlowManager per-flow Scope), #4034 (codex/governor/copilot OAuth + 15 router sites), #4035 (coderOauthService). The Config class serializes all mutations through a private promise-chain queue feeding a private `saveConfig` — the module docs record the lost-update history (stale-snapshot writes resurrecting removed workspaces). This phase re-expresses that serialization in Effect while preserving those protections exactly.

## Implementation

### Mutation-surface conversion (`src/node/config/index.ts`)

- `editConfigQueue` promise chain → `Semaphore.makeUnsafe(1)` (`editSemaphore`). FIFO permits map the old chain 1:1: each edit's read happens only after the previous edit's write landed, and a failed edit releases its permit on the way out (the old "keep the queue alive on failure" behavior).
- `enqueueConfigEdit` stays the only Promise entry point (public `editConfig` is widely spied/overridden in tests, so named mutators keep routing through it unchanged). It defers the fiber start by one microtask: Effect v4 `runPromise` executes fibers synchronously until the first async boundary, but the old chain always ran edit bodies on a later microtask, and `loadConfigOrDefault`'s one-shot `migrationPersist` guard depends on the body observing the guard assignment (otherwise load-time migrations would double-schedule their write-back).
- The corrupt-file gate (backup-signature CAS) runs inside a single `Effect.try` step immediately followed by the `saveConfig` yield — no new await points between the check and the write it approves.
- `saveConfig` stays private and keeps its Promise signature (tests spy on it with Promise mocks to simulate swallowed writes); its body moves to `saveConfigEffect`, an `Effect.Effect<void>` with a whole-pipeline `Effect.catch` + `Effect.catchDefect` fold mirroring the old total try/catch (log-and-swallow; never fails). The serialized pipeline routes the write through the facade so spies keep intercepting it. Load-time-migration write-back semantics (identity transform re-run under the serialized pipeline) are untouched.
- Raw error identity is preserved end-to-end: v4 `runPromise`/`runSync` reject/throw with the original error for both typed failures and defects (verified empirically), so `editConfig` callers and tests observe byte-identical rejections.

### Catch-discipline classification (stores)

| Method | Pre-Effect discipline | Effect shape |
| --- | --- | --- |
| `Config.saveConfig` | total try/catch, log-and-swallow | whole-pipeline `catch` + `catchDefect` fold → `Effect<void>` (never fails) |
| `Config.enqueueConfigEdit` | throw-through (gate + transform) | `Effect.try` with `catch: (e) => e`; raw error to caller via facade |
| `ProvidersConfigStore.loadProvidersConfig` | total, fold → `null` (logged) | `Effect.try` + `catch` fold → `Effect<ProvidersConfig \| null>` |
| `ProvidersConfigStore.getProvidersFileFingerprint` | total, fold → `null` (silent) | `Effect.try` + `catch` fold → `Effect<string \| null>` |
| `ProvidersConfigStore.saveProvidersConfig` | log-then-rethrow | `Effect.try` + `tapError` log; raw failure via `runSync` facade |
| `ProvidersConfigStore.watchProvidersFile` | callback/watcher lifecycle | not converted (fs.watch callback seam; no Effect value) |
| `SecretsStore.loadSecretsConfig` / `loadRawSecretsConfig` | total, fold → `{}` (logged) | `Effect.try` + `catch` fold |
| `SecretsStore.saveSecretsConfig` | log-then-rethrow | async `Effect.tryPromise` thunk + `tapError`; raw rejection via `runPromise` facade |
| `SecretsStore.updateSecretsBucket` (+ `updateGlobalSecrets`/`updateProjectSecrets`) | throw-through composition | `Effect.gen` composing load → sync bucket fold → save |
| `SecretsStore.getEffectiveSecrets` / `getGlobalSecrets` etc. | pure/sync, no catch | unchanged (nothing fallible to convert) |

Legacy-data passthrough (unsupported secret entries, legacy bestOf metadata, unknown fields) is untouched — the conversion moves control flow only.

### fileLeaseManager

**Not converted (deliberate).** Its lock/lease lifecycle is cross-process (lock directories on disk, PID liveness, stale-breaking, TTLs), not an in-process resource: per the wrap-around-locks doctrine from #4035, Effect wraps *around* such cross-process critical sections at the caller, never through them. Its Promise seams stay byte-identical.

### Router interruption posture (per-procedure)

Reads are single `Effect.sync` steps (interruption is a don't-care: no partial state possible). Mutations wrap the whole pre-Effect handler body in **one `Effect.promise` thunk**, making them uninterruptible by construction: a client abort interrupts the handler fiber but never the in-flight config edit, and multi-step bodies cannot be torn between steps. Rejections become defects → the same internal error the old async handlers produced.

| Procedure | Kind | Posture |
| --- | --- | --- |
| `splashScreens.getViewedSplashScreens` | read | don't-care (`Effect.sync`) |
| `splashScreens.markSplashScreenViewed` | mutation | uninterruptible (single thunk) |
| `config.getConfig` | read | don't-care (`Effect.sync`) |
| `config.onConfigChanged` | subscription | **not converted** — event-iterator seam waits for the Effect Stream bridge phase |
| `config.updateAgentAiDefaults` | mutation | uninterruptible (single thunk) |
| `config.updateMuxGatewayPrefs` | mutation ×2 steps | uninterruptible (mutate + providerService.notifyConfigChanged in one thunk) |
| `config.updateRoutePreferences` | mutation (via providerService) | uninterruptible (single thunk) |
| `config.updateMinThinkingLevels` | mutation | uninterruptible (single thunk) |
| `config.updateModelFallbacks` | mutation | uninterruptible (single thunk) |
| `config.updateModelPreferences` | mutation | uninterruptible (single thunk) |
| `config.updateCoderPrefs` | mutation | uninterruptible (single thunk) |
| `config.updateRuntimeEnablement` | mutation | uninterruptible (single thunk) |
| `config.saveConfig` | mutation ×2 steps | uninterruptible (saveUserConfig + maybeStartQueuedTasks in one thunk) |
| `config.updateChatTranscriptFullWidth` | mutation | uninterruptible (single thunk) |
| `config.updateLlmDebugLogs` | mutation | uninterruptible (single thunk) |
| `config.updateHeartbeatDefaultPrompt` | mutation | uninterruptible (single thunk) |
| `config.updateHeartbeatDefaultIntervalMs` | mutation | uninterruptible (single thunk) |
| `config.updateGoalDefaults` | mutation | uninterruptible (single thunk) |
| `config.unenrollMuxGovernor` | mutation ×2 steps | uninterruptible (unenroll + policyService.refreshNow in one thunk) |
| `uiLayouts.getAll` | read | don't-care (`Effect.sync`) |
| `uiLayouts.saveAll` | mutation | uninterruptible (single thunk) |

Additionally, `enqueueConfigEditEffect` itself is `Effect.uninterruptible` (defense in depth: the corrupt-file gate, write, and change notification form one unit) while waiting for the permit stays interruptible.

## Validation

- Empirical Effect v4 probes (rc.112): `runPromise`/`runSync` raw error identity for failures and defects; Semaphore FIFO + serialization; sync fiber start (motivates the microtask defer).
- `src/node/config.test.ts` 113/113; `src/node/config/` 34/34 (secretsStore, providersConfigStore, fileLeaseManager); `workspaceService.configResurrection.test.ts` 4/4 (the lost-update contract); router + effectBridge suites; providerService/backup + workspaceService heartbeat/tags/goalDefaults + projectService + updateService + worktreeArchiveSnapshotService consumer suites.
- `tests/ipc/config` jest: 7/9 suites green; `mcpConfig.test.ts` and `modelNotFound.test.ts` failures reproduce identically on the unmodified base (live-AI bridge environment; see Risks note) — verified via stash/run/pop.
- Pre-existing env baselines unrelated to this change: taskService (2), workspaceService (bash-monitor-wake), BackupRepoCache 200-commit timeout.

## Risks

Severity: medium (config serialization is the app's central persistence chokepoint). The conversion is control-flow-preserving by construction: same read→gate→write→notify order under the same mutual exclusion, same error contracts (verified empirically for identity), same on-disk serialization (untouched). The main behavioral surface is scheduling: the microtask defer preserves the old chain's assignment-before-body ordering that the migration-persist one-shot guard depends on; the config suite pins this (migration write-back tests).

## Lessons for Phase 8 (memoryConsolidationService Schedule conversion + workspaceStatusGenerator dispatcher)

1. **Effect v4 fibers start synchronously on `runPromise`.** Any facade replacing a promise-chain/queue must check whether callers depend on deferred body execution (one-shot guards, listener registration windows) and add an explicit microtask defer if so. This will matter for workspaceStatusGenerator's dispatcher loop.
2. **Test-spy seams pin conversion boundaries.** `editConfig` is spied/overridden across many suites, so the Effect pipeline had to live *behind* the existing method rather than replacing named mutators with Effect surfaces. Check `spyOn`/property-override usage before choosing the Effect-native surface for memoryConsolidationService.
3. **Wrap-around-locks confirmed again:** fileLeaseManager (cross-process dir locks) stayed Promise-native; memoryConsolidationService's file-lock ordering should keep lock interiors byte-identical and put Effect around them.
4. **Merge-queue flake watch:** MemoryConsolidationService "rejects a second trigger" 5s-timeout flake evicted #4035 from the queue once; expect it again (verify locally, re-enqueue). Phase 8 touches that very service — consider fixing the flake as part of the phase.
5. `Semaphore.makeUnsafe(1)` + `withPermits(1)` maps AsyncMutex/promise-queue semantics 1:1 (FIFO, release-on-failure), no `acquireUseRelease` needed.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$17.43`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=17.43 -->

