### PR TITLE
🤖 release: v0.28.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coder/xum",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "desktopName": "xum.desktop",
   "description": "xum - coding agent multiplexer",
   "author": "Coder",


### PR DESCRIPTION
## Summary

Version bump for the v0.28.3 patch release. The headline changes since v0.28.2 are the Claude Fable 5.1 (#3988) and Claude Mythos 5.1 (#3991) promotions, landed on launch day with pricing and model ids verified against Anthropic's official docs. The release also carries the Z.ai provider with GLM 5.3 Flash (#4007) plus accumulated fixes on main.

After this PR merges, the `v0.28.3` tag will be applied to the squash commit and the GitHub Release published to trigger the desktop/npm/docker pipelines.

---

_Generated with `xum` • Model: `anthropic:claude-fable-5` • Thinking: `xhigh` • Cost: `$49.19`_

<!-- mux-attribution: model=anthropic:claude-fable-5 thinking=xhigh costs=49.19 -->
