### PR TITLE
🤖 fix: release preparing after superseded monitor wakes

### DIFF
--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -784,9 +784,16 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       runtimeConfig: { type: "local" },
     });
     let queuedMode: string | undefined;
+    let queuedCancelState: { canceledBeforeAcceptance: boolean } | undefined;
     const sendMessage = mock(
-      (_workspaceId: string, _prompt: string, options: { queueDispatchMode?: string }) => {
+      (
+        _workspaceId: string,
+        _prompt: string,
+        options: { queueDispatchMode?: string },
+        internal?: { cancelState?: { canceledBeforeAcceptance: boolean } }
+      ) => {
         queuedMode = options.queueDispatchMode;
+        queuedCancelState = internal?.cancelState;
         return Promise.resolve(Ok(undefined));
       }
     );
@@ -829,6 +836,7 @@ describe("WorkspaceService bash monitor wake reconciler wiring", () => {
       expect(outcome).toBe("in-flight");
       expect(sendMessage).toHaveBeenCalledTimes(1);
       expect(queuedMode).toBe("tool-end");
+      expect(queuedCancelState).toEqual({ canceledBeforeAcceptance: false });
       expect(afterIdle).not.toHaveBeenCalled();
     } finally {
       await cleanup();

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2457,6 +2457,9 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
       }
 
       let accepted = false;
+      // A queued wake can be superseded after dequeue. Share cancellation state so
+      // AgentSession can release PREPARING when cancellation wins before acceptance.
+      const cancelState = { canceledBeforeAcceptance: false };
       const sendResult = await this.sendMessage(
         ownerWorkspaceId,
         dispatch.prompt,
@@ -2469,6 +2472,7 @@ export class WorkspaceService extends EventEmitter implements WorkspaceHost {
           skipAutoResumeReset: true,
           synthetic: true,
           agentInitiated: true,
+          cancelState,
           cancelSignal: dispatch.cancelSignal,
           queueDedupeKey: dispatch.dedupeKey,
           removableQueueDedupeKey: true,


### PR DESCRIPTION
## Summary

Keep bash-monitor wake dispatches from leaving a workspace permanently stuck in `PREPARING` when the level-triggered reconciler supersedes a queued wake before acceptance.

## Background

The reconciler can queue a match wake while a model turn is active, then cancel it when process settlement produces a newer wake. `AgentSession.sendQueuedMessages()` claims `PREPARING` before dispatch and relies on shared cancellation state to return to idle when cancellation wins. Bash-monitor dispatches passed the abort signal but omitted that state, so the canceled send returned successfully without starting a stream or releasing `PREPARING`. The newer settlement wake then deferred forever because the session appeared busy.

## Implementation

- Create one cancellation-state object for each bash-monitor wake dispatch and pass it alongside the reconciler's abort signal.
- Extend the existing WorkspaceService wiring test to require that state on queued monitor wakes. Existing AgentSession queue tests already cover the downstream cancellation and idle transition.

## Validation

- `bun test src/node/services/workspaceService.test.ts`
- `bun test src/node/services/agentSession.queueDispatch.test.ts`
- `make static-check`

## Risks

Low. The change only adds bookkeeping to the existing cancelable monitor-wake path. Accepted wakes and non-monitor queue entries keep their current behavior.

---

_Generated with `xum` • Model: `openai:gpt-5.6-sol` • Thinking: `xhigh` • Cost: `$0.00`_

<!-- mux-attribution: model=openai:gpt-5.6-sol thinking=xhigh costs=0.00 -->
